### PR TITLE
fix(shared): fixes search input - fixes #463

### DIFF
--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -91,7 +91,9 @@ export class Focusable extends FocusVisiblePolyfillMixin(LitElement) {
 
     protected manageFocusIn(): void {
         this.addEventListener('mousedown', (event) => {
-            event.preventDefault();
+            if (event.composedPath()[0] !== this.focusElement) {
+                event.preventDefault();
+            }
         });
         this.addEventListener('focusin', (event) => {
             if (event.composedPath()[0] === this) {

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -90,11 +90,6 @@ export class Focusable extends FocusVisiblePolyfillMixin(LitElement) {
     }
 
     protected manageFocusIn(): void {
-        this.addEventListener('mousedown', (event) => {
-            if (event.composedPath()[0] !== this.focusElement) {
-                event.preventDefault();
-            }
-        });
         this.addEventListener('focusin', (event) => {
             if (event.composedPath()[0] === this) {
                 this.handleFocus();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A prior change prevented default mousedown event behavior, this change prevented focusable input elements like search from functioning correctly. This PR fixes this issue by allowing the mousedown event to do its default behavior if the event is targeting the focus element.

## Related Issue

#463 

## Motivation and Context

Search input does not work when clicked today.

## How Has This Been Tested?

Storybook testing.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
