### PR TITLE
fix(tab-list): transition indicator "width" as well as position

### DIFF
--- a/packages/tab-list/src/tab-list.css
+++ b/packages/tab-list/src/tab-list.css
@@ -23,6 +23,10 @@ governing permissions and limitations under the License.
     );
 }
 
+:host([direction='horizontal']) #selectionIndicator {
+    width: 1px;
+}
+
 /* Original selector from spectrum-css:
  * .spectrum-Tabs--horizontal .spectrum-Tabs-item + *:not(.spectrum-Tabs-selectionIndicator)
  *
@@ -47,6 +51,7 @@ governing permissions and limitations under the License.
 :host([direction='vertical-right']) #selectionIndicator,
 :host([direction='vertical']) #selectionIndicator {
     top: 0;
+    height: 1px;
 }
 
 /* 

--- a/packages/tab-list/src/tab-list.ts
+++ b/packages/tab-list/src/tab-list.ts
@@ -217,20 +217,21 @@ export class TabList extends Focusable {
             return;
         }
         await selectedElement.updateComplete;
-        const bounds = selectedElement.getBoundingClientRect();
+        const tabBoundingClientRect = selectedElement.getBoundingClientRect();
+        const parentBoundingClientRect = this.getBoundingClientRect();
 
         if (this.direction === 'horizontal') {
-            const width = bounds.width;
-            const parentOffset = this.getBoundingClientRect().left;
-            const offset = bounds.left - parentOffset;
+            const width = tabBoundingClientRect.width;
+            const offset =
+                tabBoundingClientRect.left - parentBoundingClientRect.left;
 
-            this.selectionIndicatorStyle = `width: ${width}px; transform: translateX(${offset}px)`;
+            this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${width});`;
         } else {
-            const height = bounds.height;
-            const parentOffset = this.getBoundingClientRect().top;
-            const offset = bounds.top - parentOffset;
+            const height = tabBoundingClientRect.height;
+            const offset =
+                tabBoundingClientRect.top - parentBoundingClientRect.top;
 
-            this.selectionIndicatorStyle = `height: ${height}px; transform: translateY(${offset}px)`;
+            this.selectionIndicatorStyle = `transform: translateY(${offset}px) scaleY(${height});`;
         }
     }
 }


### PR DESCRIPTION
## Description 
Apply "width" via `scaleX` or `scaleY` so that it, too, can be animated when changing tabs. This is particularly apparent when the tab names have widely varying lengths.

## Motivation and Context
Transitions should be smooth as butter.

## How Has This Been Tested?
Visually.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
