### PR TITLE
docs: use the "new" glob syntax

### DIFF
--- a/documentation/scripts/buildSearchIndex.js
+++ b/documentation/scripts/buildSearchIndex.js
@@ -34,7 +34,7 @@ async function main() {
     const documents = [];
 
     // Components
-    for await (const path of globby.stream(`${projectDir}/packages/*/*.md`)) {
+    for await (const path of globby.stream(`${projectDir}/packages/**/*.md`)) {
         let componentName = /([^/]+)\/([a-zA-Z-]+)\.md$/.exec(path)[1];
         const fileName = /([a-zA-Z-]+)\.md$/.exec(path)[0];
         if (fileName === 'CHANGELOG.md') {
@@ -64,7 +64,7 @@ async function main() {
         });
     }
 
-    const index = lunr(function() {
+    const index = lunr(function () {
         this.ref('url');
         this.field('title', { boost: 10 });
         this.field('body');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,6 +17,7 @@ const {
     docsBuildProduction,
     docsBuildStaging,
     docsWatchCompile,
+    buildSearchIndex,
 } = require('./tasks/documentation');
 
 // default is to compile, build and copy
@@ -30,3 +31,4 @@ exports.watch = watchTasks;
 exports.docsBuildProduction = docsBuildProduction;
 exports.docsBuildStaging = docsBuildStaging;
 exports.docsWatchCompile = docsWatchCompile;
+exports.buildSearchIndex = buildSearchIndex;


### PR DESCRIPTION
Get the docs to build correctly with the new globby version.