### PR TITLE
fix(slider): use internal "input" for value sanitation

### DIFF
--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -9,18 +9,10 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import {
-    html,
-    action,
-    text,
-    number,
-    select,
-    boolean,
-} from '@open-wc/demoing-storybook';
-import { ifDefined } from 'lit-html/directives/if-defined';
+import { html, action, text, number } from '@open-wc/demoing-storybook';
 
 import '../';
-import { variants, Slider } from '../';
+import { Slider } from '../';
 import { TemplateResult } from 'lit-html';
 
 export default {
@@ -29,20 +21,6 @@ export default {
 };
 
 export const Default = (): TemplateResult => {
-    const sliderVariants = ['', ...variants];
-    const value = number('Value', 50, {}, 'Element');
-    const min = number('Min', 0, {}, 'Element');
-    const max = number('Max', 100, {}, 'Element');
-    const step = number('Step', 1, {}, 'Element');
-    const tickStep = number('Tick Step', 10, {}, 'Element');
-    const label = text('Label', 'Opacity', 'Element');
-    const tickLabels = boolean('Tick Labels', false, 'Element');
-    const variant = select(
-        'Variant',
-        sliderVariants,
-        sliderVariants[0],
-        'Element'
-    );
     const handleEvent = (event: Event): void => {
         const target = event.target as Slider;
         action(event.type)(target.value);
@@ -50,17 +28,12 @@ export const Default = (): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
-                value="${value}"
-                step="${step}"
-                tick-step="${tickStep}"
-                min="${min}"
-                max="${max}"
-                label="${label}"
-                ?tick-labels="${tickLabels}"
-                id="opacity-slider"
-                variant=${ifDefined(variant || undefined)}
-                @sp-slider:input=${handleEvent}
-                @sp-slider:change=${handleEvent}
+                label="Opacity"
+                max="100"
+                min="0"
+                value="50"
+                @input=${handleEvent}
+                @change=${handleEvent}
             ></sp-slider>
         </div>
     `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Use the `input` element internal to the slider to sanitize values to avoid JS quirks in rounding values to match `step` management.
- Reduce the number of calls to `this.getBoundingClientRect()` as it can cause unnecessary layouts.

## Related Issue
fixes #481 

## Motivation and Context
Because `12.120000000000001` doesn't conform to `step="0.01"`...

## How Has This Been Tested?
Tests run just fine.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
