### PR TITLE
fix: allow expanding a sidenav item that has no value

### DIFF
--- a/documentation/src/components/side-nav.ts
+++ b/documentation/src/components/side-nav.ts
@@ -73,9 +73,10 @@ class SideNav extends LitElement {
                     </div>
                 </div>
                 <div id="navigation">
-                    <sp-sidenav variant="multilevel">
+                    <sp-sidenav manage-tab-index variant="multilevel">
                         <sp-sidenav-item
                             label="Components"
+                            expanded
                             @sidenav-select=${this.handleComponentSelect}
                         >
                             ${this.components.map(
@@ -90,6 +91,7 @@ class SideNav extends LitElement {
                         </sp-sidenav-item>
                         <sp-sidenav-item
                             label="Contributing"
+                            expanded
                             @sidenav-select=${this.handleGuideSelect}
                         >
                             <sp-sidenav-item

--- a/packages/sidenav/src/sidenav-item.ts
+++ b/packages/sidenav/src/sidenav-item.ts
@@ -91,10 +91,10 @@ export class SideNavItem extends Focusable {
         if (!this.href && event) {
             event.preventDefault();
         }
-        if (this.value && !this.disabled) {
+        if (!this.disabled) {
             if (this.hasChildren) {
                 this.expanded = !this.expanded;
-            } else {
+            } else if (this.value) {
                 const selectDetail: SidenavSelectDetail = {
                     value: this.value,
                 };

--- a/packages/sidenav/test/sidenav-item.test.ts
+++ b/packages/sidenav/test/sidenav-item.test.ts
@@ -49,4 +49,43 @@ describe('Sidenav Item', () => {
 
         expect(selected).to.be.true;
     });
+
+    it('clicking expands a sidenav item with children', async () => {
+        const el = await fixture<SideNavItem>(
+            html`
+                <sp-sidenav-item>
+                    <sp-sidenav-item
+                        value="Section 1"
+                        label="Section 1"
+                    ></sp-sidenav-item>
+                    <sp-sidenav-item
+                        value="Section 2"
+                        label="Section 2"
+                    ></sp-sidenav-item>
+                </sp-sidenav-item>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot).to.exist;
+        if (!el.shadowRoot) return;
+
+        let slot = el.shadowRoot.querySelector('slot');
+        expect(slot).not.to.exist;
+
+        expect(el.expanded).to.be.false;
+
+        el.click();
+
+        await elementUpdated(el);
+
+        expect(el.expanded).to.be.true;
+
+        slot = el.shadowRoot.querySelector('slot');
+        expect(slot).to.exist;
+        if (!slot) return;
+
+        expect(slot.assignedElements().length).to.equal(2);
+    });
 });


### PR DESCRIPTION

## Description

Fix it so that an `sp-sidenav-item` that has no value can be expanded. Also, make the top level sidenav items in the docs expanded by default.

## Related Issue

fixes #410 

## Motivation and Context

We need the docs to be navigable

## How Has This Been Tested?

By running the docs locally.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
