### PR TITLE
ci: persist build assets to workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
                       - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
             - run:
                   name: Installing Dependencies
-                  command: yarn install
+                  command: yarn install --ignore-scripts
             - save_cache:
                   paths:
                       - node_modules
@@ -31,6 +31,9 @@ jobs:
         steps:
             - setup
             - run:
+                  name: Get Ready
+                  command: yarn get-ready
+            - run:
                   name: Lint
                   command: yarn lint
             - run: yarn analyze
@@ -44,19 +47,18 @@ jobs:
                   name: Generate Docs
                   command: yarn docs:ci
 
-            - save_cache:
+            - persist_to_workspace:
+                  root: ~/
                   paths:
-                      - documentation/dist/storybook
-                  key: v1-dependencies-{{ arch }}-{{ .Revision }}
+                      - project/documentation/dist
 
     visual-testing:
         executor: node8
 
         steps:
             - setup
-            - restore_cache:
-                  keys:
-                      - v1-dependencies-{{ arch }}-{{ .Revision }}
+            - attach_workspace:
+                  at: ~/
             - run: yarn test:visual:ci
             - store_artifacts:
                   path: test/visual/screenshots-current
@@ -66,7 +68,8 @@ jobs:
 
         steps:
             - setup
-            - run: yarn docs:build
+            - attach_workspace:
+                  at: ~/
             - run: cp documentation/404.html documentation/dist/
             - run: git config --global user.email "circleci@adobe.com" && git config --global user.name "CircleCI"
             - run: yarn gh-pages -d documentation/dist -m "[skip ci] update demonstration site"


### PR DESCRIPTION
## Description 
Make CI faster by leveraging workspace caching

## Motivation and Context
The CI should be faster!

## How Has This Been Tested?
The following screen shot shows a build that started a minute later than the previous build and made it through the docs publish process about 3.5 minutes faster 😱 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/71920701-5b2edb00-3155-11ea-9ae3-eaf36b2d80f4.png)

## Types of changes
- [x] Tooling

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
