### PR TITLE
Allow for external height to manage SVG height

### DIFF
--- a/src/icon/icon.css
+++ b/src/icon/icon.css
@@ -11,3 +11,7 @@ governing permissions and limitations under the License.
 */
 
 @import './spectrum-icon.css';
+
+#container {
+    height: 100%;
+}


### PR DESCRIPTION
## Description
As discovered here: https://github.com/adobe/spectrum-web-components/pull/111#pullrequestreview-273396127 by @andrewhatran the `<sp-icon/>` element doesn't vertically align, this corrects that by making the `#container` element height 100%.

## How Has This Been Tested?
Visually in Storybook.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/62872985-8c14fc00-bcec-11e9-8a61-42f0aaa334f0.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
