### PR TITLE
Accessibility review updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-66b66fec937b5ce4a0cffd1225ffd8a6300f9774
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-bc9377f5f2d6dae36da1ed6c49f8c76bd16e6b81
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/dropzone/README.md
+++ b/packages/dropzone/README.md
@@ -28,7 +28,7 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 ## Example
 
 ```html
-<sp-dropzone id="dropzone" tabindex="1" style="width: 400px; height: 200px">
+<sp-dropzone id="dropzone-1" tabindex="1" style="width: 400px; height: 200px">
     <sp-illustrated-message heading="Drag and Drop Your File">
         <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -45,8 +45,8 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 
     <div>
         <div>
-            <label for="file-input">
-                <sp-link>Select a File</sp-link>
+            <label for="file-input" onclick="this.nextElementSibling.click()">
+                <sp-link href="javascript:;">Select a File</sp-link>
                 from your computer
             </label>
             <input type="file" id="file-input" style="display: none" />
@@ -86,8 +86,8 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 
     <div>
         <div>
-            <label for="file-input">
-                <sp-link>Select a File</sp-link>
+            <label for="file-input" onclick="this.nextElementSibling.click()">
+                <sp-link href="javascript:;">Select a File</sp-link>
                 from your computer
             </label>
             <input type="file" id="file-input" style="display: none" />

--- a/packages/illustrated-message/src/IllustratedMessage.ts
+++ b/packages/illustrated-message/src/IllustratedMessage.ts
@@ -40,8 +40,8 @@ export class IllustratedMessage extends LitElement {
     protected render(): TemplateResult {
         return html`
             <div id="illustration"><slot></slot></div>
-            <div id="heading">${this.heading}</div>
-            <div id="description">${this.description}</div>
+            <h2 id="heading">${this.heading}</h2>
+            <p id="description">${this.description}</p>
         `;
     }
 }

--- a/packages/illustrated-message/src/illustrated-message.css
+++ b/packages/illustrated-message/src/illustrated-message.css
@@ -41,6 +41,17 @@ governing permissions and limitations under the License.
     );
 }
 
+/* 
+    @TODO: Implement spectrum typography components (ex: specturm-heading, spectrum-body)
+
+    The following block maps to the .spectrum-Body--secondary selector 
+    in spectrum-css/dist/components/typography
+
+    The css in that folder defines multiple typography classes, such as
+    .spectrum-Heading and .spectrum-Body
+
+    These components need to be implemented in another pass
+*/
 #description {
     font-size: var(
         --spectrum-body-4-text-size,

--- a/packages/illustrated-message/src/illustrated-message.css
+++ b/packages/illustrated-message/src/illustrated-message.css
@@ -35,6 +35,36 @@ governing permissions and limitations under the License.
     text-transform: var(--spectrum-heading-quiet-2-text-transform, none);
     margin-top: 0;
     margin-bottom: 0;
+    color: var(
+        --spectrum-heading-page-title-text-color,
+        var(--spectrum-global-color-gray-700)
+    );
+}
+
+#description {
+    font-size: var(
+        --spectrum-body-4-text-size,
+        var(--spectrum-alias-font-size-default)
+    );
+    font-weight: var(
+        --spectrum-body-4-text-font-weight,
+        var(--spectrum-alias-body-text-font-weight)
+    );
+    line-height: var(
+        --spectrum-body-4-text-line-height,
+        var(--spectrum-alias-body-text-line-height)
+    );
+    letter-spacing: var(
+        --spectrum-body-4-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    text-transform: var(--spectrum-body-4-text-transform, none);
+    margin-top: 0;
+    margin-bottom: 0;
+    color: var(
+        --spectrum-body-secondary-text-color,
+        var(--spectrum-global-color-gray-700)
+    );
 }
 
 /* Ensure that SVGs with viewBox attributes size correctly. */


### PR DESCRIPTION
## Description
- use `h1` and `p` elements in the content of `sp-illustrated-message`
- ensure `sp-dropzone` documentation can be accessed via keyboard only interactions

## Related Issue
fixes #732
fixes #765

## Motivation and Context
Our elements should be accessible to everyone.

## How Has This Been Tested?
Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
