### PR TITLE
docs: remove "npm run" references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ By default the resulting site will be available at [http://localhost:6006](http:
 
 ## Linting
 
-The project will be linted on a pre-commit hook, but you can also run the lint suite with `npm run lint`. It uses ESLint to lint the JS / TS files, and StyleLint to lint the CSS files.
+The project will be linted on a pre-commit hook, but you can also run the lint suite with `yarn lint`. It uses ESLint to lint the JS / TS files, and StyleLint to lint the CSS files.
 
 ## Testing
 
@@ -52,7 +52,7 @@ Tests are implemented using the Karma test runner with Chai, Mocha and Sinon fra
 yarn test
 ```
 
-During development you may wish to use `npm run test:watch` to automatically build and re-run the test suites.
+During development you may wish to use `yarn test:watch` to automatically build and re-run the test suites.
 
 ## Benchmarking
 
@@ -63,7 +63,7 @@ yarn build:tests
 yarn test:bench
 ```
 
-This will run the defined [Tachometer](https://www.npmjs.com/package/tachometer) tests and report the current runtime cost of each individual element. When not making changes to the benchmarks thy have been built on your local machine, you can stip `npm run build:tests` for later passes.
+This will run the defined [Tachometer](https://www.npmjs.com/package/tachometer) tests and report the current runtime cost of each individual element. When not making changes to the benchmarks thy have been built on your local machine, you can stip `yarn build:tests` for later passes.
 
 ## Anatomy of a Component
 


### PR DESCRIPTION
## Description 
The README had some confusing references to `npm run ...` that needed to be updated to `yarn ...`

## Motivation and Context
Clarity for a new user.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
