### PR TITLE
docs: use appropriate attributes in examples

### DIFF
--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -16,10 +16,21 @@ yarn add @spectrum-web-components/popover
 
 ```html
 <div
-    style="color: var(--spectrum-global-color-gray-800); position: relative; width: 320px; height: 200px"
+    style="
+        color: var(--spectrum-global-color-gray-800);
+        height: 200px;
+        position: relative;
+        width: 320px;
+    "
 >
-    <sp-popover variant="dialog" open>
-        <div style="padding-bottom: 30px; font-size: 18px; font-weight: 700">
+    <sp-popover dialog open>
+        <div
+            style="
+            font-size: 18px;
+            font-weight: 700;
+            padding-bottom: 30px;
+        "
+        >
             Popover title
         </div>
         <div style="font-size: 14px">
@@ -40,12 +51,21 @@ element by default. The default popover has no padding by default
 
 ```html
 <div
-    style="color: var(--spectrum-global-color-gray-800); width: 320px; height: 200px"
+    style="
+        color: var(--spectrum-global-color-gray-800);
+        height: 200px;
+        position: relative;
+        width: 320px;
+    "
 >
     <sp-popover variant="default" open style="max-width: 320px">
         <div style="font-size: 14px; padding: 10px">
             <div
-                style="padding-bottom: 30px; font-size: 18px; font-weight: 700"
+                style="
+                font-size: 18px;
+                font-weight: 700;
+                padding-bottom: 30px;
+            "
             >
                 Popover title
             </div>
@@ -65,10 +85,21 @@ Popovers with padding, ideal for dialogs.
 
 ```html
 <div
-    style="color: var(--spectrum-global-color-gray-800); position: relative; width: 320px; height: 200px"
+    style="
+        color: var(--spectrum-global-color-gray-800);
+        height: 200px;
+        position: relative;
+        width: 320px;
+    "
 >
-    <sp-popover variant="dialog" open>
-        <div style="padding-bottom: 30px; font-size: 18px; font-weight: 700">
+    <sp-popover dialog open>
+        <div
+            style="
+            font-size: 18px;
+            font-weight: 700;
+            padding-bottom: 30px;
+        "
+        >
             Popover title
         </div>
         <div style="font-size: 14px">
@@ -84,10 +115,21 @@ Popovers with padding, ideal for dialogs.
 
 ```html
 <div
-    style="color: var(--spectrum-global-color-gray-800); position: relative; width: 320px; height: 200px"
+    style="
+        color: var(--spectrum-global-color-gray-800);
+        height: 200px;
+        position: relative;
+        width: 320px;
+    "
 >
-    <sp-popover variant="dialog" placement="bottom" tip open>
-        <div style="padding-bottom: 30px; font-size: 18px; font-weight: 700">
+    <sp-popover dialog placement="bottom" tip open>
+        <div
+            style="
+            font-size: 18px;
+            font-weight: 700;
+            padding-bottom: 30px;
+        "
+        >
             Popover title
         </div>
         <div style="font-size: 14px">
@@ -101,10 +143,21 @@ Popovers with padding, ideal for dialogs.
 
 ```html
 <div
-    style="color: var(--spectrum-global-color-gray-800); position: relative; width: 320px; height: 200px"
+    style="
+        color: var(--spectrum-global-color-gray-800);
+        height: 200px;
+        position: relative;
+        width: 320px;
+    "
 >
-    <sp-popover variant="dialog" placement="top" tip open>
-        <div style="padding-bottom: 30px; font-size: 18px; font-weight: 700">
+    <sp-popover dialog placement="top" tip open>
+        <div
+            style="
+            font-size: 18px;
+            font-weight: 700;
+            padding-bottom: 30px;
+        "
+        >
             Popover title
         </div>
         <div style="font-size: 14px">
@@ -118,10 +171,21 @@ Popovers with padding, ideal for dialogs.
 
 ```html
 <div
-    style="color: var(--spectrum-global-color-gray-800); position: relative; width: 320px; height: 200px"
+    style="
+        color: var(--spectrum-global-color-gray-800);
+        height: 200px;
+        position: relative;
+        width: 320px;
+    "
 >
-    <sp-popover variant="dialog" placement="left" tip open>
-        <div style="padding-bottom: 30px; font-size: 18px; font-weight: 700">
+    <sp-popover dialog placement="left" tip open>
+        <div
+            style="
+            font-size: 18px;
+            font-weight: 700;
+            padding-bottom: 30px;
+        "
+        >
             Popover title
         </div>
         <div style="font-size: 14px">
@@ -135,10 +199,21 @@ Popovers with padding, ideal for dialogs.
 
 ```html
 <div
-    style="color: var(--spectrum-global-color-gray-800); position: relative; width: 320px; height: 200px"
+    style="
+        color: var(--spectrum-global-color-gray-800);
+        height: 200px;
+        position: relative;
+        width: 320px;
+    "
 >
-    <sp-popover variant="dialog" placement="right" tip open>
-        <div style="padding-bottom: 30px; font-size: 18px; font-weight: 700">
+    <sp-popover dialog placement="right" tip open>
+        <div
+            style="
+            font-size: 18px;
+            font-weight: 700;
+            padding-bottom: 30px;
+        "
+        >
             Popover title
         </div>
         <div style="font-size: 14px">


### PR DESCRIPTION
## Description
Ensure the documentation for Popover displays the most correct application of the currently available attributes/code.

## Related Issue
fixes #584 

## Motivation and Context
![image](https://user-images.githubusercontent.com/1156657/79008761-15a2f500-7b2c-11ea-9f1f-b9659c07cfa5.png)


## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/79008782-1dfb3000-7b2c-11ea-8813-06c573d4be18.png)

## Types of changes
- [x] Documentation

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
