### PR TITLE
fix: include element is bundle side effects

### DIFF
--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -31,8 +31,8 @@
         "/src/"
     ],
     "sideEffects": [
-        "./lib/index.js",
-        "./src/index.ts"
+        "./elements.js",
+        "./elements.ts"
     ],
     "scripts": {
         "test": "karma start --coverage"


### PR DESCRIPTION
Include elements.ts in the side effects for the bundle so that indirectly included elements would be included in the documentation site build.