### PR TITLE
fix(tab): use Spectrum CSS relative values for overrides

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-a35c199bc7939bbbe697b91e3351f7f7d6cec1bb
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-0741e17563c0c52a09b4688d373cdd427f394182
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/tab/src/tab.css
+++ b/packages/tab/src/tab.css
@@ -17,13 +17,30 @@ governing permissions and limitations under the License.
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    height: auto;
+    height: var(--spectrum-tabs-vertical-item-height, auto) !important;
+
+    --sp-tab-vertial-margin-y: calc(
+        (
+                var(
+                        --spectrum-tabs-vertical-item-height,
+                        var(--spectrum-global-dimension-size-550)
+                    ) -
+                    var(
+                        --spectrum-tabs-focus-ring-height,
+                        var(--spectrum-alias-single-line-height)
+                    )
+            ) / 2
+    );
 }
 
 :host([vertical]):before {
     /* .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
-    left: calc(-1 * var(--spectrum-tabs-focus-ring-size, 2px));
-    right: calc(-1 * var(--spectrum-tabs-focus-ring-size, 2px));
+    left: calc(
+        -1 * var(--spectrum-tabs-focus-ring-size, var(--spectrum-alias-border-size-thick))
+    );
+    right: calc(
+        -1 * var(--spectrum-tabs-focus-ring-size, var(--spectrum-alias-border-size-thick))
+    );
 
     /* Custom */
     height: auto;
@@ -33,13 +50,19 @@ governing permissions and limitations under the License.
 }
 
 :host([vertical]) ::slotted([slot='icon']) {
-    flex-shrink: 0;
+    margin-top: var(--sp-tab-vertial-margin-y);
+    height: auto;
 }
 
 :host([vertical]) #itemLabel {
-    font-size: 13px;
-    padding: 8px 0;
-    font-weight: 400;
+    font-size: var(
+        --spectrum-tabs-text-size,
+        var(--spectrum-alias-font-size-default)
+    );
+    font-weight: var(
+        --spectrum-tabs-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
     line-height: 1;
-    margin: 0;
+    margin: var(--sp-tab-vertial-margin-y) 0;
 }

--- a/packages/tab/stories/tabs.stories.ts
+++ b/packages/tab/stories/tabs.stories.ts
@@ -222,6 +222,38 @@ iconsIi.story = {
     name: 'Icons II',
 };
 
+export const iconsIii = (): TemplateResult => {
+    return html`
+        <sp-icons-medium></sp-icons-medium>
+        <sp-tab-list selected="1" direction="vertical">
+            <sp-tab label="Tab 1" value="1">
+                <sp-icon
+                    slot="icon"
+                    size="s"
+                    name="ui:CheckmarkSmall"
+                ></sp-icon>
+            </sp-tab>
+            <sp-tab label="Tab 2" value="2">
+                <sp-icon slot="icon" size="s" name="ui:CrossSmall"></sp-icon>
+            </sp-tab>
+            <sp-tab label="Tab 3" value="3">
+                <sp-icon
+                    slot="icon"
+                    size="s"
+                    name="ui:ChevronDownSmall"
+                ></sp-icon>
+            </sp-tab>
+            <sp-tab label="Tab 4" value="4">
+                <sp-icon slot="icon" size="s" name="ui:HelpSmall"></sp-icon>
+            </sp-tab>
+        </sp-tab-list>
+    `;
+};
+
+iconsIii.story = {
+    name: 'Icons III',
+};
+
 export const Quiet = (): TemplateResult => {
     const directions = {
         horizontal: 'horizontal',

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -122,6 +122,7 @@ module.exports = [
     'tabs--icons',
     'tabs--icons-only',
     'tabs--icons-ii',
+    'tabs--icons-iii',
     'tabs--quiet',
     'tabs--compact',
     'tabs--quiet-compact',


### PR DESCRIPTION
## Description
Ensure local customization is based as close as possible on Spectrum CSS based custom properties. Add a new visual regression to manage.

## Related Issue
fixes #123 

## Motivation and Context
Maintainability.

## How Has This Been Tested?
Visually and with regression tests.

## Screenshots (if appropriate):
### Before
![image](https://user-images.githubusercontent.com/1156657/79980040-79a0b400-8470-11ea-8410-2a1f6ea5b34d.png)

### After
![image](https://user-images.githubusercontent.com/1156657/79980119-9c32cd00-8470-11ea-911a-d4f516253b42.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
