### PR TITLE
feat(dialog): descendent attribute support, responsive attribute added

### DIFF
--- a/packages/dialog/src/dialog-wrapper.ts
+++ b/packages/dialog/src/dialog-wrapper.ts
@@ -73,6 +73,9 @@ export class DialogWrapper extends LitElement {
     public headline = '';
 
     @property({ type: Boolean })
+    public responsive = false;
+
+    @property({ type: Boolean })
     public underlay = false;
 
     private dismiss(): void {

--- a/packages/dialog/src/spectrum-config.js
+++ b/packages/dialog/src/spectrum-config.js
@@ -25,12 +25,21 @@ module.exports = {
                     name: 'open',
                 },
                 {
-                    type: 'enum',
-                    name: 'mode',
-                    values: [
-                        '.spectrum-Dialog--fullscreen',
-                        '.spectrum-Dialog--fullscreenTakeover',
-                    ],
+                    type: 'boolean',
+                    selector: '.spectrum-Dialog--responsive',
+                    name: 'responsive',
+                },
+            ],
+            descendantAttributes: [
+                {
+                    type: 'boolean',
+                    name: 'mode="fullscreen"',
+                    selector: '.spectrum-Dialog--fullscreen',
+                },
+                {
+                    type: 'boolean',
+                    name: 'mode="fullscreen"',
+                    selector: '.spectrum-Dialog--fullscreenTakeover',
                 },
             ],
             classes: [

--- a/packages/dialog/src/spectrum-dialog-wrapper.css
+++ b/packages/dialog/src/spectrum-dialog-wrapper.css
@@ -31,7 +31,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Dialog-wrapper.is-open */
     visibility: visible;
 }
-.dialog:not(.spectrum-Dialog--fullscreen):not(.spectrum-Dialog--fullscreenTakeover) {
+.dialog:not([mode='fullscreen']):not([mode='fullscreen']) {
     /* .spectrum-Dialog-wrapper .spectrum-Dialog:not(.spectrum-Dialog--fullscreen):not(.spectrum-Dialog--fullscreenTakeover) */
     pointer-events: auto;
     position: relative;
@@ -45,12 +45,11 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     margin-top: -2vh;
 }
-:host([open])
-    .dialog:not(.spectrum-Dialog--fullscreen):not(.spectrum-Dialog--fullscreenTakeover) {
+:host([open]) .dialog:not([mode='fullscreen']):not([mode='fullscreen']) {
     /* .spectrum-Dialog-wrapper .spectrum-Dialog:not(.spectrum-Dialog--fullscreen):not(.spectrum-Dialog--fullscreenTakeover).is-open */
     transform: translateY(0);
 }
-.spectrum-Dialog--responsive {
+:host([responsive]) {
     /* .spectrum-Dialog-wrapper .spectrum-Dialog--responsive */
     margin-top: 0;
 }


### PR DESCRIPTION
## Description
Adds support for processing selectors like `.spectrum-Dialog .spectrum-Button--cta` -> `[variant='cta']`, previously attribute selectors could only be applied to `:host()`

Leverage this and the addition of the `responsive` attribute processing to `sp-dialog`.

## Motivation and Context
Previously the process pushed errors into the output without causing a hard failure.

## How Has This Been Tested?
- by reading the output.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
