### PR TITLE
chore: update spectrum CSS dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-5e0d0a3b649f0a88345048785ad3ba64663b3606
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-345b51f115ae4d1e51e573cc5e92d20bcd6639e5
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -38,7 +38,7 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/button": "^2.0.2"
+        "@spectrum-css/button": "^2.1.0"
     },
     "dependencies": {
         "@spectrum-web-components/icon": "^0.4.3",

--- a/packages/button/src/spectrum-action-button.css
+++ b/packages/button/src/spectrum-action-button.css
@@ -36,8 +36,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
         box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
     text-decoration: none;
-    font-family: adobe-clean-ux, adobe-clean, Source Sans Pro, -apple-system,
-        BlinkMacSystemFont, Segoe UI, Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-body-text-font-family,
+        var(--spectrum-global-font-family-base)
+    );
     line-height: 1.3;
     cursor: pointer; /* .spectrum-ActionButton,
    * .spectrum-Tool */

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -36,8 +36,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
         box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
     text-decoration: none;
-    font-family: adobe-clean-ux, adobe-clean, Source Sans Pro, -apple-system,
-        BlinkMacSystemFont, Segoe UI, Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-body-text-font-family,
+        var(--spectrum-global-font-family-base)
+    );
     line-height: 1.3;
     cursor: pointer; /* .spectrum-Button */
     border-width: var(
@@ -66,8 +68,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                     var(--spectrum-alias-border-size-thick)
                 )
         );
-    padding-bottom: calc(var(--spectrum-global-dimension-size-50) + 0.5px);
-    padding-top: calc(var(--spectrum-global-dimension-size-50) - 0.5px);
+    padding-bottom: calc(var(--spectrum-global-dimension-size-50) + 1px);
+    padding-top: calc(var(--spectrum-global-dimension-size-50) - 1px);
     font-size: var(
         --spectrum-button-primary-text-size,
         var(--spectrum-alias-pill-button-text-size)

--- a/packages/button/src/spectrum-clear-button.css
+++ b/packages/button/src/spectrum-clear-button.css
@@ -36,8 +36,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
         box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
     text-decoration: none;
-    font-family: adobe-clean-ux, adobe-clean, Source Sans Pro, -apple-system,
-        BlinkMacSystemFont, Segoe UI, Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-body-text-font-family,
+        var(--spectrum-global-font-family-base)
+    );
     line-height: 1.3;
     cursor: pointer; /* .spectrum-ClearButton */
     width: var(

--- a/packages/button/src/spectrum-fieldbutton.css
+++ b/packages/button/src/spectrum-fieldbutton.css
@@ -36,8 +36,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
         box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
     text-decoration: none;
-    font-family: adobe-clean-ux, adobe-clean, Source Sans Pro, -apple-system,
-        BlinkMacSystemFont, Segoe UI, Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-body-text-font-family,
+        var(--spectrum-global-font-family-base)
+    );
     line-height: 1.3;
     cursor: pointer; /* .spectrum-FieldButton */
     height: var(

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -38,7 +38,7 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/checkbox": "^2.0.4"
+        "@spectrum-css/checkbox": "^2.0.5"
     },
     "dependencies": {
         "@spectrum-web-components/icon": "^0.4.3",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -38,7 +38,7 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^2.0.2"
+        "@spectrum-css/icon": "^2.0.4"
     },
     "dependencies": {
         "@spectrum-web-components/iconset": "^0.1.7",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -36,7 +36,7 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/link": "^2.0.2"
+        "@spectrum-css/link": "^2.0.4"
     },
     "dependencies": {
         "@spectrum-web-components/shared": "^0.4.3",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -38,7 +38,7 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/menu": "^2.1.2"
+        "@spectrum-css/menu": "^2.1.4"
     },
     "dependencies": {
         "tslib": "^1.10.0"

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -38,7 +38,7 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^2.0.2"
+        "@spectrum-css/slider": "^2.0.4"
     },
     "dependencies": {
         "@spectrum-web-components/shared": "^0.4.3",

--- a/packages/styles/core-global.css
+++ b/packages/styles/core-global.css
@@ -47,6 +47,8 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-gray-700: rgb(116, 116, 116);
     --spectrum-global-color-static-gray-800: rgb(80, 80, 80);
     --spectrum-global-color-static-gray-900: rgb(50, 50, 50);
+    --spectrum-global-color-static-blue-200: rgb(90, 169, 250);
+    --spectrum-global-color-static-blue-300: rgb(75, 156, 245);
     --spectrum-global-color-static-blue-400: rgb(55, 142, 240);
     --spectrum-global-color-static-blue-500: rgb(38, 128, 235);
     --spectrum-global-color-static-blue-600: rgb(20, 115, 230);
@@ -63,18 +65,25 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-green-500: rgb(45, 157, 120);
     --spectrum-global-color-static-green-600: rgb(38, 142, 108);
     --spectrum-global-color-static-green-700: rgb(18, 128, 92);
+    --spectrum-global-color-static-celery-200: rgb(88, 224, 111);
+    --spectrum-global-color-static-celery-300: rgb(81, 210, 103);
     --spectrum-global-color-static-celery-400: rgb(75, 195, 95);
     --spectrum-global-color-static-celery-500: rgb(68, 181, 86);
     --spectrum-global-color-static-celery-600: rgb(61, 167, 78);
     --spectrum-global-color-static-celery-700: rgb(55, 153, 71);
+    --spectrum-global-color-static-chartreuse-300: rgb(155, 236, 84);
     --spectrum-global-color-static-chartreuse-400: rgb(142, 222, 73);
     --spectrum-global-color-static-chartreuse-500: rgb(133, 208, 68);
     --spectrum-global-color-static-chartreuse-600: rgb(124, 195, 63);
     --spectrum-global-color-static-chartreuse-700: rgb(115, 181, 58);
+    --spectrum-global-color-static-yellow-200: rgb(255, 226, 46);
+    --spectrum-global-color-static-yellow-300: rgb(250, 217, 0);
     --spectrum-global-color-static-yellow-400: rgb(237, 204, 0);
     --spectrum-global-color-static-yellow-500: rgb(223, 191, 0);
     --spectrum-global-color-static-yellow-600: rgb(210, 178, 0);
     --spectrum-global-color-static-yellow-700: rgb(196, 166, 0);
+    --spectrum-global-color-static-magenta-200: rgb(245, 107, 183);
+    --spectrum-global-color-static-magenta-300: rgb(236, 90, 170);
     --spectrum-global-color-static-magenta-400: rgb(226, 73, 157);
     --spectrum-global-color-static-magenta-500: rgb(216, 55, 144);
     --spectrum-global-color-static-magenta-600: rgb(202, 41, 130);
@@ -87,10 +96,15 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-purple-500: rgb(146, 86, 217);
     --spectrum-global-color-static-purple-600: rgb(134, 76, 204);
     --spectrum-global-color-static-purple-700: rgb(122, 66, 191);
+    --spectrum-global-color-static-purple-800: rgb(111, 56, 177);
+    --spectrum-global-color-static-indigo-200: rgb(144, 144, 250);
+    --spectrum-global-color-static-indigo-300: rgb(130, 130, 246);
     --spectrum-global-color-static-indigo-400: rgb(117, 117, 241);
     --spectrum-global-color-static-indigo-500: rgb(103, 103, 236);
     --spectrum-global-color-static-indigo-600: rgb(92, 92, 224);
     --spectrum-global-color-static-indigo-700: rgb(81, 81, 211);
+    --spectrum-global-color-static-seafoam-200: rgb(38, 192, 199);
+    --spectrum-global-color-static-seafoam-300: rgb(35, 178, 184);
     --spectrum-global-color-static-seafoam-400: rgb(32, 163, 168);
     --spectrum-global-color-static-seafoam-500: rgb(27, 149, 154);
     --spectrum-global-color-static-seafoam-600: rgb(22, 135, 140);
@@ -111,6 +125,30 @@ governing permissions and limitations under the License.
     --spectrum-global-color-opacity-6: 0.06;
     --spectrum-global-color-opacity-5: 0.05;
     --spectrum-global-color-opacity-4: 0.04;
+    --spectrum-global-color-sequential-cerulean: [ '#E9FFF1', '#C8F1E4',
+        '#A5E3D7', '#82D5CA', '#68C5C1', '#54B4BA', '#3FA2B2', '#2991AC',
+        '#2280A2', '#1F6D98', '#1D5C8D', '#1A4B83', '#1A3979', '#1A266F',
+        '#191264', '#180057' ];
+    --spectrum-global-color-sequential-forest: [ '#FFFFDF', '#E2F6BA', '#C4EB95',
+        '#A4E16D', '#8DD366', '#77C460', '#5FB65A', '#48A754', '#36984F',
+        '#2C894D', '#237A4A', '#196B47', '#105C45', '#094D41', '#033F3E',
+        '#00313A' ];
+    --spectrum-global-color-sequential-rose: [ '#FFF4DD', '#FFDDD7', '#FFC5D2',
+        '#FEAECB', '#FA96C4', '#F57EBD', '#EF64B5', '#E846AD', '#D238A1',
+        '#BB2E96', '#A3248C', '#8A1B83', '#71167C', '#560F74', '#370B6E',
+        '#000968' ];
+    --spectrum-global-color-diverging-orange-yellow-seafoam: [ '#580000',
+        '#79260B', '#9C4511', '#BD651A', '#DD8629', '#F5AD52', '#FED693',
+        '#FFFFE0', '#BBE4D1', '#76C7BE', '#3EA8A6', '#208288', '#076769',
+        '#00494B', '#002C2D' ];
+    --spectrum-global-color-diverging-red-yellow-blue: [ '#4A001E', '#751232',
+        '#A52747', '#C65154', '#E47961', '#F0A882', '#FAD4AC', '#FFFFE0',
+        '#BCE2CF', '#89C0C4', '#579EB9', '#397AA8', '#1C5796', '#163771',
+        '#10194D' ];
+    --spectrum-global-color-diverging-red-blue: [ '#4A001E', '#731331',
+        '#9F2945', '#CC415A', '#E06E85', '#ED9AB0', '#F8C3D9', '#FAF0FF',
+        '#C6D0F2', '#92B2DE', '#5D94CB', '#2F74B3', '#265191', '#163670',
+        '#0B194C' ];
 
     /* spectrum-colorSemantics.css */
     --spectrum-semantic-negative-color-background: var(
@@ -507,10 +545,13 @@ governing permissions and limitations under the License.
         --spectrum-global-font-weight-black
     );
     --spectrum-alias-detail-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-detail-text-font-weight-light: var(
         --spectrum-global-font-weight-regular
     );
     --spectrum-alias-detail-text-font-weight-strong: var(
-        --spectrum-global-font-weight-bold
+        --spectrum-global-font-weight-black
     );
     --spectrum-alias-serif-text-font-family: var(
         --spectrum-global-font-family-serif
@@ -638,6 +679,12 @@ governing permissions and limitations under the License.
     --spectrum-alias-body-margin-bottom: var(
         --spectrum-global-font-multiplier-75
     );
+    --spectrum-alias-loupe-entry-animation-duration: var(
+        --spectrum-global-animation-duration-300
+    );
+    --spectrum-alias-loupe-exit-animation-duration: var(
+        --spectrum-global-animation-duration-300
+    );
 }
 
 :root,
@@ -698,16 +745,40 @@ governing permissions and limitations under the License.
     --spectrum-alias-workflow-icon-size: var(
         --spectrum-global-dimension-size-225
     );
+    --spectrum-alias-heading-display1-text-size: var(
+        --spectrum-global-dimension-font-size-1300
+    );
+    --spectrum-alias-heading-xxxl-text-size: var(
+        --spectrum-global-dimension-font-size-1300
+    );
     --spectrum-alias-heading-han-display1-text-size: var(
-        --spectrum-global-dimension-font-size-1000
+        --spectrum-global-dimension-font-size-1300
     );
     --spectrum-alias-heading-han-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1000
+        --spectrum-global-dimension-font-size-1300
     );
     --spectrum-alias-heading-han-display1-margin-top: var(
-        --spectrum-global-dimension-font-size-900
+        --spectrum-global-dimension-font-size-1200
     );
     --spectrum-alias-heading-han-xxxl-margin-top: var(
+        --spectrum-global-dimension-font-size-1200
+    );
+    --spectrum-alias-heading-display1-margin-top: var(
+        --spectrum-global-dimension-font-size-1200
+    );
+    --spectrum-alias-heading-xxxl-margin-top: var(
+        --spectrum-global-dimension-font-size-1200
+    );
+    --spectrum-alias-heading-display2-text-size: var(
+        --spectrum-global-dimension-font-size-1100
+    );
+    --spectrum-alias-heading-xxl-text-size: var(
+        --spectrum-global-dimension-font-size-1100
+    );
+    --spectrum-alias-heading-display2-margin-top: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading-xxl-margin-top: var(
         --spectrum-global-dimension-font-size-900
     );
     --spectrum-alias-heading-han-display2-text-size: var(
@@ -722,6 +793,18 @@ governing permissions and limitations under the License.
     --spectrum-alias-heading-han-xxl-margin-top: var(
         --spectrum-global-dimension-font-size-800
     );
+    --spectrum-alias-heading1-text-size: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading-xl-text-size: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading1-margin-top: var(
+        --spectrum-global-dimension-font-size-800
+    );
+    --spectrum-alias-heading-xl-margin-top: var(
+        --spectrum-global-dimension-font-size-800
+    );
     --spectrum-alias-heading1-han-text-size: var(
         --spectrum-global-dimension-font-size-800
     );
@@ -734,6 +817,18 @@ governing permissions and limitations under the License.
     --spectrum-alias-heading-han-xl-margin-top: var(
         --spectrum-global-dimension-font-size-700
     );
+    --spectrum-alias-heading2-text-size: var(
+        --spectrum-global-dimension-font-size-700
+    );
+    --spectrum-alias-heading-l-text-size: var(
+        --spectrum-global-dimension-font-size-700
+    );
+    --spectrum-alias-heading2-margin-top: var(
+        --spectrum-global-dimension-font-size-600
+    );
+    --spectrum-alias-heading-l-margin-top: var(
+        --spectrum-global-dimension-font-size-600
+    );
     --spectrum-alias-heading2-han-text-size: var(
         --spectrum-global-dimension-font-size-600
     );
@@ -745,6 +840,18 @@ governing permissions and limitations under the License.
     );
     --spectrum-alias-heading-han-l-margin-top: var(
         --spectrum-global-dimension-font-size-500
+    );
+    --spectrum-alias-heading3-text-size: var(
+        --spectrum-global-dimension-font-size-500
+    );
+    --spectrum-alias-heading-m-text-size: var(
+        --spectrum-global-dimension-font-size-500
+    );
+    --spectrum-alias-heading3-margin-top: var(
+        --spectrum-global-dimension-font-size-400
+    );
+    --spectrum-alias-heading-m-margin-top: var(
+        --spectrum-global-dimension-font-size-400
     );
     --spectrum-alias-heading3-han-text-size: var(
         --spectrum-global-dimension-font-size-400
@@ -878,6 +985,54 @@ governing permissions and limitations under the License.
     --spectrum-alias-icon-color-error: var(--spectrum-global-color-red-400);
     --spectrum-alias-toolbar-background-color: var(
         --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-categorical-color-1: var(
+        --spectrum-global-color-static-seafoam-200
+    );
+    --spectrum-alias-categorical-color-2: var(
+        --spectrum-global-color-static-indigo-700
+    );
+    --spectrum-alias-categorical-color-3: var(
+        --spectrum-global-color-static-orange-500
+    );
+    --spectrum-alias-categorical-color-4: var(
+        --spectrum-global-color-static-magenta-500
+    );
+    --spectrum-alias-categorical-color-5: var(
+        --spectrum-global-color-static-indigo-200
+    );
+    --spectrum-alias-categorical-color-6: var(
+        --spectrum-global-color-static-celery-200
+    );
+    --spectrum-alias-categorical-color-7: var(
+        --spectrum-global-color-static-blue-500
+    );
+    --spectrum-alias-categorical-color-8: var(
+        --spectrum-global-color-static-purple-800
+    );
+    --spectrum-alias-categorical-color-9: var(
+        --spectrum-global-color-static-yellow-500
+    );
+    --spectrum-alias-categorical-color-10: var(
+        --spectrum-global-color-static-orange-700
+    );
+    --spectrum-alias-categorical-color-11: var(
+        --spectrum-global-color-static-green-600
+    );
+    --spectrum-alias-categorical-color-12: var(
+        --spectrum-global-color-static-chartreuse-300
+    );
+    --spectrum-alias-categorical-color-13: var(
+        --spectrum-global-color-static-blue-200
+    );
+    --spectrum-alias-categorical-color-14: var(
+        --spectrum-global-color-static-fuchsia-500
+    );
+    --spectrum-alias-categorical-color-15: var(
+        --spectrum-global-color-static-magenta-200
+    );
+    --spectrum-alias-categorical-color-16: var(
+        --spectrum-global-color-static-yellow-200
     );
 }
 

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -36,7 +36,7 @@
     },
     "devDependencies": {
         "@spectrum-css/commons": "^2.0.0",
-        "@spectrum-css/typography": "^2.0.3",
-        "@spectrum-css/vars": "^2.0.2"
+        "@spectrum-css/typography": "^2.1.0",
+        "@spectrum-css/vars": "^2.1.0"
     }
 }

--- a/packages/styles/scale-large.css
+++ b/packages/styles/scale-large.css
@@ -71,66 +71,8 @@ governing permissions and limitations under the License.
     --spectrum-global-dimension-font-size-900: 44px;
     --spectrum-global-dimension-font-size-1000: 49px;
     --spectrum-global-dimension-font-size-1100: 55px;
-    --spectrum-alias-heading-display1-text-size: var(
-        --spectrum-global-dimension-font-size-1000
-    );
-    --spectrum-alias-heading-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1000
-    );
-    --spectrum-alias-heading-display1-margin-top: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-xxxl-margin-top: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-display2-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-xxl-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-display2-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-xxl-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading1-text-size: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-xl-text-size: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading1-margin-top: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading-xl-margin-top: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading2-text-size: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading-l-text-size: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading2-margin-top: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading-l-margin-top: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading3-text-size: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading-m-text-size: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading3-margin-top: var(
-        --spectrum-global-dimension-font-size-300
-    );
-    --spectrum-alias-heading-m-margin-top: var(
-        --spectrum-global-dimension-font-size-300
-    );
+    --spectrum-global-dimension-font-size-1200: 62px;
+    --spectrum-global-dimension-font-size-1300: 70px;
     --spectrum-actionbutton-touch-hit-x: var(
         --spectrum-global-dimension-static-size-50
     );
@@ -179,7 +121,9 @@ governing permissions and limitations under the License.
     --spectrum-breadcrumb-multiline-button-touch-hit-y: var(
         --spectrum-global-dimension-static-size-50
     );
-    --spectrum-button-cta-text-padding-bottom: [object Object];
+    --spectrum-button-cta-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-cta-min-width: 90px;
     --spectrum-button-cta-touch-hit-x: var(
         --spectrum-global-dimension-static-size-50
@@ -187,7 +131,9 @@ governing permissions and limitations under the License.
     --spectrum-button-cta-touch-hit-y: var(
         --spectrum-global-dimension-static-size-50
     );
-    --spectrum-button-over-background-text-padding-bottom: [object Object];
+    --spectrum-button-over-background-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-over-background-min-width: 90px;
     --spectrum-button-over-background-touch-hit-x: var(
         --spectrum-global-dimension-static-size-50
@@ -195,7 +141,9 @@ governing permissions and limitations under the License.
     --spectrum-button-over-background-touch-hit-y: var(
         --spectrum-global-dimension-static-size-50
     );
-    --spectrum-button-primary-text-padding-bottom: [object Object];
+    --spectrum-button-primary-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-primary-min-width: 90px;
     --spectrum-button-primary-touch-hit-x: var(
         --spectrum-global-dimension-static-size-50
@@ -203,7 +151,9 @@ governing permissions and limitations under the License.
     --spectrum-button-primary-touch-hit-y: var(
         --spectrum-global-dimension-static-size-50
     );
-    --spectrum-button-quiet-over-background-text-padding-bottom: [object Object];
+    --spectrum-button-quiet-over-background-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-quiet-over-background-min-width: 90px;
     --spectrum-button-quiet-over-background-touch-hit-x: var(
         --spectrum-global-dimension-static-size-250
@@ -214,7 +164,9 @@ governing permissions and limitations under the License.
     --spectrum-button-quiet-over-background-cursor-hit-x: var(
         --spectrum-global-dimension-static-size-250
     );
-    --spectrum-button-quiet-primary-text-padding-bottom: [object Object];
+    --spectrum-button-quiet-primary-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-quiet-primary-min-width: 90px;
     --spectrum-button-quiet-primary-touch-hit-x: var(
         --spectrum-global-dimension-static-size-250
@@ -225,7 +177,9 @@ governing permissions and limitations under the License.
     --spectrum-button-quiet-primary-cursor-hit-x: var(
         --spectrum-global-dimension-static-size-250
     );
-    --spectrum-button-quiet-secondary-text-padding-bottom: [object Object];
+    --spectrum-button-quiet-secondary-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-quiet-secondary-min-width: 90px;
     --spectrum-button-quiet-secondary-touch-hit-x: var(
         --spectrum-global-dimension-static-size-250
@@ -236,7 +190,9 @@ governing permissions and limitations under the License.
     --spectrum-button-quiet-secondary-cursor-hit-x: var(
         --spectrum-global-dimension-static-size-250
     );
-    --spectrum-button-quiet-warning-text-padding-bottom: [object Object];
+    --spectrum-button-quiet-warning-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-quiet-warning-min-width: 90px;
     --spectrum-button-quiet-warning-touch-hit-x: var(
         --spectrum-global-dimension-static-size-250
@@ -247,7 +203,9 @@ governing permissions and limitations under the License.
     --spectrum-button-quiet-warning-cursor-hit-x: var(
         --spectrum-global-dimension-static-size-250
     );
-    --spectrum-button-secondary-text-padding-bottom: [object Object];
+    --spectrum-button-secondary-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-secondary-min-width: 90px;
     --spectrum-button-secondary-touch-hit-x: var(
         --spectrum-global-dimension-static-size-50
@@ -255,7 +213,9 @@ governing permissions and limitations under the License.
     --spectrum-button-secondary-touch-hit-y: var(
         --spectrum-global-dimension-static-size-50
     );
-    --spectrum-button-warning-text-padding-bottom: [object Object];
+    --spectrum-button-warning-text-padding-bottom: var(
+        --spectrum-global-dimension-size-100
+    );
     --spectrum-button-warning-min-width: 90px;
     --spectrum-button-warning-touch-hit-x: var(
         --spectrum-global-dimension-static-size-50

--- a/packages/styles/scale-medium.css
+++ b/packages/styles/scale-medium.css
@@ -71,66 +71,8 @@ governing permissions and limitations under the License.
     --spectrum-global-dimension-font-size-900: 36px;
     --spectrum-global-dimension-font-size-1000: 40px;
     --spectrum-global-dimension-font-size-1100: 45px;
-    --spectrum-alias-heading-display1-text-size: var(
-        --spectrum-global-dimension-font-size-1100
-    );
-    --spectrum-alias-heading-xxxl-text-size: var(
-        --spectrum-global-dimension-font-size-1100
-    );
-    --spectrum-alias-heading-display1-margin-top: var(
-        --spectrum-global-dimension-font-size-1000
-    );
-    --spectrum-alias-heading-xxxl-margin-top: var(
-        --spectrum-global-dimension-font-size-1000
-    );
-    --spectrum-alias-heading-display2-text-size: var(
-        --spectrum-global-dimension-font-size-1000
-    );
-    --spectrum-alias-heading-xxl-text-size: var(
-        --spectrum-global-dimension-font-size-1000
-    );
-    --spectrum-alias-heading-display2-margin-top: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-xxl-margin-top: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading1-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading-xl-text-size: var(
-        --spectrum-global-dimension-font-size-900
-    );
-    --spectrum-alias-heading1-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading-xl-margin-top: var(
-        --spectrum-global-dimension-font-size-800
-    );
-    --spectrum-alias-heading2-text-size: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading-l-text-size: var(
-        --spectrum-global-dimension-font-size-700
-    );
-    --spectrum-alias-heading2-margin-top: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading-l-margin-top: var(
-        --spectrum-global-dimension-font-size-600
-    );
-    --spectrum-alias-heading3-text-size: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading-m-text-size: var(
-        --spectrum-global-dimension-font-size-500
-    );
-    --spectrum-alias-heading3-margin-top: var(
-        --spectrum-global-dimension-font-size-400
-    );
-    --spectrum-alias-heading-m-margin-top: var(
-        --spectrum-global-dimension-font-size-400
-    );
+    --spectrum-global-dimension-font-size-1200: 50px;
+    --spectrum-global-dimension-font-size-1300: 60px;
     --spectrum-actionbutton-touch-hit-x: var(
         --spectrum-global-dimension-static-size-100
     );
@@ -185,7 +127,9 @@ governing permissions and limitations under the License.
     --spectrum-breadcrumb-multiline-button-touch-hit-y: var(
         --spectrum-global-dimension-static-size-100
     );
-    --spectrum-button-cta-text-padding-bottom: [object Object];
+    --spectrum-button-cta-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-cta-min-width: var(--spectrum-global-dimension-size-900);
     --spectrum-button-cta-touch-hit-x: var(
         --spectrum-global-dimension-static-size-100
@@ -193,7 +137,9 @@ governing permissions and limitations under the License.
     --spectrum-button-cta-touch-hit-y: var(
         --spectrum-global-dimension-static-size-100
     );
-    --spectrum-button-over-background-text-padding-bottom: [object Object];
+    --spectrum-button-over-background-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-over-background-min-width: var(
         --spectrum-global-dimension-size-900
     );
@@ -203,7 +149,9 @@ governing permissions and limitations under the License.
     --spectrum-button-over-background-touch-hit-y: var(
         --spectrum-global-dimension-static-size-100
     );
-    --spectrum-button-primary-text-padding-bottom: [object Object];
+    --spectrum-button-primary-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-primary-min-width: var(
         --spectrum-global-dimension-size-900
     );
@@ -213,7 +161,9 @@ governing permissions and limitations under the License.
     --spectrum-button-primary-touch-hit-y: var(
         --spectrum-global-dimension-static-size-100
     );
-    --spectrum-button-quiet-over-background-text-padding-bottom: [object Object];
+    --spectrum-button-quiet-over-background-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-quiet-over-background-min-width: var(
         --spectrum-global-dimension-size-900
     );
@@ -226,7 +176,9 @@ governing permissions and limitations under the License.
     --spectrum-button-quiet-over-background-cursor-hit-x: var(
         --spectrum-global-dimension-static-size-200
     );
-    --spectrum-button-quiet-primary-text-padding-bottom: [object Object];
+    --spectrum-button-quiet-primary-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-quiet-primary-min-width: var(
         --spectrum-global-dimension-size-900
     );
@@ -239,7 +191,9 @@ governing permissions and limitations under the License.
     --spectrum-button-quiet-primary-cursor-hit-x: var(
         --spectrum-global-dimension-static-size-200
     );
-    --spectrum-button-quiet-secondary-text-padding-bottom: [object Object];
+    --spectrum-button-quiet-secondary-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-quiet-secondary-min-width: var(
         --spectrum-global-dimension-size-900
     );
@@ -252,7 +206,9 @@ governing permissions and limitations under the License.
     --spectrum-button-quiet-secondary-cursor-hit-x: var(
         --spectrum-global-dimension-static-size-200
     );
-    --spectrum-button-quiet-warning-text-padding-bottom: [object Object];
+    --spectrum-button-quiet-warning-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-quiet-warning-min-width: var(
         --spectrum-global-dimension-size-900
     );
@@ -265,7 +221,9 @@ governing permissions and limitations under the License.
     --spectrum-button-quiet-warning-cursor-hit-x: var(
         --spectrum-global-dimension-static-size-200
     );
-    --spectrum-button-secondary-text-padding-bottom: [object Object];
+    --spectrum-button-secondary-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-secondary-min-width: var(
         --spectrum-global-dimension-size-900
     );
@@ -275,7 +233,9 @@ governing permissions and limitations under the License.
     --spectrum-button-secondary-touch-hit-y: var(
         --spectrum-global-dimension-static-size-100
     );
-    --spectrum-button-warning-text-padding-bottom: [object Object];
+    --spectrum-button-warning-text-padding-bottom: var(
+        --spectrum-global-dimension-size-85
+    );
     --spectrum-button-warning-min-width: var(
         --spectrum-global-dimension-size-900
     );

--- a/packages/styles/typography.css
+++ b/packages/styles/typography.css
@@ -13,8 +13,10 @@ governing permissions and limitations under the License.
 /* stylelint-disable */
 :root,
 :host {
-    font-family: 'adobe-clean-ux', 'adobe-clean', 'Source Sans Pro',
-        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-body-text-font-family,
+        var(--spectrum-global-font-family-base)
+    );
     font-size: var(
         --spectrum-alias-font-size-default,
         var(--spectrum-global-dimension-font-size-100)
@@ -22,43 +24,125 @@ governing permissions and limitations under the License.
 }
 
 .spectrum:lang(ar) {
-    font-family: 'adobe-arabic', 'myriad-arabic', -apple-system,
-        BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-font-family-ar,
+        myriad-arabic,
+        adobe-clean,
+        'Source Sans Pro',
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        Roboto,
+        Ubuntu,
+        'Trebuchet MS',
+        'Lucida Grande',
+        sans-serif
+    );
 }
 
 .spectrum:lang(he) {
-    font-family: 'adobe-hebrew', -apple-system, BlinkMacSystemFont, 'Segoe UI',
-        Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-font-family-he,
+        myriad-hebrew,
+        adobe-clean,
+        'Source Sans Pro',
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        Roboto,
+        Ubuntu,
+        'Trebuchet MS',
+        'Lucida Grande',
+        sans-serif
+    );
 }
 
 .spectrum:lang(zh-Hans) {
-    font-family: 'adobe-clean-han-simplified-c', 'SimSun', 'Heiti SC Light',
-        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-font-family-zhhans,
+        adobe-clean-han-simplified-c,
+        source-han-simplified-c,
+        'SimSun',
+        'Heiti SC Light',
+        'sans-serif'
+    );
 }
 
 .spectrum:lang(zh-Hant) {
-    font-family: 'adobe-clean-han-traditional', 'Microsoft JhengHei UI',
-        'Microsoft JhengHei', 'Heiti TC Light', -apple-system,
-        BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-font-family-zh,
+        adobe-clean-han-traditional,
+        source-han-traditional,
+        'MingLiu',
+        'Heiti TC Light',
+        'sans-serif'
+    );
 }
 
 .spectrum:lang(zh) {
-    font-family: 'adobe-clean-han-simplified-c', 'SimSun', 'Heiti SC Light',
-        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-font-family-zh,
+        adobe-clean-han-traditional,
+        source-han-traditional,
+        'MingLiu',
+        'Heiti TC Light',
+        'sans-serif'
+    );
 }
 
 .spectrum:lang(ko) {
-    font-family: 'adobe-clean-han-korean', 'Malgun Gothic', 'Apple Gothic',
-        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-font-family-ko,
+        adobe-clean-han-korean,
+        source-han-korean,
+        'Malgun Gothic',
+        'Apple Gothic',
+        'sans-serif'
+    );
 }
 
 .spectrum:lang(ja) {
-    font-family: 'adobe-clean-han-japanese', 'Yu Gothic',
+    font-family: var(
+        --spectrum-alias-font-family-ja,
+        adobe-clean-han-japanese,
+        source-han-japanese,
+        'Yu Gothic',
         '\\30E1 \\30A4 \\30EA \\30AA',
         '\\30D2 \\30E9 \\30AE \\30CE \\89D2 \\30B4  Pro W3',
-        'Hiragino Kaku Gothic Pro W3', 'Osaka',
-        '\\FF2D \\FF33 \\FF30 \\30B4 \\30B7 \\30C3 \\30AF', 'MS PGothic',
-        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        'Hiragino Kaku Gothic Pro W3',
+        'Osaka',
+        '\\FF2D \\FF33 \\FF30 \\30B4 \\30B7 \\30C3 \\30AF',
+        'MS PGothic',
+        'sans-serif'
+    );
+}
+
+.spectrum,
+.spectrum.spectrum-Body,
+.spectrum-Body {
+    font-size: var(
+        --spectrum-body-4-text-size,
+        var(--spectrum-alias-font-size-default)
+    );
+    font-weight: var(
+        --spectrum-body-4-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-body-4-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-4-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+}
+
+.spectrum-Body--italic {
+    font-style: var(
+        --spectrum-body-4-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
 }
 
 .spectrum-Body1 {
@@ -83,58 +167,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-body-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Body1 em {
-    font-size: var(
-        --spectrum-body-1-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-400)
-    );
-    font-weight: var(
-        --spectrum-body-1-emphasis-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-1-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-1-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Body1 strong {
-    font-size: var(
-        --spectrum-body-1-strong-text-size,
-        var(--spectrum-global-dimension-font-size-400)
-    );
-    font-weight: var(
-        --spectrum-body-1-strong-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-1-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-1-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -166,60 +198,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Body2 em,
-.spectrum-Body--large em {
-    font-size: var(
-        --spectrum-body-2-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-300)
-    );
-    font-weight: var(
-        --spectrum-body-2-emphasis-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-2-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-2-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Body2 strong,
-.spectrum-Body--large strong {
-    font-size: var(
-        --spectrum-body-2-strong-text-size,
-        var(--spectrum-global-dimension-font-size-300)
-    );
-    font-weight: var(
-        --spectrum-body-2-strong-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-2-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-2-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Body3 {
     font-size: var(
         --spectrum-body-3-text-size,
@@ -242,58 +220,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-body-3-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Body3 em {
-    font-size: var(
-        --spectrum-body-3-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    font-weight: var(
-        --spectrum-body-3-emphasis-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-3-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-3-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-3-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-3-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Body3 strong {
-    font-size: var(
-        --spectrum-body-3-strong-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    font-weight: var(
-        --spectrum-body-3-strong-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-3-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-3-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-3-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-3-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -325,60 +251,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Body4 em,
-.spectrum-Body--secondary em {
-    font-size: var(
-        --spectrum-body-4-emphasis-text-size,
-        var(--spectrum-alias-font-size-default)
-    );
-    font-weight: var(
-        --spectrum-body-4-emphasis-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-4-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-4-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-4-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-4-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Body4 strong,
-.spectrum-Body--secondary strong {
-    font-size: var(
-        --spectrum-body-4-strong-text-size,
-        var(--spectrum-alias-font-size-default)
-    );
-    font-weight: var(
-        --spectrum-body-4-strong-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-4-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-4-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-4-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-4-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Body5,
 .spectrum-Body--small {
     font-size: var(
@@ -402,60 +274,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-body-5-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Body5 em,
-.spectrum-Body--small em {
-    font-size: var(
-        --spectrum-body-5-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    font-weight: var(
-        --spectrum-body-5-emphasis-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-5-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-5-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-5-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-5-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Body5 strong,
-.spectrum-Body--small strong {
-    font-size: var(
-        --spectrum-body-5-strong-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    font-weight: var(
-        --spectrum-body-5-strong-text-font-weight,
-        var(--spectrum-alias-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-5-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-5-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-5-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-5-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -486,58 +304,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Heading1 em {
-    font-size: var(
-        --spectrum-heading-1-emphasis-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-1-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-1-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1 strong {
-    font-size: var(
-        --spectrum-heading-1-strong-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-1-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-1-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Heading2 {
     font-size: var(
         --spectrum-heading-2-text-size,
@@ -564,58 +330,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Heading2 em {
-    font-size: var(
-        --spectrum-heading-2-emphasis-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-2-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-2-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading2 strong {
-    font-size: var(
-        --spectrum-heading-2-strong-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-2-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-2-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Heading3 {
     font-size: var(
         --spectrum-heading-3-text-size,
@@ -638,58 +352,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-heading-3-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading3 em {
-    font-size: var(
-        --spectrum-heading-3-emphasis-text-size,
-        var(--spectrum-alias-heading3-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-3-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-3-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-3-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-3-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-3-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading3 strong {
-    font-size: var(
-        --spectrum-heading-3-strong-text-size,
-        var(--spectrum-alias-heading3-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-3-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-3-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-3-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-3-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-3-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -721,60 +383,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Heading4 em,
-.spectrum-Heading--subtitle1 em {
-    font-size: var(
-        --spectrum-heading-4-emphasis-text-size,
-        var(--spectrum-alias-heading4-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-4-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-4-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-4-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-4-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-4-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading4 strong,
-.spectrum-Heading--subtitle1 strong {
-    font-size: var(
-        --spectrum-heading-4-strong-text-size,
-        var(--spectrum-alias-heading4-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-4-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-4-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-4-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-4-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-4-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Heading5 {
     font-size: var(
         --spectrum-heading-5-text-size,
@@ -797,58 +405,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-heading-5-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading5 em {
-    font-size: var(
-        --spectrum-heading-5-emphasis-text-size,
-        var(--spectrum-alias-heading5-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-5-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-5-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-5-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-5-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-5-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading5 strong {
-    font-size: var(
-        --spectrum-heading-5-strong-text-size,
-        var(--spectrum-alias-heading5-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-5-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-5-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-5-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-5-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-5-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -880,60 +436,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Heading6 em,
-.spectrum-Heading--subtitle2 em {
-    font-size: var(
-        --spectrum-heading-6-emphasis-text-size,
-        var(--spectrum-alias-heading6-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-6-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-6-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-6-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-6-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-6-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading6 strong,
-.spectrum-Heading--subtitle2 strong {
-    font-size: var(
-        --spectrum-heading-6-strong-text-size,
-        var(--spectrum-alias-heading6-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-6-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-6-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-6-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-6-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-6-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Subheading,
 .spectrum-Heading--subtitle3 {
     font-size: var(
@@ -957,63 +459,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-medium)
     );
     text-transform: var(--spectrum-subheading-text-transform, uppercase);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Subheading em,
-.spectrum-Heading--subtitle3 em {
-    font-size: var(
-        --spectrum-subheading-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-subheading-emphasis-text-font-weight,
-        var(--spectrum-alias-subheading-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-subheading-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-subheading-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-subheading-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-medium)
-    );
-    text-transform: var(
-        --spectrum-subheading-emphasis-text-transform,
-        uppercase
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Subheading strong,
-.spectrum-Heading--subtitle3 strong {
-    font-size: var(
-        --spectrum-subheading-strong-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-subheading-strong-text-font-weight,
-        var(--spectrum-alias-subheading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-subheading-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-subheading-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-subheading-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-medium)
-    );
-    text-transform: var(--spectrum-subheading-strong-text-transform, uppercase);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -1044,58 +489,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Detail em {
-    font-size: var(
-        --spectrum-detail-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-detail-emphasis-text-font-weight,
-        var(--spectrum-alias-detail-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-detail-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-detail-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-detail-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-medium)
-    );
-    text-transform: var(--spectrum-detail-emphasis-text-transform, uppercase);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Detail strong {
-    font-size: var(
-        --spectrum-detail-strong-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-detail-strong-text-font-weight,
-        var(--spectrum-alias-detail-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-detail-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-detail-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-detail-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-medium)
-    );
-    text-transform: var(--spectrum-detail-strong-text-transform, uppercase);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Heading1--quiet {
     font-size: var(
         --spectrum-heading-quiet-1-text-size,
@@ -1118,61 +511,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-heading-quiet-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--quiet em {
-    font-size: var(
-        --spectrum-heading-quiet-1-emphasis-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-1-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-quiet)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--quiet strong {
-    font-size: var(
-        --spectrum-heading-quiet-1-strong-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-1-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-quiet-1-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -1204,63 +542,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Heading2--quiet em,
-.spectrum-Heading--pageTitle em {
-    font-size: var(
-        --spectrum-heading-quiet-2-emphasis-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-2-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-quiet)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading2--quiet strong,
-.spectrum-Heading--pageTitle strong {
-    font-size: var(
-        --spectrum-heading-quiet-2-strong-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-2-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-heading-quiet-2-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Heading1--strong {
     font-size: var(
         --spectrum-heading-strong-1-text-size,
@@ -1283,64 +564,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-heading-strong-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--strong em {
-    font-size: var(
-        --spectrum-heading-strong-1-emphasis-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-strong-1-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-strong-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-strong-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-strong-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-heading-strong-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--strong strong {
-    font-size: var(
-        --spectrum-heading-strong-1-strong-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-strong-1-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-strong-strong)
-    );
-    line-height: var(
-        --spectrum-heading-strong-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-strong-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-strong-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-heading-strong-1-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -1371,64 +594,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Heading2--strong em {
-    font-size: var(
-        --spectrum-heading-strong-2-emphasis-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-strong-2-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-strong-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-strong-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-strong-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-heading-strong-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading2--strong strong {
-    font-size: var(
-        --spectrum-heading-strong-2-strong-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-strong-2-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-strong-strong)
-    );
-    line-height: var(
-        --spectrum-heading-strong-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-strong-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-strong-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-heading-strong-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Heading1--display {
     font-size: var(
         --spectrum-display-1-text-size,
@@ -1451,58 +616,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-display-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--display em {
-    font-size: var(
-        --spectrum-display-1-emphasis-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-1-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-display-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-display-1-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--display strong {
-    font-size: var(
-        --spectrum-display-1-strong-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-1-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-display-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-display-1-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -1533,58 +646,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Heading2--display em {
-    font-size: var(
-        --spectrum-display-2-emphasis-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-2-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-display-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-display-2-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading2--display strong {
-    font-size: var(
-        --spectrum-display-2-strong-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-2-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-display-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-display-2-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Heading1--display.spectrum-Heading1--strong {
     font-size: var(
         --spectrum-display-strong-1-text-size,
@@ -1607,64 +668,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-display-strong-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--display.spectrum-Heading1--strong em {
-    font-size: var(
-        --spectrum-display-strong-1-emphasis-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-strong-1-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-display-strong-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-strong-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-strong-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-display-strong-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--display.spectrum-Heading1--strong strong {
-    font-size: var(
-        --spectrum-display-strong-1-strong-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-strong-1-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-strong-strong)
-    );
-    line-height: var(
-        --spectrum-display-strong-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-strong-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-strong-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-display-strong-1-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -1695,64 +698,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Heading2--display.spectrum-Heading2--strong em {
-    font-size: var(
-        --spectrum-display-strong-2-emphasis-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-strong-2-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-display-strong-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-strong-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-strong-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-display-strong-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading2--display.spectrum-Heading2--strong strong {
-    font-size: var(
-        --spectrum-display-strong-2-strong-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-strong-2-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-strong-strong)
-    );
-    line-height: var(
-        --spectrum-display-strong-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-strong-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-strong-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-display-strong-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Heading1--display.spectrum-Heading1--quiet {
     font-size: var(
         --spectrum-display-quiet-1-text-size,
@@ -1775,61 +720,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-display-quiet-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--display.spectrum-Heading1--quiet em {
-    font-size: var(
-        --spectrum-display-quiet-1-emphasis-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-1-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-quiet)
-    );
-    line-height: var(
-        --spectrum-display-quiet-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading1--display.spectrum-Heading1--quiet strong {
-    font-size: var(
-        --spectrum-display-quiet-1-strong-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-1-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-display-quiet-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-display-quiet-1-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -1857,63 +747,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-display-quiet-2-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading2--display.spectrum-Heading2--quiet em,
-.spectrum-Heading--display em {
-    font-size: var(
-        --spectrum-display-quiet-2-emphasis-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-2-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-quiet)
-    );
-    line-height: var(
-        --spectrum-display-quiet-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Heading2--display.spectrum-Heading2--quiet strong,
-.spectrum-Heading--display strong {
-    font-size: var(
-        --spectrum-display-quiet-2-strong-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-2-strong-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-display-quiet-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-display-quiet-2-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -2194,61 +1027,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Body1 em {
-    font-size: var(
-        --spectrum-body-article-1-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-400)
-    );
-    font-weight: var(
-        --spectrum-body-article-1-emphasis-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-article-1-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-body-article-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Body1 strong {
-    font-size: var(
-        --spectrum-body-article-1-strong-text-size,
-        var(--spectrum-global-dimension-font-size-400)
-    );
-    font-weight: var(
-        --spectrum-body-article-1-strong-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-article-1-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-article-1-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Body2,
 .spectrum-Article .spectrum-Body--large {
     font-size: var(
@@ -2276,63 +1054,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Body2 em,
-.spectrum-Article .spectrum-Body--large em {
-    font-size: var(
-        --spectrum-body-article-2-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-300)
-    );
-    font-weight: var(
-        --spectrum-body-article-2-emphasis-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-article-2-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-body-article-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Body2 strong,
-.spectrum-Article .spectrum-Body--large strong {
-    font-size: var(
-        --spectrum-body-article-2-strong-text-size,
-        var(--spectrum-global-dimension-font-size-300)
-    );
-    font-weight: var(
-        --spectrum-body-article-2-strong-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-article-2-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-article-2-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Body3 {
     font-size: var(
         --spectrum-body-article-3-text-size,
@@ -2355,61 +1076,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-body-article-3-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Body3 em {
-    font-size: var(
-        --spectrum-body-article-3-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    font-weight: var(
-        --spectrum-body-article-3-emphasis-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-article-3-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-3-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-3-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-body-article-3-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Body3 strong {
-    font-size: var(
-        --spectrum-body-article-3-strong-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    font-weight: var(
-        --spectrum-body-article-3-strong-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-article-3-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-3-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-3-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-article-3-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -2441,63 +1107,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Body4 em,
-.spectrum-Article .spectrum-Body--secondary em {
-    font-size: var(
-        --spectrum-body-article-4-emphasis-text-size,
-        var(--spectrum-alias-font-size-default)
-    );
-    font-weight: var(
-        --spectrum-body-article-4-emphasis-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-article-4-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-4-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-4-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-body-article-4-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Body4 strong,
-.spectrum-Article .spectrum-Body--secondary strong {
-    font-size: var(
-        --spectrum-body-article-4-strong-text-size,
-        var(--spectrum-alias-font-size-default)
-    );
-    font-weight: var(
-        --spectrum-body-article-4-strong-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-article-4-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-4-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-4-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-article-4-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Body5,
 .spectrum-Article .spectrum-Body--small {
     font-size: var(
@@ -2521,63 +1130,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-none)
     );
     text-transform: var(--spectrum-body-article-5-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Body5 em,
-.spectrum-Article .spectrum-Body--small em {
-    font-size: var(
-        --spectrum-body-article-5-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    font-weight: var(
-        --spectrum-body-article-5-emphasis-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-body-article-5-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-5-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-5-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-body-article-5-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Body5 strong,
-.spectrum-Article .spectrum-Body--small strong {
-    font-size: var(
-        --spectrum-body-article-5-strong-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    font-weight: var(
-        --spectrum-body-article-5-strong-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-article-5-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-article-5-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-article-5-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-body-article-5-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -2608,64 +1160,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Heading1 em {
-    font-size: var(
-        --spectrum-heading-article-1-emphasis-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-1-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-article-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading1 strong {
-    font-size: var(
-        --spectrum-heading-article-1-strong-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-1-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-article-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-1-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Heading2 {
     font-size: var(
         --spectrum-heading-article-2-text-size,
@@ -2692,64 +1186,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Heading2 em {
-    font-size: var(
-        --spectrum-heading-article-2-emphasis-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-2-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-article-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading2 strong {
-    font-size: var(
-        --spectrum-heading-article-2-strong-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-2-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-article-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Heading3 {
     font-size: var(
         --spectrum-heading-article-3-text-size,
@@ -2772,64 +1208,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-small)
     );
     text-transform: var(--spectrum-heading-article-3-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading3 em {
-    font-size: var(
-        --spectrum-heading-article-3-emphasis-text-size,
-        var(--spectrum-alias-heading3-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-3-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-article-3-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-3-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-3-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-3-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading3 strong {
-    font-size: var(
-        --spectrum-heading-article-3-strong-text-size,
-        var(--spectrum-alias-heading3-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-3-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-article-3-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-3-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-3-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-3-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -2861,66 +1239,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Heading4 em,
-.spectrum-Article .spectrum-Heading--subtitle1 em {
-    font-size: var(
-        --spectrum-heading-article-4-emphasis-text-size,
-        var(--spectrum-alias-heading4-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-4-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-article-4-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-4-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-4-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-4-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading4 strong,
-.spectrum-Article .spectrum-Heading--subtitle1 strong {
-    font-size: var(
-        --spectrum-heading-article-4-strong-text-size,
-        var(--spectrum-alias-heading4-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-4-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-article-4-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-4-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-4-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-4-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Heading5 {
     font-size: var(
         --spectrum-heading-article-5-text-size,
@@ -2943,64 +1261,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-small)
     );
     text-transform: var(--spectrum-heading-article-5-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading5 em {
-    font-size: var(
-        --spectrum-heading-article-5-emphasis-text-size,
-        var(--spectrum-alias-heading5-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-5-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-article-5-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-5-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-5-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-5-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading5 strong {
-    font-size: var(
-        --spectrum-heading-article-5-strong-text-size,
-        var(--spectrum-alias-heading5-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-5-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-article-5-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-5-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-5-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-5-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -3032,66 +1292,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Heading6 em,
-.spectrum-Article .spectrum-Heading--subtitle2 em {
-    font-size: var(
-        --spectrum-heading-article-6-emphasis-text-size,
-        var(--spectrum-alias-heading6-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-6-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-heading-article-6-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-6-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-6-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-6-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading6 strong,
-.spectrum-Article .spectrum-Heading--subtitle2 strong {
-    font-size: var(
-        --spectrum-heading-article-6-strong-text-size,
-        var(--spectrum-alias-heading6-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-article-6-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-article-6-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-article-6-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-article-6-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-article-6-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Subheading,
 .spectrum-Article .spectrum-Heading--subtitle3 {
     font-size: var(
@@ -3115,66 +1315,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-small)
     );
     text-transform: var(--spectrum-subheading-article-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Subheading em,
-.spectrum-Article .spectrum-Heading--subtitle3 em {
-    font-size: var(
-        --spectrum-subheading-article-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-subheading-article-emphasis-text-font-weight,
-        var(--spectrum-alias-article-subheading-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-subheading-article-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-subheading-article-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-subheading-article-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-subheading-article-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Subheading strong,
-.spectrum-Article .spectrum-Heading--subtitle3 strong {
-    font-size: var(
-        --spectrum-subheading-article-strong-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-subheading-article-strong-text-font-weight,
-        var(--spectrum-alias-article-subheading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-subheading-article-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-subheading-article-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-subheading-article-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-subheading-article-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -3205,61 +1345,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Detail em {
-    font-size: var(
-        --spectrum-detail-article-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-detail-article-emphasis-text-font-weight,
-        var(--spectrum-alias-article-body-text-font-weight)
-    );
-    line-height: var(
-        --spectrum-detail-article-emphasis-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-detail-article-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-detail-article-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(
-        --spectrum-detail-article-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Detail strong {
-    font-size: var(
-        --spectrum-detail-article-strong-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-detail-article-strong-text-font-weight,
-        var(--spectrum-alias-article-detail-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-detail-article-strong-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
-    );
-    font-style: var(
-        --spectrum-detail-article-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-detail-article-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    text-transform: var(--spectrum-detail-article-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Heading1--quiet {
     font-size: var(
         --spectrum-heading-quiet-article-1-text-size,
@@ -3283,64 +1368,6 @@ governing permissions and limitations under the License.
     );
     text-transform: var(
         --spectrum-heading-quiet-article-1-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading1--quiet em {
-    font-size: var(
-        --spectrum-heading-quiet-article-1-emphasis-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-article-1-emphasis-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-quiet)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-article-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-article-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-article-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-article-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading1--quiet strong {
-    font-size: var(
-        --spectrum-heading-quiet-article-1-strong-text-size,
-        var(--spectrum-alias-heading1-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-article-1-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-article-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-article-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-article-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-article-1-strong-text-transform,
         none
     );
     margin-top: 0;
@@ -3377,66 +1404,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Heading2--quiet em,
-.spectrum-Article .spectrum-Heading--pageTitle em {
-    font-size: var(
-        --spectrum-heading-quiet-article-2-emphasis-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-article-2-emphasis-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-quiet)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-article-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-article-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-article-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-article-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading2--quiet strong,
-.spectrum-Article .spectrum-Heading--pageTitle strong {
-    font-size: var(
-        --spectrum-heading-quiet-article-2-strong-text-size,
-        var(--spectrum-alias-heading2-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-article-2-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-article-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-article-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-article-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-article-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Heading1--display {
     font-size: var(
         --spectrum-display-article-1-text-size,
@@ -3459,64 +1426,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-small)
     );
     text-transform: var(--spectrum-display-article-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading1--display em {
-    font-size: var(
-        --spectrum-display-article-1-emphasis-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-article-1-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-display-article-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-article-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-article-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-display-article-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading1--display strong {
-    font-size: var(
-        --spectrum-display-article-1-strong-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-article-1-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-display-article-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-article-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-article-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-display-article-1-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -3547,64 +1456,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Heading2--display em {
-    font-size: var(
-        --spectrum-display-article-2-emphasis-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-article-2-emphasis-text-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-display-article-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-article-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-article-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-display-article-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading2--display strong {
-    font-size: var(
-        --spectrum-display-article-2-strong-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-article-2-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-display-article-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-article-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-article-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-display-article-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Article .spectrum-Heading1--display.spectrum-Heading1--quiet {
     font-size: var(
         --spectrum-display-quiet-article-1-text-size,
@@ -3628,64 +1479,6 @@ governing permissions and limitations under the License.
     );
     text-transform: var(
         --spectrum-display-quiet-article-1-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading1--display.spectrum-Heading1--quiet em {
-    font-size: var(
-        --spectrum-display-quiet-article-1-emphasis-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-article-1-emphasis-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-quiet)
-    );
-    line-height: var(
-        --spectrum-display-quiet-article-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-article-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-article-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-article-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading1--display.spectrum-Heading1--quiet strong {
-    font-size: var(
-        --spectrum-display-quiet-article-1-strong-text-size,
-        var(--spectrum-alias-heading-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-article-1-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-display-quiet-article-1-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-article-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-article-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-article-1-strong-text-transform,
         none
     );
     margin-top: 0;
@@ -3722,66 +1515,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum-Article .spectrum-Heading2--display.spectrum-Heading2--quiet em,
-.spectrum-Article .spectrum-Heading--display em {
-    font-size: var(
-        --spectrum-display-quiet-article-2-emphasis-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-article-2-emphasis-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-quiet)
-    );
-    line-height: var(
-        --spectrum-display-quiet-article-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-article-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-article-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-article-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Article .spectrum-Heading2--display.spectrum-Heading2--quiet strong,
-.spectrum-Article .spectrum-Heading--display strong {
-    font-size: var(
-        --spectrum-display-quiet-article-2-strong-text-size,
-        var(--spectrum-alias-heading-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-article-2-strong-text-font-weight,
-        var(--spectrum-alias-article-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-display-quiet-article-2-strong-text-line-height,
-        var(--spectrum-alias-heading-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-article-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-article-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-small)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-article-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Body1,
 .spectrum:lang(ko) .spectrum-Body1,
 .spectrum:lang(zh) .spectrum-Body1 {
@@ -3806,62 +1539,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-body-han-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Body1 em,
-.spectrum:lang(ko) .spectrum-Body1 em,
-.spectrum:lang(zh) .spectrum-Body1 em {
-    font-size: var(
-        --spectrum-body-han-1-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-400)
-    );
-    font-weight: var(
-        --spectrum-body-han-1-emphasis-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-emphasis)
-    );
-    line-height: var(
-        --spectrum-body-han-1-emphasis-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-1-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Body1 strong,
-.spectrum:lang(ko) .spectrum-Body1 strong,
-.spectrum:lang(zh) .spectrum-Body1 strong {
-    font-size: var(
-        --spectrum-body-han-1-strong-text-size,
-        var(--spectrum-global-dimension-font-size-400)
-    );
-    font-weight: var(
-        --spectrum-body-han-1-strong-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-han-1-strong-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-1-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -3897,68 +1574,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Body2 em,
-.spectrum:lang(ko) .spectrum-Body2 em,
-.spectrum:lang(zh) .spectrum-Body2 em,
-.spectrum:lang(ja) .spectrum-Body--large em,
-.spectrum:lang(ko) .spectrum-Body--large em,
-.spectrum:lang(zh) .spectrum-Body--large em {
-    font-size: var(
-        --spectrum-body-han-2-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-300)
-    );
-    font-weight: var(
-        --spectrum-body-han-2-emphasis-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-emphasis)
-    );
-    line-height: var(
-        --spectrum-body-han-2-emphasis-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-2-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Body2 strong,
-.spectrum:lang(ko) .spectrum-Body2 strong,
-.spectrum:lang(zh) .spectrum-Body2 strong,
-.spectrum:lang(ja) .spectrum-Body--large strong,
-.spectrum:lang(ko) .spectrum-Body--large strong,
-.spectrum:lang(zh) .spectrum-Body--large strong {
-    font-size: var(
-        --spectrum-body-han-2-strong-text-size,
-        var(--spectrum-global-dimension-font-size-300)
-    );
-    font-weight: var(
-        --spectrum-body-han-2-strong-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-han-2-strong-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-2-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Body3,
 .spectrum:lang(ko) .spectrum-Body3,
 .spectrum:lang(zh) .spectrum-Body3 {
@@ -3983,62 +1598,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-body-han-3-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Body3 em,
-.spectrum:lang(ko) .spectrum-Body3 em,
-.spectrum:lang(zh) .spectrum-Body3 em {
-    font-size: var(
-        --spectrum-body-han-3-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    font-weight: var(
-        --spectrum-body-han-3-emphasis-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-emphasis)
-    );
-    line-height: var(
-        --spectrum-body-han-3-emphasis-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-3-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-3-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-3-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Body3 strong,
-.spectrum:lang(ko) .spectrum-Body3 strong,
-.spectrum:lang(zh) .spectrum-Body3 strong {
-    font-size: var(
-        --spectrum-body-han-3-strong-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    font-weight: var(
-        --spectrum-body-han-3-strong-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-han-3-strong-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-3-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-3-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-3-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -4074,68 +1633,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Body4 em,
-.spectrum:lang(ko) .spectrum-Body4 em,
-.spectrum:lang(zh) .spectrum-Body4 em,
-.spectrum:lang(ja) .spectrum-Body--secondary em,
-.spectrum:lang(ko) .spectrum-Body--secondary em,
-.spectrum:lang(zh) .spectrum-Body--secondary em {
-    font-size: var(
-        --spectrum-body-han-4-emphasis-text-size,
-        var(--spectrum-alias-font-size-default)
-    );
-    font-weight: var(
-        --spectrum-body-han-4-emphasis-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-emphasis)
-    );
-    line-height: var(
-        --spectrum-body-han-4-emphasis-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-4-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-4-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-4-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Body4 strong,
-.spectrum:lang(ko) .spectrum-Body4 strong,
-.spectrum:lang(zh) .spectrum-Body4 strong,
-.spectrum:lang(ja) .spectrum-Body--secondary strong,
-.spectrum:lang(ko) .spectrum-Body--secondary strong,
-.spectrum:lang(zh) .spectrum-Body--secondary strong {
-    font-size: var(
-        --spectrum-body-han-4-strong-text-size,
-        var(--spectrum-alias-font-size-default)
-    );
-    font-weight: var(
-        --spectrum-body-han-4-strong-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-han-4-strong-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-4-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-4-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-4-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Body5,
 .spectrum:lang(ko) .spectrum-Body5,
 .spectrum:lang(zh) .spectrum-Body5,
@@ -4163,68 +1660,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-body-han-5-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Body5 em,
-.spectrum:lang(ko) .spectrum-Body5 em,
-.spectrum:lang(zh) .spectrum-Body5 em,
-.spectrum:lang(ja) .spectrum-Body--small em,
-.spectrum:lang(ko) .spectrum-Body--small em,
-.spectrum:lang(zh) .spectrum-Body--small em {
-    font-size: var(
-        --spectrum-body-han-5-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    font-weight: var(
-        --spectrum-body-han-5-emphasis-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-emphasis)
-    );
-    line-height: var(
-        --spectrum-body-han-5-emphasis-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-5-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-5-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-5-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Body5 strong,
-.spectrum:lang(ko) .spectrum-Body5 strong,
-.spectrum:lang(zh) .spectrum-Body5 strong,
-.spectrum:lang(ja) .spectrum-Body--small strong,
-.spectrum:lang(ko) .spectrum-Body--small strong,
-.spectrum:lang(zh) .spectrum-Body--small strong {
-    font-size: var(
-        --spectrum-body-han-5-strong-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    font-weight: var(
-        --spectrum-body-han-5-strong-text-font-weight,
-        var(--spectrum-alias-han-body-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-han-5-strong-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-han-5-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-han-5-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-body-han-5-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -4257,62 +1692,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading1 em,
-.spectrum:lang(ko) .spectrum-Heading1 em,
-.spectrum:lang(zh) .spectrum-Heading1 em {
-    font-size: var(
-        --spectrum-heading-han-1-emphasis-text-size,
-        var(--spectrum-alias-heading1-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-1-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-han-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-1-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1 strong,
-.spectrum:lang(ko) .spectrum-Heading1 strong,
-.spectrum:lang(zh) .spectrum-Heading1 strong {
-    font-size: var(
-        --spectrum-heading-han-1-strong-text-size,
-        var(--spectrum-alias-heading1-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-1-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-han-1-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-1-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Heading2,
 .spectrum:lang(ko) .spectrum-Heading2,
 .spectrum:lang(zh) .spectrum-Heading2 {
@@ -4341,62 +1720,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading2 em,
-.spectrum:lang(ko) .spectrum-Heading2 em,
-.spectrum:lang(zh) .spectrum-Heading2 em {
-    font-size: var(
-        --spectrum-heading-han-2-emphasis-text-size,
-        var(--spectrum-alias-heading2-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-2-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-han-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-2-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading2 strong,
-.spectrum:lang(ko) .spectrum-Heading2 strong,
-.spectrum:lang(zh) .spectrum-Heading2 strong {
-    font-size: var(
-        --spectrum-heading-han-2-strong-text-size,
-        var(--spectrum-alias-heading2-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-2-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-han-2-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-2-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Heading3,
 .spectrum:lang(ko) .spectrum-Heading3,
 .spectrum:lang(zh) .spectrum-Heading3 {
@@ -4421,62 +1744,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-heading-han-3-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading3 em,
-.spectrum:lang(ko) .spectrum-Heading3 em,
-.spectrum:lang(zh) .spectrum-Heading3 em {
-    font-size: var(
-        --spectrum-heading-han-3-emphasis-text-size,
-        var(--spectrum-alias-heading3-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-3-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-han-3-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-3-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-3-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-3-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading3 strong,
-.spectrum:lang(ko) .spectrum-Heading3 strong,
-.spectrum:lang(zh) .spectrum-Heading3 strong {
-    font-size: var(
-        --spectrum-heading-han-3-strong-text-size,
-        var(--spectrum-alias-heading3-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-3-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-han-3-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-3-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-3-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-3-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -4512,68 +1779,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading4 em,
-.spectrum:lang(ko) .spectrum-Heading4 em,
-.spectrum:lang(zh) .spectrum-Heading4 em,
-.spectrum:lang(ja) .spectrum-Heading--subtitle1 em,
-.spectrum:lang(ko) .spectrum-Heading--subtitle1 em,
-.spectrum:lang(zh) .spectrum-Heading--subtitle1 em {
-    font-size: var(
-        --spectrum-heading-han-4-emphasis-text-size,
-        var(--spectrum-alias-heading4-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-4-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-han-4-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-4-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-4-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-4-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading4 strong,
-.spectrum:lang(ko) .spectrum-Heading4 strong,
-.spectrum:lang(zh) .spectrum-Heading4 strong,
-.spectrum:lang(ja) .spectrum-Heading--subtitle1 strong,
-.spectrum:lang(ko) .spectrum-Heading--subtitle1 strong,
-.spectrum:lang(zh) .spectrum-Heading--subtitle1 strong {
-    font-size: var(
-        --spectrum-heading-han-4-strong-text-size,
-        var(--spectrum-alias-heading4-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-4-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-han-4-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-4-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-4-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-4-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Heading5,
 .spectrum:lang(ko) .spectrum-Heading5,
 .spectrum:lang(zh) .spectrum-Heading5 {
@@ -4598,62 +1803,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-heading-han-5-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading5 em,
-.spectrum:lang(ko) .spectrum-Heading5 em,
-.spectrum:lang(zh) .spectrum-Heading5 em {
-    font-size: var(
-        --spectrum-heading-han-5-emphasis-text-size,
-        var(--spectrum-alias-heading5-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-5-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-han-5-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-5-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-5-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-5-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading5 strong,
-.spectrum:lang(ko) .spectrum-Heading5 strong,
-.spectrum:lang(zh) .spectrum-Heading5 strong {
-    font-size: var(
-        --spectrum-heading-han-5-strong-text-size,
-        var(--spectrum-alias-heading5-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-5-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-han-5-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-5-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-5-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-5-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -4689,68 +1838,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading6 em,
-.spectrum:lang(ko) .spectrum-Heading6 em,
-.spectrum:lang(zh) .spectrum-Heading6 em,
-.spectrum:lang(ja) .spectrum-Heading--subtitle2 em,
-.spectrum:lang(ko) .spectrum-Heading--subtitle2 em,
-.spectrum:lang(zh) .spectrum-Heading--subtitle2 em {
-    font-size: var(
-        --spectrum-heading-han-6-emphasis-text-size,
-        var(--spectrum-alias-heading6-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-6-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-han-6-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-6-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-6-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-6-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading6 strong,
-.spectrum:lang(ko) .spectrum-Heading6 strong,
-.spectrum:lang(zh) .spectrum-Heading6 strong,
-.spectrum:lang(ja) .spectrum-Heading--subtitle2 strong,
-.spectrum:lang(ko) .spectrum-Heading--subtitle2 strong,
-.spectrum:lang(zh) .spectrum-Heading--subtitle2 strong {
-    font-size: var(
-        --spectrum-heading-han-6-strong-text-size,
-        var(--spectrum-alias-heading6-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-han-6-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-heading-han-6-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-han-6-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-han-6-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-heading-han-6-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Subheading,
 .spectrum:lang(ko) .spectrum-Subheading,
 .spectrum:lang(zh) .spectrum-Subheading,
@@ -4778,71 +1865,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-subheading-han-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Subheading em,
-.spectrum:lang(ko) .spectrum-Subheading em,
-.spectrum:lang(zh) .spectrum-Subheading em,
-.spectrum:lang(ja) .spectrum-Heading--subtitle3 em,
-.spectrum:lang(ko) .spectrum-Heading--subtitle3 em,
-.spectrum:lang(zh) .spectrum-Heading--subtitle3 em {
-    font-size: var(
-        --spectrum-subheading-han-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-subheading-han-emphasis-text-font-weight,
-        var(--spectrum-alias-han-subheading-text-font-weight-emphasis)
-    );
-    line-height: var(
-        --spectrum-subheading-han-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-subheading-han-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-subheading-han-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-subheading-han-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Subheading strong,
-.spectrum:lang(ko) .spectrum-Subheading strong,
-.spectrum:lang(zh) .spectrum-Subheading strong,
-.spectrum:lang(ja) .spectrum-Heading--subtitle3 strong,
-.spectrum:lang(ko) .spectrum-Heading--subtitle3 strong,
-.spectrum:lang(zh) .spectrum-Heading--subtitle3 strong {
-    font-size: var(
-        --spectrum-subheading-han-strong-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-subheading-han-strong-text-font-weight,
-        var(--spectrum-alias-han-subheading-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-subheading-han-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-subheading-han-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-subheading-han-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-subheading-han-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -4875,62 +1897,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Detail em,
-.spectrum:lang(ko) .spectrum-Detail em,
-.spectrum:lang(zh) .spectrum-Detail em {
-    font-size: var(
-        --spectrum-detail-han-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-detail-han-emphasis-text-font-weight,
-        var(--spectrum-alias-han-detail-text-font-weight-emphasis)
-    );
-    line-height: var(
-        --spectrum-detail-han-emphasis-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-detail-han-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-detail-han-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-detail-han-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Detail strong,
-.spectrum:lang(ko) .spectrum-Detail strong,
-.spectrum:lang(zh) .spectrum-Detail strong {
-    font-size: var(
-        --spectrum-detail-han-strong-text-size,
-        var(--spectrum-global-dimension-font-size-50)
-    );
-    font-weight: var(
-        --spectrum-detail-han-strong-text-font-weight,
-        var(--spectrum-alias-han-detail-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-detail-han-strong-text-line-height,
-        var(--spectrum-alias-body-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-detail-han-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-detail-han-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-detail-han-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Heading1--quiet,
 .spectrum:lang(ko) .spectrum-Heading1--quiet,
 .spectrum:lang(zh) .spectrum-Heading1--quiet {
@@ -4955,68 +1921,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-heading-quiet-han-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--quiet em,
-.spectrum:lang(ko) .spectrum-Heading1--quiet em,
-.spectrum:lang(zh) .spectrum-Heading1--quiet em {
-    font-size: var(
-        --spectrum-heading-quiet-han-1-emphasis-text-size,
-        var(--spectrum-alias-heading1-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-han-1-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-quiet-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-han-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-han-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-han-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-han-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--quiet strong,
-.spectrum:lang(ko) .spectrum-Heading1--quiet strong,
-.spectrum:lang(zh) .spectrum-Heading1--quiet strong {
-    font-size: var(
-        --spectrum-heading-quiet-han-1-strong-text-size,
-        var(--spectrum-alias-heading1-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-han-1-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-han-1-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-han-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-han-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-han-1-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -5052,74 +1956,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading2--quiet em,
-.spectrum:lang(ko) .spectrum-Heading2--quiet em,
-.spectrum:lang(zh) .spectrum-Heading2--quiet em,
-.spectrum:lang(ja) .spectrum-Heading--pageTitle em,
-.spectrum:lang(ko) .spectrum-Heading--pageTitle em,
-.spectrum:lang(zh) .spectrum-Heading--pageTitle em {
-    font-size: var(
-        --spectrum-heading-quiet-han-2-emphasis-text-size,
-        var(--spectrum-alias-heading2-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-han-2-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-quiet-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-han-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-han-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-han-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-han-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading2--quiet strong,
-.spectrum:lang(ko) .spectrum-Heading2--quiet strong,
-.spectrum:lang(zh) .spectrum-Heading2--quiet strong,
-.spectrum:lang(ja) .spectrum-Heading--pageTitle strong,
-.spectrum:lang(ko) .spectrum-Heading--pageTitle strong,
-.spectrum:lang(zh) .spectrum-Heading--pageTitle strong {
-    font-size: var(
-        --spectrum-heading-quiet-han-2-strong-text-size,
-        var(--spectrum-alias-heading2-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-quiet-han-2-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-heading-quiet-han-2-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-quiet-han-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-quiet-han-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-heading-quiet-han-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Heading1--strong,
 .spectrum:lang(ko) .spectrum-Heading1--strong,
 .spectrum:lang(zh) .spectrum-Heading1--strong {
@@ -5144,68 +1980,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-heading-strong-han-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--strong em,
-.spectrum:lang(ko) .spectrum-Heading1--strong em,
-.spectrum:lang(zh) .spectrum-Heading1--strong em {
-    font-size: var(
-        --spectrum-heading-strong-han-1-emphasis-text-size,
-        var(--spectrum-alias-heading1-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-strong-han-1-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-strong-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-strong-han-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-strong-han-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-strong-han-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-heading-strong-han-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--strong strong,
-.spectrum:lang(ko) .spectrum-Heading1--strong strong,
-.spectrum:lang(zh) .spectrum-Heading1--strong strong {
-    font-size: var(
-        --spectrum-heading-strong-han-1-strong-text-size,
-        var(--spectrum-alias-heading1-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-strong-han-1-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-strong-strong)
-    );
-    line-height: var(
-        --spectrum-heading-strong-han-1-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-strong-han-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-strong-han-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-heading-strong-han-1-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -5238,68 +2012,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading2--strong em,
-.spectrum:lang(ko) .spectrum-Heading2--strong em,
-.spectrum:lang(zh) .spectrum-Heading2--strong em {
-    font-size: var(
-        --spectrum-heading-strong-han-2-emphasis-text-size,
-        var(--spectrum-alias-heading2-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-strong-han-2-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-strong-emphasis)
-    );
-    line-height: var(
-        --spectrum-heading-strong-han-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-strong-han-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-strong-han-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-heading-strong-han-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading2--strong strong,
-.spectrum:lang(ko) .spectrum-Heading2--strong strong,
-.spectrum:lang(zh) .spectrum-Heading2--strong strong {
-    font-size: var(
-        --spectrum-heading-strong-han-2-strong-text-size,
-        var(--spectrum-alias-heading2-han-text-size)
-    );
-    font-weight: var(
-        --spectrum-heading-strong-han-2-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-strong-strong)
-    );
-    line-height: var(
-        --spectrum-heading-strong-han-2-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-heading-strong-han-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-heading-strong-han-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-heading-strong-han-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Heading1--display,
 .spectrum:lang(ko) .spectrum-Heading1--display,
 .spectrum:lang(zh) .spectrum-Heading1--display {
@@ -5324,62 +2036,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-display-han-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--display em,
-.spectrum:lang(ko) .spectrum-Heading1--display em,
-.spectrum:lang(zh) .spectrum-Heading1--display em {
-    font-size: var(
-        --spectrum-display-han-1-emphasis-text-size,
-        var(--spectrum-alias-heading-han-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-han-1-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
-    );
-    line-height: var(
-        --spectrum-display-han-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-han-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-han-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-display-han-1-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--display strong,
-.spectrum:lang(ko) .spectrum-Heading1--display strong,
-.spectrum:lang(zh) .spectrum-Heading1--display strong {
-    font-size: var(
-        --spectrum-display-han-1-strong-text-size,
-        var(--spectrum-alias-heading-han-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-han-1-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-display-han-1-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-han-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-han-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-display-han-1-strong-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -5412,62 +2068,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading2--display em,
-.spectrum:lang(ko) .spectrum-Heading2--display em,
-.spectrum:lang(zh) .spectrum-Heading2--display em {
-    font-size: var(
-        --spectrum-display-han-2-emphasis-text-size,
-        var(--spectrum-alias-heading-han-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-han-2-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
-    );
-    line-height: var(
-        --spectrum-display-han-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-han-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-han-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-display-han-2-emphasis-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading2--display strong,
-.spectrum:lang(ko) .spectrum-Heading2--display strong,
-.spectrum:lang(zh) .spectrum-Heading2--display strong {
-    font-size: var(
-        --spectrum-display-han-2-strong-text-size,
-        var(--spectrum-alias-heading-han-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-han-2-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-regular-strong)
-    );
-    line-height: var(
-        --spectrum-display-han-2-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-han-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-han-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(--spectrum-display-han-2-strong-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Heading1--display.spectrum-Heading1--strong,
 .spectrum:lang(ko) .spectrum-Heading1--display.spectrum-Heading1--strong,
 .spectrum:lang(zh) .spectrum-Heading1--display.spectrum-Heading1--strong {
@@ -5492,70 +2092,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-display-strong-han-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--display.spectrum-Heading1--strong em,
-.spectrum:lang(ko) .spectrum-Heading1--display.spectrum-Heading1--strong em,
-.spectrum:lang(zh) .spectrum-Heading1--display.spectrum-Heading1--strong em {
-    font-size: var(
-        --spectrum-display-strong-han-1-emphasis-text-size,
-        var(--spectrum-alias-heading-han-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-strong-han-1-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-strong-emphasis)
-    );
-    line-height: var(
-        --spectrum-display-strong-han-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-strong-han-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-strong-han-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-display-strong-han-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--display.spectrum-Heading1--strong strong,
-.spectrum:lang(ko) .spectrum-Heading1--display.spectrum-Heading1--strong strong,
-.spectrum:lang(zh)
-    .spectrum-Heading1--display.spectrum-Heading1--strong
-    strong {
-    font-size: var(
-        --spectrum-display-strong-han-1-strong-text-size,
-        var(--spectrum-alias-heading-han-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-strong-han-1-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-strong-strong)
-    );
-    line-height: var(
-        --spectrum-display-strong-han-1-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-strong-han-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-strong-han-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-display-strong-han-1-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -5588,70 +2124,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading2--display.spectrum-Heading2--strong em,
-.spectrum:lang(ko) .spectrum-Heading2--display.spectrum-Heading2--strong em,
-.spectrum:lang(zh) .spectrum-Heading2--display.spectrum-Heading2--strong em {
-    font-size: var(
-        --spectrum-display-strong-han-2-emphasis-text-size,
-        var(--spectrum-alias-heading-han-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-strong-han-2-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-strong-emphasis)
-    );
-    line-height: var(
-        --spectrum-display-strong-han-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-strong-han-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-strong-han-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-display-strong-han-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading2--display.spectrum-Heading2--strong strong,
-.spectrum:lang(ko) .spectrum-Heading2--display.spectrum-Heading2--strong strong,
-.spectrum:lang(zh)
-    .spectrum-Heading2--display.spectrum-Heading2--strong
-    strong {
-    font-size: var(
-        --spectrum-display-strong-han-2-strong-text-size,
-        var(--spectrum-alias-heading-han-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-strong-han-2-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-strong-strong)
-    );
-    line-height: var(
-        --spectrum-display-strong-han-2-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-strong-han-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-strong-han-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-display-strong-han-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum:lang(ja) .spectrum-Heading1--display.spectrum-Heading1--quiet,
 .spectrum:lang(ko) .spectrum-Heading1--display.spectrum-Heading1--quiet,
 .spectrum:lang(zh) .spectrum-Heading1--display.spectrum-Heading1--quiet {
@@ -5676,68 +2148,6 @@ governing permissions and limitations under the License.
         var(--spectrum-global-font-letter-spacing-han)
     );
     text-transform: var(--spectrum-display-quiet-han-1-text-transform, none);
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--display.spectrum-Heading1--quiet em,
-.spectrum:lang(ko) .spectrum-Heading1--display.spectrum-Heading1--quiet em,
-.spectrum:lang(zh) .spectrum-Heading1--display.spectrum-Heading1--quiet em {
-    font-size: var(
-        --spectrum-display-quiet-han-1-emphasis-text-size,
-        var(--spectrum-alias-heading-han-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-han-1-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-quiet-emphasis)
-    );
-    line-height: var(
-        --spectrum-display-quiet-han-1-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-han-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-han-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-han-1-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading1--display.spectrum-Heading1--quiet strong,
-.spectrum:lang(ko) .spectrum-Heading1--display.spectrum-Heading1--quiet strong,
-.spectrum:lang(zh) .spectrum-Heading1--display.spectrum-Heading1--quiet strong {
-    font-size: var(
-        --spectrum-display-quiet-han-1-strong-text-size,
-        var(--spectrum-alias-heading-han-display1-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-han-1-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-display-quiet-han-1-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-han-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-han-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-han-1-strong-text-transform,
-        none
-    );
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -5773,74 +2183,6 @@ governing permissions and limitations under the License.
     margin-bottom: 0;
 }
 
-.spectrum:lang(ja) .spectrum-Heading2--display.spectrum-Heading2--quiet em,
-.spectrum:lang(ko) .spectrum-Heading2--display.spectrum-Heading2--quiet em,
-.spectrum:lang(zh) .spectrum-Heading2--display.spectrum-Heading2--quiet em,
-.spectrum:lang(ja) .spectrum-Heading--display em,
-.spectrum:lang(ko) .spectrum-Heading--display em,
-.spectrum:lang(zh) .spectrum-Heading--display em {
-    font-size: var(
-        --spectrum-display-quiet-han-2-emphasis-text-size,
-        var(--spectrum-alias-heading-han-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-han-2-emphasis-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-quiet-emphasis)
-    );
-    line-height: var(
-        --spectrum-display-quiet-han-2-emphasis-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-han-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-han-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-han-2-emphasis-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum:lang(ja) .spectrum-Heading2--display.spectrum-Heading2--quiet strong,
-.spectrum:lang(ko) .spectrum-Heading2--display.spectrum-Heading2--quiet strong,
-.spectrum:lang(zh) .spectrum-Heading2--display.spectrum-Heading2--quiet strong,
-.spectrum:lang(ja) .spectrum-Heading--display strong,
-.spectrum:lang(ko) .spectrum-Heading--display strong,
-.spectrum:lang(zh) .spectrum-Heading--display strong {
-    font-size: var(
-        --spectrum-display-quiet-han-2-strong-text-size,
-        var(--spectrum-alias-heading-han-display2-text-size)
-    );
-    font-weight: var(
-        --spectrum-display-quiet-han-2-strong-text-font-weight,
-        var(--spectrum-alias-han-heading-text-font-weight-quiet-strong)
-    );
-    line-height: var(
-        --spectrum-display-quiet-han-2-strong-text-line-height,
-        var(--spectrum-alias-heading-han-text-line-height)
-    );
-    font-style: var(
-        --spectrum-display-quiet-han-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-display-quiet-han-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-han)
-    );
-    text-transform: var(
-        --spectrum-display-quiet-han-2-strong-text-transform,
-        none
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Code1 {
     font-size: var(
         --spectrum-body-code-1-text-size,
@@ -5868,56 +2210,6 @@ governing permissions and limitations under the License.
         --spectrum-body-code-1-text-font-family,
         var(--spectrum-alias-code-text-font-family)
     );
-}
-
-.spectrum-Code1 em {
-    font-size: var(
-        --spectrum-body-code-1-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-400)
-    );
-    font-weight: var(
-        --spectrum-body-code-1-emphasis-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-body-code-1-emphasis-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-1-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-1-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Code1 strong {
-    font-size: var(
-        --spectrum-body-code-1-strong-text-size,
-        var(--spectrum-global-dimension-font-size-400)
-    );
-    font-weight: var(
-        --spectrum-body-code-1-strong-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-code-1-strong-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-1-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-1-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
 }
 
 .spectrum-Code2 {
@@ -5949,56 +2241,6 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Code2 em {
-    font-size: var(
-        --spectrum-body-code-2-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-300)
-    );
-    font-weight: var(
-        --spectrum-body-code-2-emphasis-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-body-code-2-emphasis-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-2-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-2-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Code2 strong {
-    font-size: var(
-        --spectrum-body-code-2-strong-text-size,
-        var(--spectrum-global-dimension-font-size-300)
-    );
-    font-weight: var(
-        --spectrum-body-code-2-strong-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-code-2-strong-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-2-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-2-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Code3 {
     font-size: var(
         --spectrum-body-code-3-text-size,
@@ -6026,56 +2268,6 @@ governing permissions and limitations under the License.
         --spectrum-body-code-3-text-font-family,
         var(--spectrum-alias-code-text-font-family)
     );
-}
-
-.spectrum-Code3 em {
-    font-size: var(
-        --spectrum-body-code-3-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    font-weight: var(
-        --spectrum-body-code-3-emphasis-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-body-code-3-emphasis-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-3-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-3-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Code3 strong {
-    font-size: var(
-        --spectrum-body-code-3-strong-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    font-weight: var(
-        --spectrum-body-code-3-strong-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-code-3-strong-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-3-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-3-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
 }
 
 .spectrum-Code4 {
@@ -6107,56 +2299,6 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Code4 em {
-    font-size: var(
-        --spectrum-body-code-4-emphasis-text-size,
-        var(--spectrum-alias-font-size-default)
-    );
-    font-weight: var(
-        --spectrum-body-code-4-emphasis-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-regular)
-    );
-    line-height: var(
-        --spectrum-body-code-4-emphasis-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-4-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-4-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Code4 strong {
-    font-size: var(
-        --spectrum-body-code-4-strong-text-size,
-        var(--spectrum-alias-font-size-default)
-    );
-    font-weight: var(
-        --spectrum-body-code-4-strong-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-code-4-strong-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-4-strong-text-font-style,
-        var(--spectrum-global-font-style-regular)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-4-strong-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
 .spectrum-Code5 {
     font-size: var(
         --spectrum-body-code-5-text-size,
@@ -6186,82 +2328,2768 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Code5 em {
+.spectrum-Heading--XXXL {
     font-size: var(
-        --spectrum-body-code-5-emphasis-text-size,
-        var(--spectrum-global-dimension-font-size-75)
+        --spectrum-heading-xxxl-text-size,
+        var(--spectrum-alias-heading-xxxl-text-size)
     );
     font-weight: var(
-        --spectrum-body-code-5-emphasis-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-regular)
+        --spectrum-heading-xxxl-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
     );
     line-height: var(
-        --spectrum-body-code-5-emphasis-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
+        --spectrum-heading-xxxl-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
     );
     font-style: var(
-        --spectrum-body-code-5-emphasis-text-font-style,
-        var(--spectrum-global-font-style-italic)
-    );
-    letter-spacing: var(
-        --spectrum-body-code-5-emphasis-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-    margin-top: 0;
-    margin-bottom: 0;
-}
-
-.spectrum-Code5 strong {
-    font-size: var(
-        --spectrum-body-code-5-strong-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    font-weight: var(
-        --spectrum-body-code-5-strong-text-font-weight,
-        var(--spectrum-alias-code-text-font-weight-strong)
-    );
-    line-height: var(
-        --spectrum-body-code-5-strong-text-line-height,
-        var(--spectrum-alias-code-text-line-height)
-    );
-    font-style: var(
-        --spectrum-body-code-5-strong-text-font-style,
+        --spectrum-heading-xxxl-text-font-style,
         var(--spectrum-global-font-style-regular)
     );
     letter-spacing: var(
-        --spectrum-body-code-5-strong-text-letter-spacing,
+        --spectrum-heading-xxxl-text-letter-spacing,
         var(--spectrum-global-font-letter-spacing-none)
     );
+    text-transform: var(--spectrum-heading-xxxl-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
 }
 
-.spectrum,
-.spectrum.spectrum-Body,
-.spectrum-Body {
+.spectrum-Heading--XXL {
     font-size: var(
-        --spectrum-body-4-text-size,
-        var(--spectrum-alias-font-size-default)
+        --spectrum-heading-xxl-text-size,
+        var(--spectrum-alias-heading-xxl-text-size)
     );
     font-weight: var(
-        --spectrum-body-4-text-font-weight,
+        --spectrum-heading-xxl-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-xxl-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-xxl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-xxl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-heading-xxl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Heading--XL {
+    font-size: var(
+        --spectrum-heading-xl-text-size,
+        var(--spectrum-alias-heading-xl-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-xl-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-xl-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-xl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-heading-xl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Heading--L {
+    font-size: var(
+        --spectrum-heading-l-text-size,
+        var(--spectrum-alias-heading-l-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-l-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-l-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-l-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-l-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-heading-l-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Heading--M {
+    font-size: var(
+        --spectrum-heading-m-text-size,
+        var(--spectrum-alias-heading-m-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-m-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-m-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-m-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-m-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-heading-m-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Heading--S {
+    font-size: var(
+        --spectrum-heading-s-text-size,
+        var(--spectrum-alias-heading-s-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-s-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-s-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-s-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-s-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-heading-s-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Heading--XS {
+    font-size: var(
+        --spectrum-heading-xs-text-size,
+        var(--spectrum-alias-heading-xs-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-xs-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-xs-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-xs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-xs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-heading-xs-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Heading--XXS {
+    font-size: var(
+        --spectrum-heading-xxs-text-size,
+        var(--spectrum-alias-heading-xxs-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-xxs-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-xxs-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-xxs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-xxs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-heading-xxs-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Heading {
+    font-family: var(
+        --spectrum-heading-xl-text-font-family,
+        var(--spectrum-alias-body-text-font-family)
+    );
+    font-weight: var(
+        --spectrum-heading-xl-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+}
+
+.spectrum-Heading em,
+.spectrum-Heading .spectrum-Heading-emphasis {
+    font-style: var(
+        --spectrum-heading-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+}
+
+.spectrum-Heading strong,
+.spectrum-Heading .spectrum-Heading-strong {
+    font-weight: var(
+        --spectrum-heading-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+}
+
+.spectrum-Heading--serif {
+    font-family: var(
+        --spectrum-body-serif-xl-text-font-family,
+        var(--spectrum-alias-serif-text-font-family)
+    );
+}
+
+.spectrum-Heading--heavy {
+    font-weight: var(
+        --spectrum-heading-heavy-xl-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+}
+
+.spectrum-Heading--heavy em,
+.spectrum-Heading--heavy .spectrum-Heading-emphasis {
+    font-style: var(
+        --spectrum-heading-heavy-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+}
+
+.spectrum-Heading--heavy strong,
+.spectrum-Heading--heavy .spectrum-Heading-strong {
+    font-weight: var(
+        --spectrum-heading-heavy-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+}
+
+.spectrum-Heading--light {
+    font-weight: var(
+        --spectrum-heading-light-xl-emphasis-text-font-weight,
+        var(--spectrum-global-font-weight-light)
+    );
+}
+
+.spectrum-Heading--light em,
+.spectrum-Heading--light .spectrum-Heading-emphasis {
+    font-style: var(
+        --spectrum-heading-light-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+}
+
+.spectrum-Heading--light strong,
+.spectrum-Heading--light .spectrum-Heading-strong {
+    font-weight: var(
+        --spectrum-heading-light-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-bold)
+    );
+}
+
+.spectrum-Body--XXXL {
+    font-size: var(
+        --spectrum-body-xxxl-text-size,
+        var(--spectrum-global-dimension-font-size-600)
+    );
+    font-weight: var(
+        --spectrum-body-xxxl-text-font-weight,
         var(--spectrum-alias-body-text-font-weight)
     );
     line-height: var(
-        --spectrum-body-4-text-line-height,
+        --spectrum-body-xxxl-text-line-height,
         var(--spectrum-alias-body-text-line-height)
     );
     font-style: var(
-        --spectrum-body-4-text-font-style,
+        --spectrum-body-xxxl-text-font-style,
         var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-xxxl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-body-xxxl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Body--XXL {
+    font-size: var(
+        --spectrum-body-xxl-text-size,
+        var(--spectrum-global-dimension-font-size-500)
+    );
+    font-weight: var(
+        --spectrum-body-xxl-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-body-xxl-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-xxl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-xxl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-body-xxl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Body--XL {
+    font-size: var(
+        --spectrum-body-xl-text-size,
+        var(--spectrum-global-dimension-font-size-400)
+    );
+    font-weight: var(
+        --spectrum-body-xl-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-body-xl-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-xl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-body-xl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Body--L {
+    font-size: var(
+        --spectrum-body-l-text-size,
+        var(--spectrum-global-dimension-font-size-300)
+    );
+    font-weight: var(
+        --spectrum-body-l-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-body-l-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-l-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-l-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-body-l-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Body--M {
+    font-size: var(
+        --spectrum-body-m-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-body-m-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-body-m-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-m-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-m-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-body-m-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Body--S {
+    font-size: var(
+        --spectrum-body-s-text-size,
+        var(--spectrum-alias-font-size-default)
+    );
+    font-weight: var(
+        --spectrum-body-s-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-body-s-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-s-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-s-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-body-s-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Body--XS {
+    font-size: var(
+        --spectrum-body-xs-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-body-xs-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-body-xs-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-xs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-xs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-body-xs-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Body {
+    font-family: var(
+        --spectrum-body-xl-text-font-family,
+        var(--spectrum-alias-body-text-font-family)
     );
 }
 
-.spectrum-Body--italic {
+.spectrum-Body strong,
+.spectrum-Body .spectrum-Body-strong {
+    font-weight: var(
+        --spectrum-body-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-bold)
+    );
+}
+
+.spectrum-Body em,
+.spectrum-Body .spectrum-Body-emphasis {
     font-style: var(
-        --spectrum-body-4-emphasis-text-font-style,
+        --spectrum-body-xl-emphasis-text-font-style,
         var(--spectrum-global-font-style-italic)
     );
+}
+
+.spectrum-Body--serif {
+    font-family: var(
+        --spectrum-body-serif-xl-text-font-family,
+        var(--spectrum-alias-serif-text-font-family)
+    );
+}
+
+.spectrum-Detail {
+    font-family: var(
+        --spectrum-heading-xl-text-font-family,
+        var(--spectrum-alias-body-text-font-family)
+    );
+}
+
+.spectrum-Detail strong,
+.spectrum-Detail .spectrum-Detail-strong {
+    font-weight: var(
+        --spectrum-detail-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+}
+
+.spectrum-Detail em,
+.spectrum-Detail .spectrum-Detail-emphasis {
+    font-style: var(
+        --spectrum-detail-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+}
+
+.spectrum-Detail--light {
+    font-style: var(
+        --spectrum-detail-light-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    font-weight: var(
+        --spectrum-detail-light-xl-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight-light)
+    );
+}
+
+.spectrum-Detail--serif {
+    font-family: var(
+        --spectrum-body-serif-xl-text-font-family,
+        var(--spectrum-alias-serif-text-font-family)
+    );
+}
+
+.spectrum-Detail--XL {
+    font-size: var(
+        --spectrum-detail-xl-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-detail-xl-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-xl-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-xl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-xl-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--XL em {
+    font-size: var(
+        --spectrum-detail-xl-emphasis-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-detail-xl-emphasis-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-xl-emphasis-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+    letter-spacing: var(
+        --spectrum-detail-xl-emphasis-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(
+        --spectrum-detail-xl-emphasis-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--XL strong {
+    font-size: var(
+        --spectrum-detail-xl-strong-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-detail-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+    line-height: var(
+        --spectrum-detail-xl-strong-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-xl-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-xl-strong-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-xl-strong-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--L {
+    font-size: var(
+        --spectrum-detail-l-text-size,
+        var(--spectrum-global-dimension-font-size-100)
+    );
+    font-weight: var(
+        --spectrum-detail-l-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-l-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-l-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-l-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-l-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--L em {
+    font-size: var(
+        --spectrum-detail-l-emphasis-text-size,
+        var(--spectrum-global-dimension-font-size-100)
+    );
+    font-weight: var(
+        --spectrum-detail-l-emphasis-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-l-emphasis-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-l-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+    letter-spacing: var(
+        --spectrum-detail-l-emphasis-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-l-emphasis-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--L strong {
+    font-size: var(
+        --spectrum-detail-l-strong-text-size,
+        var(--spectrum-global-dimension-font-size-100)
+    );
+    font-weight: var(
+        --spectrum-detail-l-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+    line-height: var(
+        --spectrum-detail-l-strong-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-l-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-l-strong-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-l-strong-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--M {
+    font-size: var(
+        --spectrum-detail-m-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-detail-m-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-m-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-m-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-m-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-m-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--M em {
+    font-size: var(
+        --spectrum-detail-m-emphasis-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-detail-m-emphasis-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-m-emphasis-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-m-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+    letter-spacing: var(
+        --spectrum-detail-m-emphasis-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-m-emphasis-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--M strong {
+    font-size: var(
+        --spectrum-detail-m-strong-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-detail-m-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+    line-height: var(
+        --spectrum-detail-m-strong-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-m-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-m-strong-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-m-strong-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--S {
+    font-size: var(
+        --spectrum-detail-s-text-size,
+        var(--spectrum-global-dimension-font-size-50)
+    );
+    font-weight: var(
+        --spectrum-detail-s-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-s-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-s-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-s-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-s-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--S em {
+    font-size: var(
+        --spectrum-detail-s-emphasis-text-size,
+        var(--spectrum-global-dimension-font-size-50)
+    );
+    font-weight: var(
+        --spectrum-detail-s-emphasis-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-s-emphasis-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-s-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+    letter-spacing: var(
+        --spectrum-detail-s-emphasis-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-s-emphasis-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Detail--S strong {
+    font-size: var(
+        --spectrum-detail-s-strong-text-size,
+        var(--spectrum-global-dimension-font-size-50)
+    );
+    font-weight: var(
+        --spectrum-detail-s-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+    line-height: var(
+        --spectrum-detail-s-strong-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-s-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-s-strong-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: var(--spectrum-detail-s-strong-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum-Code {
+    font-family: var(
+        --spectrum-heading-xl-text-font-family,
+        var(--spectrum-alias-body-text-font-family)
+    );
+}
+
+.spectrum-Code strong,
+.spectrum-Code .spectrum-Code-strong {
+    font-weight: var(
+        --spectrum-code-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-bold)
+    );
+}
+
+.spectrum-Code em,
+.spectrum-Code .spectrum-Code-emphasis {
+    font-style: var(
+        --spectrum-code-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-italic)
+    );
+}
+
+.spectrum-Code--serif {
+    font-family: var(
+        --spectrum-body-serif-xl-text-font-family,
+        var(--spectrum-alias-serif-text-font-family)
+    );
+}
+
+.spectrum-Code--XL {
+    font-size: var(
+        --spectrum-code-xl-text-size,
+        var(--spectrum-global-dimension-font-size-400)
+    );
+    font-weight: var(
+        --spectrum-code-xl-text-font-weight,
+        var(--spectrum-alias-code-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-xl-text-line-height,
+        var(--spectrum-alias-code-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-xl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-xl-text-font-family,
+        var(--spectrum-alias-code-text-font-family)
+    );
+}
+
+.spectrum-Code--L {
+    font-size: var(
+        --spectrum-code-l-text-size,
+        var(--spectrum-global-dimension-font-size-300)
+    );
+    font-weight: var(
+        --spectrum-code-l-text-font-weight,
+        var(--spectrum-alias-code-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-l-text-line-height,
+        var(--spectrum-alias-code-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-l-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-l-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-l-text-font-family,
+        var(--spectrum-alias-code-text-font-family)
+    );
+}
+
+.spectrum-Code--M {
+    font-size: var(
+        --spectrum-code-m-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-code-m-text-font-weight,
+        var(--spectrum-alias-code-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-m-text-line-height,
+        var(--spectrum-alias-code-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-m-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-m-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-m-text-font-family,
+        var(--spectrum-alias-code-text-font-family)
+    );
+}
+
+.spectrum-Code--S {
+    font-size: var(
+        --spectrum-code-s-text-size,
+        var(--spectrum-alias-font-size-default)
+    );
+    font-weight: var(
+        --spectrum-code-s-text-font-weight,
+        var(--spectrum-alias-code-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-s-text-line-height,
+        var(--spectrum-alias-code-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-s-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-s-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-s-text-font-family,
+        var(--spectrum-alias-code-text-font-family)
+    );
+}
+
+.spectrum-Code--XS {
+    font-size: var(
+        --spectrum-code-xs-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-code-xs-text-font-weight,
+        var(--spectrum-alias-code-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-xs-text-line-height,
+        var(--spectrum-alias-code-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-xs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-xs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-xs-text-font-family,
+        var(--spectrum-alias-code-text-font-family)
+    );
+}
+
+.spectrum-Typography .spectrum-Heading--XXXL {
+    margin-top: var(
+        --spectrum-heading-xxxl-margin-top,
+        var(--spectrum-alias-heading-xxxl-margin-top)
+    );
+    margin-bottom: var(
+        --spectrum-heading-xxxl-margin-bottom,
+        var(--spectrum-global-dimension-size-130)
+    );
+}
+
+.spectrum-Typography .spectrum-Heading--XXL {
+    margin-top: var(
+        --spectrum-heading-xxl-margin-top,
+        var(--spectrum-alias-heading-xxl-margin-top)
+    );
+    margin-bottom: var(
+        --spectrum-heading-xxl-margin-bottom,
+        var(--spectrum-global-dimension-size-125)
+    );
+}
+
+.spectrum-Typography .spectrum-Heading--XL {
+    margin-top: var(
+        --spectrum-heading-xl-margin-top,
+        var(--spectrum-alias-heading-xl-margin-top)
+    );
+    margin-bottom: var(
+        --spectrum-heading-xl-margin-bottom,
+        var(--spectrum-global-dimension-size-115)
+    );
+}
+
+.spectrum-Typography .spectrum-Heading--L {
+    margin-top: var(
+        --spectrum-heading-l-margin-top,
+        var(--spectrum-alias-heading-l-margin-top)
+    );
+    margin-bottom: var(
+        --spectrum-heading-l-margin-bottom,
+        var(--spectrum-global-dimension-size-85)
+    );
+}
+
+.spectrum-Typography .spectrum-Heading--M {
+    margin-top: var(
+        --spectrum-heading-m-margin-top,
+        var(--spectrum-alias-heading-m-margin-top)
+    );
+    margin-bottom: var(
+        --spectrum-heading-m-margin-bottom,
+        var(--spectrum-global-dimension-size-75)
+    );
+}
+
+.spectrum-Typography .spectrum-Heading--S {
+    margin-top: var(
+        --spectrum-heading-s-margin-top,
+        var(--spectrum-alias-heading-s-margin-top)
+    );
+    margin-bottom: var(
+        --spectrum-heading-s-margin-bottom,
+        var(--spectrum-global-dimension-size-65)
+    );
+}
+
+.spectrum-Typography .spectrum-Heading--XS {
+    margin-top: var(
+        --spectrum-heading-xs-margin-top,
+        var(--spectrum-alias-heading-xs-margin-top)
+    );
+    margin-bottom: var(
+        --spectrum-heading-xs-margin-bottom,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+
+.spectrum-Typography .spectrum-Heading--XXS {
+    margin-top: var(
+        --spectrum-heading-xxs-margin-top,
+        var(--spectrum-alias-heading-xxs-margin-top)
+    );
+    margin-bottom: var(
+        --spectrum-heading-xxs-margin-bottom,
+        var(--spectrum-global-dimension-size-40)
+    );
+}
+
+.spectrum-Typography .spectrum-Body--XXXL {
+    margin-top: var(--spectrum-body-xxxl-margin-top, 0px);
+    margin-bottom: var(
+        --spectrum-body-xxxl-margin-bottom,
+        var(--spectrum-global-dimension-size-400)
+    );
+}
+
+.spectrum-Typography .spectrum-Body--XXL {
+    margin-top: var(--spectrum-body-xxl-margin-top, 0px);
+    margin-bottom: var(
+        --spectrum-body-xxl-margin-bottom,
+        var(--spectrum-global-dimension-size-300)
+    );
+}
+
+.spectrum-Typography .spectrum-Body--XL {
+    margin-top: var(--spectrum-body-xl-margin-top, 0px);
+    margin-bottom: var(
+        --spectrum-body-xl-margin-bottom,
+        var(--spectrum-global-dimension-size-200)
+    );
+}
+
+.spectrum-Typography .spectrum-Body--L {
+    margin-top: var(--spectrum-body-l-margin-top, 0px);
+    margin-bottom: var(
+        --spectrum-body-l-margin-bottom,
+        var(--spectrum-global-dimension-size-160)
+    );
+}
+
+.spectrum-Typography .spectrum-Body--M {
+    margin-top: var(--spectrum-body-m-margin-top, 0px);
+    margin-bottom: var(
+        --spectrum-body-m-margin-bottom,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+
+.spectrum-Typography .spectrum-Body--S {
+    margin-top: var(--spectrum-body-s-margin-top, 0px);
+    margin-bottom: var(
+        --spectrum-body-s-margin-bottom,
+        var(--spectrum-global-dimension-size-125)
+    );
+}
+
+.spectrum-Typography .spectrum-Body--XS {
+    margin-top: var(--spectrum-body-xs-margin-top, 0px);
+    margin-bottom: var(
+        --spectrum-body-xs-margin-bottom,
+        var(--spectrum-global-dimension-size-115)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XXXL,
+.spectrum:lang(ko) .spectrum-Heading--XXXL,
+.spectrum:lang(zh) .spectrum-Heading--XXXL {
+    font-size: var(
+        --spectrum-heading-han-xxxl-text-size,
+        var(--spectrum-alias-heading-xxxl-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-han-xxxl-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-han-xxxl-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-han-xxxl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-han-xxxl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-heading-han-xxxl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XXL,
+.spectrum:lang(ko) .spectrum-Heading--XXL,
+.spectrum:lang(zh) .spectrum-Heading--XXL {
+    font-size: var(
+        --spectrum-heading-han-xxl-text-size,
+        var(--spectrum-alias-heading-han-xxl-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-han-xxl-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-han-xxl-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-han-xxl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-han-xxl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-heading-han-xxl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XL,
+.spectrum:lang(ko) .spectrum-Heading--XL,
+.spectrum:lang(zh) .spectrum-Heading--XL {
+    font-size: var(
+        --spectrum-heading-han-xl-text-size,
+        var(--spectrum-alias-heading-han-xl-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-han-xl-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-han-xl-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-han-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-han-xl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-heading-han-xl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Heading--L,
+.spectrum:lang(ko) .spectrum-Heading--L,
+.spectrum:lang(zh) .spectrum-Heading--L {
+    font-size: var(
+        --spectrum-heading-han-l-text-size,
+        var(--spectrum-alias-heading-han-l-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-han-l-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-han-l-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-han-l-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-han-l-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-heading-han-l-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Heading--M,
+.spectrum:lang(ko) .spectrum-Heading--M,
+.spectrum:lang(zh) .spectrum-Heading--M {
+    font-size: var(
+        --spectrum-heading-han-m-text-size,
+        var(--spectrum-alias-heading-han-m-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-han-m-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-han-m-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-han-m-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-han-m-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-heading-han-m-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Heading--S,
+.spectrum:lang(ko) .spectrum-Heading--S,
+.spectrum:lang(zh) .spectrum-Heading--S {
+    font-size: var(
+        --spectrum-heading-han-s-text-size,
+        var(--spectrum-alias-heading-s-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-han-s-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-han-s-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-han-s-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-han-s-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-heading-han-s-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XS,
+.spectrum:lang(ko) .spectrum-Heading--XS,
+.spectrum:lang(zh) .spectrum-Heading--XS {
+    font-size: var(
+        --spectrum-heading-han-xs-text-size,
+        var(--spectrum-alias-heading-xs-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-han-xs-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-han-xs-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-han-xs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-han-xs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-heading-han-xs-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XXS,
+.spectrum:lang(ko) .spectrum-Heading--XXS,
+.spectrum:lang(zh) .spectrum-Heading--XXS {
+    font-size: var(
+        --spectrum-heading-han-xxs-text-size,
+        var(--spectrum-alias-heading-xxs-text-size)
+    );
+    font-weight: var(
+        --spectrum-heading-han-xxs-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-heading-han-xxs-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-heading-han-xxs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-heading-han-xxs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-heading-han-xxs-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Heading--heavy,
+.spectrum:lang(ko) .spectrum-Heading--heavy,
+.spectrum:lang(zh) .spectrum-Heading--heavy {
+    font-weight: var(
+        --spectrum-heading-han-xl-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--heavy em,
+.spectrum:lang(ja) .spectrum-Heading--heavy .spectrum-Heading--emphasis,
+.spectrum:lang(ko) .spectrum-Heading--heavy em,
+.spectrum:lang(ko) .spectrum-Heading--heavy .spectrum-Heading--emphasis,
+.spectrum:lang(zh) .spectrum-Heading--heavy em,
+.spectrum:lang(zh) .spectrum-Heading--heavy .spectrum-Heading--emphasis {
+    font-style: var(
+        --spectrum-heading-han-heavy-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    font-weight: var(
+        --spectrum-heading-han-heavy-xl-emphasis-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-heavy-emphasis)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--heavy strong,
+.spectrum:lang(ja) .spectrum-Heading--heavy .spectrum-Heading--strong,
+.spectrum:lang(ko) .spectrum-Heading--heavy strong,
+.spectrum:lang(ko) .spectrum-Heading--heavy .spectrum-Heading--strong,
+.spectrum:lang(zh) .spectrum-Heading--heavy strong,
+.spectrum:lang(zh) .spectrum-Heading--heavy .spectrum-Heading--strong {
+    font-style: var(
+        --spectrum-heading-heavy-xl-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    font-weight: var(
+        --spectrum-heading-heavy-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--light,
+.spectrum:lang(ko) .spectrum-Heading--light,
+.spectrum:lang(zh) .spectrum-Heading--light {
+    font-weight: var(
+        --spectrum-heading-han-xl-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--light em,
+.spectrum:lang(ja) .spectrum-Heading--light .spectrum-Heading--emphasis,
+.spectrum:lang(ko) .spectrum-Heading--light em,
+.spectrum:lang(ko) .spectrum-Heading--light .spectrum-Heading--emphasis,
+.spectrum:lang(zh) .spectrum-Heading--light em,
+.spectrum:lang(zh) .spectrum-Heading--light .spectrum-Heading--emphasis {
+    font-style: var(
+        --spectrum-heading-han-light-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    font-weight: var(
+        --spectrum-heading-han-light-xl-emphasis-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-light-emphasis)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--light strong,
+.spectrum:lang(ja) .spectrum-Heading--light .spectrum-Heading--strong,
+.spectrum:lang(ko) .spectrum-Heading--light strong,
+.spectrum:lang(ko) .spectrum-Heading--light .spectrum-Heading--strong,
+.spectrum:lang(zh) .spectrum-Heading--light strong,
+.spectrum:lang(zh) .spectrum-Heading--light .spectrum-Heading--strong {
+    font-style: var(
+        --spectrum-heading-han-light-xl-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    font-weight: var(
+        --spectrum-heading-han-light-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-bold)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Body--XXXL,
+.spectrum:lang(ko) .spectrum-Body--XXXL,
+.spectrum:lang(zh) .spectrum-Body--XXXL {
+    font-size: var(
+        --spectrum-body-han-xxxl-text-size,
+        var(--spectrum-global-dimension-font-size-600)
+    );
+    font-weight: var(
+        --spectrum-body-han-xxxl-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-body-han-xxxl-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-han-xxxl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-han-xxxl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-body-han-xxxl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Body--XXL,
+.spectrum:lang(ko) .spectrum-Body--XXL,
+.spectrum:lang(zh) .spectrum-Body--XXL {
+    font-size: var(
+        --spectrum-body-han-xxl-text-size,
+        var(--spectrum-global-dimension-font-size-500)
+    );
+    font-weight: var(
+        --spectrum-body-han-xxl-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-body-han-xxl-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-han-xxl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-han-xxl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-body-han-xxl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Body--XL,
+.spectrum:lang(ko) .spectrum-Body--XL,
+.spectrum:lang(zh) .spectrum-Body--XL {
+    font-size: var(
+        --spectrum-body-han-xl-text-size,
+        var(--spectrum-global-dimension-font-size-400)
+    );
+    font-weight: var(
+        --spectrum-body-han-xl-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-body-han-xl-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-han-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-han-xl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-body-han-xl-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Body--L,
+.spectrum:lang(ko) .spectrum-Body--L,
+.spectrum:lang(zh) .spectrum-Body--L {
+    font-size: var(
+        --spectrum-body-han-l-text-size,
+        var(--spectrum-global-dimension-font-size-300)
+    );
+    font-weight: var(
+        --spectrum-body-han-l-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-body-han-l-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-han-l-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-han-l-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-body-han-l-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Body--M,
+.spectrum:lang(ko) .spectrum-Body--M,
+.spectrum:lang(zh) .spectrum-Body--M {
+    font-size: var(
+        --spectrum-body-han-m-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-body-han-m-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-body-han-m-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-han-m-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-han-m-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-body-han-m-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Body--S,
+.spectrum:lang(ko) .spectrum-Body--S,
+.spectrum:lang(zh) .spectrum-Body--S {
+    font-size: var(
+        --spectrum-body-han-s-text-size,
+        var(--spectrum-alias-font-size-default)
+    );
+    font-weight: var(
+        --spectrum-body-han-s-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-body-han-s-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-han-s-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-han-s-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-body-han-s-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Body--XS,
+.spectrum:lang(ko) .spectrum-Body--XS,
+.spectrum:lang(zh) .spectrum-Body--XS {
+    font-size: var(
+        --spectrum-body-han-xs-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-body-han-xs-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-body-han-xs-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-body-han-xs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-body-han-xs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-body-han-xs-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--XL,
+.spectrum:lang(ko) .spectrum-Detail--XL,
+.spectrum:lang(zh) .spectrum-Detail--XL {
+    font-size: var(
+        --spectrum-detail-han-xl-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-detail-han-xl-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-han-xl-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-xl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-detail-han-xl-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--XL em,
+.spectrum:lang(ko) .spectrum-Detail--XL em,
+.spectrum:lang(zh) .spectrum-Detail--XL em {
+    font-size: var(
+        --spectrum-detail-han-xl-emphasis-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-detail-han-xl-emphasis-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
+    );
+    line-height: var(
+        --spectrum-detail-han-xl-emphasis-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-xl-emphasis-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(
+        --spectrum-detail-han-xl-emphasis-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--XL strong,
+.spectrum:lang(ko) .spectrum-Detail--XL strong,
+.spectrum:lang(zh) .spectrum-Detail--XL strong {
+    font-size: var(
+        --spectrum-detail-han-xl-strong-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-detail-han-xl-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+    line-height: var(
+        --spectrum-detail-han-xl-strong-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-xl-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-xl-strong-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(
+        --spectrum-detail-han-xl-strong-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--L,
+.spectrum:lang(ko) .spectrum-Detail--L,
+.spectrum:lang(zh) .spectrum-Detail--L {
+    font-size: var(
+        --spectrum-detail-han-l-text-size,
+        var(--spectrum-global-dimension-font-size-100)
+    );
+    font-weight: var(
+        --spectrum-detail-han-l-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-han-l-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-l-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-l-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-detail-han-l-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--L em,
+.spectrum:lang(ko) .spectrum-Detail--L em,
+.spectrum:lang(zh) .spectrum-Detail--L em {
+    font-size: var(
+        --spectrum-detail-han-l-emphasis-text-size,
+        var(--spectrum-global-dimension-font-size-100)
+    );
+    font-weight: var(
+        --spectrum-detail-han-l-emphasis-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
+    );
+    line-height: var(
+        --spectrum-detail-han-l-emphasis-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-l-emphasis-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-l-emphasis-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(
+        --spectrum-detail-han-l-emphasis-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--L strong,
+.spectrum:lang(ko) .spectrum-Detail--L strong,
+.spectrum:lang(zh) .spectrum-Detail--L strong {
+    font-size: var(
+        --spectrum-detail-han-l-strong-text-size,
+        var(--spectrum-global-dimension-font-size-100)
+    );
+    font-weight: var(
+        --spectrum-detail-han-l-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+    line-height: var(
+        --spectrum-detail-han-l-strong-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-l-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-l-strong-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(
+        --spectrum-detail-han-l-strong-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--M,
+.spectrum:lang(ko) .spectrum-Detail--M,
+.spectrum:lang(zh) .spectrum-Detail--M {
+    font-size: var(
+        --spectrum-detail-han-m-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-detail-han-m-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-han-m-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-m-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-m-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-detail-han-m-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--M em,
+.spectrum:lang(ko) .spectrum-Detail--M em,
+.spectrum:lang(zh) .spectrum-Detail--M em {
+    font-size: var(
+        --spectrum-detail-han-m-emphasis-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-detail-han-m-emphasis-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
+    );
+    line-height: var(
+        --spectrum-detail-han-m-emphasis-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-m-emphasis-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-m-emphasis-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(
+        --spectrum-detail-han-m-emphasis-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--M strong,
+.spectrum:lang(ko) .spectrum-Detail--M strong,
+.spectrum:lang(zh) .spectrum-Detail--M strong {
+    font-size: var(
+        --spectrum-detail-han-m-strong-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-detail-han-m-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+    line-height: var(
+        --spectrum-detail-han-m-strong-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-m-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-m-strong-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(
+        --spectrum-detail-han-m-strong-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--S,
+.spectrum:lang(ko) .spectrum-Detail--S,
+.spectrum:lang(zh) .spectrum-Detail--S {
+    font-size: var(
+        --spectrum-detail-han-s-text-size,
+        var(--spectrum-global-dimension-font-size-50)
+    );
+    font-weight: var(
+        --spectrum-detail-han-s-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-detail-han-s-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-s-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-s-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(--spectrum-detail-han-s-text-transform, uppercase);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--S em,
+.spectrum:lang(ko) .spectrum-Detail--S em,
+.spectrum:lang(zh) .spectrum-Detail--S em {
+    font-size: var(
+        --spectrum-detail-han-s-emphasis-text-size,
+        var(--spectrum-global-dimension-font-size-50)
+    );
+    font-weight: var(
+        --spectrum-detail-han-s-emphasis-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-regular-emphasis)
+    );
+    line-height: var(
+        --spectrum-detail-han-s-emphasis-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-s-emphasis-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-s-emphasis-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(
+        --spectrum-detail-han-s-emphasis-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--S strong,
+.spectrum:lang(ko) .spectrum-Detail--S strong,
+.spectrum:lang(zh) .spectrum-Detail--S strong {
+    font-size: var(
+        --spectrum-detail-han-s-strong-text-size,
+        var(--spectrum-global-dimension-font-size-50)
+    );
+    font-weight: var(
+        --spectrum-detail-han-s-strong-text-font-weight,
+        var(--spectrum-global-font-weight-black)
+    );
+    line-height: var(
+        --spectrum-detail-han-s-strong-text-line-height,
+        var(--spectrum-alias-heading-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-detail-han-s-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-detail-han-s-strong-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    text-transform: var(
+        --spectrum-detail-han-s-strong-text-transform,
+        uppercase
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.spectrum:lang(ja) .spectrum-Detail--light,
+.spectrum:lang(ko) .spectrum-Detail--light,
+.spectrum:lang(zh) .spectrum-Detail--light {
+    font-weight: var(
+        --spectrum-detail-han-xl-text-font-weight,
+        var(--spectrum-alias-detail-text-font-weight)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Detail--light em,
+.spectrum:lang(ja) .spectrum-Detail--light .spectrum-Detail--emphasis,
+.spectrum:lang(ko) .spectrum-Detail--light em,
+.spectrum:lang(ko) .spectrum-Detail--light .spectrum-Detail--emphasis,
+.spectrum:lang(zh) .spectrum-Detail--light em,
+.spectrum:lang(zh) .spectrum-Detail--light .spectrum-Detail--emphasis {
+    font-style: var(
+        --spectrum-detail-han-light-xl-emphasis-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    font-weight: var(
+        --spectrum-detail-han-light-xl-emphasis-text-font-weight,
+        var(--spectrum-alias-han-heading-text-font-weight-light-emphasis)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Detail--light strong,
+.spectrum:lang(ja) .spectrum-Detail--light .spectrum-Detail--strong,
+.spectrum:lang(ko) .spectrum-Detail--light strong,
+.spectrum:lang(ko) .spectrum-Detail--light .spectrum-Detail--strong,
+.spectrum:lang(zh) .spectrum-Detail--light strong,
+.spectrum:lang(zh) .spectrum-Detail--light .spectrum-Detail--strong {
+    font-style: var(
+        --spectrum-detail-han-light-xl-strong-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    font-weight: var(
+        --spectrum-detail-han-light-xl-strong-text-font-weight,
+        var(--spectrum-alias-heading-text-font-weight-regular)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Code--XL,
+.spectrum:lang(ko) .spectrum-Code--XL,
+.spectrum:lang(zh) .spectrum-Code--XL {
+    font-size: var(
+        --spectrum-code-han-xl-text-size,
+        var(--spectrum-global-dimension-font-size-400)
+    );
+    font-weight: var(
+        --spectrum-code-han-xl-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-han-xl-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-han-xl-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-han-xl-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-han-xl-text-font-family,
+        var(--spectrum-alias-font-family-zh)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Code--L,
+.spectrum:lang(ko) .spectrum-Code--L,
+.spectrum:lang(zh) .spectrum-Code--L {
+    font-size: var(
+        --spectrum-code-han-l-text-size,
+        var(--spectrum-global-dimension-font-size-300)
+    );
+    font-weight: var(
+        --spectrum-code-han-l-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-han-l-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-han-l-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-han-l-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-han-l-text-font-family,
+        var(--spectrum-alias-font-family-zh)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Code--M,
+.spectrum:lang(ko) .spectrum-Code--M,
+.spectrum:lang(zh) .spectrum-Code--M {
+    font-size: var(
+        --spectrum-code-han-m-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    font-weight: var(
+        --spectrum-code-han-m-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-han-m-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-han-m-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-han-m-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-han-m-text-font-family,
+        var(--spectrum-alias-font-family-zh)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Code--S,
+.spectrum:lang(ko) .spectrum-Code--S,
+.spectrum:lang(zh) .spectrum-Code--S {
+    font-size: var(
+        --spectrum-code-han-s-text-size,
+        var(--spectrum-alias-font-size-default)
+    );
+    font-weight: var(
+        --spectrum-code-han-s-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-han-s-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-han-s-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-han-s-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-han-s-text-font-family,
+        var(--spectrum-alias-font-family-zh)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Code--XS,
+.spectrum:lang(ko) .spectrum-Code--XS,
+.spectrum:lang(zh) .spectrum-Code--XS {
+    font-size: var(
+        --spectrum-code-han-xs-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    font-weight: var(
+        --spectrum-code-han-xs-text-font-weight,
+        var(--spectrum-alias-han-body-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-han-xs-text-line-height,
+        var(--spectrum-alias-body-han-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-han-xs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-han-xs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-han)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-han-xs-text-font-family,
+        var(--spectrum-alias-font-family-zh)
+    );
+}
+
+.spectrum-Heading--XXXL {
+    color: var(
+        --spectrum-heading-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading--XXL {
+    color: var(
+        --spectrum-heading-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading--XL {
+    color: var(
+        --spectrum-heading-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading--L {
+    color: var(
+        --spectrum-heading-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading--M {
+    color: var(
+        --spectrum-heading-m-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading--S {
+    color: var(
+        --spectrum-heading-s-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading--XS {
+    color: var(
+        --spectrum-heading-xs-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading--XXS {
+    color: var(
+        --spectrum-heading-xxs-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XXXL--light {
+    color: var(
+        --spectrum-heading-light-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XXL--light {
+    color: var(
+        --spectrum-heading-light-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XL--light {
+    color: var(
+        --spectrum-heading-light-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-L--light {
+    color: var(
+        --spectrum-heading-light-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XXXL--heavy {
+    color: var(
+        --spectrum-heading-heavy-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XXL--heavy {
+    color: var(
+        --spectrum-heading-heavy-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XL--heavy {
+    color: var(
+        --spectrum-heading-heavy-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-L--heavy {
+    color: var(
+        --spectrum-heading-heavy-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XXXL--heading {
+    color: var(
+        --spectrum-heading-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XXL--heading {
+    color: var(
+        --spectrum-heading-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-XL--heading {
+    color: var(
+        --spectrum-heading-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Heading-L--heading {
+    color: var(
+        --spectrum-heading-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Body--XXXL {
+    color: var(
+        --spectrum-body-xxxl-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum-Body--XXL {
+    color: var(
+        --spectrum-body-xxl-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum-Body--XL {
+    color: var(--spectrum-body-xl-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Body--L {
+    color: var(--spectrum-body-l-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Body--M {
+    color: var(--spectrum-body-m-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Body--S {
+    color: var(--spectrum-body-s-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Body--XS {
+    color: var(--spectrum-body-xs-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Detail--XL {
+    color: var(
+        --spectrum-detail-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Detail--L {
+    color: var(
+        --spectrum-detail-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Detail--M {
+    color: var(
+        --spectrum-detail-m-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Detail--S {
+    color: var(
+        --spectrum-detail-s-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum-Code--XL {
+    color: var(--spectrum-code-xl-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Code--L {
+    color: var(--spectrum-code-l-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Code--M {
+    color: var(--spectrum-code-m-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Code--S {
+    color: var(--spectrum-code-s-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum-Code--XS {
+    color: var(--spectrum-code-xs-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum:lang(ja) .spectrum-Body--XXXL,
+.spectrum:lang(ko) .spectrum-Body--XXXL,
+.spectrum:lang(zh) .spectrum-Body--XXXL {
+    color: var(
+        --spectrum-body-han-xxxl-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Body--XXL,
+.spectrum:lang(ko) .spectrum-Body--XXL,
+.spectrum:lang(zh) .spectrum-Body--XXL {
+    color: var(
+        --spectrum-body-han-xxl-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Body--XL,
+.spectrum:lang(ko) .spectrum-Body--XL,
+.spectrum:lang(zh) .spectrum-Body--XL {
+    color: var(
+        --spectrum-body-han-xl-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Body--L,
+.spectrum:lang(ko) .spectrum-Body--L,
+.spectrum:lang(zh) .spectrum-Body--L {
+    color: var(
+        --spectrum-body-han-l-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Body--M,
+.spectrum:lang(ko) .spectrum-Body--M,
+.spectrum:lang(zh) .spectrum-Body--M {
+    color: var(
+        --spectrum-body-han-m-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Body--S,
+.spectrum:lang(ko) .spectrum-Body--S,
+.spectrum:lang(zh) .spectrum-Body--S {
+    color: var(
+        --spectrum-body-han-s-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Body--XS,
+.spectrum:lang(ko) .spectrum-Body--XS,
+.spectrum:lang(zh) .spectrum-Body--XS {
+    color: var(
+        --spectrum-body-han-xs-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XXXL,
+.spectrum:lang(ko) .spectrum-Heading--XXXL,
+.spectrum:lang(zh) .spectrum-Heading--XXXL {
+    color: var(
+        --spectrum-heading-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XXL,
+.spectrum:lang(ko) .spectrum-Heading--XXL,
+.spectrum:lang(zh) .spectrum-Heading--XXL {
+    color: var(
+        --spectrum-heading-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XL,
+.spectrum:lang(ko) .spectrum-Heading--XL,
+.spectrum:lang(zh) .spectrum-Heading--XL {
+    color: var(
+        --spectrum-heading-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--L,
+.spectrum:lang(ko) .spectrum-Heading--L,
+.spectrum:lang(zh) .spectrum-Heading--L {
+    color: var(
+        --spectrum-heading-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--M,
+.spectrum:lang(ko) .spectrum-Heading--M,
+.spectrum:lang(zh) .spectrum-Heading--M {
+    color: var(
+        --spectrum-heading-m-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--S,
+.spectrum:lang(ko) .spectrum-Heading--S,
+.spectrum:lang(zh) .spectrum-Heading--S {
+    color: var(
+        --spectrum-heading-s-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XS,
+.spectrum:lang(ko) .spectrum-Heading--XS,
+.spectrum:lang(zh) .spectrum-Heading--XS {
+    color: var(
+        --spectrum-heading-xs-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading--XXS,
+.spectrum:lang(ko) .spectrum-Heading--XXS,
+.spectrum:lang(zh) .spectrum-Heading--XXS {
+    color: var(
+        --spectrum-heading-xxs-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XXXL--light,
+.spectrum:lang(ko) .spectrum-Heading-XXXL--light,
+.spectrum:lang(zh) .spectrum-Heading-XXXL--light {
+    color: var(
+        --spectrum-heading-light-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XXL--light,
+.spectrum:lang(ko) .spectrum-Heading-XXL--light,
+.spectrum:lang(zh) .spectrum-Heading-XXL--light {
+    color: var(
+        --spectrum-heading-light-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XL--light,
+.spectrum:lang(ko) .spectrum-Heading-XL--light,
+.spectrum:lang(zh) .spectrum-Heading-XL--light {
+    color: var(
+        --spectrum-heading-light-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-L--light,
+.spectrum:lang(ko) .spectrum-Heading-L--light,
+.spectrum:lang(zh) .spectrum-Heading-L--light {
+    color: var(
+        --spectrum-heading-light-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XXXL--heavy,
+.spectrum:lang(ko) .spectrum-Heading-XXXL--heavy,
+.spectrum:lang(zh) .spectrum-Heading-XXXL--heavy {
+    color: var(
+        --spectrum-heading-heavy-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XXL--heavy,
+.spectrum:lang(ko) .spectrum-Heading-XXL--heavy,
+.spectrum:lang(zh) .spectrum-Heading-XXL--heavy {
+    color: var(
+        --spectrum-heading-heavy-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XL--heavy,
+.spectrum:lang(ko) .spectrum-Heading-XL--heavy,
+.spectrum:lang(zh) .spectrum-Heading-XL--heavy {
+    color: var(
+        --spectrum-heading-heavy-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-L--heavy,
+.spectrum:lang(ko) .spectrum-Heading-L--heavy,
+.spectrum:lang(zh) .spectrum-Heading-L--heavy {
+    color: var(
+        --spectrum-heading-heavy-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XXXL--heading,
+.spectrum:lang(ko) .spectrum-Heading-XXXL--heading,
+.spectrum:lang(zh) .spectrum-Heading-XXXL--heading {
+    color: var(
+        --spectrum-heading-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XXL--heading,
+.spectrum:lang(ko) .spectrum-Heading-XXL--heading,
+.spectrum:lang(zh) .spectrum-Heading-XXL--heading {
+    color: var(
+        --spectrum-heading-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-XL--heading,
+.spectrum:lang(ko) .spectrum-Heading-XL--heading,
+.spectrum:lang(zh) .spectrum-Heading-XL--heading {
+    color: var(
+        --spectrum-heading-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Heading-L--heading,
+.spectrum:lang(ko) .spectrum-Heading-L--heading,
+.spectrum:lang(zh) .spectrum-Heading-L--heading {
+    color: var(
+        --spectrum-heading-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Detail--XL,
+.spectrum:lang(ko) .spectrum-Detail--XL,
+.spectrum:lang(zh) .spectrum-Detail--XL {
+    color: var(
+        --spectrum-detail-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Detail--L,
+.spectrum:lang(ko) .spectrum-Detail--L,
+.spectrum:lang(zh) .spectrum-Detail--L {
+    color: var(
+        --spectrum-detail-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Detail--M,
+.spectrum:lang(ko) .spectrum-Detail--M,
+.spectrum:lang(zh) .spectrum-Detail--M {
+    color: var(
+        --spectrum-detail-m-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Detail--S,
+.spectrum:lang(ko) .spectrum-Detail--S,
+.spectrum:lang(zh) .spectrum-Detail--S {
+    color: var(
+        --spectrum-detail-s-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+
+.spectrum:lang(ja) .spectrum-Code--XL,
+.spectrum:lang(ko) .spectrum-Code--XL,
+.spectrum:lang(zh) .spectrum-Code--XL {
+    color: var(--spectrum-code-xl-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum:lang(ja) .spectrum-Code--L,
+.spectrum:lang(ko) .spectrum-Code--L,
+.spectrum:lang(zh) .spectrum-Code--L {
+    color: var(--spectrum-code-l-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum:lang(ja) .spectrum-Code--M,
+.spectrum:lang(ko) .spectrum-Code--M,
+.spectrum:lang(zh) .spectrum-Code--M {
+    color: var(--spectrum-code-m-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum:lang(ja) .spectrum-Code--S,
+.spectrum:lang(ko) .spectrum-Code--S,
+.spectrum:lang(zh) .spectrum-Code--S {
+    color: var(--spectrum-code-s-text-color, var(--spectrum-alias-text-color));
+}
+
+.spectrum:lang(ja) .spectrum-Code--XS,
+.spectrum:lang(ko) .spectrum-Code--XS,
+.spectrum:lang(zh) .spectrum-Code--XS {
+    color: var(--spectrum-code-xs-text-color, var(--spectrum-alias-text-color));
 }
 
 .spectrum-Body1 {

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -38,7 +38,7 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/textfield": "^2.0.4"
+        "@spectrum-css/textfield": "^2.0.5"
     },
     "dependencies": {
         "@spectrum-web-components/icon": "^0.4.3",

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -78,8 +78,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     vertical-align: top;
     margin: 0;
     overflow: visible;
-    font-family: adobe-clean-ux, adobe-clean, Source Sans Pro, -apple-system,
-        BlinkMacSystemFont, Segoe UI, Roboto, sans-serif;
+    font-family: var(
+        --spectrum-alias-body-text-font-family,
+        var(--spectrum-global-font-family-base)
+    );
     font-size: var(
         --spectrum-textfield-text-size,
         var(--spectrum-alias-font-size-default)
@@ -194,6 +196,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             --spectrum-icon-alert-medium-width,
             var(--spectrum-global-dimension-size-225)
         );
+    background-position: calc(
+            100% -
+                var(
+                    --spectrum-textfield-padding-x,
+                    var(--spectrum-global-dimension-size-150)
+                ) +
+                var(
+                    --spectrum-textfield-border-size,
+                    var(--spectrum-alias-border-size-thin)
+                )
+        )
+        calc(
+            var(
+                    --spectrum-textfield-height,
+                    var(--spectrum-alias-single-line-height)
+                ) / 2 -
+                var(
+                    --spectrum-icon-alert-medium-height,
+                    var(--spectrum-global-dimension-size-225)
+                ) / 2 -
+                var(
+                    --spectrum-textfield-quiet-border-size,
+                    var(--spectrum-alias-border-size-thin)
+                )
+        );
     padding-right: calc(
         var(
                 --spectrum-textfield-padding-x,
@@ -213,12 +240,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
-:host([invalid]) #input,
-:host([valid]) #input,
-#input:invalid {
-    /* .spectrum-Textfield.is-invalid,
-   * .spectrum-Textfield.is-valid,
-   * .spectrum-Textfield:invalid */
+:host([valid]) #input {
+    /* .spectrum-Textfield.is-valid */
+    background-size: var(--spectrum-icon-checkmark-medium-width)
+        var(--spectrum-icon-checkmark-medium-width);
     background-position: calc(
             100% -
                 var(
@@ -230,12 +255,12 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                     var(--spectrum-alias-border-size-thin)
                 )
         )
-        50%;
-}
-:host([valid]) #input {
-    /* .spectrum-Textfield.is-valid */
-    background-size: var(--spectrum-icon-checkmark-medium-width)
-        var(--spectrum-icon-checkmark-medium-width);
+        calc(
+            var(
+                    --spectrum-textfield-height,
+                    var(--spectrum-alias-single-line-height)
+                ) / 2 - var(--spectrum-icon-checkmark-medium-height) / 2
+        );
     padding-right: calc(
         var(
                 --spectrum-textfield-padding-x,
@@ -297,27 +322,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 )
         );
     overflow: auto;
-}
-:host([multiline][invalid]) #input,
-:host([multiline][valid]) #input,
-:host([multiline]) #input:invalid {
-    /* .spectrum-Textfield--multiline.is-invalid,
-   * .spectrum-Textfield--multiline.is-valid,
-   * .spectrum-Textfield--multiline:invalid */
-    background-position: calc(
-            100% -
-                var(
-                    --spectrum-textfield-icon-size,
-                    var(--spectrum-global-dimension-size-225)
-                ) / 2
-        )
-        calc(
-            100% -
-                var(
-                    --spectrum-textfield-icon-size,
-                    var(--spectrum-global-dimension-size-225)
-                ) / 2
-        );
 }
 :host([quiet]) #input {
     /* .spectrum-Textfield--quiet */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3639,20 +3639,20 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-2.0.2.tgz#d0454c6dd6ae8bdf8ba2fe8aee252e75e2bb2d84"
   integrity sha512-urLOIRMtomQBoQjxKOwAk7AhJ9HHguiaboijKsMjQUuXvaDZ/5X5Oi/c76Y+ayuj4gGh6m4D+i+X3coo9vyQJg==
 
-"@spectrum-css/button@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-2.0.2.tgz#ad4a3375ab0aec032cc4e23c2ded2eccf49f086c"
-  integrity sha512-PIXDEH4MfrZFr9GMcb8UT6cm3D4qQie5JAAYZqmdCFpCVZbv8DLFyY7Mhjlfl9GUKuP0R1OyWMiv7e5MvfMoww==
+"@spectrum-css/button@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-2.1.0.tgz#f9de76294a88946de9b580dd1c4d8607fa6d1b4a"
+  integrity sha512-T+xMoMn+zRjqgnZJHJqI/sqDKSiF8cCNB1RQlL7JaPpNjZ8m2US3UCOQD4gh4t0eYYF5dbFjfhahr9mZKpHJeA==
 
 "@spectrum-css/card@^2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-2.0.4.tgz#5eb46bef589e284af9c2d976739a09126eb1b1f3"
   integrity sha512-YD3S98d3Bj+FLvNdf7B+npF8PAYaeTycfYVn71ryBIO+gdpotYalx0Fjy7MI8vS24Nb5fQGpf95/44UxpYqOUQ==
 
-"@spectrum-css/checkbox@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-2.0.4.tgz#03ca80a605704f2687999d15b53ddb6d3c875e17"
-  integrity sha512-OnRz/lCycAO2UucCKqEU4V7bGD4++/clwQuZvmNAEesUhqQ9oVeVhZ1DQh5veYDlIU+Jd9jB9YpXAnqA/TB/rw==
+"@spectrum-css/checkbox@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-2.0.5.tgz#5736c041b4be725b55688ba352cadc5e6a8a972e"
+  integrity sha512-wH4OX2/710mkU174CXhkCERYA+a0aLApj87OFsJy6vESHTazxkewLjwz/qI9D+P/8y4bsk2Ph0+TMPTp6OVGcA==
 
 "@spectrum-css/circleloader@^2.0.2":
   version "2.0.2"
@@ -3674,25 +3674,30 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-2.0.2.tgz#efe5bcc08d2936c8b18cb50e4db1fbf88618e73a"
   integrity sha512-D9vwVA5lIvG2mM/UMQvP+17HrJMsdetd4j9rHr+b9lHX4pLmgYobG1GC+kz7IJtdmcMBvgGDYg4pz5MAfQvgLQ==
 
-"@spectrum-css/icon@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-2.0.2.tgz#1e325863f042945d77badc0588f6600d6f9d1b89"
-  integrity sha512-n3JYSPNia7KU9iTtN0ROw5bnq8XziOVENi7Zx/bLcR47mw9+oxmAnYRVK81WAzDIY9t0S8OIVA6wv0TJJ/6QtQ==
+"@spectrum-css/icon@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-2.0.4.tgz#701127aea2c72d05315b081fed04b39a501b5308"
+  integrity sha512-ZQx/GVYrYn5pR61oWGrrHFwh85soCknoBq2I0pLKE693lUgsJoFvJd4GMfr3tkw8RC9e2fJiF3PmBec2e5cL2g==
 
 "@spectrum-css/illustratedmessage@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-2.0.2.tgz#f46ba45e8d5d7a18e04f300aed04740f7452ad91"
   integrity sha512-LMyAaQrdt4+XVQSfzg/TmmIWOclt9hO2N2uzSDH7zl25GTKeSj+n1mSsis8KjOiX+2lXXGlTw7aeESqZ6le9Uw==
 
-"@spectrum-css/link@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-2.0.2.tgz#577499c9ef7d7e53c3c2893f358bbe3766c3c2e9"
-  integrity sha512-XxG93Wr3N6puLuJszxz9xa+UdaO8QfX/pAl+vopPRdZsAr6LNd2dYIua6uEjF3u9/osUNuQzvFU+1drrLICtEw==
+"@spectrum-css/link@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-2.0.4.tgz#e4484848b73532a7296b8b095a3570226bd18f3a"
+  integrity sha512-D+tgnV5u2ekt6094CPP8/WT9aFP76R13lb+w1Z+SiG7sq/AZSBO8/pOVWmPDmBJWmnZqBy8yJsJznfoKnHPJfA==
 
 "@spectrum-css/menu@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-2.1.2.tgz#56669f2ef7de296439f6292abf1abe3abfca021e"
   integrity sha512-vcM/Df0XnAPwHROq/JM5nTwXgLnwLYqNDm09w6mCxcTFvdZbaxRuzf5f0GCRFfKe4DcQ+cP0j5Fc35rb/2grLg==
+
+"@spectrum-css/menu@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-2.1.4.tgz#05c3a07bb5a0d1149f2e2db7af29fa5378532a70"
+  integrity sha512-68oWyCwQLrC+EtD5Y76km50vkuxXJb4SekePeHyEXa3jt6KBaSCMjiR+FAImRdFGXbzleefMGPBA4kVhK1Pi5w==
 
 "@spectrum-css/popover@^2.0.4":
   version "2.0.4"
@@ -3721,10 +3726,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-2.0.3.tgz#cc3ae49966e3e597bf2562e401e4eb233844abbe"
   integrity sha512-2XlHQNEDHId7Cr3cz5emH/o0dcnqPDz68xqISZE3Zk6TvoZtAzz1LXdN6JsT+ueZyz1tIbm5aLAX4EfyDtn1EQ==
 
-"@spectrum-css/slider@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-2.0.2.tgz#71a621107d443832cae3a0cb3cafb1a532df406e"
-  integrity sha512-uD1tlzYn6VaMIFNdaHclD/ayLobm+PgRa86xR9n7NYSoYgPdkrs5DYMFurAjJxon71i8Kr73yIruPZp5epE8lg==
+"@spectrum-css/slider@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-2.0.4.tgz#89fb578ce45118281d89d9c2ee71b3ac69ad0e91"
+  integrity sha512-ioGbDWmU28jEWUTBR9wbeGSlRDIyrWUHoIsZHBLXveJw/Wq55rYcfcH0vC8hfbQ4xqyc/wJB0O7UJVVSbTlEDw==
 
 "@spectrum-css/statuslight@^2.0.2":
   version "2.0.2"
@@ -3741,10 +3746,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-2.1.1.tgz#058b006b1f20178ab66c84414ca43ec1bd86bfd5"
   integrity sha512-vC9aZhbZlYDMnAlqZcQxgnTAvjiOVVG4nBd7nWqBLopPxgVC+dsVNqzW6GHr6dSy7CNdBSGD9NUFaZPHAgpDwA==
 
-"@spectrum-css/textfield@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-2.0.4.tgz#4f8d301e66d46170afb829ae9a2f543bce65fcba"
-  integrity sha512-fw90xTkjLY3wnjFbcrsppZr3KLmqkedKzEH13qOVKMczcKMPFVZ1oc6tE6Qm8tC9P8zMlarRPR3q53yfA7ZEOA==
+"@spectrum-css/textfield@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-2.0.5.tgz#45a665dd49981e40a4f3e8f5caf465ea54172679"
+  integrity sha512-ef/yHrGwAjIBzJ800ec/52zkUnWkWzTpd102tK6NJ6CmQplL9S87DT1gBjehWtWfl1wdpSXd1zKQoVE7QfouDQ==
 
 "@spectrum-css/toast@^2.0.2":
   version "2.0.2"
@@ -3761,20 +3766,20 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-2.0.2.tgz#7b322966404fafbec9d085246f3590e184f350f2"
   integrity sha512-/oWbFHfQQaSXWmenW+qSJtcSc5xGot/jnFk7IGPnd2TZOVPazWUsSZRhNM+VLrsYZs/9bXbZTzsa+EuPZ8Jr6w==
 
-"@spectrum-css/typography@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-2.0.3.tgz#0db7027434275d90d714a25ca1236f05366c20fb"
-  integrity sha512-7+JPw249/hDWrjerRmFnjGYAwE3NPKzGqMzjxvRAnGHWhz/5oLVPxwp769MjeBFwTYnLCVIpBKgkSeHs2ETRbw==
-
-"@spectrum-css/vars@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-2.0.2.tgz#235ae6965a4e3ffff4884617e583425e382776f6"
-  integrity sha512-BKzC3a+gdhsC9tBjenXUmv/lpmrLLYNV6KO0f67HIVJLKcY9Va4uaO0BfWaS3FCEm7msB4R8ANJkZtqNq5NbTg==
+"@spectrum-css/typography@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-2.1.0.tgz#36dfc04ef9bbcbdab85f34eadcf5a6b8b43c7c4d"
+  integrity sha512-3c6OWn6Wci/yO79mUS3U3GEqcstd1O76fxGifwd4Atv2E4vjmOmce35+8h38RriDwdtBeFRLxedmOX1JimNYHA==
 
 "@spectrum-css/vars@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-2.0.3.tgz#4372a0b0f3ce9034d8dea59c5cee08eb84059289"
   integrity sha512-q3cLSAb7/wh8cufwSMGzAJXLEkhz9FW4Vfs9RiBj5TBeK021T1YtnRJvshFKxgiBl8EHC0L3gwkbC6UvkLuQqA==
+
+"@spectrum-css/vars@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-2.1.0.tgz#dbc76c39e3abcd63b9de294240c2c750625d803b"
+  integrity sha512-o0E63blA8jH1iHJ7gI6VPTnKJpEXKgDVINl9+aYsYbVrVV0cTxXE+FiFIsqzL2ZDd2HZn8qAdAsGvfI71qnn5g==
 
 "@storybook/addon-docs@5.3.1":
   version "5.3.1"


### PR DESCRIPTION
## Description
Update to the latest Spectrum CSS dependencies. This is separate from the "general update" as there should be (and is) actual changes to the golden images in this update, and it makes them easier to review.

## Related Issue
fixes #496 
fixes #497 
fixes #498 
fixes #499 
fixes #500
fixes #501 
fixes #502 
fixes #503 
fixes #504  

## Motivation and Context
Keeping us up-to-date with Spectrum CSS/DNA changes.

## How Has This Been Tested?
Visual regressions confirmed and updated in the golden images cache.

## Types of changes
- [x] Chore (keep abreast of upstream projects)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
