### PR TITLE
fix(link): process Spectrum CSS without overwriting specificity

### DIFF
--- a/packages/link/src/spectrum-config-utils.js
+++ b/packages/link/src/spectrum-config-utils.js
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const parser = require('postcss-selector-parser');
+
+// The transform duplicates `:focus-visible` selectors and prepends various
+// component states to prevent specificity being overriden.
+module.exports.mangleSpecificity = (selector) => {
+    const result = selector.clone();
+    let isFocusVisible = false;
+    result.walkPseudos((node) => {
+        if (node.value.match(/focus-visible$/) !== null) {
+            isFocusVisible = true;
+        }
+    });
+    if (isFocusVisible) {
+        const overSelector = parser.selector();
+        const quietSelector = parser.selector();
+        const overResult = result.clone();
+        const quietResult = result.clone();
+        overHost.append(parser.attribute({ attribute: 'over-background' }));
+        quietHost.append(parser.attribute({ attribute: 'quiet' }));
+        overSelector.append(parser.pseudo({ value: ':host' }));
+        quietSelector.append(parser.pseudo({ value: ':host' }));
+        overSelector.append(parser.combinator({ value: ' ' }));
+        quietSelector.append(parser.combinator({ value: ' ' }));
+        overSelector.append(overResult);
+        quietSelector.append(quietResult);
+        result.prepend(parser.combinator({ value: ',' }));
+        result.prepend(overSelector);
+        result.prepend(parser.combinator({ value: ',' }));
+        result.prepend(quietSelector);
+    }
+    return result;
+};

--- a/packages/link/src/spectrum-config.js
+++ b/packages/link/src/spectrum-config.js
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const { mangleSpecificity } = require('./spectrum-config-utils');
+
 module.exports = {
     spectrum: 'link',
     components: [
@@ -31,6 +33,7 @@ module.exports = {
                 },
             ],
             exclude: [/\.is-disabled/, /\.spectrum-Link--subtle/],
+            selectorTransforms: [mangleSpecificity],
         },
     ],
 };

--- a/packages/link/src/spectrum-link.css
+++ b/packages/link/src/spectrum-link.css
@@ -31,7 +31,9 @@ a:hover {
         var(--spectrum-global-color-blue-600)
     );
 }
-a:focus-visible {
+a:focus-visible,
+:host([over-background]) a:focus-visible,
+:host([quiet]) a:focus-visible {
     /* .spectrum-Link.focus-ring */
     text-decoration: underline;
     -webkit-text-decoration-style: double;


### PR DESCRIPTION
## Description
Update the Spectrum Config for the link element to process the CSS without mangling the specificity. I didn't know this was a thing until @cuberoot did it for the [Overlay work](https://github.com/adobe/spectrum-web-components/pull/452/files#diff-326ffef068d4c7c520f1332940a2684d), and I'm not sure if it's really better than #431 or not, but it seems cool.

## Related Issue
fixes #85 
closes #431 

## Motivation and Context
The `focus` states were previously being overwritten.

## How Has This Been Tested?
Manually in storybook.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/73476892-06dbdd00-4348-11ea-9f7a-f3c06b77cbc7.png)
![image](https://user-images.githubusercontent.com/1156657/73476907-0e9b8180-4348-11ea-9d14-973097a09a58.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
