### PR TITLE
docs: make Spectrum design updates to docs site

### DIFF
--- a/documentation/src/components/code-example.css
+++ b/documentation/src/components/code-example.css
@@ -15,14 +15,15 @@ governing permissions and limitations under the License.
     margin: 1rem -4px 2rem -4px;
     flex-direction: column;
     border-radius: 6px;
-    border: 1px solid var(--spectrum-alias-border-color-mid);
-    box-shadow: 0 0 18px var(--spectrum-alias-dropshadow-color);
+    border: 1px solid var(--spectrum-global-color-gray-100);
+    width: 100%;
 }
 
 #demo {
     flex: 1;
     padding: 3rem 4rem;
     border-radius: 6px 6px 0 0;
+    background: var(--spectrum-global-color-gray-100);
 }
 
 #markup {
@@ -30,8 +31,8 @@ governing permissions and limitations under the License.
     max-width: 100%;
     padding: 0.75rem 1.5rem;
     border-radius: 0 0 6px 6px;
-    border-top: 1px solid var(--spectrum-alias-border-color-mid);
-    background: var(--spectrum-global-color-gray-50);
+    border-top: 1px solid var(--spectrum-global-color-gray-100);
+    background: var(--spectrum-global-color-gray-75);
     overflow: hidden;
     line-height: 1.3em;
     overflow-x: auto;

--- a/documentation/src/components/component.ts
+++ b/documentation/src/components/component.ts
@@ -63,7 +63,7 @@ function buildTable(
     cells: ((property: JsDocTagParsed) => TemplateResult)[]
 ): TemplateResult {
     return html`
-        <h2 class="spectrum-Heading2--quiet">${title}</h2>
+        <h2 class="spectrum-Heading3">${title}</h2>
         <table class="spectrum-Table">
             <thead class="spectrum-Table-head">
                 <tr>

--- a/documentation/src/components/home.css
+++ b/documentation/src/components/home.css
@@ -20,7 +20,6 @@ governing permissions and limitations under the License.
 
 #hero-buttons {
     margin-top: 1em;
-    text-align: center;
 }
 
 #features {
@@ -73,6 +72,6 @@ governing permissions and limitations under the License.
     margin-top: 2em;
 }
 
-code-example {
-    max-width: 500px;
+.spectrum-Heading4 {
+    margin-bottom: 16px;
 }

--- a/documentation/src/components/home.ts
+++ b/documentation/src/components/home.ts
@@ -13,31 +13,29 @@ class HomeElement extends LayoutElement {
             <section id="hero">
                 <div class="spectrum-Article">
                     <h1 class="spectrum-Heading1--display">
-                        Meet Spectrum Web Components
+                        Spectrum Web Components
                     </h1>
                 </div>
                 <p class="spectrum-Body3">
                     The Spectrum Web Components project is an implementation of
-                    Adobe's
                     <sp-link href="https://spectrum.adobe.com/">
-                        Spectrum design system
+                        Spectrum, Adobe’s design system
                     </sp-link>
-                    that is designed to work with any web framework, or even
+                    . It's designed to work with any web framework — or even
                     without one.
                 </p>
                 <div id="hero-buttons">
                     <sp-button
                         href="https://github.com/adobe/spectrum-web-components"
-                        variant="secondary"
+                        variant="primary"
                     >
-                        Github
+                        View on GitHub
                     </sp-button>
                 </div>
             </section>
-            <hr class="spectrum-Rule spectrum-Rule--large" />
             <section id="features">
                 <div class="feature">
-                    <h2 class="spectrum-Heading spectrum-Heading--pageTitle">
+                    <h2 class="spectrum-Heading4">
                         Standards Based
                     </h2>
                     <p class="spectrum-Body3">
@@ -46,42 +44,43 @@ class HomeElement extends LayoutElement {
                         >
                             Web Components
                         </sp-link>
-                        are set of technologies that work together to allow you
-                        create custom elements that work just like the standard
-                        HTML elements that are built into your browser.
+                        are a set of technologies that work together, letting
+                        you create custom elements that work just like the
+                        standard HTML elements built into your browser.
                     </p>
                 </div>
                 <div class="feature">
-                    <h2 class="spectrum-Heading spectrum-Heading--pageTitle">
+                    <h2 class="spectrum-Heading4">
                         Light Weight
                     </h2>
                     <p class="spectrum-Body3">
-                        The Spectrum Web Components are implemented using the
+                        Spectrum Web Components are implemented using the
                         <sp-link
                             href="https://lit-element.polymer-project.org/"
                         >
                             LitElement
                         </sp-link>
-                        base class. LitElement is designed for creating Web
-                        Components with a minimum amount of overhead.
+                        base class. LitElement is designed for creating web
+                        components with a minimum amount of overhead.
                     </p>
                 </div>
                 <div class="feature">
-                    <h2 class="spectrum-Heading spectrum-Heading--pageTitle">
+                    <h2 class="spectrum-Heading4">
                         Framework Agnostic
                     </h2>
                     <p class="spectrum-Body3">
-                        Because Web Components are supported and encapsulated at
-                        the browser level, you can use them with any framework.
+                        You can use web components with any framework, since
+                        they’re supported and encapsulated at the browser level.
                     </p>
                 </div>
             </section>
             <section id="example">
-                <h2 class="spectrum-Heading spectrum-Heading--pageTitle">
-                    Example
+                <h2 class="spectrum-Heading">
+                    Sample Element Usage
                 </h2>
                 <code-example class="language-html">
-                    &lt;sp-button variant='cta'&gt;Click Here&lt;/sp-button&gt;
+                    &lt;sp-button variant='cta' href='/components/button'&gt;Use
+                    Spectrum Web Component buttons&lt;/sp-button&gt;
                 </code-example>
             </section>
         `;

--- a/documentation/src/components/markdown.css
+++ b/documentation/src/components/markdown.css
@@ -42,3 +42,7 @@ article {
 .spectrum-Table {
     width: 100%;
 }
+
+.spectrum-Table-body {
+    --spectrum-table-row-background-color: var(--spectrum-global-color-gray-75);
+}

--- a/documentation/src/components/side-nav.css
+++ b/documentation/src/components/side-nav.css
@@ -112,3 +112,12 @@ docs-spectrum-logo {
     font-style: normal;
     letter-spacing: 0;
 }
+
+sp-sidenav {
+    width: 100%;
+}
+
+.spectrum-web {
+    margin-top: 80px;
+    display: block;
+}

--- a/documentation/src/components/side-nav.ts
+++ b/documentation/src/components/side-nav.ts
@@ -103,6 +103,11 @@ class SideNav extends LitElement {
                                 label="Spectrum Config Reference"
                             ></sp-sidenav-item>
                         </sp-sidenav-item>
+                        <sp-sidenav-item
+                            class="spectrum-web"
+                            label="Spectrum"
+                            href="https://spectrum.adobe.com/"
+                        ></sp-sidenav-item>
                     </sp-sidenav>
                 </div>
             </aside>

--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An `<sp-action-menu />` is simply an action button with a Popover. Use an `<sp-menu>` element to outline the items that will be made available to the user when interacting with the `sp-action-menu` element.
 
@@ -44,7 +44,7 @@ yarn add @spectrum-web-components/action-menu
 
 ## Variants
 
-### No Visible Label
+### No visible label
 
 The visible label that is be provided via the default `<slot>` interface can be ommitted in preference of an icon only interface. In this context be sure that the `<sp-action-menu>` remains accessible to screen readers by applying the `label` attribute. This will apply an `aria-label` attribute of the same value to the `<botton>` element that toggles the menu list.
 
@@ -75,7 +75,7 @@ The visible label that is be provided via the default `<slot>` interface can be 
 </sp-action-menu>
 ```
 
-### Alternate Icon
+### Alternate icon
 
 A custom icon can be supplied via the `icon` slot in order to replace the default meatballs icon.
 

--- a/packages/actionbar/README.md
+++ b/packages/actionbar/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 A `<sp-actionbar>` delivers a floating action bar that is a convenient way to deliver stateful actions in cases like selection mode. `<sp-actionbar>` can be deployed in two variants beyond the default: `[varient="fixed"]`, to position the element in relation to the page, and `[variant=sticky]`, to position the content in relation to content that may scroll.
 

--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-avatar** is a great way to feature a visual representation of a user.
 

--- a/packages/banner/README.md
+++ b/packages/banner/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-banner** is an additional label an existing component may have. Banners cannot be interacted with. Banners in Spectrum have three variations for different uses as well as the ability to place it overlaid in the top-right corner of a container.
 
@@ -23,7 +23,7 @@ yarn add @spectrum-web-components/banner
 
 ## Variants
 
-### Info Banners
+### Info banners
 
 Banners intended for providing information. This is the default banner variant.
 
@@ -34,7 +34,7 @@ Banners intended for providing information. This is the default banner variant.
 </sp-banner>
 ```
 
-### Warning Banners
+### Warning banners
 
 Banners intended to provided a warning with a brief description. Less severe than an error banner.
 
@@ -45,7 +45,7 @@ Banners intended to provided a warning with a brief description. Less severe tha
 </sp-banner>
 ```
 
-### Error Banners
+### Error banners
 
 Banners intended to indicate an error as occurred, with a brief description of the issue. More severe than a warning banner.
 
@@ -56,7 +56,7 @@ Banners intended to indicate an error as occurred, with a brief description of t
 </sp-banner>
 ```
 
-## Corner Placement
+## Corner placement
 
 In addition to the variant, banners can be placed in the top-right corner of its container by giving them a corner prop. Note that the position of the containing element needs to be either relative or absolute
 

--- a/packages/bundle/README.md
+++ b/packages/bundle/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 `@spectrum-web-components/bundle` is a master dependancy that allows a project to import any and all of the the Spectrum Web Components. While it is a great approach to prototyping, the fact that is versions all of the Spectrum Web Components packages collectively means that depending on it can leave you with a lot of package udpates to manage at any one version change. For a more predicatable upgrade process we suggest that you depend upon individual packages directly, but hope you find this bundle productive when initially trying to get into the act of developing with Spectrum Web Components!
 

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-button** represents an action a user can take. sp-buttons can be clicked
 or tapped to perform an action or to navigate to another page. sp-buttons in
@@ -85,13 +85,13 @@ attribute prevents focus and disallows `click` events.
 <sp-button variant="primary" disabled>Disabled</sp-button>
 ```
 
-## Handling Events
+## Handling events
 
 Events handlers for clicks and other user actions can be registered on a
 `spectrum-button` just as on a normal HTML `button` element.
 
 ```html
-<sp-button onclick="alert('spectrum-button clicked!')">Click me!</sp-button>
+<sp-button onclick="alert('spectrum-button clicked!')">Click me</sp-button>
 ```
 
 ### Autofocus

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-card** represents a rectangular card that contains
 a variety of text and image layouts. Cards are typically used

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 **sp-checkbox** allow users to select multiple items from a list of independent
 options, or to mark an individual option as selected.
@@ -24,7 +24,7 @@ yarn add @spectrum-web-components/checkbox
 <sp-checkbox>Web component</sp-checkbox>
 ```
 
-### Standard Checkboxes
+### Standard checkboxes
 
 Standard checkboxes are the default style for checkboxes. The blue color
 provides a visual prominence that is optimal for forms, settings, lists or grids
@@ -34,7 +34,7 @@ of assets, etc. where the checkboxes need to be noticed.
 <sp-checkbox checked>Web component</sp-checkbox>
 ```
 
-### Quiet Checkboxes
+### Quiet checkboxes
 
 Quiet checkboxes are a secondary style for checkboxes. The gray color provides a
 less prominent style than the standard checkboxes. They are optimal for
@@ -66,7 +66,7 @@ checkbox, and also prevents clicks from activating it.
 <sp-checkbox disabled>Web component</sp-checkbox>
 ```
 
-### Handling Events
+### Handling events
 
 Event handlers for clicks and other user actions can be registered on an `sp-checkbox` just as a normal `<input type="checkbox">` element.
 

--- a/packages/circleloader/README.md
+++ b/packages/circleloader/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An `<sp-circleloader>` shows the progression of a system operation such as downloading, uploading, processing, etc. in a visual way. It can represent determinate or indeterminate progress.
 
@@ -28,7 +28,7 @@ An `<sp-circleloader>` is used to visually show the progression of a system oper
 </div>
 ```
 
-### Over Background
+### Over background
 
 When a loader needs to be placed on top of a colored background, use the over background loader as signified by `[over-background]`. This loader uses a white opaque color no matter the background. Make sure the background offers enough contrast for the loader to be legible.
 

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An `<sp-dropdown />` is an alternative to HTML's `select` element. Use an `<sp-menu>` element to outline the options that will be made available to the user when interacting with the `sp-dropdown` element.
 

--- a/packages/dropzone/README.md
+++ b/packages/dropzone/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 A **sp-dropzone** is an area on the screen into which an object can be dragged and dropped to accomplish a task. For example, a DropZone might be used in an upload workflow to enable the user to simply drop a file from their operating system into the DropZone, which is a more efficient and intuitive action, rather than utilize the standard "Choose File" dialog.
 

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 `<sp-icon>` renders an icon to the page. By default the `name` attribute will pair with separately registered icon sets to deliver the icons. When not present, `<sp-icon>` will subsequently check for its `src` attribute which could populate the icon via an image, and then fallback to any slotted content for an element based icon.
 
@@ -37,7 +37,7 @@ Icons are available in various sizes in Spectrum ranging from `xxs` to `xxl`, `m
 <sp-icon size="xxl" name="ui:Magnifier"></sp-icon>
 ```
 
-## Color Icon
+## Color icon
 
 Icons apply their color as `currentColor` so change the `color` property of the element for customization.
 
@@ -45,7 +45,7 @@ Icons apply their color as `currentColor` so change the `color` property of the 
 <sp-icon name="ui:Magnifier" style="color: red;"></sp-icon>
 ```
 
-## Image Icon
+## Image icon
 
 An image icon can be supplied via the `src` attribute. Remember that you cannot style the contents of an image via CSS, so use graphics that are appropriately prepared for including in your applications design requirements.
 
@@ -80,7 +80,7 @@ An image icon can be supplied via the `src` attribute. Remember that you cannot 
 ></sp-icon>
 ```
 
-## Element Icon
+## Element icon
 
 Icons can also be supplied as HTML elements to be applied via the default `<slot>`.
 

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 The `<sp-icons-medium>` and `<sp-icons-large>` elements that are included in this package supply your application with the Spectrum CSS Icons at both the medium and large sizes for use via the `<sp-icon>` element also provided by the Spectrum Web Components library. Include at least one of these elements in a project that makes use of icons in these sets, but feel free to include these sets in the scope of any element that leverages them as they will be deduplicated as appropriate to ensure all of your components are able to deliver the icons included therein.
 

--- a/packages/iconset/README.md
+++ b/packages/iconset/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 Extend either the `Iconset` or `IconsetSVG` exports of this package to supply your application with a custom icon set to power the use of `<sp-icon>` elements throughout. Give your new icon set a custom name, and you'll be ready to supply them as `<sp-icon name="custom-icons:icon'>` across your application.
 

--- a/packages/illustrated-message/README.md
+++ b/packages/illustrated-message/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-illustrated-message** displays an illustration icon and a message, usually in an empty state or on an error page. It is also used inside a DropZone.
 
@@ -35,7 +35,7 @@ yarn add @spectrum-web-components/illustrated-message
 
 ## Variants
 
-### CTA Variant
+### CTA variant
 
 In this variant, the description text is not italisized.
 

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-link** allow users to navigate to a different location. They can be presented in-line inside a paragraph or as a standalone text.
 
@@ -21,7 +21,7 @@ This is an <sp-link href="#">example link</sp-link>.
 
 ## Variants
 
-### Standard Links
+### Standard links
 
 Standard links can follow any of the character styles defined in Spectrum. Therefore, they can be displayed in various font sizes and weights. Standard links appear blue, in order to stand out from the rest of the text and be recognized as interactive.
 
@@ -30,7 +30,7 @@ Standard links can follow any of the character styles defined in Spectrum. There
 This is a <sp-link href="#">standard link</sp-link>.
 ```
 
-### Quiet Links
+### Quiet links
 
 Quiet links appear with an underline and use the default text color. The subdued appearance is optimal for use in content lower in your application’s hierarchy such as links in a footer.
 
@@ -39,7 +39,7 @@ Quiet links appear with an underline and use the default text color. The subdued
 This is a <sp-link quiet href="#">quiet link</sp-link>.
 ```
 
-### Links Over Backgrounds
+### Links over backgrounds
 
 When a link needs to be placed on top of a colored background or a visual, use the over background link. This link uses a white opaque color instead of a blue color and stands out from the rest of the text with the addition of an underline.
 

--- a/packages/menu-group/README.md
+++ b/packages/menu-group/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An `<sp-menu />` is used for creating a menu list. The various elements inside a menu are given as `<sp-menu-group/>`, `<sp-menu-item />`, or `<sp-menu-divider />`.
 

--- a/packages/menu-item/README.md
+++ b/packages/menu-item/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An `<sp-menu />` is used for creating a menu list. The various elements inside a menu are given as `<sp-menu-group/>`, `<sp-menu-item />`, or `<sp-menu-divider />`.
 
@@ -14,7 +14,7 @@ yarn add @spectrum-web-components/menu-item
 
 ## Variants
 
-### Menu Items
+### Menu items
 
 Menus are a collection of `<sp-menu-items />` that can be modified to be `disabled` or `selected`.
 

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An `<sp-menu />` is used for creating a menu list. The various elements inside a menu are given as `<sp-menu-group/>`, `<sp-menu-item />`, or `<sp-menu-divider />`. Often a `<sp-menu />` element will appear in a `<sp-popover />` element so that it displays as a togglig menu.
 

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 To ensure that content the requires it (modals, menus, etc) can escape overflow rules, the z-index, et al, Spectrum Web Components provides an overlay system that is made up of three interrelated elements, `<overlay-trigger>`, `<active-overlay>`, and `<sp-theme>`. DOM that should be overlaid on _hover_ (`[slot="hover-content"]`) and _click_ (`[slot="click-content"]`) are outlined in the light DOM content of an `<overlay-trigger>`. Said content will be overlayed onto the DOM via an `<active-overlay>` element that will be appended to the `<body>`. Content delivered in this way will acquire CSS Custom Properties for `color` and `size` from the trigger's nearest ancestor `<sp-theme>`.
 

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-popover** is used to display transient content (menus, options, additional actions etc.) and appears when clicking/tapping on a source (tools, buttons, etc.) It stands out via its visual style (stroke and drop shadow) and floats on top of the rest of the interface. This component does not implement the actual overlay behavior and interactions. This is handled in the `Overlay Root` and `Overlay Trigger`.
 
@@ -33,7 +33,7 @@ yarn add @spectrum-web-components/popover
 
 ## Variants
 
-### Default with No Tip
+### Default with no tip
 
 Default popover with no tip and no direction. Popovers will fill up the space of they're containing
 element by default. The default popover has no padding by default
@@ -59,7 +59,7 @@ element by default. The default popover has no padding by default
 </div>
 ```
 
-### Dialog Popovers
+### Dialog popovers
 
 Popovers with padding, ideal for dialogs.
 
@@ -80,7 +80,7 @@ Popovers with padding, ideal for dialogs.
 </div>
 ```
 
-### Popover with Tip
+### Popover with tip
 
 ```html
 <div

--- a/packages/radio-group/README.md
+++ b/packages/radio-group/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 **sp-radio** and **sp-radio-group** allow users to select a single option from a list of mutually exclusive options. All possible options are exposed up front for users to compare.
 
@@ -25,7 +25,7 @@ yarn add @spectrum-web-components/radio-group
 </sp-radio-group>
 ```
 
-### Radio Group Column
+### Radio group column
 
 By default, radio groups are inline and appear vertically. By adding the `column` property to **sp-radio-group**
 the radio buttons will be listed vertically on their own line.

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 **sp-radio** and **sp-radio-group** allow users to select a single option from a list of mutually exclusive options. All possible options are exposed up front for users to compare.
 
@@ -27,7 +27,7 @@ yarn add @spectrum-web-components/radio
 
 ## Variants
 
-### Standard Radio
+### Standard radio
 
 Standard radio buttons are the default style for radio buttons. The blue color provides a visual prominence that is optimal for forms, settings, etc. where the radio buttons need to be noticed.
 
@@ -35,7 +35,7 @@ Standard radio buttons are the default style for radio buttons. The blue color p
 <sp-radio>Standard Radio Button</sp-radio>
 ```
 
-### Quiet Radio
+### Quiet radio
 
 Quiet radio buttons are a secondary style for radio buttons. The gray color provides a
 less prominent style than the standard radioes. They are optimal for
@@ -76,7 +76,7 @@ When the radio button is no longer interactable. The button cannot be checked.
 <sp-radio disabled>Disabled Radio Button</sp-radio>
 ```
 
-### Handling Events
+### Handling events
 
 Event handlers for clicks and other user actions can be registered on an `sp-radio` just as a normal `<input type="radio">` element.
 

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 The `<sp-search />` element delivers a single input field with a "reset" button as well as a mangifying glass icon with which to power search interactions.
 

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,4 +1,6 @@
-## Overview
+## Description
+
+Shared mixins, tools, etc. that support developing Spectrum Web Components.
 
 ### Installation
 

--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 Side navigation allows users to locate information and features within the UI.
 It can be used for either hierarchical or flat navigation, and gives the ability
@@ -58,7 +58,7 @@ yarn add @spectrum-web-components/sidenav
 </sp-sidenav>
 ```
 
-## Multi-Level
+## Multi-level
 
 Use this variation when you have multiple layers of hierarchical navigation. The
 headers are styled differently and possess the same interactive behavior as a

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 **sp-slider** allows users to quickly select a value within a range. They should be used when the upper and lower bounds to the range are invariable.
 
@@ -38,7 +38,7 @@ yarn add @spectrum-web-components/slider
 <sp-slider variant="tick" tick-step="4"></sp-slider>
 ```
 
-#### Tick w/ Labels
+#### Tick w/ labels
 
 ```html
 <sp-slider variant="tick" tick-step="5" tick-labels></sp-slider>

--- a/packages/status-light/README.md
+++ b/packages/status-light/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-status-light** is a great way to convey semantic meaning, such as statuses and categories.
 

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 Spectrum Web Components are a [`LitElement`](https://lit-element.polymer-project.org) powered web component library of patterns built ontop of the [Spectrum CSS](https://opensource.adobe.com/spectrum-css) specification. Styles for these components are made available (and in some cases customizable) via CSS Custom Properties, e.g. `var(--spectrum-global-color-static-black)`. In this package you will find the various CSS Custom Properties that power the various color and size themese defined by Spectrum CSS.
 
@@ -14,7 +14,7 @@ npm install @spectrum-web-components/styles
 yarn add @spectrum-web-components/styles
 ```
 
-## Theme Packages
+## Theme packages
 
 ```
 @import '@spectrum-web-components/styles/all-medium-dark.css';
@@ -52,7 +52,7 @@ This file brings together the globals variables and font settings with the "Ligh
 
 This file brings together the globals variables and font settings with the "Lightest" color set and "Large" scale system specification.
 
-## Color Sets
+## Color sets
 
 ### Dark
 

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-switch** is used to turn an option on or off. Switches allow users to select the state of a single option at a time. Use a switch rather than a checkbox when activating (or deactivating) an option, instead of selecting.
 
@@ -20,7 +20,7 @@ yarn add @spectrum-web-components/switch
 
 ## Variants
 
-### Standard Switches
+### Standard switches
 
 Standard switches are the default style for switches. The blue color provides a
 visual prominence that is optimal for forms, settings, etc. where the switches
@@ -30,7 +30,7 @@ need to be noticed.
 <sp-switch checked>Web component</sp-switch>
 ```
 
-### Quiet Switches
+### Quiet switches
 
 Quiet switches are a secondary style for switches. The gray color provides a
 less prominent style than the standard switches. They are optimal for

--- a/packages/tab-list/README.md
+++ b/packages/tab-list/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 The `<sp-tab-list>` component contains set of tab-item elements. This is typically used as the interface for controlling a set of layered sections of content that display one panel of content at a time
 
@@ -58,7 +58,7 @@ yarn add @spectrum-web-components/tab-list
 </sp-tab-list>
 ```
 
-## With Icons
+## With icons
 
 ```html
 <div>

--- a/packages/tab/README.md
+++ b/packages/tab/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 The `<sp-tab>` component is intended to be the child of an `<sp-tab-list>` element and accepts both a `label` attribute and a `[slot="icon"]` child to define its contents. Those contents can be further customized with the `vertical` attribute which stacks them in the UI rather than listing them in a row.
 
@@ -34,7 +34,7 @@ yarn add @spectrum-web-components/tab
 </sp-tab>
 ```
 
-### Vertical w/ Icon
+### Vertical w/ icon
 
 ```html
 <sp-tab label="Tab 1" value="1" vertical>

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 `sp-textfield` components are text boxes that allow users to input custom text entries with a keyboard. Various decorations can be displayed around the field to communicate the entry requirements.
 

--- a/packages/textfield/textarea.md
+++ b/packages/textfield/textarea.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 `sp-textfield[multiline]` components are text areas that allow users to input custom multiline text entries with a keyboard. Various decorations can be displayed around the field to communicate the entry requirements.
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 An **sp-theme** sets the rendering theme for all child components.
 The Spectrum design system supports four color themes and two different

--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 `sp-toast`s display brief, temporary notifications. They are noticeable but do not disrupt the user experience and do not require an action to be taken.
 
@@ -20,7 +20,7 @@ yarn add @spectrum-web-components/toast
 <sp-toast>This is important information that you should read, soon.</sp-toast>
 ```
 
-### With Actions
+### With actions
 
 ```html
 <sp-toast>

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -1,4 +1,4 @@
-## Overview
+## Description
 
 `sp-tooltip` allow users to get contextual help or information about specific components when hovering or focusing on them.
 


### PR DESCRIPTION
## Description
The Spectrum team has given us some great direction around style adherence for our documentation site, this catches up to ~80% of those recommendations.

## Motivation and Context
We're a part of the Spectrum family.

## Screenshots (if appropriate):
![localhost_8080_components_action-menu_api](https://user-images.githubusercontent.com/1156657/73309520-3ddeb100-41d7-11ea-8cc3-9e9e5036ad31.png)

## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
