### PR TITLE
Support icon before iconset in the DOM/before iconset is fully registered.

### DIFF
--- a/src/iconset/iconset-svg.ts
+++ b/src/iconset/iconset-svg.ts
@@ -38,12 +38,13 @@ export class IconsetSVG extends Iconset {
      * @param el - the element to apply the icon to
      * @param icon - the name of the icon within this set to apply.
      */
-    public applyIconToElement(
+    public async applyIconToElement(
         el: HTMLElement,
         icon: string,
         size: string,
         label: string
-    ): void {
+    ): Promise<void> {
+        await this.updateComplete;
         const iconSymbol = this.iconMap.get(icon);
         if (!iconSymbol) {
             throw new Error(`Unable to find icon ${icon}`);

--- a/test/iconset.spec.ts
+++ b/test/iconset.spec.ts
@@ -19,12 +19,15 @@ import { html } from 'lit-element';
 defineCustomElements(...Object.values(MediumIcons));
 
 describe('Iconset', () => {
-    before(() => {
-        let icons = document.createElement('sp-icons-medium');
-        document.body.append(icons);
+    after(() => {
+        const sets = [...document.querySelectorAll('sp-icons-medium')];
+        sets.map((set) => set.remove());
     });
 
     it('renders after adding and removing a second iconset', async () => {
+        let icons = document.createElement('sp-icons-medium');
+        document.body.append(icons);
+
         let icons2 = document.createElement('sp-icons-medium');
         document.body.append(icons2);
 
@@ -43,4 +46,18 @@ describe('Iconset', () => {
         const svg = el.shadowRoot!.querySelector('[role="img"]');
         expect(svg).to.not.be.null;
     });
+
+    it('can be after `<sp-icon/>` in the DOM order', async () => {
+        const el = await fixture<Icon>(
+            html`
+                <sp-icon size="xxs" name="ui:CheckmarkMedium"></sp-icon>
+                <sp-icons-medium></sp-icons-medium>
+            `
+        );
+
+        const svg = el.shadowRoot!.querySelector('[role="img"]');
+        expect(svg).to.not.be.null;
+    });
 });
+
+describe('Iconset order', () => {});


### PR DESCRIPTION
## Description
Make `applyIconToElement()` async so that it can be flexible to the unpredictability of its registered state.

## Related Issue


## Motivation and Context
Particularly when there are multiple versions of the same iconset being registered and unregistered across the lifecycle of an application it is possible to fall into a state where the set is not yet ready when an icon element requests an icon. This corrects for this.

## How Has This Been Tested?
This can be simulated by placing the requesting icon element before the iconset element and has been added to the test suite for iconset.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
