### PR TITLE
Focus management fixes for elements extended `focusable`

### DIFF
--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -70,6 +70,10 @@ export class Focusable extends FocusVisiblePolyfillMixin(LitElement) {
         this.focusElement.blur();
     }
 
+    public click(): void {
+        this.focusElement.click();
+    }
+
     protected manageAutoFocus(): void {
         if (this.autofocus) {
             /* Trick :focus-visible polyfill into thinking keyboard based focus */
@@ -89,11 +93,25 @@ export class Focusable extends FocusVisiblePolyfillMixin(LitElement) {
         this.manageShiftTab();
     }
 
+    private refocusTimeout = 0;
+
     protected manageFocusIn(): void {
         this.addEventListener('focusin', (event) => {
             if (event.composedPath()[0] === this) {
                 this.handleFocus();
             }
+            const innerHandler = (): void => {
+                this.refocusTimeout = setTimeout(() => {
+                    this.focus();
+                });
+            };
+            const outerHandler = (): void => {
+                clearTimeout(this.refocusTimeout);
+                this.focusElement.removeEventListener('focusout', innerHandler);
+                this.removeEventListener('focusout', outerHandler);
+            };
+            this.focusElement.addEventListener('focusout', innerHandler);
+            this.addEventListener('focusout', outerHandler);
         });
     }
 

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -75,9 +75,12 @@ export class Tabs extends Focusable {
 
     private tabs: Tab[] = [];
 
-    public get focusElement(): Tab {
-        return (this.querySelector('[tabindex="0"]') ||
-            this.querySelector('sp-tab')) as Tab;
+    public get focusElement(): Tab | Tabs {
+        const focusElement = this.tabs.find((tab) => tab.selected);
+        if (focusElement) {
+            return focusElement;
+        }
+        return this.tabs[0] || this;
     }
 
     constructor() {
@@ -188,7 +191,7 @@ export class Tabs extends Focusable {
     private onClick = (event: Event): void => {
         const target = event.target as HTMLElement;
         this.selectTarget(target);
-        if (this.shouldApplyFocusVisible) {
+        if (this.shouldApplyFocusVisible && event.composedPath()[0] !== this) {
             /* Trick :focus-visible polyfill into thinking keyboard based focus */
             this.dispatchEvent(
                 new KeyboardEvent('keydown', {


### PR DESCRIPTION
## Description
Revisiting #318 this change prevent Firefox and Safari on MacOS (various testing points to this not occurring in Window to begin with, but I cannot confirm) from allowing the `:host()` element of a component extended from `Focuable` to take "focus". This is particularly important in checkbox-like element where maintaining focus is needed to allow for keyboard alterations to the state of the element.

- when `focusout` throws on the `focusElement`, but not on the `:host()` (which occurs when focus is leaving the element all together) call `this.focus()` so that focus is applied appropriately.
- extends `focus`/`blur` passing to the `click` method as well
- correct the focus entry element in `sp-tabs` elements

## Related Issue
fixes #770
fixes #516 

## Motivation and Context
Keyboard accessibility is important.

## How Has This Been Tested?
- unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
