### PR TITLE
fix(link): apply workaround for specificity mangling

### DIFF
--- a/packages/link/src/link.css
+++ b/packages/link/src/link.css
@@ -15,3 +15,16 @@ governing permissions and limitations under the License.
 :host {
     display: inline;
 }
+
+/*
+Current processing of Spectrum CSS turns `.spectrum-Link.focus-ring` into `a:focus-visible` and _then_
+`.spectrum-Link--overBackground` into `:host([over-background]) a` inverting the specificty relationship.
+Until we find a non-spot fix, this manual extension of the selector specificity will be required.
+*/
+:host([over-background]) a:focus-visible,
+:host([quiet]) a:focus-visible {
+    /* .spectrum-Link.focus-ring */
+    text-decoration: underline;
+    -webkit-text-decoration-style: double;
+    text-decoration-style: double; /* .spectrum-Link.focus-ring */
+}


### PR DESCRIPTION
## Description
Add a workaround to apply the right specificity to link styling until a more robust processor for Spectrum CSS can be imagined.

## Related Issue
refs #123 

## Motivation and Context
Style adherence

## How Has This Been Tested?
Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
