### PR TITLE
Manage tab order and focus placement with Overlay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-a10ea095a6027c585624ab4cbfcf129d6f6a543c
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-d20458bbe31764a19c212eee867f0d7aba580dbf
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -5,5 +5,5 @@ export default create({
     brandTitle: 'Spectrum Web Components',
     brandUrl: 'https://opensource.adobe.com/spectrum-web-components',
     brandImage:
-        'https://opensource.adobe.com/spectrum-css/static/adobe_logo-2.svg',
+        'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI0LjEuMiwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzMCAyNiIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzAgMjY7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkEwRjAwO30KPC9zdHlsZT4KPGc+Cgk8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjE5LDAgMzAsMCAzMCwyNiAJIi8+Cgk8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjExLjEsMCAwLDAgMCwyNiAJIi8+Cgk8cG9seWdvbiBjbGFzcz0ic3QwIiBwb2ludHM9IjE1LDkuNiAyMi4xLDI2IDE3LjUsMjYgMTUuNCwyMC44IDEwLjIsMjAuOCAJIi8+CjwvZz4KPC9zdmc+Cg==',
 });

--- a/__snapshots__/Dropdown.md
+++ b/__snapshots__/Dropdown.md
@@ -3,7 +3,10 @@
 #### `loads`
 
 ```html
-<sp-menu role="listbox">
+<sp-menu
+  role="listbox"
+  tabindex="0"
+>
   <sp-menu-item
     data-js-focus-visible=""
     role="option"

--- a/documentation/src/components/layout.css
+++ b/documentation/src/components/layout.css
@@ -16,6 +16,7 @@ governing permissions and limitations under the License.
     left: 0;
     right: 0;
     bottom: 0;
+    height: 100vh;
 }
 
 #app {

--- a/documentation/src/main.css
+++ b/documentation/src/main.css
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 :root,
 body {
     width: 100%;
-    height: 100%;
+    height: 100vh;
     overflow: hidden;
     margin: 0;
     -webkit-font-smoothing: antialiased;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -54,10 +54,10 @@ module.exports = (config) => {
             coverageIstanbulReporter: {
                 thresholds: {
                     global: {
-                        statements: 98,
+                        statements: 97,
                         branches: 93,
-                        functions: 98,
-                        lines: 98,
+                        functions: 97,
+                        lines: 97,
                     },
                 },
             },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -54,10 +54,10 @@ module.exports = (config) => {
             coverageIstanbulReporter: {
                 thresholds: {
                     global: {
-                        statements: 97,
-                        branches: 93,
-                        functions: 97,
-                        lines: 97,
+                        statements: 98,
+                        branches: 94,
+                        functions: 98,
+                        lines: 98,
                     },
                 },
             },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -54,10 +54,10 @@ module.exports = (config) => {
             coverageIstanbulReporter: {
                 thresholds: {
                     global: {
-                        statements: 97,
-                        branches: 92,
-                        functions: 97,
-                        lines: 97,
+                        statements: 98,
+                        branches: 93,
+                        functions: 98,
+                        lines: 98,
                     },
                 },
             },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "storybook:start": "start-storybook",
         "storybook:stories:build": "tsc --build .storybook/tsconfig.json",
         "storybook:stories:watch": "tsc --build .storybook/tsconfig.json -w",
+        "prestorybook:build": "yarn prestorybook",
         "storybook:build": "yarn storybook:stories:build && build-storybook",
         "docs:analyze": "wca analyze 'packages/**/sp-*.ts' --format json --outFile documentation/custom-elements.json",
         "postdocs:analyze": "node ./scripts/add-custom-properties.js --src='documentation/custom-elements.json'",

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -16,6 +16,7 @@ import {
     TemplateResult,
     property,
     CSSResultArray,
+    query,
 } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined';
 
@@ -24,6 +25,7 @@ import '@spectrum-web-components/button/sp-button.js';
 
 import '../sp-dialog.js';
 import styles from './dialog-wrapper.css.js';
+import { Dialog } from './dialog.js';
 
 /**
  * @element sp-dialog-wrapper
@@ -82,6 +84,33 @@ export class DialogWrapper extends LitElement {
 
     @property({ type: Boolean })
     public underlay = false;
+
+    @query('sp-dialog')
+    private dialog!: Dialog;
+
+    public focus(): void {
+        /* istanbul ignore else */
+        if (this.shadowRoot) {
+            const firstFocusable = this.shadowRoot.querySelector(
+                'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+            ) as LitElement;
+            if (firstFocusable) {
+                /* istanbul ignore else */
+                if (firstFocusable.updateComplete) {
+                    firstFocusable.updateComplete.then(() =>
+                        firstFocusable.focus()
+                    );
+                } else {
+                    firstFocusable.focus();
+                }
+                this.removeAttribute('tabindex');
+            } else {
+                this.dialog.focus();
+            }
+        } else {
+            super.focus();
+        }
+    }
 
     private dismiss(): void {
         this.close();

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -25,7 +25,7 @@ import '@spectrum-web-components/button/sp-button.js';
 
 import '../sp-dialog.js';
 import styles from './dialog-wrapper.css.js';
-import { Dialog } from './dialog.js';
+import { Dialog } from './Dialog.js';
 
 /**
  * @element sp-dialog-wrapper

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -15,7 +15,8 @@ import { spy } from 'sinon';
 
 import '../sp-dialog-wrapper.js';
 import { Dialog, DialogWrapper } from '../';
-import { Button } from '@spectrum-web-components/button';
+import { Button, ActionButton } from '@spectrum-web-components/button';
+import { Underlay } from '@spectrum-web-components/underlay';
 import {
     wrapperLabeledHero,
     wrapperDismissible,
@@ -23,7 +24,6 @@ import {
     wrapperFullscreen,
     wrapperButtonsUnderlay,
 } from '../stories/dialog-wrapper.stories.js';
-import { Underlay } from '@spectrum-web-components/underlay';
 
 describe('Dialog Wrapper', () => {
     it('loads wrapped dialog accessibly', async () => {
@@ -77,6 +77,50 @@ describe('Dialog Wrapper', () => {
 
         await elementUpdated(el);
         expect(el.open).to.be.false;
+    });
+    it('manages entry focus - dismissible', async () => {
+        const el = await fixture<DialogWrapper>(wrapperDismissible());
+
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
+        expect(document.activeElement, 'no focused').to.not.equal(el);
+
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const dialog = root.querySelector('sp-dialog') as Dialog;
+        const dialogRoot = dialog.shadowRoot ? dialog.shadowRoot : dialog;
+        const dismissButton = dialogRoot.querySelector(
+            '.close-button'
+        ) as ActionButton;
+
+        el.focus();
+        await elementUpdated(el);
+        expect(document.activeElement, 'focused generally').to.equal(el);
+        expect(
+            (dismissButton.getRootNode() as Document).activeElement,
+            'focused specifically'
+        ).to.equal(dismissButton);
+
+        dismissButton.click();
+        await elementUpdated(el);
+        expect(el.open).to.be.false;
+    });
+    it('manages entry focus - buttons', async () => {
+        const el = await fixture<DialogWrapper>(wrapperButtons());
+
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
+        expect(document.activeElement, 'no focused').to.not.equal(el);
+
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const button = root.querySelector('sp-button') as Button;
+
+        el.focus();
+        await elementUpdated(el);
+        expect(document.activeElement, 'focused generally').to.equal(el);
+        expect(
+            (button.getRootNode() as Document).activeElement,
+            'focused specifically'
+        ).to.equal(button);
     });
     it('dispatches `confirm`, `cancel` and `secondary`', async () => {
         const confirmSpy = spy();

--- a/packages/dropdown/src/Dropdown.ts
+++ b/packages/dropdown/src/Dropdown.ts
@@ -262,7 +262,7 @@ export class DropdownBase extends Focusable {
         }
         this.closeOverlay = await Overlay.open(
             this.button,
-            'inline',
+            'replace',
             this.popover,
             {
                 placement: this.placement,

--- a/packages/dropdown/src/Dropdown.ts
+++ b/packages/dropdown/src/Dropdown.ts
@@ -169,12 +169,14 @@ export class DropdownBase extends Focusable {
         if (event.code !== 'ArrowDown') {
             return;
         }
+        event.preventDefault();
         /* istanbul ignore if */
         if (!this.optionsMenu) {
             return;
         }
         this.open = true;
     }
+
     public setValueFromItem(item: MenuItem): void {
         const oldSelectedItemText = this.selectedItemText;
         const oldValue = this.value;
@@ -200,7 +202,6 @@ export class DropdownBase extends Focusable {
         }
         item.selected = true;
         this.open = false;
-        this.focus();
     }
 
     public toggle(): void {
@@ -261,25 +262,14 @@ export class DropdownBase extends Focusable {
         }
         this.closeOverlay = await Overlay.open(
             this.button,
-            'click',
+            'inline',
             this.popover,
             {
                 placement: this.placement,
+                receivesFocus: 'auto',
             }
         );
-        requestAnimationFrame(() => {
-            /* istanbul ignore else */
-            if (this.optionsMenu) {
-                /* Trick :focus-visible polyfill into thinking keyboard based focus */
-                this.dispatchEvent(
-                    new KeyboardEvent('keydown', {
-                        code: 'Tab',
-                    })
-                );
-                this.optionsMenu.focus();
-            }
-            this.menuStateResolver();
-        });
+        this.menuStateResolver();
     }
 
     private closeMenu(): void {

--- a/packages/dropdown/stories/dropdown.stories.ts
+++ b/packages/dropdown/stories/dropdown.stories.ts
@@ -55,6 +55,17 @@ export const Default = (): TemplateResult => {
                 </sp-menu-item>
             </sp-menu>
         </sp-dropdown>
+        <p>
+            This is some text.
+        </p>
+        <p>
+            This is some text.
+        </p>
+        <p>
+            This is a
+            <a href="#">link</a>
+            .
+        </p>
     `;
 };
 

--- a/packages/dropdown/test/dropdown.test.ts
+++ b/packages/dropdown/test/dropdown.test.ts
@@ -36,6 +36,7 @@ const keyboardEvent = (code: string): KeyboardEvent =>
     });
 const arrowDownEvent = keyboardEvent('ArrowDown');
 const arrowUpEvent = keyboardEvent('ArrowUp');
+const tabEvent = keyboardEvent('Tab');
 
 describe('Dropdown', () => {
     const dropdownFixture = async (): Promise<Dropdown> => {
@@ -283,6 +284,34 @@ describe('Dropdown', () => {
         );
         expect(el.open).to.be.true;
         expect(document.activeElement === firstItem).to.be.true;
+    });
+    it('allows tabing to close', async () => {
+        const el = await dropdownFixture();
+
+        await elementUpdated(el);
+        const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+
+        el.open = true;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        el.focus();
+        await elementUpdated(el);
+        await waitUntil(() => document.activeElement === firstItem);
+        await waitUntil(
+            () => document.activeElement === firstItem,
+            'first item refocused'
+        );
+        expect(el.open).to.be.true;
+        expect(document.activeElement === firstItem).to.be.true;
+
+        firstItem.dispatchEvent(tabEvent);
+        await elementUpdated(el);
+        await waitUntil(() => !el.open);
+
+        expect(el.open, 'closes').to.be.false;
+        expect(document.activeElement === firstItem, 'focuses something else')
+            .to.be.false;
     });
     it('displays selected item text by default', async () => {
         const focusSelectedSpy = spy();

--- a/packages/icon/test/icon.test.ts
+++ b/packages/icon/test/icon.test.ts
@@ -76,18 +76,21 @@ describe('Icon', () => {
         expect(icon.getAttribute('aria-label')).to.equal('Magnify');
     });
 
-    it('does not error when name is missing', () => {
-        const el = document.createElement('sp-icon');
+    it('does not error when name is missing', async () => {
+        const el = await fixture<Icon>(
+            html`
+                <sp-icon></sp-icon>
+            `
+        );
 
-        document.body.appendChild(el);
         return elementUpdated(el);
     });
 
-    it('does not error with unknown set', () => {
-        const el = document.createElement('sp-icon');
-        el.name = 'unknown-icon';
+    it('does not error with unknown set', async () => {
+        const el = await fixture<Icon>(html`
+            <sp-icon name="unknown-icon"></sp-icon>
+        `);
 
-        document.body.appendChild(el);
         return elementUpdated(el);
     });
 
@@ -103,5 +106,6 @@ describe('Icon', () => {
                 throw error;
             }).to.throw();
         }
+        el.remove();
     });
 });

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -185,6 +185,10 @@ export class Menu extends LitElement {
         `;
     }
 
+    protected firstUpdated(): void {
+        this.tabIndex = 0;
+    }
+
     public connectedCallback(): void {
         super.connectedCallback();
         if (!this.hasAttribute('role')) {

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -41,6 +41,9 @@ export class OverlayTrigger extends LitElement {
     @property({ reflect: true })
     public placement: Placement = 'bottom';
 
+    @property()
+    public type?: 'inline' | 'modal';
+
     @property({ type: Number, reflect: true })
     public offset = 6;
 
@@ -55,9 +58,9 @@ export class OverlayTrigger extends LitElement {
         return html`
             <div
                 id="trigger"
-                @click=${this.onTriggerClick}
-                @mouseenter=${this.onTriggerMouseEnter}
-                @mouseleave=${this.onTriggerMouseLeave}
+                @click=${this.onTrigger}
+                @mouseenter=${this.onTrigger}
+                @mouseleave=${this.onTrigger}
             >
                 <slot
                     @slotchange=${this.onTargetSlotChange}
@@ -77,16 +80,37 @@ export class OverlayTrigger extends LitElement {
         `;
     }
 
+    private onTrigger(event: Event): void {
+        if (this.disabled) {
+            return;
+        }
+        switch (event.type) {
+            case 'click':
+                this.onTriggerClick();
+                return;
+            case 'mouseenter':
+                this.onTriggerMouseEnter();
+                return;
+            case 'mouseleave':
+                this.onTriggerMouseLeave();
+                return;
+        }
+    }
+
     public async onTriggerClick(): Promise<void> {
         /* istanbul ignore else */
         if (this.targetContent && this.clickContent) {
+            if (this.type === 'modal') {
+                this.clickContent.tabIndex = 0;
+            }
             this.closeClickOverlay = await Overlay.open(
                 this.targetContent,
-                'click',
+                this.type ? this.type : 'click',
                 this.clickContent,
                 {
                     offset: this.offset,
                     placement: this.placement,
+                    receivesFocus: this.type ? 'auto' : undefined,
                 }
             );
         }
@@ -156,7 +180,6 @@ export class OverlayTrigger extends LitElement {
             this.closeClickOverlay();
             delete this.closeClickOverlay;
         }
-
         super.disconnectedCallback();
     }
 }

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -20,7 +20,7 @@ import {
 
 import overlayTriggerStyles from './overlay-trigger.css.js';
 
-import { Placement } from './overlay-types';
+import { Placement, TriggerInteractions } from './overlay-types';
 import { Overlay } from './overlay.js';
 
 /**
@@ -42,7 +42,7 @@ export class OverlayTrigger extends LitElement {
     public placement: Placement = 'bottom';
 
     @property()
-    public type?: 'inline' | 'modal';
+    public type?: Extract<TriggerInteractions, 'inline' | 'modal' | 'replace'>;
 
     @property({ type: Number, reflect: true })
     public offset = 6;
@@ -101,7 +101,12 @@ export class OverlayTrigger extends LitElement {
         /* istanbul ignore else */
         if (this.targetContent && this.clickContent) {
             if (this.type === 'modal') {
-                this.clickContent.tabIndex = 0;
+                const firstFocusable = this.querySelector(
+                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+                ) as HTMLElement;
+                if (!firstFocusable) {
+                    this.clickContent.tabIndex = 0;
+                }
             }
             this.closeClickOverlay = await Overlay.open(
                 this.targetContent,
@@ -110,7 +115,10 @@ export class OverlayTrigger extends LitElement {
                 {
                     offset: this.offset,
                     placement: this.placement,
-                    receivesFocus: this.type ? 'auto' : undefined,
+                    receivesFocus:
+                        this.type && this.type !== 'inline'
+                            ? 'auto'
+                            : undefined,
                 }
             );
         }

--- a/packages/overlay/src/active-overlay.css
+++ b/packages/overlay/src/active-overlay.css
@@ -49,8 +49,11 @@ sp-theme,
 #contents {
     display: inline-block;
     pointer-events: none;
-    animation-duration: var(--spectrum-global-animation-duration-200);
-    animation-timing-function: var(--spectrum-global-animation-ease-out);
+    animation-duration: var(--spectrum-global-animation-duration-200, 160ms);
+    animation-timing-function: var(
+        --spectrum-global-animation-ease-out,
+        ease-out
+    );
     opacity: 1;
     visibility: visible;
 }

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -40,6 +40,7 @@ export class OverlayStack {
     private overlayHolder!: HTMLElement;
 
     private initTabTrapping(): void {
+        /* istanbul ignore if */
         if (this.document.body.shadowRoot) {
             this.canTabTrap = false;
             return;
@@ -87,6 +88,7 @@ export class OverlayStack {
     }
 
     private startTabTrapping(): void {
+        /* istanbul ignore if */
         if (!this.canTabTrap) {
             return;
         }
@@ -95,6 +97,7 @@ export class OverlayStack {
     }
 
     private stopTabTrapping(): void {
+        /* istanbul ignore if */
         if (!this.canTabTrap) {
             return;
         }

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -17,6 +17,7 @@ export type TriggerInteractions =
     | 'click'
     | 'hover'
     | 'custom'
+    | 'replace'
     | 'inline'
     | 'modal';
 

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -13,7 +13,12 @@ governing permissions and limitations under the License.
 import { ThemeData } from '@spectrum-web-components/theme';
 import { Placement as PopperPlacement } from './popper';
 
-export type TriggerInteractions = 'click' | 'hover' | 'custom';
+export type TriggerInteractions =
+    | 'click'
+    | 'hover'
+    | 'custom'
+    | 'inline'
+    | 'modal';
 
 export interface OverlayOpenDetail {
     content: HTMLElement;
@@ -21,6 +26,7 @@ export interface OverlayOpenDetail {
     delayed: boolean;
     offset: number;
     placement?: Placement;
+    receivesFocus?: 'auto';
     trigger: HTMLElement;
     interaction: TriggerInteractions;
     theme: ThemeData;

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -22,6 +22,7 @@ type OverlayOptions = {
     delayed?: boolean;
     placement?: Placement;
     offset?: number;
+    receivesFocus?: 'auto';
 };
 
 /**
@@ -99,6 +100,7 @@ export class Overlay {
         delayed,
         offset = 0,
         placement = 'top',
+        receivesFocus,
     }: OverlayOptions): Promise<boolean> {
         /* istanbul ignore if */
         if (this.isOpen) return true;
@@ -140,6 +142,7 @@ export class Overlay {
             trigger: this.owner,
             interaction: this.interaction,
             theme: queryThemeDetail,
+            receivesFocus,
             ...overlayDetailQuery,
         });
         this.isOpen = true;

--- a/packages/overlay/src/popper-arrow-rotate.ts
+++ b/packages/overlay/src/popper-arrow-rotate.ts
@@ -18,6 +18,7 @@ import { ModifierArguments, Modifier } from '@popperjs/core/lib/types';
 function computeArrowRotateStylesFn(
     ref: ModifierArguments<Record<string, unknown>>
 ): undefined {
+    /* istanbul ignore if */
     if (!ref.state.styles || !ref.state.styles.arrow) return;
 
     let rotation: number;
@@ -41,6 +42,7 @@ function computeArrowRotateStylesFn(
         case 'right-end':
             rotation = 90;
             break;
+        /* istanbul ignore next */
         default:
             return;
     }
@@ -48,6 +50,8 @@ function computeArrowRotateStylesFn(
     ref.state.styles.arrow.transform += ` rotate(${rotation}deg)`;
     // Manage Spectrum CSS usage of negative left margin for centering.
     ref.state.styles.arrow.marginLeft = '0';
+    // Manage Spectrum CSS usage of negative top margin for centering.
+    ref.state.styles.arrow.marginTop = '0';
 
     return;
 }

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -183,6 +183,35 @@ export const inline = (): TemplateResult => {
     `;
 };
 
+export const replace = (): TemplateResult => {
+    const closeEvent = new Event('close', { bubbles: true, composed: true });
+    return html`
+        <overlay-trigger type="replace">
+            <sp-button slot="trigger">Open</sp-button>
+            <sp-overlay open slot="click-content">
+                <sp-button
+                    @click=${(event: Event & { target: HTMLElement }): void => {
+                        event.target.dispatchEvent(closeEvent);
+                    }}
+                >
+                    Close
+                </sp-button>
+            </sp-overlay>
+        </overlay-trigger>
+        <p>
+            This is some text.
+        </p>
+        <p>
+            This is some text.
+        </p>
+        <p>
+            This is a
+            <a href="#">link</a>
+            .
+        </p>
+    `;
+};
+
 export const modal = (): TemplateResult => {
     const closeEvent = new Event('close', { bubbles: true, composed: true });
     return html`
@@ -249,7 +278,7 @@ export const deepNesting = (): TemplateResult => {
         <sp-theme color=${outter}>
             <sp-theme color=${color}>
                 <recursive-popover
-                    tabindex="-1"
+                    tabindex=""
                     style="
                         background-color: var(--spectrum-global-color-gray-100);
                         color: var(--spectrum-global-color-gray-800);

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -13,6 +13,8 @@ import { TemplateResult } from 'lit-element';
 
 import { Placement } from '../';
 import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
+import { DialogWrapper } from '@spectrum-web-components/dialog';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/slider/sp-slider.js';
@@ -152,6 +154,85 @@ export const Default = (): TemplateResult => {
     `;
 };
 
+export const inline = (): TemplateResult => {
+    const closeEvent = new Event('close', { bubbles: true, composed: true });
+    return html`
+        <overlay-trigger type="inline">
+            <sp-button slot="trigger">Open</sp-button>
+            <sp-overlay open slot="click-content">
+                <sp-button
+                    @click=${(event: Event & { target: HTMLElement }): void => {
+                        event.target.dispatchEvent(closeEvent);
+                    }}
+                >
+                    Close
+                </sp-button>
+            </sp-overlay>
+        </overlay-trigger>
+        <p>
+            This is some text.
+        </p>
+        <p>
+            This is some text.
+        </p>
+        <p>
+            This is a
+            <a href="#">link</a>
+            .
+        </p>
+    `;
+};
+
+export const modal = (): TemplateResult => {
+    const closeEvent = new Event('close', { bubbles: true, composed: true });
+    return html`
+        <overlay-trigger type="modal" placement="none">
+            <sp-button slot="trigger">Open</sp-button>
+            <sp-dialog-wrapper
+                tabindex="0"
+                underlay
+                open
+                slot="click-content"
+                headline="Wrapped Dialog w/ Hero Image"
+                style="width: 100vw; height: 100vh;"
+                confirm-label="Keep Both"
+                secondary-label="Replace"
+                cancel-label="Cancel"
+                footer="Content for footer"
+                @confirm=${(event: Event & { target: DialogWrapper }): void => {
+                    event.target.dispatchEvent(closeEvent);
+                }}
+                @secondary=${(
+                    event: Event & { target: DialogWrapper }
+                ): void => {
+                    event.target.dispatchEvent(closeEvent);
+                }}
+                @cancel=${(event: Event & { target: DialogWrapper }): void => {
+                    event.target.dispatchEvent(closeEvent);
+                }}
+                @sp-overlay-closed=${(
+                    event: Event & { target: DialogWrapper }
+                ): void => {
+                    event.target.open = true;
+                }}
+            >
+                Content of the dialog
+            </sp-dialog-wrapper>
+        </overlay-trigger>
+        <p>
+            This is some text.
+        </p>
+        <p>
+            This is some text.
+        </p>
+        <p>
+            This is a
+            <a href="#">link</a>
+            .
+        </p>
+    `;
+};
+
 export const deepNesting = (): TemplateResult => {
     const colorOptions = {
         Light: 'light',
@@ -168,6 +249,7 @@ export const deepNesting = (): TemplateResult => {
         <sp-theme color=${outter}>
             <sp-theme color=${color}>
                 <recursive-popover
+                    tabindex="-1"
                     style="
                         background-color: var(--spectrum-global-color-gray-100);
                         color: var(--spectrum-global-color-gray-800);

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -601,6 +601,7 @@ describe('Overlay Trigger', () => {
         const mouseEnter = new MouseEvent('mouseenter');
         const mouseLeave = new MouseEvent('mouseleave');
         triggerShadowDiv.dispatchEvent(mouseEnter);
+        await nextFrame();
         triggerShadowDiv.dispatchEvent(mouseLeave);
 
         await waitUntil(

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -16,6 +16,7 @@ import {
     property,
     CSSResultArray,
     TemplateResult,
+    queryAssignedNodes,
 } from 'lit-element';
 
 import radioGroupStyles from './radio-group.css.js';
@@ -31,6 +32,153 @@ export class RadioGroup extends LitElement {
         return [radioGroupStyles];
     }
 
+    @queryAssignedNodes('')
+    public defaultNodes!: Node[];
+
+    public get buttons(): Radio[] {
+        return this.defaultNodes.filter(
+            (node) => (node as HTMLElement) instanceof Radio
+        ) as Radio[];
+    }
+
+    constructor() {
+        super();
+        this.addEventListener('focusin', this.handleFocusin);
+    }
+
+    public focus(): void {
+        if (!this.buttons.length) {
+            return;
+        }
+        const firstButtonNonDisabled = this.buttons.find((button) => {
+            if (this.selected) {
+                return button.checked;
+            }
+            return !button.disabled;
+        });
+        /* istanbul ignore else */
+        if (firstButtonNonDisabled) {
+            firstButtonNonDisabled.focus();
+        }
+    }
+
+    private handleFocusin = (event: FocusEvent): void => {
+        const target = event.target as Radio;
+        this.selected = target.value;
+        this.addEventListener('focusout', this.handleFocusout);
+        this.addEventListener('keydown', this.handleKeydown);
+        requestAnimationFrame(() => {
+            const firstButtonWithTabIndex = this.buttons.find(
+                (button) => button.tabIndex === 0
+            );
+            if (firstButtonWithTabIndex) {
+                firstButtonWithTabIndex.tabIndex = -1;
+            }
+        });
+    };
+
+    private handleKeydown = (event: KeyboardEvent): void => {
+        const { code } = event;
+        const activeElement = (this.getRootNode() as Document)
+            .activeElement as Radio;
+        /* istanbul ignore if */
+        if (!activeElement) {
+            return;
+        }
+        let nextIndex = this.buttons.indexOf(activeElement);
+        /* istanbul ignore if */
+        if (nextIndex === -1) {
+            return;
+        }
+        const circularIndexedElement = <T extends HTMLElement>(
+            list: T[],
+            index: number
+        ): T => list[(list.length + index) % list.length];
+        switch (code) {
+            case 'ArrowUp':
+            case 'ArrowLeft': {
+                nextIndex -= 1;
+                while (
+                    circularIndexedElement(this.buttons, nextIndex).disabled
+                ) {
+                    nextIndex -= 1;
+                }
+                break;
+            }
+            case 'ArrowRight':
+            case 'ArrowDown':
+                nextIndex += 1;
+                while (
+                    circularIndexedElement(this.buttons, nextIndex).disabled
+                ) {
+                    nextIndex += 1;
+                }
+                break;
+            case 'End':
+                nextIndex = this.buttons.length - 1;
+                while (
+                    circularIndexedElement(this.buttons, nextIndex).disabled
+                ) {
+                    nextIndex -= 1;
+                }
+                break;
+            case 'Home':
+                nextIndex = 0;
+                while (
+                    circularIndexedElement(this.buttons, nextIndex).disabled
+                ) {
+                    nextIndex += 1;
+                }
+                break;
+            case 'PageUp':
+            case 'PageDown':
+                const tagsSiblings = [
+                    ...(this.getRootNode() as Document).querySelectorAll<
+                        RadioGroup
+                    >('sp-radio-group'),
+                ];
+                if (tagsSiblings.length < 2) {
+                    return;
+                }
+                event.preventDefault();
+                const currentIndex = tagsSiblings.indexOf(this);
+                const offset = code === 'PageUp' ? -1 : 1;
+                let nextRadioGroupIndex = currentIndex + offset;
+                let nextRadioGroup = circularIndexedElement(
+                    tagsSiblings,
+                    nextRadioGroupIndex
+                );
+                while (!nextRadioGroup.buttons.length) {
+                    nextRadioGroupIndex += offset;
+                    nextRadioGroup = circularIndexedElement(
+                        tagsSiblings,
+                        nextRadioGroupIndex
+                    );
+                }
+                nextRadioGroup.focus();
+                return;
+            default:
+                return;
+        }
+        event.preventDefault();
+        circularIndexedElement(this.buttons, nextIndex).focus();
+    };
+
+    private handleFocusout = (): void => {
+        const firstButtonNonDisabled = this.buttons.find((button) => {
+            if (this.selected) {
+                return button.checked;
+            }
+            return !button.disabled;
+        });
+        /* istanbul ignore else */
+        if (firstButtonNonDisabled) {
+            firstButtonNonDisabled.tabIndex = 0;
+        }
+        this.removeEventListener('keydown', this.handleKeydown);
+        this.removeEventListener('focusout', this.handleFocusout);
+    };
+
     @property({ type: String, reflect: true })
     public name = '';
 
@@ -42,19 +190,27 @@ export class RadioGroup extends LitElement {
     }
 
     public set selected(value: string) {
+        const old = this.selected;
         const radio = value
             ? (this.querySelector(`sp-radio[value="${value}"]`) as Radio)
             : undefined;
 
-        this.deselectChecked();
-
-        if (radio) {
-            this._selected = value;
-            radio.checked = true;
-        } else {
-            // If no matching radio, selected is reset to empty string
-            this._selected = '';
+        // If no matching radio, selected is reset to empty string
+        this._selected = radio ? value : '';
+        const applyDefault = this.dispatchEvent(
+            new Event('change', {
+                cancelable: true,
+                bubbles: true,
+                composed: true,
+            })
+        );
+        if (!applyDefault) {
+            this._selected = old;
+            return;
         }
+        this.deselectChecked();
+        if (radio) radio.checked = true;
+        this.requestUpdate('selected', old);
     }
 
     protected render(): TemplateResult {
@@ -70,9 +226,25 @@ export class RadioGroup extends LitElement {
         // If selected already assigned, don't overwrite
         this.selected = this.selected || checkedRadioValue;
 
-        this.addEventListener('change', (event: Event) => {
-            const target = event.target as Radio;
-            this.selected = target.value;
+        this.buttons.map((button) => {
+            button.addEventListener('change', (event: Event) => {
+                event.stopPropagation();
+                const target = event.target as Radio;
+                this.selected = target.value;
+            });
+        });
+    }
+
+    protected updated(): void {
+        this.buttons.map((button, index) => {
+            const focusable = this.selected
+                ? !button.disabled && button.value === this.selected
+                    ? '0'
+                    : '-1'
+                : !button.disabled && index === 0
+                ? '0'
+                : '-1';
+            button.setAttribute('tabindex', focusable);
         });
     }
 

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -16,6 +16,216 @@ import '@spectrum-web-components/radio/sp-radio.js';
 import { Radio } from '@spectrum-web-components/radio';
 import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
 
+const keyboardEvent = (code: string): KeyboardEvent =>
+    new KeyboardEvent('keydown', {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        code,
+        key: code,
+    });
+const arrowUpEvent = keyboardEvent('ArrowUp');
+const arrowDownEvent = keyboardEvent('ArrowDown');
+const arrowLeftEvent = keyboardEvent('ArrowLeft');
+const arrowRightEvent = keyboardEvent('ArrowRight');
+const endEvent = keyboardEvent('End');
+const homeEvent = keyboardEvent('Home');
+const pageUpEvent = keyboardEvent('PageUp');
+const pageDownEvent = keyboardEvent('PageDown');
+const enterEvent = keyboardEvent('Enter');
+
+describe('Radio Group - focus control', () => {
+    it('does not accept focus when empty', async () => {
+        const el = await fixture<RadioGroup>(
+            html`
+                <sp-radio-group></sp-radio-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(document.activeElement === el).to.be.false;
+
+        el.focus();
+        await elementUpdated(el);
+
+        expect(document.activeElement === el).to.be.false;
+    });
+    it('focuses selected before first', async () => {
+        const el = await fixture<RadioGroup>(
+            html`
+                <sp-radio-group selected="second">
+                    <sp-radio value="first">Option 1</sp-radio>
+                    <sp-radio value="second">Option 2</sp-radio>
+                    <sp-radio value="third">Option 3</sp-radio>
+                </sp-radio-group>
+            `
+        );
+
+        await elementUpdated(el);
+        const selected = el.querySelector('[value="second"]') as Radio;
+
+        expect(document.activeElement === el).to.be.false;
+
+        el.focus();
+        await elementUpdated(el);
+
+        expect(document.activeElement === selected).to.be.true;
+    });
+    it('loads accepts keyboard events while focused', async () => {
+        const el = await fixture<RadioGroup>(
+            html`
+                <sp-radio-group>
+                    <sp-radio>Options 1</sp-radio>
+                    <sp-radio>Options 2</sp-radio>
+                    <sp-radio>Options 3</sp-radio>
+                    <sp-radio>Options 4</sp-radio>
+                    <sp-radio>Options 5</sp-radio>
+                </sp-radio-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const radio1 = el.querySelector('sp-radio:nth-child(1)') as Radio;
+        const radio2 = el.querySelector('sp-radio:nth-child(2)') as Radio;
+        const radio3 = el.querySelector('sp-radio:nth-child(3)') as Radio;
+        const radio4 = el.querySelector('sp-radio:nth-child(4)') as Radio;
+        const radio5 = el.querySelector('sp-radio:nth-child(5)') as Radio;
+
+        radio1.focus();
+        await elementUpdated(el);
+
+        el.dispatchEvent(pageUpEvent);
+        el.dispatchEvent(arrowRightEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio2).to.be.true;
+
+        el.dispatchEvent(arrowDownEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio3).to.be.true;
+
+        el.dispatchEvent(endEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio5).to.be.true;
+
+        el.dispatchEvent(arrowLeftEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio4).to.be.true;
+
+        el.dispatchEvent(arrowUpEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio3).to.be.true;
+
+        el.dispatchEvent(homeEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio1).to.be.true;
+
+        radio1.blur();
+    });
+    it('loads accepts keyboard events while focused', async () => {
+        const el = await fixture<RadioGroup>(
+            html`
+                <sp-radio-group>
+                    <sp-radio disabled>Option 1</sp-radio>
+                    <sp-radio>Option 2</sp-radio>
+                    <sp-radio>Option 3</sp-radio>
+                    <sp-radio>Option 4</sp-radio>
+                    <sp-radio disabled>Option 5</sp-radio>
+                </sp-radio-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const radio2 = el.querySelector('sp-radio:nth-child(2)') as Radio;
+        const radio4 = el.querySelector('sp-radio:nth-child(4)') as Radio;
+
+        radio2.focus();
+        await elementUpdated(el);
+
+        el.dispatchEvent(enterEvent);
+        el.dispatchEvent(endEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio4).to.be.true;
+
+        el.dispatchEvent(homeEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio2).to.be.true;
+
+        el.dispatchEvent(arrowUpEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio4).to.be.true;
+
+        el.dispatchEvent(arrowDownEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === radio2).to.be.true;
+    });
+    it('loads accepts "PageUp" and "PageDown" keys', async () => {
+        const el = await fixture<HTMLDivElement>(
+            html`
+                <div>
+                    <sp-radio-group>
+                        <sp-radio>Option 1</sp-radio>
+                    </sp-radio-group>
+                    <sp-radio-group>
+                        <sp-radio>Option 2</sp-radio>
+                    </sp-radio-group>
+                    <sp-radio-group></sp-radio-group>
+                    <sp-radio-group>
+                        <sp-radio disabled>Option 3</sp-radio>
+                        <sp-radio>Option 4</sp-radio>
+                    </sp-radio-group>
+                </div>
+            `
+        );
+
+        const radioGroup1 = el.querySelector(
+            'sp-radio-group:nth-child(1)'
+        ) as RadioGroup;
+        const radioGroup2 = el.querySelector(
+            'sp-radio-group:nth-child(2)'
+        ) as RadioGroup;
+        const radioGroup4 = el.querySelector(
+            'sp-radio-group:nth-child(4)'
+        ) as RadioGroup;
+
+        const radio1 = radioGroup1.querySelector('sp-radio') as Radio;
+        const radio2 = radioGroup2.querySelector('sp-radio') as Radio;
+        const radio4 = radioGroup4.querySelector(
+            'sp-radio:not([disabled])'
+        ) as Radio;
+
+        radio1.focus();
+        radio1.dispatchEvent(pageUpEvent);
+
+        expect(document.activeElement === radio4).to.be.true;
+
+        radio4.dispatchEvent(pageDownEvent);
+
+        expect(document.activeElement === radio1).to.be.true;
+
+        radio1.dispatchEvent(pageDownEvent);
+
+        expect(document.activeElement === radio2).to.be.true;
+
+        radio2.dispatchEvent(pageDownEvent);
+
+        expect(document.activeElement === radio4, 'Focuses `radio4`').to.be
+            .true;
+    });
+});
+
 function inputForRadio(radio: Radio): HTMLInputElement {
     if (!radio.shadowRoot) throw new Error('No shadowRoot');
 
@@ -101,6 +311,27 @@ describe('Radio Group', () => {
         radioGroup.selected = 'missing';
 
         expect(radioGroup.selected).to.equal('');
+    });
+    
+    it('can have selection prevented', async () => {
+        const el = testDiv.querySelector(
+            'sp-radio-group#test-default'
+        ) as RadioGroup;
+
+        await elementUpdated(el);
+        expect(el.selected).to.equal('first');
+
+        el.selected = 'second';
+
+        await elementUpdated(el);
+        expect(el.selected).to.equal('second');
+
+        el.addEventListener('change', (event) => event.preventDefault());
+
+        el.selected = 'third';
+
+        await elementUpdated(el);
+        expect(el.selected).to.equal('second');
     });
 
     it('reflects checked radio with selected property', async () => {


### PR DESCRIPTION
## Description
- adds inline and modal style overlays as described in https://github.com/adobe/spectrum-web-components/issues/710#issuecomment-643331874
- adds focus throwing via `receivedFocus`
- adds tab trapping via composed shadow DOM
- leverages new API in `sp-dropdown` and extension
  - updates timing to not include arbitrary `requestAnimationFrame` calls
- adds stories and tests to the functionality
  - sets overlay story element to "submit" on `enter` press
- updates `sp-radio-group` to appropriately manage keyboard interactions

Demo available at: https://westbrook-overlay-focus--spectrum-web-components.netlify.app/storybook/index.html?path=/story/action-menu--icon-only

## Related Issue
fixes #709 
fixes #710 
fixes #723 
fixes #727

## Motivation and Context
- increase the keyboard accessibility of our components and UI powered by our APIs
- code cleanliness

## How Has This Been Tested?
- added unit testing
- updated screenshot testing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
