### PR TITLE
[rfc|feature branch] Spectrum CSS 3.0.0 releases and '[dir="rtl|ltr"]'

### DIFF
--- a/__snapshots__/Checkbox.md
+++ b/__snapshots__/Checkbox.md
@@ -1,0 +1,16 @@
+# `Checkbox`
+
+#### `loads`
+
+```html
+<sp-checkbox
+  data-js-focus-visible=""
+  dir="ltr"
+  id="checkbox0"
+  tabindex="5"
+>
+  Component
+</sp-checkbox>
+
+```
+

--- a/__snapshots__/Dropdown.md
+++ b/__snapshots__/Dropdown.md
@@ -9,6 +9,7 @@
 >
   <sp-menu-item
     data-js-focus-visible=""
+    dir="ltr"
     role="option"
     tabindex="0"
   >
@@ -16,6 +17,7 @@
   </sp-menu-item>
   <sp-menu-item
     data-js-focus-visible=""
+    dir="ltr"
     role="option"
     tabindex="-1"
     value="option-2"
@@ -24,6 +26,7 @@
   </sp-menu-item>
   <sp-menu-item
     data-js-focus-visible=""
+    dir="ltr"
     role="option"
     tabindex="-1"
   >
@@ -31,6 +34,7 @@
   </sp-menu-item>
   <sp-menu-item
     data-js-focus-visible=""
+    dir="ltr"
     role="option"
     tabindex="-1"
   >
@@ -40,6 +44,7 @@
   </sp-menu-divider>
   <sp-menu-item
     data-js-focus-visible=""
+    dir="ltr"
     role="option"
     tabindex="-1"
   >
@@ -48,6 +53,7 @@
   <sp-menu-item
     aria-disabled="true"
     data-js-focus-visible=""
+    dir="ltr"
     disabled=""
     role="option"
     tabindex="-1"

--- a/__snapshots__/Search.md
+++ b/__snapshots__/Search.md
@@ -17,6 +17,7 @@
   </sp-icon>
   <sp-clear-button
     data-js-focus-visible=""
+    dir="ltr"
     id="button"
     label="Reset"
     tabindex="-1"

--- a/packages/actionbar/package.json
+++ b/packages/actionbar/package.json
@@ -47,9 +47,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/actionbar": "^2.1.5"
+        "@spectrum-css/actionbar": "^3.0.0-beta.3"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "lit-element": "^2.1.0",
         "lit-html": "^1.0.0",
         "tslib": "^2.0.0"

--- a/packages/actionbar/src/Actionbar.ts
+++ b/packages/actionbar/src/Actionbar.ts
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     property,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import actionbarStyles from './actionbar.css.js';
 
@@ -25,7 +25,7 @@ export const actionbarVariants = ['sticky', 'fixed'];
 /**
  * Actionbar component
  */
-export class Actionbar extends LitElement {
+export class Actionbar extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [actionbarStyles];
     }

--- a/packages/actionbar/src/spectrum-actionbar.css
+++ b/packages/actionbar/src/spectrum-actionbar.css
@@ -34,10 +34,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     opacity: 1;
 }
+:host([dir='ltr'][variant='sticky']) {
+    /* [dir=ltr] .spectrum-ActionBar--sticky */
+    left: 0;
+}
+:host([dir='ltr'][variant='sticky']),
+:host([dir='rtl'][variant='sticky']) {
+    /* [dir=ltr] .spectrum-ActionBar--sticky,
+   * [dir=rtl] .spectrum-ActionBar--sticky */
+    right: 0;
+}
+:host([dir='rtl'][variant='sticky']) {
+    /* [dir=rtl] .spectrum-ActionBar--sticky */
+    left: 0;
+}
 :host([variant='sticky']) {
     /* .spectrum-ActionBar--sticky */
-    left: 0;
-    right: 0;
     position: -webkit-sticky;
     position: sticky;
 }

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -1,0 +1,29 @@
+## Description
+
+The `SpectrumElement` base class as created by mixing `SpectrumMixin` onto `LitElement` adopts `dir` values from the `document` at connection time with a fallback to `lrt`. In a TypeScript context, it also enforces the presence of `this.shadowRoot` on extending components.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/base?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/base)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/base?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/base)
+
+```
+yarn add @spectrum-web-components/base
+```
+
+When looking to leverage the `SpectrumElement` base class as a type and/or for extension purposes, do so via:
+
+```
+import { SpectrumElement } from '@spectrum-web-components/base';
+
+export MyElement extends SpectrumElement {}
+
+```
+
+Similarly the `SpectrumMixin` class factory mixin is available via:
+
+```
+import { SpectrumMixin } from '@spectrum-web-components/base';
+
+export MyElement extends SpectrumMixin(HTMLElement) {}
+```

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,0 +1,49 @@
+{
+    "name": "@spectrum-web-components/base",
+    "publishConfig": {
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adobe/spectrum-web-components.git",
+        "directory": "packages/base"
+    },
+    "bugs": {
+        "url": "https://github.com/adobe/spectrum-web-components/issues"
+    },
+    "homepage": "https://adobe.github.io/spectrum-web-components/components/base",
+    "keywords": [
+        "spectrum css",
+        "web components",
+        "lit-element",
+        "lit-html"
+    ],
+    "version": "0.0.1",
+    "description": "",
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        "./src/": "./src/",
+        "./custom-elements.json": "./custom-elements.json",
+        "./package.json": "./package.json"
+    },
+    "files": [
+        "custom-elements.json",
+        "*.d.ts",
+        "*.js",
+        "*.js.map",
+        "/src/"
+    ],
+    "sideEffects": false,
+    "scripts": {
+        "test": "karma start --coverage"
+    },
+    "author": "",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "lit-element": "^2.1.0",
+        "lit-html": "^1.0.0",
+        "tslib": "^2.0.0"
+    }
+}

--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -22,11 +22,6 @@ type Constructor<T = Record<string, unknown>> = {
     prototype: T;
 };
 
-// export interface SlotTextObservingInterface {
-//     slotHasContent: boolean;
-//     manageObservedSlot(): void;
-// }
-
 export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
     constructor: T
 ): T & Constructor<UpdatingElement> {

--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { LitElement } from 'lit-element';
+
+export * from 'lit-element';
+
+import { UpdatingElement } from 'lit-element';
+
+type Constructor<T = Record<string, unknown>> = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new (...args: any[]): T;
+    prototype: T;
+};
+
+// export interface SlotTextObservingInterface {
+//     slotHasContent: boolean;
+//     manageObservedSlot(): void;
+// }
+
+export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
+    constructor: T
+): T & Constructor<UpdatingElement> {
+    return class SlotTextObservingElement extends constructor {
+        public shadowRoot!: ShadowRoot;
+
+        public connectedCallback(): void {
+            if (!this.hasAttribute('dir')) {
+                this.dir = document.dir || 'ltr';
+            }
+            super.connectedCallback();
+        }
+    };
+}
+
+export class SpectrumElement extends SpectrumMixin(LitElement) {}

--- a/packages/base/src/index.ts
+++ b/packages/base/src/index.ts
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export * from './Base.js';

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "./"
+    },
+    "include": ["*.ts", "src/*.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"]
+}

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -47,7 +47,7 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/checkbox": "^2.1.0"
+        "@spectrum-css/checkbox": "^3.0.0-beta.3"
     },
     "dependencies": {
         "@spectrum-web-components/icon": "^0.5.1",

--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -45,18 +45,16 @@ export class Checkbox extends CheckboxBase {
 
     protected render(): TemplateResult {
         return html`
-            <label id="root">
-                ${super.render()}
-                <span id="box">
-                    <sp-icon id="checkmark" size="s" class="checkmark-small">
-                        ${CheckmarkSmallIcon({ hidden: true })}
-                    </sp-icon>
-                    <sp-icon id="partialCheckmark" size="s" class="dash-small">
-                        ${DashSmallIcon({ hidden: true })}
-                    </sp-icon>
-                </span>
-                <span id="label"><slot></slot></span>
-            </label>
+            ${super.render()}
+            <span id="box">
+                <sp-icon id="checkmark" size="s" class="checkmark-small">
+                    ${CheckmarkSmallIcon({ hidden: true })}
+                </sp-icon>
+                <sp-icon id="partialCheckmark" size="s" class="dash-small">
+                    ${DashSmallIcon({ hidden: true })}
+                </sp-icon>
+            </span>
+            <label id="label"><slot></slot></label>
         `;
     }
 

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -10,7 +10,25 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-#root {
+:host([dir='ltr']) {
+    /* [dir=ltr] .spectrum-Checkbox */
+    margin-right: calc(
+        var(
+                --spectrum-checkbox-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * 2
+    );
+}
+:host([dir='rtl']) {
+    /* [dir=rtl] .spectrum-Checkbox */
+    margin-left: calc(
+        var(
+                --spectrum-checkbox-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * 2
+    );
+}
+:host {
     /* .spectrum-Checkbox */
     display: inline-flex;
     align-items: flex-start;
@@ -20,12 +38,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-400)
     );
     max-width: 100%;
-    margin-right: calc(
-        var(
-                --spectrum-checkbox-cursor-hit-x,
-                var(--spectrum-global-dimension-size-100)
-            ) * 2
-    );
     vertical-align: top; /* .spectrum-Checkbox */
     color: var(
         --spectrum-checkbox-text-color,
@@ -34,6 +46,24 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border-color: var(
         --spectrum-checkbox-emphasized-box-border-color,
         var(--spectrum-global-color-gray-600)
+    );
+}
+:host([dir='ltr']) #input {
+    /* [dir=ltr] .spectrum-Checkbox-input */
+    left: calc(
+        var(
+                --spectrum-checkbox-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * -1
+    );
+}
+:host([dir='rtl']) #input {
+    /* [dir=rtl] .spectrum-Checkbox-input */
+    right: calc(
+        var(
+                --spectrum-checkbox-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * -1
     );
 }
 #input {
@@ -47,12 +77,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding: 0;
     position: absolute;
     top: 0;
-    left: calc(
-        var(
-                --spectrum-checkbox-cursor-hit-x,
-                var(--spectrum-global-dimension-size-100)
-            ) * -1
-    );
     width: calc(
         100% +
             var(
@@ -101,8 +125,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-focus-ring-color)
         );
 }
-:host([indeterminate]) #root #box:before,
-:host([indeterminate]) #root #input:checked + #box:before {
+:host([indeterminate]) #box:before,
+:host([indeterminate]) #input:checked + #box:before {
     /* .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
     border-width: calc(
@@ -112,26 +136,38 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) / 2
     );
 }
-:host([indeterminate]) #root #box #checkmark,
-:host([indeterminate]) #root #input:checked + #box #checkmark {
+:host([indeterminate]) #box #checkmark,
+:host([indeterminate]) #input:checked + #box #checkmark {
     /* .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-box .spectrum-Checkbox-checkmark,
    * .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box .spectrum-Checkbox-checkmark */
     display: none;
 }
-:host([indeterminate]) #root #box #partialCheckmark,
-:host([indeterminate]) #root #input:checked + #box #partialCheckmark {
+:host([indeterminate]) #box #partialCheckmark,
+:host([indeterminate]) #input:checked + #box #partialCheckmark {
     /* .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-box .spectrum-Checkbox-partialCheckmark,
    * .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box .spectrum-Checkbox-partialCheckmark */
     display: block;
     transform: scale(1);
     opacity: 1;
 }
-#label {
-    /* .spectrum-Checkbox-label */
+:host([dir='ltr']) #label {
+    /* [dir=ltr] .spectrum-Checkbox-label */
+    text-align: left; /* [dir=ltr] .spectrum-Checkbox-label */
     margin-left: var(
         --spectrum-checkbox-text-gap,
         var(--spectrum-global-dimension-size-125)
     );
+}
+:host([dir='rtl']) #label {
+    /* [dir=rtl] .spectrum-Checkbox-label */
+    text-align: right; /* [dir=rtl] .spectrum-Checkbox-label */
+    margin-right: var(
+        --spectrum-checkbox-text-gap,
+        var(--spectrum-global-dimension-size-125)
+    );
+}
+#label {
+    /* .spectrum-Checkbox-label */
     margin-top: var(--spectrum-global-dimension-size-65);
     font-size: var(
         --spectrum-checkbox-text-size,
@@ -234,6 +270,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     transition: box-shadow var(--spectrum-global-animation-duration-100, 0.13s)
             ease-out,
         margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
+    transform: translate(0);
+}
+:host([dir='ltr']) #checkmark,
+:host([dir='ltr']) #partialCheckmark {
+    /* [dir=ltr] .spectrum-Checkbox-checkmark,
+   * [dir=ltr] .spectrum-Checkbox-partialCheckmark */
+    left: 50%;
+}
+:host([dir='rtl']) #checkmark,
+:host([dir='rtl']) #partialCheckmark {
+    /* [dir=rtl] .spectrum-Checkbox-checkmark,
+   * [dir=rtl] .spectrum-Checkbox-partialCheckmark */
+    right: 50%;
+}
+:host([dir='ltr']) #checkmark,
+:host([dir='ltr']) #partialCheckmark {
+    /* [dir=ltr] .spectrum-Checkbox-checkmark,
+   * [dir=ltr] .spectrum-Checkbox-partialCheckmark */
+    margin-left: calc(var(--spectrum-icon-checkmark-small-width) / -2);
+}
+:host([dir='rtl']) #checkmark,
+:host([dir='rtl']) #partialCheckmark {
+    /* [dir=rtl] .spectrum-Checkbox-checkmark,
+   * [dir=rtl] .spectrum-Checkbox-partialCheckmark */
+    margin-right: calc(var(--spectrum-icon-checkmark-small-width) / -2);
 }
 #checkmark,
 #partialCheckmark {
@@ -241,9 +302,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Checkbox-partialCheckmark */
     position: absolute;
     top: 50%;
-    left: 50%;
     margin-top: calc(var(--spectrum-icon-checkmark-small-height) / -2);
-    margin-left: calc(var(--spectrum-icon-checkmark-small-width) / -2);
     opacity: 0;
     transform: scale(0);
     transition: opacity var(--spectrum-global-animation-duration-100, 0.13s)
@@ -265,7 +324,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 #input:checked + #box:before,
-:host([indeterminate]) #root #box:before {
+:host([indeterminate]) #box:before {
     /* .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before,
    * .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-box:before */
     border-color: var(
@@ -273,8 +332,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-blue-500)
     );
 }
-:host([indeterminate]) #root:hover #box:before,
-#root:hover #input:checked + #box:before {
+:host(:hover[indeterminate]) #box:before,
+:host(:hover) #input:checked + #box:before {
     /* .spectrum-Checkbox:hover.is-indeterminate .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox:hover .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -282,8 +341,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-blue-600)
     );
 }
-:host([indeterminate]) #root:active #box:before,
-#root:active #input:checked + #box:before {
+:host(:active[indeterminate]) #box:before,
+:host(:active) #input:checked + #box:before {
     /* .spectrum-Checkbox:active.is-indeterminate .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox:active .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -291,28 +350,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-blue-700)
     );
 }
-#root:hover #box:before {
+:host(:hover) #box:before {
     /* .spectrum-Checkbox:hover .spectrum-Checkbox-box:before */
     border-color: var(
         --spectrum-checkbox-emphasized-box-border-color-hover,
         var(--spectrum-global-color-gray-700)
     );
 }
-#root:hover #label {
+:host(:hover) #label {
     /* .spectrum-Checkbox:hover .spectrum-Checkbox-label */
     color: var(
         --spectrum-checkbox-emphasized-text-color-hover,
         var(--spectrum-alias-text-color-hover)
     );
 }
-#root:active #box:before {
+:host(:active) #box:before {
     /* .spectrum-Checkbox:active .spectrum-Checkbox-box:before */
     border-color: var(
         --spectrum-checkbox-emphasized-box-border-color-down,
         var(--spectrum-global-color-gray-800)
     );
 }
-#root:active #label {
+:host(:active) #label {
     /* .spectrum-Checkbox:active .spectrum-Checkbox-label */
     color: var(
         --spectrum-checkbox-emphasized-text-color-down,
@@ -349,7 +408,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 #input:checked:focus-visible + #box:before,
-:host([indeterminate]) #root #input:focus-visible + #box:before {
+:host([indeterminate]) #input:focus-visible + #box:before {
     /* .spectrum-Checkbox-input:checked.focus-ring+.spectrum-Checkbox-box:before,
    * .spectrum-Checkbox.is-indeterminate .spectrum-Checkbox-input.focus-ring+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -364,8 +423,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([quiet][indeterminate]) #root #box:before,
-:host([quiet][indeterminate]) #root #input:focus-visible + #box:before,
+:host([quiet][indeterminate]) #box:before,
+:host([quiet][indeterminate]) #input:focus-visible + #box:before,
 :host([quiet]) #input:checked + #box:before {
     /* .spectrum-Checkbox--quiet.is-indeterminate .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox--quiet.is-indeterminate .spectrum-Checkbox-input.focus-ring+.spectrum-Checkbox-box:before,
@@ -375,8 +434,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host([quiet][indeterminate]) #root:hover #box:before,
-:host([quiet]) #root:hover #input:checked + #box:before {
+:host([quiet][indeterminate]:hover) #box:before,
+:host([quiet]:hover) #input:checked + #box:before {
     /* .spectrum-Checkbox--quiet:hover.is-indeterminate .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox--quiet:hover .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -384,8 +443,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([quiet][indeterminate]) #root:active #box:before,
-:host([quiet]) #root:active #input:checked + #box:before {
+:host([quiet][indeterminate]:active) #box:before,
+:host([quiet]:active) #input:checked + #box:before {
     /* .spectrum-Checkbox--quiet:active.is-indeterminate .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox--quiet:active .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -393,8 +452,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([invalid]) #root #box:before,
-:host([invalid]) #root #input:checked + #box:before {
+:host([invalid]) #box:before,
+:host([invalid]) #input:checked + #box:before {
     /* .spectrum-Checkbox.is-invalid .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox.is-invalid .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -402,15 +461,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-500)
     );
 }
-:host([invalid]) #root #label {
+:host([invalid]) #label {
     /* .spectrum-Checkbox.is-invalid .spectrum-Checkbox-label */
     color: var(
         --spectrum-checkbox-text-color-error,
         var(--spectrum-global-color-red-600)
     );
 }
-:host([invalid][indeterminate]) #root #input:focus-visible + #box:before,
-:host([invalid]) #root #input:focus-visible + #box:before {
+:host([invalid][indeterminate]) #input:focus-visible + #box:before,
+:host([invalid]) #input:focus-visible + #box:before {
     /* .spectrum-Checkbox.is-invalid.is-indeterminate .spectrum-Checkbox-input.focus-ring+.spectrum-Checkbox-box:before,
    * .spectrum-Checkbox.is-invalid .spectrum-Checkbox-input.focus-ring+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -418,8 +477,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-600)
     );
 }
-:host([invalid][indeterminate]) #root #input:focus-visible ~ #label,
-:host([invalid]) #root #input:focus-visible ~ #label {
+:host([invalid][indeterminate]) #input:focus-visible ~ #label,
+:host([invalid]) #input:focus-visible ~ #label {
     /* .spectrum-Checkbox.is-invalid.is-indeterminate .spectrum-Checkbox-input.focus-ring~.spectrum-Checkbox-label,
    * .spectrum-Checkbox.is-invalid .spectrum-Checkbox-input.focus-ring~.spectrum-Checkbox-label */
     color: var(
@@ -427,8 +486,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-700)
     );
 }
-:host([invalid]) #root:hover #box:before,
-:host([invalid]) #root:hover #input:checked + #box:before {
+:host(:hover[invalid]) #box:before,
+:host(:hover[invalid]) #input:checked + #box:before {
     /* .spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -436,15 +495,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-600)
     );
 }
-:host([invalid]) #root:hover #label {
+:host(:hover[invalid]) #label {
     /* .spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-label */
     color: var(
         --spectrum-checkbox-text-color-error-hover,
         var(--spectrum-global-color-red-700)
     );
 }
-:host([invalid]) #root:active #box:before,
-:host([invalid]) #root:active #input:checked + #box:before {
+:host(:active[invalid]) #box:before,
+:host(:active[invalid]) #input:checked + #box:before {
     /* .spectrum-Checkbox.is-invalid:active .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox.is-invalid:active .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
     border-color: var(
@@ -452,7 +511,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-700)
     );
 }
-:host([invalid]) #root:active #label {
+:host(:active[invalid]) #label {
     /* .spectrum-Checkbox.is-invalid:active .spectrum-Checkbox-label */
     color: var(
         --spectrum-checkbox-text-color-error-down,

--- a/packages/checkbox/src/spectrum-config.js
+++ b/packages/checkbox/src/spectrum-config.js
@@ -17,7 +17,6 @@ module.exports = {
             name: 'checkbox',
             host: {
                 selector: '.spectrum-Checkbox',
-                shadowSelector: '#root',
             },
             focus: '#input',
             attributes: [

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -74,11 +74,7 @@ describe('Checkbox', () => {
         await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         expect(el).to.not.equal(undefined);
-        expect(el).dom.to.equal(`
-            <sp-checkbox data-js-focus-visible="" id="checkbox0" tabindex="5">
-                Component
-            </sp-checkbox>
-        `);
+        expect(el).dom.to.equalSnapshot();
         const textNode = labelNodeForCheckbox(el);
         const content = (textNode.textContent || '').trim();
         expect(content).to.equal('Component');

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,6 +42,7 @@
     "author": "",
     "license": "Apache-2.0",
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "focus-visible": "^5.0.2",
         "lit-element": "^2.1.0",
         "lit-html": "^1.0.0",

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -10,11 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import {
-    LitElement,
+    SpectrumElement,
     property,
     CSSResultArray,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import focusableStyles from './focusable.css.js';
 
 import { FocusVisiblePolyfillMixin } from './focus-visible.js';
@@ -27,7 +27,7 @@ type DisableableElement = HTMLElement & { disabled?: boolean };
  * This implementation is based heavily on the aybolit delegate-focus-mixin at
  * https://github.com/web-padawan/aybolit/blob/master/packages/core/src/mixins/delegate-focus-mixin.js
  */
-export class Focusable extends FocusVisiblePolyfillMixin(LitElement) {
+export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public static get styles(): CSSResultArray {
         return [focusableStyles];
     }

--- a/scripts/process-spectrum-postcss-plugin.js
+++ b/scripts/process-spectrum-postcss-plugin.js
@@ -378,6 +378,8 @@ class SpectrumProcessor {
         const result = [];
 
         const startsWithHost = re`^${this.component.hostSelector}`;
+        const hasHost = re`${this.component.hostSelector}(?![-])`;
+        const startsWithDir = new RegExp(/\[dir\=/);
         const selectorTransform = this.selectorTransform;
         let skipAll = false;
 
@@ -391,6 +393,23 @@ class SpectrumProcessor {
         }
         if (!skipAll) {
             for (let selector of rule.selectors) {
+                if (startsWithDir.test(selector)) {
+                    if (!hasHost.test(selector)) {
+                        selector = `${this.component.hostSelector}${selector}`;
+                    } else if (selector.search(/\[dir\=ltr\]/) > -1) {
+                        selector = selector.replace('[dir=ltr] ', '');
+                        selector = selector.replace(
+                            hasHost,
+                            `${this.component.hostSelector}[dir=ltr]`
+                        );
+                    } else if (selector.search(/\[dir\=rtl\]/) > -1) {
+                        selector = selector.replace('[dir=rtl] ', '');
+                        selector = selector.replace(
+                            hasHost,
+                            `${this.component.hostSelector}[dir=rtl]`
+                        );
+                    }
+                }
                 if (!startsWithHost.test(selector)) {
                     // This selector does not match the component we are
                     // working on. Check to see if it matches an id

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,10 +2442,10 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@spectrum-css/actionbar@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-2.1.5.tgz#20cb0e6346e5d11f8002c9be9185057df7ecf13c"
-  integrity sha512-1De319CZMR9PYvN2JiUZQrxds89q8uj1jpTnu57fbnjF6u3fAx7O+PjF/0FArfTai/+K7DSDjmW/TK08GPkKkA==
+"@spectrum-css/actionbar@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-3.0.0-beta.3.tgz#6438b1097a56b53fdaa71e2623053b1eac8549f2"
+  integrity sha512-I8temHdEfT1pRgk2I3hx5Db83E/WEx+qfQgAqdwvjP9OpWfgz2SU8/rIcmuFBv19hQyQF1ot+Q4l4EjftE824A==
 
 "@spectrum-css/asset@^3.0.0-beta.2":
   version "3.0.0-beta.2"
@@ -2482,10 +2482,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-2.0.6.tgz#e6b69978e8551875d1dab037faba74011a365736"
   integrity sha512-5dnQYNpePLSnxK2gtljXhOom8iCkV9meGdgHCKBZk6bRVhKe2sjX5ljwd0o2BdZYjp9CdrEAzkPTQTvBax1G2Q==
 
-"@spectrum-css/checkbox@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-2.1.0.tgz#a981a01ff618993e5bfa71d367cdc36d4f11e0df"
-  integrity sha512-par9qG6+3hxNrPzg1mx46OZHsViSKlOKJIGoa8L2kTS5XLVWCTl7XH+QE55X/QPcUrmItX72terrJr0FZu9pjw==
+"@spectrum-css/checkbox@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-3.0.0-beta.3.tgz#7789ba8be60b1edb3db99e8e5c94e7122366ab9c"
+  integrity sha512-z+BZzGr2/l4g3uZ/Yn/u7gSfKXSLi3MMTKOfSxDBIGbL+3GBVXCMw5iBSrouepAomWCH82nRYl1mqSKWod6pLQ==
 
 "@spectrum-css/circleloader@^2.0.5":
   version "2.0.5"


### PR DESCRIPTION
## Description
Spectrum CSS is getting close to a v3.0.0 release of all of its components and this branch should be able to serve as a base for testing out individual package upgrades.
- add a "base" package that vends `SpectrumMixin` and `SpectrumElement`, very open to alternate naming conventions if you have them.
  - adds `public shadowRoot!: ShadowRoot;` to the element as we currently use shadow DOM in all of our elements and it's a pain to test for it in TS _all_ the time
  - add a `connectedCallback()` that queries document direction and then applies it to the element tag so that elements extending from his can have an `[dir="rtl|ltr"]` selector to leverage in their styles
- extends the Spectrum CSS processing to include `[dir="rtl|ltr"]` selectors in the output by appending them to the host selector (by default they are included as "context" selectors the director corollary of which in shadow DOM are not available cross-browser)
- exemplifies `sp-actionbar` as a very simple upgrade (just the version bump)
- exemplifies `sp-checkbox` as a more complex upgrade (leverages mixins and requires DOM updates, etc.)

I'm gonna work with the Spectrum CSS team and catch up on how they're documenting the lack of support for `dir="auto"` in this update, as we'll need to include matching instructions in our docs so that users don't fall into any traps there. I'll also confirm whether the team is targeting any other specifically breaking changes (e.g. t-shirt sizes) before moving these releases to stable.

## Related Issue
related to #477 
related to #513 
related to #543 
related to #669 
related to #739

## Motivation and Context
Need to keep up with out source material

## How Has This Been Tested?
- snapshots for the effected elements have been updated
- hopefully visual regressions "just work" 🤞 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
