### PR TITLE
Ensure that pointer events fire before input events for Sliders

### DIFF
--- a/packages/slider/src/slider.ts
+++ b/packages/slider/src/slider.ts
@@ -144,9 +144,7 @@ export class Slider extends Focusable {
 
     protected updated(changedProperties: PropertyValues): void {
         if (changedProperties.has('value')) {
-            if (this.dragging) {
-                this.dispatchInputEvent();
-            }
+            this.dispatchInputEvent();
         }
     }
 
@@ -383,6 +381,14 @@ export class Slider extends Focusable {
         this.dragging = true;
         this.handle.setPointerCapture(event.pointerId);
 
+        /**
+         * Dispatch a synthetic pointerdown event to ensure that pointerdown
+         * handlers attached to the slider are invoked before input handlers
+         */
+        event.stopPropagation();
+        const syntheticPointerEvent = new PointerEvent('pointerdown', event);
+        this.dispatchEvent(syntheticPointerEvent);
+
         this.value = this.calculateHandlePosition(event);
     }
 
@@ -440,6 +446,9 @@ export class Slider extends Focusable {
     }
 
     private dispatchInputEvent(): void {
+        if (!this.dragging) {
+            return;
+        }
         const inputEvent = new Event('input', {
             bubbles: true,
             composed: true,
@@ -476,8 +485,9 @@ export class Slider extends Focusable {
     private get trackRightStyle(): string {
         const width = `width: ${(1 - this.trackProgress) * 100}%;`;
         const halfHandleWidth = `var(--spectrum-slider-handle-width, var(--spectrum-global-dimension-size-200)) / 2`;
-        const offset = `left: calc(${this.trackProgress *
-            100}% + ${halfHandleWidth})`;
+        const offset = `left: calc(${
+            this.trackProgress * 100
+        }% + ${halfHandleWidth})`;
 
         return width + offset;
     }


### PR DESCRIPTION
Fixes an issue where the ordering of `pointerdown` and `input` events was incorrect when the track was interacted with.

```
<sp-slider @pointerdown=${this.onPointerDown}  @input=${this.onInput}></sp-slider>
```

When the track is moused down in the above example, `onInput` will execute before `onPointerDown`.

## Description

 **onTrackPointerDown()** 
- stop the propagation of the original pointer event
- Before the slider value is set, dispatch a syntethic event with the same properties as the original event


## Related Issue

[Issue 576](https://github.com/adobe/spectrum-web-components/issues/576)

## Motivation and Context

 For `<input type="range"/>` elements, the ordering of `pointerdown` and `input` is swapped. We want our `sp-sliders` to reflect this behavior.

## How Has This Been Tested?

Unfortunately, testing the ordering of events is a difficult challenge.

We are leveraging `dispatchEvent` to simulate pointer events in our tests. Unlike native DOM events, `dispatchEvent` will [invoke all affected handlers synchronously](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent)

For this reason, we can not rely in `dispatchEvent` to test the correct ordering of our events

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
