### PR TITLE
feat(button): allow icon only buttons

### DIFF
--- a/packages/button/src/button-base.ts
+++ b/packages/button/src/button-base.ts
@@ -32,6 +32,8 @@ export class ButtonBase extends Focusable {
         return !!this.querySelector('[slot="icon"]');
     }
 
+    private hasLabel = false;
+
     public get focusElement(): HTMLElement {
         /* istanbul ignore if */
         if (!this.shadowRoot) {
@@ -40,13 +42,30 @@ export class ButtonBase extends Focusable {
         return this.shadowRoot.querySelector('#button') as HTMLElement;
     }
 
+    private manageLabelSlot(e: Event): void {
+        const slot = e.target as HTMLSlotElement;
+        let assignedElements = slot.assignedElements
+            ? slot.assignedNodes()
+            : [...this.childNodes].filter((node) => {
+                  const el = node as HTMLElement;
+                  return !el.hasAttribute('slot');
+              });
+        assignedElements = assignedElements.filter((node) => {
+            return node.textContent ? node.textContent.trim() : false;
+        });
+        this.hasLabel = assignedElements.length > 0;
+        this.requestUpdate();
+    }
+
     protected get buttonContent(): TemplateResult[] {
         const icon = html`
             <slot name="icon"></slot>
         `;
         const content = [
             html`
-                <div id="label"><slot></slot></div>
+                <div id="label" ?hidden=${!this.hasLabel}>
+                    <slot @slotchange=${this.manageLabelSlot}></slot>
+                </div>
             `,
         ];
         if (!this.hasIcon) {

--- a/packages/button/stories/action-button.stories.ts
+++ b/packages/button/stories/action-button.stories.ts
@@ -45,10 +45,22 @@ function renderButtonsSelected(properties: Properties): TemplateResult {
     `;
 }
 
-storiesOf('ActionButton', module).add('Default', () => {
-    return renderButtonsSelected({
-        quiet: false,
-        disabled: false,
-        selected: false,
+storiesOf('ActionButton', module)
+    .add('Default', () => {
+        return renderButtonsSelected({
+            quiet: false,
+            disabled: false,
+            selected: false,
+        });
+    })
+    .add('Icon button', () => {
+        return html`
+            <sp-action-button>
+                <svg slot="icon" id="spectrum-icon-18-Edit" viewBox="0 0 36 36">
+                    <path
+                        d="M33.567 8.2L27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945zM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73z"
+                    ></path>
+                </svg>
+            </sp-action-button>
+        `;
     });
-});

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -57,6 +57,21 @@ describe('Button', () => {
             `<button id="button" tabindex="0"><slot name="icon"></slot><div id="label"><slot></slot></div></button>`
         );
     });
+    it('loads default only icon', async () => {
+        const el = await fixture<Button>(
+            html`
+                <sp-button>
+                    <svg slot="icon"></svg>
+                </sp-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el).to.not.be.undefined;
+        expect(el).shadowDom.to.equal(
+            `<button id="button" tabindex="0"><slot name="icon"></slot><div id="label" hidden><slot></slot></div></button>`
+        );
+    });
     it('loads default w/ an icon on the right', async () => {
         const el = await fixture<Button>(
             html`


### PR DESCRIPTION
## Description
Hide the `[id=label]` element when there is no label content in order to allow icon-only buttons.

<!--- Describe your changes in detail -->

## Related Issue
fixes #244 

## Motivation and Context
While `<sp-button>` doesn't technically support icon only buttons at the Spectrum CSS level, `<sp-action-button>` does and it is often used in applications.

## How Has This Been Tested?
Added `shadowDom` check in the unit tests for the hidden attribute.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/66443581-a974f680-ea0d-11e9-89b7-dba78f2d691d.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
