### PR TITLE
Fix iconset to not set attribute in constructor

### DIFF
--- a/src/iconset/iconset.ts
+++ b/src/iconset/iconset.ts
@@ -20,10 +20,6 @@ export abstract class Iconset extends LitElement {
 
     private _name!: string;
 
-    public constructor() {
-        super();
-    }
-
     protected firstUpdated(
         changedProperties: Map<string | number | symbol, unknown>
     ): void {


### PR DESCRIPTION

## Description

Fix code that violates the requirements for custom element constructors (see [spec](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance)).

Chrome was flagging this as a problem in LrWeb.

## Related Issue

#67 

## Motivation and Context

This issue is causing iconsets to not work in my project in Chrome Canary

## How Has This Been Tested?

All tests pass and I checked that the iconsets were loading in the Storybook stories

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
