### PR TITLE
Tab selection focus on focusable components

### DIFF
--- a/packages/button/src/action-button.ts
+++ b/packages/button/src/action-button.ts
@@ -25,6 +25,6 @@ export class ActionButton extends ButtonBase {
     public holdAffordance = false;
 
     public static get styles(): CSSResultArray {
-        return [buttonStyles];
+        return [...super.styles, buttonStyles];
     }
 }

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -21,14 +21,10 @@ governing permissions and limitations under the License.
     flex: 1 1 auto;
 
     /* spectrum-css uses "-webkit-appearance: button" to workaround an
-     * iOS and Safari issue. However, it results in incorrect styling 
+     * iOS and Safari issue. However, it results in incorrect styling
      * when applied in :host
      */
     -webkit-appearance: none;
-}
-
-:host([disabled]) {
-    pointer-events: none;
 }
 
 slot[name='icon']::slotted(svg) {

--- a/packages/button/src/button-base.ts
+++ b/packages/button/src/button-base.ts
@@ -10,12 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { property, html, TemplateResult } from 'lit-element';
+import { property, html, TemplateResult, CSSResultArray } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { Focusable } from '@spectrum-web-components/shared/lib/focusable.js';
 import { ObserveSlotText } from '@spectrum-web-components/shared/lib/observe-slot-text';
 
 export class ButtonBase extends ObserveSlotText(Focusable) {
+    public static get styles(): CSSResultArray {
+        return [...super.styles];
+    }
+
     /**
      * Supplies an address that the browser will navigate to when this button is
      * clicked

--- a/packages/button/src/button.ts
+++ b/packages/button/src/button.ts
@@ -43,6 +43,6 @@ export class Button extends ButtonBase {
     public quiet = false;
 
     public static get styles(): CSSResultArray {
-        return [buttonStyles];
+        return [...super.styles, buttonStyles];
     }
 }

--- a/packages/button/src/clear-button.ts
+++ b/packages/button/src/clear-button.ts
@@ -17,7 +17,7 @@ import crossMediumStyles from '@spectrum-web-components/icon/lib/spectrum-icon-c
 
 export class ClearButton extends ButtonBase {
     public static get styles(): CSSResultArray {
-        return [buttonStyles, crossMediumStyles];
+        return [...super.styles, buttonStyles, crossMediumStyles];
     }
 
     /**

--- a/packages/dropdown/src/dropdown.ts
+++ b/packages/dropdown/src/dropdown.ts
@@ -45,6 +45,7 @@ import '@spectrum-web-components/popover';
 export class Dropdown extends Focusable {
     public static get styles(): CSSResultArray {
         return [
+            ...super.styles,
             actionButtonStyles,
             fieldButtonStyles,
             dropdownStyles,

--- a/packages/shared/src/focusable.css
+++ b/packages/shared/src/focusable.css
@@ -10,6 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-:host([disabled]) {
+:host {
     pointer-events: none;
+}
+
+:host(:not([disabled])) > * {
+    pointer-events: all;
 }


### PR DESCRIPTION
## Description
Removing selected outline on focusable components (checkbox, button, dropdown) when clicking on components.

## Related Issue
[#318](https://github.com/adobe/spectrum-web-components/issues/318)

## Motivation and Context
Clicking on components should select the component and not show tab focus.

## How Has This Been Tested?
Manual interaction in storybook.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/32367695/70672836-4da93280-1c35-11ea-8714-33642fdb3623.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
