### PR TITLE
sp-sidenav-item spacing and docs delivery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-314192b37a820f729dd96d24a7ef63c85d5372a5
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-746ba68179ee3bdb5c72a4d60cfc5d1036346a08
                       - v1-golden-images-master-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/documentation/src/main.css
+++ b/documentation/src/main.css
@@ -16,4 +16,5 @@ body {
     height: 100%;
     overflow: hidden;
     margin: 0;
+    -webkit-font-smoothing: antialiased;
 }

--- a/packages/sidenav/src/sidenav-item.css
+++ b/packages/sidenav/src/sidenav-item.css
@@ -12,6 +12,10 @@ governing permissions and limitations under the License.
 
 @import './spectrum-sidenav-item.css';
 
+:host {
+    display: block;
+}
+
 :host([multiLevel]) {
     --spectrum-web-component-sidenav-font-weight: var(
         --spectrum-sidenav-item-font-weight,

--- a/packages/sidenav/src/sidenav.css
+++ b/packages/sidenav/src/sidenav.css
@@ -16,13 +16,13 @@ governing permissions and limitations under the License.
 
     --spectrum-web-component-sidenav-font-weight: var(
         --spectrum-sidenav-item-font-weight,
-        400
+        var(--spectrum-global-font-weight-regular)
     );
 }
 
 :host([variant='multilevel']) {
     --spectrum-web-component-sidenav-font-weight: var(
         --spectrum-sidenav-multilevel-main-item-font-weight,
-        700
+        var(--spectrum-global-font-weight-bold)
     );
 }


### PR DESCRIPTION
## Description
Help our docs match the Spectrum CSS docs, while ensuring a more correct delivery of `sp-sidnav-item` elements.

## Related Issue
fixes #587

## Motivation and Context
Spectrum CSS adherence.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1156657/82734392-bfa79c80-9ce8-11ea-8fc0-d2b552fd60aa.png)

### After
![image](https://user-images.githubusercontent.com/1156657/82734382-b1f21700-9ce8-11ea-9b8e-c664f1672cb5.png)


## How Has This Been Tested?
- visual regressions updated

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
