### PR TITLE
fix: normalize "event" and "error" argument names

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "root": true,
-    "plugins": ["notice"],
+    "plugins": ["notice", "spectrum-web-components"],
     "env": {
         "browser": true,
         "node": true,
@@ -12,6 +12,10 @@
         "sourceType": "module"
     },
     "rules": {
+        "spectrum-web-components/prevent-argument-names": [
+            "error",
+            ["e", "ev", "evt", "err"]
+        ],
         "notice/notice": [
             "error",
             {

--- a/linters/eslint/index.js
+++ b/linters/eslint/index.js
@@ -1,0 +1,29 @@
+module.exports = {
+    rules: {
+        'prevent-argument-names': {
+            create: function(context) {
+                const argumentNames = context.options[0];
+                function preventArgumentNames(node) {
+                    if (!argumentNames) {
+                        return;
+                    }
+                    argumentNames.forEach((name) => {
+                        if (node.name === name) {
+                            context.report({
+                                node,
+                                message: `"${name}" shouldn't be used as an argument name`,
+                                data: {
+                                    identifier: node.name,
+                                },
+                            });
+                        }
+                    });
+                }
+
+                return {
+                    Identifier: preventArgumentNames,
+                };
+            },
+        },
+    },
+};

--- a/linters/eslint/package.json
+++ b/linters/eslint/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "eslint-plugin-spectrum-web-components",
+    "version": "1.0.1",
+    "main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
         "eslint-formatter-pretty": "^2.1.1",
         "eslint-plugin-notice": "^0.8.9",
         "eslint-plugin-prettier": "^3.0.1",
+        "eslint-plugin-spectrum-web-components": "file:./linters/eslint",
         "express": "^4.16.4",
         "extract-loader": "^3.1.0",
         "fs-extra": "^8.1.0",

--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -6,13 +6,17 @@
         "es6": true
     },
     "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint", "notice"],
+    "plugins": ["@typescript-eslint", "notice", "spectrum-web-components"],
     "extends": [
         "plugin:@typescript-eslint/recommended",
         "prettier",
         "prettier/@typescript-eslint"
     ],
     "rules": {
+        "spectrum-web-components/prevent-argument-names": [
+            "error",
+            ["e", "ev", "evt", "err"]
+        ],
         "notice/notice": [
             "error",
             {

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -28,8 +28,8 @@ storiesOf('Action menu', module).add('Default', () => {
             ?disabled=${boolean('Is Disabled', false, 'Component')}
             ?invalid=${boolean('Is Invalid', false, 'Component')}
             ?quiet=${boolean('Is Quiet', false, 'Component')}
-            @change="${(e: Event) => {
-                const actionMenu = e.target as ActionMenu;
+            @change="${(event: Event) => {
+                const actionMenu = event.target as ActionMenu;
                 action(`Change: ${actionMenu.value}`)();
             }}"
         >

--- a/packages/dropdown/src/dropdown.ts
+++ b/packages/dropdown/src/dropdown.ts
@@ -143,8 +143,8 @@ export class Dropdown extends Focusable {
         this.button.addEventListener('keydown', this.onKeydown);
     }
 
-    public onClick(ev: Event): void {
-        const path = ev.composedPath();
+    public onClick(event: Event): void {
+        const path = event.composedPath();
         const target = path.find((el) => {
             if (!(el instanceof Element) || this.optionsMenu === null) {
                 return false;
@@ -157,8 +157,8 @@ export class Dropdown extends Focusable {
         this.setValueFromItem(target);
     }
 
-    public onKeydown(ev: KeyboardEvent): void {
-        if (ev.code !== 'ArrowDown') {
+    public onKeydown(event: KeyboardEvent): void {
+        if (event.code !== 'ArrowDown') {
             return;
         }
         /* istanbul ignore if */

--- a/packages/dropdown/stories/dropdown.stories.ts
+++ b/packages/dropdown/stories/dropdown.stories.ts
@@ -26,8 +26,8 @@ storiesOf('Dropdown', module)
                 ?disabled=${boolean('Is Disabled', false, 'Component')}
                 ?invalid=${boolean('Is Invalid', false, 'Component')}
                 ?quiet=${boolean('Is Quiet', false, 'Component')}
-                @change="${(e: Event) => {
-                    const dropdown = e.target as Dropdown;
+                @change="${(event: Event) => {
+                    const dropdown = event.target as Dropdown;
                     action(`Change: ${dropdown.value}`)();
                 }}"
             >
@@ -71,8 +71,8 @@ storiesOf('Dropdown', module)
                 ?disabled=${boolean('Is Disabled', false, 'Component')}
                 ?invalid=${boolean('Is Invalid', false, 'Component')}
                 ?quiet=${boolean('Is Quiet', false, 'Component')}
-                @change="${(e: Event) => {
-                    const dropdown = e.target as Dropdown;
+                @change="${(event: Event) => {
+                    const dropdown = event.target as Dropdown;
                     action(`Change: ${dropdown.value}`)();
                 }}"
                 value=${select('Value', values, values[2], 'Component')}

--- a/packages/dropdown/test/dropdown.test.ts
+++ b/packages/dropdown/test/dropdown.test.ts
@@ -186,8 +186,8 @@ describe('Dropdown', () => {
         expect(el.value).to.equal('');
         expect(secondItem.selected).to.be.false;
 
-        el.addEventListener('change', (e: Event): void => {
-            e.preventDefault();
+        el.addEventListener('change', (event: Event): void => {
+            event.preventDefault();
         });
 
         secondItem.click();

--- a/packages/dropzone/src/dropzone.ts
+++ b/packages/dropzone/src/dropzone.ts
@@ -66,39 +66,39 @@ export class Dropzone extends LitElement {
         this.removeEventListener('dragleave', this.onDragLeave);
     }
 
-    public onDragOver(ev: DragEvent): void {
+    public onDragOver(event: DragEvent): void {
         const shouldAcceptEvent = new CustomEvent('sp-dropzone-should-accept', {
             bubbles: true,
             cancelable: true,
             composed: true,
-            detail: ev,
+            detail: event,
         });
         // dispatch event returns true if preventDefault() is not called
         const shouldAccept = this.dispatchEvent(shouldAcceptEvent);
-        if (!ev.dataTransfer) {
+        if (!event.dataTransfer) {
             return;
         }
         if (!shouldAccept) {
-            ev.dataTransfer.dropEffect = 'none';
+            event.dataTransfer.dropEffect = 'none';
             return;
         }
 
-        ev.preventDefault();
+        event.preventDefault();
 
         this.clearDebouncedDragLeave();
 
         this.isDragged = true;
 
-        ev.dataTransfer.dropEffect = this.dropEffect;
+        event.dataTransfer.dropEffect = this.dropEffect;
         const dragOverEvent = new CustomEvent('sp-dropzone-dragover', {
             bubbles: true,
             composed: true,
-            detail: ev,
+            detail: event,
         });
         this.dispatchEvent(dragOverEvent);
     }
 
-    public onDragLeave(ev: DragEvent): void {
+    public onDragLeave(event: DragEvent): void {
         this.clearDebouncedDragLeave();
 
         this.debouncedDragLeave = window.setTimeout(() => {
@@ -107,14 +107,14 @@ export class Dropzone extends LitElement {
             const dragLeave = new CustomEvent('sp-dropzone-dragleave', {
                 bubbles: true,
                 composed: true,
-                detail: ev,
+                detail: event,
             });
             this.dispatchEvent(dragLeave);
         }, 100);
     }
 
-    public onDrop(ev: DragEvent): void {
-        ev.preventDefault();
+    public onDrop(event: DragEvent): void {
+        event.preventDefault();
 
         this.clearDebouncedDragLeave();
 
@@ -122,7 +122,7 @@ export class Dropzone extends LitElement {
         const dropEvent = new CustomEvent('sp-dropzone-drop', {
             bubbles: true,
             composed: true,
-            detail: ev,
+            detail: event,
         });
         this.dispatchEvent(dropEvent);
     }

--- a/packages/dropzone/test/dropzone.test.ts
+++ b/packages/dropzone/test/dropzone.test.ts
@@ -100,8 +100,8 @@ describe('Dropzone', () => {
         // However, Chrome doesn't like it in the context of a test...
     });
     it('allows `dragover` events to be canceled', async () => {
-        const canceledDrag = (e: DragEvent): void => {
-            e.preventDefault();
+        const canceledDrag = (event: DragEvent): void => {
+            event.preventDefault();
         };
         const el = await fixture<Dropzone>(
             html`

--- a/packages/icon/src/icon.ts
+++ b/packages/icon/src/icon.ts
@@ -71,13 +71,13 @@ export class Icon extends LitElement {
         this.updateIconPromise = this.updateIcon(); // any of our attributes change, update our icon
     }
 
-    private iconsetListener = (ev: CustomEvent): void => {
+    private iconsetListener = (event: CustomEvent): void => {
         if (!this.name) {
             return;
         }
         // parse the icon name to get iconset name
         const icon = this.parseIcon(this.name);
-        if (ev.detail.name === icon.iconset) {
+        if (event.detail.name === icon.iconset) {
             this.updateIconPromise = this.updateIcon();
         }
     };

--- a/packages/icon/test/icon.test.ts
+++ b/packages/icon/test/icon.test.ts
@@ -97,9 +97,9 @@ describe('Icon', () => {
             document.body.appendChild(el);
             await elementUpdated(el);
             expect('failed').to.not.equal('failed');
-        } catch (err) {
+        } catch (error) {
             expect(() => {
-                throw err;
+                throw error;
             }).to.throw();
         }
     });

--- a/packages/iconset/src/iconset-svg.ts
+++ b/packages/iconset/src/iconset-svg.ts
@@ -137,8 +137,8 @@ export abstract class IconsetSVG extends Iconset {
         return svgNodes;
     }
 
-    private onSlotChange(evt: Event): void {
-        const slotTarget = evt.target as HTMLSlotElement;
+    private onSlotChange(event: Event): void {
+        const slotTarget = event.target as HTMLSlotElement;
         const svgNodes = this.getSVGNodes(slotTarget);
         this.updateSVG(svgNodes);
     }

--- a/packages/menu/src/menu.ts
+++ b/packages/menu/src/menu.ts
@@ -65,8 +65,8 @@ export class Menu extends LitElement {
         focusInItem.focus();
     }
 
-    private onClick(ev: Event): void {
-        const path = ev.composedPath();
+    private onClick(event: Event): void {
+        const path = event.composedPath();
         const target = path.find((el) => {
             if (!(el instanceof Element)) {
                 return false;
@@ -90,8 +90,8 @@ export class Menu extends LitElement {
         this.removeEventListener('keydown', this.handleKeydown);
     }
 
-    public handleKeydown(e: KeyboardEvent): void {
-        const { code } = e;
+    public handleKeydown(event: KeyboardEvent): void {
+        const { code } = event;
         if (code === 'Tab') {
             this.prepareToCleanUp();
             return;
@@ -99,7 +99,7 @@ export class Menu extends LitElement {
         if (code !== 'ArrowDown' && code !== 'ArrowUp') {
             return;
         }
-        e.preventDefault();
+        event.preventDefault();
         const direction = code === 'ArrowDown' ? 1 : -1;
         this.focusMenuItemByOffset(direction);
     }

--- a/packages/overlay-root/src/active-overlay.ts
+++ b/packages/overlay-root/src/active-overlay.ts
@@ -165,12 +165,12 @@ export class ActiveOverlay extends LitElement {
         });
     }
 
-    private extractEventDetail(ev: CustomEvent<OverlayOpenDetail>): void {
-        this.overlayContent = ev.detail.content;
-        this.trigger = ev.detail.trigger;
-        this.placement = ev.detail.placement;
-        this.offset = ev.detail.offset;
-        this.interaction = ev.detail.interaction;
+    private extractEventDetail(event: CustomEvent<OverlayOpenDetail>): void {
+        this.overlayContent = event.detail.content;
+        this.trigger = event.detail.trigger;
+        this.placement = event.detail.placement;
+        this.offset = event.detail.offset;
+        this.interaction = event.detail.interaction;
     }
 
     public dispose(): void {

--- a/packages/radio-group/src/radio-group.ts
+++ b/packages/radio-group/src/radio-group.ts
@@ -70,8 +70,8 @@ export class RadioGroup extends LitElement {
         // If selected already assigned, don't overwrite
         this.selected = this.selected || checkedRadioValue;
 
-        this.addEventListener('change', (ev: Event) => {
-            const target = ev.target as Radio;
+        this.addEventListener('change', (event: Event) => {
+            const target = event.target as Radio;
             this.selected = target.value;
         });
     }

--- a/packages/radio/test/radio.test.ts
+++ b/packages/radio/test/radio.test.ts
@@ -69,8 +69,8 @@ describe('Radio', () => {
         let value = '';
         let checked = false;
         const el = testDiv.querySelector('[value=third]') as Radio;
-        el.addEventListener('change', (e) => {
-            const target = e.target as Radio;
+        el.addEventListener('change', (event) => {
+            const target = event.target as Radio;
             value = target.value;
             checked = target.checked;
         });

--- a/packages/search/stories/search.stories.ts
+++ b/packages/search/stories/search.stories.ts
@@ -21,9 +21,9 @@ storiesOf('Search', module)
         'Default',
         () => html`
             <sp-search
-                @submit=${(e: Event) => {
-                    e.preventDefault();
-                    const search = e.target as Search;
+                @submit=${(event: Event) => {
+                    event.preventDefault();
+                    const search = event.target as Search;
                     action(`Search: ${search.value}`)();
                 }}
             ></sp-search>
@@ -35,9 +35,9 @@ storiesOf('Search', module)
         () => html`
             <sp-search
                 quiet
-                @submit=${(e: Event) => {
-                    e.preventDefault();
-                    const search = e.target as Search;
+                @submit=${(event: Event) => {
+                    event.preventDefault();
+                    const search = event.target as Search;
                     action(`Search: ${search.value}`)();
                 }}
             ></sp-search>

--- a/packages/search/test/benchmark/test-basic.ts
+++ b/packages/search/test/benchmark/test-basic.ts
@@ -18,8 +18,8 @@ measureFixtureCreation(html`
     <sp-search
         placeholder="Search millions of images"
         label="Search for an image"
-        @submit=${(e: Event) => {
-            e.preventDefault();
+        @submit=${(event: Event) => {
+            event.preventDefault();
         }}
     ></sp-search>
 `);

--- a/packages/search/test/search.test.ts
+++ b/packages/search/test/search.test.ts
@@ -84,8 +84,8 @@ describe('Search', () => {
         const el = await litFixture<Search>(
             html`
                 <sp-search
-                    @submit=${(e: Event) => {
-                        e.preventDefault();
+                    @submit=${(event: Event) => {
+                        event.preventDefault();
                     }}
                 ></sp-search>
             `

--- a/packages/shared/test/focusable.test.ts
+++ b/packages/shared/test/focusable.test.ts
@@ -26,9 +26,9 @@ describe('Focusable', () => {
             );
             await elementUpdated(el);
             expect('failed').to.not.equal('failed');
-        } catch (err) {
+        } catch (error) {
             expect(() => {
-                throw err;
+                throw error;
             }).to.throw('Must implement focusElement getter!');
         }
     });

--- a/packages/sidenav/src/sidenav-item.ts
+++ b/packages/sidenav/src/sidenav-item.ts
@@ -70,16 +70,16 @@ export class SideNavItem extends LitElement {
     protected firstUpdated(): void {
         const parentSideNav = this.parentSideNav;
         if (parentSideNav) {
-            parentSideNav.addEventListener('sidenav-select', (ev) =>
-                this.handleSideNavSelect(ev)
+            parentSideNav.addEventListener('sidenav-select', (event) =>
+                this.handleSideNavSelect(event)
             );
             this.selected =
                 this.value != null && this.value === parentSideNav.value;
         }
     }
 
-    protected handleSideNavSelect(ev: Event): void {
-        this.selected = ev.target === this;
+    protected handleSideNavSelect(event: Event): void {
+        this.selected = event.target === this;
     }
 
     protected handleClick(): void {

--- a/packages/sidenav/src/sidenav.ts
+++ b/packages/sidenav/src/sidenav.ts
@@ -32,8 +32,8 @@ export class SideNav extends LitElement {
     @property({ reflect: true })
     public value: string | undefined = undefined;
 
-    private handleSelect(ev: CustomEvent<SidenavSelectDetail>): void {
-        this.value = ev.detail.value;
+    private handleSelect(event: CustomEvent<SidenavSelectDetail>): void {
+        this.value = event.detail.value;
     }
 
     protected render(): TemplateResult {

--- a/packages/slider/src/slider.ts
+++ b/packages/slider/src/slider.ts
@@ -283,16 +283,16 @@ export class Slider extends Focusable {
         `;
     }
 
-    private onPointerDown(ev: PointerEvent): void {
+    private onPointerDown(event: PointerEvent): void {
         if (this.disabled) {
             return;
         }
         this.focus();
         this.dragging = true;
-        this.handle.setPointerCapture(ev.pointerId);
+        this.handle.setPointerCapture(event.pointerId);
     }
 
-    private onMouseDown(ev: MouseEvent): void {
+    private onMouseDown(event: MouseEvent): void {
         if (this.supportsPointerEvent) {
             return;
         }
@@ -303,7 +303,7 @@ export class Slider extends Focusable {
         document.addEventListener('mouseup', this.onMouseUp);
         this.focus();
         this.dragging = true;
-        this.currentMouseEvent = ev;
+        this.currentMouseEvent = event;
         this._trackMouseEvent();
     }
 
@@ -315,19 +315,19 @@ export class Slider extends Focusable {
         requestAnimationFrame(() => this._trackMouseEvent());
     }
 
-    private onPointerUp(ev: PointerEvent): void {
+    private onPointerUp(event: PointerEvent): void {
         // Retain focus on input element after mouse up to enable keyboard interactions
         this.focus();
         this.handleHighlight = false;
         this.dragging = false;
-        this.handle.releasePointerCapture(ev.pointerId);
+        this.handle.releasePointerCapture(event.pointerId);
         this.dispatchChangeEvent();
     }
 
-    private onMouseUp = (ev: MouseEvent): void => {
+    private onMouseUp = (event: MouseEvent): void => {
         // Retain focus on input element after mouse up to enable keyboard interactions
         this.focus();
-        this.currentMouseEvent = ev;
+        this.currentMouseEvent = event;
         document.removeEventListener('mousemove', this.onMouseMove);
         document.removeEventListener('mouseup', this.onMouseUp);
         requestAnimationFrame(() => {
@@ -337,47 +337,47 @@ export class Slider extends Focusable {
         });
     };
 
-    private onPointerMove(ev: PointerEvent): void {
+    private onPointerMove(event: PointerEvent): void {
         if (!this.dragging) {
             return;
         }
-        this.value = this.calculateHandlePosition(ev);
+        this.value = this.calculateHandlePosition(event);
     }
 
-    private onMouseMove = (ev: MouseEvent): void => {
-        this.currentMouseEvent = ev;
+    private onMouseMove = (event: MouseEvent): void => {
+        this.currentMouseEvent = event;
     };
 
-    private onPointerCancel(ev: PointerEvent): void {
+    private onPointerCancel(event: PointerEvent): void {
         this.dragging = false;
-        this.handle.releasePointerCapture(ev.pointerId);
+        this.handle.releasePointerCapture(event.pointerId);
     }
 
     /**
      * Move the handle under the cursor and begin start a pointer capture when the track
      * is moused down
      */
-    private onTrackPointerDown(ev: PointerEvent): void {
-        if (ev.target === this.handle || this.disabled) {
+    private onTrackPointerDown(event: PointerEvent): void {
+        if (event.target === this.handle || this.disabled) {
             return;
         }
         this.dragging = true;
-        this.handle.setPointerCapture(ev.pointerId);
+        this.handle.setPointerCapture(event.pointerId);
 
-        this.value = this.calculateHandlePosition(ev);
+        this.value = this.calculateHandlePosition(event);
     }
 
-    private onTrackMouseDown(ev: MouseEvent): void {
+    private onTrackMouseDown(event: MouseEvent): void {
         if (this.supportsPointerEvent) {
             return;
         }
-        if (ev.target === this.handle || this.disabled) {
+        if (event.target === this.handle || this.disabled) {
             return;
         }
         document.addEventListener('mousemove', this.onMouseMove);
         document.addEventListener('mouseup', this.onMouseUp);
         this.dragging = true;
-        this.currentMouseEvent = ev;
+        this.currentMouseEvent = event;
         this._trackMouseEvent();
     }
 
@@ -405,10 +405,10 @@ export class Slider extends Focusable {
      * @param: PointerEvent on slider
      * @return: Slider value that correlates to the position under the pointer
      */
-    private calculateHandlePosition(ev: PointerEvent | MouseEvent): number {
+    private calculateHandlePosition(event: PointerEvent | MouseEvent): number {
         const rect = this.getBoundingClientRect();
         const minOffset = rect.left;
-        const offset = ev.clientX;
+        const offset = event.clientX;
         const size = rect.width;
 
         const percent = (offset - minOffset) / size;

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -34,9 +34,9 @@ storiesOf('Slider', module)
             sliderVariants[0],
             'Element'
         );
-        const handleEvent = (e: Event): void => {
-            const target = e.target as Slider;
-            action(e.type)(target.value);
+        const handleEvent = (event: Event): void => {
+            const target = event.target as Slider;
+            action(event.type)(target.value);
         };
         return html`
             <div style="width: 500px; margin: 20px;">

--- a/packages/tab-list/src/tab-list.ts
+++ b/packages/tab-list/src/tab-list.ts
@@ -72,15 +72,15 @@ export class TabList extends LitElement {
         `;
     }
 
-    private onClick(ev: Event): void {
-        const target = ev.target as HTMLElement;
+    private onClick(event: Event): void {
+        const target = event.target as HTMLElement;
         this.selectTarget(target);
     }
 
-    private onKeyDown(ev: KeyboardEvent): void {
-        if (ev.key === 'Enter' || ev.key === ' ') {
-            ev.preventDefault();
-            const target = ev.target as HTMLElement;
+    private onKeyDown(event: KeyboardEvent): void {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            const target = event.target as HTMLElement;
             if (target) {
                 this.selectTarget(target);
             }

--- a/packages/tab-list/test/tab-list.test.ts
+++ b/packages/tab-list/test/tab-list.test.ts
@@ -213,7 +213,7 @@ describe('TabList', () => {
         expect(el.selected).to.be.equal('first');
     });
     it('allows selection to be cancellable', async () => {
-        const cancelSelection = (e: Event): void => e.preventDefault();
+        const cancelSelection = (event: Event): void => event.preventDefault();
         const el = await fixture<TabList>(html`
             <sp-tab-list selected="first" @change=${cancelSelection}>
                 <sp-tab label="Tab 1" value="first" tabindex="1"></sp-tab>

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -179,8 +179,8 @@ describe('Textfield', () => {
     it('dispatches a `change` event', async () => {
         const testValue = 'Test Name';
         let eventSource = null as Textfield | null;
-        const onChange = (e: Event): void => {
-            eventSource = e.composedPath()[0] as Textfield;
+        const onChange = (event: Event): void => {
+            eventSource = event.composedPath()[0] as Textfield;
         };
         const el = await litFixture<Textfield>(
             html`

--- a/scripts/process-spectrum-css.js
+++ b/scripts/process-spectrum-css.js
@@ -33,7 +33,7 @@ async function processComponent(componentPath) {
             `@spectrum-css/${spectrumConfig.spectrum}/dist/index-vars.css`
         );
         packageCss = true;
-    } catch (e) {
+    } catch (error) {
         console.error(
             chalk.bold.red(
                 `!!! '${spectrumConfig.spectrum}' does not have a local Spectrum CSS dependency !!!`

--- a/scripts/spectrum-vars.js
+++ b/scripts/spectrum-vars.js
@@ -21,9 +21,9 @@ const license = fs.readFileSync(
 );
 
 const processCSS = (srcPath, dstPath, identifier) => {
-    fs.readFile(srcPath, 'utf8', function(err, data) {
-        if (err) {
-            return console.log(err);
+    fs.readFile(srcPath, 'utf8', function(error, data) {
+        if (error) {
+            return console.log(error);
         }
 
         /* lit-html is a JS litteral, so `\` escapes by default.

--- a/test/visual/get-from-ci.js
+++ b/test/visual/get-from-ci.js
@@ -34,7 +34,7 @@ const build = process.argv.slice(2)[1] || 'latest';
                             const dest = fs.createWriteStream(path);
                             resp.body.pipe(dest);
                         })
-                        .catch((err) => console.log(err));
+                        .catch((error) => console.log(error));
                 }
             });
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7751,6 +7751,9 @@ eslint-plugin-prettier@^3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+"eslint-plugin-spectrum-web-components@file:./linters/eslint":
+  version "1.0.1"
+
 eslint-rule-docs@^1.1.5:
   version "1.1.158"
   resolved "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.158.tgz#aa85789f11b164ee5f9f8be38aa98456bf20dade"


### PR DESCRIPTION
## Description
- update existing code to meet the argument naming standard
- create and apply an eslint plugin to prevent this from happening with understood names in the future.

## Related Issue
fixes #153

## Motivation and Context
Code should be more predictable

## How Has This Been Tested?
- wrote some non-compliant code and then tried to commit it, eslist said "NO"

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/69269848-e3562280-0b9f-11ea-9a1c-df761a6dd32f.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
