### PR TITLE
Add our Adobe Clean typekit to the storybook pages & instructions on …

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -4,6 +4,14 @@
     delete Document.prototype.adoptedStyleSheets;
 </script>
 
+<!-- For Adobe Clean font support -->
+<link rel="stylesheet" href="https://use.typekit.net/evk7lzt.css" />
+
+<!-- Use this to test Adobe Clean UX support (SpectrumCSS dependency) -->
+<!-- NOTE: you'll need to rebuild storybook to test this locally.
+<link rel="stylesheet" href="https://use.typekit.net/yfg6hha.css" />
+-->
+
 <style>
     /* @TODO: Implement more default storybook styling here using spectrum theme variables */
     body {


### PR DESCRIPTION
…testing Clean UX

Fixes #152 by loading in a new typekit. I'll put access instructions for that in the Adobe slack.

## Description

Add Adobe Clean support to the doc pages.

## Related Issue

#152 
https://github.com/adobe/spectrum-css/issues/189 (Adobe Clean UX support in SpectrumCSS)

## Motivation and Context

For Adobe clients, seeing the docs match what they'll be seeing in the app is important, and at least near-term that feels like the right preview to show. We may want to add a followup issue that allows for more variants to be easily viewed on the doc site.

## How Has This Been Tested?

Compared the storybook docs before/after the change and noted the clear font difference.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.