### PR TITLE
fix(sidenav): expand aria support and keyboard accesibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-e1a675e52a2f080749bf48aed64c5def316b9120
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-a10ea095a6027c585624ab4cbfcf129d6f6a543c
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/sidenav/src/Sidenav.ts
+++ b/packages/sidenav/src/Sidenav.ts
@@ -80,10 +80,30 @@ export class SideNav extends Focusable {
 
     private startListeningToKeyboard = (): void => {
         this.addEventListener('keydown', this.handleKeydown);
+        /* istanbul ignore else */
+        if (this.value) {
+            const selected = this.querySelector(
+                `[value="${this.value}"]`
+            ) as SideNavItem;
+            /* istanbul ignore else */
+            if (selected) {
+                selected.tabIndex = -1;
+            }
+        }
     };
 
     private stopListeningToKeyboard = (): void => {
         this.removeEventListener('keydown', this.handleKeydown);
+        /* istanbul ignore else */
+        if (this.value) {
+            const selected = this.querySelector(
+                `[value="${this.value}"]`
+            ) as SideNavItem;
+            /* istanbul ignore else */
+            if (selected) {
+                selected.tabIndex = 0;
+            }
+        }
     };
 
     private handleKeydown(event: KeyboardEvent): void {
@@ -141,6 +161,10 @@ export class SideNav extends Focusable {
     protected firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.tabIndex = 0;
+        const selectedChild = this.querySelector('[selected]') as SideNavItem;
+        if (selectedChild) {
+            this.value = selectedChild.value;
+        }
     }
 
     protected updated(changes: PropertyValues): void {

--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -87,19 +87,23 @@ export class SideNavItem extends LikeAnchor(Focusable) {
             if (this.hasChildren) {
                 this.expanded = !this.expanded;
             } else if (this.value) {
-                const selectDetail: SidenavSelectDetail = {
-                    value: this.value,
-                };
-
-                const selectionEvent = new CustomEvent('sidenav-select', {
-                    bubbles: true,
-                    composed: true,
-                    detail: selectDetail,
-                });
-
-                this.dispatchEvent(selectionEvent);
+                this.announceSelected(this.value);
             }
         }
+    }
+
+    private announceSelected(value: string): void {
+        const selectDetail: SidenavSelectDetail = {
+            value,
+        };
+
+        const selectionEvent = new CustomEvent('sidenav-select', {
+            bubbles: true,
+            composed: true,
+            detail: selectDetail,
+        });
+
+        this.dispatchEvent(selectionEvent);
     }
 
     public click(): void {

--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -125,6 +125,9 @@ export class SideNavItem extends LikeAnchor(Focusable) {
                 data-level="${this.depth}"
                 @click="${this.handleClick}"
                 id="itemLink"
+                aria-current=${ifDefined(
+                    this.selected && this.href ? 'page' : undefined
+                )}
             >
                 <slot name="icon"></slot>
                 ${this.label}

--- a/packages/sidenav/stories/sidenav.stories.ts
+++ b/packages/sidenav/stories/sidenav.stories.ts
@@ -109,8 +109,14 @@ export const levelsAndDisabled = (): TemplateResult => {
 
 export const Hrefs = (): TemplateResult => {
     return html`
-        <sp-sidenav @sidenav-select=${action('select')}>
+        <sp-sidenav @sidenav-select=${action('select')} value="current">
             <sp-sidenav-heading label="GITHUB">
+                <sp-sidenav-item
+                    href=${window.location.href}
+                    label="Current"
+                    value="current"
+                    selected
+                ></sp-sidenav-item>
                 <sp-sidenav-item
                     href="https://github.com/adobe/spectrum-web-components"
                     label="Code"

--- a/packages/sidenav/test/sidenav-item.test.ts
+++ b/packages/sidenav/test/sidenav-item.test.ts
@@ -92,4 +92,41 @@ describe('Sidenav Item', () => {
 
         expect(slot.assignedElements().length).to.equal(2);
     });
+
+    it('populated `aria-current`', async () => {
+        const el = await fixture<SideNavItem>(
+            html`
+                <sp-sidenav value="Section 2">
+                    <sp-sidenav-item
+                        href="https://opensource.adobe.com/spectrum-web-components/"
+                        label="Section 1"
+                        value="Section 1"
+                    ></sp-sidenav-item>
+                    <sp-sidenav-item
+                        href=${window.location.href}
+                        label="Section 2"
+                        value="Section 2"
+                        selected
+                    ></sp-sidenav-item>
+                </sp-sidenav>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const currentItem = el.querySelector(
+            'sp-sidenav-item:nth-child(2)'
+        ) as SideNavItem;
+        const otherItem = el.querySelector(
+            'sp-sidenav-item:nth-child(1)'
+        ) as SideNavItem;
+
+        await elementUpdated(currentItem);
+        await elementUpdated(otherItem);
+
+        expect(currentItem.focusElement.hasAttribute('aria-current'), 'current')
+            .to.be.true;
+        expect(otherItem.focusElement.hasAttribute('aria-current'), 'other').to
+            .be.false;
+    });
 });

--- a/packages/sidenav/test/sidenav.test.ts
+++ b/packages/sidenav/test/sidenav.test.ts
@@ -14,7 +14,13 @@ import '../sp-sidenav.js';
 import '../sp-sidenav-item.js';
 import '../sp-sidenav-heading.js';
 import { SideNav, SideNavItem } from '../';
-import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    waitUntil,
+} from '@open-wc/testing';
 import { TemplateResult } from 'lit-html';
 import { LitElement } from 'lit-element';
 
@@ -165,6 +171,67 @@ describe('Sidenav', () => {
         await elementUpdated(el);
 
         expect(el.value).to.equal('Section 2a');
+    });
+    it('prevents [tabindex=0] while `focusin`', async () => {
+        const el = await fixture<SideNav>(
+            html`
+                <sp-sidenav manage-tab-index>
+                    <sp-sidenav-heading label="CATEGORY 1">
+                        <sp-sidenav-item
+                            value="Section 0"
+                            label="Section 0"
+                        ></sp-sidenav-item>
+                        <sp-sidenav-item
+                            value="Section 1"
+                            label="Section 1"
+                            selected
+                        ></sp-sidenav-item>
+                        <sp-sidenav-item
+                            value="Section 2"
+                            label="Section 2"
+                            disabled
+                        ></sp-sidenav-item>
+                        <sp-sidenav-item value="Section 3" label="Section 3">
+                            <sp-sidenav-item
+                                value="Section 3a"
+                                label="Section 3a"
+                            ></sp-sidenav-item>
+                        </sp-sidenav-item>
+                    </sp-sidenav-heading>
+                </sp-sidenav>
+            `
+        );
+        const selected = el.querySelector('[value="Section 1"]') as SideNavItem;
+        const toBeSelected = el.querySelector(
+            '[value="Section 0"]'
+        ) as SideNavItem;
+
+        await elementUpdated(el);
+        await waitUntil(() => el.value === 'Section 1', 'wait for selection');
+
+        expect(el.value).to.equal('Section 1');
+        expect(selected.tabIndex).to.equal(0);
+
+        el.dispatchEvent(new Event('focusin'));
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal('Section 1');
+        expect(selected.tabIndex).to.equal(-1);
+
+        el.dispatchEvent(new Event('focusout'));
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal('Section 1');
+        expect(selected.tabIndex).to.equal(0);
+
+        toBeSelected.click();
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal('Section 0');
+        expect(toBeSelected.tabIndex).to.equal(0);
     });
     it('manage tab index', async () => {
         const el = await fixture<SideNav>(

--- a/projects/templates/plop-templates/benchmark.ts.hbs
+++ b/projects/templates/plop-templates/benchmark.ts.hbs
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '../../';
+import '@spectrum-web-components/{{ name }}/{{> tagnamePartial }}.js';
 import { html } from 'lit-html';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers';
 


### PR DESCRIPTION
blocked by #683 

## Description
- correctly handle the `tabindex` value of the "selected" item when navigating through the items with the keyboard
- leverage `aria-current="page"` in an item when conditions warrant
- expand stories and testing

## Related Issue
fixes #733 

## Motivation and Context
Better keyboard accessibility
Better accessibility tree.

## How Has This Been Tested?
- unit tests
- update visual regressions

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
