### PR TITLE
feat(asset): add the asset pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-bc9377f5f2d6dae36da1ed6c49f8c76bd16e6b81
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-4a23fcdd0e9e472a6d0b7773ce17942fb530ce2b
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/asset/README.md
+++ b/packages/asset/README.md
@@ -1,0 +1,36 @@
+## Description
+
+Use an `<sp-asset>` element to visually represent a file, folder or image in your application. File and folder representations will center themselves horizontally and vertically in the space provided to the element. Images will be contained to the element, growing to the element's full height while centering itself within the width provided.
+
+### Installation
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/asset?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/asset)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/asset?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/asset)
+
+```
+npm install @spectrum-web-components/asset
+
+# or
+
+yarn add @spectrum-web-components/asset
+```
+
+## Example
+
+```html
+<sp-asset style="height: 128px">
+    <img src="https://placedog.net/500/500" alt="Demo Image" />
+</sp-asset>
+```
+
+### File
+
+```html
+<sp-asset variant="file"></sp-asset>
+```
+
+### Folder
+
+```html
+<sp-asset variant="file"></sp-asset>
+```

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -1,0 +1,59 @@
+{
+    "name": "@spectrum-web-components/asset",
+    "publishConfig": {
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adobe/spectrum-web-components.git",
+        "directory": "packages/asset"
+    },
+    "bugs": {
+        "url": "https://github.com/adobe/spectrum-web-components/issues"
+    },
+    "homepage": "https://adobe.github.io/spectrum-web-components/components/asset",
+    "keywords": [
+        "spectrum css",
+        "web components",
+        "lit-element",
+        "lit-html"
+    ],
+    "version": "0.0.1",
+    "description": "",
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        "./src/": "./src/",
+        "./custom-elements.json": "./custom-elements.json",
+        "./package.json": "./package.json",
+        "./sp-asset": "./sp-asset.js",
+        "./sp-asset.js": "./sp-asset.js"
+    },
+    "files": [
+        "custom-elements.json",
+        "*.d.ts",
+        "*.js",
+        "*.js.map",
+        "/src/"
+    ],
+    "sideEffects": [
+        "./sp-asset.js",
+        "./sp-asset.ts"
+    ],
+    "scripts": {
+        "test": "karma start --coverage"
+    },
+    "author": "",
+    "license": "Apache-2.0",
+    "peerDependencies": {
+        "lit-element": "^2.1.0",
+        "lit-html": "^1.0.0"
+    },
+    "devDependencies": {
+        "@spectrum-css/asset": "^3.0.0-beta.2"
+    },
+    "dependencies": {
+        "tslib": "^2.0.0"
+    }
+}

--- a/packages/asset/sp-asset.ts
+++ b/packages/asset/sp-asset.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Asset } from './src/Asset.js';
+
+customElements.define('sp-asset', Asset);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-asset': Asset;
+    }
+}

--- a/packages/asset/src/Asset.ts
+++ b/packages/asset/src/Asset.ts
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    LitElement,
+    CSSResultArray,
+    TemplateResult,
+    property,
+} from 'lit-element';
+
+import styles from './asset.css.js';
+
+const file = (): TemplateResult => html`
+    <svg viewBox="0 0 128 128" class="file">
+        <path
+            class="fileBackground"
+            d="M24,126c-5.5,0-10-4.5-10-10V12c0-5.5,4.5-10,10-10h61.5c2.1,0,4.1,0.8,5.6,2.3l20.5,20.4c1.5,1.5,2.4,3.5,2.4,5.7V116c0,5.5-4.5,10-10,10H24z"
+        ></path>
+        <path
+            class="fileOutline"
+            d="M113.1,23.3L92.6,2.9C90.7,1,88.2,0,85.5,0H24c-6.6,0-12,5.4-12,12v104c0,6.6,5.4,12,12,12h80c6.6,0,12-5.4,12-12V30.4C116,27.8,114.9,25.2,113.1,23.3z M90,6l20.1,20H92c-1.1,0-2-0.9-2-2V6z M112,116c0,4.4-3.6,8-8,8H24c-4.4,0-8-3.6-8-8V12c0-4.4,3.6-8,8-8h61.5c0.2,0,0.3,0,0.5,0v20c0,3.3,2.7,6,6,6h20c0,0.1,0,0.3,0,0.4V116z"
+        ></path>
+    </svg>
+`;
+
+const folder = (): TemplateResult => html`
+    <svg viewBox="0 0 32 32" class="folder">
+        <path
+            class="folderBackground"
+            d="M3,29.5c-1.4,0-2.5-1.1-2.5-2.5V5c0-1.4,1.1-2.5,2.5-2.5h10.1c0.5,0,1,0.2,1.4,0.6l3.1,3.1c0.2,0.2,0.4,0.3,0.7,0.3H29c1.4,0,2.5,1.1,2.5,2.5v18c0,1.4-1.1,2.5-2.5,2.5H3z"
+        ></path>
+        <path
+            class="folderOutline"
+            d="M29,6H18.3c-0.1,0-0.2,0-0.4-0.2l-3.1-3.1C14.4,2.3,13.8,2,13.1,2H3C1.3,2,0,3.3,0,5v22c0,1.6,1.3,3,3,3h26c1.7,0,3-1.4,3-3V9C32,7.3,30.7,6,29,6z M31,27c0,1.1-0.9,2-2,2H3c-1.1,0-2-0.9-2-2V7h28c1.1,0,2,0.9,2,2V27z"
+        ></path>
+    </svg>
+`;
+
+/**
+ * @element sp-asset
+ */
+export class Asset extends LitElement {
+    public static get styles(): CSSResultArray {
+        return [styles];
+    }
+
+    @property({ type: String, reflect: true })
+    public variant: 'file' | 'folder' | undefined;
+
+    protected render(): TemplateResult {
+        if (this.variant === 'file') {
+            return file();
+        } else if (this.variant === 'folder') {
+            return folder();
+        }
+        return html`
+            <slot></slot>
+        `;
+    }
+}

--- a/packages/asset/src/asset.css
+++ b/packages/asset/src/asset.css
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import './spectrum-asset.css';

--- a/packages/asset/src/index.ts
+++ b/packages/asset/src/index.ts
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export * from './Asset.js';

--- a/packages/asset/src/spectrum-asset.css
+++ b/packages/asset/src/spectrum-asset.css
@@ -1,0 +1,69 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host {
+    /* .spectrum-Asset */
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+::slotted(*) {
+    /* .spectrum-Asset-image */
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    transition: opacity var(--spectrum-global-animation-duration-100, 0.13s);
+}
+.file,
+.folder {
+    /* .spectrum-Asset-file,
+   * .spectrum-Asset-folder */
+    width: 100%;
+    height: 100%;
+    min-width: var(
+        --spectrum-asset-icon-min-width,
+        var(--spectrum-global-dimension-size-600)
+    );
+    max-width: var(
+        --spectrum-asset-icon-max-width,
+        var(--spectrum-global-dimension-static-size-1000)
+    );
+    margin: var(
+        --spectrum-asset-icon-margin,
+        var(--spectrum-global-dimension-size-250)
+    );
+}
+.folderBackground {
+    /* .spectrum-Asset-folderBackground */
+    fill: var(
+        --spectrum-asset-folder-background-color,
+        var(--spectrum-global-color-gray-300)
+    );
+}
+.fileBackground {
+    /* .spectrum-Asset-fileBackground */
+    fill: var(
+        --spectrum-asset-file-background-color,
+        var(--spectrum-global-color-gray-50)
+    );
+}
+.fileOutline,
+.folderOutline {
+    /* .spectrum-Asset-fileOutline,
+   * .spectrum-Asset-folderOutline */
+    fill: var(
+        --spectrum-asset-icon-outline-color,
+        var(--spectrum-global-color-gray-500)
+    );
+}

--- a/packages/asset/src/spectrum-config.js
+++ b/packages/asset/src/spectrum-config.js
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+module.exports = {
+    spectrum: 'asset',
+    components: [
+        {
+            name: 'asset',
+            host: {
+                selector: '.spectrum-Asset',
+            },
+            slots: [
+                {
+                    selector: '.spectrum-Asset-image',
+                },
+            ],
+            classes: [
+                {
+                    selector: '.spectrum-Asset-file',
+                    name: 'file',
+                },
+                {
+                    selector: '.spectrum-Asset-folder',
+                    name: 'folder',
+                },
+                {
+                    selector: '.spectrum-Asset-folderBackground',
+                    name: 'folderBackground',
+                },
+                {
+                    selector: '.spectrum-Asset-fileBackground',
+                    name: 'fileBackground',
+                },
+                {
+                    selector: '.spectrum-Asset-fileOutline',
+                    name: 'fileOutline',
+                },
+                {
+                    selector: '.spectrum-Asset-folderOutline',
+                    name: 'folderOutline',
+                },
+            ],
+        },
+    ],
+};

--- a/packages/asset/stories/asset.stories.ts
+++ b/packages/asset/stories/asset.stories.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, TemplateResult } from 'lit-html';
+
+import '../sp-asset.js';
+import { portrait } from '@spectrum-web-components/card/stories/images';
+
+export default {
+    title: 'Asset',
+    component: 'sp-asset',
+};
+
+export const Default = (): TemplateResult => {
+    return html`
+        <sp-asset style="height: 128px">
+            <img src=${portrait} alt="Demo Image" />
+        </sp-asset>
+    `;
+};
+
+export const File = (): TemplateResult => {
+    return html`
+        <sp-asset variant="file"></sp-asset>
+    `;
+};
+
+export const Folder = (): TemplateResult => {
+    return html`
+        <sp-asset variant="folder"></sp-asset>
+    `;
+};

--- a/packages/asset/test/asset.test.ts
+++ b/packages/asset/test/asset.test.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, elementUpdated, expect } from '@open-wc/testing';
+
+import '..';
+import { Asset } from '..';
+import { Default, File, Folder } from '../stories/asset.stories.js';
+
+describe('Asset', () => {
+    it('loads default asset accessibly', async () => {
+        const el = await fixture<Asset>(Default());
+
+        await elementUpdated(el);
+
+        expect(el).to.be.accessible();
+    });
+    it('loads [variant="file"] accessibly', async () => {
+        const el = await fixture<Asset>(File());
+
+        await elementUpdated(el);
+
+        expect(el).to.be.accessible();
+    });
+    it('loads [variant="folder"] accessibly', async () => {
+        const el = await fixture<Asset>(Folder());
+
+        await elementUpdated(el);
+
+        expect(el).to.be.accessible();
+    });
+});

--- a/packages/asset/test/benchmark/basic-test.ts
+++ b/packages/asset/test/benchmark/basic-test.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '../../';
+import { html } from 'lit-html';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers';
+
+measureFixtureCreation(html`
+    <sp-asset open></sp-asset>
+`);

--- a/packages/asset/tsconfig.json
+++ b/packages/asset/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "./"
+    },
+    "include": ["*.ts", "src/*.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"]
+}

--- a/packages/bundle/elements.ts
+++ b/packages/bundle/elements.ts
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/actionbar/sp-actionbar.js';
+import '@spectrum-web-components/asset/sp-asset.js';
 import '@spectrum-web-components/avatar/sp-avatar.js';
 import '@spectrum-web-components/banner/sp-banner.js';
 import '@spectrum-web-components/bar-loader/sp-bar-loader.js';

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -49,6 +49,7 @@
     "dependencies": {
         "@spectrum-web-components/action-menu": "^0.5.0",
         "@spectrum-web-components/actionbar": "^0.3.0",
+        "@spectrum-web-components/asset": "^0.0.1",
         "@spectrum-web-components/avatar": "^0.3.0",
         "@spectrum-web-components/banner": "^0.3.0",
         "@spectrum-web-components/bar-loader": "^0.1.0",

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 export * from '@spectrum-web-components/action-menu';
 export * from '@spectrum-web-components/actionbar';
 export * from '@spectrum-web-components/avatar';
+export * from '@spectrum-web-components/asset';
 export * from '@spectrum-web-components/banner';
 export * from '@spectrum-web-components/bar-loader';
 export * from '@spectrum-web-components/button';

--- a/packages/bundle/tsconfig.json
+++ b/packages/bundle/tsconfig.json
@@ -9,6 +9,7 @@
     "references": [
         { "path": "../action-menu" },
         { "path": "../actionbar" },
+        { "path": "../asset" },
         { "path": "../avatar" },
         { "path": "../banner" },
         { "path": "../bar-loader" },

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -12,6 +12,9 @@ governing permissions and limitations under the License.
 module.exports = [
     'action-menu--default',
     'actionbar--default',
+    'asset--default',
+    'asset--file',
+    'asset--folder',
     'avatar--default',
     'banner--default',
     'banner--banner-types',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,6 +2447,11 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-2.1.5.tgz#20cb0e6346e5d11f8002c9be9185057df7ecf13c"
   integrity sha512-1De319CZMR9PYvN2JiUZQrxds89q8uj1jpTnu57fbnjF6u3fAx7O+PjF/0FArfTai/+K7DSDjmW/TK08GPkKkA==
 
+"@spectrum-css/asset@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.0-beta.2.tgz#9cf43a1fcf02312da9e45a2849a38d83fe05b262"
+  integrity sha512-Vr5MlLUozF93BxIcxpj7Z6ob1B6MrOn/kZzsV0XPPq1DAI4F06glKLtGP1INrD2JndW2YWvuooaa6iWw8Bd0IQ==
+
 "@spectrum-css/avatar@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-2.0.5.tgz#4e4e7cf273ed6b5925b4a8cad05946114790030a"


### PR DESCRIPTION
## Description
Implements the `<sp-asset>` pattern.
- leverages Spectrum CSS `^3.0.0`
- doesn't leverage `[dir="rtl|ltr"]`, so no need for `@spectrum-web-components/base`

## Related Issue
refs #279 

## Motivation and Context
Pattern availability

## How Has This Been Tested?
- Accessibility tests
- Screenshot tests

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/87938584-cc383f00-ca64-11ea-9db8-e909a255ced0.png)
![image](https://user-images.githubusercontent.com/1156657/87938600-d2c6b680-ca64-11ea-8626-957fb200ddf2.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
