### PR TITLE
ci: publish docs when merging to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,6 @@ workflows:
                   filters:
                       branches:
                           only:
-                              - master_disabled # change this to `master` once we are ready to publish
+                              - master
                   requires:
                       - build


### PR DESCRIPTION
## Description
Let's publish the documentation on a regular basis! How's every time we merge to master?

## Related Issue
fixes #77 

## Motivation and Context
Up-to-date docs are great.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
