### PR TITLE
fix(search): ensure "reset" surfaces "input" and "change" events

### DIFF
--- a/packages/search/src/search.ts
+++ b/packages/search/src/search.ts
@@ -64,13 +64,29 @@ export class Search extends Textfield {
         }
     }
 
-    public reset(): void {
+    public async reset(): Promise<void> {
         /* istanbul ignore if */
         if (!this.form) {
             return;
         }
         this.value = '';
         this.form.reset();
+        await this.updateComplete;
+        this.focusElement.dispatchEvent(
+            new InputEvent('input', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+        // The native `change` event on an `input` element is not composed,
+        // so this synthetic replication of a `change` event must not be
+        // either as the `Textfield` baseclass should only need to handle
+        // the native variant of this interaction.
+        this.focusElement.dispatchEvent(
+            new InputEvent('change', {
+                bubbles: true,
+            })
+        );
     }
 
     protected render(): TemplateResult {


### PR DESCRIPTION
## Description
Manual dispatch `input` and `change` events from the `input` element in the `Search` component so that an appropriate response can be made in implementing applications.

## Related Issue
fixes #313

## Motivation and Context
Tighter interaction loop.

## How Has This Been Tested?
- unit test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
