### PR TITLE
fix(theme): support lazily loading theme fragments

### DIFF
--- a/packages/theme/test/theme-lazy.test.ts
+++ b/packages/theme/test/theme-lazy.test.ts
@@ -1,0 +1,128 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '../lib/theme.js';
+import { Theme, ThemeFragmentMap } from '../lib/theme.js';
+import coreStyles from '../lib/theme.css';
+import lightStyles from '../lib/theme-light.css.js';
+import lightestStyles from '../lib/theme-lightest.css.js';
+import darkStyles from '../lib/theme-dark.css.js';
+import darkestStyles from '../lib/theme-darkest.css.js';
+import largeStyles from '../lib/scale-large.css.js';
+import mediumStyles from '../lib/scale-medium.css.js';
+import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+
+type TestableTheme = {
+    hasAdoptedStyles: boolean;
+};
+
+type TestableThemeConstructor = {
+    instances: Set<Theme>;
+    themeFragmentsByKind: ThemeFragmentMap;
+};
+
+describe('Themes - lazy', () => {
+    beforeEach(() => {
+        ((Theme as unknown) as TestableThemeConstructor).themeFragmentsByKind.clear();
+        // Core is registered by default in `theme.ts`
+        Theme.registerThemeFragment('core', 'core', coreStyles);
+    });
+    after(() => {
+        Theme.registerThemeFragment('light', 'color', lightStyles);
+        Theme.registerThemeFragment('lightest', 'color', lightestStyles);
+        Theme.registerThemeFragment('dark', 'color', darkStyles);
+        Theme.registerThemeFragment('darkest', 'color', darkestStyles);
+        Theme.registerThemeFragment('large', 'scale', largeStyles);
+        Theme.registerThemeFragment('medium', 'scale', mediumStyles);
+    });
+    it('loads w/ no themes and none set', async () => {
+        const el = await fixture<Theme>(
+            html`
+                <sp-theme></sp-theme>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(((el as unknown) as TestableTheme).hasAdoptedStyles).to.be.false;
+        expect(el.color).to.equal('');
+        expect(el.scale).to.equal('');
+    });
+    it('loads w/ themes and none set', async () => {
+        const el = await fixture<Theme>(
+            html`
+                <sp-theme></sp-theme>
+            `
+        );
+
+        await elementUpdated(el);
+
+        Theme.registerThemeFragment('light', 'color', lightStyles);
+        Theme.registerThemeFragment('medium', 'scale', mediumStyles);
+
+        await elementUpdated(el);
+
+        expect(((el as unknown) as TestableTheme).hasAdoptedStyles).to.be.true;
+        expect(el.color).to.equal('light');
+        expect(el.scale).to.equal('medium');
+    });
+    it('loads w/ no themes', async () => {
+        const el = await fixture<Theme>(
+            html`
+                <sp-theme color="lightest" scale="large"></sp-theme>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(((el as unknown) as TestableTheme).hasAdoptedStyles).to.be.false;
+    });
+    it('loads w/ not enough themes', async () => {
+        const el = await fixture<Theme>(
+            html`
+                <sp-theme color="lightest" scale="large"></sp-theme>
+            `
+        );
+
+        await elementUpdated(el);
+
+        Theme.registerThemeFragment('light', 'color', lightStyles);
+        Theme.registerThemeFragment('medium', 'scale', mediumStyles);
+
+        await elementUpdated(el);
+
+        expect(((el as unknown) as TestableTheme).hasAdoptedStyles).to.be.false;
+    });
+    it('loads w/ lazy themes', async () => {
+        const el = await fixture<Theme>(
+            html`
+                <sp-theme color="lightest" scale="large"></sp-theme>
+            `
+        );
+
+        await elementUpdated(el);
+
+        Theme.registerThemeFragment('light', 'color', lightStyles);
+        Theme.registerThemeFragment('medium', 'scale', mediumStyles);
+
+        await elementUpdated(el);
+
+        expect(((el as unknown) as TestableTheme).hasAdoptedStyles).to.be.false;
+
+        Theme.registerThemeFragment('lightest', 'color', lightestStyles);
+        Theme.registerThemeFragment('large', 'scale', largeStyles);
+
+        await elementUpdated(el);
+
+        expect(((el as unknown) as TestableTheme).hasAdoptedStyles).to.be.true;
+    });
+});


### PR DESCRIPTION
## Description
Through experiments around reducing the initial load of the documentation site, it became clear that `sp-theme` wasn't fully delivering the flexibility of load currently outlined in its [documentation](https://opensource.adobe.com/spectrum-web-components/components/theme). The ability to load only the style fragments you need, when you need them, is particularly important for the `scale` fragments which top out around 28kb parsed, but the `color` fragments also use up about 6kb of parsed JS, so having more than you need of either is wasteful.

- better structure `Theme` for use with lazily loaded theme fragments
- use the `scale` and `color` attributes before falling back to the fragment "defaults" when establishing the current themes
- always require the presence of a fragment for each of `color, scale and core` before rendering styles
- tighten up TS
- expand tests

## Motivation and Context
Fast sites do less. This makes sure our themeing can be delivered with the smallest amount of JS, and opens the possibility of delivering first themes in CSS and waiting for user interaction to load further customization.

## How Has This Been Tested?
- update old unit tests
- add new unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
