### PR TITLE
Stabilize Visual Regressions of the Card Components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-4a23fcdd0e9e472a6d0b7773ce17942fb530ce2b
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-17098538628044736d6c2a2cc7b03649ae427daa
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -50,6 +50,7 @@
         "@spectrum-css/card": "^2.0.6"
     },
     "dependencies": {
+        "@spectrum-web-components/asset": "^0.1.0",
         "@spectrum-web-components/shared": "^0.5.1",
         "lit-element": "^2.1.0",
         "lit-html": "^1.0.0",

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -19,6 +19,7 @@ import {
     PropertyValues,
 } from 'lit-element';
 import { FocusVisiblePolyfillMixin } from '@spectrum-web-components/shared/src/focus-visible.js';
+import '@spectrum-web-components/asset/sp-asset.js';
 
 import cardStyles from './card.css.js';
 
@@ -58,9 +59,9 @@ export class Card extends FocusVisiblePolyfillMixin(LitElement) {
 
     protected get renderPreviewImage(): TemplateResult {
         return html`
-            <div id="preview">
+            <sp-asset id="preview">
                 <slot name="preview"></slot>
-            </div>
+            </sp-asset>
         `;
     }
 
@@ -94,9 +95,9 @@ export class Card extends FocusVisiblePolyfillMixin(LitElement) {
 
     protected renderDefault(): TemplateResult {
         return html`
-            <div id="cover-photo">
+            <sp-asset id="cover-photo">
                 <slot name="cover-photo"></slot>
-            </div>
+            </sp-asset>
             <div id="body">
                 <div id="header">
                     ${this.renderTitle}


### PR DESCRIPTION
## Description
Something about recent changes to the CSS had caused the Visual Regression suite to become unstable regarding the testing of the Card component across the various themes. This change is a small step in the larger work to catch the Card component fully up to the Spectrum CSS output as listed in #279 AND it seems to stabilize the test suite.

## Related Issue
refs #279 

## Motivation and Context
If tests are flaky, ain't nobody happy!

## How Has This Been Tested?
Visual Regressions.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
