### PR TITLE
fix(overlay): ensure undefined data is not passed into theme

### DIFF
--- a/packages/overlay/src/active-overlay.ts
+++ b/packages/overlay/src/active-overlay.ts
@@ -25,6 +25,7 @@ import {
     property,
     PropertyValues,
 } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import styles from './active-overlay.css.js';
 
 export interface PositionResult {
@@ -401,10 +402,9 @@ export class ActiveOverlay extends LitElement {
     }
 
     public renderTheme(content: TemplateResult): TemplateResult {
-        const color = this.color as Color;
-        const scale = this.scale as Scale;
+        const { color, scale } = this;
         return html`
-            <sp-theme .color=${color} .scale=${scale}>
+            <sp-theme color=${ifDefined(color)} scale=${ifDefined(scale)}>
                 ${content}
             </sp-theme>
         `;


### PR DESCRIPTION
## Description 
Clean up the possibility of passing `undefined` into `color` or `scale` values in a `sp-theme` element.

## Motivation and Context
Lazily defined root themes might not always supply full themes to the overlay system.

## How Has This Been Tested?
Manually while developing on `westbrook/11ty`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
