### PR TITLE
docs: use headers for accessibility

### DIFF
--- a/documentation/src/components/component.ts
+++ b/documentation/src/components/component.ts
@@ -71,11 +71,11 @@ class ComponentElement extends LayoutElement {
             result = html`
                 <article class="spectrum-Typography">
                     <div id="title-header" class="spectrum-Article">
-                        <p
+                        <h1
                             class="spectrum-Heading1--display spectrum-Heading1--quiet"
                         >
                             ${this.componentName}
-                        </p>
+                        </h1>
                     </div>
                     ${hasAPIdocs
                         ? html`

--- a/documentation/src/components/home.ts
+++ b/documentation/src/components/home.ts
@@ -37,9 +37,9 @@ class HomeElement extends LayoutElement {
             <hr class="spectrum-Rule spectrum-Rule--large" />
             <section id="features">
                 <div class="feature">
-                    <p class="spectrum-Heading spectrum-Heading--pageTitle">
+                    <h2 class="spectrum-Heading spectrum-Heading--pageTitle">
                         Standards Based
-                    </p>
+                    </h2>
                     <p class="spectrum-Body3">
                         <a
                             class="spectrum-Link"
@@ -53,9 +53,9 @@ class HomeElement extends LayoutElement {
                     </p>
                 </div>
                 <div class="feature">
-                    <p class="spectrum-Heading spectrum-Heading--pageTitle">
+                    <h2 class="spectrum-Heading spectrum-Heading--pageTitle">
                         Light Weight
-                    </p>
+                    </h2>
                     <p class="spectrum-Body3">
                         The Spectrum Web Components are implemented using the
                         <a
@@ -69,9 +69,9 @@ class HomeElement extends LayoutElement {
                     </p>
                 </div>
                 <div class="feature">
-                    <p class="spectrum-Heading spectrum-Heading--pageTitle">
+                    <h2 class="spectrum-Heading spectrum-Heading--pageTitle">
                         Framework Agnostic
-                    </p>
+                    </h2>
                     <p class="spectrum-Body3">
                         Because Web Components are supported and encapsulated at
                         the browser level, you can use them with any framework.
@@ -79,9 +79,9 @@ class HomeElement extends LayoutElement {
                 </div>
             </section>
             <section id="example">
-                <p class="spectrum-Heading spectrum-Heading--pageTitle">
+                <h2 class="spectrum-Heading spectrum-Heading--pageTitle">
                     Example
-                </p>
+                </h2>
                 <code-example class="language-html">
                     &lt;sp-button variant='cta'&gt;Click Here&lt;/sp-button&gt;
                 </code-example>


### PR DESCRIPTION
## Description
Use headers more consistently.

## Related Issue
fixes #330

## Motivation and Context
Things should be accessible.

## How Has This Been Tested?
Visual comparison between current site and updates.

## Screenshots (if appropriate):
![localhost_8080_](https://user-images.githubusercontent.com/1156657/69765317-65ff5480-1141-11ea-94b4-4df9c581f83f.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
