### PR TITLE
Tooltip/Overlay Updates

### DIFF
--- a/packages/overlay-root/src/active-overlay.ts
+++ b/packages/overlay-root/src/active-overlay.ts
@@ -137,6 +137,7 @@ export class ActiveOverlay extends LitElement {
     public offset = 6;
     private position?: PositionResult;
     public interaction: TriggerInteractions = 'hover';
+    private positionAnimationFrame = 0;
 
     private timeout?: number;
     private hiddenDeferred?: Deferred<void>;
@@ -254,8 +255,8 @@ export class ActiveOverlay extends LitElement {
             positionOptions.crossOffset
         );
 
-        this.style.setProperty('top', `${this.position.positionTop}px`);
         this.style.setProperty('left', `${this.position.positionLeft}px`);
+        this.style.setProperty('top', `${this.position.positionTop}px`);
     }
 
     public async hide(): Promise<void> {
@@ -271,14 +272,21 @@ export class ActiveOverlay extends LitElement {
         }
     };
 
-    private onSlotChange(): void {
+    private schedulePositionUpdate(): void {
         // Edge needs a little time to update the DOM before computing the layout
-        requestAnimationFrame(() => this.updateOverlayPosition());
+        cancelAnimationFrame(this.positionAnimationFrame);
+        this.positionAnimationFrame = requestAnimationFrame(() =>
+            this.updateOverlayPosition()
+        );
+    }
+
+    private onSlotChange(): void {
+        this.schedulePositionUpdate();
     }
 
     public connectedCallback(): void {
         super.connectedCallback();
-        this.updateOverlayPosition();
+        this.schedulePositionUpdate();
     }
 
     public render(): TemplateResult {

--- a/packages/overlay-root/stories/overlay-root.stories.ts
+++ b/packages/overlay-root/stories/overlay-root.stories.ts
@@ -257,4 +257,84 @@ storiesOf('Overlay Root', module)
                 <recursive-popover></recursive-popover>
             </overlay-root>
         `;
+    })
+    .add('Edges', () => {
+        return html`
+            <style>
+                overlay-root {
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 100vw;
+                    height: 100vh;
+                }
+                overlay-trigger {
+                    position: absolute;
+                }
+                .top-right {
+                    top: 0;
+                    right: 0;
+                }
+                .bottom-right {
+                    bottom: 0;
+                    right: 0;
+                }
+                .bottom-left {
+                    bottom: 0;
+                    left: 0;
+                }
+            </style>
+            <overlay-root>
+                <overlay-trigger class="top-left" placement="bottom">
+                    <sp-button slot="trigger">
+                        Top/
+                        <br />
+                        Right
+                    </sp-button>
+                    <sp-tooltip
+                        slot="hover-content"
+                        delay="100"
+                        open
+                        tip="bottom"
+                    >
+                        Triskaidekaphobia and More
+                    </sp-tooltip>
+                </overlay-trigger>
+                <overlay-trigger class="top-right" placement="bottom">
+                    <sp-button slot="trigger">
+                        Top/
+                        <br />
+                        Right
+                    </sp-button>
+                    <sp-tooltip
+                        slot="hover-content"
+                        delay="100"
+                        open
+                        tip="bottom"
+                    >
+                        Triskaidekaphobia and More
+                    </sp-tooltip>
+                </overlay-trigger>
+                <overlay-trigger class="bottom-left" placement="top">
+                    <sp-button slot="trigger">
+                        Bottom/
+                        <br />
+                        Left
+                    </sp-button>
+                    <sp-tooltip slot="hover-content" delay="100" open tip="top">
+                        Triskaidekaphobia and More
+                    </sp-tooltip>
+                </overlay-trigger>
+                <overlay-trigger class="bottom-right" placement="top">
+                    <sp-button slot="trigger">
+                        Bottom/
+                        <br />
+                        Right
+                    </sp-button>
+                    <sp-tooltip slot="hover-content" delay="100" open tip="top">
+                        Triskaidekaphobia and More
+                    </sp-tooltip>
+                </overlay-trigger>
+            </overlay-root>
+        `;
     });


### PR DESCRIPTION
## Description
- update `active-overlay` to position itself after the RAF _always_ so that it is measured after styles are applied and that it's not placed twice where it can cancel the mouse over event and hide errantly.

## Motivation and Context
Delivery UI fidelity and hover interactions as expected.

## How Has This Been Tested?
Manually in Storybook, see below...

## Screenshots (if appropriate):
### After
![image](https://user-images.githubusercontent.com/1156657/70804591-dda9c200-1d84-11ea-8358-5c14dae76425.png)
### Before
![image](https://user-images.githubusercontent.com/1156657/70804879-9243e380-1d85-11ea-8c90-d95bafc84d07.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
