### PR TITLE
Contrast Updates in the Docs Site

### DIFF
--- a/packages/banner/README.md
+++ b/packages/banner/README.md
@@ -37,17 +37,6 @@ Banners intended for providing information. This is the default banner variant.
 </sp-banner>
 ```
 
-### Warning banners
-
-Banners intended to provided a warning with a brief description. Less severe than an error banner.
-
-```html
-<sp-banner type="warning">
-    <div slot="header">This is a warning banner</div>
-    <div slot="content">Be careful!</div>
-</sp-banner>
-```
-
 ### Error banners
 
 Banners intended to indicate an error as occurred, with a brief description of the issue. More severe than a warning banner.
@@ -67,7 +56,7 @@ In addition to the variant, banners can be placed in the top-right corner of its
 <div
     style="width: 300px; height: 100px; background-color: #ba598b; position: relative;"
 >
-    <sp-banner type="warning" corner>
+    <sp-banner corner>
         <div slot="header">This banner is in a corner</div>
         <div slot="content">Neat!</div>
     </sp-banner>

--- a/packages/dropzone/README.md
+++ b/packages/dropzone/README.md
@@ -35,7 +35,7 @@ yarn add @spectrum-web-components/dropzone
         </svg>
     </sp-illustrated-message>
 
-    <div style="color: grey">
+    <div>
         <div>
             <label for="file-input">
                 <sp-link>Select a File</sp-link>
@@ -76,7 +76,7 @@ yarn add @spectrum-web-components/dropzone
         </svg>
     </sp-illustrated-message>
 
-    <div style="color: grey">
+    <div>
         <div>
             <label for="file-input">
                 <sp-link>Select a File</sp-link>

--- a/packages/status-light/src/status-light.ts
+++ b/packages/status-light/src/status-light.ts
@@ -16,6 +16,7 @@ import {
     property,
     CSSResultArray,
     TemplateResult,
+    PropertyValues,
 } from 'lit-element';
 import statusLightStyles from './status-light.css.js';
 
@@ -59,5 +60,16 @@ export class StatusLight extends LitElement {
                 <slot></slot>
             </div>
         `;
+    }
+
+    protected updated(changes: PropertyValues): void {
+        super.updated(changes);
+        if (changes.has('disabled')) {
+            if (this.disabled) {
+                this.setAttribute('aria-disabled', 'true');
+            } else {
+                this.removeAttribute('aria-disabled');
+            }
+        }
     }
 }

--- a/packages/status-light/test/status-light.test.ts
+++ b/packages/status-light/test/status-light.test.ts
@@ -27,4 +27,21 @@ describe('Status Light', () => {
             : (el.querySelector('#root') as HTMLImageElement);
         expect(rootEl).to.not.be.undefined;
     });
+    it('[disabled] manages [aria-disabled]', async () => {
+        const el = await fixture<StatusLight>(
+            html`
+                <sp-status-light variant="positive"></sp-status-light>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.hasAttribute('aria-disabled')).to.be.false;
+
+        el.disabled = true;
+        await elementUpdated(el);
+
+        expect(el.hasAttribute('aria-disabled')).to.be.true;
+        expect(el.getAttribute('aria-disabled')).to.equal('true');
+    });
 });


### PR DESCRIPTION
## Description 
- let `disabeld` manage `aria-disabled` in `<sp-status-light>`
- remove inline styles from Dropzone documentation
- remove `type="warning"` Banners from the Docs as they are not currently accessible. This pattern is "deprecated" and the Spectrum CSS level and we should find a path to do so as well here, separately.

## Motivation and Context
Comes from the deque review of the Docs site.

## Types of changes
- [x] docs update

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
