### PR TITLE
ci: configure dependabot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-04aa5bb7e349289ef820679eceba33db6b2fc292
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-e1a675e52a2f080749bf48aed64c5def316b9120
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'tuesday'
+          time: '12:00'
+          timezone: 'America/Los_Angeles'
+      open-pull-requests-limit: 1
+      reviewers:
+          - 'adixon-adobe'
+          - 'westbrook'


### PR DESCRIPTION
## Description 
With the demise of Greenkeeper, I had turned on Snyk for a little bit, but it wasn't quite to same functionality. It seems that Dependabot _is_ and that we can get back to managing version floors and ceilings by adding this config and relying on it being a part of github now to make this work.

## Motivation and Context
Dependency management.

## Types of changes
- [x] repo health

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
