### PR TITLE
test: use cache when visual testing

### DIFF
--- a/test/visual/screenshots-baseline/regenerate.js
+++ b/test/visual/screenshots-baseline/regenerate.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const puppeteer = require('puppeteer');
+var rimraf = require('rimraf');
 const { startServer } = require('polyserve');
 const path = require('path');
 const fs = require('fs');
@@ -38,12 +39,19 @@ module.exports = {
                 if (!fs.existsSync(`${baselineDir}/${type}`)) {
                     fs.mkdirSync(`${baselineDir}/${type}`);
                 }
+
+                if (fs.existsSync(`${baselineDir}/${type}/userDataDir`)) {
+                    rimraf.sync(`${baselineDir}/${type}/userDataDir`);
+                }
+                fs.mkdirSync(`${baselineDir}/${type}/userDataDir`);
             });
 
             after((done) => polyserve.close(done));
 
             beforeEach(async function() {
-                browser = await puppeteer.launch();
+                browser = await puppeteer.launch({
+                    userDataDir: `${baselineDir}/${type}/userDataDir`,
+                });
                 page = await browser.newPage();
             });
 

--- a/test/visual/visual.js
+++ b/test/visual/visual.js
@@ -14,6 +14,7 @@ const expect = require('chai').expect;
 const { startServer } = require('polyserve');
 const path = require('path');
 const fs = require('fs');
+var rimraf = require('rimraf');
 const PNG = require('pngjs').PNG;
 const pixelmatch = require('pixelmatch');
 const stories = require('./stories');
@@ -43,12 +44,19 @@ module.exports = {
                 if (!fs.existsSync(`${currentDir}/${type}`)) {
                     fs.mkdirSync(`${currentDir}/${type}`);
                 }
+
+                if (fs.existsSync(`${baselineDir}/${type}/userDataDir`)) {
+                    rimraf.sync(`${baselineDir}/${type}/userDataDir`);
+                }
+                fs.mkdirSync(`${baselineDir}/${type}/userDataDir`);
             });
 
             after((done) => polyserve.close(done));
 
             beforeEach(async function() {
-                browser = await puppeteer.launch();
+                browser = await puppeteer.launch({
+                    userDataDir: `${baselineDir}/${type}/userDataDir`,
+                });
                 page = await browser.newPage();
             });
 


### PR DESCRIPTION
## Description
Speed up visual tests by using cacheing... who knew?

## Motivation and Context
Faster feedback, better code!

## How Has This Been Tested?
Ran the CI a couple of times and regularly rated >2 minutes _faster_ that before 🎉 You're better off not questioning my statistical process here...

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/69744397-16536580-110e-11ea-946b-e588c4fc30f3.png)


## Types of changes
- [x] CI

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
