### PR TITLE
fix(textfield): update validation path, add "allowed-keys"

### DIFF
--- a/packages/textfield/stories/textfield.stories.ts
+++ b/packages/textfield/stories/textfield.stories.ts
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 */
 import {
     html,
-    boolean,
     withKnobs,
     withWebComponentsKnobs,
 } from '@open-wc/demoing-storybook';
@@ -26,49 +25,51 @@ export default {
 };
 
 export const Default = (): TemplateResult => {
-    const quiet = boolean('Quiet', false, 'Element');
+    return html`
+        <sp-textfield placeholder="Enter your name"></sp-textfield>
+        <sp-textfield placeholder="Enter your name" disabled></sp-textfield>
+        <sp-textfield
+            placeholder="Enter your name"
+            pattern="[\\w\\s]*"
+            required
+            value="A valid input"
+        ></sp-textfield>
+        <sp-textfield
+            placeholder="Enter your name"
+            pattern="[\\w\\s]*"
+            required
+            value="A valid input"
+            disabled
+        ></sp-textfield>
+        <sp-textfield
+            placeholder="Enter your name"
+            pattern="[\\d]*"
+            value="Not a valid input"
+        ></sp-textfield>
+        <sp-textfield
+            placeholder="Enter your name"
+            pattern="^[\\d]$"
+            required
+            value="Not a valid input"
+            disabled
+        ></sp-textfield>
+    `;
+};
+
+export const notRequiredWithPattern = (): TemplateResult => {
+    return html`
+        <sp-textfield
+            placeholder="Enter z, x, c, or v"
+            pattern="[zxcv]+"
+        ></sp-textfield>
+    `;
+};
+
+export const allowedKeys = (): TemplateResult => {
     return html`
         <sp-textfield
             placeholder="Enter your name"
-            ?quiet=${quiet}
-        ></sp-textfield>
-        <sp-textfield
-            placeholder="Enter your name"
-            disabled
-            ?quiet=${quiet}
-        ></sp-textfield>
-        <sp-textfield
-            placeholder="Enter your name"
-            pattern="[\\w\\s]+"
-            required
-            valid
-            value="A valid input"
-            ?quiet=${quiet}
-        ></sp-textfield>
-        <sp-textfield
-            placeholder="Enter your name"
-            pattern="[\\w\\s]+"
-            required
-            valid
-            value="A valid input"
-            disabled
-            ?quiet=${quiet}
-        ></sp-textfield>
-        <sp-textfield
-            placeholder="Enter your name"
-            pattern="[\\d]+"
-            required
-            value="Not a valid input"
-            ?quiet=${quiet}
-        ></sp-textfield>
-        <sp-textfield
-            placeholder="Enter your name"
-            pattern="[\\d]+"
-            invalid
-            required
-            value="Not a valid input"
-            disabled
-            ?quiet=${quiet}
+            allowed-keys="a-z"
         ></sp-textfield>
     `;
 };

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -200,7 +200,6 @@ describe('Textfield', () => {
         const testSource = eventSource as Textfield;
         expect(testSource.isSameNode(el)).to.be.true;
     });
-
     it('passes through `autocomplete` attribute', async () => {
         let el = await litFixture<Textfield>(
             html`
@@ -225,5 +224,53 @@ describe('Textfield', () => {
         if (input) {
             expect(input.getAttribute('autocomplete')).to.not.exist;
         }
+    });
+    it('tests on `required` changes', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield value=""></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        expect(el.invalid).to.be.false;
+
+        el.required = true;
+        await elementUpdated(el);
+        expect(el.invalid).to.be.true;
+    });
+    it('manages `allowed-keys`', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield allowed-keys="asdf"></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        expect(el.value).to.equal('');
+
+        const inputElement = (el.shadowRoot
+            ? el.shadowRoot.querySelector('#input')
+            : el.querySelector('#input')) as HTMLInputElement;
+
+        inputElement.value = 'asdf';
+        inputElement.dispatchEvent(new InputEvent('input'));
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('asdf');
+
+        inputElement.value = `asdff`;
+        inputElement.setSelectionRange(1, 1);
+        inputElement.dispatchEvent(new InputEvent('input'));
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('asdff');
+        expect(inputElement.selectionStart).to.equal(1);
+
+        inputElement.value = `asdoff`;
+        inputElement.setSelectionRange(4, 4);
+        inputElement.dispatchEvent(new InputEvent('input'));
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('asdff');
+        expect(inputElement.selectionStart).to.equal(3);
     });
 });


### PR DESCRIPTION
## Description
`required` means that a value _must_ be present.
`pattern` will verify that a value (when present) matches that pattern
`allowed-keys` will populate a regex to prevent input when the value is incorrect.

## Related Issue
fixes #476
fixes #211

## Motivation and Context
Don't always want validation UI.

## How Has This Been Tested?
- new tests!

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
