### PR TITLE
fix: remove "type: "module"" in package.json for node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     ],
     "main": "lib/index.js",
     "module": "lib/index.js",
-    "type": "module",
     "browser": "lib/index.js",
     "engines": {
         "node": ">=10.18.1",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -22,7 +22,6 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
-    "type": "module",
     "files": [
         "custom-elements.json",
         "/lib/",

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -22,7 +22,6 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
-    "type": "module",
     "files": [
         "custom-elements.json",
         "/lib/",

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -22,7 +22,6 @@
     "description": "",
     "main": "lib/index.js",
     "module": "lib/index.js",
-    "type": "module",
     "files": [
         "custom-elements.json",
         "/lib/",


### PR DESCRIPTION
## Description 
`type: "module"` forces Node@12+ to think everything should be a module and blocks development. This removes those properties where local scripting is required.

## Motivation and Context
Get things working in Node 12.

## How Has This Been Tested?
- locally it installs build and tests in Node@12.16.3
  - `yarn` (which includes all of the build steps by default)
  - `yarn test`
  - `yarn storybook`
  - `yarn docs:start`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
