### PR TITLE
fix(link): correct white space in template/docs site

### DIFF
--- a/documentation/src/components/home.ts
+++ b/documentation/src/components/home.ts
@@ -2,6 +2,8 @@ import { html, CSSResultArray } from 'lit-element';
 import { RouteComponent } from './route-component';
 import componentStyles from './markdown.css';
 import homeStyles from './home.css';
+import '@spectrum-web-components/button';
+import '@spectrum-web-components/link';
 
 class HomeElement extends RouteComponent {
     public static get styles(): CSSResultArray {
@@ -9,6 +11,7 @@ class HomeElement extends RouteComponent {
     }
 
     render() {
+        // prettier-ignore
         return html`
             <section id="hero">
                 <div class="spectrum-Article">
@@ -17,11 +20,9 @@ class HomeElement extends RouteComponent {
                     </h1>
                 </div>
                 <p class="spectrum-Body3">
-                    The Spectrum Web Components project is an implementation of
-                    <sp-link href="https://spectrum.adobe.com/">
-                        Spectrum, Adobe’s design system
-                    </sp-link>
-                    . It's designed to work with any web framework — or even
+                    The Spectrum Web Components project is an implementation of <sp-link
+                    href="https://spectrum.adobe.com/">Spectrum, Adobe’s design system</sp-link
+                    >. It's designed to work with any web framework — or even
                     without one.
                 </p>
                 <div id="hero-buttons">

--- a/packages/link/src/link.ts
+++ b/packages/link/src/link.ts
@@ -61,7 +61,6 @@ export class Link extends Focusable {
                 href=${ifDefined(this.href)}
                 download=${ifDefined(this.download)}
                 target=${ifDefined(this.target)}
-            ><slot></slot></a>
-        `;
+            ><slot></slot></a>`;
     }
 }

--- a/packages/styles/fonts.css
+++ b/packages/styles/fonts.css
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 /* stylelint-disable */
 
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -59,7 +59,7 @@ governing permissions and limitations under the License.
 }
 
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## Description
This: 
![image](https://user-images.githubusercontent.com/1156657/78409002-94e97380-75d6-11ea-8878-09590f481a16.png)
Becomes, this:
![image](https://user-images.githubusercontent.com/1156657/78409007-9d41ae80-75d6-11ea-8630-856e630eabe3.png)