### PR TITLE
Fixes component names from spectrum- prefix to sp-

### DIFF
--- a/lib/dropzone/demo/index.html
+++ b/lib/dropzone/demo/index.html
@@ -34,8 +34,8 @@
                     files.
                 </div>
                 <div slot="demo">
-                    <spectrum-dropzone id="dropzone">
-                        <spectrum-illustrated-message
+                    <sp-dropzone id="dropzone">
+                        <sp-illustrated-message
                             heading="Drag and Drop Your File"
                         >
                             <svg>
@@ -43,12 +43,12 @@
                                     xlink:href="geometry.svg#upload_geometry"
                                 />
                             </svg>
-                        </spectrum-illustrated-message>
+                        </sp-illustrated-message>
 
                         <div style="color: grey">
                             <div>
                                 <label for="file-input">
-                                    <spectrum-link>Select a File</spectrum-link>
+                                    <sp-link>Select a File</sp-link>
                                     from your computer
                                 </label>
                                 <input
@@ -59,15 +59,15 @@
                             </div>
                             <div>
                                 or
-                                <spectrum-link
+                                <sp-link
                                     href="http://stock.adobe.com"
                                     target="blank"
                                 >
                                     Search Adobe Stock
-                                </spectrum-link>
+                                </sp-link>
                             </div>
                         </div>
-                    </spectrum-dropzone>
+                    </sp-dropzone>
 
                     <script>
                         const dropzone = document.getElementById('dropzone');

--- a/lib/dropzone/dropzone.ts
+++ b/lib/dropzone/dropzone.ts
@@ -17,7 +17,7 @@ import dropzoneStyles from './dropzone.css.js';
 export type DropzoneEventDetail = DragEvent;
 
 export class Dropzone extends LitElement {
-    public static readonly is = 'spectrum-dropzone';
+    public static readonly is = 'sp-dropzone';
 
     public static get styles() {
         return [dropzoneStyles];

--- a/lib/illustrated-message/demo/index.html
+++ b/lib/illustrated-message/demo/index.html
@@ -27,7 +27,7 @@
                     preferably an SVG with a heading and description below it.
                 </div>
                 <div slot="demo">
-                    <spectrum-illustrated-message
+                    <sp-illustrated-message
                         heading="No Results"
                         description="Try another search"
                     >
@@ -36,7 +36,7 @@
                                 xlink:href="error_message_geometry.svg#error-notice"
                             />
                         </svg>
-                    </spectrum-illustrated-message>
+                    </sp-illustrated-message>
                 </div>
             </demo-section>
         </demo-page>

--- a/lib/illustrated-message/illustrated-message.ts
+++ b/lib/illustrated-message/illustrated-message.ts
@@ -15,7 +15,7 @@ import { html, LitElement, property } from 'lit-element';
 import messageStyles from './illustrated-message.css.js';
 
 export class IllustratedMessage extends LitElement {
-    public static readonly is = 'spectrum-illustrated-message';
+    public static readonly is = 'sp-illustrated-message';
 
     public static get styles() {
         return [messageStyles];

--- a/lib/link/demo/index.html
+++ b/lib/link/demo/index.html
@@ -26,17 +26,17 @@
                     The link component adds basic link styling to its content.
                 </div>
                 <div slot="demo">
-                    <spectrum-link
+                    <sp-link
                         href="https://www.adobe.com"
                         title="Go to Adobe.com"
                         target="_blank"
                     >
                         link to adobe.com
-                    </spectrum-link>
+                    </sp-link>
                     and this is a
-                    <spectrum-link href="https://www.adobe.com" disabled>
+                    <sp-link href="https://www.adobe.com" disabled>
                         disabled link
-                    </spectrum-link>
+                    </sp-link>
                 </div>
             </demo-section>
         </demo-page>

--- a/lib/link/link.ts
+++ b/lib/link/link.ts
@@ -16,7 +16,7 @@ import { ifDefined } from 'lit-html/directives/if-defined';
 import linkStyles from './link.css.js';
 
 export class Link extends LitElement {
-    public static readonly is = 'spectrum-link';
+    public static readonly is = 'sp-link';
 
     public static get styles() {
         return [linkStyles];

--- a/lib/slider/demo/index.html
+++ b/lib/slider/demo/index.html
@@ -28,7 +28,7 @@
                     within a range.
                 </div>
                 <div class="slider-demo" slot="demo">
-                    <spectrum-slider
+                    <sp-slider
                         value="5"
                         step="0.5"
                         min="0"
@@ -46,7 +46,7 @@
                     </script>
                 </div>
                 <div class="slider-demo" slot="demo">
-                    <spectrum-slider
+                    <sp-slider
                         disabled
                         value="5"
                         step="0.5"
@@ -62,7 +62,7 @@
                     within a range.
                 </div>
                 <div class="slider-demo" slot="demo">
-                    <spectrum-slider-color
+                    <sp-slider-color
                         value="5"
                         step="0.5"
                         min="0"
@@ -80,7 +80,7 @@
                     </script>
                 </div>
                 <div class="slider-demo" slot="demo">
-                    <spectrum-slider-color
+                    <sp-slider-color
                         has-alpha
                         value="5"
                         step="0.5"
@@ -90,7 +90,7 @@
                     />
                 </div>
                 <div class="slider-demo" slot="demo">
-                    <spectrum-slider-color
+                    <sp-slider-color
                         disabled
                         value="5"
                         step="0.5"

--- a/lib/slider/slider-color.ts
+++ b/lib/slider/slider-color.ts
@@ -18,8 +18,8 @@ import sliderStyles from './slider.css.js';
 
 export type ISliderColorEventDetail = number;
 
-export class SpectrumSliderColor extends LitElement {
-    public static is = 'spectrum-slider-color';
+export class SliderColor extends LitElement {
+    public static is = 'sp-slider-color';
 
     public static get styles() {
         return [sliderStyles, sliderSkinStyles, sliderColorStyles];

--- a/lib/slider/slider.ts
+++ b/lib/slider/slider.ts
@@ -17,8 +17,8 @@ import sliderStyles from './slider.css.js';
 
 export type ISliderEventDetail = number;
 
-export class SpectrumSlider extends LitElement {
-    public static is = 'spectrum-slider';
+export class Slider extends LitElement {
+    public static is = 'sp-slider';
 
     public static get styles() {
         return [sliderStyles, sliderSkinStyles];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publishConfig": {
         "registry": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-crisp-release-local/"
     },
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "",
     "files": [
         "lib",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

All components should be registered with `sp-` prefix rather than `spectrum-` prefix to save developer sanity. Also we don't need to prefix class names with `Spectrum` since we're developing using es-modules there's no namespace collision issues.

## How Has This Been Tested?

Test run, and demo pages have been checked.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
