### PR TITLE
fix(card): correctly apply :focus-visible styling to variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-0741e17563c0c52a09b4688d373cdd427f394182
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-74099043d3fa7de78170c12ad578e987ef9bbf6f
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/__snapshots__/card.md
+++ b/__snapshots__/card.md
@@ -3,7 +3,9 @@
 #### `loads`
 
 ```html
-<slot id="cover-photo" name="cover-photo"></slot>
+<div id="cover-photo">
+    <slot name="cover-photo"></slot>
+</div>
 <div id="body">
     <div id="header">
         <div id="title">
@@ -26,7 +28,9 @@
 #### `loads - [quiet]`
 
 ```html
-<slot name="preview"></slot>
+<div id="preview">
+    <slot name="preview"></slot>
+</div>
 <div id="body">
     <div id="header">
         <div id="title">
@@ -47,7 +51,9 @@
 #### `loads - [gallery]`
 
 ```html
-<slot name="preview"></slot>
+<div id="preview">
+    <slot name="preview"></slot>
+</div>
 <div id="body">
     <div id="header">
         <div id="title">

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -45,6 +45,7 @@
         "@spectrum-css/card": "^2.0.6"
     },
     "dependencies": {
+        "@spectrum-web-components/shared": "^0.4.6",
         "tslib": "^1.10.0"
     }
 }

--- a/packages/card/src/card.css
+++ b/packages/card/src/card.css
@@ -12,17 +12,6 @@ governing permissions and limitations under the License.
 
 @import './spectrum-card.css';
 
-/* Since we're using <img> tags instead of background-image for the cover photo,
-we need an additional object-fit property to preserve the aspect ratio of the image
-In spectrum-css, background-size is used */
-slot[name='cover-photo']::slotted(*) {
-    object-fit: cover;
-}
-
-slot[name='preview']::slotted(*) {
-    object-fit: cover;
-}
-
 /* The description slot has a psuedo-element that also needs to receive the font styling. 
 We need to add the declaration to the slot as well */
 slot[name='description'] {
@@ -30,4 +19,24 @@ slot[name='description'] {
         --spectrum-card-subtitle-text-size,
         var(--spectrum-global-dimension-font-size-50)
     );
+}
+
+#preview,
+#cover-photo {
+    overflow: hidden;
+}
+
+#preview ::slotted(*),
+#cover-photo ::slotted(*) {
+    width: 100%;
+    display: block;
+
+    /* Since we're using <img> tags instead of background-image for the cover photo,
+    we need an additional object-fit property to preserve the aspect ratio of the image
+    In spectrum-css, background-size is used */
+    object-fit: cover;
+}
+
+:host(:not([variant='gallery'])) #preview ::slotted(*) {
+    height: 100%;
 }

--- a/packages/card/src/card.ts
+++ b/packages/card/src/card.ts
@@ -16,7 +16,9 @@ import {
     property,
     CSSResultArray,
     TemplateResult,
+    PropertyValues,
 } from 'lit-element';
+import { FocusVisiblePolyfillMixin } from '@spectrum-web-components/shared/lib/focus-visible.js';
 
 import cardStyles from './card.css.js';
 
@@ -27,13 +29,16 @@ import cardStyles from './card.css.js';
  * @slot description - A description of the card
  * @slot footer - Footer text
  */
-export class Card extends LitElement {
-    @property({ reflect: true })
-    public variant: 'default' | 'gallery' | 'quiet' = 'default';
-
+export class Card extends FocusVisiblePolyfillMixin(LitElement) {
     public static get styles(): CSSResultArray {
         return [cardStyles];
     }
+
+    @property({ reflect: true })
+    public variant: 'default' | 'gallery' | 'quiet' = 'default';
+
+    @property({ type: Boolean, reflect: true })
+    public selected = false;
 
     @property()
     public title = '';
@@ -51,9 +56,17 @@ export class Card extends LitElement {
         `;
     }
 
+    protected get renderPreviewImage(): TemplateResult {
+        return html`
+            <div id="preview">
+                <slot name="preview"></slot>
+            </div>
+        `;
+    }
+
     protected renderGallery(): TemplateResult {
         return html`
-            <slot name="preview"></slot>
+            ${this.renderPreviewImage}
             <div id="body">
                 <div id="header">
                     ${this.renderTitle}
@@ -66,7 +79,7 @@ export class Card extends LitElement {
 
     protected renderQuiet(): TemplateResult {
         return html`
-            <slot name="preview"></slot>
+            ${this.renderPreviewImage}
             <div id="body">
                 <div id="header">
                     ${this.renderTitle}
@@ -81,7 +94,9 @@ export class Card extends LitElement {
 
     protected renderDefault(): TemplateResult {
         return html`
-            <slot name="cover-photo" id="cover-photo"></slot>
+            <div id="cover-photo">
+                <slot name="cover-photo"></slot>
+            </div>
             <div id="body">
                 <div id="header">
                     ${this.renderTitle}
@@ -103,5 +118,11 @@ export class Card extends LitElement {
             default:
                 return this.renderDefault();
         }
+    }
+
+    protected firstUpdated(changes: PropertyValues): void {
+        super.firstUpdated(changes);
+        this.setAttribute('role', 'figure');
+        this.tabIndex = 0;
     }
 }

--- a/packages/card/src/spectrum-card.css
+++ b/packages/card/src/spectrum-card.css
@@ -104,7 +104,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Card-quickActions .spectrum-Checkbox */
     margin: 0;
 }
-::slotted([slot='cover-photo']) {
+#cover-photo {
     /* .spectrum-Card-coverPhoto */
     height: var(
         --spectrum-card-coverphoto-height,
@@ -174,7 +174,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-border-radius-regular)
         );
 }
-::slotted([slot='preview']) {
+#preview {
     /* .spectrum-Card-preview */
     overflow: hidden;
     border-radius: calc(
@@ -294,7 +294,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: flex;
     justify-content: flex-end;
 }
-:host([variant='quiet']) ::slotted([slot='preview']) {
+:host([variant='quiet']) #preview {
     /* .spectrum-Card--quiet .spectrum-Card-preview */
     min-height: var(
         --spectrum-card-quiet-min-size,
@@ -315,8 +315,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border-radius: 0;
     overflow: visible;
 }
-:host([variant='gallery']) ::slotted([slot='preview']),
-:host([variant='quiet']) ::slotted([slot='preview']) {
+:host([variant='gallery']) #preview,
+:host([variant='quiet']) #preview {
     /* .spectrum-Card--gallery .spectrum-Card-preview,
    * .spectrum-Card--quiet .spectrum-Card-preview */
     width: 100%;
@@ -336,8 +336,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-animation-duration-100, 0.13s);
     overflow: visible;
 }
-:host([variant='gallery'][drop-target]) ::slotted([slot='preview']),
-:host([variant='quiet'][drop-target]) ::slotted([slot='preview']) {
+:host([variant='gallery']) #preview:before,
+:host([variant='quiet']) #preview:before {
+    /* .spectrum-Card--gallery .spectrum-Card-preview:before,
+   * .spectrum-Card--quiet .spectrum-Card-preview:before */
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    border-radius: inherit;
+    border: var(
+            --spectrum-card-quiet-border-size,
+            var(--spectrum-alias-border-size-thin)
+        )
+        solid transparent;
+}
+:host([variant='gallery'][drop-target]) #preview,
+:host([variant='quiet'][drop-target]) #preview {
     /* .spectrum-Card--gallery.is-drop-target .spectrum-Card-preview,
    * .spectrum-Card--quiet.is-drop-target .spectrum-Card-preview */
     transition: none;
@@ -379,7 +397,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-125)
     );
 }
-.spectrum-Card--small ::slotted([slot='preview']) {
+.spectrum-Card--small #preview {
     /* .spectrum-Card--small .spectrum-Card-preview */
     padding: var(
         --spectrum-card-quiet-small-preview-padding,
@@ -412,7 +430,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Card--horizontal */
     flex-direction: row;
 }
-.spectrum-Card--horizontal ::slotted([slot='preview']) {
+.spectrum-Card--horizontal #preview {
     /* .spectrum-Card--horizontal .spectrum-Card-preview */
     flex-shrink: 0;
     min-height: 0;
@@ -468,7 +486,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Card--gallery */
     min-width: 0;
 }
-:host([variant='gallery']) ::slotted([slot='preview']) {
+:host([variant='gallery']) #preview {
     /* .spectrum-Card--gallery .spectrum-Card-preview */
     padding: 0;
     border-radius: 0;
@@ -516,8 +534,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border-color: transparent;
     background-color: initial;
 }
-:host([variant='gallery']) ::slotted([slot='preview']),
-:host([variant='quiet']) ::slotted([slot='preview']) {
+:host([variant='gallery']) #preview,
+:host([variant='quiet']) #preview {
     /* .spectrum-Card--gallery .spectrum-Card-preview,
    * .spectrum-Card--quiet .spectrum-Card-preview */
     background-color: var(
@@ -525,14 +543,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-200)
     );
 }
-:host([variant='gallery']) :hover,
-:host([variant='quiet']) :hover {
+:host([variant='gallery']:hover),
+:host([variant='quiet']:hover) {
     /* .spectrum-Card--gallery:hover,
    * .spectrum-Card--quiet:hover */
     border-color: transparent;
 }
-:host([variant='gallery']) :hover ::slotted([slot='preview']),
-:host([variant='quiet']) :hover ::slotted([slot='preview']) {
+:host([variant='gallery']:hover) #preview,
+:host([variant='quiet']:hover) #preview {
     /* .spectrum-Card--gallery:hover .spectrum-Card-preview,
    * .spectrum-Card--quiet:hover .spectrum-Card-preview */
     background-color: var(
@@ -540,9 +558,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-300)
     );
 }
-:host([variant='gallery']) :focus-visible,
+:host([variant='gallery']:focus-visible),
 :host([variant='gallery'][selected]),
-:host([variant='quiet']) :focus-visible,
+:host([variant='quiet']:focus-visible),
 :host([variant='quiet'][selected]) {
     /* .spectrum-Card--gallery.focus-ring,
    * .spectrum-Card--gallery.is-selected,
@@ -551,10 +569,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border-color: transparent;
     box-shadow: none;
 }
-:host([variant='gallery']) :focus-visible ::slotted([slot='preview']),
-:host([variant='gallery'][selected]) ::slotted([slot='preview']),
-:host([variant='quiet']) :focus-visible ::slotted([slot='preview']),
-:host([variant='quiet'][selected]) ::slotted([slot='preview']) {
+:host([variant='gallery']:focus-visible) #preview,
+:host([variant='gallery'][selected]) #preview,
+:host([variant='quiet']:focus-visible) #preview,
+:host([variant='quiet'][selected]) #preview {
     /* .spectrum-Card--gallery.focus-ring .spectrum-Card-preview,
    * .spectrum-Card--gallery.is-selected .spectrum-Card-preview,
    * .spectrum-Card--quiet.focus-ring .spectrum-Card-preview,
@@ -564,6 +582,24 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-200)
     );
 }
+:host([variant='gallery']:focus-visible) #preview:before,
+:host([variant='gallery'][selected]) #preview:before,
+:host([variant='quiet']:focus-visible) #preview:before,
+:host([variant='quiet'][selected]) #preview:before {
+    /* .spectrum-Card--gallery.focus-ring .spectrum-Card-preview:before,
+   * .spectrum-Card--gallery.is-selected .spectrum-Card-preview:before,
+   * .spectrum-Card--quiet.focus-ring .spectrum-Card-preview:before,
+   * .spectrum-Card--quiet.is-selected .spectrum-Card-preview:before */
+    border-color: var(
+        --spectrum-card-quiet-border-color-selected,
+        var(--spectrum-global-color-blue-500)
+    );
+    box-shadow: 0 0 0 1px
+        var(
+            --spectrum-card-quiet-border-color-selected,
+            var(--spectrum-global-color-blue-500)
+        );
+}
 :host([variant='gallery'][drop-target]),
 :host([variant='quiet'][drop-target]) {
     /* .spectrum-Card--gallery.is-drop-target,
@@ -572,11 +608,25 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     background-color: initial;
     box-shadow: none;
 }
-:host([variant='gallery'][drop-target]) ::slotted([slot='preview']),
-:host([variant='quiet'][drop-target]) ::slotted([slot='preview']) {
+:host([variant='gallery'][drop-target]) #preview,
+:host([variant='quiet'][drop-target]) #preview {
     /* .spectrum-Card--gallery.is-drop-target .spectrum-Card-preview,
    * .spectrum-Card--quiet.is-drop-target .spectrum-Card-preview */
     background-color: var(--spectrum-alias-highlight-selected);
+}
+:host([variant='gallery'][drop-target]) #preview:before,
+:host([variant='quiet'][drop-target]) #preview:before {
+    /* .spectrum-Card--gallery.is-drop-target .spectrum-Card-preview:before,
+   * .spectrum-Card--quiet.is-drop-target .spectrum-Card-preview:before */
+    border-color: var(
+        --spectrum-card-quiet-border-color-selected,
+        var(--spectrum-global-color-blue-500)
+    );
+    box-shadow: 0 0 0 1px
+        var(
+            --spectrum-card-quiet-border-color-selected,
+            var(--spectrum-global-color-blue-500)
+        );
 }
 :host([variant='gallery'][drop-target]) .spectrum-Asset-fileBackground,
 :host([variant='gallery'][drop-target]) .spectrum-Asset-folderBackground,
@@ -619,7 +669,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-.spectrum-Card--horizontal:hover ::slotted([slot='preview']) {
+.spectrum-Card--horizontal:hover #preview {
     /* .spectrum-Card--horizontal:hover .spectrum-Card-preview */
     border-color: var(
         --spectrum-card-border-color-hover,

--- a/packages/card/src/spectrum-config.js
+++ b/packages/card/src/spectrum-config.js
@@ -38,20 +38,12 @@ module.exports = {
             ],
             slots: [
                 {
-                    name: 'cover-photo',
-                    selector: '.spectrum-Card-coverPhoto',
-                },
-                {
                     name: 'footer',
                     selector: '.spectrum-Card-footer',
                 },
                 {
                     name: 'description',
                     selector: '.spectrum-Card-description',
-                },
-                {
-                    name: 'preview',
-                    selector: '.spectrum-Card-preview',
                 },
             ],
             ids: [
@@ -86,6 +78,14 @@ module.exports = {
                 {
                     selector: '.spectrum-Card-actions',
                     name: 'actions',
+                },
+                {
+                    name: 'cover-photo',
+                    selector: '.spectrum-Card-coverPhoto',
+                },
+                {
+                    name: 'preview',
+                    selector: '.spectrum-Card-preview',
                 },
             ],
         },

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -320,14 +320,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host([quiet][checked]) :hover #input:enabled + #switch {
+:host(:hover[quiet][checked]) #input:enabled + #switch {
     /* .spectrum-ToggleSwitch--quiet:hover .spectrum-ToggleSwitch-input:checked:enabled+.spectrum-ToggleSwitch-switch */
     background-color: var(
         --spectrum-switch-quiet-track-color-selected-hover,
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([quiet][checked]) :hover #input:enabled + #switch:before {
+:host(:hover[quiet][checked]) #input:enabled + #switch:before {
     /* .spectrum-ToggleSwitch--quiet:hover .spectrum-ToggleSwitch-input:checked:enabled+.spectrum-ToggleSwitch-switch:before */
     border-color: var(
         --spectrum-switch-quiet-handle-border-color-selected-hover,
@@ -390,7 +390,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 :host([quiet][checked]) #input:focus-visible + #switch,
-:host([quiet][checked]) :hover #input:focus-visible + #switch {
+:host([quiet][checked]:hover) #input:focus-visible + #switch {
     /* .spectrum-ToggleSwitch--quiet .spectrum-ToggleSwitch-input.focus-ring:checked+.spectrum-ToggleSwitch-switch,
    * .spectrum-ToggleSwitch--quiet:hover .spectrum-ToggleSwitch-input.focus-ring:checked+.spectrum-ToggleSwitch-switch */
     background-color: var(
@@ -399,7 +399,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 :host([quiet][checked]) #input:focus-visible + #switch:before,
-:host([quiet][checked]) :hover #input:focus-visible + #switch:before {
+:host([quiet][checked]:hover) #input:focus-visible + #switch:before {
     /* .spectrum-ToggleSwitch--quiet .spectrum-ToggleSwitch-input.focus-ring:checked+.spectrum-ToggleSwitch-switch:before,
    * .spectrum-ToggleSwitch--quiet:hover .spectrum-ToggleSwitch-input.focus-ring:checked+.spectrum-ToggleSwitch-switch:before */
     border-color: var(

--- a/scripts/process-spectrum-postcss-plugin.js
+++ b/scripts/process-spectrum-postcss-plugin.js
@@ -270,29 +270,48 @@ class SpectrumProcessor {
 
                 attributeFound = true;
             });
-            if (attributeFound && !this.component.spectrumClassIsHost) {
-                // The CSS for the spectrum root class is not on the :host
-                // element. Apply these CSS rules to the element that correlates
-                // with the spectrum root class. Add that selector (e.g. #button)
-                // if it isn't already there
-                if (result.length === 1) {
-                    result.append(parser.combinator({ value: ' ' }));
-                    result.append(
-                        this.component.hostShadowSelectorNode.clone()
-                    );
-                } else if (
-                    result.length === 3 &&
-                    result.at(1).type === 'combinator'
-                ) {
-                    // If there is only a pseudo selector following the :host,
-                    // then we need to prepend the root selector to the pseudo
-                    // node (e.g ":host([quiet]) :hover" -> ":host([quiet]) #button:hover")
-                    const lastNode = result.at(2);
-                    if (lastNode.type === 'pseudo') {
-                        result.insertBefore(
-                            lastNode,
+            if (attributeFound) {
+                if (this.component.spectrumClassIsHost) {
+                    if (
+                        result.length >= 3 &&
+                        result.at(1).type === 'combinator'
+                    ) {
+                        // If there is only a pseudo selector following the :host,
+                        // then we need to append the pseudo to the root
+                        // node (e.g ":host([quiet]) :hover" -> ":host([quiet]:hover)")
+                        const lastNode = result.at(2);
+                        if (
+                            lastNode.type === 'pseudo' &&
+                            lastNode.value !== '::slotted'
+                        ) {
+                            lastNode.remove();
+                            addNodeToHost(result, lastNode);
+                        }
+                    }
+                } else {
+                    // The CSS for the spectrum root class is not on the :host
+                    // element. Apply these CSS rules to the element that correlates
+                    // with the spectrum root class. Add that selector (e.g. #button)
+                    // if it isn't already there
+                    if (result.length === 1) {
+                        result.append(parser.combinator({ value: ' ' }));
+                        result.append(
                             this.component.hostShadowSelectorNode.clone()
                         );
+                    } else if (
+                        result.length === 3 &&
+                        result.at(1).type === 'combinator'
+                    ) {
+                        // If there is only a pseudo selector following the :host,
+                        // then we need to prepend the root selector to the pseudo
+                        // node (e.g ":host([quiet]) :hover" -> ":host([quiet]) #button:hover")
+                        const lastNode = result.at(2);
+                        if (lastNode.type === 'pseudo') {
+                            result.insertBefore(
+                                lastNode,
+                                this.component.hostShadowSelectorNode.clone()
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
- correctly process `.spectrum-Card--gallery.focus-ring` to `:host([variant='gallery']:focus-visible)` instead of `:host([variant='gallery']) :focus-visible`
- style slot wrappers instead of slots so we can accurate styles `:before` elements
- apply `tabindex` and `role` for more accurate accessibility

## Related Issue
refs #279 

## Motivation and Context
- better adherence to the Spectrum specification.
- higher quality accessibility

## How Has This Been Tested?
Visually.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/79982956-106f6f80-8475-11ea-9995-ed78a7b65b4f.png)
![image](https://user-images.githubusercontent.com/1156657/79982975-182f1400-8475-11ea-8194-d83a4d5eac55.png)
![image](https://user-images.githubusercontent.com/1156657/79983018-29782080-8475-11ea-8403-37e86f670e75.png)

*Corrected hover styles for quiet switches*
![image](https://user-images.githubusercontent.com/1156657/79983080-3e54b400-8475-11ea-98f8-cfc152728f94.png)
was
![image](https://user-images.githubusercontent.com/1156657/79983494-de124200-8475-11ea-987b-5ebb535569d7.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
