### PR TITLE
feat(slider): adds getAriaValueText property, fixes #381

### DIFF
--- a/__snapshots__/Slider.md
+++ b/__snapshots__/Slider.md
@@ -5,12 +5,9 @@
 ```html
 <div id="labelContainer">
     <label for="input" id="label"></label>
-    <div
-        aria-labelledby="label"
-        aria-readonly="true"
-        id="value"
-        role="textbox"
-    ></div>
+    <div aria-labelledby="label" aria-readonly="true" id="value" role="textbox">
+        10
+    </div>
 </div>
 <div id="controls">
     <div
@@ -25,7 +22,8 @@
             aria-label=""
             aria-valuemax="20"
             aria-valuemin="0"
-            aria-valuetext=""
+            aria-valuenow="10"
+            aria-valuetext="10"
             id="input"
             max="20"
             min="0"
@@ -48,12 +46,9 @@
 ```html
 <div id="labelContainer">
     <label for="input" id="label"></label>
-    <div
-        aria-labelledby="label"
-        aria-readonly="true"
-        id="value"
-        role="textbox"
-    ></div>
+    <div aria-labelledby="label" aria-readonly="true" id="value" role="textbox">
+        10
+    </div>
 </div>
 <div id="controls">
     <div class="track"></div>
@@ -63,7 +58,8 @@
             aria-label=""
             aria-valuemax="20"
             aria-valuemin="0"
-            aria-valuetext=""
+            aria-valuenow="10"
+            aria-valuetext="10"
             id="input"
             max="20"
             min="0"
@@ -1104,6 +1100,7 @@
             aria-label=""
             aria-valuemax="100"
             aria-valuemin="-100"
+            aria-valuenow="0"
             aria-valuetext="0"
             id="input"
             max="100"

--- a/__snapshots__/Slider.md
+++ b/__snapshots__/Slider.md
@@ -5,9 +5,12 @@
 ```html
 <div id="labelContainer">
     <label for="input" id="label"></label>
-    <div aria-labelledby="label" aria-readonly="true" id="value" role="textbox">
-        10
-    </div>
+    <div
+        aria-labelledby="label"
+        aria-readonly="true"
+        id="value"
+        role="textbox"
+    ></div>
 </div>
 <div id="controls">
     <div
@@ -22,7 +25,7 @@
             aria-label=""
             aria-valuemax="20"
             aria-valuemin="0"
-            aria-valuetext="10"
+            aria-valuetext=""
             id="input"
             max="20"
             min="0"
@@ -45,9 +48,12 @@
 ```html
 <div id="labelContainer">
     <label for="input" id="label"></label>
-    <div aria-labelledby="label" aria-readonly="true" id="value" role="textbox">
-        10
-    </div>
+    <div
+        aria-labelledby="label"
+        aria-readonly="true"
+        id="value"
+        role="textbox"
+    ></div>
 </div>
 <div id="controls">
     <div class="track"></div>
@@ -57,7 +63,7 @@
             aria-label=""
             aria-valuemax="20"
             aria-valuemin="0"
-            aria-valuetext="10"
+            aria-valuetext=""
             id="input"
             max="20"
             min="0"

--- a/packages/slider/src/slider.ts
+++ b/packages/slider/src/slider.ts
@@ -46,7 +46,6 @@ export class Slider extends Focusable {
         }
 
         this._value = value;
-        this.ariaValueText = this.getAriaValueText(this._value);
         this.requestUpdate('value', oldValue);
     }
 
@@ -78,8 +77,13 @@ export class Slider extends Focusable {
     @property({ attribute: false })
     public getAriaValueText: (value: number) => string = (value) => `${value}`;
 
-    @property({ reflect: true, attribute: 'aria-valuetext' })
-    private ariaValueText = '';
+    @property({ attribute: false })
+    private get ariaValueText(): string {
+        if (!this.getAriaValueText) {
+            return `${this.value}`;
+        }
+        return this.getAriaValueText(this.value);
+    }
 
     @property()
     public label = '';
@@ -254,6 +258,7 @@ export class Slider extends Focusable {
                     max="${this.max}"
                     aria-disabled=${this.disabled ? 'true' : 'false'}
                     aria-label=${this.ariaLabel || this.label}
+                    aria-valuenow=${this.value}
                     aria-valuemin=${this.min}
                     aria-valuemax=${this.max}
                     aria-valuetext=${this.ariaValueText}

--- a/packages/slider/src/slider.ts
+++ b/packages/slider/src/slider.ts
@@ -46,6 +46,7 @@ export class Slider extends Focusable {
         }
 
         this._value = value;
+        this.ariaValueText = this.getAriaValueText(this._value);
         this.requestUpdate('value', oldValue);
     }
 
@@ -73,6 +74,12 @@ export class Slider extends Focusable {
 
     /* Ensure that a '' value for `variant` removes the attribute instead of a blank value */
     private _variant = '';
+
+    @property({ attribute: false })
+    public getAriaValueText: (value: number) => string = (value) => `${value}`;
+
+    @property({ reflect: true, attribute: 'aria-valuetext' })
+    private ariaValueText = '';
 
     @property()
     public label = '';
@@ -145,7 +152,7 @@ export class Slider extends Focusable {
                     aria-readonly="true"
                     aria-labelledby="label"
                 >
-                    ${this.value}
+                    ${this.ariaValueText}
                 </div>
             </div>
         `;
@@ -249,7 +256,7 @@ export class Slider extends Focusable {
                     aria-label=${this.ariaLabel || this.label}
                     aria-valuemin=${this.min}
                     aria-valuemax=${this.max}
-                    aria-valuetext=${this.value}
+                    aria-valuetext=${this.ariaValueText}
                     @change=${this.onInputChange}
                     @focus=${this.onInputFocus}
                     @blur=${this.onInputBlur}

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -71,6 +71,22 @@ storiesOf('Slider', module)
             </div>
         `;
     })
+    .add('Value Text', () => {
+        const label = text('Label', 'Percentage');
+        return html`
+            <div style="width: 500px; margin: 20px;">
+                <sp-slider
+                    value="0.5"
+                    step="0.1"
+                    min="0"
+                    max="1"
+                    label="${label}"
+                    .getAriaValueText=${(value: number) =>
+                        `${Math.floor(value * 100)}%`}
+                ></sp-slider>
+            </div>
+        `;
+    })
     .add('Color', () => {
         return html`
             <div style="width: 500px; margin: 20px;">

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -600,11 +600,12 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.getAttribute('aria-valuetext')).to.equal('50%');
+        const input = el.focusElement as HTMLInputElement;
+        expect(input.getAttribute('aria-valuetext')).to.equal('50%');
 
         el.value = 100;
         await elementUpdated(el);
 
-        expect(el.getAttribute('aria-valuetext')).to.equal('100%');
+        expect(input.getAttribute('aria-valuetext')).to.equal('100%');
     });
 });

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -586,4 +586,25 @@ describe('Slider', () => {
         expect(input).to.not.be.undefined;
         expect(input.type).to.equal('range');
     });
+    it('displays result of getAriaValueText', async () => {
+        const el = await fixture<Slider>(
+            html`
+                <sp-slider
+                    value="50"
+                    min="0"
+                    max="100"
+                    .getAriaValueText=${(value: number) => `${value}%`}
+                ></sp-slider>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.getAttribute('aria-valuetext')).to.equal('50%');
+
+        el.value = 100;
+        await elementUpdated(el);
+
+        expect(el.getAttribute('aria-valuetext')).to.equal('100%');
+    });
 });


### PR DESCRIPTION
## Description

Adds a new property `getAriaValueText` which accepts a function converting a value number argument into a string to be displayed.

## Related Issue

#381 

## Motivation and Context

Need to be able to control how the value of the slider is presented, both in aria presentation and in our visual presentation above the slider.

## How Has This Been Tested?

* Unit testing has been updated to test that the aria text value is updated correctly.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/332843/70939501-3edbca80-1ffd-11ea-98de-6e4266b4dc2a.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
