### PR TITLE
fix(tab-list): position the indicator correctly when sized

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-7ff1646ce8e3deef0ca67ea350121658ccf81c49
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-a0c1c2bfbcac071d38028cc988c87fce7ccf4fd1
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/tab-list/src/tab-list.css
+++ b/packages/tab-list/src/tab-list.css
@@ -40,6 +40,15 @@ governing permissions and limitations under the License.
     );
 }
 
+/*
+ * While https://github.com/adobe/spectrum-css/issues/641 goes unaddressed,
+ * then we'll need to place this at `top: 0;` ourselves.
+ */
+:host([direction='vertical-right']) #selectionIndicator,
+:host([direction='vertical']) #selectionIndicator {
+    top: 0;
+}
+
 /* 
  * Since #tab is the shadowSelector for tab-item, the default line-height
  * declaration in #tab overrides the compact line-height declared in

--- a/packages/tab/stories/tabs.stories.ts
+++ b/packages/tab/stories/tabs.stories.ts
@@ -54,8 +54,33 @@ export const Vertical = (): TemplateResult => {
     `;
 };
 
+export const VerticalSized = (): TemplateResult => {
+    return html`
+        <style>
+            sp-tab-list {
+                height: 75vh;
+                flex-direction: column;
+                justify-content: center;
+            }
+        </style>
+        <sp-tab-list selected="1" direction="vertical">
+            <sp-tab label="Tab 1" value="1"></sp-tab>
+            <sp-tab label="Tab 2" value="2"></sp-tab>
+            <sp-tab label="Tab 3" value="3"></sp-tab>
+            <sp-tab label="Tab 4" value="4"></sp-tab>
+        </sp-tab-list>
+    `;
+};
+
 export const VerticalRight = (): TemplateResult => {
     return html`
+        <style>
+            sp-tab-list {
+                height: 75vh;
+                flex-direction: column;
+                justify-content: center;
+            }
+        </style>
         <sp-tab-list selected="1" direction="vertical-right">
             <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -112,6 +112,8 @@ module.exports = [
     'tabs--default',
     'tabs--autofocus',
     'tabs--vertical',
+    'tabs--vertical-sized',
+    'tabs--vertical-right',
     'tabs--icons',
     'tabs--icons-ii',
     'tabs--quiet',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds support for the following type of styles on `sp-tab-list`...
```
            height: 75vh;
            flex-direction: column;
            justify-content: center;
```

## Related Issue
fixes #537

## Motivation and Context
It makes application styling easier.

## How Has This Been Tested?
- added a visual regression.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/76579969-8828a280-64a4-11ea-94a3-d00e394752b9.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
