### PR TITLE
refactor(shared): remove lazy import of focus-visible polyfill

### DIFF
--- a/packages/shared/src/focus-visible.ts
+++ b/packages/shared/src/focus-visible.ts
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import 'focus-visible';
+
 declare global {
     interface Window {
         applyFocusVisiblePolyfill?: (scope: Document | ShadowRoot) => void;
@@ -110,7 +112,6 @@ export const FocusVisiblePolyfillMixin = <
         // document:
         connectedCallback(): void {
             super.connectedCallback && super.connectedCallback();
-            import('focus-visible');
             if (this[$endPolyfillCoordination] == null) {
                 this[$endPolyfillCoordination] = coordinateWithPolyfill(this);
             }


### PR DESCRIPTION
## Description
I initially placed this load behind a dynamic import so that it wouldn't block initial load. However, after working to optimize the documentation site I've learned that the benefits aren't what I'd hoped. By the nature of it being so small (just 1KB gzipped + minified), and being unrelated to other imports together with which it could multiple the late load benefits, any possible gains to load time are outweighed by the additional request, and the need to wait for what would otherwise be a required piece of code for something the had `autofocus` and this polyfill applied. As such, I think we should move it back to the static dependency graph.

## Types of changes
- [x] refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
