### PR TITLE
fix: font.css not auto-generated from spectrum-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
         "@open-wc/polyfills-loader": "^0.3.2",
         "@open-wc/testing": "^2.3.3",
         "@open-wc/testing-karma": "^3.1.24",
-        "@spectrum-css/commons": "^2.0.0",
         "@spectrum-css/link": "^2.0.2",
         "@spectrum-css/rule": "^2.0.2",
         "@spectrum-css/table": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "@open-wc/polyfills-loader": "^0.3.2",
         "@open-wc/testing": "^2.3.3",
         "@open-wc/testing-karma": "^3.1.24",
+        "@spectrum-css/commons": "^2.0.0",
         "@spectrum-css/link": "^2.0.2",
         "@spectrum-css/rule": "^2.0.2",
         "@spectrum-css/table": "^2.0.2",

--- a/packages/styles/fonts.css
+++ b/packages/styles/fonts.css
@@ -10,46 +10,110 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+/* stylelint-disable */
+
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
 :root,
 :host {
-    font-family: var(--spectrum-global-font-family-base);
-    font-size: var(--spectrum-alias-font-size-default);
+    font-family: var(--spectrum-font-family-base);
+    font-size: var(--spectrum-text-size);
 
+    &:lang(ar) {
+        font-family: var(--spectrum-font-family-ar);
+    }
+
+    &:lang(he) {
+        font-family: var(--spectrum-font-family-he);
+    }
+
+    &:lang(zh-Hans) {
+        font-family: var(--spectrum-font-family-zhhans);
+    }
+
+    &:lang(zh-Hant) {
+        font-family: var(--spectrum-font-family-zhhant);
+    }
+
+    &:lang(zh) {
+        font-family: var(--spectrum-font-family-zh);
+    }
+
+    &:lang(ko) {
+        font-family: var(--spectrum-font-family-ko);
+    }
+
+    &:lang(ja) {
+        font-family: var(--spectrum-font-family-ja);
+    }
+}
+
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+:root {
     --spectrum-font-fallbacks-sans: -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, sans-serif;
-    --spectrum-font-fallbacks-serif: serif;
-    --spectrum-font-fallbacks-mono: monospace;
-    --spectrum-font-family-ar: myriad-arabic,
+
+    /* Not used
+  --spectrum-font-fallbacks-serif: serif;
+  --spectrum-font-fallbacks-mono: monospace;
+  --spectrum-font-family-article: adobe-clean-serif, 'Source Serif', var(--spectrum-font-fallbacks-serif);
+  --spectrum-font-family-article-ar: adobe-arabic, var(--spectrum-font-fallbacks-serif);
+  --spectrum-font-family-article-he: adobe-hebrew, var(--spectrum-font-fallbacks-serif);
+  --spectrum-font-family-article-ja: source-han-serif-japanese, var(--spectrum-font-fallbacks-serif);
+  --spectrum-font-family-article-ko: source-han-serif-korean, var(--spectrum-font-fallbacks-serif);
+  --spectrum-font-family-article-zh-hans: source-han-serif-sc, var(--spectrum-font-fallbacks-serif);
+  --spectrum-font-family-article-zh-hant: source-han-serif-tc, 'MingLiu', var(--spectrum-font-fallbacks-serif);
+  --spectrum-font-family-code: source-code-pro, 'Source Code Pro', var(--spectrum-font-fallbacks-mono);
+  --spectrum-font-family-condensed: adobe-clean-condensed, var(--spectrum-font-family-base);
+  */
+
+    --spectrum-font-family-base: 'adobe-clean-ux', 'adobe-clean',
+        'Source Sans Pro', var(--spectrum-font-fallbacks-sans);
+    --spectrum-font-family-han: 'adobe-clean-han-japanese',
         var(--spectrum-font-fallbacks-sans);
-    --spectrum-font-family-article: adobe-clean-serif, 'Source Serif',
-        var(--spectrum-font-fallbacks-serif);
-    --spectrum-font-family-article-ar: adobe-arabic,
-        var(--spectrum-font-fallbacks-serif);
-    --spectrum-font-family-article-he: adobe-hebrew,
-        var(--spectrum-font-fallbacks-serif);
-    --spectrum-font-family-article-ja: source-han-serif-japanese,
-        var(--spectrum-font-fallbacks-serif);
-    --spectrum-font-family-article-ko: source-han-serif-korean,
-        var(--spectrum-font-fallbacks-serif);
-    --spectrum-font-family-article-zh-hans: source-han-serif-sc,
-        var(--spectrum-font-fallbacks-serif);
-    --spectrum-font-family-article-zh-hant: source-han-serif-tc,
-        var(--spectrum-font-fallbacks-serif);
-    --spectrum-font-family-base: adobe-clean, 'Source Sans Pro',
+    --spectrum-font-family-ar: 'adobe-arabic', 'myriad-arabic',
         var(--spectrum-font-fallbacks-sans);
-    --spectrum-font-family-code: source-code-pro, 'Source Code Pro',
-        var(--spectrum-font-fallbacks-mono);
-    --spectrum-font-family-han: adobe-clean-han-japanese,
+    --spectrum-font-family-he: 'adobe-hebrew',
         var(--spectrum-font-fallbacks-sans);
-    --spectrum-font-family-he: var(--spectrum-font-fallbacks-sans);
-    --spectrum-font-family-zh: var(--spectrum-font-family-han);
-    --spectrum-font-family-zhhans: var(--spectrum-font-family-han);
-    --spectrum-font-family-ko: var(--spectrum-font-family-han);
-    --spectrum-font-family-ja: var(--spectrum-font-family-han);
-    --spectrum-font-family-condensed: adobe-clean-condensed,
-        var(--spectrum-font-family-base);
+    --spectrum-font-family-zhhans: 'adobe-clean-han-simplified-c', 'SimSun',
+        'Heiti SC Light', var(--spectrum-font-fallbacks-sans);
+    --spectrum-font-family-zh: var(--spectrum-font-family-zhhans);
+    --spectrum-font-family-zhhant: 'adobe-clean-han-traditional',
+        'Microsoft JhengHei UI', 'Microsoft JhengHei', 'Heiti TC Light',
+        var(--spectrum-font-fallbacks-sans);
+    --spectrum-font-family-ko: 'adobe-clean-han-korean', 'Malgun Gothic',
+        'Apple Gothic', var(--spectrum-font-fallbacks-sans);
+    --spectrum-font-family-ja: 'adobe-clean-han-japanese', 'Yu Gothic',
+        '\\30E1 \\30A4 \\30EA \\30AA',
+        '\\30D2 \\30E9 \\30AE \\30CE \\89D2 \\30B4  Pro W3',
+        'Hiragino Kaku Gothic Pro W3', 'Osaka',
+        '\\FF2D \\FF33 \\FF30 \\30B4 \\30B7 \\30C3 \\30AF', 'MS PGothic',
+        var(--spectrum-font-fallbacks-sans);
     --spectrum-text-size: var(--spectrum-alias-font-size-default);
     --spectrum-text-body-line-height: var(--spectrum-alias-line-height-medium);
     --spectrum-text-size-text-label: var(--spectrum-label-text-size);
     --spectrum-line-height-text-label: var(--spectrum-label-text-line-height);
 }
+
+/* stylelint-enable */

--- a/packages/styles/fonts.css
+++ b/packages/styles/fonts.css
@@ -24,52 +24,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-:root,
-:host {
-    font-family: var(--spectrum-font-family-base);
-    font-size: var(--spectrum-text-size);
-
-    &:lang(ar) {
-        font-family: var(--spectrum-font-family-ar);
-    }
-
-    &:lang(he) {
-        font-family: var(--spectrum-font-family-he);
-    }
-
-    &:lang(zh-Hans) {
-        font-family: var(--spectrum-font-family-zhhans);
-    }
-
-    &:lang(zh-Hant) {
-        font-family: var(--spectrum-font-family-zhhant);
-    }
-
-    &:lang(zh) {
-        font-family: var(--spectrum-font-family-zh);
-    }
-
-    &:lang(ko) {
-        font-family: var(--spectrum-font-family-ko);
-    }
-
-    &:lang(ja) {
-        font-family: var(--spectrum-font-family-ja);
-    }
-}
-
-/*
-Copyright 2019 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-*/
-
 :root {
     --spectrum-font-fallbacks-sans: -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, sans-serif;
@@ -114,6 +68,52 @@ governing permissions and limitations under the License.
     --spectrum-text-body-line-height: var(--spectrum-alias-line-height-medium);
     --spectrum-text-size-text-label: var(--spectrum-label-text-size);
     --spectrum-line-height-text-label: var(--spectrum-label-text-line-height);
+}
+
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+:root,
+:host {
+    font-family: var(--spectrum-font-family-base);
+    font-size: var(--spectrum-text-size);
+
+    &:lang(ar) {
+        font-family: var(--spectrum-font-family-ar);
+    }
+
+    &:lang(he) {
+        font-family: var(--spectrum-font-family-he);
+    }
+
+    &:lang(zh-Hans) {
+        font-family: var(--spectrum-font-family-zhhans);
+    }
+
+    &:lang(zh-Hant) {
+        font-family: var(--spectrum-font-family-zhhant);
+    }
+
+    &:lang(zh) {
+        font-family: var(--spectrum-font-family-zh);
+    }
+
+    &:lang(ko) {
+        font-family: var(--spectrum-font-family-ko);
+    }
+
+    &:lang(ja) {
+        font-family: var(--spectrum-font-family-ja);
+    }
 }
 
 /* stylelint-enable */

--- a/packages/styles/fonts.css
+++ b/packages/styles/fonts.css
@@ -24,7 +24,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-:root {
+:root,
+:host {
     --spectrum-font-fallbacks-sans: -apple-system, BlinkMacSystemFont,
         'Segoe UI', Roboto, sans-serif;
 

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -35,6 +35,7 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
+        "@spectrum-css/commons": "^2.0.0",
         "@spectrum-css/typography": "^2.0.2",
         "@spectrum-css/vars": "^2.0.2"
     }

--- a/scripts/spectrum-vars.js
+++ b/scripts/spectrum-vars.js
@@ -28,7 +28,8 @@ const processCSSData = (data, identifier) => {
     let result = data.replace(/\\/g, '\\\\');
 
     // possible selectors to replace
-    const selector1 = `.spectrum--${identifier}`;
+    const selector1 =
+        identifier == ':root ' ? identifier : `.spectrum--${identifier}`;
     const selector2 = '.spectrum';
 
     // new selector values
@@ -55,6 +56,11 @@ const processCSSData = (data, identifier) => {
     return result;
 };
 
+const writeProcessedCSSToFile = (dstPath, contents) => {
+    result = `${license}\n/* stylelint-disable */\n${contents}\n/* stylelint-enable */`;
+    fs.writeFile(dstPath, result, 'utf8');
+};
+
 const processCSS = (srcPath, dstPath, identifier) => {
     fs.readFile(srcPath, 'utf8', function(error, data) {
         if (error) {
@@ -62,9 +68,7 @@ const processCSS = (srcPath, dstPath, identifier) => {
         }
 
         let result = processCSSData(data, identifier);
-        result = `${license}\n/* stylelint-disable */\n${result}\n/* stylelint-enable */`;
-
-        fs.writeFile(dstPath, result, 'utf8');
+        writeProcessedCSSToFile(dstPath, result);
     });
 };
 
@@ -77,8 +81,7 @@ const processMultiSourceCSS = (srcPaths, dstPath, identifier) => {
         result = `${result}\n${processCSSData(data, identifier)}`;
     }
 
-    result = `${license}\n/* stylelint-disable */\n${result}\n/* stylelint-enable */`;
-    fs.writeFile(dstPath, result, 'utf8');
+    writeProcessedCSSToFile(dstPath, result);
 };
 
 // where is spectrum-css?
@@ -182,7 +185,7 @@ cores.forEach(async (core) => {
         );
         console.log(`processing fonts from commons & typography`);
         processes.push(
-            processMultiSourceCSS([srcPath1, srcPath2], dstPath, 'typography')
+            processMultiSourceCSS([srcPath1, srcPath2], dstPath, ':root ')
         );
     }
 }

--- a/scripts/spectrum-vars.js
+++ b/scripts/spectrum-vars.js
@@ -175,8 +175,8 @@ cores.forEach(async (core) => {
 
     // fonts.css (2 sources so a little tricky)
     {
-        const srcPath1 = path.join(typographyPath, 'font.css');
-        const srcPath2 = path.join(commonsPath, 'fonts.css');
+        const srcPath1 = path.join(commonsPath, 'fonts.css');
+        const srcPath2 = path.join(typographyPath, 'font.css');
         const dstPath = path.resolve(
             path.join(__dirname, '..', 'packages', 'styles', 'fonts.css')
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2763,6 +2763,11 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/circleloader/-/circleloader-2.0.2.tgz#03dac5ae543f6ec302ca86d6a2149a4afd03b94e"
   integrity sha512-pIaPHo165hlAVItJOeSqI0C99i3kqMjJ0M7hvVG4IWf97VB2qurzEbqdxsGg/JFmUx/Pv2K0IzuUG7cw/SeINQ==
 
+"@spectrum-css/commons@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-2.0.0.tgz#556fc2b2904e624657245eae97dce85a13c9059a"
+  integrity sha512-GGbhwFwK7Bi2vHXWPM4hRcKpbFq/V9tVcyucjU3+Tws6UHArienkXuWSh1PrLZWUDCGCICCXU83S2aUZ6558Aw==
+
 "@spectrum-css/dropdown@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@spectrum-css/dropdown/-/dropdown-2.1.1.tgz#2db88de635c5e24841b0db85674744856867577a"


### PR DESCRIPTION
## Description

Added the @spectrum-css/commons package since we need to source our
fonts.css from 2 file to get what we need. Also updated the generation
script to allow building from multiple source files.

## Related Issue

Fixes #308

## Motivation and Context

Let's get rid of manual changes needed to update spectrum css.

## How Has This Been Tested?

I ran the visual tests locally, and also did some testing on the local doc site (including a bit of manual inspection to make sure the styles I expected to see were there).

I haven't done a deep inspection though, since I'm still not sure how much this affects.

## Screenshots (if appropriate):

## Types of changes

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
