### PR TITLE
fix: for docs, add webcomponent polyfill for Edge

### DIFF
--- a/documentation/webpack.config.js
+++ b/documentation/webpack.config.js
@@ -29,6 +29,11 @@ const litComponentDirectories = [
 
 const openWcConfig = createDefaultConfig({
     input: path.resolve(__dirname, './index.html'),
+    webpackIndexHTMLPlugin: {
+        polyfills: {
+            webcomponents: true, // Needed until Chromium Edge is released
+        },
+    },
 });
 
 const babelLoader = openWcConfig.module.rules.find(


### PR DESCRIPTION

## Description

Include the webcomponents polyfill for Edge (until Edgium is out)

## Related Issue

#376 

## Motivation and Context

It lets us load the site on Edge

## How Has This Been Tested?

Ran docs site locally and looked at it on Edge

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
