### PR TITLE
docs: update to support responsive documentation delivery

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8" />
         <title>Spectrum Web Components</title>
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+        />
         <base href="/" />
 
         <!-- For Adobe Clean font support -->

--- a/documentation/src/components/home.css
+++ b/documentation/src/components/home.css
@@ -26,20 +26,47 @@ governing permissions and limitations under the License.
 #features {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 .feature {
-    flex: 1 1 33%;
-    padding: 0 20px 20px 20px;
+    flex: 0 1 calc(33.33% - 30px);
+    padding: 0 0 20px;
     box-sizing: border-box;
 }
 
-.feature:first-of-type {
-    padding-left: 0;
+@media screen and (max-width: 1100px) {
+    .feature {
+        flex: 0 1 calc(50% - 30px);
+    }
+    .feature:first-of-type {
+        flex-basis: 100%;
+    }
 }
 
-.feature:last-of-type {
-    padding-right: 0;
+@media screen and (max-width: 960px) {
+    .feature {
+        flex: 0 1 calc(33.33% - 30px);
+    }
+    .feature:first-of-type {
+        flex: 0 1 calc(33.33% - 30px);
+    }
+}
+
+@media screen and (max-width: 725px) {
+    .feature {
+        flex: 0 1 calc(50% - 30px);
+    }
+    .feature:first-of-type {
+        flex-basis: 100%;
+    }
+}
+
+@media screen and (max-width: 525px) {
+    .feature {
+        flex: 0 1 100%;
+    }
 }
 
 #example {

--- a/documentation/src/components/layout.css
+++ b/documentation/src/components/layout.css
@@ -30,7 +30,6 @@ governing permissions and limitations under the License.
     flex: 1 1 auto;
     padding-bottom: 40px;
     height: 100%;
-    background-color: var(--spectrum-global-color-gray-100);
     color: var(--spectrum-global-color-gray-800);
 }
 
@@ -44,7 +43,27 @@ governing permissions and limitations under the License.
 
 #body #layout-content #page {
     padding: 40px 52px 24px 52px;
-    max-width: 1080px;
+    max-width: 960px;
     margin-left: auto;
     margin-right: auto;
+}
+
+header {
+    height: 48px;
+    border-bottom: 1px solid var(--spectrum-global-color-gray-200);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: var(--spectrum-global-color-gray-50);
+    top: 0px;
+    right: 0px;
+    left: 0px;
+    padding-left: 8px;
+    z-index: 10;
+}
+
+@media screen and (min-width: 961px) {
+    header {
+        display: none;
+    }
 }

--- a/documentation/src/components/layout.ts
+++ b/documentation/src/components/layout.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, CSSResultArray } from 'lit-element';
+import { html, CSSResultArray, property } from 'lit-element';
 import './side-nav';
 import layoutStyles from './layout.css';
 import { RouteComponent } from './route-component';
@@ -18,6 +18,13 @@ import { RouteComponent } from './route-component';
 export class LayoutElement extends RouteComponent {
     public static get styles(): CSSResultArray {
         return [layoutStyles];
+    }
+
+    @property({ type: Boolean })
+    public open = false;
+
+    toggleNav() {
+        this.open = !this.open;
     }
 
     renderContent() {
@@ -29,13 +36,61 @@ export class LayoutElement extends RouteComponent {
     render() {
         return html`
             <sp-theme color="light" scale="medium" id="app">
+                <header>
+                    <sp-action-button
+                        quiet
+                        aria-label="Open Navigation"
+                        @click=${this.toggleNav}
+                    >
+                        <svg
+                            slot="icon"
+                            viewBox="0 0 36 36"
+                            focusable="false"
+                            aria-hidden="true"
+                            role="img"
+                            width="18"
+                            height="18"
+                            fill="currentColor"
+                        >
+                            <rect
+                                height="4"
+                                rx="1"
+                                ry="1"
+                                width="28"
+                                x="4"
+                                y="16"
+                            ></rect>
+                            <rect
+                                height="4"
+                                rx="1"
+                                ry="1"
+                                width="28"
+                                x="4"
+                                y="6"
+                            ></rect>
+                            <rect
+                                height="4"
+                                rx="1"
+                                ry="1"
+                                width="28"
+                                x="4"
+                                y="26"
+                            ></rect>
+                        </svg>
+                    </sp-action-button>
+                </header>
                 <div id="body">
-                    <docs-side-nav id="side-nav"></docs-side-nav>
-                    <div id="layout-content">
+                    <docs-side-nav
+                        id="side-nav"
+                        ?inert=${!this.open}
+                        ?open=${this.open}
+                        @close=${this.toggleNav}
+                    ></docs-side-nav>
+                    <main id="layout-content" ?inert=${this.open} role="main">
                         <div id="page">
                             ${this.renderContent()}
                         </div>
-                    </div>
+                    </main>
                 </div>
             </sp-theme>
         `;

--- a/documentation/src/components/side-nav.css
+++ b/documentation/src/components/side-nav.css
@@ -11,11 +11,47 @@ governing permissions and limitations under the License.
 */
 
 :host {
-    display: flex;
-    flex-direction: column;
-    max-height: 100vh;
-    overflow: auto;
-    position: relative;
+    background-color: var(--spectrum-global-color-gray-100);
+}
+
+@media screen and (max-width: 960px) {
+    aside {
+        display: flex;
+        flex-direction: column;
+        max-height: 100vh;
+        overflow: auto;
+        position: fixed;
+        top: 0;
+        left: 0;
+        transition: transform var(--spectrum-global-animation-duration-200)
+            ease-in-out;
+        transform: translateX(-100%);
+        z-index: 1;
+        background: inherit;
+    }
+
+    :host([open]) aside {
+        transform: translateX(0);
+    }
+
+    .scrim {
+        position: fixed;
+        background-color: var(--spectrum-alias-background-color-modal-overlay);
+        top: 0;
+        left: 0;
+        width: 100vw;
+        height: 100vh;
+        pointer-events: none;
+        z-index: 1;
+        opacity: 0;
+        transition: opacity var(--spectrum-global-animation-duration-200)
+            ease-in 0ms;
+    }
+
+    :host([open]) .scrim {
+        pointer-events: all;
+        opacity: 1;
+    }
 }
 
 #nav-header {

--- a/documentation/src/components/side-nav.ts
+++ b/documentation/src/components/side-nav.ts
@@ -9,7 +9,13 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { LitElement, html, CSSResultArray } from 'lit-element';
+import {
+    LitElement,
+    html,
+    CSSResultArray,
+    property,
+    PropertyValues,
+} from 'lit-element';
 import { ComponentDocs } from '../../components';
 import { AppRouter } from '../router';
 import { SidenavSelectDetail } from '../../../packages/sidenav';
@@ -20,6 +26,9 @@ class SideNav extends LitElement {
     public static get styles(): CSSResultArray {
         return [sideNavStyles];
     }
+
+    @property({ type: Boolean, reflect: true })
+    public open = false;
 
     private get components(): string[] {
         return Array.from(ComponentDocs.keys());
@@ -43,52 +52,65 @@ class SideNav extends LitElement {
         this.handleSelect(event, 'guides');
     }
 
+    public toggle() {
+        this.open = !this.open;
+    }
+
     render() {
         return html`
-            <div id="nav-header">
-                <div id="logo-container">
-                    <a href="#">
-                        <docs-spectrum-logo></docs-spectrum-logo>
-                        <div id="header-title">
-                            Spectrum
-                            <br />
-                            Web Components
-                        </div>
-                    </a>
+            <div class="scrim" @click=${this.toggle}></div>
+            <aside>
+                <div id="nav-header">
+                    <div id="logo-container">
+                        <a href="#">
+                            <docs-spectrum-logo></docs-spectrum-logo>
+                            <div id="header-title">
+                                Spectrum
+                                <br />
+                                Web Components
+                            </div>
+                        </a>
+                    </div>
                 </div>
-            </div>
-            <div id="navigation">
-                <sp-sidenav variant="multilevel">
-                    <sp-sidenav-item
-                        label="Components"
-                        @sidenav-select=${this.handleComponentSelect}
-                    >
-                        ${this.components.map(
-                            (name) =>
-                                html`
-                                    <sp-sidenav-item
-                                        value="${name}"
-                                        label="${name}"
-                                    ></sp-sidenav-item>
-                                `
-                        )}
-                    </sp-sidenav-item>
-                    <sp-sidenav-item
-                        label="Contributing"
-                        @sidenav-select=${this.handleGuideSelect}
-                    >
+                <div id="navigation">
+                    <sp-sidenav variant="multilevel">
                         <sp-sidenav-item
-                            value="adding-component"
-                            label="Adding Components"
-                        ></sp-sidenav-item>
+                            label="Components"
+                            @sidenav-select=${this.handleComponentSelect}
+                        >
+                            ${this.components.map(
+                                (name) =>
+                                    html`
+                                        <sp-sidenav-item
+                                            value="${name}"
+                                            label="${name}"
+                                        ></sp-sidenav-item>
+                                    `
+                            )}
+                        </sp-sidenav-item>
                         <sp-sidenav-item
-                            value="spectrum-config"
-                            label="Spectrum Config Reference"
-                        ></sp-sidenav-item>
-                    </sp-sidenav-item>
-                </sp-sidenav>
-            </div>
+                            label="Contributing"
+                            @sidenav-select=${this.handleGuideSelect}
+                        >
+                            <sp-sidenav-item
+                                value="adding-component"
+                                label="Adding Components"
+                            ></sp-sidenav-item>
+                            <sp-sidenav-item
+                                value="spectrum-config"
+                                label="Spectrum Config Reference"
+                            ></sp-sidenav-item>
+                        </sp-sidenav-item>
+                    </sp-sidenav>
+                </div>
+            </aside>
         `;
+    }
+
+    updated(changes: PropertyValues) {
+        if (changes.has('open') && !this.open && changes.get('open')) {
+            this.dispatchEvent(new Event('close'));
+        }
     }
 }
 customElements.define('docs-side-nav', SideNav);


### PR DESCRIPTION
## Description
Introduce mobile delivery of the documentation site.
- add collapsable left-hand drawer
- add a header with toggle button
- update the main content area to switch column breakdown by available space.

## Motivation and Context
Make this more accessible on mobile

## How Has This Been Tested?
Visually

## Screenshots (if appropriate):
![localhost_8081_](https://user-images.githubusercontent.com/1156657/69965422-3d30e380-14e2-11ea-9dc9-eb7f51a3cae1.png)


## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
