### PR TITLE
fix(overlay): new popper version tracks scroll through assigned slots

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -38,7 +38,7 @@
         "lit-html": "^1.0.0"
     },
     "dependencies": {
-        "@popperjs/core": "^2.0.4",
+        "@popperjs/core": "^2.2.2",
         "@spectrum-web-components/theme": "^0.3.2",
         "tslib": "^1.10.0"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2504,10 +2504,10 @@
   resolved "https://registry.yarnpkg.com/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz#4e77f2f59b29b01e0ad02aa83d33716cddc5f9f9"
   integrity sha512-h+hqYkL+tQV/y2ESD5gFXMl5z4cC+XY1jTlBeGSBaTcj3VbB5OBEScbvRXm63NcEbBneQQYbHfBAXAkF9i9wIA==
 
-"@popperjs/core@^2.0.4":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.1.1.tgz#12c572ab88ef7345b43f21883fca26631c223085"
-  integrity sha512-sLqWxCzC5/QHLhziXSCAksBxHfOnQlhPRVgPK0egEw+ktWvG75T2k+aYWVjVh9+WKeT3tlG3ZNbZQvZLmfuOIw==
+"@popperjs/core@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.2.2.tgz#2e254f5eb31f3abc35470060fb7116937d837739"
+  integrity sha512-LaSssaO8QHSAnRI4ZZB+jTD/hmndqOzwabDwKuySS1ME0pj+La6pV77i5CIQ61kVtz3pE13DhmkaYFGtrrCMeg==
 
 "@reach/router@^1.2.1":
   version "1.3.3"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use the latest version of popper.js so that scrolling will be tracked through slots.

## Related Issue
fixes #604

## Motivation and Context
The docs were broke.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![captured (13)](https://user-images.githubusercontent.com/1156657/78917362-c5a92d00-7a5c-11ea-8ff1-99d17ec1e7c7.gif)

## Types of changes
- [x] Chore

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
