### PR TITLE
fix(action-menu): spectrum adherence update

### DIFF
--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -51,7 +51,7 @@ The visible label that is be provided via the default `<slot>` interface can be 
 <!-- prettier-ignore -->
 ```html
 <sp-action-menu label="More Actions">
-    <sp-menu slot="options">
+    <sp-menu slot="options" style="min-width: 125px">
         <sp-menu-item>
             Deselect
         </sp-menu-item>

--- a/packages/action-menu/src/action-menu.css
+++ b/packages/action-menu/src/action-menu.css
@@ -15,8 +15,15 @@ governing permissions and limitations under the License.
 }
 
 .icon {
+    /* Sizing for .icon is needed because we are using a raw <svg> due to https://github.com/adobe/spectrum-web-components/issues/155 */
     width: 18px;
     height: 18px;
+
+    /**
+     * Because .icon is acting as default content for its slot, the `::slotted([slot="icon"])` styles do not apply.
+     * In the future it may be necessary to add a default content selector to the style processing code.
+     */
+    flex-shrink: 0;
 }
 
 #popover {

--- a/packages/action-menu/src/action-menu.ts
+++ b/packages/action-menu/src/action-menu.ts
@@ -17,14 +17,14 @@ import {
     PropertyValues,
     html,
 } from 'lit-element';
-import { Dropdown } from '@spectrum-web-components/dropdown';
+import { DropdownBase } from '@spectrum-web-components/dropdown';
 import { ObserveSlotText } from '@spectrum-web-components/shared/lib/observe-slot-text';
 import actionMenuStyles from './action-menu.css.js';
 
 /**
  * @slot options - The menu with options that will display when the dropdown is open
  */
-export class ActionMenu extends ObserveSlotText(Dropdown) {
+export class ActionMenu extends ObserveSlotText(DropdownBase) {
     public static get styles(): CSSResultArray {
         return [...super.styles, actionMenuStyles];
     }
@@ -51,6 +51,7 @@ export class ActionMenu extends ObserveSlotText(Dropdown) {
                         class="icon"
                         focusable="false"
                         aria-hidden="true"
+                        fill="currentColor"
                     >
                         <circle cx="17.8" cy="18.2" r="3.4"></circle>
                         <circle cx="29.5" cy="18.2" r="3.4"></circle>

--- a/packages/dropdown/src/dropdown.ts
+++ b/packages/dropdown/src/dropdown.ts
@@ -42,12 +42,11 @@ import '@spectrum-web-components/popover';
  * @slot default - The placeholder content for the dropdown
  * @slot options - The menu with options that will display when the dropdown is open
  */
-export class Dropdown extends Focusable {
+export class DropdownBase extends Focusable {
     public static get styles(): CSSResultArray {
         return [
             ...super.styles,
             actionButtonStyles,
-            fieldButtonStyles,
             dropdownStyles,
             alertSmallStyles,
             chevronDownMediumStyles,
@@ -294,5 +293,11 @@ export class Dropdown extends Focusable {
                 this.optionsMenu.focus();
             });
         }
+    }
+}
+
+export class Dropdown extends DropdownBase {
+    public static get styles(): CSSResultArray {
+        return [...super.styles, fieldButtonStyles];
     }
 }


### PR DESCRIPTION
## Description
Responding to design feedback from Spectrum team.

Ensure the `action-button` inside of `action-menu` doesn't apply `field-button` styles.

## Motivation and Context
Spectrum specification adherence.

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/72583495-7bc50680-38b4-11ea-816c-f1b71f09e9a9.png)

## Types of changes
- [x] Visual Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
