### PR TITLE
fix(overlay): override SpectrumCSS tip rules and process usage in popper

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,6 +10,14 @@ import {
 } from '@open-wc/demoing-storybook';
 import '@spectrum-web-components/theme';
 
+// While https://github.com/open-wc/open-wc/issues/1210 and
+// go https://github.com/popperjs/popper-core/issues/933 persist
+// without an acceptable outcome, this allows the built storybook
+// to function with `process.env.NODE_ENV`... :/
+window.process = window.process || {};
+window.process.env = window.process.env || {};
+window.process.env.NODE_ENV = window.process.env.NODE_ENV || 'production';
+
 async function run() {
     const customElements = await (await fetch(
         new URL('../custom-elements.json', import.meta.url)

--- a/packages/overlay/src/popper-arrow-rotate.ts
+++ b/packages/overlay/src/popper-arrow-rotate.ts
@@ -44,6 +44,8 @@ function computeArrowRotateStylesFn(ref: ModifierArguments<{}>): undefined {
     }
 
     ref.state.styles.arrow.transform += ` rotate(${rotation}deg)`;
+    // Manage Spectrum CSS usage of negative left margin for centering.
+    ref.state.styles.arrow.marginLeft = '0';
 
     return;
 }


### PR DESCRIPTION
## Description
- Reliance on `margin-left` in the Spectrum CSS rules for `#tip` would cause its placement to be slightly off when managed by `popper.js`
- `es-dev-server` isn't used in `storybook-build` so the output JS would error on `process.env`: https://opensource.adobe.com/spectrum-web-components/storybook/?path=/story/overlay--default

After the work in #468 is complete, and possibly in #157, I'd like to revisit how regressions get listed so that we can more easily put "open" states, etc into that pipeline to catch things like this in the future.

## Motivation and Context
Design adherence.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
### Before
![image](https://user-images.githubusercontent.com/1156657/73766480-12fadc80-4744-11ea-9403-a06ff19719ee.png)

### After
![image](https://user-images.githubusercontent.com/1156657/73766512-1ee69e80-4744-11ea-99d2-0873f9b32f97.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
