### PR TITLE
fix(button): allow element content in the default/label slot

### DIFF
--- a/packages/button/src/button-base.ts
+++ b/packages/button/src/button-base.ts
@@ -54,6 +54,9 @@ export class ButtonBase extends Focusable {
                   return !el.hasAttribute('slot');
               });
         assignedElements = assignedElements.filter((node) => {
+            if ((node as HTMLElement).tagName) {
+                return true;
+            }
             return node.textContent ? node.textContent.trim() : false;
         });
         this.hasLabel = assignedElements.length > 0;

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -40,6 +40,19 @@ describe('Button', () => {
             `<button id="button" tabindex="0"><div id="label"><slot></slot></div></button>`
         );
     });
+    it('loads default w/ element content', async () => {
+        const el = await fixture<Button>(
+            html`
+                <sp-button><svg></svg></sp-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el).to.not.be.undefined;
+        expect(el).shadowDom.to.equal(
+            `<button id="button" tabindex="0"><div id="label"><slot></slot></div></button>`
+        );
+    });
     it('loads default w/ an icon', async () => {
         const el = await fixture<Button>(
             html`


### PR DESCRIPTION


## Description
Allow:
```
<sp-buton>
    <content-element></content-element>
</sp-button>
```
to populate the "label" element.


## Motivation and Context
Only allowing elements with light DOM textContent is restrictive.

## How Has This Been Tested?
Unit tests added to support the use case.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
