### PR TITLE
fix(theme): prevent property sets attribute set property stack overflow

### DIFF
--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -72,6 +72,9 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
         old: string | null,
         value: string | null
     ): void {
+        if (old === value) {
+            return;
+        }
         if (attrName === 'color') {
             this.color = value as Color;
         } else if (attrName === 'scale') {
@@ -109,14 +112,15 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
             !!newValue && ColorValues.includes(newValue)
                 ? newValue
                 : this.color;
+        if (color !== this._color) {
+            this._color = color;
+            this.requestUpdate();
+        }
         if (color) {
             this.setAttribute('color', color);
         } else {
             this.removeAttribute('color');
         }
-        if (color === this._color) return;
-        this._color = color;
-        this.requestUpdate();
     }
 
     private _scale: Scale | '' = '';
@@ -134,14 +138,15 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
             !!newValue && ScaleValues.includes(newValue)
                 ? newValue
                 : this.scale;
+        if (scale !== this._scale) {
+            this._scale = scale;
+            this.requestUpdate();
+        }
         if (scale) {
             this.setAttribute('scale', scale);
         } else {
             this.removeAttribute('scale');
         }
-        if (scale === this._scale) return;
-        this._scale = scale;
-        this.requestUpdate();
     }
 
     private get styles(): CSSResult[] {


### PR DESCRIPTION
## Description
#714 did the work of creating lazily loadable fragments, however, while it worked in the browser and passed all of its tests, it also created a stack overflow in the console. This corrects the code path and gating to prevent this from happening while continuing to deliver on the lazy features.

## Motivation and Context
A clean console.

## How Has This Been Tested?
Manually in https://westbrook-11ty--spectrum-web-components.netlify.app/ vs https://opensource.adobe.com/spectrum-web-components/components/dialog-wrapper

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/84043918-e0bcee00-a974-11ea-943a-2b2967b03e4d.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
