### PR TITLE
Make possible to get selected tab in change event

### DIFF
--- a/src/tab-list/tab-list.ts
+++ b/src/tab-list/tab-list.ts
@@ -92,9 +92,11 @@ export class TabList extends LitElement {
     private selectTarget(target: HTMLElement): void {
         const value = target.getAttribute('value');
         if (value) {
+            const oldValue = this.selected;
+            this.selected = value;
             const applyDefault = this.dispatchEvent(new Event('change'));
-            if (applyDefault) {
-                this.selected = value;
+            if (!applyDefault) {
+                this.selected = oldValue;
             }
         }
     }


### PR DESCRIPTION

## Description

Make the newly selected tab name available when the change event is fired

## Related Issue

#106

## Motivation and Context

I need to handle the switching of tabs in the documentation app, but I couldn't get the information about which tab had been selected

## How Has This Been Tested?

I tested this change in the documentation app

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
