### PR TITLE
refactor: use mixin to manage shared anchor like properties

### DIFF
--- a/packages/button/src/button-base.ts
+++ b/packages/button/src/button-base.ts
@@ -12,26 +12,14 @@ governing permissions and limitations under the License.
 
 import { property, html, TemplateResult, CSSResultArray } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { LikeAnchor } from '@spectrum-web-components/shared/lib/like-anchor.js';
 import { Focusable } from '@spectrum-web-components/shared/lib/focusable.js';
 import { ObserveSlotText } from '@spectrum-web-components/shared/lib/observe-slot-text';
 
-export class ButtonBase extends ObserveSlotText(Focusable) {
+export class ButtonBase extends LikeAnchor(ObserveSlotText(Focusable)) {
     public static get styles(): CSSResultArray {
         return [...super.styles];
     }
-
-    /**
-     * Supplies an address that the browser will navigate to when this button is
-     * clicked
-     */
-    @property()
-    public href?: string;
-
-    @property()
-    public label?: string;
-
-    @property()
-    public target?: '_blank' | '_parent' | '_self' | '_top';
 
     @property({ type: Boolean, reflect: true, attribute: 'icon-right' })
     protected iconRight = false;
@@ -75,16 +63,10 @@ export class ButtonBase extends ObserveSlotText(Focusable) {
 
     protected render(): TemplateResult {
         return this.href && this.href.length > 0
-            ? html`
-                  <a
-                      href="${this.href}"
-                      id="button"
-                      target=${ifDefined(this.target)}
-                      aria-label=${ifDefined(this.label)}
-                  >
-                      ${this.buttonContent}
-                  </a>
-              `
+            ? this.renderAnchor({
+                  id: 'button',
+                  anchorContent: this.buttonContent,
+              })
             : html`
                   <button id="button" aria-label=${ifDefined(this.label)}>
                       ${this.buttonContent}

--- a/packages/link/src/link.ts
+++ b/packages/link/src/link.ts
@@ -10,14 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import {
-    html,
-    property,
-    CSSResultArray,
-    TemplateResult,
-    query,
-} from 'lit-element';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { CSSResultArray, TemplateResult, query } from 'lit-element';
+import { LikeAnchor } from '@spectrum-web-components/shared/lib/like-anchor.js';
 import { Focusable } from '@spectrum-web-components/shared/lib/focusable.js';
 
 import linkStyles from './link.css.js';
@@ -28,7 +22,7 @@ import linkStyles from './link.css.js';
  * @attr quiet - uses quiet styles or not
  * @attr over-background - uses over background styles or not
  */
-export class Link extends Focusable {
+export class Link extends LikeAnchor(Focusable) {
     public static get styles(): CSSResultArray {
         return [...super.styles, linkStyles];
     }
@@ -44,23 +38,7 @@ export class Link extends Focusable {
         return this.anchorElement;
     }
 
-    @property({ reflect: true })
-    public href: string | undefined = undefined;
-
-    @property({ reflect: true })
-    public download: string | undefined = undefined;
-
-    @property({ reflect: true })
-    public target?: '_blank' | '_parent' | '_self' | '_top';
-
     protected render(): TemplateResult {
-        // prettier-ignore
-        return html
-            `<a
-                id="anchor"
-                href=${ifDefined(this.href)}
-                download=${ifDefined(this.download)}
-                target=${ifDefined(this.target)}
-            ><slot></slot></a>`;
+        return this.renderAnchor({ id: 'anchor' });
     }
 }

--- a/packages/shared/src/like-anchor.ts
+++ b/packages/shared/src/like-anchor.ts
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { UpdatingElement, property, TemplateResult, html } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
+
+type Constructor<T = object> = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new (...args: any[]): T;
+    prototype: T;
+};
+
+export interface LikeAnchorInterface {
+    download?: string;
+    label?: string;
+    href?: string;
+    target?: '_blank' | '_parent' | '_self' | '_top';
+    renderAnchor(options: {
+        id: string;
+        anchorContent?: TemplateResult | TemplateResult[];
+    }): TemplateResult;
+}
+
+export function LikeAnchor<T extends Constructor<UpdatingElement>>(
+    constructor: T
+): T & Constructor<LikeAnchorInterface> {
+    class LikeAnchorElement extends constructor {
+        @property({ reflect: true })
+        public download?: string;
+
+        @property()
+        public label?: string;
+
+        @property({ reflect: true })
+        public href?: string;
+
+        @property({ reflect: true })
+        public target?: '_blank' | '_parent' | '_self' | '_top';
+
+        public renderAnchor({
+            id,
+            // prettier-ignore
+            anchorContent = html`<slot></slot>`
+        }: {
+            id: string;
+            anchorContent: TemplateResult | TemplateResult[];
+        }): TemplateResult {
+            // prettier-ignore
+            return html
+                `<a
+                    id=${id}
+                    href=${ifDefined(this.href)}
+                    download=${ifDefined(this.download)}
+                    target=${ifDefined(this.target)}
+                    aria-label=${ifDefined(this.label)}
+                >${anchorContent}</a>`;
+        }
+    }
+    return LikeAnchorElement;
+}

--- a/packages/sidenav/src/sidenav-item.ts
+++ b/packages/sidenav/src/sidenav-item.ts
@@ -17,6 +17,7 @@ import {
     property,
     PropertyValues,
 } from 'lit-element';
+import { LikeAnchor } from '@spectrum-web-components/shared/lib/like-anchor.js';
 import { Focusable } from '@spectrum-web-components/shared';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
@@ -24,7 +25,7 @@ import { SidenavSelectDetail, SideNav } from './sidenav.js';
 
 import sidenavItemStyles from './sidenav-item.css.js';
 
-export class SideNavItem extends Focusable {
+export class SideNavItem extends LikeAnchor(Focusable) {
     public static get styles(): CSSResultArray {
         return [sidenavItemStyles];
     }
@@ -43,15 +44,6 @@ export class SideNavItem extends Focusable {
 
     @property({ type: Boolean, reflect: true })
     public expanded = false;
-
-    @property()
-    public href: string | undefined = undefined;
-
-    @property()
-    public target?: '_blank' | '_parent' | '_self' | '_top';
-
-    @property()
-    public label = '';
 
     protected get parentSideNav(): SideNav | undefined {
         return this.closest('sp-sidenav') as SideNav | undefined;
@@ -129,6 +121,7 @@ export class SideNavItem extends Focusable {
                 tabindex=${this.manageTabIndex ? tabIndexForSelectedState : '0'}
                 href=${this.href || '#'}
                 target=${ifDefined(this.target)}
+                download=${ifDefined(this.download)}
                 data-level="${this.depth}"
                 @click="${this.handleClick}"
                 id="itemLink"


### PR DESCRIPTION
## Description
Add the `LikeAnchor` mixin with a relatively general purpose `renderAnchor` method knowing that in some cases the elements that this is mixed into will leverage their own rendering to define the DOM of the anchor.

## Related Issue
fixes #595 please see this issue for further discussion

## Motivation and Context
- Less bumpy API
- Support for early adopters

## How Has This Been Tested?
Refactor passes current tests.

## Types of changes
- [x] refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
