### PR TITLE
fix(button): add "toggles" attribute to action button

### DIFF
--- a/packages/button/action-button.md
+++ b/packages/button/action-button.md
@@ -52,3 +52,13 @@ yarn add @spectrum-web-components/button
     </svg>
 </sp-action-button>
 ```
+
+## Toggles
+
+With the application of the `toggles` attribute, the button will self manage its `selected` property on `click`:
+
+```html demo
+<sp-action-button toggles>
+    Toggle button
+</sp-action-button>
+```

--- a/packages/button/src/action-button.ts
+++ b/packages/button/src/action-button.ts
@@ -10,21 +10,46 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { CSSResultArray, property } from 'lit-element';
+import { CSSResultArray, property, PropertyValues } from 'lit-element';
 import { ButtonBase } from './button-base.js';
 import buttonStyles from './action-button.css.js';
 
 export class ActionButton extends ButtonBase {
-    @property({ type: Boolean, reflect: true })
-    public quiet = false;
-
-    @property({ type: Boolean, reflect: true })
-    public selected = false;
+    public static get styles(): CSSResultArray {
+        return [...super.styles, buttonStyles];
+    }
 
     @property({ type: Boolean, reflect: true, attribute: 'hold-affordance' })
     public holdAffordance = false;
 
-    public static get styles(): CSSResultArray {
-        return [...super.styles, buttonStyles];
+    @property({ type: Boolean, reflect: true })
+    public selected = false;
+
+    @property({ type: Boolean, reflect: true })
+    public toggles = false;
+
+    @property({ type: Boolean, reflect: true })
+    public quiet = false;
+
+    constructor() {
+        super();
+        this.addEventListener('click', this.onClick);
+    }
+
+    private onClick = (): void => {
+        if (!this.toggles) {
+            return;
+        }
+        this.selected = !this.selected;
+    };
+
+    protected updated(changes: PropertyValues): void {
+        super.updated(changes);
+        if (this.toggles && changes.has('selected')) {
+            this.focusElement.setAttribute(
+                'aria-pressed',
+                this.selected ? 'true' : 'false'
+            );
+        }
     }
 }

--- a/packages/button/stories/action-button.stories.ts
+++ b/packages/button/stories/action-button.stories.ts
@@ -15,9 +15,10 @@ import { TemplateResult } from 'lit-html';
 import '../';
 
 interface Properties {
-    quiet: boolean;
-    disabled: boolean;
-    selected: boolean;
+    quiet?: boolean;
+    disabled?: boolean;
+    selected?: boolean;
+    toggles?: boolean;
 }
 
 function renderButton(properties: Properties): TemplateResult {
@@ -26,6 +27,7 @@ function renderButton(properties: Properties): TemplateResult {
             .quiet="${!!properties.quiet}"
             .disabled=${!!properties.disabled}
             .selected=${!!properties.selected}
+            .toggles=${!!properties.toggles}
             @click=${action(`Action`)}
         >
             Action
@@ -54,6 +56,12 @@ export const Default = (): TemplateResult => {
         quiet: false,
         disabled: false,
         selected: false,
+    });
+};
+
+export const toggles = (): TemplateResult => {
+    return renderButtonsSelected({
+        toggles: true,
     });
 };
 

--- a/packages/button/test/action-button.test.ts
+++ b/packages/button/test/action-button.test.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '../';
+import { ActionButton } from '../';
+import { html } from 'lit-element';
+import { fixture, elementUpdated, expect } from '@open-wc/testing';
+
+describe('Button', () => {
+    it('loads default', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button>Button</sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el).to.not.be.undefined;
+        expect(el.textContent).to.include('Button');
+        expect(el).shadowDom.to.equalSnapshot();
+    });
+    it('toggles', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button toggles>Button</sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        const button = el.focusElement;
+
+        expect(el.toggles).to.be.true;
+        expect(el.selected).to.be.false;
+        expect(button.getAttribute('aria-pressed')).to.equal('false');
+
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.toggles).to.be.true;
+        expect(el.selected).to.be.true;
+        expect(button.getAttribute('aria-pressed')).to.equal('true');
+    });
+});


### PR DESCRIPTION
## Description
Encapsulate dynamic management of the `selected` attribute via the presence of a `toggles` attribute.

To do: confirm with the accessibility team whether the `aria-pressed` attribute should always be managed on this element.

## Related Issue
fixes #483

## Motivation and Context
a11y and functionality should be componentized too!

## How Has This Been Tested?
- added unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
