### PR TITLE
feat(link): support rel attribute

### DIFF
--- a/packages/link/test/link.test.ts
+++ b/packages/link/test/link.test.ts
@@ -58,7 +58,7 @@ describe('Link', () => {
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
-        expect(el.getAttribute('rel')).to.eq('external'));
+        expect(el.getAttribute('rel')).to.eq('external');
 
         await expect(el).to.be.accessible();
     });

--- a/packages/link/test/link.test.ts
+++ b/packages/link/test/link.test.ts
@@ -58,7 +58,7 @@ describe('Link', () => {
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
-        expect(el.getAttribute('rel')).to.eq('external');
+        expect(el.focusElement.getAttribute('rel')).to.eq('external');
 
         await expect(el).to.be.accessible();
     });

--- a/packages/link/test/link.test.ts
+++ b/packages/link/test/link.test.ts
@@ -46,4 +46,20 @@ describe('Link', () => {
 
         await expect(el).to.be.accessible();
     });
+
+    it('loads[rel]', async () => {
+        const el = await fixture<Link>(
+            html`
+                <sp-link href="test_url" rel="external">
+                    Default Link
+                </sp-link>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el).to.not.be.undefined;
+        expect(el.getAttribute('rel')).to.eq('external'));
+
+        await expect(el).to.be.accessible();
+    });
 });

--- a/packages/shared/src/like-anchor.ts
+++ b/packages/shared/src/like-anchor.ts
@@ -22,6 +22,7 @@ export interface LikeAnchorInterface {
     download?: string;
     label?: string;
     href?: string;
+    rel?: string;
     target?: '_blank' | '_parent' | '_self' | '_top';
     renderAnchor(options: {
         id: string;
@@ -45,6 +46,9 @@ export function LikeAnchor<T extends Constructor<UpdatingElement>>(
         @property({ reflect: true })
         public target?: '_blank' | '_parent' | '_self' | '_top';
 
+        @property({ reflect: true })
+        public rel?: string;
+
         public renderAnchor({
             id,
             // prettier-ignore
@@ -61,6 +65,7 @@ export function LikeAnchor<T extends Constructor<UpdatingElement>>(
                     download=${ifDefined(this.download)}
                     target=${ifDefined(this.target)}
                     aria-label=${ifDefined(this.label)}
+                    rel=${ifDefined(this.rel)}
                 >${anchorContent}</a>`;
         }
     }


### PR DESCRIPTION
## Description

Add support for the `rel` attribute to the `LikeAnchor` (and thus `sp-link`) component

## Related Issue

- fixes #791

## Motivation and Context

- support `pwa-helpers` router behavior for handling links with `rel="external"`:

https://github.com/Polymer/pwa-helpers/blob/ce6be1a18655350c33b0f8949a1a16371d2caaa6/src/router.ts#L56

```ts
if (!anchor || anchor.target ||
        anchor.hasAttribute('download') ||
        anchor.getAttribute('rel') === 'external') return;
```

## How Has This Been Tested?

- unit test added

## Screenshots (if appropriate):

- n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
