### PR TITLE
docs(dropdown): include [quiet] examples in README

### DIFF
--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -25,10 +25,37 @@ import { Dropdown } from '@spectrum-web-components/dropdown';
 
 ## Example
 
-<!-- prettier-ignore -->
 ```html
+<p><strong>Standard:</strong></p>
+<sp-dropdown label="Select a Country with a very long label, too long in fact">
+    <sp-menu>
+        <sp-menu-item>
+            Deselect
+        </sp-menu-item>
+        <sp-menu-item>
+            Select inverse
+        </sp-menu-item>
+        <sp-menu-item>
+            Feather...
+        </sp-menu-item>
+        <sp-menu-item>
+            Select and mask...
+        </sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>
+            Save selection
+        </sp-menu-item>
+        <sp-menu-item disabled>
+            Make work path
+        </sp-menu-item>
+    </sp-menu>
+</sp-dropdown>
+<br />
+<br />
+<p><strong>Quiet:</strong></p>
 <sp-dropdown
     label="Select a Country with a very long label, too long in fact"
+    quiet
 >
     <sp-menu>
         <sp-menu-item>
@@ -54,15 +81,45 @@ import { Dropdown } from '@spectrum-web-components/dropdown';
 </sp-dropdown>
 ```
 
-## Variants
+## States
 
 ### Invalid
 
-<!-- prettier-ignore -->
 ```html
+<p><strong>Standard:</strong></p>
 <sp-dropdown
     label="Select a Country with a very long label, too long in fact"
     invalid
+>
+    <sp-menu>
+        <sp-menu-item>
+            Deselect
+        </sp-menu-item>
+        <sp-menu-item>
+            Select inverse
+        </sp-menu-item>
+        <sp-menu-item>
+            Feather...
+        </sp-menu-item>
+        <sp-menu-item>
+            Select and mask...
+        </sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>
+            Save selection
+        </sp-menu-item>
+        <sp-menu-item disabled>
+            Make work path
+        </sp-menu-item>
+    </sp-menu>
+</sp-dropdown>
+<br />
+<br />
+<p><strong>Quiet:</strong></p>
+<sp-dropdown
+    label="Select a Country with a very long label, too long in fact"
+    invalid
+    quiet
 >
     <sp-menu>
         <sp-menu-item>
@@ -90,11 +147,41 @@ import { Dropdown } from '@spectrum-web-components/dropdown';
 
 ### Disabled
 
-<!-- prettier-ignore -->
 ```html
+<p><strong>Standard:</strong></p>
 <sp-dropdown
     label="Select a Country with a very long label, too long in fact"
     disabled
+>
+    <sp-menu>
+        <sp-menu-item>
+            Deselect
+        </sp-menu-item>
+        <sp-menu-item>
+            Select inverse
+        </sp-menu-item>
+        <sp-menu-item>
+            Feather...
+        </sp-menu-item>
+        <sp-menu-item>
+            Select and mask...
+        </sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>
+            Save selection
+        </sp-menu-item>
+        <sp-menu-item disabled>
+            Make work path
+        </sp-menu-item>
+    </sp-menu>
+</sp-dropdown>
+<br />
+<br />
+<p><strong>Quiet:</strong></p>
+<sp-dropdown
+    label="Select a Country with a very long label, too long in fact"
+    disabled
+    quiet
 >
     <sp-menu>
         <sp-menu-item>


### PR DESCRIPTION
## Description

Add `sp-dropdow[quiet]` listings to the README.

## Related Issue
fixes #663

## Motivation and Context
Users should have an easy time understanding what they get out of our packages.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/87794242-5b024d00-c814-11ea-9ac5-3bd6659e4b7f.png)

## Types of changes

- [x] Documentation

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
