### PR TITLE
Complete Sidenav Documentation and Remove Prettier from Docs

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -446,6 +446,80 @@
             ]
         },
         {
+            "name": "sp-card",
+            "path": "./packages/card/src/index.ts",
+            "attributes": [
+                {
+                    "name": "variant",
+                    "type": "\"default\" | \"gallery\" | \"quiet\"",
+                    "default": "\"default\""
+                },
+                {
+                    "name": "selected",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                {
+                    "name": "title",
+                    "type": "string",
+                    "default": "\"\""
+                },
+                {
+                    "name": "subtitle",
+                    "type": "string",
+                    "default": "\"\""
+                }
+            ],
+            "properties": [
+                {
+                    "name": "variant",
+                    "attribute": "variant",
+                    "type": "\"default\" | \"gallery\" | \"quiet\"",
+                    "default": "\"default\""
+                },
+                {
+                    "name": "selected",
+                    "attribute": "selected",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                {
+                    "name": "title",
+                    "attribute": "title",
+                    "type": "string",
+                    "default": "\"\""
+                },
+                {
+                    "name": "subtitle",
+                    "attribute": "subtitle",
+                    "type": "string",
+                    "default": "\"\""
+                }
+            ],
+            "slots": [
+                {
+                    "name": "preview",
+                    "description": "This is the preview image for Gallery Cards"
+                },
+                {
+                    "name": "title",
+                    "description": "HTML content to be listed as the title"
+                },
+                {
+                    "name": "cover-photo",
+                    "description": "This is the cover photo for Default and Quiet Cards"
+                },
+                {
+                    "name": "description",
+                    "description": "A description of the card"
+                },
+                {
+                    "name": "footer",
+                    "description": "Footer text"
+                }
+            ]
+        },
+        {
             "name": "sp-checkbox",
             "path": "./packages/checkbox/src/index.ts",
             "attributes": [
@@ -518,80 +592,6 @@
             "events": [
                 {
                     "name": "change"
-                }
-            ]
-        },
-        {
-            "name": "sp-card",
-            "path": "./packages/card/src/index.ts",
-            "attributes": [
-                {
-                    "name": "variant",
-                    "type": "\"default\" | \"gallery\" | \"quiet\"",
-                    "default": "\"default\""
-                },
-                {
-                    "name": "selected",
-                    "type": "boolean",
-                    "default": "false"
-                },
-                {
-                    "name": "title",
-                    "type": "string",
-                    "default": "\"\""
-                },
-                {
-                    "name": "subtitle",
-                    "type": "string",
-                    "default": "\"\""
-                }
-            ],
-            "properties": [
-                {
-                    "name": "variant",
-                    "attribute": "variant",
-                    "type": "\"default\" | \"gallery\" | \"quiet\"",
-                    "default": "\"default\""
-                },
-                {
-                    "name": "selected",
-                    "attribute": "selected",
-                    "type": "boolean",
-                    "default": "false"
-                },
-                {
-                    "name": "title",
-                    "attribute": "title",
-                    "type": "string",
-                    "default": "\"\""
-                },
-                {
-                    "name": "subtitle",
-                    "attribute": "subtitle",
-                    "type": "string",
-                    "default": "\"\""
-                }
-            ],
-            "slots": [
-                {
-                    "name": "preview",
-                    "description": "This is the preview image for Gallery Cards"
-                },
-                {
-                    "name": "title",
-                    "description": "HTML content to be listed as the title"
-                },
-                {
-                    "name": "cover-photo",
-                    "description": "This is the cover photo for Default and Quiet Cards"
-                },
-                {
-                    "name": "description",
-                    "description": "A description of the card"
-                },
-                {
-                    "name": "footer",
-                    "description": "Footer text"
                 }
             ]
         },
@@ -816,6 +816,11 @@
                     "default": "\"\""
                 },
                 {
+                    "name": "responsive",
+                    "type": "boolean",
+                    "default": "false"
+                },
+                {
                     "name": "underlay",
                     "type": "boolean",
                     "default": "false"
@@ -891,6 +896,12 @@
                     "attribute": "headline",
                     "type": "string",
                     "default": "\"\""
+                },
+                {
+                    "name": "responsive",
+                    "attribute": "responsive",
+                    "type": "boolean",
+                    "default": "false"
                 },
                 {
                     "name": "underlay",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
         "posthtml-attrs-parser": "^0.1.1",
         "posthtml-loader": "^1.0.2",
         "posthtml-match-helper": "^1.0.1",
-        "prettier": "^2.0.2",
+        "prettier": "^2.0.5",
         "pretty-quick": "^2.0.1",
         "prismjs": "^1.15.0",
         "puppeteer": "3.0.4",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -47,7 +47,7 @@
         "glob": "^7.1.3",
         "http-server": "^0.11.1",
         "path": "^0.12.7",
-        "prettier": "^2.0.4"
+        "prettier": "^2.0.5"
     },
     "peerDependencies": {
         "lit-element": "^2.1.0",

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -51,7 +51,7 @@
         "glob": "^7.1.3",
         "http-server": "^0.11.1",
         "path": "^0.12.7",
-        "prettier": "^2.0.2"
+        "prettier": "^2.0.5"
     },
     "peerDependencies": {
         "lit-element": "^2.1.0",

--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -72,9 +72,9 @@ will send the user to the location of the item.
 ```html
 <sp-sidenav variant="multilevel" defaultValue="Layout">
     <sp-sidenav-item value="Guidelines" label="Guidelines"></sp-sidenav-item>
-    <sp-sidenav-item value="Styles" label="Styles">
+    <sp-sidenav-item value="Styles" label="Styles" expanded>
         <sp-sidenav-item value="Color" label="Color"></sp-sidenav-item>
-        <sp-sidenav-item value="Grid" label="Grid">
+        <sp-sidenav-item value="Grid" label="Grid" expanded>
             <sp-sidenav-item value="Layout" label="Layout"></sp-sidenav-item>
             <sp-sidenav-item value="Responsive" label="Responsive"></sp-sidenav-item>
         </sp-sidenav-item>
@@ -83,6 +83,40 @@ will send the user to the location of the item.
     <sp-sidenav-item value="Elements" label="Elements"></sp-sidenav-item>
     <sp-sidenav-item value="Patterns" label="Patterns"></sp-sidenav-item>
 </sp-sidenav-itm>
+```
+
+## Icon
+
+```html
+<sp-icons-medium></sp-icons-medium>
+<sp-sidenav>
+    <sp-sidenav-item value="Section Title 1" label="Section Title 1">
+        <sp-icon slot="icon" size="s" name="ui:Star"></sp-icon>
+    </sp-sidenav-item>
+    <sp-sidenav-item value="Section Title 2" label="Section Title 2">
+        <sp-icon slot="icon" size="s" name="ui:Star"></sp-icon>
+    </sp-sidenav-item>
+    <sp-sidenav-item value="Section Title 3" label="Section Title 3">
+        <sp-icon slot="icon" size="s" name="ui:Star"></sp-icon>
+    </sp-sidenav-item>
+</sp-sidenav>
+```
+
+## Heading
+
+```html
+<sp-sidenav variant="multilevel">
+    <sp-sidenav-item value="Section 1" label="Section 1"></sp-sidenav-item>
+    <sp-sidenav-item value="Section 2" label="Section 2"></sp-sidenav-item>
+    <sp-sidenav-heading label="Category 1">
+        <sp-sidenav-item value="Section 3" label="Section 3"></sp-sidenav-item>
+        <sp-sidenav-item value="Section 4" label="Section 4"></sp-sidenav-item>
+    </sp-sidenav-heading>
+    <sp-sidenav-heading label="Category 2">
+        <sp-sidenav-item value="Section 5" label="Section 5"></sp-sidenav-item>
+        <sp-sidenav-item value="Section 6" label="Section 6"></sp-sidenav-item>
+    </sp-sidenav-heading>
+</sp-sidenav>
 ```
 
 ## Accessibility

--- a/packages/sidenav/src/sidenav-item.ts
+++ b/packages/sidenav/src/sidenav-item.ts
@@ -126,6 +126,7 @@ export class SideNavItem extends LikeAnchor(Focusable) {
                 @click="${this.handleClick}"
                 id="itemLink"
             >
+                <slot name="icon"></slot>
                 ${this.label}
             </a>
             ${this.expanded

--- a/packages/sidenav/src/spectrum-config.js
+++ b/packages/sidenav/src/spectrum-config.js
@@ -55,6 +55,12 @@ module.exports = {
                     name: 'list',
                 },
             ],
+            slots: [
+                {
+                    name: 'icon',
+                    selector: '.spectrum-SideNav-itemIcon',
+                },
+            ],
         },
         {
             name: 'sidenav-heading',

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -98,7 +98,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-focus)
     );
 }
-#itemLink .spectrum-SideNav-itemIcon {
+#itemLink ::slotted([slot='icon']) {
     /* .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
     margin-right: var(
         --spectrum-sidenav-icon-gap,

--- a/packages/sidenav/test/sidenav-item.test.ts
+++ b/packages/sidenav/test/sidenav-item.test.ts
@@ -71,7 +71,9 @@ describe('Sidenav Item', () => {
         expect(el.shadowRoot).to.exist;
         if (!el.shadowRoot) return;
 
-        let slot = el.shadowRoot.querySelector('slot');
+        let slot: HTMLSlotElement | null = el.shadowRoot.querySelector(
+            'slot:not([name])'
+        );
         expect(slot).not.to.exist;
 
         expect(el.expanded).to.be.false;
@@ -82,7 +84,9 @@ describe('Sidenav Item', () => {
 
         expect(el.expanded).to.be.true;
 
-        slot = el.shadowRoot.querySelector('slot');
+        slot = el.shadowRoot.querySelector(
+            'slot:not([name])'
+        ) as HTMLSlotElement;
         expect(slot).to.exist;
         if (!slot) return;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14847,15 +14847,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
-  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
-
-prettier@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
-  integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-bytes@^5.1.0:
   version "5.3.0"


### PR DESCRIPTION
## Description
- add support for icons in sidenav-items
- document the above and the previously existing heading elements
- clean up dependencies so that "Prettier" doesn't look like a component we ship

## Related Issue
fixes #588 

## Motivation and Context
Clearer and more complete support for Spectrum CSS source and compliance with Spectrum design review.

## How Has This Been Tested?
Available in documentation

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/82721462-3ca42900-9c8b-11ea-9c9b-c9656f2f4c96.png)

## Types of changes
- [x] Docs
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
