### PR TITLE
fix(theme): track default theme values dynamically

### DIFF
--- a/packages/overlay/src/active-overlay.ts
+++ b/packages/overlay/src/active-overlay.ts
@@ -399,7 +399,6 @@ export class ActiveOverlay extends LitElement {
     }
 
     public renderTheme(content: TemplateResult): TemplateResult {
-        import('@spectrum-web-components/theme');
         const color = this.color as Color;
         const scale = this.scale as Scale;
         return html`

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -11,9 +11,9 @@ governing permissions and limitations under the License.
 */
 export * from './theme.js';
 
-import './theme-dark.js';
-import './theme-darkest.js';
 import './theme-light.js';
 import './theme-lightest.js';
+import './theme-dark.js';
+import './theme-darkest.js';
 import './scale-medium.js';
 import './scale-large.js';


### PR DESCRIPTION
## Description
Support manually configuring what theme fragments to load in an application by dynamically acquiring the "default" fragment for each theme "type".

## Related Issue
fixes #532 

## Motivation and Context
We shouldn't HAVE to load all the themes ALL the time.

## How Has This Been Tested?
- probably needs more tests if we agree on this path forward.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
