### PR TITLE
fix(menu): support menu item list change in deep decendents

### DIFF
--- a/packages/menu-group/src/menu-group.ts
+++ b/packages/menu-group/src/menu-group.ts
@@ -17,6 +17,9 @@ import menuGroupStyles from './menu-group.css.js';
 /**
  * Spectrum Menu Group Component
  * @element sp-menu-group
+ *
+ * @slot header - headline of the menu group
+ * @slot - menu items to be listed in the group
  */
 export class MenuGroup extends LitElement {
     public static get styles(): CSSResultArray {

--- a/packages/menu-item/src/menu-item.ts
+++ b/packages/menu-item/src/menu-item.ts
@@ -54,6 +54,13 @@ export class MenuItem extends ActionButton {
         }
     }
 
+    /**
+     * Hide this getter from web-component-analyzer until
+     * https://github.com/runem/web-component-analyzer/issues/131
+     * has been addressed.
+     *
+     * @private
+     */
     public get itemText(): string {
         return (this.textContent || /* istanbul ignore next */ '').trim();
     }


### PR DESCRIPTION
## Description
Adds the ability for `sp-menu` to observe deep changes to its menu-item list to support the use of `sp-menu-group` elements as are found in the search interface of the documentation site.

## Motivation and Context
A menu should be able to understand what items are inside of it.

## How Has This Been Tested?
- new unit tests

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/82903752-6b422e00-9f2f-11ea-8e75-0635041a2e46.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
