### PR TITLE
docs: close nav when resetting scroll

### DIFF
--- a/documentation/src/components/layout.ts
+++ b/documentation/src/components/layout.ts
@@ -55,6 +55,10 @@ export class LayoutElement extends LitElement {
         this.open = !this.open;
     }
 
+    closeNav() {
+        this.open = false;
+    }
+
     private updateColor(event: Event) {
         this.color = (event.target as Dropdown).value as Color;
     }
@@ -131,7 +135,7 @@ export class LayoutElement extends LitElement {
                         id="side-nav"
                         ?inert=${!this.open}
                         ?open=${this.open}
-                        @close=${this.toggleNav}
+                        @close=${this.closeNav}
                     ></docs-side-nav>
                     <main id="layout-content" ?inert=${this.open} role="main">
                         <div id="page">

--- a/documentation/src/components/page.ts
+++ b/documentation/src/components/page.ts
@@ -33,6 +33,7 @@ export class Page extends LayoutElement {
         if (!this.contentElement) return;
 
         this.contentElement.scroll(0, 0);
+        this.open = false;
     }
 }
 


### PR DESCRIPTION
## Description
Ensures that the navigation closes when moving between pages in the documentation.

## Motivation and Context
Less clicks for content

## How Has This Been Tested?
Manually

## Types of changes
- [x] feature

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
