### PR TITLE
test(overlay): clean up coverage for async disparities

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -134,6 +134,7 @@ export class OverlayStack {
         if (overlay) {
             await overlay.hide();
             const index = this.overlays.indexOf(overlay);
+            /* istanbul ignore else */
             if (index >= 0) {
                 this.overlays[index].dispose();
                 this.overlays.splice(index, 1);

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -138,6 +138,43 @@ describe('Overlays', () => {
         expect(isVisible(outerPopover)).to.be.true;
     });
 
+    it('does not open a hover popover when a click popover is open', async () => {
+        const button = testDiv.querySelector('#outer-button') as HTMLElement;
+        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
+        const hoverContent = testDiv.querySelector(
+            '#hover-content'
+        ) as HTMLDivElement;
+
+        expect(isVisible(outerPopover)).to.be.false;
+        expect(isVisible(hoverContent)).to.be.false;
+
+        expect(button).to.exist;
+        button.click();
+
+        // Wait for the DOM node to be stolen and reparented into the overlay
+        await waitForPredicate(
+            () => !(outerPopover.parentElement instanceof OverlayTrigger)
+        );
+
+        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
+            OverlayTrigger
+        );
+        expect(isVisible(outerPopover)).to.be.true;
+        expect(isVisible(hoverContent)).to.be.false;
+
+        button.dispatchEvent(
+            new Event('mouseenter', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+
+        await nextFrame();
+
+        expect(isVisible(outerPopover)).to.be.true;
+        expect(isVisible(hoverContent)).to.be.false;
+    });
+
     it('does not open a popover when [disabled]', async () => {
         const trigger = testDiv.querySelector('#trigger') as OverlayTrigger;
         const root = trigger.shadowRoot ? trigger.shadowRoot : trigger;


### PR DESCRIPTION
## Description
CircleCI ran into some non-deterministic test coverage results:

https://app.circleci.com/jobs/github/adobe/spectrum-web-components/1874/parallel-runs/0/steps/0-108
![image](https://user-images.githubusercontent.com/1156657/71913805-41d26280-3146-11ea-987e-9defe164c36c.png)

https://app.circleci.com/jobs/github/adobe/spectrum-web-components/1873/parallel-runs/0/steps/0-110
![image](https://user-images.githubusercontent.com/1156657/71913829-4d258e00-3146-11ea-8768-88dbf450dedb.png)

I tracked the root to:
![image](https://user-images.githubusercontent.com/1156657/71913936-7e9e5980-3146-11ea-84b6-56017f68526f.png)

The line in question is part of some `async` activity leading me to believe there's an unload timing issue at play, so I've ignored that line for coverage and added another test while I was there.

## Motivation and Context
Coverage results should be predictable

## How Has This Been Tested?
CI

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/71914010-a68dbd00-3146-11ea-9d0b-c13724513c74.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
