### PR TITLE
docs: update readme to required node version 10.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It will not support older browsers and will only target modern ever-green browse
 
 # Requirements
 
--   NodeJS >= 8.10.0
+-   NodeJS >= 10.15
 -   Typescript
 -   Browsers with Custom Elements V1 and Shadow DOM support, e.g. Chrome, Firefox, Safari.
 


### PR DESCRIPTION
## Description

Update the readme to reflect that node version 10.15 is required to build.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

I was running node 10.13.  When running `yarn`, I received the error:
```
error selenium-webdriver@4.0.0-alpha.5: The engine "node" is incompatible with this module. Expected version ">= 10.15.0". Got "10.13.0"
```
But the readme indicated `NodeJS >= 8.10.0`.

## How Has This Been Tested?

Documentation only fix.  But, I successfully built with 10.15.3, after updating my node version.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
