### PR TITLE
Allows spectrum-css classes to be mapped to new classes

### DIFF
--- a/scripts/process-spectrum-postcss-plugin.js
+++ b/scripts/process-spectrum-postcss-plugin.js
@@ -147,13 +147,13 @@ class SpectrumProcessor {
         astTransforms.push((selector, rule) => {
             const result = selector.clone();
             result.walkClasses((selector) => {
-                const matchingClass = this.component.classes.find(
-                    (classItem) => {
-                        return selector.value === classItem.selector.slice(1);
+                if (selector.value) {
+                    const matchingClass = this.component.classes.get(
+                        selector.value
+                    );
+                    if (matchingClass) {
+                        selector.value = matchingClass;
                     }
-                );
-                if (matchingClass) {
-                    selector.value = matchingClass.name;
                 }
             });
             return result;
@@ -664,6 +664,18 @@ class ComponentConfig {
         });
 
         this.classes = this.classes || [];
+        this.classes = new Map(
+            this.classes.map((obj) => {
+                const name = obj.name;
+                const selector = obj.selector;
+                if (!selector || !name) {
+                    const componentName = this.spectrumClass;
+                    const message = `Class mapping for ${componentName} is invalid. Usage: { selector: string, name: string }`;
+                    throw new Error(message);
+                }
+                return [selector.slice(1), name];
+            })
+        );
     }
 }
 


### PR DESCRIPTION
## Description

Currently, the `process-spectrum-postcss-plugin` can map `spectrum-css` class selectors to `#id` selectors.

This PR allows `spectrum-css` classes to be mapped to new classes.

## Motivation and Context

Mapping class selectors to id selectors is extremely useful. 
However, sometimes these selectors need to remain as class selectors, since there may be more than one instance of the class within the component.

The classes in `spectrum-css` follow a naming paradigm that does not match the style of this project. These classes need to be renamed.

**Example:**

`.spectrum-Slider-track` needs to be mapped to `.track`

## How Has This Been Tested?

1. Added a `spectrum-config` file for sliders. Added an array of class selectors to replace.
2. Ran `process-spectrum-css` locally
3. Confirmed that the selectors mapped properly in `spectrum-slider.css`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
