### PR TITLE
feat(dropdown): open menu UI with overlay system

### DIFF
--- a/__snapshots__/Action menu.md
+++ b/__snapshots__/Action menu.md
@@ -3,8 +3,8 @@
 #### `loads`
 
 ```html
-<sp-menu role="listbox" slot="options">
-    <sp-menu-item data-js-focus-visible="" role="menuitem" tabindex="-1">
+<sp-menu role="menu">
+    <sp-menu-item data-js-focus-visible="" role="menuitem" tabindex="0">
         Deselect
     </sp-menu-item>
     <sp-menu-item data-js-focus-visible="" role="menuitem" tabindex="-1">
@@ -37,29 +37,17 @@
 <button aria-haspopup="true" id="button" tabindex="0">
     <slot name="icon"></slot>
     <div hidden="" id="label">
-        <slot id="slot"></slot>
+        <slot id="slot" name="label"></slot>
     </div>
 </button>
-<sp-popover direction="bottom" id="popover" placement="none">
-    <slot name="options">
-        <sp-menu-item
-            aria-disabled="true"
-            data-js-focus-visible=""
-            disabled=""
-            role="menuitem"
-            tabindex="-1"
-        >
-            There are no options currently available.
-        </sp-menu-item>
-    </slot>
-</sp-popover>
+<sp-popover id="popover" open="" placement="none"></sp-popover>
 ```
 
 #### `loads - [label]`
 
 ```html
-<sp-menu role="listbox" slot="options">
-    <sp-menu-item data-js-focus-visible="" role="menuitem" tabindex="-1">
+<sp-menu role="menu">
+    <sp-menu-item data-js-focus-visible="" role="menuitem" tabindex="0">
         Deselect
     </sp-menu-item>
     <sp-menu-item data-js-focus-visible="" role="menuitem" tabindex="-1">
@@ -92,20 +80,8 @@
 <button aria-haspopup="true" aria-label="More Actions" id="button" tabindex="0">
     <slot name="icon"></slot>
     <div hidden="" id="label">
-        <slot id="slot"></slot>
+        <slot id="slot" name="label"></slot>
     </div>
 </button>
-<sp-popover direction="bottom" id="popover" placement="none">
-    <slot name="options">
-        <sp-menu-item
-            aria-disabled="true"
-            data-js-focus-visible=""
-            disabled=""
-            role="menuitem"
-            tabindex="-1"
-        >
-            There are no options currently available.
-        </sp-menu-item>
-    </slot>
-</sp-popover>
+<sp-popover id="popover" open="" placement="none"></sp-popover>
 ```

--- a/__snapshots__/Dropdown.md
+++ b/__snapshots__/Dropdown.md
@@ -3,8 +3,7 @@
 #### `loads`
 
 ```html
-Select a Country with a very long label, too long in fact
-<sp-menu role="listbox" slot="options">
+<sp-menu role="listbox">
     <sp-menu-item data-js-focus-visible="" role="option" tabindex="0">
         Deselect
     </sp-menu-item>
@@ -40,9 +39,16 @@ Select a Country with a very long label, too long in fact
 
 ```html
 <sp-icons-medium style="display: none;"></sp-icons-medium>
-<button aria-haspopup="true" id="button" tabindex="0">
+<button
+    aria-haspopup="true"
+    aria-label="Select a Country with a very long label, too long in fact"
+    id="button"
+    tabindex="0"
+>
     <div class="placeholder" id="label">
-        <slot></slot>
+        <slot name="label">
+            Select a Country with a very long label, too long in fact
+        </slot>
     </div>
     <sp-icon
         class="chevron-down-medium dropdown icon"
@@ -50,26 +56,13 @@ Select a Country with a very long label, too long in fact
         size="s"
     ></sp-icon>
 </button>
-<sp-popover direction="bottom" id="popover" placement="none">
-    <slot name="options">
-        <sp-menu-item
-            aria-disabled="true"
-            data-js-focus-visible=""
-            disabled=""
-            role="option"
-            tabindex="-1"
-        >
-            There are no options currently available.
-        </sp-menu-item>
-    </slot>
-</sp-popover>
+<sp-popover id="popover" open="" placement="none"></sp-popover>
 ```
 
 #### `renders invalid`
 
 ```html
-Select a Country with a very long label, too long in fact
-<sp-menu role="listbox" slot="options">
+<sp-menu role="listbox">
     <sp-menu-item data-js-focus-visible="" role="option" tabindex="0">
         Deselect
     </sp-menu-item>
@@ -105,9 +98,16 @@ Select a Country with a very long label, too long in fact
 
 ```html
 <sp-icons-medium style="display: none;"></sp-icons-medium>
-<button aria-haspopup="true" id="button" tabindex="0">
+<button
+    aria-haspopup="true"
+    aria-label="Select a Country with a very long label, too long in fact"
+    id="button"
+    tabindex="0"
+>
     <div class="placeholder" id="label">
-        <slot></slot>
+        <slot name="label">
+            Select a Country with a very long label, too long in fact
+        </slot>
     </div>
     <sp-icon class="alert-small icon" name="ui:AlertSmall" size="s"></sp-icon>
     <sp-icon
@@ -116,17 +116,5 @@ Select a Country with a very long label, too long in fact
         size="s"
     ></sp-icon>
 </button>
-<sp-popover direction="bottom" id="popover" placement="none">
-    <slot name="options">
-        <sp-menu-item
-            aria-disabled="true"
-            data-js-focus-visible=""
-            disabled=""
-            role="option"
-            tabindex="-1"
-        >
-            There are no options currently available.
-        </sp-menu-item>
-    </slot>
-</sp-popover>
+<sp-popover id="popover" open="" placement="none"></sp-popover>
 ```

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -51,7 +51,7 @@ module.exports = (config) => {
                 thresholds: {
                     global: {
                         statements: 97,
-                        branches: 90,
+                        branches: 91,
                         functions: 97,
                         lines: 97,
                     },

--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -17,8 +17,8 @@ yarn add @spectrum-web-components/action-menu
 <!-- prettier-ignore -->
 ```html
 <sp-action-menu>
-    More actions
-    <sp-menu slot="options">
+    <span slot="label">More Actions</span>
+    <sp-menu>
         <sp-menu-item>
             Deselect
         </sp-menu-item>
@@ -50,8 +50,8 @@ The visible label that is be provided via the default `<slot>` interface can be 
 
 <!-- prettier-ignore -->
 ```html
-<sp-action-menu label="More actions">
-    <sp-menu slot="options" style="min-width: 125px">
+<sp-action-menu label="More Actions">
+    <sp-menu>
         <sp-menu-item>
             Deselect
         </sp-menu-item>
@@ -85,8 +85,8 @@ A custom icon can be supplied via the `icon` slot in order to replace the defaul
 ```html
 <sp-action-menu label="More actions">
     <sp-icon slot="icon" size="xxs" name="ui:ChevronDownSmall"></sp-icon>
-    Actions under the arrow
-    <sp-menu slot="options">
+    <span slot="label">Actions Under the Arrow</span>
+    <sp-menu>
         <sp-menu-item>
             Deselect
         </sp-menu-item>

--- a/packages/action-menu/src/action-menu.ts
+++ b/packages/action-menu/src/action-menu.ts
@@ -60,6 +60,7 @@ export class ActionMenu extends ObserveSlotText(DropdownBase) {
                 </slot>
                 <div id="label" ?hidden=${!this.hasLabel}>
                     <slot
+                        name="label"
                         id="slot"
                         @slotchange=${this.manageObservedSlot}
                     ></slot>

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -23,14 +23,11 @@ export default {
     title: 'Action menu',
 };
 
-export const iconOnly = (): TemplateResult => html`
-    <style>
-        sp-menu {
-            min-width: 125px;
-        }
-    </style>
-    ${ActionMenuMarkup()}
-`;
+export const iconOnly = (): TemplateResult => {
+    return html`
+        ${ActionMenuMarkup()}
+    `;
+};
 
 export const Default = (): TemplateResult => {
     const ariaLabel = text('Arial Label', 'More Actions', 'Component');

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -11,6 +11,10 @@ governing permissions and limitations under the License.
 */
 import { html, TemplateResult } from 'lit-html';
 
+import '../';
+import '../../menu';
+import '../../menu-item';
+
 export const ActionMenuMarkup = ({
     ariaLabel = 'More Actions',
     changeHandler = (() => undefined) as ((event: Event) => void),
@@ -23,8 +27,12 @@ export const ActionMenuMarkup = ({
             ?disabled=${disabled}
             @change="${changeHandler}"
         >
-            ${visibleLabel}
-            <sp-menu slot="options">
+            ${visibleLabel
+                ? html`
+                      <span slot="label">${visibleLabel}</span>
+                  `
+                : html``}
+            <sp-menu>
                 <sp-menu-item>
                     Deselect
                 </sp-menu-item>

--- a/packages/action-menu/test/action-menu.test.ts
+++ b/packages/action-menu/test/action-menu.test.ts
@@ -18,36 +18,38 @@ import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
 import { waitForPredicate } from '../../../test/testing-helpers';
 import '../../shared/lib/focus-visible.js';
 
+const actionMenuFixture = async (): Promise<ActionMenu> =>
+    await fixture<ActionMenu>(
+        html`
+            <sp-action-menu>
+                <sp-menu>
+                    <sp-menu-item>
+                        Deselect
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Select Inverse
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Feather...
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Select and Mask...
+                    </sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>
+                        Save Selection
+                    </sp-menu-item>
+                    <sp-menu-item disabled>
+                        Make Work Path
+                    </sp-menu-item>
+                </sp-menu>
+            </sp-action-menu>
+        `
+    );
+
 describe('Action menu', () => {
     it('loads', async () => {
-        const el = await fixture<ActionMenu>(
-            html`
-                <sp-action-menu>
-                    <sp-menu slot="options" role="listbox">
-                        <sp-menu-item>
-                            Deselect
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Select Inverse
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Feather...
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Select and Mask...
-                        </sp-menu-item>
-                        <sp-menu-divider></sp-menu-divider>
-                        <sp-menu-item>
-                            Save Selection
-                        </sp-menu-item>
-                        <sp-menu-item disabled>
-                            Make Work Path
-                        </sp-menu-item>
-                    </sp-menu>
-                </sp-action-menu>
-            `
-        );
-
+        const el = await actionMenuFixture();
         await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
         await elementUpdated(el);
 
@@ -59,7 +61,7 @@ describe('Action menu', () => {
         const el = await fixture<ActionMenu>(
             html`
                 <sp-action-menu label="More Actions">
-                    <sp-menu slot="options" role="listbox">
+                    <sp-menu>
                         <sp-menu-item>
                             Deselect
                         </sp-menu-item>
@@ -92,34 +94,8 @@ describe('Action menu', () => {
         expect(el).shadowDom.to.equalSnapshot();
     });
     it('stays `quiet`', async () => {
-        const el = await fixture<ActionMenu>(
-            html`
-                <sp-action-menu>
-                    <sp-menu slot="options" role="listbox">
-                        <sp-menu-item>
-                            Deselect
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Select Inverse
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Feather...
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Select and Mask...
-                        </sp-menu-item>
-                        <sp-menu-divider></sp-menu-divider>
-                        <sp-menu-item>
-                            Save Selection
-                        </sp-menu-item>
-                        <sp-menu-item disabled>
-                            Make Work Path
-                        </sp-menu-item>
-                    </sp-menu>
-                </sp-action-menu>
-            `
-        );
-
+        const el = await actionMenuFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
         await elementUpdated(el);
 
         expect(el.quiet).to.be.true;
@@ -130,33 +106,8 @@ describe('Action menu', () => {
         expect(el.quiet).to.be.true;
     });
     it('stay `valid`', async () => {
-        const el = await fixture<ActionMenu>(
-            html`
-                <sp-action-menu>
-                    <sp-menu slot="options" role="listbox">
-                        <sp-menu-item>
-                            Deselect
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Select Inverse
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Feather...
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Select and Mask...
-                        </sp-menu-item>
-                        <sp-menu-divider></sp-menu-divider>
-                        <sp-menu-item>
-                            Save Selection
-                        </sp-menu-item>
-                        <sp-menu-item disabled>
-                            Make Work Path
-                        </sp-menu-item>
-                    </sp-menu>
-                </sp-action-menu>
-            `
-        );
+        const el = await actionMenuFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
 
@@ -166,5 +117,16 @@ describe('Action menu', () => {
         await elementUpdated(el);
 
         expect(el.invalid).to.be.false;
+    });
+    it('opens unmeasured', async () => {
+        const el = await actionMenuFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
+
+        await elementUpdated(el);
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
     });
 });

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -16,9 +16,10 @@ yarn add @spectrum-web-components/dropdown
 
 <!-- prettier-ignore -->
 ```html
-<sp-dropdown>
-    Select a country with a very long label, too long in fact
-    <sp-menu slot="options" role="listbox">
+<sp-dropdown
+    label="Select a Country with a very long label, too long in fact"
+>
+    <sp-menu>
         <sp-menu-item>
             Deselect
         </sp-menu-item>
@@ -49,10 +50,10 @@ yarn add @spectrum-web-components/dropdown
 <!-- prettier-ignore -->
 ```html
 <sp-dropdown
+    label="Select a Country with a very long label, too long in fact"
     invalid
 >
-    Select a country with a very long label, too long in fact
-    <sp-menu slot="options" role="listbox">
+    <sp-menu>
         <sp-menu-item>
             Deselect
         </sp-menu-item>
@@ -81,10 +82,10 @@ yarn add @spectrum-web-components/dropdown
 <!-- prettier-ignore -->
 ```html
 <sp-dropdown
+    label="Select a Country with a very long label, too long in fact"
     disabled
 >
-    Select a country with a very long label, too long in fact
-    <sp-menu slot="options" role="listbox">
+    <sp-menu>
         <sp-menu-item>
             Deselect
         </sp-menu-item>

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -46,6 +46,7 @@
         "@spectrum-web-components/icons": "^0.2.3",
         "@spectrum-web-components/menu": "^0.2.3",
         "@spectrum-web-components/menu-item": "^0.3.8",
+        "@spectrum-web-components/overlay": "^0.2.1",
         "@spectrum-web-components/popover": "^0.3.1",
         "@spectrum-web-components/shared": "^0.4.3",
         "tslib": "^1.10.0"

--- a/packages/dropdown/src/dropdown.ts
+++ b/packages/dropdown/src/dropdown.ts
@@ -37,10 +37,11 @@ import {
     MenuItemQueryRoleEventDetail,
 } from '@spectrum-web-components/menu-item';
 import '@spectrum-web-components/popover';
+import { Overlay, Placement } from '@spectrum-web-components/overlay';
 
 /**
- * @slot default - The placeholder content for the dropdown
- * @slot options - The menu with options that will display when the dropdown is open
+ * @slot label - The placeholder content for the dropdown
+ * @slot {"sp-menu"} - The menu of options that will display when the dropdown is open
  */
 export class DropdownBase extends Focusable {
     public static get styles(): CSSResultArray {
@@ -68,7 +69,10 @@ export class DropdownBase extends Focusable {
     @property({ type: Boolean, reflect: true })
     public open = false;
 
-    public optionsMenu: Menu | null = null;
+    public optionsMenu?: Menu;
+
+    @property()
+    public placement: Placement = 'bottom-start';
 
     @property({ type: Boolean, reflect: true })
     public quiet = false;
@@ -79,14 +83,18 @@ export class DropdownBase extends Focusable {
     @property({ type: String })
     public selectedItemText = '';
 
+    private closeOverlay?: () => void;
+
+    @query('sp-popover')
+    private popover?: HTMLElement;
+
     protected listRole = 'listbox';
     protected itemRole = 'option';
+    private placeholder?: Comment;
 
     public constructor() {
         super();
-        this.onClick = this.onClick.bind(this);
         this.onKeydown = this.onKeydown.bind(this);
-        this.addEventListener('click', this.onClick);
 
         this.addEventListener(
             'sp-menu-item-query-role',
@@ -109,14 +117,10 @@ export class DropdownBase extends Focusable {
         if (typeof this.button === 'undefined') {
             return this;
         }
-        return this.button;
-    }
-
-    public onOptionsChange(): void {
-        this.optionsMenu = this.querySelector('sp-menu');
-        if (this.value) {
-            this.requestUpdate('value');
+        if (this.open && this.optionsMenu) {
+            return this.optionsMenu;
         }
+        return this.button;
     }
 
     public onButtonBlur(): void {
@@ -132,10 +136,6 @@ export class DropdownBase extends Focusable {
     }
 
     public onButtonFocus(): void {
-        if (this.open) {
-            this.requestUpdate('open');
-            return;
-        }
         /* istanbul ignore if */
         if (typeof this.button === 'undefined') {
             return;
@@ -144,14 +144,12 @@ export class DropdownBase extends Focusable {
     }
 
     public onClick(event: Event): void {
-        const path = event.composedPath();
-        const target = path.find((el) => {
-            if (!(el instanceof Element) || this.optionsMenu === null) {
-                return false;
+        const target = event.target as MenuItem;
+        /* istanbul ignore if */
+        if (!target || target.disabled) {
+            if (target) {
+                this.focus();
             }
-            return el.getAttribute('role') === this.optionsMenu.childRole;
-        }) as MenuItem;
-        if (!target) {
             return;
         }
         this.setValueFromItem(target);
@@ -162,7 +160,7 @@ export class DropdownBase extends Focusable {
             return;
         }
         /* istanbul ignore if */
-        if (this.optionsMenu === null) {
+        if (!this.optionsMenu) {
             return;
         }
         this.open = true;
@@ -182,7 +180,11 @@ export class DropdownBase extends Focusable {
             this.value = oldValue;
             return;
         }
-        const selectedItem = this.querySelector('[selected]') as MenuItem;
+        const parentElement = item.parentElement as Element;
+        const selectedItem = parentElement.querySelector(
+            '[selected]'
+        ) as MenuItem;
+        /* istanbul ignore if */
         if (selectedItem) {
             selectedItem.selected = false;
         }
@@ -195,6 +197,68 @@ export class DropdownBase extends Focusable {
         this.open = !this.open;
     }
 
+    public close(): void {
+        this.open = false;
+    }
+
+    private onOverlayClosed(): void {
+        this.close();
+        /* istanbul ignore else */
+        if (this.optionsMenu && this.placeholder) {
+            const parentElement =
+                this.placeholder.parentElement ||
+                this.placeholder.getRootNode();
+
+            /* istanbul ignore else */
+            if (parentElement) {
+                parentElement.replaceChild(this.optionsMenu, this.placeholder);
+            }
+        }
+
+        delete this.placeholder;
+    }
+
+    private openMenu(): void {
+        /* istanbul ignore if */
+        if (
+            !this.popover ||
+            !this.button ||
+            !this.optionsMenu ||
+            this.optionsMenu.children.length === 0
+        )
+            return;
+
+        this.placeholder = document.createComment(
+            'placeholder for optionsMenu'
+        );
+
+        const parentElement =
+            this.optionsMenu.parentElement || this.optionsMenu.getRootNode();
+
+        /* istanbul ignore else */
+        if (parentElement) {
+            parentElement.replaceChild(this.placeholder, this.optionsMenu);
+        }
+
+        this.popover.append(this.optionsMenu);
+
+        // only use `this.offsetWidth` when Standard variant
+        const menuWidth = !this.quiet && `${this.offsetWidth}px`;
+        if (menuWidth) {
+            this.popover.style.setProperty('width', menuWidth);
+        }
+        this.closeOverlay = Overlay.open(this.button, 'click', this.popover, {
+            placement: this.placement,
+        });
+    }
+
+    private closeMenu(): void {
+        if (this.closeOverlay) {
+            this.closeOverlay();
+            delete this.closeOverlay;
+        }
+    }
+
     protected get buttonContent(): TemplateResult[] {
         return [
             html`
@@ -205,7 +269,7 @@ export class DropdownBase extends Focusable {
                     ${this.value
                         ? this.selectedItemText
                         : html`
-                              <slot></slot>
+                              <slot name="label">${this.label}</slot>
                           `}
                 </div>
                 ${this.invalid
@@ -240,14 +304,19 @@ export class DropdownBase extends Focusable {
             >
                 ${this.buttonContent}
             </button>
-            <sp-popover direction="bottom" id="popover" ?open=${this.open}>
-                <slot name="options" @slotchange=${this.onOptionsChange}>
-                    <sp-menu-item disabled>
-                        There are no options currently available.
-                    </sp-menu-item>
-                </slot>
-            </sp-popover>
+            <sp-popover
+                open
+                id="popover"
+                @click=${this.onClick}
+                @sp-overlay-closed=${this.onOverlayClosed}
+            ></sp-popover>
         `;
+    }
+
+    protected firstUpdated(changedProperties: PropertyValues): void {
+        super.firstUpdated(changedProperties);
+
+        this.optionsMenu = this.querySelector('sp-menu') as Menu;
     }
 
     protected updated(changedProperties: PropertyValues): void {
@@ -278,21 +347,32 @@ export class DropdownBase extends Focusable {
         if (changedProperties.has('disabled') && this.disabled) {
             this.open = false;
         }
-        if (changedProperties.has('open') && this.open) {
-            requestAnimationFrame(() => {
-                /* istanbul ignore if */
-                if (this.optionsMenu === null) {
-                    return;
-                }
-                /* Trick :focus-visible polyfill into thinking keyboard based focus */
-                this.dispatchEvent(
-                    new KeyboardEvent('keydown', {
-                        code: 'Tab',
-                    })
-                );
-                this.optionsMenu.focus();
-            });
+        if (changedProperties.has('open')) {
+            if (this.open) {
+                this.openMenu();
+                requestAnimationFrame(() => {
+                    /* istanbul ignore if */
+                    if (!this.optionsMenu) {
+                        return;
+                    }
+                    /* Trick :focus-visible polyfill into thinking keyboard based focus */
+                    this.dispatchEvent(
+                        new KeyboardEvent('keydown', {
+                            code: 'Tab',
+                        })
+                    );
+                    this.optionsMenu.focus();
+                });
+            } else {
+                this.closeMenu();
+            }
         }
+    }
+
+    public disconnectedCallback(): void {
+        this.open = false;
+
+        super.disconnectedCallback();
     }
 }
 

--- a/packages/dropdown/stories/dropdown.stories.ts
+++ b/packages/dropdown/stories/dropdown.stories.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { html, action, boolean, select } from '@open-wc/demoing-storybook';
+import { html, action } from '@open-wc/demoing-storybook';
 
 import '../';
 import { Dropdown } from '../';
@@ -25,16 +25,15 @@ export default {
 export const Default = (): TemplateResult => {
     return html`
         <sp-dropdown
-            ?disabled=${boolean('Is Disabled', false, 'Component')}
-            ?invalid=${boolean('Is Invalid', false, 'Component')}
-            ?quiet=${boolean('Is Quiet', false, 'Component')}
             @change="${(event: Event) => {
                 const dropdown = event.target as Dropdown;
                 action(`Change: ${dropdown.value}`)();
             }}"
         >
-            Select a Country with a very long label, too long in fact
-            <sp-menu slot="options" role="listbox">
+            <span slot="label">
+                Select a Country with a very long label, too long in fact
+            </span>
+            <sp-menu>
                 <sp-menu-item>
                     Deselect
                 </sp-menu-item>
@@ -59,29 +58,85 @@ export const Default = (): TemplateResult => {
     `;
 };
 
+export const Open = (): TemplateResult => {
+    return html`
+        <style>
+            fieldset {
+                float: left;
+                clear: left;
+                display: inline-block;
+                margin-bottom: 15px;
+            }
+        </style>
+        <fieldset>
+            <sp-dropdown
+                label="Open dropdown"
+                open
+                @change="${(event: Event) => {
+                    const dropdown = event.target as Dropdown;
+                    action(`Change: ${dropdown.value}`)();
+                }}"
+            >
+                <span slot="label">
+                    Select a Country with a very long label, too long in fact
+                </span>
+                <sp-menu>
+                    <sp-menu-item>
+                        Deselect
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Select Inverse
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Feather...
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Select and Mask...
+                    </sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>
+                        Save Selection
+                    </sp-menu-item>
+                    <sp-menu-item disabled>
+                        Make Work Path
+                    </sp-menu-item>
+                </sp-menu>
+            </sp-dropdown>
+        </fieldset>
+        <fieldset>
+            <sp-dropdown
+                label="Dropdown that displays below the options"
+                @change="${(event: Event) => {
+                    const dropdown = event.target as Dropdown;
+                    action(`Change: ${dropdown.value}`)();
+                }}"
+            >
+                <span slot="label">
+                    Other menu that goes behind the open one
+                </span>
+                <sp-menu>
+                    <sp-menu-item>
+                        Not so many options...
+                    </sp-menu-item>
+                </sp-menu>
+            </sp-dropdown>
+        </fieldset>
+    `;
+};
+
 export const initialValue = (): TemplateResult => {
-    const values = [
-        '',
-        'item-1',
-        'item-2',
-        'item-3',
-        'item-4',
-        'item-5',
-        'item-6',
-    ];
     return html`
         <sp-dropdown
-            ?disabled=${boolean('Is Disabled', false, 'Component')}
-            ?invalid=${boolean('Is Invalid', false, 'Component')}
-            ?quiet=${boolean('Is Quiet', false, 'Component')}
             @change="${(event: Event) => {
                 const dropdown = event.target as Dropdown;
                 action(`Change: ${dropdown.value}`)();
             }}"
-            value=${select('Value', values, values[2], 'Component')}
+            value="item-2"
         >
-            Select a Country with a very long label, too long in fact
-            <sp-menu slot="options" role="listbox">
+            <span slot="label">
+                Select a Country with a very long label, too long in fact
+            </span>
+            <sp-menu>
                 <sp-menu-item value="item-1">
                     Deselect
                 </sp-menu-item>

--- a/packages/dropdown/test/dropdown.test.ts
+++ b/packages/dropdown/test/dropdown.test.ts
@@ -15,6 +15,7 @@ import { Dropdown } from '../';
 import '../../menu';
 import '../../menu-item';
 import { MenuItem } from '../../menu-item';
+import { Popover } from '../../popover';
 import {
     fixture,
     elementUpdated,
@@ -22,6 +23,7 @@ import {
     expect,
     nextFrame,
 } from '@open-wc/testing';
+import { waitUntil } from '@open-wc/testing-helpers';
 import { waitForPredicate } from '../../../test/testing-helpers';
 import '../../shared/lib/focus-visible.js';
 import { spy } from 'sinon';
@@ -36,12 +38,17 @@ const keyboardEvent = (code: string): KeyboardEvent =>
 const arrowDownEvent = keyboardEvent('ArrowDown');
 const arrowUpEvent = keyboardEvent('ArrowUp');
 
+type testableDropdown = {
+    popover: Popover;
+};
+
 const dropdownFixture = async (): Promise<Dropdown> =>
     await fixture<Dropdown>(
         html`
-            <sp-dropdown>
-                Select a Country with a very long label, too long in fact
-                <sp-menu slot="options">
+            <sp-dropdown
+                label="Select a Country with a very long label, too long in fact"
+            >
+                <sp-menu>
                     <sp-menu-item>
                         Deselect
                     </sp-menu-item>
@@ -69,8 +76,8 @@ const dropdownFixture = async (): Promise<Dropdown> =>
 describe('Dropdown', () => {
     it('loads', async () => {
         const el = await dropdownFixture();
-
         await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
+
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
         expect(el).lightDom.to.equalSnapshot();
@@ -78,6 +85,7 @@ describe('Dropdown', () => {
     });
     it('renders invalid', async () => {
         const el = await dropdownFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
 
@@ -90,6 +98,7 @@ describe('Dropdown', () => {
     });
     it('closes when becoming disabled', async () => {
         const el = await dropdownFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
 
@@ -105,6 +114,7 @@ describe('Dropdown', () => {
     });
     it('selects', async () => {
         const el = await dropdownFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
 
@@ -129,6 +139,7 @@ describe('Dropdown', () => {
     });
     it('re-selects', async () => {
         const el = await dropdownFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
 
@@ -170,6 +181,7 @@ describe('Dropdown', () => {
     });
     it('can have selection prevented', async () => {
         const el = await dropdownFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
 
@@ -198,6 +210,7 @@ describe('Dropdown', () => {
     });
     it('opens on ArrowDown', async () => {
         const el = await dropdownFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
 
@@ -232,6 +245,7 @@ describe('Dropdown', () => {
     });
     it('loads', async () => {
         const el = await dropdownFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
@@ -240,8 +254,10 @@ describe('Dropdown', () => {
     });
     it('refocuses on list when open', async () => {
         const el = await dropdownFixture();
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         await elementUpdated(el);
+        const firstItem = el.querySelector('sp-menu-item') as MenuItem;
 
         el.open = true;
         await elementUpdated(el);
@@ -249,10 +265,9 @@ describe('Dropdown', () => {
         el.blur();
         await elementUpdated(el);
 
-        const firstItem = el.querySelector(
-            'sp-menu-item:nth-of-type(1)'
-        ) as MenuItem;
+        expect(el.open).to.be.true;
         el.focus();
+        await elementUpdated(el);
         await waitForPredicate(() => document.activeElement === firstItem);
         expect(el.open).to.be.true;
         expect(document.activeElement === firstItem).to.be.true;
@@ -264,60 +279,11 @@ describe('Dropdown', () => {
         const handleSelectedFocus = (): void => focusSelectedSpy();
         const el = await fixture<Dropdown>(
             html`
-                <sp-dropdown value="inverse">
-                    Select a Country with a very long label, too long in fact
-                    <sp-menu slot="options">
-                        <sp-menu-item
-                            value="deselect"
-                            @focus=${handleFirstFocus}
-                        >
-                            Deselect Text
-                        </sp-menu-item>
-                        <sp-menu-item
-                            value="inverse"
-                            @focus=${handleSelectedFocus}
-                        >
-                            Select Inverse
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Feather...
-                        </sp-menu-item>
-                        <sp-menu-item>
-                            Select and Mask...
-                        </sp-menu-item>
-                        <sp-menu-divider></sp-menu-divider>
-                        <sp-menu-item>
-                            Save Selection
-                        </sp-menu-item>
-                        <sp-menu-item disabled>
-                            Make Work Path
-                        </sp-menu-item>
-                    </sp-menu>
-                </sp-dropdown>
-            `
-        );
-
-        await elementUpdated(el);
-
-        expect(el.value).to.equal('inverse');
-        expect(el.selectedItemText).to.equal('Select Inverse');
-
-        const button = el.button as HTMLButtonElement;
-        button.click();
-
-        await elementUpdated(el);
-        await nextFrame();
-
-        expect(focusFirstSpy.called, 'do not focus first element').to.be.false;
-        expect(focusSelectedSpy.calledOnce, 'focus selected element').to.be
-            .true;
-    });
-    it('resets value when item not available', async () => {
-        const el = await fixture<Dropdown>(
-            html`
-                <sp-dropdown value="missing">
-                    Select a Country with a very long label, too long in fact
-                    <sp-menu slot="options">
+                <sp-dropdown
+                    value="inverse"
+                    label="Select a Country with a very long label, too long in fact"
+                >
+                    <sp-menu>
                         <sp-menu-item value="deselect">
                             Deselect Text
                         </sp-menu-item>
@@ -343,8 +309,109 @@ describe('Dropdown', () => {
         );
 
         await elementUpdated(el);
+        await waitUntil(() => el.selectedItemText === 'Select Inverse');
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        firstItem.addEventListener('focus', handleFirstFocus);
+        secondItem.addEventListener('focus', handleSelectedFocus);
+
+        expect(el.value).to.equal('inverse');
+        expect(el.selectedItemText).to.equal('Select Inverse');
+
+        const button = el.button as HTMLButtonElement;
+        button.click();
+
+        await elementUpdated(el);
+        await nextFrame();
+
+        expect(focusFirstSpy.called, 'do not focus first element').to.be.false;
+        expect(focusSelectedSpy.calledOnce, 'focus selected element').to.be
+            .true;
+    });
+    it('resets value when item not available', async () => {
+        const el = await fixture<Dropdown>(
+            html`
+                <sp-dropdown
+                    value="missing"
+                    label="Select a Country with a very long label, too long in fact"
+                >
+                    <sp-menu>
+                        <sp-menu-item value="deselect">
+                            Deselect Text
+                        </sp-menu-item>
+                        <sp-menu-item value="inverse">
+                            Select Inverse
+                        </sp-menu-item>
+                        <sp-menu-item>
+                            Feather...
+                        </sp-menu-item>
+                        <sp-menu-item>
+                            Select and Mask...
+                        </sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>
+                            Save Selection
+                        </sp-menu-item>
+                        <sp-menu-item disabled>
+                            Make Work Path
+                        </sp-menu-item>
+                    </sp-menu>
+                </sp-dropdown>
+            `
+        );
+
+        await elementUpdated(el);
+        await waitUntil(() => el.value === '');
 
         expect(el.value).to.equal('');
         expect(el.selectedItemText).to.equal('');
+    });
+
+    it('resets value when item not available', async () => {
+        const mouseenterSpy = spy();
+        const handleMouseenter = (): void => mouseenterSpy();
+        const el = await fixture<Dropdown>(
+            html`
+                <sp-dropdown
+                    value="missing"
+                    label="Select a Country with a very long label, too long in fact"
+                >
+                    <sp-menu>
+                        <sp-menu-item
+                            value="deselect"
+                            @mouseenter=${handleMouseenter}
+                        >
+                            Deselect Text
+                        </sp-menu-item>
+                    </sp-menu>
+                </sp-dropdown>
+            `
+        );
+
+        await elementUpdated(el);
+        await waitUntil(() => el.value === '');
+
+        el.open = true;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        const hoverEl = ((el as unknown) as testableDropdown).popover.querySelector(
+            'sp-menu-item'
+        ) as MenuItem;
+        hoverEl.dispatchEvent(new MouseEvent('mouseenter'));
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        el.open = false;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(mouseenterSpy.calledOnce).to.be.true;
     });
 });

--- a/packages/dropdown/tsconfig.json
+++ b/packages/dropdown/tsconfig.json
@@ -12,6 +12,7 @@
         { "path": "../icons" },
         { "path": "../menu" },
         { "path": "../menu-item" },
+        { "path": "../overlay" },
         { "path": "../popover" },
         { "path": "../shared" }
     ]

--- a/packages/menu-item/stories/menu-item.stories.ts
+++ b/packages/menu-item/stories/menu-item.stories.ts
@@ -9,17 +9,19 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-@import './spectrum-dropdown.css';
+import { html, TemplateResult } from 'lit-html';
 
-sp-popover {
-    display: none;
-}
+import '../';
 
-#label ~ .dropdown {
-    /* .spectrum-Icon + .spectrum-Dropdown-icon
-        with specificity bump to counteract #label ~ .dropdown elsewhere */
-    margin-left: var(
-        --spectrum-dropdown-icon-gap,
-        var(--spectrum-global-dimension-size-100)
-    );
-}
+export default {
+    component: 'sp-menu-item',
+    title: 'Menu Item',
+};
+
+export const Default = (): TemplateResult => {
+    return html`
+        <sp-menu-item>
+            Menu Item
+        </sp-menu-item>
+    `;
+};

--- a/packages/overlay/src/active-overlay.ts
+++ b/packages/overlay/src/active-overlay.ts
@@ -260,9 +260,11 @@ export class ActiveOverlay extends LitElement {
             );
         }
 
+        const parentElement = element.parentElement || element.getRootNode();
+
         /* istanbul ignore else */
-        if (element.parentElement) {
-            element.parentElement.replaceChild(this.placeholder, element);
+        if (parentElement) {
+            parentElement.replaceChild(this.placeholder, element);
         }
 
         this.overlayContent = element;
@@ -287,11 +289,20 @@ export class ActiveOverlay extends LitElement {
         }
 
         /* istanbul ignore else */
-        if (this.placeholder && this.placeholder.parentElement) {
-            this.placeholder.parentElement.replaceChild(
-                this.overlayContent,
-                this.placeholder
-            );
+        if (this.placeholder) {
+            const parentElement =
+                this.placeholder.parentElement ||
+                this.placeholder.getRootNode();
+            /* istanbul ignore else */
+            if (parentElement) {
+                parentElement.replaceChild(
+                    this.overlayContent,
+                    this.placeholder
+                );
+                this.overlayContent.dispatchEvent(
+                    new Event('sp-overlay-closed')
+                );
+            }
         }
 
         if (this.originalPlacement) {


### PR DESCRIPTION
## Description
Tie `sp-dropdown` and it's derivatives into the new `Overlay` system.
- ensures content is "over" other content
- ensures that the content breaks any overflow rules
- ensures that the content respects the browser edges
- moves the content to ensure event listeners are maintained
- uses the widths of the `sp-dropdown` for the menu content in Standard variants and allows content to size itself in the Quiet variant

### Notes
- New PR as a number of the implementation details, tests, etc have changed from #486 
- This is a breaking change!
- There's lots of room for additional documentation if people like the new DOM and attribute APIs.
- continue to require an `sp-menu` in the light DOM even though it's a small leak of our implementation details as it falls closer to the API found in [React Spectrum's `MenuTrigger`](https://git.corp.adobe.com/React/react-spectrum-v3/blob/master/specs/api/MenuTrigger.md) 

## Related Issue
fixes #157 
fixes #148 
closes #486 

## Motivation and Context
Make things work better, be easier to use, and be more like we'd expect in the browsing experience.

## How Has This Been Tested?
- manual
- unit tests

There's a possibility to add `dropdown--open` to the [list of visual regressions](https://github.com/adobe/spectrum-web-components/blob/master/test/visual/stories.js) but it's timing-based (the menu opens with an animation) so I'm hesitant to add a possibly flaky test to the suite. This might point to the benefit of some sort of "no-first-transition" style attribute later down the line, both as a helper for testing but for the possibility that certain states that are traditionally animated into might be desired on load in production.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/74055404-f7930a00-49ad-11ea-84cd-cd2839e9a491.png)

## Types of changes
- [x] breaking change that adds new features.

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.