### PR TITLE
Fix overlay demo and example project from button change

### DIFF
--- a/example-project/src/index.html
+++ b/example-project/src/index.html
@@ -17,8 +17,8 @@
     </head>
 
     <body>
-        <sp-button-primary>Primary</sp-button-primary>
-        <sp-button-secondary quiet>secondary</sp-button-secondary>
+        <sp-button variant="primary">Primary</sp-button>
+        <sp-button variant="secondary" quiet>secondary</sp-button>
         <script async src="main.bundle.js"></script>
     </body>
 </html>

--- a/example-project/src/index.js
+++ b/example-project/src/index.js
@@ -14,9 +14,5 @@ governing permissions and limitations under the License.
 import './styles.css';
 
 // import the components we'll use in this page
-import {
-    defineCustomElements,
-    ButtonPrimary,
-    ButtonSecondary,
-} from '../../lib';
-defineCustomElements(ButtonPrimary, ButtonSecondary);
+import { defineCustomElements, Button } from '../../lib';
+defineCustomElements(Button);

--- a/src/overlay-root/demo/index.html
+++ b/src/overlay-root/demo/index.html
@@ -10,7 +10,7 @@
             import {
                 defineCustomElements,
                 OverlayTrigger,
-                ButtonPrimary,
+                Button,
                 Popover,
                 Slider,
             } from '../../index.js';
@@ -22,7 +22,7 @@
             defineCustomElements(
                 ...Object.values(Elements),
                 ...Object.values(DemoElements),
-                ButtonPrimary,
+                Button,
                 OverlayTrigger,
                 Popover,
                 Slider
@@ -46,9 +46,9 @@
                     <overlay-root class="root">
                         <div class="root-content">
                             <overlay-trigger>
-                                <sp-button-primary slot="trigger">
+                                <sp-button variant="primary" slot="trigger">
                                     Bottom Popover
-                                </sp-button-primary>
+                                </sp-button>
                                 <sp-popover slot="click-content" bottom>
                                     <div class="options-popover-content">
                                         <sp-slider
@@ -88,9 +88,9 @@
                     <overlay-root class="root">
                         <div class="root-content">
                             <overlay-trigger placement="left">
-                                <sp-button-primary slot="trigger">
+                                <sp-button variant="primary" slot="trigger">
                                     Left Popover
-                                </sp-button-primary>
+                                </sp-button>
                                 <sp-popover slot="click-content" left>
                                     <div class="options-popover-content">
                                         <sp-slider
@@ -118,9 +118,9 @@
                                 </div>
                             </overlay-trigger>
                             <overlay-trigger placement="top">
-                                <sp-button-primary slot="trigger">
+                                <sp-button variant="primary" slot="trigger">
                                     Top Popover
-                                </sp-button-primary>
+                                </sp-button>
                                 <sp-popover slot="click-content" top>
                                     <div class="options-popover-content">
                                         <sp-slider
@@ -148,9 +148,9 @@
                                 </div>
                             </overlay-trigger>
                             <overlay-trigger placement="right">
-                                <sp-button-primary slot="trigger">
+                                <sp-button variant="primary" slot="trigger">
                                     Right Popover
-                                </sp-button-primary>
+                                </sp-button>
                                 <sp-popover slot="click-content" right>
                                     <div class="options-popover-content">
                                         <sp-slider
@@ -189,9 +189,9 @@
                     <overlay-root class="root">
                         <div class="root-content">
                             <overlay-trigger>
-                                <sp-button-primary slot="trigger">
+                                <sp-button variant="primary" slot="trigger">
                                     Bottom Popover
-                                </sp-button-primary>
+                                </sp-button>
                                 <sp-popover slot="click-content" bottom>
                                     <div class="options-popover-content">
                                         <overlay-root class="nested-root">
@@ -203,11 +203,12 @@
                                                 class="marker-size-slider"
                                             ></sp-slider>
                                             <overlay-trigger placement="left">
-                                                <sp-button-primary
+                                                <sp-button
+                                                    variant="primary"
                                                     slot="trigger"
                                                 >
                                                     Nest is Best
-                                                </sp-button-primary>
+                                                </sp-button>
                                                 <sp-popover
                                                     slot="click-content"
                                                     left
@@ -228,11 +229,12 @@
                                                             <overlay-trigger
                                                                 placement="bottom"
                                                             >
-                                                                <sp-button-primary
+                                                                <sp-button
+                                                                    variant="primary"
                                                                     slot="trigger"
                                                                 >
                                                                     Nest is Best
-                                                                </sp-button-primary>
+                                                                </sp-button>
                                                                 <sp-popover
                                                                     slot="click-content"
                                                                     bottom


### PR DESCRIPTION
Update example and demo code to reflect changes to `sp-button` where the variant is provided via an attribute

## Description

Make references to `sp-button` pass the variant as an attribute

## Related Issue

Related to #35

## Motivation and Context

Fixes breakage

## How Has This Been Tested?

Tested using the demo pages

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
