### PR TITLE
feat(tags): manage aria-disabled from disabled attribute

### DIFF
--- a/packages/tags/src/tag.ts
+++ b/packages/tags/src/tag.ts
@@ -109,4 +109,15 @@ export class Tag extends LitElement {
                 : '-1'
         );
     }
+
+    protected updated(changes: PropertyValues): void {
+        super.updated(changes);
+        if (changes.has('disabled')) {
+            if (this.disabled) {
+                this.setAttribute('aria-disabled', 'true');
+            } else {
+                this.removeAttribute('aria-disabled');
+            }
+        }
+    }
 }

--- a/packages/tags/test/tag.test.ts
+++ b/packages/tags/test/tag.test.ts
@@ -48,6 +48,26 @@ describe('Tag', () => {
 
         await expect(el).to.be.accessible();
     });
+    it('[disabled] manages [aria-disabled]', async () => {
+        const el = await fixture<Tag>(
+            html`
+                <sp-tags>
+                    <sp-tag>Tag 1</sp-tag>
+                    <sp-tag invalid>Tag 2</sp-tag>
+                    <sp-tag disabled>Tag 3</sp-tag>
+                    <sp-tag deletable>Tag 4</sp-tag>
+                </sp-tags>
+            `
+        );
+        const notDisabled = el.querySelector('sp-tag') as Tag;
+        const disabled = el.querySelector('[disabled]') as Tag;
+
+        await elementUpdated(disabled);
+
+        expect(notDisabled.hasAttribute('aria-disabled')).to.be.false;
+        expect(disabled.hasAttribute('aria-disabled')).to.be.true;
+        expect(disabled.getAttribute('aria-disabled')).to.equal('true');
+    });
     it('dispatches `delete` events on click', async () => {
         const deleteSpy = spy();
         const handleDelete = (): void => deleteSpy();


### PR DESCRIPTION
## Description
Workaround provided color contrast in `<sp-tag disabled>` element by ensuring that `aria-disabled="true"` is also available in this context.

## Related Issue
fixes #741

## Motivation and Context
Accessible elements.

## How Has This Been Tested?
- unit test added

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
