### PR TITLE
Update Tabs Delivery as per Spectrum Specification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-4748d6e58ec745e6f226b751ea5d740c25a00530
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-bc0913ab049dc0c13600b275604c7d7779a9ce36
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/tab-list/README.md
+++ b/packages/tab-list/README.md
@@ -65,16 +65,16 @@ yarn add @spectrum-web-components/tab-list
     <sp-icons-medium></sp-icons-medium>
     <sp-tab-list selected="1" direction="horizontal">
         <sp-tab label="Tab 1" value="1" tabindex="1">
-            <sp-icon slot="icon" size="m" name="ui:CheckmarkSmall"></sp-icon>
+            <sp-icon slot="icon" size="s" name="ui:CheckmarkSmall"></sp-icon>
         </sp-tab>
         <sp-tab label="Tab 2" value="2" tabindex="2">
-            <sp-icon slot="icon" size="m" name="ui:CrossSmall"></sp-icon>
+            <sp-icon slot="icon" size="s" name="ui:CrossSmall"></sp-icon>
         </sp-tab>
         <sp-tab label="Tab 3" value="3" tabindex="3">
-            <sp-icon slot="icon" size="m" name="ui:ChevronDownSmall"></sp-icon>
+            <sp-icon slot="icon" size="s" name="ui:ChevronDownSmall"></sp-icon>
         </sp-tab>
         <sp-tab label="Tab 4" value="4" tabindex="4">
-            <sp-icon slot="icon" size="m" name="ui:HelpSmall"></sp-icon>
+            <sp-icon slot="icon" size="s" name="ui:HelpSmall"></sp-icon>
         </sp-tab>
     </sp-tab-list>
 </div>

--- a/packages/tab-list/src/tab-list.css
+++ b/packages/tab-list/src/tab-list.css
@@ -12,17 +12,7 @@ governing permissions and limitations under the License.
 
 @import './spectrum-tab-list.css';
 
-/* 
- * The shorthand border declaration in :host([direction='horizontal']) was overiding
- * the border-bottom-color declared in :host 
- */
-:host([direction='horizontal']) {
-    border-bottom-color: var(
-        --spectrum-tabs-rule-color,
-        var(--spectrum-global-color-gray-200)
-    );
-}
-
+/* Power scale based indicator transitions */
 :host([direction='horizontal']) #selectionIndicator {
     width: 1px;
 }
@@ -156,5 +146,16 @@ governing permissions and limitations under the License.
     background-color: var(
         --spectrum-tabs-quiet-selection-indicator-color,
         var(--spectrum-global-color-gray-900)
+    );
+}
+
+/* 
+ * The shorthand border declaration in :host([direction='horizontal']) was overiding
+ * the border-bottom-color declared in :host 
+ */
+:host([direction='horizontal']:not([quiet])) {
+    border-bottom-color: var(
+        --spectrum-tabs-rule-color,
+        var(--spectrum-global-color-gray-200)
     );
 }

--- a/packages/tab/README.md
+++ b/packages/tab/README.md
@@ -30,7 +30,7 @@ yarn add @spectrum-web-components/tab
 ```html
 <sp-icons-medium></sp-icons-medium>
 <sp-tab label="Tab 1" value="1">
-    <sp-icon slot="icon" size="m" name="ui:CheckmarkSmall"></sp-icon>
+    <sp-icon slot="icon" size="s" name="ui:CheckmarkSmall"></sp-icon>
 </sp-tab>
 ```
 
@@ -38,7 +38,7 @@ yarn add @spectrum-web-components/tab
 
 ```html
 <sp-tab label="Tab 1" value="1" vertical>
-    <sp-icon slot="icon" size="m" name="ui:CheckmarkSmall"></sp-icon>
+    <sp-icon slot="icon" size="s" name="ui:CheckmarkSmall"></sp-icon>
 </sp-tab>
 ```
 


### PR DESCRIPTION
## Description
Correct the display of `<sp-tab-list quiet>` and the size of icons in both the `<sp-tab-list>` and `<sp-tab>` README.md, as per feedback from the Spectrum team.

## Motivation and Context
Quality adherence of the Spectrum specification.

## How Has This Been Tested?
Visual regressions are updated to support the corrected delivery.

## Screenshots (if appropriate):
### Quiet
![image](https://user-images.githubusercontent.com/1156657/78142680-37e59600-73fb-11ea-8b1d-df3ca95bed34.png)

### Icons
![image](https://user-images.githubusercontent.com/1156657/78142700-416efe00-73fb-11ea-9b29-bbd9fb3dcd8e.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Docs update

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
