### PR TITLE
fix(tab-list): add support for "vertical-right"

### DIFF
--- a/packages/tab-list/src/tab-list.css
+++ b/packages/tab-list/src/tab-list.css
@@ -48,3 +48,99 @@ governing permissions and limitations under the License.
 :host([compact]) {
     --spectrum-tabs-height: var(--spectrum-tabs-quiet-compact-height);
 }
+
+/*
+ * The following manually add the `vertical-right` direction to sp-tab-list
+ * It can be removed after https://github.com/adobe/spectrum-css/issues/637 is resolved
+ * In the interim, if there are ever Visual Regression failures to the 'Vertical' tabs story
+ * then it is likely that this CSS will need to be updated with changes in @spectrum-css/tabs
+ */
+:host([direction='vertical-right']) {
+    /* .spectrum-Tabs--vertical */
+    display: inline-flex;
+    flex-direction: column;
+    padding: 0;
+    border-right: var(
+            --spectrum-tabs-vertical-rule-width,
+            var(--spectrum-alias-border-size-thick)
+        )
+        solid; /* .spectrum-Tabs--vertical */
+
+    border-right-color: var(
+        --spectrum-tabs-vertical-rule-color,
+        var(--spectrum-global-color-gray-200)
+    );
+}
+:host([direction='vertical-right']) ::slotted(*) {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
+    height: var(
+        --spectrum-tabs-vertical-item-height,
+        var(--spectrum-global-dimension-size-550)
+    );
+    padding: 0
+        var(
+            --spectrum-tabs-focus-ring-padding-x,
+            var(--spectrum-global-dimension-size-100)
+        );
+    margin-right: calc(
+        var(
+                --spectrum-tabs-vertical-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) -
+            var(
+                --spectrum-tabs-focus-ring-padding-x,
+                var(--spectrum-global-dimension-size-100)
+            )
+    );
+    margin-bottom: var(
+        --spectrum-tabs-vertical-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+:host([direction='vertical-right'][compact]) ::slotted(*) {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-item */
+    line-height: var(
+        --spectrum-tabs-compact-vertical-item-height,
+        var(--spectrum-global-dimension-size-400)
+    );
+    margin-bottom: var(
+        --spectrum-tabs-compact-vertical-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    ); /* .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-item,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-item .spectrum-Icon */
+
+    height: var(
+        --spectrum-tabs-compact-vertical-item-height,
+        var(--spectrum-global-dimension-size-400)
+    );
+}
+:host([direction='vertical-right']) #selectionIndicator {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+    position: absolute;
+    left: auto;
+    width: var(
+        --spectrum-tabs-vertical-rule-width,
+        var(--spectrum-alias-border-size-thick)
+    );
+    right: calc(
+        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
+    );
+}
+:host([direction='vertical-right'][compact]),
+:host([direction='vertical-right'][quiet]) {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
+    border-right-color: var(
+        --spectrum-tabs-quiet-vertical-rule-color,
+        var(--spectrum-alias-border-color-transparent)
+    );
+}
+:host([direction='vertical-right'][compact]) #selectionIndicator,
+:host([direction='vertical-right'][quiet]) #selectionIndicator {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-selectionIndicator,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet .spectrum-Tabs-selectionIndicator */
+    background-color: var(
+        --spectrum-tabs-quiet-selection-indicator-color,
+        var(--spectrum-global-color-gray-900)
+    );
+}

--- a/packages/tab-list/src/tab-list.ts
+++ b/packages/tab-list/src/tab-list.ts
@@ -24,6 +24,7 @@ import tabStyles from './tab-list.css.js';
 
 const availableArrowsByDirection = {
     vertical: ['ArrowUp', 'ArrowDown'],
+    ['vertical-right']: ['ArrowUp', 'ArrowDown'],
     horizontal: ['ArrowLeft', 'ArrowRight'],
 };
 
@@ -38,7 +39,8 @@ export class TabList extends Focusable {
         return [tabStyles];
     }
     @property({ reflect: true })
-    public direction: 'vertical' | 'horizontal' = 'horizontal';
+    public direction: 'vertical' | 'vertical-right' | 'horizontal' =
+        'horizontal';
 
     @property()
     public selectionIndicatorStyle = '';
@@ -102,10 +104,10 @@ export class TabList extends Focusable {
     protected updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('direction')) {
-            if (this.direction === 'vertical') {
-                this.setAttribute('aria-orientation', 'vertical');
-            } else {
+            if (this.direction === 'horizontal') {
                 this.removeAttribute('aria-orientation');
+            } else {
+                this.setAttribute('aria-orientation', 'vertical');
             }
         }
     }

--- a/packages/tab/stories/tabs.stories.ts
+++ b/packages/tab/stories/tabs.stories.ts
@@ -54,6 +54,17 @@ export const Vertical = (): TemplateResult => {
     `;
 };
 
+export const VerticalRight = (): TemplateResult => {
+    return html`
+        <sp-tab-list selected="1" direction="vertical-right">
+            <sp-tab label="Tab 1" value="1"></sp-tab>
+            <sp-tab label="Tab 2" value="2"></sp-tab>
+            <sp-tab label="Tab 3" value="3"></sp-tab>
+            <sp-tab label="Tab 4" value="4"></sp-tab>
+        </sp-tab-list>
+    `;
+};
+
 export const Icons = (): TemplateResult => {
     const directions = {
         horizontal: 'horizontal',


### PR DESCRIPTION
## Description 
Add support for a "vertical-right" variant in the `sp-tab-list` component.

It's possible that this requires further documentation, and could benefit from some cleaned up CSS, but I wanted to leave that until I get feedback from Spectrum CSS as to whether this variant could be included at some point in the future in their specification. [This issue](https://github.com/adobe/spectrum-css/issues/637) tracks the possible addition of this pattern in their project.

## Motivation and Context
Product design requirement

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/76368051-54fbdd00-6305-11ea-8aed-6c339351f4dc.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
