### PR TITLE
feat: pass through autocomplete attribute to text inputs

### DIFF
--- a/packages/textfield/src/textfield.ts
+++ b/packages/textfield/src/textfield.ts
@@ -76,6 +76,11 @@ export class Textfield extends Focusable {
     @property({ type: Boolean, reflect: true })
     public required = false;
 
+    @property({ type: String, reflect: true })
+    public autocomplete?:
+        | HTMLInputElement['autocomplete']
+        | HTMLTextAreaElement['autocomplete'];
+
     public get focusElement(): HTMLInputElement | HTMLTextAreaElement {
         return this.inputElement;
     }
@@ -124,6 +129,7 @@ export class Textfield extends Focusable {
                           <div id="sizer">${this.value}</div>
                       `
                     : nothing}
+                <!-- @ts-ignore -->
                 <textarea
                     aria-label=${this.label || this.placeholder}
                     id="input"
@@ -134,11 +140,13 @@ export class Textfield extends Focusable {
                     @input=${this.onInput}
                     ?disabled=${this.disabled}
                     ?required=${this.required}
+                    autocomplete=${ifDefined(this.autocomplete)}
                 ></textarea>
                 ${this.renderStateIcons()}
             `;
         }
         return html`
+            <!-- @ts-ignore -->
             <input
                 aria-label=${this.label || this.placeholder}
                 id="input"
@@ -149,6 +157,7 @@ export class Textfield extends Focusable {
                 @input=${this.onInput}
                 ?disabled=${this.disabled}
                 ?required=${this.required}
+                autocomplete=${ifDefined(this.autocomplete)}
             />
             ${this.renderStateIcons()}
         `;

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -200,4 +200,30 @@ describe('Textfield', () => {
         const testSource = eventSource as Textfield;
         expect(testSource.isSameNode(el)).to.be.true;
     });
+
+    it('passes through `autocomplete` attribute', async () => {
+        let el = await litFixture<Textfield>(
+            html`
+                <sp-textfield autocomplete="off"></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        let input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.getAttribute('autocomplete')).to.equal('off');
+        }
+
+        el = await litFixture<Textfield>(
+            html`
+                <sp-textfield></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.getAttribute('autocomplete')).to.not.exist;
+        }
+    });
 });

--- a/packages/toast/src/toast.ts
+++ b/packages/toast/src/toast.ts
@@ -55,7 +55,6 @@ export class Toast extends LitElement {
     @property({ type: Number })
     public set timeout(timeout: number | null) {
         const hasTimeout = typeof timeout !== null && (timeout as number) > 0;
-        debugger;
         const newTimeout = hasTimeout
             ? Math.max(6000, timeout as number)
             : null;


### PR DESCRIPTION

## Description

For text fields, allow the passing through of the [`autocomplete`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) attribute

## Related Issue

#314 

## Motivation and Context

I need this feature to stop the search field from autocompleting when I am implementing my own autocomplete.

## How Has This Been Tested?

I tested this in my branch where I am adding a search field to the documentation.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
