### PR TITLE
Imports CSSResultArray in global.d.ts

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { CSSResultArray } from 'lit-element';
+
 declare module '*.css' {
     const content: CSSResultArray;
     export default content;


### PR DESCRIPTION
## Description

Imports CSSResultArray in `global.d.ts`

## Motivation and Context

`global.d.ts` was missing a CSSResultArray import. This PR addresses this

## How Has This Been Tested?

Built and run locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
