### PR TITLE
Adds strict custom event typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prismjs": "^1.15.0"
     },
     "devDependencies": {
-        "@adobe/es-modules-middleware": "^1.0.0",
+        "@adobe/es-modules-middleware": "~1.1.0",
         "@adobe/spectrum-css": "^2.9.0",
         "@babel/core": "^7.4.0",
         "@storybook/addon-knobs": "^5.0.5",

--- a/src/dropzone/demo/index.html
+++ b/src/dropzone/demo/index.html
@@ -72,7 +72,7 @@
                     <script>
                         const dropzone = document.getElementById('dropzone');
                         dropzone.addEventListener(
-                            'dropzone-should-accept',
+                            'sp-dropzone:should-accept',
                             (ev) => {
                                 var fileType = ev.detail.dataTransfer.items[0].type.split(
                                     '/'
@@ -82,7 +82,7 @@
                                 }
                             }
                         );
-                        dropzone.addEventListener('dropzone-drop', (ev) => {
+                        dropzone.addEventListener('sp-dropzone:drop', (ev) => {
                             // do something with ev.detail.dataTransfer
                             alert(
                                 'Uploading : ' +

--- a/src/dropzone/dropzone.ts
+++ b/src/dropzone/dropzone.ts
@@ -19,6 +19,7 @@ import {
 } from 'lit-element';
 
 import dropzoneStyles from './dropzone.css';
+import { strictCustomEvent } from '../events';
 
 export type DropzoneEventDetail = DragEvent;
 
@@ -47,8 +48,8 @@ export class Dropzone extends LitElement {
     private debouncedDragLeave: number | null = null;
 
     public onDragOver(ev: DragEvent): void {
-        const shouldAcceptEvent = new CustomEvent<DropzoneEventDetail>(
-            'dropzone-should-accept',
+        const shouldAcceptEvent = strictCustomEvent(
+            'sp-dropzone:should-accept',
             {
                 bubbles: true,
                 cancelable: true,
@@ -73,14 +74,11 @@ export class Dropzone extends LitElement {
         this.isDragged = true;
 
         ev.dataTransfer.dropEffect = this.dropEffect;
-        const dragOverEvent = new CustomEvent<DropzoneEventDetail>(
-            'dropzone-dragover',
-            {
-                bubbles: true,
-                composed: true,
-                detail: ev,
-            }
-        );
+        const dragOverEvent = strictCustomEvent('sp-dropzone:dragover', {
+            bubbles: true,
+            composed: true,
+            detail: ev,
+        });
         this.dispatchEvent(dragOverEvent);
     }
 
@@ -92,14 +90,11 @@ export class Dropzone extends LitElement {
                 this.isDragged = false;
             }
 
-            const dragLeave = new CustomEvent<DropzoneEventDetail>(
-                'dropzone-dragleave',
-                {
-                    bubbles: true,
-                    composed: true,
-                    detail: ev,
-                }
-            );
+            const dragLeave = strictCustomEvent('sp-dropzone:dragleave', {
+                bubbles: true,
+                composed: true,
+                detail: ev,
+            });
             this.dispatchEvent(dragLeave);
         }, 100);
     }
@@ -112,14 +107,11 @@ export class Dropzone extends LitElement {
         if (this.isDragged) {
             this.isDragged = false;
         }
-        const dropEvent = new CustomEvent<DropzoneEventDetail>(
-            'dropzone-drop',
-            {
-                bubbles: true,
-                composed: true,
-                detail: ev,
-            }
-        );
+        const dropEvent = strictCustomEvent('sp-dropzone:drop', {
+            bubbles: true,
+            composed: true,
+            detail: ev,
+        });
         this.dispatchEvent(dropEvent);
     }
 
@@ -141,5 +133,14 @@ export class Dropzone extends LitElement {
             clearTimeout(this.debouncedDragLeave);
             this.debouncedDragLeave = null;
         }
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-dropzone:should-accept': CustomEvent<DragEvent>;
+        'sp-dropzone:dragover': CustomEvent<DragEvent>;
+        'sp-dropzone:dragleave': CustomEvent<DragEvent>;
+        'sp-dropzone:drop': CustomEvent<DragEvent>;
     }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,53 @@
+/**
+ * Omit the given keys from an object type.
+ */
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+export type Omit<T, K extends keyof T> = T extends any
+    ? Pick<T, Exclude<keyof T, K>>
+    : never;
+
+/**
+ * Extracts a CustomEvent payload type from a CustomEvent type.
+ */
+type UnpackCustomEventPayload<T> = T extends CustomEvent<infer U> ? U : never;
+
+/**
+ * Extracts the CustomEvent detail type from a CustomEvent type using the name of the event as the key
+ * and the DocumentEventMap.
+ * E.g. UnpackCustomEventDetail<'my-cool-event'>
+ */
+export type UnpackCustomEventDetail<
+    T extends keyof DocumentEventMap
+> = UnpackCustomEventPayload<DocumentEventMap[T]>;
+
+/**
+ * A strongly typed CustomEvent based on the event name using the global DocumentEventMap.
+ * E.g. StrictCustomEvent<'my-cool-event'>
+ */
+export type StrictCustomEvent<T extends keyof DocumentEventMap> = CustomEvent<
+    UnpackCustomEventPayload<DocumentEventMap[T]>
+>;
+
+/**
+ * A helper type to create a CustomEventInit type from a event detail type.
+ */
+type StrictCustomEventInit<T> = T extends void
+    ? CustomEventInit<T>
+    : Omit<CustomEventInit<T>, 'detail'> & { detail: T };
+
+/**
+ * Creates a strictly typed CustomEvent<T> using the DocumentEventMap.
+ *
+ * To make use of this helper ensure that your events are added to the DocumentEventMap. The
+ * easiest way to do this is to include them in the GlobalEventMap
+ *
+ * @param name The name of the CustomEvent to create
+ * @param payload The arguments for the CustomEvent constructor
+ */
+export function strictCustomEvent<
+    T extends keyof DocumentEventMap,
+    D extends UnpackCustomEventPayload<DocumentEventMap[T]>,
+    C extends StrictCustomEventInit<D>
+>(name: T, payload: C): CustomEvent<D> {
+    return new CustomEvent<D>(name, payload);
+}

--- a/src/icon/icon.ts
+++ b/src/icon/icon.ts
@@ -61,13 +61,13 @@ export class Icon extends LitElement {
                 this.updateIcon();
             }
         }) as EventListener;
-        window.addEventListener('sp-iconset-added', this.iconsetListener);
+        window.addEventListener('sp-iconset:added', this.iconsetListener);
     }
     public disconnectedCallback(): void {
         super.disconnectedCallback();
         if (this.iconsetListener) {
             window.removeEventListener(
-                'sp-iconset-added',
+                'sp-iconset:added',
                 this.iconsetListener
             );
         }

--- a/src/iconset/iconset-registry.ts
+++ b/src/iconset/iconset-registry.ts
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import { Iconset } from './iconset';
+import { strictCustomEvent } from '../events';
 
 export class IconsetRegistry {
     // singleton getter
@@ -29,7 +30,7 @@ export class IconsetRegistry {
         // dispatch a sp-iconset-added event on window to let everyone know we have a new iconset
         // note we're using window here for efficiency since we don't need to bubble through the dom since everyone
         // will know where to look for this event
-        const event = new CustomEvent('sp-iconset-added', {
+        const event = strictCustomEvent('sp-iconset:added', {
             detail: { name, iconset },
         });
         // we're dispatching this event in the next tick to allow the iconset to finish any slotchange or other event
@@ -42,7 +43,7 @@ export class IconsetRegistry {
         // dispatch a sp-iconset-removed event on window to let everyone know we have a new iconset
         // note we're using window here for efficiency since we don't need to bubble through the dom since everyone
         // will know where to look for this event
-        const event = new CustomEvent('sp-iconset-removed', {
+        const event = strictCustomEvent('sp-iconset:removed', {
             detail: { name },
         });
         // we're dispatching this event in the next tick To keep the event model consistent with the added event
@@ -50,5 +51,12 @@ export class IconsetRegistry {
     }
     public getIconset(name: string): Iconset | undefined {
         return this.iconsetMap.get(name);
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-iconset:added': CustomEvent<{ name: string; iconset: Iconset }>;
+        'sp-iconset:removed': CustomEvent<{ name: string }>;
     }
 }

--- a/src/iconset/iconset.ts
+++ b/src/iconset/iconset.ts
@@ -70,7 +70,9 @@ export abstract class Iconset extends LitElement {
     /**
      * On updated we register the iconset if we're not already registered
      */
-    public updated(): void {
+    public connectedCallback(): void {
+        super.connectedCallback();
+
         if (!this.name || this.registered) {
             return;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,5 +28,6 @@ export * from './overlay-trigger';
 export * from './popover';
 
 export * from './define';
+export * from './events';
 
 // NOTE: we do not export demo-page because it has dependencies on other modules we don't want to force on users

--- a/src/overlay-root/overlay-root.ts
+++ b/src/overlay-root/overlay-root.ts
@@ -23,12 +23,13 @@ import {
 import overlayStyles from './overlay-root.css.js';
 
 import calculatePosition, { PositionResult } from './calculate-position';
+import { strictCustomEvent, StrictCustomEvent } from '../events.js';
 
 export type TriggerInteractions = 'click' | 'hover';
 
 export type Placement = 'top' | 'right' | 'bottom' | 'left';
 
-export interface PopoverOpenDetail {
+export interface OverlayOpenDetail {
     content: HTMLElement;
     delay: number;
     offset: number;
@@ -37,7 +38,7 @@ export interface PopoverOpenDetail {
     interaction: TriggerInteractions;
 }
 
-export interface PopoverCloseDetail {
+export interface OverlayCloseDetail {
     content: HTMLElement;
 }
 
@@ -104,7 +105,7 @@ export class OverlayRoot extends LitElement {
 
         this.removeOverlay();
 
-        const clickOutEvent = new CustomEvent('overlay-click-out', {
+        const clickOutEvent = strictCustomEvent('sp-overlay:click-out', {
             bubbles: true,
             composed: true,
             detail: ev,
@@ -114,7 +115,7 @@ export class OverlayRoot extends LitElement {
         this.visible = false;
     }
 
-    public onPopoverOpen(ev: CustomEvent<PopoverOpenDetail>): void {
+    public onOverlayOpen(ev: StrictCustomEvent<'sp-overlay:open'>): void {
         if (this.active) {
             return;
         }
@@ -132,7 +133,7 @@ export class OverlayRoot extends LitElement {
         }, ev.detail.delay);
     }
 
-    public onPopoverClose(ev: CustomEvent<PopoverCloseDetail>): void {
+    public onOverlayClose(ev: StrictCustomEvent<'sp-overlay:close'>): void {
         if (this.timeout) {
             clearTimeout(this.timeout);
         }
@@ -153,8 +154,8 @@ export class OverlayRoot extends LitElement {
 
         return html`
             <slot
-                @popover-open=${this.onPopoverOpen}
-                @popover-close=${this.onPopoverClose}
+                @sp-overlay:open=${this.onOverlayOpen}
+                @sp-overlay:close=${this.onOverlayClose}
                 @click=${maskClickListener}
             ></slot>
             <div
@@ -192,7 +193,7 @@ export class OverlayRoot extends LitElement {
         }
     }
 
-    private extractEventDetail(ev: CustomEvent<PopoverOpenDetail>): void {
+    private extractEventDetail(ev: CustomEvent<OverlayOpenDetail>): void {
         this.overlayContent = ev.detail.content;
         this.trigger = ev.detail.trigger;
         this.placement = ev.detail.placement;
@@ -236,5 +237,13 @@ export class OverlayRoot extends LitElement {
         }
 
         return '';
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-overlay:click-out': CustomEvent<Event>;
+        'sp-overlay:open': CustomEvent<OverlayOpenDetail>;
+        'sp-overlay:close': CustomEvent<OverlayCloseDetail>;
     }
 }

--- a/src/overlay-trigger/overlay-trigger.ts
+++ b/src/overlay-trigger/overlay-trigger.ts
@@ -21,11 +21,12 @@ import {
 import overlayTriggerStyles from './overlay-trigger.css.js';
 
 import {
-    PopoverCloseDetail,
-    PopoverOpenDetail,
+    OverlayCloseDetail,
+    OverlayOpenDetail,
     TriggerInteractions,
     Placement,
 } from '../overlay-root';
+import { strictCustomEvent } from '../events.js';
 
 export class OverlayTrigger extends LitElement {
     public static is = 'overlay-trigger';
@@ -44,19 +45,19 @@ export class OverlayTrigger extends LitElement {
 
     private hoverContent?: HTMLElement;
 
-    public onPopoverOpen(ev: Event, interaction: TriggerInteractions): void {
+    public onOverlayOpen(ev: Event, interaction: TriggerInteractions): void {
         const isClick = interaction === 'click';
-        const popoverElement = isClick ? this.clickContent : this.hoverContent;
-        const delayAttribute = popoverElement
-            ? popoverElement.getAttribute('delay')
+        const overlayElement = isClick ? this.clickContent : this.hoverContent;
+        const delayAttribute = overlayElement
+            ? overlayElement.getAttribute('delay')
             : null;
         const delay = delayAttribute ? parseFloat(delayAttribute) : 0;
 
-        if (!popoverElement) {
+        if (!overlayElement) {
             return;
         }
-        const popoverOpenDetail: PopoverOpenDetail = {
-            content: popoverElement,
+        const overlayOpenDetail: OverlayOpenDetail = {
+            content: overlayElement,
             delay: delay,
             offset: this.offset,
             placement: this.placement,
@@ -64,57 +65,51 @@ export class OverlayTrigger extends LitElement {
             interaction: interaction,
         };
 
-        const popoverOpenEvent = new CustomEvent<PopoverOpenDetail>(
-            'popover-open',
-            {
-                bubbles: true,
-                composed: true,
-                detail: popoverOpenDetail,
-            }
-        );
+        const overlayOpenEvent = strictCustomEvent('sp-overlay:open', {
+            bubbles: true,
+            composed: true,
+            detail: overlayOpenDetail,
+        });
 
-        this.dispatchEvent(popoverOpenEvent);
+        this.dispatchEvent(overlayOpenEvent);
     }
 
-    public onPopoverClose(ev: Event, interaction: TriggerInteractions): void {
+    public onOverlayClose(ev: Event, interaction: TriggerInteractions): void {
         const isClick = interaction === 'click';
-        const popoverElement = isClick ? this.clickContent : this.hoverContent;
+        const overlayElement = isClick ? this.clickContent : this.hoverContent;
 
-        if (!popoverElement) {
+        if (!overlayElement) {
             return;
         }
 
-        const popoverCloseDetail: PopoverCloseDetail = {
-            content: popoverElement,
+        const overlayCloseDetail: OverlayCloseDetail = {
+            content: overlayElement,
         };
 
-        const popoverCloseEvent = new CustomEvent<PopoverCloseDetail>(
-            'popover-close',
-            {
-                bubbles: true,
-                composed: true,
-                detail: popoverCloseDetail,
-            }
-        );
+        const overlayCloseEvent = strictCustomEvent('sp-overlay:close', {
+            bubbles: true,
+            composed: true,
+            detail: overlayCloseDetail,
+        });
 
-        this.dispatchEvent(popoverCloseEvent);
+        this.dispatchEvent(overlayCloseEvent);
     }
 
     public onTriggerClick(ev: Event): void {
         if (this.clickContent) {
-            this.onPopoverOpen(ev, 'click');
+            this.onOverlayOpen(ev, 'click');
         }
     }
 
     public onTriggerMouseOver(ev: Event): void {
         if (this.hoverContent) {
-            this.onPopoverOpen(ev, 'hover');
+            this.onOverlayOpen(ev, 'hover');
         }
     }
 
     public onTriggerMouseLeave(ev: Event): void {
         if (this.hoverContent) {
-            this.onPopoverClose(ev, 'hover');
+            this.onOverlayClose(ev, 'hover');
         }
     }
 

--- a/src/slider/demo/index.html
+++ b/src/slider/demo/index.html
@@ -40,7 +40,7 @@
                         const opacitySlider = document.getElementById(
                             'opacity-slider'
                         );
-                        opacitySlider.addEventListener('slider-input', (ev) => {
+                        opacitySlider.addEventListener('sp-slider:input', (ev) => {
                             console.log(ev.detail);
                         });
                     </script>
@@ -74,7 +74,7 @@
                         const colorSlider = document.getElementById(
                             'color-slider'
                         );
-                        colorSlider.addEventListener('slider-change', (ev) => {
+                        colorSlider.addEventListener('sp-slider-color:change', (ev) => {
                             console.log(ev.detail);
                         });
                     </script>

--- a/src/slider/slider-color.ts
+++ b/src/slider/slider-color.ts
@@ -22,8 +22,9 @@ import {
 import sliderColorStyles from './slider-color.css';
 import sliderSkinStyles from './slider-skin.css';
 import sliderStyles from './slider.css';
+import { strictCustomEvent } from '../events';
 
-export type ISliderColorEventDetail = number;
+export type SliderColorEventDetail = number;
 
 export class SliderColor extends LitElement {
     public static is = 'sp-slider-color';
@@ -64,27 +65,21 @@ export class SliderColor extends LitElement {
 
         this.value = parseFloat(inputValue);
 
-        const inputEvent = new CustomEvent<ISliderColorEventDetail>(
-            'slider-input',
-            {
-                bubbles: true,
-                composed: true,
-                detail: this.value,
-            }
-        );
+        const inputEvent = strictCustomEvent('sp-slider-color:input', {
+            bubbles: true,
+            composed: true,
+            detail: this.value,
+        });
 
         this.dispatchEvent(inputEvent);
     }
 
     public onChange(): void {
-        const changeEvent = new CustomEvent<ISliderColorEventDetail>(
-            'slider-change',
-            {
-                bubbles: true,
-                composed: true,
-                detail: this.value,
-            }
-        );
+        const changeEvent = strictCustomEvent('sp-slider-color:change', {
+            bubbles: true,
+            composed: true,
+            detail: this.value,
+        });
 
         this.dispatchEvent(changeEvent);
     }
@@ -132,5 +127,12 @@ export class SliderColor extends LitElement {
 
     private get handleStyle(): string {
         return `left: ${this.trackProgress * 100}%`;
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-slider-color:input': CustomEvent<SliderColorEventDetail>;
+        'sp-slider-color:change': CustomEvent<SliderColorEventDetail>;
     }
 }

--- a/src/slider/slider.ts
+++ b/src/slider/slider.ts
@@ -21,8 +21,9 @@ import {
 
 import sliderSkinStyles from './slider-skin.css';
 import sliderStyles from './slider.css';
+import { strictCustomEvent } from '../events';
 
-export type ISliderEventDetail = number;
+export type SliderEventDetail = number;
 
 export class Slider extends LitElement {
     public static is = 'sp-slider';
@@ -63,7 +64,7 @@ export class Slider extends LitElement {
 
         this.value = parseFloat(inputValue);
 
-        const inputEvent = new CustomEvent<ISliderEventDetail>('slider-input', {
+        const inputEvent = strictCustomEvent('sp-slider:input', {
             bubbles: true,
             composed: true,
             detail: this.value,
@@ -73,14 +74,11 @@ export class Slider extends LitElement {
     }
 
     public onChange(): void {
-        const changeEvent = new CustomEvent<ISliderEventDetail>(
-            'slider-change',
-            {
-                bubbles: true,
-                composed: true,
-                detail: this.value,
-            }
-        );
+        const changeEvent = strictCustomEvent('sp-slider:change', {
+            bubbles: true,
+            composed: true,
+            detail: this.value,
+        });
 
         this.dispatchEvent(changeEvent);
     }
@@ -150,5 +148,12 @@ export class Slider extends LitElement {
 
     private get handleStyle(): string {
         return `left: ${this.trackProgress * 100}%`;
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-slider:input': CustomEvent<SliderEventDetail>;
+        'sp-slider:change': CustomEvent<SliderEventDetail>;
     }
 }

--- a/src/tab-list/tab-list.ts
+++ b/src/tab-list/tab-list.ts
@@ -19,6 +19,7 @@ import {
 } from 'lit-element';
 
 import tabListStyles from './tab-list.css';
+import { strictCustomEvent } from '../events';
 
 export class TabList extends LitElement {
     public static readonly is = 'sp-tab-list';
@@ -55,7 +56,7 @@ export class TabList extends LitElement {
             const value = target.getAttribute('value');
             if (value) {
                 const applyDefault = this.dispatchEvent(
-                    new CustomEvent<{ selected: string }>('change', {
+                    strictCustomEvent('sp-tab-list:change', {
                         bubbles: true,
                         composed: true,
                         detail: {
@@ -98,5 +99,11 @@ export class TabList extends LitElement {
                 currentChecked.setAttribute('selected', '');
             }
         }
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-tab-list:change': CustomEvent<{ selected: string }>;
     }
 }


### PR DESCRIPTION
## Description

CustomEvents can be typed to enforce the detail payload, one approach to this is to export an interface for the detail, and then specify the type when constructing the custom event, e.g. `new CustomEvent<MyFooEventDetail>` but this is prone to mistakes and does not enforce that a specific event name will be associated with a specific event detail type (i.e. you can emit any typed custom event you like for any event name).

This PR introduces another approach where we define the event detail types using the `GlobalEventHandlersEventMap` which is how typescript types the [standard DOM event details](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L16841). By defining our event detail types in this map we can use a helper method `strictCustomEvent` to construct a custom event using the correct type based on the event name.

NOTE this pr also changes the event names to be properly namespaced to avoid collisions with other libraries/events.

## How Has This Been Tested?

Run through all the demo pages to confirm they're still functioning.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
