### PR TITLE
docs(icon): correct link pathing for base tag usage

### DIFF
--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -14,7 +14,7 @@ yarn add @spectrum-web-components/icon
 
 ## Example
 
-Names icons on this page are provided by the [`<sp-icons-medium>` icon set](/components/icons). Learn how to create your own via [`sp-iconset`](/components/iconset).
+Names icons on this page are provided by the [`<sp-icons-medium>` icon set](components/icons). Learn how to create your own via [`sp-iconset`](components/iconset).
 
 ```html
 <sp-icons-medium></sp-icons-medium>


### PR DESCRIPTION
## Description
Ensure that the linking in the icons docs is correct no matter the value of the `<base/>` tag.

## Motivation and Context
Links should work.

## How Has This Been Tested?
Manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
