### PR TITLE
Update Status Light as per Spectrum Specification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-a0c1c2bfbcac071d38028cc988c87fce7ccf4fd1
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-4748d6e58ec745e6f226b751ea5d740c25a00530
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,6 +4,7 @@
     "rules": {
         "header/header": "config/license.js",
         "length-zero-no-unit": [true, { "ignore": "custom-properties" }],
-        "selector-type-no-unknown": [true, { "ignore": ["custom-elements"] }]
+        "selector-type-no-unknown": [true, { "ignore": ["custom-elements"] }],
+        "selector-pseudo-element-colon-notation": ["single"]
     }
 }

--- a/packages/status-light/README.md
+++ b/packages/status-light/README.md
@@ -36,3 +36,9 @@ attribute controls the main variant of the status light, and `neutral` being the
 -   magenta
 -   celery
 -   purple
+
+### Disabled
+
+```html
+<sp-status-light variant="positive" disabled>disabled</sp-status-light>
+```

--- a/packages/status-light/src/status-light.css
+++ b/packages/status-light/src/status-light.css
@@ -11,3 +11,14 @@ governing permissions and limitations under the License.
 */
 
 @import './spectrum-status-light.css';
+
+/* Force cascade position of [disabled] styling */
+:host([disabled]) #root:before,
+#root[disabled]:before {
+    /* .spectrum-StatusLight.is-disabled:before,
+   * .spectrum-StatusLight[disabled]:before */
+    background-color: var(
+        --spectrum-statuslight-dot-color-disabled,
+        var(--spectrum-global-color-gray-400)
+    );
+}

--- a/packages/status-light/src/status-light.ts
+++ b/packages/status-light/src/status-light.ts
@@ -29,6 +29,12 @@ export class StatusLight extends LitElement {
     }
 
     /**
+     * A status light in a disabled state shows that a status exists, but is not available in that circumstance. This can be used to maintain layout continuity and communicate that a status may become available later.
+     */
+    @property({ type: Boolean, reflect: true })
+    public disabled = false;
+
+    /**
      * The visual variant to apply to this status light.
      */
     @property({ reflect: true })
@@ -45,7 +51,7 @@ export class StatusLight extends LitElement {
         | 'chartreuse'
         | 'magenta'
         | 'celery'
-        | 'purple' = 'neutral';
+        | 'purple' = 'info';
 
     protected render(): TemplateResult {
         return html`

--- a/packages/tab/src/tab.css
+++ b/packages/tab/src/tab.css
@@ -20,8 +20,8 @@ governing permissions and limitations under the License.
     height: auto;
 }
 
-:host([vertical])::before {
-    /* .spectrum-Tabs--vertical .spectrum-Tabs-item::before */
+:host([vertical]):before {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
     left: calc(-1 * var(--spectrum-tabs-focus-ring-size, 2px));
     right: calc(-1 * var(--spectrum-tabs-focus-ring-size, 2px));
 


### PR DESCRIPTION
## Description 
- tweak Stylelint to that we can copy overrides straight out of processed Spectrum CSS output
- document `disabled` delivery
- manually correct cascade of `[disabled]` styles

## Motivation and Context
Adherence to the Spectrum spec.

## How Has This Been Tested?
Visual regressions are updated to support the corrected delivery.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/78147037-f3f58f80-7400-11ea-9d19-1da9b6925d4e.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
