### PR TITLE
fix(slider): simplify application of the gradient backgrounds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v2-golden-images-d79a43f1c33fd53928ac1767521d4350daffd96e-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
+                      - v2-golden-images-76e51ef79b854a5531a0b65bb2a104a74792d983-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
                       - v2-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
             - run:

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -172,7 +172,7 @@ export class Slider extends Focusable {
             <div
                 class="track"
                 id="track-left"
-                style=${this.trackLeftStyle}
+                style=${this.trackStartClipPath}
                 role="presentation"
             ></div>
         `;
@@ -186,7 +186,7 @@ export class Slider extends Focusable {
             <div
                 class="track"
                 id="track-right"
-                style=${this.trackRightStyle}
+                style=${this.trackEndClipPath}
                 role="presentation"
             ></div>
         `;
@@ -274,16 +274,14 @@ export class Slider extends Focusable {
 
     private renderTrack(): TemplateResult {
         return html`
-            <div id="controls"
+            <div
+                id="controls"
                 @pointerdown=${this.onTrackPointerDown}
                 @mousedown=${this.onTrackMouseDown}
             >
-                ${this.renderTrackLeft()}
-                ${this.renderRamp()}
-                ${this.renderTicks()}
-                ${this.renderHandle()}
+                ${this.renderTrackLeft()} ${this.renderRamp()}
+                ${this.renderTicks()} ${this.renderHandle()}
                 ${this.renderTrackRight()}
-                </div>
             </div>
         `;
     }
@@ -478,18 +476,62 @@ export class Slider extends Focusable {
         return progress / range;
     }
 
-    private get trackLeftStyle(): string {
-        return `width: ${this.trackProgress * 100}%`;
+    private get trackStartClipPath(): string {
+        return this.isLTR ? this.trackLeftClipPath : this.trackRightClipPath;
     }
 
-    private get trackRightStyle(): string {
-        const width = `width: ${(1 - this.trackProgress) * 100}%;`;
-        const halfHandleWidth = `var(--spectrum-slider-handle-width, var(--spectrum-global-dimension-size-200)) / 2`;
-        const offset = `${this.isLTR ? 'left' : 'right'}: calc(${
-            this.trackProgress * 100
-        }% + ${halfHandleWidth})`;
+    private get trackEndClipPath(): string {
+        return this.isLTR ? this.trackRightClipPath : this.trackLeftClipPath;
+    }
 
-        return width + offset;
+    /**
+     * The track that appears on the left, regardless of text direction.
+     */
+    private get trackLeftClipPath(): string {
+        const movingX = `calc(
+            ${
+                this.isLTR
+                    ? this.trackProgress * 100
+                    : 100 - this.trackProgress * 100
+            }% -
+            var(
+                --spectrum-slider-handle-gap,
+                var(
+                    --spectrum-alias-border-size-thicker
+                )
+            )
+        )`;
+        return `clip-path: polygon(
+            0 0,
+            ${movingX} 0,
+            ${movingX} 100%,
+            0 100%
+        );`;
+    }
+
+    /**
+     * The track that appears on the right, regardless of text direction.
+     */
+    private get trackRightClipPath(): string {
+        const movingX = `calc(
+            ${
+                this.isLTR
+                    ? this.trackProgress * 100
+                    : 100 - this.trackProgress * 100
+            }% +
+            var(
+                --spectrum-slider-handle-gap,
+                var(
+                    --spectrum-alias-border-size-thicker
+                )
+            )
+        )`;
+        return `clip-path: polygon(
+            ${movingX} 0,
+            100% 0,
+            100% 100%,
+            ${movingX} 100%
+        );`;
     }
 
     private get handleStyle(): string {

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -21,6 +21,10 @@ governing permissions and limitations under the License.
     outline-width: 0;
 }
 
+.track {
+    width: 100%;
+}
+
 /* 
  * Placeholder gradient for color variant with alpha on. In the long run, the gradient
  * should be produced programatically 

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -39,6 +39,28 @@ export const Default = (): TemplateResult => {
     `;
 };
 
+export const Gradient = (): TemplateResult => {
+    const handleEvent = (event: Event): void => {
+        const target = event.target as Slider;
+        action(event.type)(target.value);
+    };
+    return html`
+        <div
+            style="width: 500px; margin: 12px 20px;--spectrum-slider-track-color:linear-gradient(to right, red, green 100%);"
+        >
+            <sp-slider
+                label="Opacity"
+                max="100"
+                min="0"
+                value="50"
+                id="opacity-slider"
+                @input=${handleEvent}
+                @change=${handleEvent}
+            ></sp-slider>
+        </div>
+    `;
+};
+
 export const Disabled = (): TemplateResult => {
     const label = text('Label', 'Intensity');
     return html`

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -164,6 +164,7 @@ module.exports = [
     'sidenav--levels-and-disabled',
     'sidenav--hrefs',
     'slider--default',
+    'slider--gradient',
     'slider--disabled',
     'slider--color',
     'slider--color-with-alpha',


### PR DESCRIPTION
## Description
Simplify the application of gradients by addressing `#track-left` and `#track-right` more uniformly and applying a `clip-path` rather than enforcing width via `left` and `right` properties.

## Related Issue
fixes #455 

## Motivation and Context
*Pros*
- requires only one deviation from Spectrum CSS `width: 100%`, which should be both easy to convince the application of and resilient to upstream change if not.
- much simpler
- doesn't rely on `variant=filled` so that you can have a fill and a gradient and that the addition of `fill-start` at a later date should be unblocked

*Cons*
- needs checking in Edge/IE 11 as `clip-path` is listed as "only supporting `url()`" in those browsers depending on which Can I Use you rely on: https://caniuse.com/#search=clip-path

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/73124767-35833d80-3f6d-11ea-9c68-fdd8322905dd.png)


## Types of changes
- [x] refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
