### PR TITLE
Removes css sourcemaps

### DIFF
--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -31,7 +31,6 @@ const configPath = path.resolve(path.join(__dirname, '..', 'config'));
 const { postCSSPlugins, wrapCSSResult } = require('../scripts/css-processing');
 
 const ts = require('gulp-typescript');
-const sourcemaps = require('gulp-sourcemaps');
 const tsProject = ts.createProject('tsconfig.json');
 
 const buildCSS = () => {
@@ -64,18 +63,11 @@ const buildCSS = () => {
             })
         )
         // feed to the typescript project
-        .pipe(sourcemaps.init())
         .pipe(tsProject());
 
     // compile the ts to js
     return merge(
-        tsResult.js
-            .pipe(
-                sourcemaps.write('.', {
-                    includeContent: true,
-                })
-            )
-            .pipe(gulp.dest(dstPath)),
+        tsResult.js.pipe(gulp.dest(dstPath)),
         tsResult.dts.pipe(gulp.dest(dstPath))
     );
 };


### PR DESCRIPTION
## Description

Sourcemaps were being generated for CSS files based on the intermediate `.css.ts` files produced by gulp. This obviously is impossible to map back to since the files never really existed. Since they have little utility anyway I've just removed them.

## Motivation and Context

This was causing errors in any consumer using sourcemaps.

## How Has This Been Tested?

Ran the build, inspected the `lib` folder for css sourcemaps.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
