### PR TITLE
docs: add 404 processing for github pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
         steps:
             - setup
             - run: yarn docs:build
+            - run: cp documentation/404.html documentation/dist/
             - run: git config --global user.email "circleci@adobe.com" && git config --global user.name "CircleCI"
             - run: yarn gh-pages -d documentation/dist -m "[skip ci] update demonstration site"
 

--- a/documentation/404.html
+++ b/documentation/404.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Single Page Apps for GitHub Pages</title>
+        <script type="text/javascript">
+            // Single Page Apps for GitHub Pages
+            // https://github.com/rafrex/spa-github-pages
+            // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+            // ----------------------------------------------------------------------
+            // This script takes the current url and converts the path and query
+            // string into just a query string, and then redirects the browser
+            // to the new url with only a query string and hash fragment,
+            // e.g. http://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+            // http://www.foo.tld/?p=/one/two&q=a=b~and~c=d#qwe
+            // Note: this 404.html file must be at least 512 bytes for it to work
+            // with Internet Explorer (it is currently > 512 bytes)
+
+            // If you're creating a Project Pages site and NOT using a custom domain,
+            // then set segmentCount to 1 (enterprise users may need to set it to > 1).
+            // This way the code will only replace the route part of the path, and not
+            // the real directory in which the app resides, for example:
+            // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+            // https://username.github.io/repo-name/?p=/one/two&q=a=b~and~c=d#qwe
+            // Otherwise, leave segmentCount as 0.
+            var segmentCount = 1;
+
+            var l = window.location;
+            l.replace(
+                l.protocol +
+                    '//' +
+                    l.hostname +
+                    (l.port ? ':' + l.port : '') +
+                    '/' +
+                    l.pathname
+                        .slice(1)
+                        .split('/')
+                        .slice(0, segmentCount)
+                        .join('/') +
+                    '/?p=/' +
+                    l.pathname
+                        .slice(1)
+                        .split('/')
+                        .slice(segmentCount)
+                        .join('/')
+                        .replace(/&/g, '~and~') +
+                    (l.search
+                        ? '&q=' + l.search.slice(1).replace(/&/g, '~and~')
+                        : '') +
+                    l.hash
+            );
+        </script>
+    </head>
+    <body></body>
+</html>


### PR DESCRIPTION
## Description
Add inserting the 404 page into the documentation site into the CircleCI process.

## Related Issue
fixes #357 

## Motivation and Context
The doc site should work from all entry URLs.

## How Has This Been Tested?

Visit: https://opensource.adobe.com/spectrum-web-components/components/dropdown


## Types of changes
- [x] Docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
