### PR TITLE
fix(tabs, tab-list): various additions and expansions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-bc0913ab049dc0c13600b275604c7d7779a9ce36
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-b88d1b2484fc6db1dd8a2fc71da5376b64544220
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/tab/src/tab.ts
+++ b/packages/tab/src/tab.ts
@@ -54,9 +54,13 @@ export class Tab extends FocusVisiblePolyfillMixin(LitElement) {
                       <slot name="icon"></slot>
                   `
                 : html``}
-            <label id="itemLabel">
-                ${this.label}
-            </label>
+            ${this.label
+                ? html`
+                      <label id="itemLabel">
+                          ${this.label}
+                      </label>
+                  `
+                : html``}
         `;
     }
 

--- a/packages/tab/stories/tabs.stories.ts
+++ b/packages/tab/stories/tabs.stories.ts
@@ -24,10 +24,10 @@ export default {
 export const Default = (): TemplateResult => {
     return html`
         <sp-tab-list selected="1">
-            <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>
             <sp-tab label="Tab 3" value="3"></sp-tab>
             <sp-tab label="Tab 4" value="4"></sp-tab>
+            <sp-tab label="Really Long Name" value="1" selected></sp-tab>
         </sp-tab-list>
     `;
 };
@@ -131,6 +131,56 @@ export const Icons = (): TemplateResult => {
             </sp-tab>
             <sp-tab
                 label="Tab 4"
+                value="4"
+                ?vertical=${tabType === directions.vertical}
+            >
+                <sp-icon slot="icon" size="s" name="ui:HelpSmall"></sp-icon>
+            </sp-tab>
+        </sp-tab-list>
+    `;
+};
+
+export const IconsOnly = (): TemplateResult => {
+    const directions = {
+        horizontal: 'horizontal',
+        vertical: 'vertical',
+    };
+    const type = radios('List Type', directions, directions.horizontal);
+    const tabType = radios('Tab Type', directions, directions.horizontal);
+    return html`
+        <sp-icons-medium></sp-icons-medium>
+        <sp-tab-list selected="1" direction="${type}">
+            <sp-tab
+                aria-label="Tab 1"
+                value="1"
+                ?vertical=${tabType === directions.vertical}
+            >
+                <sp-icon
+                    slot="icon"
+                    size="s"
+                    name="ui:CheckmarkSmall"
+                ></sp-icon>
+            </sp-tab>
+            <sp-tab
+                aria-label="Tab 2"
+                value="2"
+                ?vertical=${tabType === directions.vertical}
+            >
+                <sp-icon slot="icon" size="s" name="ui:CrossSmall"></sp-icon>
+            </sp-tab>
+            <sp-tab
+                aria-label="Tab 3"
+                value="3"
+                ?vertical=${tabType === directions.vertical}
+            >
+                <sp-icon
+                    slot="icon"
+                    size="s"
+                    name="ui:ChevronDownSmall"
+                ></sp-icon>
+            </sp-tab>
+            <sp-tab
+                aria-label="Tab 4"
                 value="4"
                 ?vertical=${tabType === directions.vertical}
             >

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -115,6 +115,7 @@ module.exports = [
     'tabs--vertical-sized',
     'tabs--vertical-right',
     'tabs--icons',
+    'tabs--icons-only',
     'tabs--icons-ii',
     'tabs--quiet',
     'tabs--compact',


### PR DESCRIPTION
## Description
- support reassuring the `indicator` after `document.fonts` has completed loading so that any font metrics that may have changed between the fallback and the new font are reflected in the indicator UI
- clarify the difference between a click being the first interaction with the `tab-list` and a click being an interaction _after_ a keyboard interaction when deciding whether to apply `focus-visible` styling
- allow `tabs` to display without visible labels.

## Motivation and Context
- correct visual delivery
- better accessibility support
- more flexibility

## How Has This Been Tested?
- added unit tests
- added visual regressions
- updated visual regressions

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/78685906-63b3c080-78c0-11ea-99a1-f223aa7f714a.png)
![image](https://user-images.githubusercontent.com/1156657/78685943-70d0af80-78c0-11ea-89b7-54d6b19c5079.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
