### PR TITLE
fix(shared): prevent focusing focusable root on second click

### DIFF
--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -90,6 +90,9 @@ export class Focusable extends FocusVisiblePolyfillMixin(LitElement) {
     }
 
     protected manageFocusIn(): void {
+        this.addEventListener('mousedown', (event) => {
+            event.preventDefault();
+        });
         this.addEventListener('focusin', (event) => {
             if (event.composedPath()[0] === this) {
                 this.handleFocus();

--- a/packages/tab-list/src/tab-list.ts
+++ b/packages/tab-list/src/tab-list.ts
@@ -110,11 +110,15 @@ export class TabList extends Focusable {
         }
     }
 
+    private isListeningToKeyboard = false;
+
     public startListeningToKeyboard = (): void => {
         this.addEventListener('keydown', this.handleKeydown);
+        this.isListeningToKeyboard = true;
     };
 
     public stopListeningToKeyboard = (): void => {
+        this.isListeningToKeyboard = false;
         this.removeEventListener('keydown', this.handleKeydown);
     };
 
@@ -136,6 +140,15 @@ export class TabList extends Focusable {
     private onClick(event: Event): void {
         const target = event.target as HTMLElement;
         this.selectTarget(target);
+        if (this.isListeningToKeyboard) {
+            /* Trick :focus-visible polyfill into thinking keyboard based focus */
+            this.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    code: 'Tab',
+                })
+            );
+            target.focus();
+        }
     }
 
     private onKeyDown(event: KeyboardEvent): void {


### PR DESCRIPTION
## Description
The fix herein roughly follows the suggestion in https://github.com/adobe/spectrum-web-components/issues/318#issuecomment-566861628 except it uses `mousedown` rather than `click` because on further investigation the `focus` state starts that early in the interaction 😱 

It feels like a bit of a hack, which I guess it is being the `Focusable` base class is a workaround for not having `delegates-focus` functionality x-browser. If it feels like too much of a hack, I'm happy to review further.

The associated `tab-list` update isn't explicitly related, but I ran into it while confirming this fix. As such, I can break it out if anyone is worried about cleanliness or what not.

## Related Issue
fixes #318 maybe?

## Motivation and Context
Focusing the things is the path to them being accessible.

## How Has This Been Tested?
Manually. Focus and the shadow DOM is hard to test... 😢 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
