### PR TITLE
docs: match to Spectrum webring

### DIFF
--- a/documentation/src/components/home.css
+++ b/documentation/src/components/home.css
@@ -11,12 +11,8 @@ governing permissions and limitations under the License.
 */
 
 #hero {
+    margin-top: 32px;
     margin-bottom: 3em;
-}
-
-#hero .spectrum-Article {
-    text-align: center;
-    padding-bottom: 2em;
 }
 
 #hero-buttons {

--- a/documentation/src/components/home.ts
+++ b/documentation/src/components/home.ts
@@ -12,7 +12,6 @@ class HomeElement extends LayoutElement {
         return html`
             <section id="hero">
                 <div class="spectrum-Article">
-                    <docs-spectrum-logo size="128px"></docs-spectrum-logo>
                     <h1 class="spectrum-Heading1--display">
                         Spectrum Web Components
                     </h1>

--- a/documentation/src/components/layout.css
+++ b/documentation/src/components/layout.css
@@ -20,7 +20,7 @@ governing permissions and limitations under the License.
 #side-nav {
     display: flex;
     flex: 0 0 auto;
-    padding: 1.5em;
+    padding: 30px 24px 24px;
     box-sizing: border-box;
 }
 

--- a/documentation/src/components/side-nav.css
+++ b/documentation/src/components/side-nav.css
@@ -19,14 +19,13 @@ governing permissions and limitations under the License.
 }
 
 #nav-header {
-    padding-top: calc(1.5rem + 30px);
+    margin: 0;
     padding-bottom: 20px;
     text-align: center;
     font-size: 12px;
     position: sticky;
     left: 0;
-    top: -1.5rem;
-    margin-top: -1.5rem;
+    top: 0;
     background-color: var(--spectrum-global-color-gray-100);
     z-index: 2;
 }
@@ -35,8 +34,13 @@ governing permissions and limitations under the License.
 #nav-header a:visited {
     color: var(--spectrum-global-color-gray-800);
     text-decoration: none;
+    display: flex;
+    font-size: 20px;
+    text-align: left;
 }
 
 #nav-header docs-spectrum-logo {
     margin-bottom: 11px;
+    margin-right: 16px;
+    flex-shrink: 0;
 }

--- a/documentation/src/components/side-nav.ts
+++ b/documentation/src/components/side-nav.ts
@@ -45,12 +45,16 @@ class SideNav extends LitElement {
 
     render() {
         return html`
-            <div id="nav-header">
+            <h1 id="nav-header">
                 <a href="/">
-                    <docs-spectrum-logo></docs-spectrum-logo>
-                    <div>SPECTRUM WEB COMPONENTS</div>
+                    <docs-spectrum-logo size="36px"></docs-spectrum-logo>
+                    <div>
+                        Spectrum
+                        <br />
+                        Web Components
+                    </div>
                 </a>
-            </div>
+            </h1>
             <sp-sidenav>
                 <sp-sidenav-heading
                     label="Components"

--- a/documentation/src/components/spectrum-logo.ts
+++ b/documentation/src/components/spectrum-logo.ts
@@ -24,32 +24,19 @@ class SpectrumLogo extends LitElement {
     render() {
         return html`
             <svg
+                xmlns="http://www.w3.org/2000/svg"
                 version="1.1"
-                id="logosvg"
+                x="0"
+                y="0"
                 width="${this.size}"
                 height="${this.size}"
-                xmlns="http://www.w3.org/2000/svg"
-                x="0px"
-                y="0px"
-                viewBox="61.2 0 177.7 150"
-                enableBackground="new 61.2 0 177.7 150"
-                xmlSpace="preserve"
+                viewBox="0 0 30 26"
+                xml:space="preserve"
             >
                 <path
-                    className="tier3"
-                    fill="#757575"
-                    d="M238.8,94.9L150,150L61.2,94.9L88.3,78l61.7,38l61.7-38L238.8,94.9z"
-                ></path>
-                <path
-                    className="tier2"
-                    fill="#999999"
-                    d="M188.3,43.5L150,67.2l-38.3-23.7L88.3,57.9l61.7,38l61.4-38L188.3,43.5z"
-                ></path>
-                <path
-                    className="tier1"
-                    fill="#C7C7C7"
-                    d="M150,0l-38.5,23.7l38.3,23.7L188,23.7L150,0z"
-                ></path>
+                    fill="#e1251b"
+                    d="M19 0h11v26zM11.1 0H0v26zM15 9.6L22.1 26h-4.6l-2.1-5.2h-5.2z"
+                />
             </svg>
         `;
     }


### PR DESCRIPTION
## Description
Prep for publication by removing the old Spectrum logo and working to more closely match the Spectrum webring sites.

### Notes
Lots more to do, of course, but this _might_ be enough to get the first public release when we reconvene with their team after the holiday.

## Motivation and Context
Spectrum mentioned these things.

## How Has This Been Tested?
Docs pages, so visually.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/69394022-d2dd9f00-0ca8-11ea-9cc3-33aab0f4be4b.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
