### PR TITLE
fix: include "type" in package.json, generate custom-elements.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ test/**/*.js
 test/**/*.js.map
 test/**/*.d.ts
 packages/*/src/**/*.css.js
+packages/*/custom-elements.json
 packages/*/test/**/*.js
 packages/*/test/**/*.js.map
 packages/*/test/**/*.d.ts

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "version": "0.0.9",
     "description": "",
     "files": [
+        "custom-elements.json",
         "lib",
         "styles"
     ],
@@ -21,6 +22,7 @@
     ],
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "browser": "lib/index.js",
     "engines": {
         "node": ">=10.15.0",
@@ -49,7 +51,8 @@
         "lint:ts": "eslint -f pretty 'packages/**/*.ts'",
         "lint:css": "stylelint 'packages/**/*.css'",
         "lint:versions": "node ./scripts/lint-versions.js",
-        "prelerna-publish": "yarn get-ready",
+        "custom-element-json": "lerna exec --ignore @spectrum-web-components/styles -- wca analyze 'src/**/*.ts' --format json --outFile custom-elements.json",
+        "prelerna-publish": "yarn get-ready && yarn custom-element-json",
         "lerna-publish": "lerna publish --message 'chore: release new versions'",
         "test": "yarn build && yarn test:ci",
         "test:build": "tsc --build test/tsconfig-test.json",
@@ -151,7 +154,7 @@
         "karma-script-launcher": "^1.0.0",
         "lerna": "^3.16.4",
         "linebyline": "^1.3.0",
-        "lit-analyzer": "^1.1.8",
+        "lit-analyzer": "^1.1.9",
         "lit-element": "^2.2.1",
         "lit-html": "^1.0.0",
         "lodash": "^4.17.15",
@@ -195,7 +198,7 @@
         "typedoc": "^0.15.0",
         "typescript": "^3.4.1",
         "walker": "^1.0.7",
-        "web-component-analyzer": "^0.1.9",
+        "web-component-analyzer": "^0.1.20",
         "webpack": "^4.41.0",
         "webpack-cli": "^3.3.0",
         "webpack-dev-server": "^3.2.1",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/actionbar/package.json
+++ b/packages/actionbar/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/circleloader/package.json
+++ b/packages/circleloader/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/menu-group/package.json
+++ b/packages/menu-group/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/menu-item/package.json
+++ b/packages/menu-item/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/overlay-root/package.json
+++ b/packages/overlay-root/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/overlay-trigger/package.json
+++ b/packages/overlay-trigger/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/slider/src/slider.ts
+++ b/packages/slider/src/slider.ts
@@ -245,7 +245,7 @@ export class Slider extends Focusable {
                     step="${this.step}"
                     min="${this.min}"
                     max="${this.max}"
-                    aria-disabled=${this.disabled}
+                    aria-disabled=${this.disabled ? 'true' : 'false'}
                     aria-label=${this.ariaLabel || this.label}
                     aria-valuemin=${this.min}
                     aria-valuemax=${this.max}

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -22,6 +22,7 @@
     "description": "",
     "style": "all-medium-lightest.css",
     "files": [
+        "custom-elements.json",
         "*.css"
     ],
     "scripts": {

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/tab-list/package.json
+++ b/packages/tab-list/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -22,7 +22,9 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
+    "type": "module",
     "files": [
+        "custom-elements.json",
         "/lib/",
         "/src/"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,10 +1865,31 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nodelib/fs.scandir@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
+  integrity sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.3"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.3", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz#34dc5f4cabbc720f4e60f75a747e7ecd6c175bd3"
+  integrity sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz#011b9202a70a6366e436ca5c065844528ab04976"
+  integrity sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.3"
+    fastq "^1.6.0"
 
 "@octokit/endpoint@^5.1.0":
   version "5.3.5"
@@ -8155,6 +8176,17 @@ fast-glob@^2.0.2, fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
+fast-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.0.tgz#77375a7e3e6f6fc9b18f061cddd28b8d1eec75ae"
+  integrity sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -8174,6 +8206,13 @@ fastparse@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
 
 fault@^1.0.2:
   version "1.0.3"
@@ -8917,6 +8956,13 @@ glob-parent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.0.0.tgz#1dc99f0f39b006d3e92c2c284068382f0c20e954"
   integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob-parent@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
   dependencies:
     is-glob "^4.0.1"
 
@@ -11542,19 +11588,19 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lit-analyzer@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/lit-analyzer/-/lit-analyzer-1.1.8.tgz#092950cc02b637b9426ffac59cd371d730a39c4e"
-  integrity sha512-Gc3fG8ZPUyEECJOwCV1e504g1EYbtn3Chcvaf8iX7PiszuKJZ0i92jc+AbB/v4Xb6BKmPXruJqPjEGhS//YpIA==
+lit-analyzer@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/lit-analyzer/-/lit-analyzer-1.1.9.tgz#703d775bbe744fb31d5f1a0f6ad94923dafe44cd"
+  integrity sha512-ISV6pgvffybnVPrO5uoRKo7Dw2wtLvvxCbCYsLDyA70s05/hj6mRScLxltTC6SHSOqORmXnoSY4sPFuz0A/F6w==
   dependencies:
     chalk "^2.4.2"
     didyoumean2 "2.0.4"
     fast-glob "^2.2.6"
     parse5 "5.1.0"
-    ts-simple-type "~0.3.5"
+    ts-simple-type "~0.3.6"
     vscode-css-languageservice "4.0.2-next.1"
     vscode-html-languageservice "2.1.12"
-    web-component-analyzer "~0.1.11"
+    web-component-analyzer "~0.1.17"
 
 lit-element@^2.2.0, lit-element@^2.2.1:
   version "2.2.1"
@@ -12242,7 +12288,7 @@ merge-stream@^1.0.0:
   dependencies:
     readable-stream "^2.0.1"
 
-merge2@^1.2.3:
+merge2@^1.2.3, merge2@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
@@ -12300,7 +12346,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.0:
+micromatch@^4.0.0, micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
@@ -16285,6 +16331,11 @@ retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
+reusify@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rfdc@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.4.tgz#ba72cc1367a0ccd9cf81a870b3b58bd3ad07f8c2"
@@ -16356,6 +16407,11 @@ run-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
   integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
+run-parallel@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+  integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -18213,10 +18269,10 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.4.tgz#ae27126960ebaefb874c6d7fa4729729ab200d90"
   integrity sha512-1J/vefLC+BWSo+qe8OnJQfWTYRS6ingxjwqmHMqaMxXMj7kFtKLgAaYW3JeX3mktjgUL+etlU8/B4VUAUI9QGw==
 
-ts-simple-type@~0.3.5:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/ts-simple-type/-/ts-simple-type-0.3.6.tgz#aa5a107c420c3ebe9cf5de2fe426984d0f77c665"
-  integrity sha512-dybO9ebUqOzldR5+SPP1uQSbxl/uiSIvjRC7dFuU45XE7H+4EoQMuxCFKoZj99qEo7pdDWSx52DEQAPZqL3SFg==
+ts-simple-type@~0.3.6:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/ts-simple-type/-/ts-simple-type-0.3.7.tgz#1e77222c3d90d7093f80a954e74c725fd99c911c"
+  integrity sha512-bDXWURwpDpe1mA5E9eldmI0Mpt9zGprhtN/ZTLOJjsAMyeMy1UT7WvGRQghYewIYBYxDZurChhe4DrsPbcCVrA==
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
@@ -18334,10 +18390,15 @@ typescript@3.5.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@^3.4.1, typescript@^3.5.1:
+typescript@^3.4.1:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+
+typescript@^3.6.4:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 typical@^2.6.1:
   version "2.6.1"
@@ -19068,14 +19129,14 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
-web-component-analyzer@^0.1.9, web-component-analyzer@~0.1.11:
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/web-component-analyzer/-/web-component-analyzer-0.1.16.tgz#db0f60980d01f583c23d85fbfa58e7d6215e6af3"
-  integrity sha512-NpGGVmkP9uk17orjTFNyxKwWfLagoJaA3azZjVMZPjYw+JMX9/QSDcEetaQudq+H7pkQRNXALQZPvGWYaj1ptQ==
+web-component-analyzer@^0.1.20, web-component-analyzer@~0.1.17:
+  version "0.1.20"
+  resolved "https://registry.yarnpkg.com/web-component-analyzer/-/web-component-analyzer-0.1.20.tgz#5d16425ade061da07452f35c50cd7b23bfdad270"
+  integrity sha512-gRQs8QoWlolyqhP8X/gVpeutiMPhZSyAxgkiuVHMf9q5B64U/Ap2Aec8JXQDSjayo2Yx7woigYaa4pvN9QATJg==
   dependencies:
-    fast-glob "^2.2.6"
-    ts-simple-type "~0.3.5"
-    typescript "^3.5.1"
+    fast-glob "^3.1.0"
+    ts-simple-type "~0.3.6"
+    typescript "^3.6.4"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## Description
- Generate a `custom-elements.json` file for all packages except `@spectrum-web-components/styles`.
- Add `custom-elements.json` to the files distributed to NPM.
- Include `"type": "module"` in `package.json` as per https://justinfagnani.com/2019/11/01/how-to-publish-web-components-to-npm/#set-type-to-module

## Related Issue
fixes #242

## Motivation and Context
Consumers should have all the perks of a high-quality package.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
