### PR TITLE
feat(card): Allow slotted html title

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-b9e157e40b4274683707eccf7f8d400ed4c719bc
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-946b082d9ecb0b839efcd8823625f58fe605e584
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/__snapshots__/card.md
+++ b/__snapshots__/card.md
@@ -7,7 +7,9 @@
 <div id="body">
     <div id="header">
         <div id="title">
-            Card Title
+            <slot name="title">
+                Card Title
+            </slot>
         </div>
     </div>
     <div id="content">

--- a/__snapshots__/card.md
+++ b/__snapshots__/card.md
@@ -30,7 +30,9 @@
 <div id="body">
     <div id="header">
         <div id="title">
-            Card Title
+            <slot name="title">
+                Card Title
+            </slot>
         </div>
     </div>
     <div id="content">
@@ -49,7 +51,9 @@
 <div id="body">
     <div id="header">
         <div id="title">
-            Card Title
+            <slot name="title">
+                Card Title
+            </slot>
         </div>
         <div id="subtitle">
             JPG

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -27,7 +27,7 @@ yarn add @spectrum-web-components/card
 
 ## Title
 
-The default application of a title for an `sp-card` is to leverage the `title` attribute. When HTML based title content is desired, the `title` slot is also available for deliverin this content.
+By default, the title for an `sp-card` is applied via the `title` attribute, which is restricted to string content only. When HTML content is desired, a slot named `title` available for applying the title.
 
 ```html demo
 <sp-card subtitle="JPG">

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -25,6 +25,18 @@ yarn add @spectrum-web-components/card
 </sp-card>
 ```
 
+## Title
+
+The default application of a title for an `sp-card` is to leverage the `title` attribute. When HTML based title content is desired, the `title` slot is also available for deliverin this content.
+
+```html demo
+<sp-card subtitle="JPG">
+    <h1 slot="title">Card Title</h1>
+    <img slot="cover-photo" src="https://picsum.photos/200/300" />
+    <div slot="footer">Footer</div>
+</sp-card>
+```
+
 ## Variants
 
 There are multiple card variants to choose from in Spectrum. The `variant`

--- a/packages/card/src/card.ts
+++ b/packages/card/src/card.ts
@@ -22,6 +22,7 @@ import cardStyles from './card.css.js';
 
 /**
  * @slot preview - This is the preview image for Gallery Cards
+ * @slot title - HTML content to be listed as the title
  * @slot cover-photo - This is the cover photo for Default and Quiet Cards
  * @slot description - A description of the card
  * @slot footer - Footer text
@@ -40,12 +41,22 @@ export class Card extends LitElement {
     @property()
     public subtitle = '';
 
+    protected get renderTitle(): TemplateResult {
+        return html`
+            <div id="title">
+                <slot name="title">
+                    ${this.title}
+                </slot>
+            </div>
+        `;
+    }
+
     protected renderGallery(): TemplateResult {
         return html`
             <slot name="preview"></slot>
             <div id="body">
                 <div id="header">
-                    <div id="title">${this.title}</div>
+                    ${this.renderTitle}
                     <div id="subtitle">${this.subtitle}</div>
                     <slot name="description"></slot>
                 </div>
@@ -57,7 +68,9 @@ export class Card extends LitElement {
         return html`
             <slot name="preview"></slot>
             <div id="body">
-                <div id="header"><div id="title">${this.title}</div></div>
+                <div id="header">
+                    ${this.renderTitle}
+                </div>
                 <div id="content">
                     <div id="subtitle">${this.subtitle}</div>
                     <slot name="description"></slot>
@@ -71,7 +84,7 @@ export class Card extends LitElement {
             <slot name="cover-photo" id="cover-photo"></slot>
             <div id="body">
                 <div id="header">
-                    <div id="title">${this.title}</div>
+                    ${this.renderTitle}
                 </div>
                 <div id="content">
                     <div id="subtitle">${this.subtitle}</div>

--- a/packages/card/stories/card.stories.ts
+++ b/packages/card/stories/card.stories.ts
@@ -13,6 +13,7 @@ import { html, TemplateResult } from 'lit-html';
 
 import '../';
 import { landscape, portrait } from './images';
+import '../../textfield';
 
 export default {
     component: 'sp-card',
@@ -53,6 +54,23 @@ export const Quiet = (): TemplateResult => {
             <sp-card variant="quiet" title="Card Title" subtitle="JPG">
                 <img slot="preview" src=${portrait} alt="Demo Image" />
                 <div slot="description">10/15/18</div>
+                <div slot="footer">Footer</div>
+            </sp-card>
+        </div>
+    `;
+};
+
+export const SlottedTitle = (): TemplateResult => {
+    return html`
+        <div
+            style="color: var(--spectrum-global-color-gray-800); --spectrum-card-body-header-height: auto;"
+        >
+            <sp-card subtitle="JPG">
+                <sp-textfield
+                    slot="title"
+                    placeholder="Enter Title"
+                ></sp-textfield>
+                <img slot="cover-photo" src=${portrait} alt="Demo Image" />
                 <div slot="footer">Footer</div>
             </sp-card>
         </div>

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -59,4 +59,56 @@ describe('card', () => {
 
         expect(el).shadowDom.to.equalSnapshot();
     });
+    it('displays the `title` attribute as `#title`', async () => {
+        const testTitle = 'This is a test title';
+        const el = await fixture<Card>(
+            html`
+                <sp-card title=${testTitle} subtitle="JPG">
+                    <img slot="preview" src="https://picsum.photos/532/192" />
+                    <div slot="footer">Footer</div>
+                </sp-card>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const titleEl = root.querySelector('#title');
+
+        expect(titleEl, 'did not find title element').to.not.be.null;
+        expect((titleEl as HTMLDivElement).textContent).to.contain(
+            testTitle,
+            'the title renders in the element'
+        );
+    });
+    it('displays the slotted content as `#title`', async () => {
+        const testTitle = 'This is a test title';
+        const el = await fixture<Card>(
+            html`
+                <sp-card subtitle="JPG">
+                    <h1 slot="title">${testTitle}</h1>
+                    <img slot="preview" src="https://picsum.photos/532/192" />
+                    <div slot="footer">Footer</div>
+                </sp-card>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const titleSlot = root.querySelector(
+            '[name="title"]'
+        ) as HTMLSlotElement;
+
+        expect(titleSlot, 'did not find slot element').to.not.be.null;
+        const nodes = titleSlot.assignedNodes();
+        const h1Element = nodes.find(
+            (node) => (node as HTMLElement).tagName === 'H1'
+        );
+        expect(h1Element, 'did not find H1 element').to.not.be.null;
+        expect((h1Element as HTMLHeadingElement).textContent).to.contain(
+            testTitle,
+            'the slotted content renders in the element'
+        );
+    });
 });

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -36,6 +36,7 @@ module.exports = [
     'card--default',
     'card--gallery',
     'card--quiet',
+    'card--slotted-title',
     'checkbox--default',
     'checkbox--checked',
     'checkbox--indeterminate',


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
Previously, we were only allowing card titles to be passed in as pure text string, meaning that they could not use html. This pr allows support for slotted titles, meaning they can be text fields, headers, strong, italicized, etc. It also continues to support the old implementation, where if a title attribute is supplied and a slot is not provided, it falls back to using the old pure text string title.

## Description

<!--- Describe your changes in detail -->
This PR adds a new renderTitle property to card, which all variant render functions use. It includes a slot named `title` which by default contains the title attribute as it's text content

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Improves flexibility of the card component, and consolidates some discrepancies between variants

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests
- tested manually
- works in storybook

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/30670379/73795747-4186b080-4760-11ea-8793-b61bcc9af6e0.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
