### PR TITLE
Bump the version of web-component-analyzer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8547,7 +8547,7 @@
             "dependencies": {
                 "abbrev": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
                     "dev": true,
                     "optional": true
@@ -8555,18 +8555,19 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                     "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
                     "dev": true,
                     "optional": true,
@@ -8578,13 +8579,15 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -8592,7 +8595,7 @@
                 },
                 "chownr": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
                     "dev": true,
                     "optional": true
@@ -8600,28 +8603,31 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
                     "dev": true,
                     "optional": true
                 },
                 "debug": {
                     "version": "2.6.9",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "dev": true,
                     "optional": true,
@@ -8631,28 +8637,28 @@
                 },
                 "deep-extend": {
                     "version": "0.6.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
                     "dev": true,
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
                     "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
                     "dev": true,
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
                     "dev": true,
                     "optional": true,
@@ -8662,14 +8668,14 @@
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                     "dev": true,
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
                     "dev": true,
                     "optional": true,
@@ -8686,7 +8692,7 @@
                 },
                 "glob": {
                     "version": "7.1.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "optional": true,
@@ -8701,14 +8707,14 @@
                 },
                 "has-unicode": {
                     "version": "2.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
                     "dev": true,
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "dev": true,
                     "optional": true,
@@ -8718,7 +8724,7 @@
                 },
                 "ignore-walk": {
                     "version": "3.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
                     "dev": true,
                     "optional": true,
@@ -8728,7 +8734,7 @@
                 },
                 "inflight": {
                     "version": "1.0.6",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "dev": true,
                     "optional": true,
@@ -8740,36 +8746,39 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
                     "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "dev": true,
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -8777,13 +8786,15 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -8791,7 +8802,7 @@
                 },
                 "minizlib": {
                     "version": "1.2.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
                     "dev": true,
                     "optional": true,
@@ -8801,23 +8812,24 @@
                 },
                 "mkdirp": {
                     "version": "0.5.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
                 },
                 "ms": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true,
                     "optional": true
                 },
                 "needle": {
                     "version": "2.2.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
                     "dev": true,
                     "optional": true,
@@ -8829,7 +8841,7 @@
                 },
                 "node-pre-gyp": {
                     "version": "0.10.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
                     "dev": true,
                     "optional": true,
@@ -8848,7 +8860,7 @@
                 },
                 "nopt": {
                     "version": "4.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "dev": true,
                     "optional": true,
@@ -8859,14 +8871,14 @@
                 },
                 "npm-bundled": {
                     "version": "1.0.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.2.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
                     "dev": true,
                     "optional": true,
@@ -8877,7 +8889,7 @@
                 },
                 "npmlog": {
                     "version": "4.1.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
                     "dev": true,
                     "optional": true,
@@ -8891,41 +8903,43 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
                     "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
                 },
                 "os-homedir": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                     "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
                     "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
                     "dev": true,
                     "optional": true,
@@ -8936,21 +8950,21 @@
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                     "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
                     "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
                     "dev": true,
                     "optional": true,
@@ -8963,7 +8977,7 @@
                     "dependencies": {
                         "minimist": {
                             "version": "1.2.0",
-                            "resolved": false,
+                            "resolved": "",
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                             "dev": true,
                             "optional": true
@@ -8972,7 +8986,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "optional": true,
@@ -8988,7 +9002,7 @@
                 },
                 "rimraf": {
                     "version": "2.6.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                     "dev": true,
                     "optional": true,
@@ -8999,48 +9013,50 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
                     "dev": true,
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                     "dev": true,
                     "optional": true
                 },
                 "semver": {
                     "version": "5.6.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
                     "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                     "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                     "dev": true,
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -9049,7 +9065,7 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "optional": true,
@@ -9059,23 +9075,24 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
                     "version": "2.0.1",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
                     "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.8",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
                     "dev": true,
                     "optional": true,
@@ -9091,14 +9108,14 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "dev": true,
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
-                    "resolved": false,
+                    "resolved": "",
                     "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
                     "dev": true,
                     "optional": true,
@@ -9109,12 +9126,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -19932,9 +19951,9 @@
             }
         },
         "web-component-analyzer": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-0.1.8.tgz",
-            "integrity": "sha512-E7Q687kM2rlLgp2cI5RCJ4t9yHNySc7JY6BG6DeXZDbkIag8gBUcyytwWn9P7L3LUOBBQKNv6IltE/gydaDm4g==",
+            "version": "0.1.9",
+            "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-0.1.9.tgz",
+            "integrity": "sha512-ADAu0nYf2++gF43eY5URyHcmoWLz1CszoCKH4LkKHJgb+HTZaVXe//aAzTxXgHTG3O+Qd5B4XnM2h04/THMlBw==",
             "dev": true,
             "requires": {
                 "fast-glob": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
         "typedoc": "^0.14.2",
         "typescript": "^3.4.1",
         "walker": "^1.0.7",
-        "web-component-analyzer": "^0.1.8",
+        "web-component-analyzer": "^0.1.9",
         "webpack": "^4.33.0",
         "webpack-cli": "^3.3.0",
         "webpack-dev-server": "^3.2.1",


### PR DESCRIPTION

## Description

Bump the version of web-component-analyzer that we depend on

## Related Issue

#65 

## Motivation and Context

The newer version extracts other tags that we would like to use like `@slot`

## How Has This Been Tested?

@andrewhatran Tried using the slot tag and it was working


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
