### PR TITLE
fix: click on docs sidenav links in Edge

### DIFF
--- a/documentation/src/components/page.ts
+++ b/documentation/src/components/page.ts
@@ -32,7 +32,7 @@ export class Page extends LayoutElement {
     public resetScroll() {
         if (!this.contentElement) return;
 
-        this.contentElement.scroll(0, 0);
+        this.contentElement.scrollTop = 0;
         this.open = false;
     }
 }


### PR DESCRIPTION
## Description

Make the sidenav component links work in pre-chromium Edge.

## Related Issue

fixes #628 

## Motivation and Context

I want to debug some issues in our components in pre-chromium Edge using the doc site, but I can't even navigate to the component pages

## How Has This Been Tested?

Manual testing in Edge

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
