### PR TITLE
refactor(icons): vend "<icons-demo>" element for use with iconsets

### DIFF
--- a/packages/icons/stories/icons.stories.ts
+++ b/packages/icons/stories/icons.stories.ts
@@ -10,65 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import { storiesOf } from '@storybook/polymer';
-import { html, TemplateResult } from 'lit-html';
+import { html } from 'lit-html';
 
 import '../';
 import '../../icon';
-import { IconsetAddedDetail } from '../../iconset';
-import { LitElement, css, CSSResult } from 'lit-element';
+import '../../iconset/lib/icons-demo';
 import { color } from '@storybook/addon-knobs';
-
-class IconsDemo extends LitElement {
-    private iconset: string[] = [];
-    public constructor() {
-        super();
-        this.iconset = [];
-        this.handleIconSetAdded = this.handleIconSetAdded.bind(this);
-    }
-    public connectedCallback(): void {
-        super.connectedCallback();
-        window.addEventListener('sp-iconset-added', this.handleIconSetAdded);
-    }
-    public handleIconSetAdded(event: CustomEvent<IconsetAddedDetail>): void {
-        const { iconset } = event.detail;
-        this.iconset = iconset.getIconList();
-        this.requestUpdate();
-    }
-    public static get styles(): CSSResult[] {
-        return [
-            css`
-                :host {
-                    display: grid;
-                    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-                    gap: 20px;
-                }
-                .icon {
-                    display: flex;
-                    flex-direction: column;
-                    align-items: center;
-                }
-                sp-icon {
-                    margin-bottom: 10px;
-                }
-            `,
-        ];
-    }
-    protected render(): TemplateResult {
-        return html`
-            <slot></slot>
-            ${this.iconset.map(
-                (icon) => html`
-                    <div class="icon">
-                        <sp-icon size="l" name=${`ui:${icon}`}></sp-icon>
-                        ${icon}
-                    </div>
-                `
-            )}
-        `;
-    }
-}
-
-customElements.define('icons-demo', IconsDemo);
 
 storiesOf('Icons', module)
     .add(

--- a/packages/iconset/src/icons-demo.ts
+++ b/packages/iconset/src/icons-demo.ts
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { IconsetAddedDetail } from './';
+import {
+    LitElement,
+    css,
+    html,
+    TemplateResult,
+    CSSResult,
+    property,
+    customElement,
+} from 'lit-element';
+
+@customElement('icons-demo')
+export class IconsDemo extends LitElement {
+    @property()
+    public name = 'ui';
+
+    private iconset: string[] = [];
+    public constructor() {
+        super();
+        this.iconset = [];
+        this.handleIconSetAdded = this.handleIconSetAdded.bind(this);
+    }
+    public connectedCallback(): void {
+        super.connectedCallback();
+        window.addEventListener('sp-iconset-added', this.handleIconSetAdded);
+    }
+    public disconnectedCallback(): void {
+        window.removeEventListener('sp-iconset-added', this.handleIconSetAdded);
+        super.disconnectedCallback();
+    }
+    public handleIconSetAdded(event: CustomEvent<IconsetAddedDetail>): void {
+        const { iconset } = event.detail;
+        this.iconset = iconset.getIconList();
+        this.requestUpdate();
+    }
+    public static get styles(): CSSResult[] {
+        return [
+            css`
+                :host {
+                    display: grid;
+                    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+                    gap: 20px;
+                }
+                .icon {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                }
+                sp-icon {
+                    margin-bottom: 10px;
+                }
+            `,
+        ];
+    }
+    protected render(): TemplateResult {
+        return html`
+            <slot></slot>
+            ${this.iconset.map(
+                (icon) => html`
+                    <div class="icon">
+                        <sp-icon
+                            size="l"
+                            name=${`${this.name}:${icon}`}
+                        ></sp-icon>
+                        ${icon}
+                    </div>
+                `
+            )}
+        `;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make a `icons-demo` module available for use in other projects the implement `iconsets`.

## Motivation and Context
I want to copy less code.

## How Has This Been Tested?
It's used for demos.

## Types of changes
- [x] Refactor

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
