### PR TITLE
fix(tabs): ensure only one active tab stop in the tabs

### DIFF
--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -54,9 +54,6 @@ export class Tabs extends Focusable {
     @property()
     public selectionIndicatorStyle = '';
 
-    @property({ type: String, reflect: true })
-    public value = '';
-
     @property({ reflect: true })
     public get selected(): string {
         return this._selected;
@@ -116,6 +113,10 @@ export class Tabs extends Focusable {
         this.setAttribute('role', 'tablist');
         this.addEventListener('mousedown', this.manageFocusinType);
         this.addEventListener('focusin', this.startListeningToKeyboard);
+        const selectedChild = this.querySelector('[selected]') as Tab;
+        if (selectedChild) {
+            this.selectTarget(selectedChild);
+        }
     }
 
     protected updated(changes: PropertyValues): void {
@@ -150,10 +151,20 @@ export class Tabs extends Focusable {
     public startListeningToKeyboard = (): void => {
         this.addEventListener('keydown', this.handleKeydown);
         this.shouldApplyFocusVisible = true;
+        const selected = this.querySelector('[selected]') as Tab;
+        /* istanbul ignore else */
+        if (selected) {
+            selected.tabIndex = -1;
+        }
 
         const stopListeningToKeyboard = (): void => {
             this.removeEventListener('keydown', this.handleKeydown);
             this.shouldApplyFocusVisible = false;
+            const selected = this.querySelector('[selected]') as Tab;
+            /* istanbul ignore else */
+            if (selected) {
+                selected.tabIndex = 0;
+            }
             this.removeEventListener('focusout', stopListeningToKeyboard);
         };
         this.addEventListener('focusout', stopListeningToKeyboard);

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -13,7 +13,13 @@ import '../sp-tabs.js';
 import '../sp-tab.js';
 import { Tabs, Tab } from '../';
 import '@spectrum-web-components/icon/sp-icon.js';
-import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    waitUntil,
+} from '@open-wc/testing';
 import { LitElement } from 'lit-element';
 import { TemplateResult } from 'lit-html';
 import { waitForPredicate } from '../../../test/testing-helpers';
@@ -255,6 +261,56 @@ describe('Tabs', () => {
         secondTab.click();
         await elementUpdated(el);
         expect(el.selected).to.be.equal('first');
+    });
+    it('prevents [tabindex=0] while `focusin`', async () => {
+        const el = await fixture<Tabs>(html`
+            <sp-tabs>
+                <sp-tab label="Tab 1" value="first" selected>
+                    <sp-icon
+                        slot="icon"
+                        size="s"
+                        name="ui:CheckmarkSmall"
+                    ></sp-icon>
+                </sp-tab>
+                <sp-tab label="Tab 2" value="second">
+                    <sp-icon
+                        slot="icon"
+                        size="s"
+                        name="ui:CheckmarkSmall"
+                    ></sp-icon>
+                </sp-tab>
+            </sp-tabs>
+        `);
+
+        const selected = el.querySelector('[value="first"]') as Tab;
+        const toBeSelected = el.querySelector('[value="second"]') as Tab;
+
+        await elementUpdated(el);
+        await waitUntil(() => el.selected === 'first', 'wait for selection');
+
+        expect(el.selected).to.equal('first');
+        expect(selected.tabIndex).to.equal(0);
+
+        el.dispatchEvent(new Event('focusin'));
+
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('first');
+        expect(selected.tabIndex).to.equal(-1);
+
+        el.dispatchEvent(new Event('focusout'));
+
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('first');
+        expect(selected.tabIndex).to.equal(0);
+
+        toBeSelected.click();
+
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('second');
+        expect(toBeSelected.tabIndex).to.equal(0);
     });
     it('accepts keyboard based selection', async () => {
         const el = await fixture<Tabs>(html`


### PR DESCRIPTION
blocked by #683

## Description
Ensure that an `<sp-tabs>` element only has one active tab stop while navigating through its children via the keyboard.

This also removes the (seemingly) completely unused `value` attribute from `<sp-tabs>`.

## Related Issue
fixes #740 

## Motivation and Context
Better keyboard accessibility. 

## How Has This Been Tested?
- new unit tests!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
