### PR TITLE
[DO NOT MERGE!] [RFC] fix(slider): request for comment on gradient backgrounds

### DIFF
--- a/packages/slider/src/gradients.ts
+++ b/packages/slider/src/gradients.ts
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+export type SliderColorListEntry = {
+    value: string;
+    stop: number;
+};
+
+export type SliderColorList = (SliderColorListEntry | string)[];
+
+export const sliderStyleStringFromColors = (
+    colors: SliderColorList
+): string | undefined => {
+    if (colors.length === 0) {
+        return undefined;
+    } else if (colors.length === 1) {
+        return `--spectrum-slider-track-color: var(${colors[0]});`;
+    }
+    let style = '';
+    if (typeof colors[0] === 'string') {
+        const distribution = 1 / (colors.length - 1);
+        style = `--spectrum-slider-fill-track-color: linear-gradient(
+                  to right,
+                  ${(colors as string[])
+                      .map(
+                          (color, i) =>
+                              `${color} calc(var(--swc-gadient-slider-width) * ${i *
+                                  distribution})`
+                      )
+                      .join(',')}
+              );
+              --spectrum-slider-track-color: linear-gradient(
+                  to left,
+                  ${(colors as SliderColorListEntry[])
+                      .map(
+                          (color, i) =>
+                              `${color} calc(var(--swc-gadient-slider-width) * ${1 -
+                                  i * distribution})`
+                      )
+                      .reverse()
+                      .join(',')}
+              );`;
+    } else {
+        style = `--spectrum-slider-fill-track-color: linear-gradient(
+                  to right,
+                  ${(colors as SliderColorListEntry[])
+                      .map(
+                          (color) =>
+                              `${color.value} calc(var(--swc-gadient-slider-width) * ${color.stop})`
+                      )
+                      .join(',')}
+              );
+              --spectrum-slider-track-color: linear-gradient(
+                  to left,
+                  ${(colors as SliderColorListEntry[])
+                      .map(
+                          (color) =>
+                              `${
+                                  color.value
+                              } calc(var(--swc-gadient-slider-width) * ${1 -
+                                  color.stop})`
+                      )
+                      .reverse()
+                      .join(',')}
+              );`;
+    }
+    return style;
+};

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -21,6 +21,7 @@ import { ifDefined } from 'lit-html/directives/if-defined';
 
 import '../';
 import { variants, Slider } from '../';
+import { sliderStyleStringFromColors } from '../lib/gradients.js';
 import { TemplateResult } from 'lit-html';
 
 export default {
@@ -169,5 +170,25 @@ export const focusTabDemo = (): TemplateResult => {
                 id="opacity-slider-saturation"
             ></sp-slider>
         </div>
+    `;
+};
+
+export const gradientBackground = (): TemplateResult => {
+    return html`
+        <style>
+            #gradient {
+                --swc-gadient-slider-width: 300px;
+                width: var(--swc-gadient-slider-width);
+            }
+        </style>
+        <sp-slider
+            id="gradient"
+            min="0"
+            max="100"
+            value="20"
+            label="Gradient Slider"
+            variant="filled"
+            style=${sliderStyleStringFromColors(['red', 'green'])}
+        ></sp-slider>
     `;
 };


### PR DESCRIPTION
This is possibly what it would look like to ship gradient background support as a helper file for `sp-slider`.

Pros:
- shippable
- flexible
   - even colors with no stop info
   - colors with specific stop info

Cons:
- currently in HTML vs CSS
- `css` wouldn't be able to support the internal usage of looping, etc.
- leverages `variant=filled`, which is a bit weird.

Alternatives:
- A similar algorithm could be achieved in SASS, but then it's in SASS 😞 
- Spectrum CSS could revisit style application
- this could be baked into `sp-slider` or a class extension
   - could look like `<sp-slider trackGradientLeft="#00FF00" trackGradientRight="#FF0000" />`, etc.

Tell me more!