### PR TITLE
Expand theme support, display options in Storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -23,7 +23,6 @@
         box-sizing: border-box;
         width: 100vw;
         height: 100vh;
-        /* Switch back to CSS Custom Property after #391 */
-        background-color: rgb(245, 245, 245);
+        background-color: var(--spectrum-global-color-gray-100);
     }
 </style>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -36,7 +36,7 @@ async function run() {
         const scale = select('Scale', scaleOptions, defaultScale, 'Theme');
         defaultScale = scale;
         return html`
-            <sp-theme id="root-theme" color=${color} size=${scale}>
+            <sp-theme id="root-theme" color=${color} scale=${scale}>
                 ${story()}
             </sp-theme>
         `;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,6 +6,7 @@ import {
     withKnobs,
     withWebComponentsKnobs,
     html,
+    select,
 } from '@open-wc/demoing-storybook';
 import '@spectrum-web-components/theme';
 
@@ -18,13 +19,28 @@ async function run() {
     addDecorator(withA11y);
     addDecorator(withKnobs);
     addDecorator(withWebComponentsKnobs);
-    addDecorator(
-        (story) => html`
-            <sp-theme id="root-theme" color="light" scale="medium">
+    const colorOptions = {
+        Lightest: 'lightest',
+        Light: 'light',
+        Dark: 'dark',
+    };
+    let defaultColor = colorOptions.Light;
+    const scaleOptions = {
+        Medium: 'medium',
+        Large: 'large',
+    };
+    let defaultScale = scaleOptions.Medium;
+    addDecorator((story) => {
+        const color = select('Color', colorOptions, defaultColor, 'Theme');
+        defaultColor = color;
+        const scale = select('Scale', scaleOptions, defaultScale, 'Theme');
+        defaultScale = scale;
+        return html`
+            <sp-theme id="root-theme" color=${color} size=${scale}>
                 ${story()}
             </sp-theme>
-        `
-    );
+        `;
+    });
 
     addParameters({
         a11y: {

--- a/packages/overlay/src/active-overlay.ts
+++ b/packages/overlay/src/active-overlay.ts
@@ -16,7 +16,7 @@ import {
     TriggerInteractions,
 } from './overlay.js';
 import calculatePosition, { PositionResult } from './calculate-position.js';
-import { Size, Color } from '@spectrum-web-components/theme';
+import { Scale, Color } from '@spectrum-web-components/theme';
 import {
     html,
     LitElement,
@@ -139,10 +139,10 @@ export class ActiveOverlay extends LitElement {
     @property({ attribute: false })
     public color?: Color;
     @property({ attribute: false })
-    public size?: Size;
+    public scale?: Scale;
 
     private get hasTheme(): boolean {
-        return !!this.color || !!this.size;
+        return !!this.color || !!this.scale;
     }
 
     public offset = 6;
@@ -185,7 +185,7 @@ export class ActiveOverlay extends LitElement {
         this.offset = event.detail.offset;
         this.interaction = event.detail.interaction;
         this.color = event.detail.theme.color;
-        this.size = event.detail.theme.size;
+        this.scale = event.detail.theme.scale;
     }
 
     public dispose(): void {
@@ -312,9 +312,9 @@ export class ActiveOverlay extends LitElement {
     public renderTheme(content: TemplateResult): TemplateResult {
         import('@spectrum-web-components/theme');
         const color = this.color as Color;
-        const size = this.size as Size;
+        const scale = this.scale as Scale;
         return html`
-            <sp-theme .color=${color} .size=${size}>
+            <sp-theme .color=${color} .scale=${scale}>
                 ${content}
             </sp-theme>
         `;

--- a/packages/overlay/src/overlay-trigger.ts
+++ b/packages/overlay/src/overlay-trigger.ts
@@ -75,7 +75,7 @@ export class OverlayTrigger extends LitElement {
 
         const queryThemeDetail: ThemeData = {
             color: undefined,
-            size: undefined,
+            scale: undefined,
         };
         const queryThemeEvent = new CustomEvent<ThemeData>('query-theme', {
             bubbles: true,

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -15,6 +15,7 @@ import './theme-dark.js';
 import './theme-light.js';
 import './theme-lightest.js';
 import './scale-medium.js';
+import './scale-large.js';
 import { Theme } from './theme.js';
 
 /* istanbul ignore else */

--- a/packages/theme/src/scale-large.css
+++ b/packages/theme/src/scale-large.css
@@ -10,4 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import '@spectrum-web-components/styles/theme-light.css';
+@import '@spectrum-web-components/styles/scale-large.css';

--- a/packages/theme/src/scale-large.ts
+++ b/packages/theme/src/scale-large.ts
@@ -10,4 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import '@spectrum-web-components/styles/theme-light.css';
+import largeStyles from './scale-large.css.js';
+import { Theme } from './theme';
+
+Theme.registerThemeFragment('large', 'size', largeStyles);

--- a/packages/theme/src/scale-large.ts
+++ b/packages/theme/src/scale-large.ts
@@ -13,4 +13,4 @@ governing permissions and limitations under the License.
 import largeStyles from './scale-large.css.js';
 import { Theme } from './theme';
 
-Theme.registerThemeFragment('large', 'size', largeStyles);
+Theme.registerThemeFragment('large', 'scale', largeStyles);

--- a/packages/theme/src/scale-medium.css
+++ b/packages/theme/src/scale-medium.css
@@ -11,7 +11,3 @@ governing permissions and limitations under the License.
 */
 
 @import '@spectrum-web-components/styles/scale-medium.css';
-
-:host {
-    display: block;
-}

--- a/packages/theme/src/scale-medium.ts
+++ b/packages/theme/src/scale-medium.ts
@@ -13,4 +13,4 @@ governing permissions and limitations under the License.
 import mediumStyles from './scale-medium.css.js';
 import { Theme } from './theme';
 
-Theme.registerThemeFragment('medium', 'size', mediumStyles);
+Theme.registerThemeFragment('medium', 'scale', mediumStyles);

--- a/packages/theme/src/theme-dark.css
+++ b/packages/theme/src/theme-dark.css
@@ -11,7 +11,3 @@ governing permissions and limitations under the License.
 */
 
 @import '@spectrum-web-components/styles/theme-dark.css';
-
-:host {
-    display: block;
-}

--- a/packages/theme/src/theme-lightest.css
+++ b/packages/theme/src/theme-lightest.css
@@ -11,7 +11,3 @@ governing permissions and limitations under the License.
 */
 
 @import '@spectrum-web-components/styles/theme-lightest.css';
-
-:host {
-    display: block;
-}

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -14,7 +14,7 @@ import coreStyles from './theme.css';
 import { CSSResult, supportsAdoptingStyleSheets } from 'lit-element';
 
 export const DefaultColor = 'light';
-export const DefaultSize = 'medium';
+export const DefaultScale = 'medium';
 
 declare global {
     interface Window {
@@ -39,15 +39,15 @@ declare global {
     }
 }
 
-type FragmentType = 'color' | 'size' | 'core';
+type FragmentType = 'color' | 'scale' | 'core';
 type FragmentMap = Map<string, { kind: FragmentType; styles: CSSResult }>;
 export type Color = 'light' | 'lightest' | 'dark' | 'darkest';
-export type Size = 'medium' | 'large';
-type FragmentName = Color | Size | 'core';
+export type Scale = 'medium' | 'large';
+type FragmentName = Color | Scale | 'core';
 
 export interface ThemeData {
     color?: Color;
-    size?: Size;
+    scale?: Scale;
 }
 
 export class Theme extends HTMLElement {
@@ -61,7 +61,7 @@ export class Theme extends HTMLElement {
     private static templateElement?: HTMLTemplateElement;
 
     static get observedAttributes(): string[] {
-        return ['color', 'size'];
+        return ['color', 'scale'];
     }
 
     get color(): Color {
@@ -79,26 +79,26 @@ export class Theme extends HTMLElement {
         this.setAttribute('color', newValue);
     }
 
-    get size(): Size {
-        const size = this.getAttribute('size');
-        if (!size) return DefaultSize;
+    get scale(): Scale {
+        const scale = this.getAttribute('scale');
+        if (!scale) return DefaultScale;
 
-        const sizeFragment = Theme.themeFragments.get(size);
-        if (sizeFragment && sizeFragment.kind === 'size') {
-            return size as Size;
+        const scaleFragment = Theme.themeFragments.get(scale);
+        if (scaleFragment && scaleFragment.kind === 'scale') {
+            return scale as Scale;
         }
-        return DefaultSize;
+        return DefaultScale;
     }
 
-    set size(newValue: Size) {
-        this.setAttribute('size', newValue);
+    set scale(newValue: Scale) {
+        this.setAttribute('scale', newValue);
     }
 
     private get styles(): CSSResult[] {
         return [
             coreStyles,
             Theme.themeFragment(this.color).styles,
-            Theme.themeFragment(this.size).styles,
+            Theme.themeFragment(this.scale).styles,
         ];
     }
 
@@ -129,7 +129,7 @@ export class Theme extends HTMLElement {
         event.preventDefault();
         const { detail: theme } = event;
         theme.color = this.color;
-        theme.size = this.size;
+        theme.scale = this.scale;
     }
 
     protected connectedCallback(): void {

--- a/packages/theme/test/themes.test.ts
+++ b/packages/theme/test/themes.test.ts
@@ -72,7 +72,7 @@ describe('Medium', () => {
     it('loads', async () => {
         const el = await fixture<Theme>(
             html`
-                <sp-theme size="medium"></sp-theme>
+                <sp-theme scale="medium"></sp-theme>
             `
         );
 
@@ -97,9 +97,9 @@ describe('Setting attributes', () => {
         expect(el).shadowDom.to.equalSnapshot();
 
         el.color = 'dark';
-        el.size = 'medium';
+        el.scale = 'medium';
         expect(el.getAttribute('color')).to.equal('dark');
-        expect(el.getAttribute('size')).to.equal('medium');
+        expect(el.getAttribute('scale')).to.equal('medium');
 
         // Invalid value
         el.setAttribute('color', 'fish');


### PR DESCRIPTION
## Description
- Adds support for `scale=large` in `sp-theme`
- Add support for `theme` knobs system wide in Storybook

## Related Issue
fixes #432 

## Motivation and Context
We're currently using a local instance of the `large` theme in our application, but everyone should be able to use it, too!

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):
### Medium
![image](https://user-images.githubusercontent.com/1156657/72459178-34495800-3798-11ea-80f4-4882aa8522f1.png)

### Large
![image](https://user-images.githubusercontent.com/1156657/72459164-2a275980-3798-11ea-8db1-07d5a38f837f.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
