### PR TITLE
Fix slider track progress behavior when min-value is below zero

### DIFF
--- a/src/slider/slider.ts
+++ b/src/slider/slider.ts
@@ -131,7 +131,10 @@ export class Slider extends LitElement {
      * Ratio representing the slider's position on the track
      */
     private get trackProgress(): number {
-        return this.value / this.max;
+        const range = this.max - this.min;
+        const progress = this.value - this.min;
+
+        return progress / range;
     }
 
     private get trackLeftStyle(): string {


### PR DESCRIPTION
## Description
 
Bad math fix.

Fixed a bug where if a Slider is given a negative min value, the track progress would not behave correctly.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on demo page

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
