### PR TITLE
Tweak the tab example so it illustrates the issue, and add css fix for Safari.

### DIFF
--- a/src/checkbox/checkbox.css
+++ b/src/checkbox/checkbox.css
@@ -14,6 +14,7 @@ governing permissions and limitations under the License.
 
 :host {
     display: inline-flex;
+    vertical-align: top;
 }
 
 /* When we use sp-icons internally, they are a different size */

--- a/stories/checkbox.stories.ts
+++ b/stories/checkbox.stories.ts
@@ -106,20 +106,10 @@ storiesOf('Checkbox', module)
     .add('Tab index example', () => {
         return html`
             <sp-icons-medium></sp-icons-medium>
-            <div>
-                <sp-checkbox tabindex="0">Checkbox 0</sp-checkbox>
-            </div>
-            <div>
-                <sp-checkbox disabled tabindex="3">Checkbox 3</sp-checkbox>
-            </div>
-            <div>
-                <sp-checkbox tabindex="4">Checkbox 4</sp-checkbox>
-            </div>
-            <div>
-                <sp-checkbox tabindex="2" autofocus>Checkbox 2</sp-checkbox>
-            </div>
-            <div>
-                <sp-checkbox tabindex="1">Checkbox 1</sp-checkbox>
-            </div>
+            <sp-checkbox tabindex="0">Checkbox 0</sp-checkbox>
+            <sp-checkbox disabled tabindex="3">Checkbox 3</sp-checkbox>
+            <sp-checkbox tabindex="4">Checkbox 4</sp-checkbox>
+            <sp-checkbox tabindex="2" autofocus>Checkbox 2</sp-checkbox>
+            <sp-checkbox tabindex="1">Checkbox 1</sp-checkbox>
         `;
     });


### PR DESCRIPTION
## Description

From what I can tell we have to define the css for the top-level component, and Safari doesn't seem to do well with `inline-flex` unless you add `vertical-align: top;`. The `label` element in the shadow DOM has both of these defined.

## Related Issue

#124 

## How Has This Been Tested?

Tested in Safari/Chrome/Firefox Mac.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.