### PR TITLE
Make overlays open in correct position on Edge

### DIFF
--- a/packages/overlay-root/src/active-overlay.ts
+++ b/packages/overlay-root/src/active-overlay.ts
@@ -272,7 +272,8 @@ export class ActiveOverlay extends LitElement {
     };
 
     private onSlotChange(): void {
-        this.updateOverlayPosition();
+        // Edge needs a little time to update the DOM before computing the layout
+        requestAnimationFrame(() => this.updateOverlayPosition());
     }
 
     public connectedCallback(): void {


### PR DESCRIPTION

## Description

This is a fix for issue #104. Overlays were opening in the wrong place on Edge because Edge had not yet done the DOM layout when the position computation was done. The overlay DOM element had a size of zero in both dimensions.

## Related Issue

#104 

## Motivation and Context

Any kind of overlay looks busted on Edge

## How Has This Been Tested?

Manual testing of Storybook cases.

## Screenshots (if appropriate):

![104](https://user-images.githubusercontent.com/154097/69697979-ee352800-1148-11ea-8ccf-d7c9d0c50d6a.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
