### PR TITLE
fix(button): add excludeSourceSelector to reduce duplication of styles

### DIFF
--- a/packages/button/src/action-button.css
+++ b/packages/button/src/action-button.css
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 */
 
 @import './spectrum-action-button.css';
-@import './button-base.css';
 
 :host(.spectrum-Dropdown-trigger) #button {
     text-align: left;

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+@import './spectrum-button-base.css';
+
 :host {
     display: inline-flex;
     flex-direction: row;

--- a/packages/button/src/button-base.ts
+++ b/packages/button/src/button-base.ts
@@ -15,10 +15,11 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LikeAnchor } from '@spectrum-web-components/shared/lib/like-anchor.js';
 import { Focusable } from '@spectrum-web-components/shared/lib/focusable.js';
 import { ObserveSlotText } from '@spectrum-web-components/shared/lib/observe-slot-text';
+import buttonStyles from './button-base.css.js';
 
 export class ButtonBase extends LikeAnchor(ObserveSlotText(Focusable)) {
     public static get styles(): CSSResultArray {
-        return [...super.styles];
+        return [...super.styles, buttonStyles];
     }
 
     @property({ type: Boolean, reflect: true, attribute: 'icon-right' })

--- a/packages/button/src/button.css
+++ b/packages/button/src/button.css
@@ -11,4 +11,3 @@ governing permissions and limitations under the License.
 */
 
 @import './spectrum-button.css';
-@import './button-base.css';

--- a/packages/button/src/button.ts
+++ b/packages/button/src/button.ts
@@ -19,6 +19,9 @@ import buttonStyles from './button.css.js';
  * @element sp-button
  */
 export class Button extends ButtonBase {
+    public static get styles(): CSSResultArray {
+        return [...super.styles, buttonStyles];
+    }
     /**
      * The visual variant to apply to this button.
      */
@@ -41,8 +44,4 @@ export class Button extends ButtonBase {
      */
     @property({ type: Boolean, reflect: true })
     public quiet = false;
-
-    public static get styles(): CSSResultArray {
-        return [...super.styles, buttonStyles];
-    }
 }

--- a/packages/button/src/clear-button.css
+++ b/packages/button/src/clear-button.css
@@ -11,4 +11,3 @@ governing permissions and limitations under the License.
 */
 
 @import './spectrum-clear-button.css';
-@import './button-base.css';

--- a/packages/button/src/spectrum-action-button.css
+++ b/packages/button/src/spectrum-action-button.css
@@ -12,37 +12,6 @@ governing permissions and limitations under the License.
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #button {
     /* .spectrum-ActionButton,
-   * .spectrum-Button,
-   * .spectrum-ClearButton,
-   * .spectrum-FieldButton,
-   * .spectrum-LogicButton,
-   * .spectrum-Tool */
-    position: relative;
-    display: inline-flex;
-    box-sizing: border-box;
-    align-items: center;
-    justify-content: center;
-    overflow: visible;
-    margin: 0;
-    border-style: solid;
-    text-transform: none;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-appearance: button;
-    vertical-align: top;
-    transition: background var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        border-color var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
-        box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
-    text-decoration: none;
-    font-family: var(
-        --spectrum-alias-body-text-font-family,
-        var(--spectrum-global-font-family-base)
-    );
-    line-height: 1.3;
-    cursor: pointer; /* .spectrum-ActionButton,
    * .spectrum-Tool */
     position: relative;
     height: var(
@@ -92,66 +61,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     color: var(
         --spectrum-actionbutton-text-color,
         var(--spectrum-alias-text-color)
-    );
-}
-#button:focus {
-    /* .spectrum-ActionButton:focus,
-   * .spectrum-Button:focus,
-   * .spectrum-ClearButton:focus,
-   * .spectrum-FieldButton:focus,
-   * .spectrum-LogicButton:focus,
-   * .spectrum-Tool:focus */
-    outline: none;
-}
-#button::-moz-focus-inner {
-    /* .spectrum-ActionButton::-moz-focus-inner,
-   * .spectrum-Button::-moz-focus-inner,
-   * .spectrum-ClearButton::-moz-focus-inner,
-   * .spectrum-FieldButton::-moz-focus-inner,
-   * .spectrum-LogicButton::-moz-focus-inner,
-   * .spectrum-Tool::-moz-focus-inner */
-    border: 0;
-    border-style: none;
-    padding: 0;
-    margin-top: -2px;
-    margin-bottom: -2px;
-}
-:host([disabled]) #button {
-    /* .spectrum-ActionButton:disabled,
-   * .spectrum-Button:disabled,
-   * .spectrum-ClearButton:disabled,
-   * .spectrum-FieldButton:disabled,
-   * .spectrum-LogicButton:disabled,
-   * .spectrum-Tool:disabled */
-    cursor: default; /* .spectrum-ActionButton.is-disabled,
-   * .spectrum-ActionButton:disabled,
-   * .spectrum-Tool:disabled */
-    background-color: var(
-        --spectrum-actionbutton-background-color-disabled,
-        var(--spectrum-global-color-gray-200)
-    );
-    border-color: var(
-        --spectrum-actionbutton-border-color-disabled,
-        var(--spectrum-global-color-gray-200)
-    );
-    color: var(
-        --spectrum-actionbutton-text-color-disabled,
-        var(--spectrum-alias-text-color-disabled)
-    );
-}
-::slotted([slot='icon']) {
-    /* .spectrum-ActionButton .spectrum-Icon,
-   * .spectrum-Button .spectrum-Icon,
-   * .spectrum-ClearButton .spectrum-Icon,
-   * .spectrum-FieldButton .spectrum-Icon,
-   * .spectrum-LogicButton .spectrum-Icon,
-   * .spectrum-Tool .spectrum-Icon */
-    max-height: 100%;
-    flex-shrink: 0; /* .spectrum-ActionButton .spectrum-Icon,
-   * .spectrum-Tool .spectrum-Icon */
-    color: var(
-        --spectrum-actionbutton-icon-color,
-        var(--spectrum-alias-icon-color)
     );
 }
 slot[name='icon'] + #label {
@@ -272,6 +181,14 @@ slot[name='icon'] + #label {
         var(--spectrum-alias-text-color)
     );
 }
+::slotted([slot='icon']) {
+    /* .spectrum-ActionButton .spectrum-Icon,
+   * .spectrum-Tool .spectrum-Icon */
+    color: var(
+        --spectrum-actionbutton-icon-color,
+        var(--spectrum-alias-icon-color)
+    );
+}
 #button:hover {
     /* .spectrum-ActionButton:hover,
    * .spectrum-Tool:hover */
@@ -364,6 +281,23 @@ slot[name='icon'] + #label {
     color: var(
         --spectrum-actionbutton-hold-icon-color-down,
         var(--spectrum-alias-icon-color-down)
+    );
+}
+:host([disabled]) #button {
+    /* .spectrum-ActionButton.is-disabled,
+   * .spectrum-ActionButton:disabled,
+   * .spectrum-Tool:disabled */
+    background-color: var(
+        --spectrum-actionbutton-background-color-disabled,
+        var(--spectrum-global-color-gray-200)
+    );
+    border-color: var(
+        --spectrum-actionbutton-border-color-disabled,
+        var(--spectrum-global-color-gray-200)
+    );
+    color: var(
+        --spectrum-actionbutton-text-color-disabled,
+        var(--spectrum-alias-text-color-disabled)
     );
 }
 :host([disabled]) #button ::slotted([slot='icon']) {

--- a/packages/button/src/spectrum-button-base.css
+++ b/packages/button/src/spectrum-button-base.css
@@ -1,0 +1,87 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+#button {
+    /* .spectrum-ActionButton,
+   * .spectrum-Button,
+   * .spectrum-ClearButton,
+   * .spectrum-FieldButton,
+   * .spectrum-LogicButton,
+   * .spectrum-Tool */
+    position: relative;
+    display: inline-flex;
+    box-sizing: border-box;
+    align-items: center;
+    justify-content: center;
+    overflow: visible;
+    margin: 0;
+    border-style: solid;
+    text-transform: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-appearance: button;
+    vertical-align: top;
+    transition: background var(--spectrum-global-animation-duration-100, 0.13s)
+            ease-out,
+        border-color var(--spectrum-global-animation-duration-100, 0.13s)
+            ease-out,
+        color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
+        box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
+    text-decoration: none;
+    font-family: var(
+        --spectrum-alias-body-text-font-family,
+        var(--spectrum-global-font-family-base)
+    );
+    line-height: 1.3;
+    cursor: pointer;
+}
+#button:focus {
+    /* .spectrum-ActionButton:focus,
+   * .spectrum-Button:focus,
+   * .spectrum-ClearButton:focus,
+   * .spectrum-FieldButton:focus,
+   * .spectrum-LogicButton:focus,
+   * .spectrum-Tool:focus */
+    outline: none;
+}
+#button::-moz-focus-inner {
+    /* .spectrum-ActionButton::-moz-focus-inner,
+   * .spectrum-Button::-moz-focus-inner,
+   * .spectrum-ClearButton::-moz-focus-inner,
+   * .spectrum-FieldButton::-moz-focus-inner,
+   * .spectrum-LogicButton::-moz-focus-inner,
+   * .spectrum-Tool::-moz-focus-inner */
+    border: 0;
+    border-style: none;
+    padding: 0;
+    margin-top: -2px;
+    margin-bottom: -2px;
+}
+#button:disabled {
+    /* .spectrum-ActionButton:disabled,
+   * .spectrum-Button:disabled,
+   * .spectrum-ClearButton:disabled,
+   * .spectrum-FieldButton:disabled,
+   * .spectrum-LogicButton:disabled,
+   * .spectrum-Tool:disabled */
+    cursor: default;
+}
+::slotted([slot='icon']) {
+    /* .spectrum-ActionButton .spectrum-Icon,
+   * .spectrum-Button .spectrum-Icon,
+   * .spectrum-ClearButton .spectrum-Icon,
+   * .spectrum-FieldButton .spectrum-Icon,
+   * .spectrum-LogicButton .spectrum-Icon,
+   * .spectrum-Tool .spectrum-Icon */
+    max-height: 100%;
+    flex-shrink: 0;
+}

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -10,117 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-#button {
-    /* .spectrum-ActionButton,
-   * .spectrum-Button,
-   * .spectrum-ClearButton,
-   * .spectrum-FieldButton,
-   * .spectrum-LogicButton,
-   * .spectrum-Tool */
-    position: relative;
-    display: inline-flex;
-    box-sizing: border-box;
-    align-items: center;
-    justify-content: center;
-    overflow: visible;
-    margin: 0;
-    border-style: solid;
-    text-transform: none;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-appearance: button;
-    vertical-align: top;
-    transition: background var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        border-color var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
-        box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
-    text-decoration: none;
-    font-family: var(
-        --spectrum-alias-body-text-font-family,
-        var(--spectrum-global-font-family-base)
-    );
-    line-height: 1.3;
-    cursor: pointer; /* .spectrum-Button */
-    border-width: var(
-        --spectrum-button-primary-border-size,
-        var(--spectrum-alias-border-size-thick)
-    );
-    border-style: solid;
-    border-radius: var(
-        --spectrum-button-primary-border-radius,
-        var(--spectrum-alias-border-radius-large)
-    );
-    min-height: var(
-        --spectrum-button-primary-height,
-        var(--spectrum-alias-single-line-height)
-    );
-    height: auto;
-    min-width: var(--spectrum-button-primary-min-width);
-    padding: var(--spectrum-global-dimension-size-50)
-        calc(
-            var(
-                    --spectrum-button-primary-padding-x,
-                    var(--spectrum-global-dimension-size-200)
-                ) -
-                var(
-                    --spectrum-button-primary-border-size,
-                    var(--spectrum-alias-border-size-thick)
-                )
-        );
-    padding-bottom: calc(var(--spectrum-global-dimension-size-50) + 1px);
-    padding-top: calc(var(--spectrum-global-dimension-size-50) - 1px);
-    font-size: var(
-        --spectrum-button-primary-text-size,
-        var(--spectrum-alias-pill-button-text-size)
-    );
-    font-weight: var(
-        --spectrum-button-primary-text-font-weight,
-        var(--spectrum-global-font-weight-bold)
-    );
-}
-#button:focus {
-    /* .spectrum-ActionButton:focus,
-   * .spectrum-Button:focus,
-   * .spectrum-ClearButton:focus,
-   * .spectrum-FieldButton:focus,
-   * .spectrum-LogicButton:focus,
-   * .spectrum-Tool:focus */
-    outline: none;
-}
-#button::-moz-focus-inner {
-    /* .spectrum-ActionButton::-moz-focus-inner,
-   * .spectrum-Button::-moz-focus-inner,
-   * .spectrum-ClearButton::-moz-focus-inner,
-   * .spectrum-FieldButton::-moz-focus-inner,
-   * .spectrum-LogicButton::-moz-focus-inner,
-   * .spectrum-Tool::-moz-focus-inner */
-    border: 0;
-    border-style: none;
-    padding: 0;
-    margin-top: -2px;
-    margin-bottom: -2px;
-}
-:host([disabled]) #button {
-    /* .spectrum-ActionButton:disabled,
-   * .spectrum-Button:disabled,
-   * .spectrum-ClearButton:disabled,
-   * .spectrum-FieldButton:disabled,
-   * .spectrum-LogicButton:disabled,
-   * .spectrum-Tool:disabled */
-    cursor: default;
-}
-::slotted([slot='icon']) {
-    /* .spectrum-ActionButton .spectrum-Icon,
-   * .spectrum-Button .spectrum-Icon,
-   * .spectrum-ClearButton .spectrum-Icon,
-   * .spectrum-FieldButton .spectrum-Icon,
-   * .spectrum-LogicButton .spectrum-Icon,
-   * .spectrum-Tool .spectrum-Icon */
-    max-height: 100%;
-    flex-shrink: 0;
-}
 #button:after {
     /* .spectrum-Button:after,
    * .spectrum-LogicButton:after */
@@ -159,6 +48,45 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 --spectrum-alias-focus-ring-gap,
                 var(--spectrum-global-dimension-static-size-25)
             ) * -2
+    );
+}
+#button {
+    /* .spectrum-Button */
+    border-width: var(
+        --spectrum-button-primary-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
+    border-style: solid;
+    border-radius: var(
+        --spectrum-button-primary-border-radius,
+        var(--spectrum-alias-border-radius-large)
+    );
+    min-height: var(
+        --spectrum-button-primary-height,
+        var(--spectrum-alias-single-line-height)
+    );
+    height: auto;
+    min-width: var(--spectrum-button-primary-min-width);
+    padding: var(--spectrum-global-dimension-size-50)
+        calc(
+            var(
+                    --spectrum-button-primary-padding-x,
+                    var(--spectrum-global-dimension-size-200)
+                ) -
+                var(
+                    --spectrum-button-primary-border-size,
+                    var(--spectrum-alias-border-size-thick)
+                )
+        );
+    padding-bottom: calc(var(--spectrum-global-dimension-size-50) + 1px);
+    padding-top: calc(var(--spectrum-global-dimension-size-50) - 1px);
+    font-size: var(
+        --spectrum-button-primary-text-size,
+        var(--spectrum-alias-pill-button-text-size)
+    );
+    font-weight: var(
+        --spectrum-button-primary-text-font-weight,
+        var(--spectrum-global-font-weight-bold)
     );
 }
 #button:active,

--- a/packages/button/src/spectrum-clear-button.css
+++ b/packages/button/src/spectrum-clear-button.css
@@ -10,39 +10,27 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host([variant='overBackground']) #button:focus-visible:after {
+    /* .spectrum-ClearButton--overBackground.focus-ring:after */
+    margin: calc(
+        var(
+                --spectrum-alias-focus-ring-gap,
+                var(--spectrum-global-dimension-static-size-25)
+            ) * -1
+    ); /* .spectrum-Button--overBackground.spectrum-Button--quiet.focus-ring:after,
+   * .spectrum-ClearButton--overBackground.focus-ring:after */
+    box-shadow: 0 0 0
+        var(
+            --spectrum-alias-focus-ring-size,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        var(
+            --spectrum-button-over-background-border-color-key-focus,
+            var(--spectrum-global-color-static-white)
+        );
+}
 #button {
-    /* .spectrum-ActionButton,
-   * .spectrum-Button,
-   * .spectrum-ClearButton,
-   * .spectrum-FieldButton,
-   * .spectrum-LogicButton,
-   * .spectrum-Tool */
-    position: relative;
-    display: inline-flex;
-    box-sizing: border-box;
-    align-items: center;
-    justify-content: center;
-    overflow: visible;
-    margin: 0;
-    border-style: solid;
-    text-transform: none;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-appearance: button;
-    vertical-align: top;
-    transition: background var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        border-color var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
-        box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
-    text-decoration: none;
-    font-family: var(
-        --spectrum-alias-body-text-font-family,
-        var(--spectrum-global-font-family-base)
-    );
-    line-height: 1.3;
-    cursor: pointer; /* .spectrum-ClearButton */
+    /* .spectrum-ClearButton */
     width: var(
         --spectrum-clearbutton-medium-width,
         var(--spectrum-alias-single-line-height)
@@ -63,66 +51,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-clearbutton-medium-icon-color,
         var(--spectrum-alias-icon-color)
     );
-}
-#button:focus {
-    /* .spectrum-ActionButton:focus,
-   * .spectrum-Button:focus,
-   * .spectrum-ClearButton:focus,
-   * .spectrum-FieldButton:focus,
-   * .spectrum-LogicButton:focus,
-   * .spectrum-Tool:focus */
-    outline: none;
-}
-#button::-moz-focus-inner {
-    /* .spectrum-ActionButton::-moz-focus-inner,
-   * .spectrum-Button::-moz-focus-inner,
-   * .spectrum-ClearButton::-moz-focus-inner,
-   * .spectrum-FieldButton::-moz-focus-inner,
-   * .spectrum-LogicButton::-moz-focus-inner,
-   * .spectrum-Tool::-moz-focus-inner */
-    border: 0;
-    border-style: none;
-    padding: 0;
-    margin-top: -2px;
-    margin-bottom: -2px;
-}
-#button:disabled {
-    /* .spectrum-ActionButton:disabled,
-   * .spectrum-Button:disabled,
-   * .spectrum-ClearButton:disabled,
-   * .spectrum-FieldButton:disabled,
-   * .spectrum-LogicButton:disabled,
-   * .spectrum-Tool:disabled */
-    cursor: default;
-}
-.spectrum-Icon {
-    /* .spectrum-ActionButton .spectrum-Icon,
-   * .spectrum-Button .spectrum-Icon,
-   * .spectrum-ClearButton .spectrum-Icon,
-   * .spectrum-FieldButton .spectrum-Icon,
-   * .spectrum-LogicButton .spectrum-Icon,
-   * .spectrum-Tool .spectrum-Icon */
-    max-height: 100%;
-    flex-shrink: 0;
-}
-:host([variant='overBackground']) #button:focus-visible:after {
-    /* .spectrum-ClearButton--overBackground.focus-ring:after */
-    margin: calc(
-        var(
-                --spectrum-alias-focus-ring-gap,
-                var(--spectrum-global-dimension-static-size-25)
-            ) * -1
-    ); /* .spectrum-Button--overBackground.spectrum-Button--quiet.focus-ring:after,
-   * .spectrum-ClearButton--overBackground.focus-ring:after */
-    box-shadow: 0 0 0
-        var(
-            --spectrum-alias-focus-ring-size,
-            var(--spectrum-global-dimension-static-size-25)
-        )
-        var(
-            --spectrum-button-over-background-border-color-key-focus,
-            var(--spectrum-global-color-static-white)
-        );
 }
 .spectrum-ClearButton--small {
     /* .spectrum-ClearButton--small */

--- a/packages/button/src/spectrum-config.js
+++ b/packages/button/src/spectrum-config.js
@@ -14,6 +14,21 @@ module.exports = {
     spectrum: 'button',
     components: [
         {
+            name: 'button-base',
+            host: {
+                selector: '.spectrum-Button',
+                shadowSelector: '#button',
+            },
+            focus: '#button',
+            slots: [
+                {
+                    name: 'icon',
+                    selector: '.spectrum-Icon',
+                },
+            ],
+            excludeSourceSelector: [/^(?!(.*),(.*),(.*),(.*),(.*),(.*))/],
+        },
+        {
             name: 'fieldbutton',
             host: {
                 selector: '.spectrum-FieldButton',
@@ -37,6 +52,9 @@ module.exports = {
                     selector: '.spectrum-Icon',
                     name: 'icon',
                 },
+            ],
+            excludeSourceSelector: [
+                /^([^\s]*),([^\s]*),([^\s]*),([^\s]*),([^\s]*),([^\s]*)$/,
             ],
         },
         {
@@ -79,6 +97,7 @@ module.exports = {
                 },
             ],
             exclude: [/\.is-disabled/],
+            excludeSourceSelector: [/^(.*),(.*),(.*),(.*),(.*),(.*)$/],
         },
         {
             name: 'action-button',
@@ -115,6 +134,7 @@ module.exports = {
                 },
             ],
             exclude: [/\.is-disabled/],
+            excludeSourceSelector: [/^(.*),(.*),(.*),(.*),(.*),(.*)$/],
         },
         {
             name: 'clear-button',
@@ -140,6 +160,7 @@ module.exports = {
                     ],
                 },
             ],
+            excludeSourceSelector: [/^(.*),(.*),(.*),(.*),(.*),(.*)$/],
         },
     ],
 };

--- a/packages/button/src/spectrum-fieldbutton.css
+++ b/packages/button/src/spectrum-fieldbutton.css
@@ -10,39 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+.icon {
+    /* .spectrum-ActionButton .spectrum-Icon,
+   * .spectrum-Button .spectrum-Icon,
+   * .spectrum-ClearButton .spectrum-Icon,
+   * .spectrum-FieldButton .spectrum-Icon,
+   * .spectrum-LogicButton .spectrum-Icon,
+   * .spectrum-Tool .spectrum-Icon */
+    max-height: 100%;
+    flex-shrink: 0;
+}
 #button {
-    /* .spectrum-ActionButton,
-   * .spectrum-Button,
-   * .spectrum-ClearButton,
-   * .spectrum-FieldButton,
-   * .spectrum-LogicButton,
-   * .spectrum-Tool */
-    position: relative;
-    display: inline-flex;
-    box-sizing: border-box;
-    align-items: center;
-    justify-content: center;
-    overflow: visible;
-    margin: 0;
-    border-style: solid;
-    text-transform: none;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-appearance: button;
-    vertical-align: top;
-    transition: background var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        border-color var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
-        box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
-    text-decoration: none;
-    font-family: var(
-        --spectrum-alias-body-text-font-family,
-        var(--spectrum-global-font-family-base)
-    );
-    line-height: 1.3;
-    cursor: pointer; /* .spectrum-FieldButton */
+    /* .spectrum-FieldButton */
     height: var(
         --spectrum-dropdown-height,
         var(--spectrum-global-dimension-size-400)
@@ -85,47 +64,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-fieldbutton-border-color,
         var(--spectrum-global-color-gray-300)
     );
-}
-#button:focus {
-    /* .spectrum-ActionButton:focus,
-   * .spectrum-Button:focus,
-   * .spectrum-ClearButton:focus,
-   * .spectrum-FieldButton:focus,
-   * .spectrum-LogicButton:focus,
-   * .spectrum-Tool:focus */
-    outline: none;
-}
-#button::-moz-focus-inner {
-    /* .spectrum-ActionButton::-moz-focus-inner,
-   * .spectrum-Button::-moz-focus-inner,
-   * .spectrum-ClearButton::-moz-focus-inner,
-   * .spectrum-FieldButton::-moz-focus-inner,
-   * .spectrum-LogicButton::-moz-focus-inner,
-   * .spectrum-Tool::-moz-focus-inner */
-    border: 0;
-    border-style: none;
-    padding: 0;
-    margin-top: -2px;
-    margin-bottom: -2px;
-}
-#button:disabled {
-    /* .spectrum-ActionButton:disabled,
-   * .spectrum-Button:disabled,
-   * .spectrum-ClearButton:disabled,
-   * .spectrum-FieldButton:disabled,
-   * .spectrum-LogicButton:disabled,
-   * .spectrum-Tool:disabled */
-    cursor: default;
-}
-.icon {
-    /* .spectrum-ActionButton .spectrum-Icon,
-   * .spectrum-Button .spectrum-Icon,
-   * .spectrum-ClearButton .spectrum-Icon,
-   * .spectrum-FieldButton .spectrum-Icon,
-   * .spectrum-LogicButton .spectrum-Icon,
-   * .spectrum-Tool .spectrum-Icon */
-    max-height: 100%;
-    flex-shrink: 0;
 }
 #button.is-disabled,
 #button:disabled {

--- a/packages/dropdown/src/dropdown.ts
+++ b/packages/dropdown/src/dropdown.ts
@@ -22,6 +22,7 @@ import { nothing } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import dropdownStyles from './dropdown.css.js';
+import buttonBaseStyles from '@spectrum-web-components/button/lib/button-base.css.js';
 import actionButtonStyles from '@spectrum-web-components/button/lib/action-button.css.js';
 import fieldButtonStyles from '@spectrum-web-components/button/lib/field-button.css.js';
 import alertSmallStyles from '@spectrum-web-components/icon/lib/spectrum-icon-alert-small.css.js';
@@ -50,6 +51,7 @@ export class DropdownBase extends Focusable {
     public static get styles(): CSSResultArray {
         return [
             ...super.styles,
+            buttonBaseStyles,
             actionButtonStyles,
             dropdownStyles,
             alertSmallStyles,


### PR DESCRIPTION
## Description
Add `excludeSourceSelector` to `process-spectrum-postcss-plugin.js` to allow greater control as to the styles that are included or excluded from a final CSS conversion. Lever this in the `button` package to structure a `button-base.css` output that contains all of the styles shared across all buttons, and prepare the rest of the packages leveraging those styles to accept this deduplicated CSS.

## Motivation and Context
Elements should be as light as possible.

## How Has This Been Tested?
Visual regressions.

## Types of changes
- [x] Refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
