### PR TITLE
Move `sp-textfiield` and `sp-search` to Spectrum CSS ^3.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-b5462e0cb61beacbd0b9dc751bd0284687baa4d4
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-c26ca5ae887c2c3c4dce6fff24335b878b31ca45
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/__snapshots__/Search.md
+++ b/__snapshots__/Search.md
@@ -4,17 +4,16 @@
 
 ```html
 <form id="form">
+  <sp-icon
+    class="icon icon-workflow magnifier"
+    size="s"
+  >
+  </sp-icon>
   <input
     aria-label="Search"
     id="input"
     placeholder="Search"
   >
-  <sp-icon
-    class="icon magnifier"
-    id="icon"
-    size="s"
-  >
-  </sp-icon>
   <sp-clear-button
     data-js-focus-visible=""
     dir="ltr"

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -47,7 +47,7 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/search": "^2.0.6"
+        "@spectrum-css/search": "^3.0.0-beta.4"
     },
     "dependencies": {
         "@spectrum-web-components/button": "^0.8.3",

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -104,10 +104,10 @@ export class Search extends Textfield {
                 @submit=${this.handleSubmit}
                 @keydown=${this.handleKeydown}
             >
-                ${super.render()}
-                <sp-icon id="icon" class="icon magnifier" size="s">
+                <sp-icon class="icon magnifier icon-workflow" size="s">
                     ${MagnifierIcon({ hidden: true })}
                 </sp-icon>
+                ${super.render()}
                 ${this.value
                     ? html`
                           <sp-clear-button

--- a/packages/search/src/spectrum-config.js
+++ b/packages/search/src/spectrum-config.js
@@ -32,21 +32,17 @@ module.exports = {
                     name: 'input',
                 },
                 {
-                    selector: '.spectrum-Search-icon',
-                    name: 'icon',
-                },
-                {
-                    selector: '.spectrum-ClearButton',
-                    name: 'button',
-                },
-                {
-                    selector: '.spectrum-Search-clear',
+                    selector: '.spectrum-Search-clearButton',
                     name: 'button',
                 },
             ],
             classes: [
                 {
                     selector: '.spectrum-Icon',
+                    name: 'icon',
+                },
+                {
+                    selector: '.spectrum-Search-icon',
                     name: 'icon',
                 },
             ],

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -15,20 +15,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: inline-block;
     position: relative;
 }
-#button {
-    /* .spectrum-Search .spectrum-ClearButton */
-    position: absolute;
+:host([dir='ltr']) #button {
+    /* [dir=ltr] .spectrum-Search-clearButton */
     right: 0;
+}
+:host([dir='rtl']) #button {
+    /* [dir=rtl] .spectrum-Search-clearButton */
+    left: 0;
+}
+#button {
+    /* .spectrum-Search-clearButton */
+    position: absolute;
     top: 0;
 }
 #input {
     /* .spectrum-Search-input */
-    display: block;
     -webkit-appearance: none;
     outline-offset: -2px;
-    padding-left: var(--spectrum-search-padding-left, 36px);
-    text-indent: 0;
-    padding-right: var(--spectrum-search-padding-right, 28px);
 }
 #input::-webkit-search-cancel-button,
 #input::-webkit-search-decoration {
@@ -36,68 +39,50 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Search-input::-webkit-search-decoration */
     -webkit-appearance: none;
 }
-:host([quiet]) #input {
-    /* .spectrum-Search-input.spectrum-Textfield--quiet */
-    padding-left: var(--spectrum-search-quiet-padding-left, 24px);
-    padding-right: var(--spectrum-search-quiet-padding-right, 20px);
-}
-:host([quiet]) #input ~ #icon {
-    /* .spectrum-Search-input.spectrum-Textfield--quiet~.spectrum-Search-icon */
-    left: 0;
-}
-:host([quiet]) #input ~ #button {
-    /* .spectrum-Search-input.spectrum-Textfield--quiet~.spectrum-Search-clear */
-    right: -8px;
-}
-:host([quiet]) #input ~ .spectrum-Search-rightIcon {
-    /* .spectrum-Search-input.spectrum-Textfield--quiet~.spectrum-Search-rightIcon */
-    right: 0;
-}
-#icon {
-    /* .spectrum-Search-icon */
-    display: block;
-    position: absolute;
-    left: 12px;
-    top: calc(
-        var(
-                --spectrum-textfield-height,
-                var(--spectrum-alias-single-line-height)
-            ) / 2 -
+.spectrum-Search--quiet #button {
+    /* .spectrum-Search--quiet .spectrum-Search-clearButton */
+    transform: translateX(
+        calc(
             var(
-                --spectrum-icon-magnifier-width,
-                var(--spectrum-global-dimension-size-200)
-            ) / 2
+                    --spectrum-fieldbutton-min-width,
+                    var(--spectrum-global-dimension-size-400)
+                ) / 2 -
+                var(
+                    --spectrum-icon-cross-small-width,
+                    var(--spectrum-global-dimension-size-100)
+                ) / 2
+        )
     );
-    transition: color var(--spectrum-global-animation-duration-100, 0.13s)
-        ease-in-out;
-    pointer-events: none;
+}
+.icon {
+    /* .spectrum-Search-icon */
     color: var(
         --spectrum-textfield-icon-color,
         var(--spectrum-alias-icon-color)
     );
 }
-#input:hover ~ #icon {
+#input:hover ~ .icon {
     /* .spectrum-Search-input:hover~.spectrum-Search-icon */
     color: var(
         --spectrum-search-icon-color-hover,
         var(--spectrum-global-color-gray-900)
     );
 }
-#input:active ~ #icon {
+#input:active ~ .icon {
     /* .spectrum-Search-input:active~.spectrum-Search-icon */
     color: var(
         --spectrum-search-icon-color-down,
         var(--spectrum-alias-icon-color-down)
     );
 }
-#input:focus-visible ~ #icon {
+#input:focus-visible ~ .icon {
     /* .spectrum-Search-input.focus-ring~.spectrum-Search-icon */
     color: var(
         --spectrum-search-icon-color-key-focus,
         var(--spectrum-global-color-gray-900)
     );
 }
-#input:disabled ~ #icon {
+#input:disabled ~ .icon {
     /* .spectrum-Search-input:disabled~.spectrum-Search-icon */
     color: var(
         --spectrum-textfield-text-color-disabled,

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -47,9 +47,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/textfield": "^2.0.5"
+        "@spectrum-css/textfield": "^3.0.0-beta.3"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/icon": "^0.5.1",
         "@spectrum-web-components/icons-ui": "^0.2.1",
         "@spectrum-web-components/shared": "^0.6.0",

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -17,7 +17,7 @@ import {
     query,
     TemplateResult,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
 import '@spectrum-web-components/icon/sp-icon.js';
@@ -123,13 +123,13 @@ export class Textfield extends Focusable {
     protected renderStateIcons(): TemplateResult | typeof nothing {
         if (this.invalid) {
             return html`
-                <sp-icon id="invalid" class="alert-small">
+                <sp-icon id="invalid" class="icon alert-small">
                     ${AlertSmallIcon({ hidden: true })}
                 </sp-icon>
             `;
         } else if (this.valid) {
             return html`
-                <sp-icon id="valid" class="checkmark-small">
+                <sp-icon id="valid" class="icon checkmark-small">
                     ${CheckmarkSmallIcon({ hidden: true })}
                 </sp-icon>
             `;
@@ -137,39 +137,35 @@ export class Textfield extends Focusable {
         return nothing;
     }
 
-    protected render(): TemplateResult {
-        if (this.multiline) {
-            return html`
-                ${this.grows
-                    ? html`
-                          <div id="sizer">${this.value}</div>
-                      `
-                    : nothing}
-                <!-- @ts-ignore -->
-                <textarea
-                    aria-label=${this.label || this.placeholder}
-                    id="input"
-                    maxlength=${ifDefined(this.maxlength)}
-                    minlength=${ifDefined(this.minlength)}
-                    pattern=${ifDefined(this.pattern)}
-                    placeholder=${this.placeholder}
-                    .value=${this.value}
-                    @change=${this.onChange}
-                    @input=${this.onInput}
-                    ?disabled=${this.disabled}
-                    ?required=${this.required}
-                    autocomplete=${ifDefined(this.autocomplete)}
-                ></textarea>
-                ${this.renderStateIcons()}
-            `;
-        }
+    private get renderMultiline(): TemplateResult {
+        return html`
+            ${this.grows
+                ? html`
+                      <div id="sizer">${this.value}</div>
+                  `
+                : nothing}
+            <!-- @ts-ignore -->
+            <textarea
+                aria-label=${this.label || this.placeholder}
+                id="input"
+                pattern=${ifDefined(this.pattern)}
+                placeholder=${this.placeholder}
+                .value=${this.value}
+                @change=${this.onChange}
+                @input=${this.onInput}
+                ?disabled=${this.disabled}
+                ?required=${this.required}
+                autocomplete=${ifDefined(this.autocomplete)}
+            ></textarea>
+        `;
+    }
+
+    private get renderInput(): TemplateResult {
         return html`
             <!-- @ts-ignore -->
             <input
                 aria-label=${this.label || this.placeholder}
                 id="input"
-                maxlength=${ifDefined(this.maxlength)}
-                minlength=${ifDefined(this.minlength)}
                 pattern=${ifDefined(this.pattern)}
                 placeholder=${this.placeholder}
                 .value=${this.value}
@@ -179,7 +175,13 @@ export class Textfield extends Focusable {
                 ?required=${this.required}
                 autocomplete=${ifDefined(this.autocomplete)}
             />
+        `;
+    }
+
+    protected render(): TemplateResult {
+        return html`
             ${this.renderStateIcons()}
+            ${this.multiline ? this.renderMultiline : this.renderInput}
         `;
     }
 

--- a/packages/textfield/src/spectrum-config.js
+++ b/packages/textfield/src/spectrum-config.js
@@ -17,8 +17,23 @@ module.exports = {
             name: 'textfield',
             host: {
                 selector: '.spectrum-Textfield',
-                shadowSelector: '#input',
             },
+            ids: [
+                {
+                    selector: '.spectrum-Textfield-input',
+                    name: 'input',
+                },
+            ],
+            classes: [
+                {
+                    selector: '.spectrum-Textfield-validationIcon',
+                    name: 'icon',
+                },
+                {
+                    selector: '.spectrum-Textfield-icon',
+                    name: 'icon-workflow',
+                },
+            ],
             attributes: [
                 {
                     type: 'boolean',
@@ -42,8 +57,13 @@ module.exports = {
                 },
                 {
                     type: 'boolean',
-                    selector: 'spectrum-Textfield--quiet',
+                    selector: '.spectrum-Textfield--quiet',
                     name: 'quiet',
+                },
+                {
+                    type: 'boolean',
+                    selector: '.is-disabled',
+                    name: 'disabled',
                 },
             ],
         },

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -10,8 +10,32 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-#input {
+:host {
     /* .spectrum-Textfield */
+    display: inline-flex;
+    position: relative;
+    min-width: var(
+        --spectrum-textfield-min-width,
+        var(--spectrum-global-dimension-size-600)
+    );
+    width: var(
+        --spectrum-alias-single-line-width,
+        var(--spectrum-global-dimension-size-2400)
+    );
+}
+:host([quiet][multiline]) #input {
+    /* .spectrum-Textfield.spectrum-Textfield--quiet.spectrum-Textfield--multiline .spectrum-Textfield-input */
+    height: var(
+        --spectrum-textfield-height,
+        var(--spectrum-alias-single-line-height)
+    );
+    min-height: var(
+        --spectrum-textfield-height,
+        var(--spectrum-alias-single-line-height)
+    );
+}
+#input {
+    /* .spectrum-Textfield-input */
     box-sizing: border-box;
     border: var(
             --spectrum-textfield-border-size,
@@ -22,58 +46,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-textfield-border-radius,
         var(--spectrum-alias-border-radius-regular)
     );
-    padding: calc(
-            var(
-                    --spectrum-textfield-padding-top,
-                    var(--spectrum-global-dimension-size-75)
-                ) -
-                var(
-                    --spectrum-textfield-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
+    padding: 3px
+        var(
+            --spectrum-textfield-padding-x,
+            var(--spectrum-global-dimension-size-150)
         )
+        5px
         calc(
             var(
                     --spectrum-textfield-padding-x,
                     var(--spectrum-global-dimension-size-150)
-                ) -
-                var(
-                    --spectrum-textfield-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
-        )
-        calc(
-            var(
-                    --spectrum-textfield-padding-bottom,
-                    var(--spectrum-global-dimension-size-115)
-                ) -
-                var(
-                    --spectrum-textfield-border-size,
-                    var(--spectrum-alias-border-size-thin)
                 ) - 1px
-        )
-        calc(
-            var(
-                    --spectrum-textfield-padding-x,
-                    var(--spectrum-global-dimension-size-150)
-                ) -
-                var(
-                    --spectrum-textfield-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
         );
     text-indent: 0;
-    min-width: var(
-        --spectrum-textfield-min-width,
-        var(--spectrum-global-dimension-size-600)
-    );
+    width: 100%;
     height: var(
         --spectrum-textfield-height,
         var(--spectrum-alias-single-line-height)
-    );
-    width: var(
-        --spectrum-alias-single-line-width,
-        var(--spectrum-global-dimension-size-2400)
     );
     vertical-align: top;
     margin: 0;
@@ -97,14 +86,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ease-in-out;
     outline: none;
     -webkit-appearance: none;
-    -moz-appearance: textfield; /* .spectrum-Textfield */
+    -moz-appearance: textfield; /* .spectrum-Textfield-input */
     background-color: var(
         --spectrum-textfield-background-color,
         var(--spectrum-global-color-gray-50)
     );
     border-color: var(
         --spectrum-textfield-border-color,
-        var(--spectrum-global-color-gray-300)
+        var(--spectrum-alias-border-color)
     );
     color: var(
         --spectrum-textfield-text-color,
@@ -112,7 +101,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 #input::placeholder {
-    /* .spectrum-Textfield::placeholder */
+    /* .spectrum-Textfield-input::placeholder */
     font-weight: var(
         --spectrum-textfield-placeholder-text-font-weight,
         var(--spectrum-global-font-weight-regular)
@@ -123,7 +112,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     transition: color var(--spectrum-global-animation-duration-100, 0.13s)
         ease-in-out;
-    opacity: 1; /* .spectrum-Textfield::placeholder */
+    opacity: 1; /* .spectrum-Textfield-input::placeholder */
     color: var(
         --spectrum-textfield-placeholder-text-color,
         var(--spectrum-alias-placeholder-text-color)
@@ -132,103 +121,78 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #input:lang(ja)::placeholder,
 #input:lang(ko)::placeholder,
 #input:lang(zh)::placeholder {
-    /* .spectrum-Textfield:lang(ja)::placeholder,
-   * .spectrum-Textfield:lang(ko)::placeholder,
-   * .spectrum-Textfield:lang(zh)::placeholder */
+    /* .spectrum-Textfield-input:lang(ja)::placeholder,
+   * .spectrum-Textfield-input:lang(ko)::placeholder,
+   * .spectrum-Textfield-input:lang(zh)::placeholder */
     font-style: normal;
 }
 #input:hover::placeholder {
-    /* .spectrum-Textfield:hover::placeholder */
+    /* .spectrum-Textfield-input:hover::placeholder */
     font-weight: var(
         --spectrum-textfield-placeholder-text-font-weight,
         var(--spectrum-global-font-weight-regular)
-    ); /* .spectrum-Textfield:hover::placeholder */
-    color: var(
-        --spectrum-textfield-placeholder-text-color-hover,
-        var(--spectrum-alias-placeholder-text-color-hover)
     );
 }
 #input:disabled {
-    /* .spectrum-Textfield:disabled */
+    /* .spectrum-Textfield-input:disabled */
     resize: none;
     opacity: 1;
 }
 #input:disabled::placeholder {
-    /* .spectrum-Textfield:disabled::placeholder */
+    /* .spectrum-Textfield-input:disabled::placeholder */
     font-weight: var(
         --spectrum-textfield-placeholder-text-font-weight,
         var(--spectrum-global-font-weight-regular)
     );
 }
 #input::-ms-clear {
-    /* .spectrum-Textfield::-ms-clear */
+    /* .spectrum-Textfield-input::-ms-clear */
     width: 0;
     height: 0;
 }
 #input::-webkit-inner-spin-button,
 #input::-webkit-outer-spin-button {
-    /* .spectrum-Textfield::-webkit-inner-spin-button,
-   * .spectrum-Textfield::-webkit-outer-spin-button */
+    /* .spectrum-Textfield-input::-webkit-inner-spin-button,
+   * .spectrum-Textfield-input::-webkit-outer-spin-button */
     -webkit-appearance: none;
     margin: 0;
 }
 #input:-moz-ui-invalid {
-    /* .spectrum-Textfield:-moz-ui-invalid */
+    /* .spectrum-Textfield-input:-moz-ui-invalid */
     box-shadow: none;
 }
-:host([invalid]) #input,
-:host([valid]) #input,
-#input:invalid {
-    /* .spectrum-Textfield.is-invalid,
-   * .spectrum-Textfield.is-valid,
-   * .spectrum-Textfield:invalid */
-    background-repeat: no-repeat;
-}
-:host([invalid]) #input,
-#input:invalid {
-    /* .spectrum-Textfield.is-invalid,
-   * .spectrum-Textfield:invalid */
-    background-size: var(
-            --spectrum-icon-alert-medium-width,
-            var(--spectrum-global-dimension-size-225)
-        )
-        var(
-            --spectrum-icon-alert-medium-width,
-            var(--spectrum-global-dimension-size-225)
-        );
-    background-position: calc(
-            100% -
-                var(
-                    --spectrum-textfield-padding-x,
-                    var(--spectrum-global-dimension-size-150)
-                ) +
-                var(
-                    --spectrum-textfield-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
-        )
-        calc(
-            var(
-                    --spectrum-textfield-height,
-                    var(--spectrum-alias-single-line-height)
-                ) / 2 -
-                var(
-                    --spectrum-icon-alert-medium-height,
-                    var(--spectrum-global-dimension-size-225)
-                ) / 2 -
-                var(
-                    --spectrum-textfield-quiet-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
-        );
+:host([dir='ltr'][valid]) #input {
+    /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-input */
     padding-right: calc(
         var(
                 --spectrum-textfield-padding-x,
                 var(--spectrum-global-dimension-size-150)
-            ) -
+            ) + var(--spectrum-icon-checkmark-medium-width) +
             var(
-                --spectrum-textfield-border-size,
-                var(--spectrum-alias-border-size-thin)
+                --spectrum-textfield-icon-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl'][valid]) #input {
+    /* [dir=rtl] .spectrum-Textfield.is-valid .spectrum-Textfield-input */
+    padding-left: calc(
+        var(
+                --spectrum-textfield-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            ) + var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-textfield-icon-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='ltr'][invalid]) #input {
+    /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-input */
+    padding-right: calc(
+        var(
+                --spectrum-textfield-padding-x,
+                var(--spectrum-global-dimension-size-150)
             ) +
             var(
                 --spectrum-icon-alert-medium-width,
@@ -240,122 +204,321 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
-:host([valid]) #input {
-    /* .spectrum-Textfield.is-valid */
-    background-size: var(--spectrum-icon-checkmark-medium-width)
-        var(--spectrum-icon-checkmark-medium-width);
-    background-position: calc(
-            100% -
-                var(
-                    --spectrum-textfield-padding-x,
-                    var(--spectrum-global-dimension-size-150)
-                ) +
-                var(
-                    --spectrum-textfield-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
-        )
-        calc(
-            var(
-                    --spectrum-textfield-height,
-                    var(--spectrum-alias-single-line-height)
-                ) / 2 - var(--spectrum-icon-checkmark-medium-height) / 2
-        );
-    padding-right: calc(
+:host([dir='rtl'][invalid]) #input {
+    /* [dir=rtl] .spectrum-Textfield.is-invalid .spectrum-Textfield-input */
+    padding-left: calc(
         var(
                 --spectrum-textfield-padding-x,
                 var(--spectrum-global-dimension-size-150)
-            ) -
+            ) +
             var(
-                --spectrum-textfield-border-size,
-                var(--spectrum-alias-border-size-thin)
-            ) + var(--spectrum-icon-checkmark-medium-width) +
+                --spectrum-icon-alert-medium-width,
+                var(--spectrum-global-dimension-size-225)
+            ) +
             var(
                 --spectrum-textfield-icon-margin-left,
                 var(--spectrum-global-dimension-size-150)
             )
-    ); /* .spectrum-Textfield.is-valid */
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='12' viewBox='0 0 12 12' width='12'%3E%3Cpath style='fill:var%28--spectrum-alert-success-icon-color%29' d='M4.5 10a1.023 1.023 0 0 1-.8-.384l-2.488-3a1 1 0 0 1 1.577-1.233L4.5 7.376l4.712-5.991a1 1 0 1 1 1.576 1.23l-5.511 7A.977.977 0 0 1 4.5 10z'/%3E%3C/svg%3E");
+    );
 }
 :host([multiline]) #input {
-    /* .spectrum-Textfield--multiline */
+    /* .spectrum-Textfield--multiline .spectrum-Textfield-input */
     height: auto;
     min-height: var(--spectrum-global-dimension-size-700);
-    padding: calc(
-            var(
-                    --spectrum-textarea-padding-top,
-                    var(--spectrum-global-dimension-size-75)
-                ) -
-                var(
-                    --spectrum-textarea-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
+    padding: 3px
+        var(
+            --spectrum-textfield-padding-x,
+            var(--spectrum-global-dimension-size-150)
         )
+        5px
         calc(
             var(
-                    --spectrum-textarea-padding-x,
+                    --spectrum-textfield-padding-x,
                     var(--spectrum-global-dimension-size-150)
-                ) -
-                var(
-                    --spectrum-textarea-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
-        )
-        calc(
-            var(
-                    --spectrum-textarea-padding-bottom,
-                    var(--spectrum-global-dimension-size-115)
-                ) -
-                var(
-                    --spectrum-textarea-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
-        )
-        calc(
-            var(
-                    --spectrum-textarea-padding-x,
-                    var(--spectrum-global-dimension-size-150)
-                ) -
-                var(
-                    --spectrum-textarea-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
+                ) - 1px
         );
     overflow: auto;
 }
+:host([dir='ltr'][quiet]) #input {
+    /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-input */
+    padding-left: var(--spectrum-textfield-quiet-padding-x, 0);
+}
+:host([dir='ltr'][quiet]) #input,
+:host([dir='rtl'][quiet]) #input {
+    /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-input,
+   * [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-input */
+    padding-right: var(--spectrum-textfield-quiet-padding-x, 0);
+}
+:host([dir='rtl'][quiet]) #input {
+    /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-input */
+    padding-left: var(--spectrum-textfield-quiet-padding-x, 0);
+}
 :host([quiet]) #input {
-    /* .spectrum-Textfield--quiet */
-    border-radius: var(--spectrum-textfield-quiet-border-radius, 0);
-    border-left-width: 0;
+    /* .spectrum-Textfield--quiet .spectrum-Textfield-input */
+    border-radius: 0;
+    border-top-width: 0;
     border-bottom-width: var(
         --spectrum-textfield-quiet-border-size,
         var(--spectrum-alias-border-size-thin)
     );
+    border-left-width: 0;
     border-right-width: 0;
-    border-top-width: 0;
-    padding-left: var(--spectrum-textfield-quiet-padding-x, 0);
-    padding-right: var(--spectrum-textfield-quiet-padding-x, 0);
     resize: none;
-    overflow-y: hidden; /* .spectrum-Textfield--quiet */
+    overflow-y: hidden; /* .spectrum-Textfield--quiet .spectrum-Textfield-input */
     background-color: var(
         --spectrum-textfield-quiet-background-color,
         var(--spectrum-alias-background-color-transparent)
     );
     border-color: var(
         --spectrum-textfield-quiet-border-color,
-        var(--spectrum-global-color-gray-300)
+        var(--spectrum-alias-border-color)
     );
 }
-:host([quiet][invalid]) #input,
-:host([quiet][valid]) #input,
-:host([quiet]) #input:invalid {
-    /* .spectrum-Textfield--quiet.is-invalid,
-   * .spectrum-Textfield--quiet.is-valid,
-   * .spectrum-Textfield--quiet:invalid */
-    background-position: 100% 50%;
+:host([dir='ltr'][invalid][quiet]) #input {
+    /* [dir=ltr] .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+    padding-right: calc(
+        var(
+                --spectrum-icon-alert-medium-width,
+                var(--spectrum-global-dimension-size-225)
+            ) +
+            var(
+                --spectrum-textfield-quiet-icon-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
 }
-:host([quiet][multiline]) #input {
-    /* .spectrum-Textfield--quiet.spectrum-Textfield--multiline */
+:host([dir='rtl'][invalid][quiet]) #input {
+    /* [dir=rtl] .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+    padding-left: calc(
+        var(
+                --spectrum-icon-alert-medium-width,
+                var(--spectrum-global-dimension-size-225)
+            ) +
+            var(
+                --spectrum-textfield-quiet-icon-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='ltr'][valid][quiet]) #input {
+    /* [dir=ltr] .is-valid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+    padding-right: calc(
+        var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-textfield-quiet-icon-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl'][valid][quiet]) #input {
+    /* [dir=rtl] .is-valid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+    padding-left: calc(
+        var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-textfield-quiet-icon-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+.icon {
+    /* .spectrum-Textfield-validationIcon */
+    position: absolute;
+    pointer-events: all;
+}
+:host([dir='ltr'][quiet]) .icon {
+    /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-validationIcon */
+    padding-right: 0;
+}
+:host([dir='rtl'][quiet]) .icon {
+    /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-validationIcon */
+    padding-left: 0;
+}
+:host([dir='ltr'][invalid]) .icon {
+    /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    right: calc(
+        var(--spectrum-textfield-icon-frame) / 2 -
+            var(
+                --spectrum-icon-alert-medium-width,
+                var(--spectrum-global-dimension-size-225)
+            ) / 2
+    ); /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    padding-right: calc(
+        var(
+                --spectrum-textfield-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            ) / 2 - var(--spectrum-global-dimension-size-10)
+    );
+}
+:host([dir='rtl'][invalid]) .icon {
+    /* [dir=rtl] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    left: calc(
+        var(--spectrum-textfield-icon-frame) / 2 -
+            var(
+                --spectrum-icon-alert-medium-width,
+                var(--spectrum-global-dimension-size-225)
+            ) / 2
+    ); /* [dir=rtl] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    padding-left: calc(
+        var(
+                --spectrum-textfield-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            ) / 2 - var(--spectrum-global-dimension-size-10)
+    );
+}
+:host([invalid]) .icon {
+    /* .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    width: var(
+        --spectrum-icon-alert-medium-width,
+        var(--spectrum-global-dimension-size-225)
+    );
+    height: var(
+        --spectrum-icon-alert-medium-height,
+        var(--spectrum-global-dimension-size-225)
+    );
+    bottom: calc(
+        var(--spectrum-textfield-icon-frame) / 2 -
+            var(
+                --spectrum-icon-alert-medium-height,
+                var(--spectrum-global-dimension-size-225)
+            ) / 2
+    ); /* .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    color: var(
+        --spectrum-textfield-validation-icon-color-error,
+        var(--spectrum-semantic-negative-color-icon)
+    );
+}
+:host([quiet][invalid]) .spectrum-Textfield[dir='ltr'] .icon {
+    /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    right: 0;
+}
+:host([quiet][invalid]) .spectrum-Textfield[dir='rtl'] .icon {
+    /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    left: 0;
+}
+:host([dir='ltr'][valid]) .icon {
+    /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    right: var(--spectrum-global-dimension-size-150);
+}
+:host([dir='rtl'][valid]) .icon {
+    /* [dir=rtl] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    left: var(--spectrum-global-dimension-size-150);
+}
+:host([valid]) .icon {
+    /* .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    width: var(--spectrum-icon-checkmark-medium-width);
+    height: var(--spectrum-icon-checkmark-medium-height);
+    bottom: calc(
+        var(--spectrum-textfield-icon-frame) / 2 -
+            var(--spectrum-icon-checkmark-medium-height) / 2
+    ); /* .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    color: var(
+        --spectrum-semantic-positive-color-icon,
+        var(--spectrum-global-color-green-600)
+    );
+}
+:host([quiet][valid]) .spectrum-Textfield[dir='ltr'] .icon {
+    /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    right: 0;
+}
+:host([quiet][valid]) .spectrum-Textfield[dir='rtl'] .icon {
+    /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    left: 0;
+}
+:host([dir='ltr']) .icon-workflow {
+    /* [dir=ltr] .spectrum-Textfield-icon */
+    left: var(
+        --spectrum-textfield-icon-margin-left,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) .icon-workflow {
+    /* [dir=rtl] .spectrum-Textfield-icon */
+    right: var(
+        --spectrum-textfield-icon-margin-left,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+.icon-workflow {
+    /* .spectrum-Textfield-icon */
+    display: block;
+    position: absolute;
+    height: var(
+        --spectrum-alias-workflow-icon-size,
+        var(--spectrum-global-dimension-size-225)
+    );
+    width: var(
+        --spectrum-alias-workflow-icon-size,
+        var(--spectrum-global-dimension-size-225)
+    );
+    top: calc(
+        var(
+                --spectrum-textfield-height,
+                var(--spectrum-alias-single-line-height)
+            ) / 2 -
+            var(
+                --spectrum-alias-workflow-icon-size,
+                var(--spectrum-global-dimension-size-225)
+            ) / 2
+    ); /* .spectrum-Textfield-icon */
+    color: var(
+        --spectrum-textfield-icon-color,
+        var(--spectrum-alias-icon-color)
+    );
+}
+:host([dir='ltr'][quiet]) .icon-workflow {
+    /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-icon */
+    left: 0;
+}
+:host([dir='rtl'][quiet]) .icon-workflow {
+    /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-icon */
+    right: 0;
+}
+:host([dir='ltr'][quiet]) .icon-workflow ~ #input {
+    /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-icon~.spectrum-Textfield-input */
+    padding-left: calc(
+        var(
+                --spectrum-alias-workflow-icon-size,
+                var(--spectrum-global-dimension-size-225)
+            ) + var(--spectrum-global-dimension-size-75)
+    );
+}
+:host([dir='rtl'][quiet]) .icon-workflow ~ #input {
+    /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-icon~.spectrum-Textfield-input */
+    padding-right: calc(
+        var(
+                --spectrum-alias-workflow-icon-size,
+                var(--spectrum-global-dimension-size-225)
+            ) + var(--spectrum-global-dimension-size-75)
+    );
+}
+:host([dir='ltr']) .icon-workflow + #input {
+    /* [dir=ltr] .spectrum-Textfield-icon+.spectrum-Textfield-input */
+    padding-left: calc(
+        var(
+                --spectrum-textfield-icon-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-alias-workflow-icon-size,
+                var(--spectrum-global-dimension-size-225)
+            ) + var(--spectrum-global-dimension-size-65)
+    );
+}
+:host([dir='rtl']) .icon-workflow + #input {
+    /* [dir=rtl] .spectrum-Textfield-icon+.spectrum-Textfield-input */
+    padding-right: calc(
+        var(
+                --spectrum-textfield-icon-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-alias-workflow-icon-size,
+                var(--spectrum-global-dimension-size-225)
+            ) + var(--spectrum-global-dimension-size-65)
+    );
+}
+:host([multiline]) .icon-workflow ~ #input {
+    /* .spectrum-Textfield--multiline .spectrum-Textfield-icon~.spectrum-Textfield-input */
     height: var(
         --spectrum-textfield-height,
         var(--spectrum-alias-single-line-height)
@@ -365,23 +528,76 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-single-line-height)
     );
 }
-#input:hover {
-    /* .spectrum-Textfield:hover */
+:host(:hover) #input {
+    /* .spectrum-Textfield:hover .spectrum-Textfield-input */
     border-color: var(
         --spectrum-textfield-border-color-hover,
-        var(--spectrum-global-color-gray-400)
+        var(--spectrum-alias-border-color-hover)
     );
     box-shadow: none;
 }
-#input:focus {
-    /* .spectrum-Textfield:focus */
-    border-color: var(
-        --spectrum-textfield-border-color-down,
-        var(--spectrum-alias-border-color-down)
+:host(:hover) #input::placeholder {
+    /* .spectrum-Textfield:hover .spectrum-Textfield-input::placeholder */
+    color: var(
+        --spectrum-textfield-placeholder-text-color-hover,
+        var(--spectrum-alias-placeholder-text-color-hover)
     );
 }
-#input:focus-visible:not(:active) {
-    /* .spectrum-Textfield.focus-ring:not(:active) */
+:host(:hover) .icon-workflow {
+    /* .spectrum-Textfield:hover .spectrum-Textfield-icon */
+    color: var(
+        --spectrum-textfield-icon-color-hover,
+        var(--spectrum-global-color-gray-900)
+    );
+}
+:host(:active) #input {
+    /* .spectrum-Textfield:active .spectrum-Textfield-input */
+    border-color: var(
+        --spectrum-textfield-border-color-down,
+        var(--spectrum-alias-border-color-mouse-focus)
+    );
+}
+:host(:active) .icon-workflow {
+    /* .spectrum-Textfield:active .spectrum-Textfield-icon */
+    color: var(
+        --spectrum-textfield-icon-color-down,
+        var(--spectrum-alias-icon-color-down)
+    );
+}
+:host(:hover[invalid]) #input {
+    /* .spectrum-Textfield.is-invalid:hover .spectrum-Textfield-input */
+    border-color: var(
+        --spectrum-textfield-border-color-error-hover,
+        var(--spectrum-semantic-negative-color-state-hover)
+    );
+}
+:host([disabled]) .icon {
+    /* .spectrum-Textfield.is-disabled .spectrum-Textfield-validationIcon */
+    color: var(
+        --spectrum-textfield-validation-icon-color-disabled,
+        var(--spectrum-global-color-gray-500)
+    );
+}
+:host([disabled]) .icon-workflow {
+    /* .spectrum-Textfield.is-disabled .spectrum-Textfield-icon */
+    color: var(
+        --spectrum-textfield-icon-color-disabled,
+        var(--spectrum-global-color-gray-500)
+    );
+}
+#input:focus,
+:host(.is-focused) #input {
+    /* .spectrum-Textfield-input:focus,
+   * .spectrum-Textfield.is-focused .spectrum-Textfield-input */
+    border-color: var(
+        --spectrum-textfield-border-color-down,
+        var(--spectrum-alias-border-color-mouse-focus)
+    );
+}
+#input:focus-visible,
+:host(.is-keyboardFocused) #input {
+    /* .spectrum-Textfield-input.focus-ring,
+   * .spectrum-Textfield.is-keyboardFocused .spectrum-Textfield-input */
     border-color: var(
         --spectrum-textfield-border-color-key-focus,
         var(--spectrum-alias-border-color-focus)
@@ -392,8 +608,32 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-border-color-focus)
         );
 }
-#input[disabled] {
-    /* .spectrum-Textfield[disabled] */
+:host([invalid]) #input {
+    /* .spectrum-Textfield.is-invalid .spectrum-Textfield-input */
+    border-color: var(
+        --spectrum-textfield-border-color-error,
+        var(--spectrum-semantic-negative-color-default)
+    );
+}
+:host([invalid]) #input:focus-visible {
+    /* .is-keyboardFocused.spectrum-Textfield.is-invalid .spectrum-Textfield-input,
+   * .spectrum-Textfield.is-invalid .spectrum-Textfield-input.focus-ring */
+    border-color: var(
+        --spectrum-textfield-border-color-error-key-focus,
+        var(--spectrum-alias-border-color-focus)
+    );
+    box-shadow: 0 0 0 1px
+        var(
+            --spectrum-textfield-border-color-error-key-focus,
+            var(--spectrum-alias-border-color-focus)
+        );
+}
+#input [disabled],
+:host([disabled]) #input,
+:host(:hover[disabled]) #input {
+    /* .spectrum-Textfield-input [disabled],
+   * .spectrum-Textfield.is-disabled .spectrum-Textfield-input,
+   * .spectrum-Textfield.is-disabled:hover .spectrum-Textfield-input */
     background-color: var(
         --spectrum-textfield-background-color-disabled,
         var(--spectrum-global-color-gray-200)
@@ -411,65 +651,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-#input[disabled]::placeholder {
-    /* .spectrum-Textfield[disabled]::placeholder */
+#input [disabled]::placeholder,
+:host([disabled]) #input::placeholder,
+:host(:hover[disabled]) #input::placeholder {
+    /* .spectrum-Textfield-input [disabled]::placeholder,
+   * .spectrum-Textfield.is-disabled .spectrum-Textfield-input::placeholder,
+   * .spectrum-Textfield.is-disabled:hover .spectrum-Textfield-input::placeholder */
     color: var(
         --spectrum-textfield-placeholder-text-color-disabled,
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([invalid]) #input,
-#input:invalid {
-    /* .spectrum-Textfield.is-invalid,
-   * .spectrum-Textfield:invalid */
-    border-color: var(
-        --spectrum-textfield-border-color-error,
-        var(--spectrum-global-color-red-500)
-    );
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' height='18' viewBox='0 0 18 18' width='18'%3E%3Cpath style='fill:var%28--spectrum-alert-error-border-color%29' d='M8.564 1.289L.2 16.256A.5.5 0 0 0 .636 17h16.728a.5.5 0 0 0 .5-.5.494.494 0 0 0-.064-.244L9.436 1.289a.5.5 0 0 0-.872 0zM10 14.75a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-1.5a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25zm0-3a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-6a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25z'/%3E%3C/svg%3E");
-}
-:host([invalid]) #input:focus-visible:not(:active),
-#input:invalid:focus-visible:not(:active) {
-    /* .spectrum-Textfield.is-invalid.focus-ring:not(:active),
-   * .spectrum-Textfield:invalid.focus-ring:not(:active) */
-    border-color: var(
-        --spectrum-textfield-border-color-error,
-        var(--spectrum-global-color-red-500)
-    );
-    box-shadow: 0 0 0 1px
-        var(
-            --spectrum-textfield-border-color-error,
-            var(--spectrum-global-color-red-500)
-        );
-}
-:host([quiet]) #input:hover {
-    /* .spectrum-Textfield--quiet:hover */
-    border-color: var(
-        --spectrum-textfield-quiet-border-color-hover,
-        var(--spectrum-global-color-gray-400)
-    );
-}
-:host([quiet]) #input:active {
-    /* .spectrum-Textfield--quiet:active */
-    border-color: var(
-        --spectrum-textfield-quiet-border-color-down,
-        var(--spectrum-alias-border-color-down)
-    );
-}
 :host([quiet]) #input:focus {
-    /* .spectrum-Textfield--quiet:focus */
+    /* .is-focused.spectrum-Textfield--quiet .spectrum-Textfield-input,
+   * .spectrum-Textfield--quiet .spectrum-Textfield-input:focus */
     border-color: var(
-        --spectrum-textfield-quiet-border-color-key-focus,
-        var(--spectrum-alias-border-color-focus)
+        --spectrum-textfield-quiet-border-color-mouse-focus,
+        var(--spectrum-alias-border-color-mouse-focus)
     );
-    box-shadow: 0 1px 0
-        var(
-            --spectrum-textfield-quiet-border-color-key-focus,
-            var(--spectrum-alias-border-color-focus)
-        );
 }
-:host([quiet]) #input:focus-visible:not(:active) {
-    /* .spectrum-Textfield--quiet.focus-ring:not(:active) */
+:host([quiet]) #input:focus-visible {
+    /* .is-keyboardFocused.spectrum-Textfield--quiet .spectrum-Textfield-input,
+   * .spectrum-Textfield--quiet .spectrum-Textfield-input.focus-ring */
     border-color: var(
         --spectrum-textfield-border-color-key-focus,
         var(--spectrum-alias-border-color-focus)
@@ -480,8 +683,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-border-color-focus)
         );
 }
-:host([quiet]) #input:disabled {
-    /* .spectrum-Textfield--quiet:disabled */
+:host([quiet]) #input [disabled] {
+    /* .is-disabled.spectrum-Textfield--quiet .spectrum-Textfield-input,
+   * .is-disabled:hover.spectrum-Textfield--quiet .spectrum-Textfield-input,
+   * .spectrum-Textfield--quiet .spectrum-Textfield-input [disabled] */
     background-color: var(
         --spectrum-textfield-quiet-background-color-disabled,
         var(--spectrum-alias-background-color-transparent)
@@ -490,37 +695,4 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-textfield-quiet-border-color-disabled,
         var(--spectrum-alias-border-color-mid)
     );
-}
-:host([quiet][invalid]) #input,
-:host([quiet]) #input:invalid {
-    /* .spectrum-Textfield--quiet.is-invalid,
-   * .spectrum-Textfield--quiet:invalid */
-    border-color: var(
-        --spectrum-textfield-border-color-error,
-        var(--spectrum-global-color-red-500)
-    );
-}
-:host([quiet][invalid]) #input:focus,
-:host([quiet]) #input:invalid:focus {
-    /* .spectrum-Textfield--quiet.is-invalid:focus,
-   * .spectrum-Textfield--quiet:invalid:focus */
-    box-shadow: 0 1px 0
-        var(
-            --spectrum-textfield-border-color-error,
-            var(--spectrum-global-color-red-500)
-        );
-}
-:host([quiet][invalid]) #input:focus-visible:not(:active),
-:host([quiet]) #input:invalid:focus-visible:not(:active) {
-    /* .spectrum-Textfield--quiet.is-invalid.focus-ring:not(:active),
-   * .spectrum-Textfield--quiet:invalid.focus-ring:not(:active) */
-    border-color: var(
-        --spectrum-textfield-border-color-error,
-        var(--spectrum-global-color-red-500)
-    );
-    box-shadow: 0 1px 0
-        var(
-            --spectrum-textfield-border-color-error,
-            var(--spectrum-global-color-red-500)
-        );
 }

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -387,11 +387,11 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-semantic-negative-color-icon)
     );
 }
-:host([quiet][invalid]) .spectrum-Textfield[dir='ltr'] .icon {
+:host([dir='ltr'][quiet][invalid]) .icon {
     /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
     right: 0;
 }
-:host([quiet][invalid]) .spectrum-Textfield[dir='rtl'] .icon {
+:host([dir='rtl'][quiet][invalid]) .icon {
     /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
     left: 0;
 }
@@ -416,11 +416,11 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-green-600)
     );
 }
-:host([quiet][valid]) .spectrum-Textfield[dir='ltr'] .icon {
+:host([dir='ltr'][quiet][valid]) .icon {
     /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
     right: 0;
 }
-:host([quiet][valid]) .spectrum-Textfield[dir='rtl'] .icon {
+:host([dir='rtl'][quiet][valid]) .icon {
     /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
     left: 0;
 }
@@ -615,6 +615,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-semantic-negative-color-default)
     );
 }
+:host([invalid]) .is-keyboardFocused.spectrum-Textfield #input,
 :host([invalid]) #input:focus-visible {
     /* .is-keyboardFocused.spectrum-Textfield.is-invalid .spectrum-Textfield-input,
    * .spectrum-Textfield.is-invalid .spectrum-Textfield-input.focus-ring */
@@ -662,6 +663,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
+:host([quiet]) .is-focused #input,
 :host([quiet]) #input:focus {
     /* .is-focused.spectrum-Textfield--quiet .spectrum-Textfield-input,
    * .spectrum-Textfield--quiet .spectrum-Textfield-input:focus */
@@ -670,6 +672,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-mouse-focus)
     );
 }
+:host([quiet]) .is-keyboardFocused #input,
 :host([quiet]) #input:focus-visible {
     /* .is-keyboardFocused.spectrum-Textfield--quiet .spectrum-Textfield-input,
    * .spectrum-Textfield--quiet .spectrum-Textfield-input.focus-ring */
@@ -683,6 +686,38 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-border-color-focus)
         );
 }
+:host([invalid][quiet]) #input {
+    /* .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+    border-color: var(
+        --spectrum-textfield-quiet-border-color-error,
+        var(--spectrum-semantic-negative-color-default)
+    );
+}
+:host([invalid][quiet]) .is-focused #input,
+:host([invalid][quiet]) #input:focus {
+    /* .is-focused.is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input,
+   * .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input:focus */
+    border-color: var(
+        --spectrum-textfield-quiet-border-color-error-mouse-focus,
+        var(--spectrum-semantic-negative-color-state-hover)
+    );
+}
+:host([invalid][quiet]) #input:focus-visible,
+:host([invalid][quiet]) .is-keyboardFocused #input {
+    /* .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input.focus-ring,
+   * .is-keyboardFocused.is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+    border-color: var(
+        --spectrum-textfield-quiet-border-color-error-key-focus,
+        var(--spectrum-alias-border-color-focus)
+    );
+    box-shadow: 0 1px 0
+        var(
+            --spectrum-textfield-quiet-border-color-error-key-focus,
+            var(--spectrum-alias-border-color-focus)
+        );
+}
+:host([disabled][quiet]) #input,
+:host([disabled][quiet]:hover) #input,
 :host([quiet]) #input [disabled] {
     /* .is-disabled.spectrum-Textfield--quiet .spectrum-Textfield-input,
    * .is-disabled:hover.spectrum-Textfield--quiet .spectrum-Textfield-input,

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -12,48 +12,6 @@ governing permissions and limitations under the License.
 
 @import './spectrum-textfield.css';
 
-:host {
-    position: relative;
-    display: inline-flex;
-    vertical-align: top;
-}
-
-#input:invalid,
-:host([invalid]) #input {
-    background-image: none;
-}
-
-#invalid,
-#valid {
-    position: absolute;
-    top: 50%;
-    right: calc(
-        var(
-                --spectrum-textfield-padding-x,
-                var(--spectrum-global-dimension-size-150)
-            ) - 3px
-    );
-    transform: translateY(-50%);
-}
-
-#valid {
-    color: var(
-        --spectrum-alert-success-icon-color,
-        var(--spectrum-global-color-green-600)
-    );
-}
-
-#invalid {
-    color: var(
-        --spectrum-alert-error-border-color,
-        var(--spectrum-global-color-red-400)
-    );
-}
-
-:host([valid]) #input {
-    background-image: none;
-}
-
 :host([grows]) #input {
     position: absolute;
     top: 0;
@@ -92,14 +50,4 @@ governing permissions and limitations under the License.
     padding-right: var(--spectrum-textfield-quiet-padding-x, 0);
     border-right-width: 0;
     border-left-width: 0;
-}
-
-:host([quiet]) #invalid,
-:host([quiet]) #valid {
-    right: -2px;
-}
-
-:host([multiline]) #invalid,
-:host([multiline]) #valid {
-    top: calc(100% - 12px);
 }

--- a/packages/textfield/stories/textarea.stories.ts
+++ b/packages/textfield/stories/textarea.stories.ts
@@ -9,10 +9,11 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { html, boolean } from '@open-wc/demoing-storybook';
+import { html, select } from '@open-wc/demoing-storybook';
 
 import '../sp-textfield.js';
 import { TemplateResult } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export default {
     component: 'sp-textfield',
@@ -20,52 +21,61 @@ export default {
 };
 
 export const Default = (): TemplateResult => {
-    const grows = boolean('Grows', false, 'Element');
-    const quiet = boolean('Quiet', false, 'Element');
+    const dir = select(
+        'Text direction',
+        {
+            None: 'none',
+            'Left to right': 'ltr',
+            'Right to left': 'rtl',
+        },
+        'ltr',
+        'Element'
+    );
     return html`
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             multiline
             label="Enter your life story"
-            ?grows=${grows}
-            ?quiet=${quiet}
+            placeholder="Enter your life story"
         ></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             multiline
             label="Enter your life story"
             disabled
-            ?grows=${grows}
-            ?quiet=${quiet}
+            placeholder="Enter your life story"
         ></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             multiline
             label="Enter your life story"
             pattern="[\\w\\s]+"
             required
             valid
             value="A valid input"
-            ?grows=${grows}
-            ?quiet=${quiet}
+            placeholder="Enter your life story"
         ></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             multiline
             label="Enter your life story"
             required
             valid
             value="A valid input"
             disabled
-            ?grows=${grows}
-            ?quiet=${quiet}
+            placeholder="Enter your life story"
         ></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             multiline
             label="Enter your life story"
             pattern="[\\d]+"
             required
             value="Not a valid input"
-            ?grows=${grows}
-            ?quiet=${quiet}
+            placeholder="Enter your life story"
         ></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             multiline
             label="Enter your life story"
             pattern="[\\d]+"
@@ -73,8 +83,7 @@ export const Default = (): TemplateResult => {
             required
             value="Not a valid input"
             disabled
-            ?grows=${grows}
-            ?quiet=${quiet}
+            placeholder="Enter your life story"
         ></sp-textfield>
     `;
 };

--- a/packages/textfield/stories/textfield.stories.ts
+++ b/packages/textfield/stories/textfield.stories.ts
@@ -9,32 +9,47 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import {
-    html,
-    withKnobs,
-    withWebComponentsKnobs,
-} from '@open-wc/demoing-storybook';
+import { html, select } from '@open-wc/demoing-storybook';
+import { TemplateResult } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined';
 
 import '../sp-textfield.js';
-import { TemplateResult } from 'lit-html';
 
 export default {
     component: 'sp-textfield',
     title: 'Textfield',
-    decorators: [withKnobs, withWebComponentsKnobs],
 };
 
 export const Default = (): TemplateResult => {
+    const dir = select(
+        'Text direction',
+        {
+            None: 'none',
+            'Left to right': 'ltr',
+            'Right to left': 'rtl',
+        },
+        'ltr',
+        'Element'
+    );
     return html`
-        <sp-textfield placeholder="Enter your name"></sp-textfield>
-        <sp-textfield placeholder="Enter your name" disabled></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
+            placeholder="Enter your name"
+        ></sp-textfield>
+        <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
+            placeholder="Enter your name"
+            disabled
+        ></sp-textfield>
+        <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             placeholder="Enter your name"
             pattern="[\\w\\s]*"
             required
             value="A valid input"
         ></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             placeholder="Enter your name"
             pattern="[\\w\\s]*"
             required
@@ -42,11 +57,13 @@ export const Default = (): TemplateResult => {
             disabled
         ></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             placeholder="Enter your name"
             pattern="[\\d]*"
             value="Not a valid input"
         ></sp-textfield>
         <sp-textfield
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
             placeholder="Enter your name"
             pattern="^[\\d]$"
             required

--- a/scripts/process-spectrum-postcss-plugin.js
+++ b/scripts/process-spectrum-postcss-plugin.js
@@ -385,6 +385,7 @@ class SpectrumProcessor {
         const result = [];
 
         const startsWithHost = re`^${this.component.hostSelector}`;
+        const startsWithModifier = re`^.is-`;
         const hasHost = re`${this.component.hostSelector}(?![a-zA-Z\-])`;
         const startsWithDir = new RegExp(/\[dir\=/);
         const selectorTransform = this.selectorTransform;
@@ -437,7 +438,11 @@ class SpectrumProcessor {
                         }
                     }
                 }
-                if (shouldStartWithHost && !startsWithHost.test(selector)) {
+                if (
+                    shouldStartWithHost &&
+                    !startsWithHost.test(selector) &&
+                    !startsWithModifier.test(selector)
+                ) {
                     // This selector does not match the component we are
                     // working on. Check to see if it matches an id
                     let skip = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,10 +2559,10 @@
   dependencies:
     "@spectrum-css/vars" "^2.2.0"
 
-"@spectrum-css/search@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-2.0.6.tgz#ef3c22c21493e793208e87029c50e9a05b90923f"
-  integrity sha512-BAOwdhm56PIyIuGRm4zABLVzmnJyW9Dg3mBr8e6utNimEtmGyDcoh+cu2nWb+B0NMJVa4I1iA/sAw/n3DR7j/g==
+"@spectrum-css/search@^3.0.0-beta.4":
+  version "3.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-3.0.0-beta.4.tgz#4e39f4966c346778c452fe03fe9597e2bcb310b1"
+  integrity sha512-s1jJ675+3H64+flXTcVacvdMaavTXEZ0qBRBCbKVk/1iH8iCoMMWjJjQlr5tWZZsilpnzU2QUaB8D3MSa5HU7g==
 
 "@spectrum-css/sidenav@^2.0.5":
   version "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2599,10 +2599,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tags/-/tags-2.0.5.tgz#13b1e4fc5f17e1f70f98959221c215cbc631a84d"
   integrity sha512-dMba2Bw9oJlOI2JM6CH+sfDQANRh7/J6XYw4PpRlVwNUvL5v6T8Z+8KN6YozE4a3FT3WDKNu9Vg9hF+5fs3rvg==
 
-"@spectrum-css/textfield@^2.0.5":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-2.0.6.tgz#2e796ee1d0c5732bf089e4168662b8940cefc9f1"
-  integrity sha512-lbr9HuXGOjmZ6K0MmODA3u7DRaaVk1P2aqqJkKy6xIY9u2nRKg/nna3TANJRqVnYMvRAdsWiH2vTWTBkRrCsGg==
+"@spectrum-css/textfield@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.0.0-beta.3.tgz#251763260fedd38e256c8a225809b0ecdc70f68f"
+  integrity sha512-ihTZKLfnUxBnlSGRH4xdSMwd23EkpunC69uUvVB2LGGw1QAcmUcBNdS9xz7PPSWFw4qkCRXzVVX9tLC/2fQFbQ==
 
 "@spectrum-css/toast@^2.0.2":
   version "2.0.5"


### PR DESCRIPTION
## Description 
Directly (or as close to directly as possible) port the `textfield` and `search` patterns to `^3.0.0`.

Separately, we should review whether the `sp-textfield` pattern needs to be updated to some form of a light dom `<input/>` element in order to appropriately pair with `label` elements and extend to patterns like the `stepper` #477. 

## Related Issue
fixes #513 
fixes #543 
fixes #750

## Motivation and Context 
Keeping up with Spectrum CSS, making customization easier.

## How Has This Been Tested?
- continues to pass unit tests
- visual regressions have been slightly updated

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/87266829-29942500-c494-11ea-8b2a-2320b1eafd9c.png)
![image](https://user-images.githubusercontent.com/1156657/87266856-34e75080-c494-11ea-9f75-193aef1e39f3.png)
![image](https://user-images.githubusercontent.com/1156657/87266871-3d3f8b80-c494-11ea-8278-c4f229526647.png)

## Types of changes
- [x] dependency management

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
