### PR TITLE
fix(overlay-trigger): allow trigger to be [disabled]

### DIFF
--- a/packages/overlay-trigger/src/overlay-trigger.css
+++ b/packages/overlay-trigger/src/overlay-trigger.css
@@ -10,6 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+:host([disabled]) #trigger {
+    pointer-events: none;
+}
+
 #overlay-content {
     display: none;
 }

--- a/packages/overlay-trigger/src/overlay-trigger.ts
+++ b/packages/overlay-trigger/src/overlay-trigger.ts
@@ -45,6 +45,9 @@ export class OverlayTrigger extends LitElement {
     @property({ type: Number, reflect: true })
     public offset = 6;
 
+    @property({ type: Boolean, reflect: true })
+    public disabled = false;
+
     private clickContent?: HTMLElement;
 
     private hoverContent?: HTMLElement;

--- a/packages/overlay-trigger/test/overlay-trigger.test.ts
+++ b/packages/overlay-trigger/test/overlay-trigger.test.ts
@@ -18,7 +18,14 @@ import '../../popover';
 import { Popover } from '../../popover';
 
 import { waitForPredicate, isVisible } from '../../../test/testing-helpers';
-import { fixture, aTimeout, html, expect, nextFrame } from '@open-wc/testing';
+import {
+    fixture,
+    aTimeout,
+    html,
+    expect,
+    nextFrame,
+    elementUpdated,
+} from '@open-wc/testing';
 
 function pressEscape(): void {
     const up = new KeyboardEvent('keyup', {
@@ -141,6 +148,22 @@ describe('Overlays', () => {
             OverlayTrigger
         );
         expect(isVisible(outerPopover)).to.be.true;
+    });
+
+    it('does not open a popover when [disabled]', async () => {
+        const trigger = testDiv.querySelector('#trigger') as OverlayTrigger;
+        const root = trigger.shadowRoot ? trigger.shadowRoot : trigger;
+        const triggerZone = root.querySelector('#trigger') as HTMLDivElement;
+        const styles = getComputedStyle(triggerZone);
+
+        expect(trigger.disabled).to.be.false;
+        expect(styles.pointerEvents).to.equal('auto');
+
+        trigger.disabled = true;
+        await elementUpdated(trigger);
+
+        expect(trigger.disabled).to.be.true;
+        expect(styles.pointerEvents).to.equal('none');
     });
 
     it('opens a nested popover', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prevent a `overlay-trigger[disabled]` element from receiving pointer-events on its trigger element.

## Related Issue
fixes #270 

## Motivation and Context
You can insert a `sp-button[disabled]` element, but it would keep the `#trigger` element open to trigger the overlay.

## How Has This Been Tested?
- unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
