### PR TITLE
fix(shared): make Focusable pass disabled always

### DIFF
--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -219,16 +219,19 @@ describe('Button', () => {
         await elementUpdated(el);
 
         expect(el.hasAttribute('aria-disabled')).to.be.false;
+        expect((el.focusElement as HTMLButtonElement).disabled).to.be.false;
 
         el.disabled = true;
         await elementUpdated(el);
 
         expect(el.hasAttribute('aria-disabled')).to.be.true;
+        expect((el.focusElement as HTMLButtonElement).disabled).to.be.true;
 
         el.disabled = false;
         await elementUpdated(el);
 
         expect(el.hasAttribute('aria-disabled')).to.be.false;
+        expect((el.focusElement as HTMLButtonElement).disabled).to.be.false;
     });
     it('manages tabIndex while disabled', async () => {
         const el = await fixture<Button>(

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -17,6 +17,8 @@ import {
 } from 'lit-element';
 import focusableStyles from './focusable.css.js';
 
+type DisableableElement = HTMLElement & { disabled?: boolean };
+
 /**
  * Focusable base class handles tabindex setting into shadowed elements automatically.
  *
@@ -50,7 +52,7 @@ export class Focusable extends LitElement {
     private newTabindex?: number = 0;
     private oldTabindex = 0;
 
-    public get focusElement(): HTMLElement {
+    public get focusElement(): DisableableElement {
         throw new Error('Must implement focusElement getter!');
     }
 
@@ -111,9 +113,7 @@ export class Focusable extends LitElement {
         super.updated(changedProperties);
 
         if (changedProperties.has('disabled')) {
-            if (this.focusElement instanceof HTMLInputElement) {
-                this.focusElement.disabled = this.disabled;
-            }
+            this.focusElement.disabled = this.disabled;
             if (this.disabled) {
                 this.blur();
             }

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -1,4 +1,4 @@
-/* stylelint-disable */ /*
+/* stylelint-disable */ /* 
 Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow `Focusable` to always pass `disabled` down to the `focusElement` target.

## Related Issue
fixes #271 

## Motivation and Context
Input elements aren't the only ones that can be disabled.

## How Has This Been Tested?
- Expanded unit tests for `sp-button`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
