### PR TITLE
[#61] Correct button alignment.

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -36,7 +36,7 @@ attributes can be combined to apply sub-variants, e.g. `quiet`.
 
 ## Content
 
-**sp-buttons** can have a label, and icon, or both. An icon is provided by
+**sp-buttons** can have a label, or a label with an icon. An icon is provided by
 placing an icon component to the `icon` slot. The icon may be an `sp-icon` or an
 SVG.
 
@@ -46,9 +46,6 @@ SVG.
 <sp-button variant="primary">
     <sp-icon slot="icon" size="s" name="ui:HelpMedium"></sp-icon>
     Icon + Label
-</sp-button>
-<sp-button variant="primary">
-    <sp-icon slot="icon" size="s" name="ui:HelpMedium"></sp-icon>
 </sp-button>
 <sp-button variant="primary">
     <svg

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 :host {
     display: inline-flex;
     flex-direction: row;
+    vertical-align: top;
 }
 
 #button {


### PR DESCRIPTION
## Description
Correct the button's vertical alignment and remove the `icon only` button as it is [not currently spec'd in Spectrum CSS](https://spectrum.corp.adobe.com/page/button).

### Before
<img width="839" alt="Screen Shot 2019-06-18 at 3 53 51 PM" src="https://user-images.githubusercontent.com/154097/59652339-74843000-91e1-11e9-9870-734cf2b2f2dd.png">

### After
![image](https://user-images.githubusercontent.com/1156657/65339726-b5059800-db9a-11e9-987e-d4f6b16435f4.png)


## Related Issue
#61

## Motivation and Context
Correctness.

## How Has This Been Tested?
Visually in the docs site.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
