### PR TITLE
Fix for Radio Button Group breaks when radio value is an integer Issue #364

### DIFF
--- a/packages/radio-group/src/radio-group.ts
+++ b/packages/radio-group/src/radio-group.ts
@@ -43,7 +43,7 @@ export class RadioGroup extends LitElement {
 
     public set selected(value: string) {
         const radio = value
-            ? (this.querySelector(`sp-radio[value=${value}]`) as Radio)
+            ? (this.querySelector(`sp-radio[value="${value}"]`) as Radio)
             : undefined;
 
         this.deselectChecked();

--- a/packages/radio-group/test/radio-group.test.ts
+++ b/packages/radio-group/test/radio-group.test.ts
@@ -64,6 +64,12 @@ describe('Radio Group', () => {
                         <sp-radio value="first" checked>Option 1</sp-radio>
                         <sp-radio value="second">Option 2</sp-radio>
                     </sp-radio-group>
+                    <sp-radio-group
+                        id="test-integer-value"
+                        selected="5">
+                        <sp-radio value="5" checked>Option 5</sp-radio>
+                        <sp-radio value="7">Option 7</sp-radio>
+                    </sp-radio-group>
                 </div>
             `
         );
@@ -240,5 +246,12 @@ describe('Radio Group', () => {
         expect(radioGroup.selected).to.equal('second');
         expect(radio1.checked).to.be.false;
         expect(radio2.checked).to.be.true;
+    });
+
+    it('handles integer values for radio buttons', () => {
+        const radioGroup = testDiv.querySelector(
+            'sp-radio-group#test-integer-value'
+        ) as RadioGroup;
+        expect(radioGroup.selected).to.equal('5');
     });
 });


### PR DESCRIPTION
https://github.com/adobe/spectrum-web-components/issues/364

I've tested this fix by extending the Radio-Group component in my project, and don't see anything bad. However, in this pull request, I'm not testing because I don't have the local environment set up

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Simply wrapped the offending selector in quotes.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Radio Button Group breaks when radio value is an integer Issue #364
https://github.com/adobe/spectrum-web-components/issues/364

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Radio Button Groups could not contain radio buttons with a value of type integer previously. The Radio Group, when set selected would throw an error due to query selection

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Have not tested this fix at all, other than extending Radio Button Group on my project to patch this issue temporarily

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
