### PR TITLE
docs(slider): add usage of labeled and disabled variants

### DIFF
--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -15,34 +15,66 @@ npm install @spectrum-web-components/slider
 yarn add @spectrum-web-components/slider
 ```
 
-### Example
+### Variants
+
+#### Standard
 
 ```html
 <sp-slider></sp-slider>
+<sp-slider disabled></sp-slider>
 ```
 
-### Variants
+#### With Label
+
+```html
+<sp-slider label="Slider Label"></sp-slider>
+<sp-slider label="Slider Label - Disabled" disabled></sp-slider>
+```
 
 #### Filled
 
 ```html
-<sp-slider variant="filled"></sp-slider>
-```
-
-#### Ramp
-
-```html
-<sp-slider variant="ramp"></sp-slider>
+<sp-slider label="Slider Label" variant="filled"></sp-slider>
+<sp-slider
+    label="Slider Label - Disabled"
+    variant="filled"
+    disabled
+></sp-slider>
 ```
 
 #### Tick
 
 ```html
-<sp-slider variant="tick" tick-step="4"></sp-slider>
+<sp-slider label="Slider Label" variant="tick" tick-step="5"></sp-slider>
+<sp-slider
+    label="Slider Label - Disabled"
+    variant="tick"
+    tick-step="5"
+    disabled
+></sp-slider>
 ```
 
-#### Tick w/ labels
+#### Tick with Labels
 
 ```html
-<sp-slider variant="tick" tick-step="5" tick-labels></sp-slider>
+<sp-slider
+    label="Slider Label"
+    variant="tick"
+    tick-step="5"
+    tick-labels
+></sp-slider>
+<sp-slider
+    label="Slider Label - Disabled"
+    variant="tick"
+    tick-step="5"
+    tick-labels
+    disabled
+></sp-slider>
+```
+
+#### Ramp
+
+```html
+<sp-slider label="Slider Label" variant="ramp"></sp-slider>
+<sp-slider label="Slider Label - Disabled" variant="ramp" disabled></sp-slider>
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `label="x"` and `disabled` usage to documentation for the `sp-slider` element.

## Related Issue
fixes #585

## Motivation and Context
Documentation coverage.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/82081164-de3be100-96b3-11ea-929a-d8a72f71e45d.png)

## Types of changes
- [x] Docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
