### PR TITLE
chore: cleanup missed circle-loader conversions

### DIFF
--- a/packages/circle-loader/package.json
+++ b/packages/circle-loader/package.json
@@ -6,12 +6,12 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/adobe/spectrum-web-components.git",
-        "directory": "packages/circleloader"
+        "directory": "packages/circle-loader"
     },
     "bugs": {
         "url": "https://github.com/adobe/spectrum-web-components/issues"
     },
-    "homepage": "https://adobe.github.io/spectrum-web-components/components/circleloader",
+    "homepage": "https://adobe.github.io/spectrum-web-components/components/circle-loader",
     "keywords": [
         "spectrum css",
         "web components",

--- a/packages/circle-loader/test/benchmark/test-basic.ts
+++ b/packages/circle-loader/test/benchmark/test-basic.ts
@@ -9,10 +9,10 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import '@spectrum-web-components/circleloader/sp-circle-loader.js';
+import '@spectrum-web-components/circle-loader/sp-circle-loader.js';
 import { html } from 'lit-html';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers';
 
 measureFixtureCreation(html`
-    <sp-circleloader indeterminate></sp-circleloader>
+    <sp-circle-loader indeterminate></sp-circle-loader>
 `);


### PR DESCRIPTION
Some missed renamings from the `circleloader`=>`circle-loader` conversion.