### PR TITLE
Add Size/Version Info, plus outline Side Effects

### DIFF
--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -4,6 +4,9 @@ An `<sp-action-menu />` is simply an action button with a Popover. Use an `<sp-m
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/action-menu?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/action-menu)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/action-menu?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/action-menu)
+
 ```
 npm install @spectrum-web-components/action-menu
 

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/actionbar/README.md
+++ b/packages/actionbar/README.md
@@ -4,6 +4,9 @@ A `<sp-actionbar>` delivers a floating action bar that is a convenient way to de
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/actionbar?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/actionbar)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/actionbar?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/actionbar)
+
 ```
 npm install @spectrum-web-components/actionbar
 

--- a/packages/actionbar/package.json
+++ b/packages/actionbar/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -4,6 +4,9 @@ An **sp-avatar** is a great way to feature a visual representation of a user.
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/avatar?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/avatar)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/avatar?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/avatar)
+
 ```
 npm install @spectrum-web-components/avatar
 

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/banner/README.md
+++ b/packages/banner/README.md
@@ -4,6 +4,9 @@ An **sp-banner** is an additional label an existing component may have. Banners 
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/banner?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/banner)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/banner?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/banner)
+
 ```
 npm install @spectrum-web-components/banner
 

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/bundle/README.md
+++ b/packages/bundle/README.md
@@ -4,6 +4,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/bundle?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/bundle)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/bundle?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/bundle)
+
 ```
 npm install @spectrum-web-components/bundle
 

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -7,6 +7,9 @@ loudness for various attention-getting needs.
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/button?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/button)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/button?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/button)
+
 ```
 npm install @spectrum-web-components/button
 

--- a/packages/button/action-button.md
+++ b/packages/button/action-button.md
@@ -4,6 +4,9 @@ An `<sp-action-button>` represents an action a user can take.
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/button?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/button)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/button?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/button)
+
 ```
 npm install @spectrum-web-components/button
 

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -8,6 +8,9 @@ Spectrum has several card variations for different uses.
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/card?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/card)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/card?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/card)
+
 ```
 npm install @spectrum-web-components/card
 

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -8,6 +8,9 @@ instead of selecting.
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/checkbox?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/checkbox)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/checkbox?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/checkbox)
+
 ```
 npm install @spectrum-web-components/checkbox
 

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/circleloader/README.md
+++ b/packages/circleloader/README.md
@@ -4,6 +4,9 @@ An `<sp-circleloader>` shows the progression of a system operation such as downl
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/circleloader?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/circleloader)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/circleloader?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/circleloader)
+
 ```
 npm install @spectrum-web-components/circleloader
 

--- a/packages/circleloader/package.json
+++ b/packages/circleloader/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/coachmark/README.md
+++ b/packages/coachmark/README.md
@@ -4,6 +4,9 @@ An `<sp-coachmark>` element can be used to bring added attention to specific par
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/coachmark?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/coachmark)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/coachmark?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/coachmark)
+
 ```
 npm install @spectrum-web-components/coachmark
 

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -4,6 +4,9 @@ An `<sp-dropdown />` is an alternative to HTML's `select` element. Use an `<sp-m
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/dropdown?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/dropdown)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/dropdown?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/dropdown)
+
 ```
 npm install @spectrum-web-components/dropdown
 

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/dropzone/README.md
+++ b/packages/dropzone/README.md
@@ -6,6 +6,9 @@ DropZones should be used with an IllustratedMessage component as a child if the 
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/dropzone?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/dropzone)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/dropzone?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/dropzone)
+
 ```
 npm install @spectrum-web-components/dropzone
 

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -4,6 +4,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/icon?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/icon)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/icon?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/icon)
+
 ```
 npm install @spectrum-web-components/icon
 

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/icons-workflow/README.md
+++ b/packages/icons-workflow/README.md
@@ -4,6 +4,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/icons-workflow?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/icons-workflow)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/icons-workflow?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/icons-workflow)
+
 ```
 npm install @spectrum-web-components/icons-workflow
 

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "build": "node ./bin/build @adobe/spectrum-css-workflow-icons/dist/18"
     },
@@ -48,7 +52,7 @@
         "glob": "^7.1.3",
         "http-server": "^0.11.1",
         "path": "^0.12.7",
-        "prettier": "^1.16.1"
+        "prettier": "^2.0.2"
     },
     "peerDependencies": {
         "lit-element": "^2.1.0",

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -4,6 +4,9 @@ The `<sp-icons-medium>` and `<sp-icons-large>` elements that are included in thi
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/icons?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/icons)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/icons?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/icons)
+
 ```
 npm install @spectrum-web-components/icons
 

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/iconset/README.md
+++ b/packages/iconset/README.md
@@ -4,6 +4,9 @@ Extend either the `Iconset` or `IconsetSVG` exports of this package to supply yo
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/iconset?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/iconset)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/iconset?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/iconset)
+
 ```
 npm install @spectrum-web-components/iconset
 

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -28,6 +28,12 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts",
+        "./lib/icons-demo.js",
+        "./src/icons-demo.ts"
+    ],
     "scripts": {},
     "author": "",
     "license": "Apache-2.0",

--- a/packages/illustrated-message/README.md
+++ b/packages/illustrated-message/README.md
@@ -4,6 +4,9 @@ An **sp-illustrated-message** displays an illustration icon and a message, usual
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/illustrated-message?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/illustrated-message)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/illustrated-message?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/illustrated-message)
+
 ```
 npm install @spectrum-web-components/illustrated-message
 

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {},
     "author": "",
     "license": "Apache-2.0",

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -4,6 +4,9 @@ An **sp-link** allow users to navigate to a different location. They can be pres
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/link?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/link)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/link?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/link)
+
 ```
 npm install @spectrum-web-components/link
 

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {},
     "author": "",
     "license": "Apache-2.0",

--- a/packages/menu-group/README.md
+++ b/packages/menu-group/README.md
@@ -4,6 +4,9 @@ An `<sp-menu />` is used for creating a menu list. The various elements inside a
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/menu-group?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/menu-group)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/menu-group?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/menu-group)
+
 ```
 npm install @spectrum-web-components/menu-group
 

--- a/packages/menu-group/package.json
+++ b/packages/menu-group/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/menu-item/README.md
+++ b/packages/menu-item/README.md
@@ -4,6 +4,9 @@ An `<sp-menu />` is used for creating a menu list. The various elements inside a
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/menu-item?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/menu-item)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/menu-item?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/menu-item)
+
 ```
 npm install @spectrum-web-components/menu-item
 

--- a/packages/menu-item/package.json
+++ b/packages/menu-item/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -4,6 +4,9 @@ An `<sp-menu />` is used for creating a menu list. The various elements inside a
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/menu?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/menu)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/menu?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/menu)
+
 ```
 npm install @spectrum-web-components/menu
 

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -6,6 +6,9 @@ Note: Cascading styles not applied via `<sp-theme>` are not currently projected 
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/overlay?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/overlay)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/overlay?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/overlay)
+
 ```
 npm install @spectrum-web-components/overlay
 

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -28,6 +28,12 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts",
+        "./stories/overlay-story-components.js",
+        "./stories/overlay-story-components.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -4,6 +4,9 @@ An **sp-popover** is used to display transient content (menus, options, addition
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/popover?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/popover)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/popover?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/popover)
+
 ```
 npm install @spectrum-web-components/popover
 

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/radio-group/README.md
+++ b/packages/radio-group/README.md
@@ -6,6 +6,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/radio-group?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/radio-group)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/radio-group?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/radio-group)
+
 ```
 npm install @spectrum-web-components/radio-group
 

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -6,6 +6,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/radio?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/radio)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/radio?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/radio)
+
 ```
 npm install @spectrum-web-components/radio
 

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -4,6 +4,9 @@ The `<sp-search />` element delivers a single input field with a "reset" button 
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/search?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/search)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/search?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/search)
+
 ```
 npm install @spectrum-web-components/search
 

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -4,6 +4,9 @@ Shared mixins, tools, etc. that support developing Spectrum Web Components.
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/shared?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/shared)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/shared?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/shared)
+
 ```
 npm install @spectrum-web-components/shared
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,6 +28,7 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": false,
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -9,6 +9,9 @@ of larger elements and mechanisms within the app frame.
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/sidenav?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/sidenav)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/sidenav?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/sidenav)
+
 ```
 npm install @spectrum-web-components/sidenav
 

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -4,6 +4,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/slider?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/slider)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/slider?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/slider)
+
 ```
 npm install @spectrum-web-components/slider
 

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/status-light/README.md
+++ b/packages/status-light/README.md
@@ -4,6 +4,9 @@ An **sp-status-light** is a great way to convey semantic meaning, such as status
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/status-light?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/status-light)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/status-light?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/status-light)
+
 ```
 npm install @spectrum-web-components/status-light
 

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -6,6 +6,9 @@ The easiest way to consume these values is via the `<sp-theme>` element, however
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/styles?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/styles)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/styles?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/styles)
+
 ```
 npm install @spectrum-web-components/styles
 

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -25,6 +25,9 @@
         "custom-elements.json",
         "*.css"
     ],
+    "sideEffects": [
+        "./*.css"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -4,6 +4,9 @@ An **sp-switch** is used to turn an option on or off. Switches allow users to se
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/switch?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/switch)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/switch?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/switch)
+
 ```
 npm install @spectrum-web-components/switch
 

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/tab-list/README.md
+++ b/packages/tab-list/README.md
@@ -4,6 +4,9 @@ The `<sp-tab-list>` component contains set of tab-item elements. This is typical
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/tab-list?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/tab-list)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/tab-list?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/tab-list)
+
 ```
 npm install @spectrum-web-components/tab-list
 

--- a/packages/tab-list/package.json
+++ b/packages/tab-list/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/tab/README.md
+++ b/packages/tab/README.md
@@ -4,6 +4,9 @@ The `<sp-tab>` component is intended to be the child of an `<sp-tab-list>` eleme
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/tab?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/tab)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/tab?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/tab)
+
 ```
 npm install @spectrum-web-components/tab
 

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -4,6 +4,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/textfield?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/textfield)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/textfield?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/textfield)
+
 ```
 npm install @spectrum-web-components/textfield
 

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/textfield/textarea.md
+++ b/packages/textfield/textarea.md
@@ -4,6 +4,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/textfield?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/textfield)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/textfield?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/textfield)
+
 ```
 npm install @spectrum-web-components/textfield
 

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -7,6 +7,9 @@ color themes (dark, light and lightest) and one one of the scales (medium).
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/theme?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/theme)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/theme?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/theme)
+
 ```
 npm install @spectrum-web-components/theme
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/*.js",
+        "./src/*.ts"
+    ],
     "scripts": {
         "test": "karma start --coverage"
     },

--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -4,6 +4,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/toast?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/toast)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/toast?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/toast)
+
 ```
 npm install @spectrum-web-components/toast
 

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -26,6 +26,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "author": "",
     "license": "Apache-2.0",
     "peerDependencies": {

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -4,6 +4,9 @@
 
 ### Installation
 
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/tooltip?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/tooltip)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/tooltip?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/tooltip)
+
 ```
 npm install @spectrum-web-components/tooltip
 

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -28,6 +28,10 @@
         "/lib/",
         "/src/"
     ],
+    "sideEffects": [
+        "./lib/index.js",
+        "./src/index.ts"
+    ],
     "author": "",
     "license": "Apache-2.0",
     "peerDependencies": {

--- a/projects/templates/plop-templates/README.md.hbs
+++ b/projects/templates/plop-templates/README.md.hbs
@@ -3,6 +3,8 @@
 
 
 ### Installation
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/{{ name }}?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/{{ name }})
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/{{ name }}?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/{{ name }})
 
 ```
 npm install @spectrum-web-components/{{ name }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16759,7 +16759,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.16.1, prettier@^1.16.4:
+prettier@^1.16.4:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==


### PR DESCRIPTION
## Description
- add bundlephobia and NPM badges to the component pages
- add `sideEffects` entries to the `package.json` files

## Related Issue
fixes #439 

## Motivation and Context
Make it easier to see how much our components will cost when used in an application.

## Screenshots (if appropriate):
### Before
![image](https://user-images.githubusercontent.com/1156657/79025076-c623ef80-7b52-11ea-98f0-d6521dcb5b20.png)
### After
![image](https://user-images.githubusercontent.com/1156657/79025052-b73d3d00-7b52-11ea-9e6f-9257a399a74c.png)
### Before
![image](https://user-images.githubusercontent.com/1156657/79025102-db008300-7b52-11ea-924e-8cb1c8412524.png)
### After
![image](https://user-images.githubusercontent.com/1156657/79025133-e9e73580-7b52-11ea-9f8e-4b0846d3c23b.png)

## Types of changes
- [x] Documentation

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
