### PR TITLE
Allows spectrum-css classes to be mapped to new classes

### DIFF
--- a/scripts/process-spectrum-postcss-plugin.js
+++ b/scripts/process-spectrum-postcss-plugin.js
@@ -82,6 +82,24 @@ class SpectrumProcessor {
             }
         }
 
+        // Map shadow DOM classes to new classes
+        // e.g. ".spectrum-Slider-track" -> ".track"
+        if (this.component.classes) {
+            for (const classItem of this.component.classes) {
+                const className =
+                    classItem.name || this.stripHostFromSelector(classItem);
+                if (className) {
+                    const classSelector = `.${className}`;
+                    transformations.push((selector) =>
+                        selector.replace(
+                            this.regexForClassSelector(classItem),
+                            classSelector
+                        )
+                    );
+                }
+            }
+        }
+
         // Map classes to slotted content
         // e.g. ".spectrum-Icon" -> "::slotted([slot='icon'])"
         if (this.component.slots) {


### PR DESCRIPTION
## Description

Currently, the `process-spectrum-postcss-plugin` can map `spectrum-css` class selectors to `#id` selectors.

This PR allows `spectrum-css` classes to be mapped to new classes.

## Motivation and Context

Mapping class selectors to id selectors is extremely useful. 
However, sometimes these selectors need to remain as class selectors, since there may be more than one instance of the class within the component.

The classes in `spectrum-css` follow a naming paradigm that does not match the style of this project. These classes need to be renamed.

**Example:**

`.spectrum-Slider-track` needs to be mapped to `.track`

## How Has This Been Tested?

1. Added a `spectrum-config` file for sliders. Added an array of class selectors to replace.
2. Ran `process-spectrum-css` locally
3. Confirmed that the selectors mapped properly in `spectrum-slider.css`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
