### PR TITLE
fix: make tab-list work on Edge

### DIFF
--- a/packages/tab-list/src/tab-list.ts
+++ b/packages/tab-list/src/tab-list.ts
@@ -28,6 +28,14 @@ const availableArrowsByDirection = {
     horizontal: ['ArrowLeft', 'ArrowRight'],
 };
 
+declare global {
+    interface Document {
+        fonts?: {
+            ready: Promise<void>,
+        }
+    }
+}
+
 /**
  * @slot - Child tab elements
  * @attr {Boolean} quiet - The tab-list border is a lot smaller
@@ -240,9 +248,8 @@ export class TabList extends Focusable {
             return;
         }
         await Promise.all([
-            await selectedElement.updateComplete,
-            await ((document as unknown) as { fonts: { ready: Promise<void> } })
-                .fonts.ready,
+            selectedElement.updateComplete,
+            document.fonts ? document.fonts.ready : Promise.resolve(),
         ]);
         const tabBoundingClientRect = selectedElement.getBoundingClientRect();
         const parentBoundingClientRect = this.getBoundingClientRect();


### PR DESCRIPTION
## Description

Make `sp-tab-list` be forgiving if `document.fonts` does not exist

## Related Issue

fixes #630 

## Motivation and Context

We have a use case for spectrum-web-components on pre-chromium Edge

## How Has This Been Tested?

Manual testing in the documentation site.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
