### PR TITLE
chore: improve documentation responsiveness

### DIFF
--- a/documentation/src/components/code-example.css
+++ b/documentation/src/components/code-example.css
@@ -19,11 +19,19 @@ governing permissions and limitations under the License.
     width: 100%;
 }
 
-#demo {
+.demo-example {
     flex: 1;
-    padding: 3rem 4rem;
+    padding: var(--spectrum-global-dimension-size-400)
+        var(--spectrum-global-dimension-size-500);
     border-radius: 6px 6px 0 0;
     background: var(--spectrum-global-color-gray-100);
+}
+
+@media (max-width: 768px) {
+    .demo-example {
+        padding: var(--spectrum-global-dimension-size-200)
+            var(--spectrum-global-dimension-size-200);
+    }
 }
 
 #markup {

--- a/documentation/src/components/code-example.ts
+++ b/documentation/src/components/code-example.ts
@@ -129,7 +129,7 @@ export class CodeExample extends LitElement {
         return html`
             ${this.showDemo
                 ? html`
-                      <div id="demo">
+                      <div class="demo-example">
                           <slot name="demo">
                               ${renderedCode}
                           </slot>

--- a/documentation/src/components/layout.css
+++ b/documentation/src/components/layout.css
@@ -55,6 +55,12 @@ governing permissions and limitations under the License.
     margin-right: auto;
 }
 
+@media screen and (max-width: 768px) {
+    #body #layout-content #page {
+        padding: 40px 16px 24px 16px;
+    }
+}
+
 header {
     min-height: var(--spectrum-global-dimension-size-600);
     border-bottom: 1px solid var(--spectrum-global-color-gray-200);


### PR DESCRIPTION
Reduce padding at smaller widths for both the `html demo` blocks,
as well as the overall left/right padding for the docs.
## Related Issue

Fixes #686 

## Motivation and Context

The docs should look better on mobile. There are still issues on some pages, but this should give us a big boost in the right direction.

## How Has This Been Tested?

I've reviewed several of the doc pages in the chrome mobile/responsive dev tool. I want some feedback on the breakpoints before I do a complete review.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
