### PR TITLE
Add target attribute support for sp-button, and a target='_blank' sto…

### DIFF
--- a/src/button/button-base.ts
+++ b/src/button/button-base.ts
@@ -21,6 +21,9 @@ export class ButtonBase extends Focusable {
     @property()
     public href?: string;
 
+    @property()
+    public target?: string;
+
     @property({ type: Boolean, reflect: true, attribute: 'icon-right' })
     protected iconRight = false;
 
@@ -51,13 +54,23 @@ export class ButtonBase extends Focusable {
         return content;
     }
 
-    protected render(): TemplateResult {
-        return this.href && this.href.length > 0
+    protected get anchorTagContent(): TemplateResult {
+        return this.target && this.target.length > 0
             ? html`
-                  <a href="${this.href}" id="button">
+                  <a href="${this.href}" target="${this.target}" id="button">
                       ${this.buttonContent}
                   </a>
               `
+            : html`
+                  <a href="${this.href}" id="button">
+                      ${this.buttonContent}
+                  </a>
+              `;
+    }
+
+    protected render(): TemplateResult {
+        return this.href && this.href.length > 0
+            ? this.anchorTagContent
             : html`
                   <button id="button">${this.buttonContent}</button>
               `;

--- a/stories/button.stories.ts
+++ b/stories/button.stories.ts
@@ -188,6 +188,16 @@ storiesOf('Button', module)
                 Github
             </sp-button>
         `;
+    })
+    .add('button with href target="_blank"', () => {
+        return html`
+            <sp-button
+                href="https://github.com/adobe/spectrum-web-components"
+                target="_blank"
+            >
+                Github
+            </sp-button>
+        `;
     });
 
 function renderButton(properties) {


### PR DESCRIPTION
…ry to demonstrate

## Description

Added support for the `target` attribute when `href` is defined. Did a little refactoring in the render as well to push that into a separate call.

## Related Issue

#134 

## Motivation and Context

The first control I tested `<sp-button>` was a custom-styled anchor tag with `target="_blank"`.

## How Has This Been Tested?

Tested by adding the story example.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.