### PR TITLE
fix(tab-list): hide indicator without selection, listen to resize events

### DIFF
--- a/packages/tab-list/src/tab-list.ts
+++ b/packages/tab-list/src/tab-list.ts
@@ -38,6 +38,7 @@ export class TabList extends Focusable {
     public static get styles(): CSSResultArray {
         return [tabStyles];
     }
+
     @property({ reflect: true })
     public direction: 'vertical' | 'vertical-right' | 'horizontal' =
         'horizontal';
@@ -235,6 +236,7 @@ export class TabList extends Focusable {
     private updateSelectionIndicator = async (): Promise<void> => {
         const selectedElement = this.querySelector('[selected]') as Tab;
         if (!selectedElement) {
+            this.selectionIndicatorStyle = `transform: translateX(0px) scaleX(0) scaleY(0);`;
             return;
         }
         await Promise.all([
@@ -262,6 +264,7 @@ export class TabList extends Focusable {
 
     public connectedCallback(): void {
         super.connectedCallback();
+        window.addEventListener('resize', this.updateSelectionIndicator);
         /* istanbul ignore else */
         if ('fonts' in document) {
             ((document as unknown) as {
@@ -279,6 +282,7 @@ export class TabList extends Focusable {
     }
 
     public disconnectedCallback(): void {
+        window.removeEventListener('resize', this.updateSelectionIndicator);
         /* istanbul ignore else */
         if ('fonts' in document) {
             ((document as unknown) as {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- hide the indicator when there isn't an active selection using `scaleX(0) scaleY(0)`
- listen for resize events to ensure indicator is sized/located appropriately before/after them

I was pretty interested in doing something like the following:
```
if (TabList.resizeObserver) TabList.resizeObserver.observe(this);
else window.addEventListener('resize', this.updateSelectionIndicator);
```
However, it looks like Typescript doesn't have support for `window.ResizeObserver` as a constructor yet. So...next time.

## Related Issue
fixes #610 
fixes #624 

## Motivation and Context
UI consistancy.

## How Has This Been Tested?
Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
