### PR TITLE
Spectrum CSS Updates for more straight forward packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-21e6c01ef65c3c4b3325970a0f4b8612b4b7e23c
+                      - v1-golden-images-<< parameters.regression_color >>-<< parameters.regression_scale >>-f509e8453d1a10d5c1da63ca2ca4f75884d4c205
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >>
             - run:

--- a/__snapshots__/Dropdown.md
+++ b/__snapshots__/Dropdown.md
@@ -4,6 +4,7 @@
 
 ```html
 <sp-menu
+  dir="ltr"
   role="listbox"
   tabindex="0"
 >
@@ -40,7 +41,10 @@
   >
     Select and Mask...
   </sp-menu-item>
-  <sp-menu-divider role="separator">
+  <sp-menu-divider
+    dir="ltr"
+    role="separator"
+  >
   </sp-menu-divider>
   <sp-menu-item
     data-js-focus-visible=""
@@ -87,6 +91,7 @@
   </sp-icon>
 </button>
 <sp-popover
+  dir="ltr"
   id="popover"
   open=""
   placement="none"

--- a/__snapshots__/Search.md
+++ b/__snapshots__/Search.md
@@ -24,6 +24,59 @@
   >
   </sp-clear-button>
 </form>
+```
+
+#### `can be cleared from button`
+
+```html
+<form id="form">
+  <sp-icon
+    class="icon icon-workflow magnifier"
+    size="s"
+  >
+  </sp-icon>
+  <input
+    aria-label="Search"
+    id="input"
+    placeholder="Search"
+  >
+  <sp-clear-button
+    data-js-focus-visible=""
+    dir="ltr"
+    id="button"
+    label="Reset"
+    tabindex="-1"
+    variant=""
+  >
+  </sp-clear-button>
+</form>
+
+```
+
+#### `can be cleared via "Escape"`
+
+```html
+<form id="form">
+  <sp-icon
+    class="icon icon-workflow magnifier"
+    size="s"
+  >
+  </sp-icon>
+  <input
+    aria-label="Search"
+    id="input"
+    placeholder="Search"
+  >
+  <sp-clear-button
+    data-js-focus-visible=""
+    dir="ltr"
+    id="button"
+    label="Reset"
+    tabindex="-1"
+    variant=""
+  >
+  </sp-clear-button>
+</form>
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "@open-wc/polyfills-loader": "^0.3.3",
         "@open-wc/testing": "^2.5.17",
         "@open-wc/testing-karma": "^3.4.2",
-        "@spectrum-css/table": "^2.0.6",
+        "@spectrum-css/table": "^3.0.0-beta.3",
         "@types/chai": "^4.1.7",
         "@types/command-line-args": "^5.0.0",
         "@types/command-line-usage": "^5.0.1",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -47,7 +47,7 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/avatar": "^2.0.5"
+        "@spectrum-css/avatar": "^3.0.0-beta.2"
     },
     "dependencies": {
         "lit-element": "^2.1.0",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -47,9 +47,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/banner": "^2.0.5"
+        "@spectrum-css/banner": "^3.0.0-beta.2"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "lit-element": "^2.1.0",
         "lit-html": "^1.0.0",
         "tslib": "^2.0.0"

--- a/packages/banner/src/Banner.ts
+++ b/packages/banner/src/Banner.ts
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     property,
     CSSResultArray,
     TemplateResult,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import bannerStyles from './banner.css.js';
 
@@ -29,7 +29,7 @@ import bannerStyles from './banner.css.js';
  * @slot header - Primary message of the banner.
  * @slot content - Secondary message of the banner. Used to provide a description.
  */
-export class Banner extends LitElement {
+export class Banner extends SpectrumElement {
     @property({ reflect: true, type: String })
     public type: 'info' | 'warning' | 'error' = 'info';
 

--- a/packages/banner/src/spectrum-banner.css
+++ b/packages/banner/src/spectrum-banner.css
@@ -42,11 +42,18 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Banner-header */
     font-weight: 700;
 }
+:host([dir='ltr'][corner]) {
+    /* [dir=ltr] .spectrum-Banner--corner */
+    right: -10px;
+}
+:host([dir='rtl'][corner]) {
+    /* [dir=rtl] .spectrum-Banner--corner */
+    left: -10px;
+}
 :host([corner]) {
     /* .spectrum-Banner--corner */
     position: absolute;
     top: -10px;
-    right: -10px;
 }
 :host([type='info']) {
     /* .spectrum-Banner--info */

--- a/packages/bar-loader/package.json
+++ b/packages/bar-loader/package.json
@@ -51,9 +51,10 @@
         "lit-html": "^1.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/barloader": "^2.0.0"
+        "@spectrum-css/barloader": "^3.0.0-beta.2"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/bar-loader/src/BarLoader.ts
+++ b/packages/bar-loader/src/BarLoader.ts
@@ -12,19 +12,19 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     PropertyValues,
     property,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import styles from './bar-loader.css.js';
 
 /**
  * @element sp-bar-loader
  */
-export class BarLoader extends LitElement {
+export class BarLoader extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [styles];
     }

--- a/packages/bar-loader/src/bar-loader.css
+++ b/packages/bar-loader/src/bar-loader.css
@@ -16,3 +16,7 @@ governing permissions and limitations under the License.
     width: 100%;
     transform-origin: left;
 }
+
+:host([dir='rtl']) .fill {
+    transform-origin: right;
+}

--- a/packages/bar-loader/src/spectrum-bar-loader.css
+++ b/packages/bar-loader/src/spectrum-bar-loader.css
@@ -10,21 +10,36 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-@keyframes indeterminate-loop {
+@keyframes indeterminate-loop-ltr {
     0% {
-        transform: translate(0);
+        transform: translate(
+            calc(
+                -1 * var(--spectrum-barloader-large-indeterminate-fill-width, var(--spectrum-global-dimension-size-1700))
+            )
+        );
+    }
+    to {
+        transform: translate(
+            var(
+                --spectrum-barloader-large-width,
+                var(--spectrum-global-dimension-size-2400)
+            )
+        );
+    }
+}
+@keyframes indeterminate-loop-rtl {
+    0% {
+        transform: translate(
+            var(
+                --spectrum-barloader-large-width,
+                var(--spectrum-global-dimension-size-2400)
+            )
+        );
     }
     to {
         transform: translate(
             calc(
-                var(
-                        --spectrum-barloader-large-width,
-                        var(--spectrum-global-dimension-size-2400)
-                    ) +
-                    var(
-                        --spectrum-barloader-large-indeterminate-fill-width,
-                        var(--spectrum-global-dimension-size-1700)
-                    )
+                -1 * var(--spectrum-barloader-large-width, var(--spectrum-global-dimension-size-2400))
             )
         );
     }
@@ -75,6 +90,18 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-blue-500)
     );
 }
+:host([dir='ltr']) .label,
+:host([dir='ltr']) .percentage {
+    /* [dir=ltr] .spectrum-BarLoader-label,
+   * [dir=ltr] .spectrum-BarLoader-percentage */
+    text-align: left;
+}
+:host([dir='rtl']) .label,
+:host([dir='rtl']) .percentage {
+    /* [dir=rtl] .spectrum-BarLoader-label,
+   * [dir=rtl] .spectrum-BarLoader-percentage */
+    text-align: right;
+}
 .label,
 .percentage {
     /* .spectrum-BarLoader-label,
@@ -91,7 +118,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-fieldlabel-text-line-height,
         var(--spectrum-global-font-line-height-small)
     );
-    text-align: left;
     margin-bottom: var(
         --spectrum-barloader-large-label-gap-y,
         var(--spectrum-global-dimension-size-115)
@@ -101,13 +127,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-BarLoader-label */
     flex: 1 1 0%;
 }
-.percentage {
-    /* .spectrum-BarLoader-percentage */
-    align-self: flex-start;
+:host([dir='ltr']) .percentage {
+    /* [dir=ltr] .spectrum-BarLoader-percentage */
     margin-left: var(
         --spectrum-barloader-small-label-gap-x,
         var(--spectrum-global-dimension-size-150)
     );
+}
+:host([dir='rtl']) .percentage {
+    /* [dir=rtl] .spectrum-BarLoader-percentage */
+    margin-right: var(
+        --spectrum-barloader-small-label-gap-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+.percentage {
+    /* .spectrum-BarLoader-percentage */
+    align-self: flex-start;
 }
 :host([side-label]) {
     /* .spectrum-BarLoader--sideLabel */
@@ -116,22 +152,43 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     justify-content: space-between;
     width: auto;
 }
-:host([side-label]) .label {
-    /* .spectrum-BarLoader--sideLabel .spectrum-BarLoader-label */
+:host([dir='ltr'][side-label]) .label {
+    /* [dir=ltr] .spectrum-BarLoader--sideLabel .spectrum-BarLoader-label */
     margin-right: var(
         --spectrum-barloader-large-label-gap-x,
         var(--spectrum-global-dimension-size-150)
     );
-    margin-bottom: 0;
 }
-:host([side-label]) .percentage {
-    /* .spectrum-BarLoader--sideLabel .spectrum-BarLoader-percentage */
-    order: 3;
-    text-align: right;
+:host([dir='rtl'][side-label]) .label {
+    /* [dir=rtl] .spectrum-BarLoader--sideLabel .spectrum-BarLoader-label */
     margin-left: var(
         --spectrum-barloader-large-label-gap-x,
         var(--spectrum-global-dimension-size-150)
     );
+}
+:host([side-label]) .label {
+    /* .spectrum-BarLoader--sideLabel .spectrum-BarLoader-label */
+    margin-bottom: 0;
+}
+:host([dir='ltr'][side-label]) .percentage {
+    /* [dir=ltr] .spectrum-BarLoader--sideLabel .spectrum-BarLoader-percentage */
+    text-align: right; /* [dir=ltr] .spectrum-BarLoader--sideLabel .spectrum-BarLoader-percentage */
+    margin-left: var(
+        --spectrum-barloader-large-label-gap-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl'][side-label]) .percentage {
+    /* [dir=rtl] .spectrum-BarLoader--sideLabel .spectrum-BarLoader-percentage */
+    text-align: left; /* [dir=rtl] .spectrum-BarLoader--sideLabel .spectrum-BarLoader-percentage */
+    margin-right: var(
+        --spectrum-barloader-large-label-gap-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([side-label]) .percentage {
+    /* .spectrum-BarLoader--sideLabel .spectrum-BarLoader-percentage */
+    order: 3;
     margin-bottom: 0;
 }
 :host([small]) {
@@ -161,20 +218,29 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-1700)
     );
     position: relative;
-    animation: indeterminate-loop
+    animation-timing-function: var(
+        --spectrum-barloader-large-indeterminate-animation-ease,
+        var(--spectrum-global-animation-ease-in-out)
+    );
+    will-change: transform;
+}
+:host([dir='ltr'][indeterminate]) .fill {
+    /* [dir=ltr] .spectrum-BarLoader--indeterminate .spectrum-BarLoader-fill */
+    animation: indeterminate-loop-ltr
         var(
             --spectrum-barloader-large-indeterminate-duration,
             var(--spectrum-global-animation-duration-2000)
         )
         infinite;
-    animation-timing-function: var(
-        --spectrum-barloader-large-indeterminate-animation-ease,
-        var(--spectrum-global-animation-ease-in-out)
-    );
-    left: calc(
-        -1 * var(--spectrum-barloader-large-indeterminate-fill-width, var(--spectrum-global-dimension-size-1700))
-    );
-    will-change: transform;
+}
+:host([dir='rtl'][indeterminate]) .fill {
+    /* [dir=rtl] .spectrum-BarLoader--indeterminate .spectrum-BarLoader-fill */
+    animation: indeterminate-loop-rtl
+        var(
+            --spectrum-barloader-large-indeterminate-duration,
+            var(--spectrum-global-animation-duration-2000)
+        )
+        infinite;
 }
 :host([over-background]) .fill {
     /* .spectrum-BarLoader.spectrum-BarLoader--overBackground .spectrum-BarLoader-fill */

--- a/packages/bar-loader/test/bar-loader.test.ts
+++ b/packages/bar-loader/test/bar-loader.test.ts
@@ -79,7 +79,10 @@ describe('BarLoader', () => {
     });
     it('returns to indeterminate', async () => {
         const el = await fixture<BarLoader>(html`
-            <sp-bar-loader progress="50"></sp-bar-loader>
+            <sp-bar-loader
+                progress="50"
+                label="Sometimes indeterminate"
+            ></sp-bar-loader>
         `);
 
         await elementUpdated(el);

--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { LitElement } from 'lit-element';
+import { LitElement, property } from 'lit-element';
 
 export * from 'lit-element';
 
@@ -24,21 +24,31 @@ type Constructor<T = Record<string, unknown>> = {
 
 export interface SpectrumInterface {
     shadowRoot: ShadowRoot;
+    isDefaultDir: boolean;
+    dir: 'ltr' | 'rtl';
 }
 
 export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
     constructor: T
 ): T & Constructor<SpectrumInterface> {
-    return class SlotTextObservingElement extends constructor {
+    class SlotTextObservingElement extends constructor {
         public shadowRoot!: ShadowRoot;
+
+        @property({ reflect: true })
+        public dir: 'ltr' | 'rtl' = 'ltr';
+
+        public get isDefaultDir(): boolean {
+            return this.dir === 'ltr';
+        }
 
         public connectedCallback(): void {
             if (!this.hasAttribute('dir')) {
-                this.dir = document.dir || 'ltr';
+                this.dir = document.dir === 'rtl' ? document.dir : 'ltr';
             }
             super.connectedCallback();
         }
-    };
+    }
+    return SlotTextObservingElement;
 }
 
 export class SpectrumElement extends SpectrumMixin(LitElement) {}

--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -37,6 +37,9 @@ export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
         @property({ reflect: true })
         public dir: 'ltr' | 'rtl' = 'ltr';
 
+        /**
+         * @private
+         */
         public get isDefaultDir(): boolean {
             return this.dir === 'ltr';
         }

--- a/packages/base/test/base.test.ts
+++ b/packages/base/test/base.test.ts
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { SpectrumElement } from '../';
+import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
+
+class DirElement extends SpectrumElement {}
+
+customElements.define('dir-element', DirElement);
+
+describe('Base', () => {
+    after(() => {
+        document.dir = '';
+    });
+    it('sets `dir` from `document`', async () => {
+        document.dir = 'rtl';
+        const el = await fixture<DirElement>(
+            html`
+                <dir-element></dir-element>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.dir).to.equal('rtl');
+        expect(el.isDefaultDir).to.be.false;
+    });
+});

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -47,12 +47,11 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/buttongroup": "^2.0.0",
+        "@spectrum-css/buttongroup": "^3.0.0-beta.3",
         "@spectrum-web-components/button": "^0.8.3"
     },
     "dependencies": {
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
+        "@spectrum-web-components/base": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/button-group/src/ButtonGroup.ts
+++ b/packages/button-group/src/ButtonGroup.ts
@@ -12,18 +12,18 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     property,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import styles from './button-group.css.js';
 
 /**
  * @element sp-button-group
  */
-export class ButtonGroup extends LitElement {
+export class ButtonGroup extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [styles];
     }

--- a/packages/button-group/src/spectrum-button-group.css
+++ b/packages/button-group/src/spectrum-button-group.css
@@ -14,38 +14,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-ButtonGroup */
     display: flex;
 }
-::slotted(sp-action-button),
-::slotted(sp-button),
-::slotted(sp-tool) {
-    /* .spectrum-ButtonGroup .spectrum-ActionButton,
-   * .spectrum-ButtonGroup .spectrum-Button,
-   * .spectrum-ButtonGroup .spectrum-Tool */
+::slotted(*) {
+    /* .spectrum-ButtonGroup .spectrum-ButtonGroup-item */
     flex-shrink: 0;
 }
-:host > ::slotted(sp-rule[vertical]) {
-    /* .spectrum-ButtonGroup>.spectrum-Rule--vertical */
-    height: auto;
-    align-self: stretch;
-}
-::slotted(sp-button:not(:first-of-type)) {
-    /* .spectrum-ButtonGroup .spectrum-Button+.spectrum-Button */
+:host([dir='ltr']) ::slotted(*:not(:first-of-type)) {
+    /* [dir=ltr] .spectrum-ButtonGroup .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
     margin-left: var(
         --spectrum-buttongroup-button-gap-x,
         var(--spectrum-global-dimension-static-size-200)
     );
 }
-::slotted(sp-action-button:not(:first-of-type)) {
-    /* .spectrum-ButtonGroup .spectrum-ActionButton+.spectrum-ActionButton */
-    margin-left: var(
-        --spectrum-actionbuttongroup-text-button-gap-x,
-        var(--spectrum-global-dimension-size-100)
-    );
-}
-::slotted(sp-tool:not(:first-of-type)) {
-    /* .spectrum-ButtonGroup .spectrum-Tool+.spectrum-Tool */
-    margin-left: var(
-        --spectrum-toolgroup-text-button-gap-x,
-        var(--spectrum-global-dimension-size-100)
+:host([dir='rtl']) ::slotted(*:not(:first-of-type)) {
+    /* [dir=rtl] .spectrum-ButtonGroup .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
+    margin-right: var(
+        --spectrum-buttongroup-button-gap-x,
+        var(--spectrum-global-dimension-static-size-200)
     );
 }
 :host([vertical]) {
@@ -53,27 +37,18 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: inline-flex;
     flex-direction: column;
 }
-:host([vertical]) ::slotted(sp-button:not(:first-of-type)) {
-    /* .spectrum-ButtonGroup--vertical .spectrum-Button+.spectrum-Button */
+:host([dir='ltr'][vertical]) ::slotted(*:not(:first-of-type)) {
+    /* [dir=ltr] .spectrum-ButtonGroup--vertical .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
+    margin-left: 0;
+}
+:host([dir='rtl'][vertical]) ::slotted(*:not(:first-of-type)) {
+    /* [dir=rtl] .spectrum-ButtonGroup--vertical .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
+    margin-right: 0;
+}
+:host([vertical]) ::slotted(*:not(:first-of-type)) {
+    /* .spectrum-ButtonGroup--vertical .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
     margin-top: var(
         --spectrum-buttongroup-button-gap-y,
         var(--spectrum-global-dimension-static-size-200)
     );
-    margin-left: 0;
-}
-:host([vertical]) ::slotted(sp-action-button:not(:first-of-type)) {
-    /* .spectrum-ButtonGroup--vertical .spectrum-ActionButton+.spectrum-ActionButton */
-    margin-top: var(
-        --spectrum-actionbuttongroup-text-button-gap-y,
-        var(--spectrum-global-dimension-size-100)
-    );
-    margin-left: 0;
-}
-:host([vertical]) ::slotted(sp-tool:not(:first-of-type)) {
-    /* .spectrum-ButtonGroup--vertical .spectrum-Tool+.spectrum-Tool */
-    margin-top: var(
-        --spectrum-toolgroup-text-button-gap-y,
-        var(--spectrum-global-dimension-size-100)
-    );
-    margin-left: 0;
 }

--- a/packages/button-group/src/spectrum-config.js
+++ b/packages/button-group/src/spectrum-config.js
@@ -27,35 +27,15 @@ module.exports = {
             ],
             slots: [
                 {
-                    contents: 'sp-action-button',
-                    selector: '.spectrum-ActionButton',
-                },
-                {
-                    contents: 'sp-button',
-                    selector: '.spectrum-Button',
-                },
-                {
-                    contents: 'sp-tool',
-                    selector: '.spectrum-Tool',
-                },
-                {
-                    contents: 'sp-rule[vertical]',
-                    selector: '.spectrum-Rule--vertical',
+                    contents: '',
+                    selector: '.spectrum-ButtonGroup-item',
                 },
             ],
             complexSelectors: [
                 {
-                    replacement: '::slotted(sp-button:not(:first-of-type))',
-                    selector: '.spectrum-Button+.spectrum-Button',
-                },
-                {
-                    replacement: '::slotted(sp-tool:not(:first-of-type))',
-                    selector: '.spectrum-Tool+.spectrum-Tool',
-                },
-                {
-                    replacement:
-                        '::slotted(sp-action-button:not(:first-of-type))',
-                    selector: '.spectrum-ActionButton+.spectrum-ActionButton',
+                    replacement: '::slotted(*:not(:first-of-type))',
+                    selector:
+                        '.spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item',
                 },
             ],
             exclude: [/\.spectrum-ActionButton-label/],

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -66,6 +66,54 @@ describe('card', () => {
 
         await expect(el).to.be.accessible();
     });
+
+    it('loads - [quiet][small]', async () => {
+        const el = await fixture<Card>(
+            html`
+                <sp-card
+                    small
+                    title="Card Title"
+                    subtitle="JPG"
+                    variant="quiet"
+                    style="width: 115px;"
+                >
+                    <img
+                        src="https://picsum.photos/300/400"
+                        alt="Demo Image"
+                        slot="preview"
+                    />
+                    <div slot="footer">Footer</div>
+                    <sp-action-menu slot="actions" placement="bottom-end">
+                        <sp-menu>
+                            <sp-menu-item>
+                                Deselect
+                            </sp-menu-item>
+                            <sp-menu-item>
+                                Select Inverse
+                            </sp-menu-item>
+                            <sp-menu-item>
+                                Feather...
+                            </sp-menu-item>
+                            <sp-menu-item>
+                                Select and Mask...
+                            </sp-menu-item>
+                            <sp-menu-divider></sp-menu-divider>
+                            <sp-menu-item>
+                                Save Selection
+                            </sp-menu-item>
+                            <sp-menu-item disabled>
+                                Make Work Path
+                            </sp-menu-item>
+                        </sp-menu>
+                    </sp-action-menu>
+                </sp-card>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
     it('loads - [gallery]', async () => {
         const el = await fixture<Card>(
             html`

--- a/packages/circle-loader/package.json
+++ b/packages/circle-loader/package.json
@@ -47,11 +47,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/circleloader": "^2.0.5"
+        "@spectrum-css/circleloader": "^3.0.0-beta.2"
     },
     "dependencies": {
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
+        "@spectrum-web-components/base": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/circle-loader/src/CircleLoader.ts
+++ b/packages/circle-loader/src/CircleLoader.ts
@@ -15,14 +15,14 @@ import {
     TemplateResult,
     html,
     property,
-    LitElement,
+    SpectrumElement,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import circleLoaderStyles from './circle-loader.css.js';
 
-export class CircleLoader extends LitElement {
+export class CircleLoader extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [circleLoaderStyles];
     }

--- a/packages/circle-loader/src/spectrum-circle-loader.css
+++ b/packages/circle-loader/src/spectrum-circle-loader.css
@@ -419,11 +419,18 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-track-color-default)
     );
 }
+:host([dir='ltr']) .fills {
+    /* [dir=ltr] .spectrum-CircleLoader-fills */
+    left: 0;
+}
+:host([dir='rtl']) .fills {
+    /* [dir=rtl] .spectrum-CircleLoader-fills */
+    right: 0;
+}
 .fills {
     /* .spectrum-CircleLoader-fills */
     position: absolute;
     top: 0;
-    left: 0;
     width: 100%;
     height: 100%;
 }

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -47,7 +47,7 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/coachmark": "^2.0.0"
+        "@spectrum-css/coachmark": "^3.0.0-beta.3"
     },
     "dependencies": {
         "lit-element": "^2.1.0",

--- a/packages/coachmark/src/spectrum-coachmark.css
+++ b/packages/coachmark/src/spectrum-coachmark.css
@@ -71,6 +71,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         );
     }
 }
+:host([dir='ltr']) .spectrum-CoachMarkPopover-footer {
+    /* [dir=ltr] .spectrum-CoachMarkPopover-footer */
+    text-align: right;
+}
+:host([dir='rtl']) .spectrum-CoachMarkPopover-footer {
+    /* [dir=rtl] .spectrum-CoachMarkPopover-footer */
+    text-align: left;
+}
 :host {
     /* .spectrum-CoachMarkIndicator */
     position: relative;
@@ -102,12 +110,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     border-radius: 50%; /* .spectrum-CoachMarkIndicator-ring */
     top: calc(
-        var(
-                --spectrum-coachmark-indicator-ring-diameter,
-                var(--spectrum-global-dimension-size-200)
-            ) * 0.75
-    );
-    left: calc(
         var(
                 --spectrum-coachmark-indicator-ring-diameter,
                 var(--spectrum-global-dimension-size-200)
@@ -149,6 +151,24 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
+:host([dir='ltr']) .ring {
+    /* [dir=ltr] .spectrum-CoachMarkIndicator-ring */
+    left: calc(
+        var(
+                --spectrum-coachmark-indicator-ring-diameter,
+                var(--spectrum-global-dimension-size-200)
+            ) * 0.75
+    );
+}
+:host([dir='rtl']) .ring {
+    /* [dir=rtl] .spectrum-CoachMarkIndicator-ring */
+    right: calc(
+        var(
+                --spectrum-coachmark-indicator-ring-diameter,
+                var(--spectrum-global-dimension-size-200)
+            ) * 0.75
+    );
+}
 .ring:first-child {
     /* .spectrum-CoachMarkIndicator-ring:first-child */
     animation-delay: calc(
@@ -174,15 +194,27 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * 2.75
     );
 }
-:host([quiet]) .ring {
-    /* .spectrum-CoachMarkIndicator--quiet .spectrum-CoachMarkIndicator-ring */
-    top: calc(
+:host([dir='ltr'][quiet]) .ring {
+    /* [dir=ltr] .spectrum-CoachMarkIndicator--quiet .spectrum-CoachMarkIndicator-ring */
+    left: calc(
         var(
                 --spectrum-coachmark-quiet-indicator-ring-diameter,
                 var(--spectrum-global-dimension-size-100)
             ) * 0.75
     );
-    left: calc(
+}
+:host([dir='rtl'][quiet]) .ring {
+    /* [dir=rtl] .spectrum-CoachMarkIndicator--quiet .spectrum-CoachMarkIndicator-ring */
+    right: calc(
+        var(
+                --spectrum-coachmark-quiet-indicator-ring-diameter,
+                var(--spectrum-global-dimension-size-100)
+            ) * 0.75
+    );
+}
+:host([quiet]) .ring {
+    /* .spectrum-CoachMarkIndicator--quiet .spectrum-CoachMarkIndicator-ring */
+    top: calc(
         var(
                 --spectrum-coachmark-quiet-indicator-ring-diameter,
                 var(--spectrum-global-dimension-size-100)

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -51,14 +51,12 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/dialog": "^2.0.0",
-        "@spectrum-css/underlay": "^2.0.6"
+        "@spectrum-css/dialog": "^3.0.0-beta.3"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/button": "^0.8.3",
         "@spectrum-web-components/underlay": "^0.2.0",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -12,12 +12,12 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     property,
     query,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/button/sp-action-button.js';
 import alertMediumStyles from '@spectrum-web-components/icon/src/spectrum-icon-alert-medium.css.js';
@@ -35,7 +35,7 @@ import styles from './dialog.css.js';
  *
  * @fires close - Announces that the dialog has been closed.
  */
-export class Dialog extends LitElement {
+export class Dialog extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [styles, alertMediumStyles, crossLargeStyles];
     }
@@ -66,7 +66,7 @@ export class Dialog extends LitElement {
         if (this.shadowRoot) {
             const firstFocusable = this.shadowRoot.querySelector(
                 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-            ) as LitElement;
+            ) as SpectrumElement;
             /* istanbul ignore else */
             if (firstFocusable) {
                 /* istanbul ignore else */

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -12,12 +12,12 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     TemplateResult,
     property,
     CSSResultArray,
     query,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 import '@spectrum-web-components/underlay/sp-underlay.js';
@@ -35,7 +35,7 @@ import { Dialog } from './Dialog.js';
  * @fires confirm - Announces that the "confirm" button has been clicked.
  * @fires close - Announces that the dialog has been closed.
  */
-export class DialogWrapper extends LitElement {
+export class DialogWrapper extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [styles];
     }
@@ -93,7 +93,7 @@ export class DialogWrapper extends LitElement {
         if (this.shadowRoot) {
             const firstFocusable = this.shadowRoot.querySelector(
                 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-            ) as LitElement;
+            ) as SpectrumElement;
             if (firstFocusable) {
                 /* istanbul ignore else */
                 if (firstFocusable.updateComplete) {

--- a/packages/dialog/src/spectrum-dialog-wrapper.css
+++ b/packages/dialog/src/spectrum-dialog-wrapper.css
@@ -10,11 +10,46 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host([dir='ltr']) .spectrum-Dialog-hero {
+    /* [dir=ltr] .spectrum-Dialog-hero */
+    margin-left: calc(
+        -1 * var(--spectrum-dialog-padding)
+    ); /* [dir=ltr] .spectrum-Dialog-hero */
+    border-top-left-radius: var(
+        --spectrum-dialog-border-radius,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+:host([dir='ltr']) .spectrum-Dialog-hero,
+:host([dir='rtl']) .spectrum-Dialog-hero {
+    /* [dir=ltr] .spectrum-Dialog-hero,
+   * [dir=rtl] .spectrum-Dialog-hero */
+    margin-right: calc(-1 * var(--spectrum-dialog-padding));
+}
+:host([dir='rtl']) .spectrum-Dialog-hero {
+    /* [dir=rtl] .spectrum-Dialog-hero */
+    margin-left: calc(
+        -1 * var(--spectrum-dialog-padding)
+    ); /* [dir=rtl] .spectrum-Dialog-hero */
+    border-top-left-radius: var(
+        --spectrum-dialog-border-radius,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+:host([dir='ltr']) .spectrum-Dialog-hero,
+:host([dir='rtl']) .spectrum-Dialog-hero {
+    /* [dir=ltr] .spectrum-Dialog-hero,
+   * [dir=rtl] .spectrum-Dialog-hero */
+    border-top-right-radius: var(
+        --spectrum-dialog-border-radius,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
 :host {
     /* .spectrum-Dialog-wrapper */
     position: fixed;
     left: 0;
-    top: 0;
+    right: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -52,4 +87,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([responsive]) {
     /* .spectrum-Dialog-wrapper .spectrum-Dialog--responsive */
     margin-top: 0;
+}
+:host([dir='ltr']) .spectrum-Dialog-closeButton {
+    /* [dir=ltr] .spectrum-Dialog-closeButton */
+    right: calc(-1 * var(--spectrum-global-dimension-size-350));
+}
+:host([dir='rtl']) .spectrum-Dialog-closeButton {
+    /* [dir=rtl] .spectrum-Dialog-closeButton */
+    left: calc(-1 * var(--spectrum-global-dimension-size-350));
+}
+:host([dir='ltr']) .spectrum-Dialog-typeIcon {
+    /* [dir=ltr] .spectrum-Dialog-typeIcon */
+    margin-left: var(
+        --spectrum-dialog-icon-margin-left,
+        var(--spectrum-global-dimension-static-size-300)
+    );
+}
+:host([dir='rtl']) .spectrum-Dialog-typeIcon {
+    /* [dir=rtl] .spectrum-Dialog-typeIcon */
+    margin-right: var(
+        --spectrum-dialog-icon-margin-left,
+        var(--spectrum-global-dimension-static-size-300)
+    );
 }

--- a/packages/dialog/src/spectrum-dialog.css
+++ b/packages/dialog/src/spectrum-dialog.css
@@ -112,7 +112,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: none; /* .spectrum-Dialog-closeButton */
     position: absolute;
     top: calc(-1 * var(--spectrum-global-dimension-size-350));
-    right: calc(-1 * var(--spectrum-global-dimension-size-350));
 }
 :host([size='small']) {
     /* .spectrum-Dialog--small */
@@ -126,19 +125,46 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Dialog--large */
     width: 640px;
 }
-::slotted([slot='hero']) {
-    /* .spectrum-Dialog-hero */
-    height: var(--spectrum-global-dimension-size-1600);
-    margin: calc(-1 * var(--spectrum-dialog-padding))
-        calc(-1 * var(--spectrum-dialog-padding)) var(--spectrum-dialog-padding);
+:host([dir='ltr']) ::slotted([slot='hero']) {
+    /* [dir=ltr] .spectrum-Dialog-hero */
+    margin-left: calc(
+        -1 * var(--spectrum-dialog-padding)
+    ); /* [dir=ltr] .spectrum-Dialog-hero */
     border-top-left-radius: var(
         --spectrum-dialog-border-radius,
         var(--spectrum-global-dimension-size-50)
     );
+}
+:host([dir='ltr']) ::slotted([slot='hero']),
+:host([dir='rtl']) ::slotted([slot='hero']) {
+    /* [dir=ltr] .spectrum-Dialog-hero,
+   * [dir=rtl] .spectrum-Dialog-hero */
+    margin-right: calc(-1 * var(--spectrum-dialog-padding));
+}
+:host([dir='rtl']) ::slotted([slot='hero']) {
+    /* [dir=rtl] .spectrum-Dialog-hero */
+    margin-left: calc(
+        -1 * var(--spectrum-dialog-padding)
+    ); /* [dir=rtl] .spectrum-Dialog-hero */
+    border-top-left-radius: var(
+        --spectrum-dialog-border-radius,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+:host([dir='ltr']) ::slotted([slot='hero']),
+:host([dir='rtl']) ::slotted([slot='hero']) {
+    /* [dir=ltr] .spectrum-Dialog-hero,
+   * [dir=rtl] .spectrum-Dialog-hero */
     border-top-right-radius: var(
         --spectrum-dialog-border-radius,
         var(--spectrum-global-dimension-size-50)
     );
+}
+::slotted([slot='hero']) {
+    /* .spectrum-Dialog-hero */
+    height: var(--spectrum-global-dimension-size-1600);
+    margin-top: calc(-1 * var(--spectrum-dialog-padding));
+    margin-bottom: var(--spectrum-dialog-padding);
     background-size: cover;
     background-position: 50%;
 }
@@ -150,15 +176,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     box-sizing: border-box;
     width: 100%;
     flex-shrink: 0;
-    border-radius: var(
-            --spectrum-dialog-border-radius,
-            var(--spectrum-global-dimension-size-50)
-        )
-        var(
-            --spectrum-dialog-border-radius,
-            var(--spectrum-global-dimension-size-50)
-        )
-        0 0;
+    border-top-left-radius: var(
+        --spectrum-dialog-border-radius,
+        var(--spectrum-global-dimension-size-50)
+    );
+    border-top-right-radius: var(
+        --spectrum-dialog-border-radius,
+        var(--spectrum-global-dimension-size-50)
+    );
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
     outline: none;
     padding-bottom: calc(
         var(
@@ -212,13 +239,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Dialog--dismissible .spectrum-Dialog-closeButton */
     display: initial;
 }
-.type-icon {
-    /* .spectrum-Dialog-typeIcon */
-    display: block;
+:host([dir='ltr']) .close-button {
+    /* [dir=ltr] .spectrum-Dialog-closeButton */
+    right: calc(-1 * var(--spectrum-global-dimension-size-350));
+}
+:host([dir='rtl']) .close-button {
+    /* [dir=rtl] .spectrum-Dialog-closeButton */
+    left: calc(-1 * var(--spectrum-global-dimension-size-350));
+}
+:host([dir='ltr']) .type-icon {
+    /* [dir=ltr] .spectrum-Dialog-typeIcon */
     margin-left: var(
         --spectrum-dialog-icon-margin-left,
         var(--spectrum-global-dimension-static-size-300)
     );
+}
+:host([dir='rtl']) .type-icon {
+    /* [dir=rtl] .spectrum-Dialog-typeIcon */
+    margin-right: var(
+        --spectrum-dialog-icon-margin-left,
+        var(--spectrum-global-dimension-static-size-300)
+    );
+}
+.type-icon {
+    /* .spectrum-Dialog-typeIcon */
+    display: block;
     flex-shrink: 0;
     align-self: flex-start; /* .spectrum-Dialog-typeIcon */
     color: var(
@@ -251,15 +296,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 .footer {
     /* .spectrum-Dialog-footer */
-    border-radius: 0 0
-        var(
-            --spectrum-dialog-border-radius,
-            var(--spectrum-global-dimension-size-50)
-        )
-        var(
-            --spectrum-dialog-border-radius,
-            var(--spectrum-global-dimension-size-50)
-        );
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: var(
+        --spectrum-dialog-border-radius,
+        var(--spectrum-global-dimension-size-50)
+    );
+    border-bottom-left-radius: var(
+        --spectrum-dialog-border-radius,
+        var(--spectrum-global-dimension-size-50)
+    );
     padding-top: calc(
         var(--spectrum-global-dimension-size-450) -
             var(--spectrum-global-dimension-size-200) / 2
@@ -307,10 +353,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([mode='fullscreen']) {
     /* .spectrum-Dialog--fullscreen */
-    left: 32px;
     top: 32px;
     right: 32px;
     bottom: 32px;
+    left: 32px;
     transform: translateY(
         var(
             --spectrum-dialog-entry-animation-distance,
@@ -353,10 +399,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([mode='fullscreenTakeover']) {
     /* .spectrum-Dialog--fullscreenTakeover */
     position: fixed;
-    left: 0;
-    right: 0;
     top: 0;
+    right: 0;
     bottom: 0;
+    left: 0;
     box-sizing: border-box;
     border: none;
     border-radius: 0;
@@ -380,7 +426,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Dialog--error .spectrum-Dialog-title */
     color: var(
         --spectrum-dialog-error-title-text-color,
-        var(--spectrum-semantic-negative-color-text-small)
+        var(--spectrum-global-color-gray-900)
     );
 }
 :host([error]) .type-icon {

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -52,9 +52,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/dropdown": "^2.1.5"
+        "@spectrum-css/dropdown": "^3.0.0-beta.3"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/button": "^0.8.3",
         "@spectrum-web-components/icon": "^0.5.1",
         "@spectrum-web-components/icons-ui": "^0.2.1",
@@ -62,8 +63,6 @@
         "@spectrum-web-components/overlay": "^0.5.1",
         "@spectrum-web-components/popover": "^0.4.5",
         "@spectrum-web-components/shared": "^0.6.0",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/dropdown/src/Dropdown.ts
+++ b/packages/dropdown/src/Dropdown.ts
@@ -17,7 +17,7 @@ import {
     CSSResultArray,
     TemplateResult,
     query,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { nothing } from 'lit-html';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 

--- a/packages/dropdown/src/Dropdown.ts
+++ b/packages/dropdown/src/Dropdown.ts
@@ -233,6 +233,8 @@ export class DropdownBase extends Focusable {
         if (this.optionsMenu && this.placeholder) {
             const parentElement =
                 this.placeholder.parentElement ||
+                /* istanbul ignore next */
+
                 this.placeholder.getRootNode();
 
             /* istanbul ignore else */
@@ -260,7 +262,8 @@ export class DropdownBase extends Focusable {
         );
 
         const parentElement =
-            this.optionsMenu.parentElement || this.optionsMenu.getRootNode();
+            this.optionsMenu.parentElement ||
+            /* istanbul ignore next */ this.optionsMenu.getRootNode();
 
         /* istanbul ignore else */
         if (parentElement) {
@@ -376,6 +379,7 @@ export class DropdownBase extends Focusable {
     }
 
     private async manageSelection(): Promise<void> {
+        /* istanbul ignore if */
         if (!this.optionsMenu) {
             return;
         }
@@ -399,6 +403,7 @@ export class DropdownBase extends Focusable {
             return;
         }
         await this.optionsMenu.updateComplete;
+        /* istanbul ignore else */
         if (this.optionsMenu.menuItems.length) {
             this.manageSelection();
         }

--- a/packages/dropdown/src/dropdown.css
+++ b/packages/dropdown/src/dropdown.css
@@ -14,12 +14,3 @@ governing permissions and limitations under the License.
 sp-popover {
     display: none;
 }
-
-#label ~ .dropdown {
-    /* .spectrum-Icon + .spectrum-Dropdown-icon
-        with specificity bump to counteract #label ~ .dropdown elsewhere */
-    margin-left: var(
-        --spectrum-dropdown-icon-gap,
-        var(--spectrum-global-dimension-size-100)
-    );
-}

--- a/packages/dropdown/src/spectrum-dropdown.css
+++ b/packages/dropdown/src/spectrum-dropdown.css
@@ -36,13 +36,23 @@ select::-ms-value {
     /* .spectrum-Dropdown select::-ms-value */
     background-color: initial;
 }
-select + .dropdown {
-    /* .spectrum-Dropdown select+.spectrum-Dropdown-icon */
-    position: absolute;
+:host([dir='ltr']) select + .dropdown {
+    /* [dir=ltr] .spectrum-Dropdown select+.spectrum-Dropdown-icon */
     right: var(
         --spectrum-dropdown-padding-x,
         var(--spectrum-global-dimension-size-150)
     );
+}
+:host([dir='rtl']) select + .dropdown {
+    /* [dir=rtl] .spectrum-Dropdown select+.spectrum-Dropdown-icon */
+    left: var(
+        --spectrum-dropdown-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+select + .dropdown {
+    /* .spectrum-Dropdown select+.spectrum-Dropdown-icon */
+    position: absolute;
     top: 50%;
     margin-top: calc(
         var(
@@ -58,6 +68,14 @@ select + .dropdown {
     display: flex;
     justify-content: space-between;
     align-items: center;
+}
+:host([dir='ltr']) #label {
+    /* [dir=ltr] .spectrum-Dropdown-label */
+    text-align: left;
+}
+:host([dir='rtl']) #label {
+    /* [dir=rtl] .spectrum-Dropdown-label */
+    text-align: right;
 }
 #label {
     /* .spectrum-Dropdown-label */
@@ -89,7 +107,6 @@ select + .dropdown {
         var(--spectrum-alias-font-size-default)
     );
     text-overflow: ellipsis;
-    text-align: left;
 }
 #label.placeholder {
     /* .spectrum-Dropdown-label.is-placeholder */
@@ -108,16 +125,44 @@ select + .dropdown {
         var(--spectrum-alias-placeholder-text-color)
     );
 }
-#label + .dropdown {
-    /* .spectrum-Dropdown-label+.spectrum-Dropdown-icon */
+:host([dir='ltr']) #label + .dropdown {
+    /* [dir=ltr] .spectrum-Dropdown-label+.spectrum-Dropdown-icon */
     margin-left: var(
         --spectrum-dropdown-icon-margin-left,
         var(--spectrum-global-dimension-size-150)
     );
 }
-#label ~ .dropdown {
-    /* .spectrum-Dropdown-label~.spectrum-Dropdown-icon */
+:host([dir='rtl']) #label + .dropdown {
+    /* [dir=rtl] .spectrum-Dropdown-label+.spectrum-Dropdown-icon */
+    margin-right: var(
+        --spectrum-dropdown-icon-margin-left,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='ltr']) .icon + #label {
+    /* [dir=ltr] .spectrum-Icon+.spectrum-Dropdown-label */
     margin-left: var(
+        --spectrum-selectlist-thumbnail-image-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl']) .icon + #label {
+    /* [dir=rtl] .spectrum-Icon+.spectrum-Dropdown-label */
+    margin-right: var(
+        --spectrum-selectlist-thumbnail-image-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='ltr']) #label ~ .dropdown {
+    /* [dir=ltr] .spectrum-Dropdown-label~.spectrum-Dropdown-icon */
+    margin-left: var(
+        --spectrum-dropdown-icon-margin-left,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) #label ~ .dropdown {
+    /* [dir=rtl] .spectrum-Dropdown-label~.spectrum-Dropdown-icon */
+    margin-right: var(
         --spectrum-dropdown-icon-margin-left,
         var(--spectrum-global-dimension-size-150)
     );
@@ -202,11 +247,32 @@ select + .dropdown {
             ) / 2
     );
 }
-#button #label + .icon:not(.dropdown) {
-    /* .spectrum-Dropdown-trigger .spectrum-Dropdown-label+.spectrum-Icon:not(.spectrum-Dropdown-icon) */
+:host([dir='ltr']) #button #label + .icon:not(.dropdown) {
+    /* [dir=ltr] .spectrum-Dropdown-trigger .spectrum-Dropdown-label+.spectrum-Icon:not(.spectrum-Dropdown-icon) */
     margin-left: var(
         --spectrum-dropdown-icon-margin-left,
         var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) #button #label + .icon:not(.dropdown) {
+    /* [dir=rtl] .spectrum-Dropdown-trigger .spectrum-Dropdown-label+.spectrum-Icon:not(.spectrum-Dropdown-icon) */
+    margin-right: var(
+        --spectrum-dropdown-icon-margin-left,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='ltr']) .icon + .dropdown {
+    /* [dir=ltr] .spectrum-Icon+.spectrum-Dropdown-icon */
+    margin-left: var(
+        --spectrum-dropdown-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl']) .icon + .dropdown {
+    /* [dir=rtl] .spectrum-Icon+.spectrum-Dropdown-icon */
+    margin-right: var(
+        --spectrum-dropdown-icon-gap,
+        var(--spectrum-global-dimension-size-100)
     );
 }
 :host([quiet]) {
@@ -221,9 +287,22 @@ select + .dropdown {
     /* .spectrum-Dropdown-popover */
     max-width: var(--spectrum-global-dimension-size-3000);
 }
-.spectrum-Dropdown-popover--quiet {
-    /* .spectrum-Dropdown-popover--quiet */
+:host([dir='ltr']) .spectrum-Dropdown-popover--quiet {
+    /* [dir=ltr] .spectrum-Dropdown-popover--quiet */
     margin-left: calc(
+        -1 * (var(
+                        --spectrum-dropdown-quiet-popover-offset-x,
+                        var(--spectrum-global-dimension-size-150)
+                    ) +
+                    var(
+                        --spectrum-popover-border-size,
+                        var(--spectrum-alias-border-size-thin)
+                    ))
+    );
+}
+:host([dir='rtl']) .spectrum-Dropdown-popover--quiet {
+    /* [dir=rtl] .spectrum-Dropdown-popover--quiet */
+    margin-right: calc(
         -1 * (var(
                         --spectrum-dropdown-quiet-popover-offset-x,
                         var(--spectrum-global-dimension-size-150)

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -47,11 +47,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/dropzone": "^2.1.1"
+        "@spectrum-css/dropzone": "^3.0.0-beta.2"
     },
     "dependencies": {
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
+        "@spectrum-web-components/base": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/dropzone/src/Dropzone.ts
+++ b/packages/dropzone/src/Dropzone.ts
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     property,
     CSSResultArray,
     TemplateResult,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import dropzoneStyles from './dropzone.css.js';
 
@@ -27,7 +27,7 @@ export type DropEffects = 'copy' | 'move' | 'link' | 'none';
 /**
  * @slot default - This is the illustrated message slot
  */
-export class Dropzone extends LitElement {
+export class Dropzone extends SpectrumElement {
     public static readonly is = 'sp-dropzone';
 
     public static get styles(): CSSResultArray {

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -47,7 +47,7 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/icon": "^2.0.5"
+        "@spectrum-css/icon": "^2.1.1"
     },
     "dependencies": {
         "@spectrum-web-components/iconset": "^0.2.0",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -42,7 +42,7 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/icon": "^2.1.0",
+        "@spectrum-css/icon": "^2.1.1",
         "@spectrum-web-components/icon": "^0.5.1",
         "@spectrum-web-components/iconset": "^0.1.7",
         "case": "^1.6.1",

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -45,11 +45,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/illustratedmessage": "^2.1.1"
+        "@spectrum-css/illustratedmessage": "^3.0.0-beta.2"
     },
     "dependencies": {
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
+        "@spectrum-web-components/base": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/illustrated-message/src/IllustratedMessage.ts
+++ b/packages/illustrated-message/src/IllustratedMessage.ts
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     property,
     CSSResultArray,
     TemplateResult,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import messageStyles from './illustrated-message.css.js';
 
@@ -24,7 +24,7 @@ import messageStyles from './illustrated-message.css.js';
  * @slot - The SVG that represents the illustration
  */
 
-export class IllustratedMessage extends LitElement {
+export class IllustratedMessage extends SpectrumElement {
     public static readonly is = 'sp-illustrated-message';
 
     public static get styles(): CSSResultArray {

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -59,15 +59,14 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/menu": "^2.1.5"
+        "@spectrum-css/menu": "^3.0.0-beta.2"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/button": "^0.8.3",
         "@spectrum-web-components/icon": "^0.5.1",
         "@spectrum-web-components/icons-ui": "^0.2.1",
         "@spectrum-web-components/shared": "^0.6.0",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -10,7 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, LitElement, CSSResultArray, TemplateResult } from 'lit-element';
+import {
+    html,
+    SpectrumElement,
+    CSSResultArray,
+    TemplateResult,
+} from '@spectrum-web-components/base';
 
 import { MenuItem } from './MenuItem.js';
 import menuStyles from './menu.css.js';
@@ -24,7 +29,7 @@ export interface MenuQueryRoleEventDetail {
  * @element sp-menu
  *
  */
-export class Menu extends LitElement {
+export class Menu extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [menuStyles];
     }

--- a/packages/menu/src/MenuDivider.ts
+++ b/packages/menu/src/MenuDivider.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { CSSResultArray, LitElement } from 'lit-element';
+import { CSSResultArray, SpectrumElement } from '@spectrum-web-components/base';
 
 import menuDividerStyles from './menu-divider.css.js';
 
@@ -19,7 +19,7 @@ import menuDividerStyles from './menu-divider.css.js';
  * @element sp-menu-divider
  *
  */
-export class MenuDivider extends LitElement {
+export class MenuDivider extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [menuDividerStyles];
     }

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -10,7 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, LitElement, CSSResultArray, TemplateResult } from 'lit-element';
+import {
+    html,
+    SpectrumElement,
+    CSSResultArray,
+    TemplateResult,
+} from '@spectrum-web-components/base';
 
 import menuGroupStyles from './menu-group.css.js';
 
@@ -21,7 +26,7 @@ import menuGroupStyles from './menu-group.css.js';
  * @slot header - headline of the menu group
  * @slot - menu items to be listed in the group
  */
-export class MenuGroup extends LitElement {
+export class MenuGroup extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [menuGroupStyles];
     }

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -10,7 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, property, CSSResultArray, TemplateResult } from 'lit-element';
+import {
+    html,
+    property,
+    CSSResultArray,
+    TemplateResult,
+} from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/icon/sp-icon.js';
 import { CheckmarkMediumIcon } from '@spectrum-web-components/icons-ui';

--- a/packages/menu/src/spectrum-menu-divider.css
+++ b/packages/menu/src/spectrum-menu-divider.css
@@ -10,6 +10,152 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host([dir='ltr']) .spectrum-Menu.is-selectable .spectrum-Menu-item {
+    /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+    padding-right: calc(
+        var(--spectrum-global-dimension-size-100) +
+            var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-selectlist-option-icon-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl']) .spectrum-Menu.is-selectable .spectrum-Menu-item {
+    /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+    padding-left: calc(
+        var(--spectrum-global-dimension-size-100) +
+            var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-selectlist-option-icon-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='ltr'])
+    .spectrum-Menu.is-selectable
+    .spectrum-Menu-item.is-selected {
+    /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
+    padding-right: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='rtl'])
+    .spectrum-Menu.is-selectable
+    .spectrum-Menu-item.is-selected {
+    /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
+    padding-left: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='ltr']) .spectrum-Menu-item {
+    /* [dir=ltr] .spectrum-Menu-item */
+    border-left: var(
+            --spectrum-selectlist-border-size-key-focus,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        solid transparent;
+}
+:host([dir='rtl']) .spectrum-Menu-item {
+    /* [dir=rtl] .spectrum-Menu-item */
+    border-right: var(
+            --spectrum-selectlist-border-size-key-focus,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        solid transparent;
+}
+:host([dir='ltr']) .spectrum-Menu-item.is-selected {
+    /* [dir=ltr] .spectrum-Menu-item.is-selected */
+    padding-right: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-item.is-selected {
+    /* [dir=rtl] .spectrum-Menu-item.is-selected */
+    padding-left: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='ltr'])
+    .spectrum-Menu-item
+    .spectrum-Icon
+    + .spectrum-Menu-itemLabel,
+:host([dir='ltr'])
+    .spectrum-Menu-item
+    .spectrum-Menu-itemIcon
+    + .spectrum-Menu-itemLabel {
+    /* [dir=ltr] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=ltr] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-left: var(
+        --spectrum-selectlist-thumbnail-image-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl'])
+    .spectrum-Menu-item
+    .spectrum-Icon
+    + .spectrum-Menu-itemLabel,
+:host([dir='rtl'])
+    .spectrum-Menu-item
+    .spectrum-Menu-itemIcon
+    + .spectrum-Menu-itemLabel {
+    /* [dir=rtl] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=rtl] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-right: var(
+        --spectrum-selectlist-thumbnail-image-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='ltr']) .spectrum-Menu-checkmark,
+:host([dir='ltr']) .spectrum-Menu-chevron {
+    /* [dir=ltr] .spectrum-Menu-checkmark,
+   * [dir=ltr] .spectrum-Menu-chevron */
+    margin-left: var(
+        --spectrum-selectlist-option-icon-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-checkmark,
+:host([dir='rtl']) .spectrum-Menu-chevron {
+    /* [dir=rtl] .spectrum-Menu-checkmark,
+   * [dir=rtl] .spectrum-Menu-chevron */
+    margin-right: var(
+        --spectrum-selectlist-option-icon-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-chevron {
+    /* [dir=rtl] .spectrum-Menu-chevron */
+    transform: matrix(-1, 0, 0, 1, 0, 0);
+}
 :host {
     /* .spectrum-Menu-divider */
     box-sizing: initial;
@@ -28,5 +174,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     background-color: var(
         --spectrum-selectlist-divider-color,
         var(--spectrum-alias-border-color-extralight)
+    );
+}
+:host([dir='ltr']) .spectrum-Menu-item:focus-visible,
+:host([dir='ltr']) .spectrum-Menu-item.is-focused {
+    /* [dir=ltr] .spectrum-Menu-item.focus-ring,
+   * [dir=ltr] .spectrum-Menu-item.is-focused */
+    border-left-color: var(
+        --spectrum-selectlist-option-focus-indicator-color,
+        var(--spectrum-alias-border-color-focus)
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-item:focus-visible,
+:host([dir='rtl']) .spectrum-Menu-item.is-focused {
+    /* [dir=rtl] .spectrum-Menu-item.focus-ring,
+   * [dir=rtl] .spectrum-Menu-item.is-focused */
+    border-right-color: var(
+        --spectrum-selectlist-option-focus-indicator-color,
+        var(--spectrum-alias-border-color-focus)
     );
 }

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -10,6 +10,54 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host([dir='ltr']) .spectrum-Menu.is-selectable #button {
+    /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+    padding-right: calc(
+        var(--spectrum-global-dimension-size-100) +
+            var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-selectlist-option-icon-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl']) .spectrum-Menu.is-selectable #button {
+    /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+    padding-left: calc(
+        var(--spectrum-global-dimension-size-100) +
+            var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-selectlist-option-icon-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='ltr'][selected]) .spectrum-Menu.is-selectable #button {
+    /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
+    padding-right: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='rtl'][selected]) .spectrum-Menu.is-selectable #button {
+    /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
+    padding-left: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
 #selected {
     /* .spectrum-Menu-checkmark */
     transform: scale(1);
@@ -18,11 +66,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     align-self: flex-start; /* .spectrum-Menu-checkmark,
    * .spectrum-Menu-chevron */
     flex-grow: 0;
-    margin-left: var(
-        --spectrum-selectlist-option-icon-padding-x,
-        var(--spectrum-global-dimension-size-150)
-    );
     margin-top: var(--spectrum-global-dimension-size-50);
+}
+:host([dir='ltr']) #button {
+    /* [dir=ltr] .spectrum-Menu-item */
+    border-left: var(
+            --spectrum-selectlist-border-size-key-focus,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        solid transparent;
+}
+:host([dir='rtl']) #button {
+    /* [dir=rtl] .spectrum-Menu-item */
+    border-right: var(
+            --spectrum-selectlist-border-size-key-focus,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        solid transparent;
 }
 #button {
     /* .spectrum-Menu-item */
@@ -48,11 +108,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 )
         );
     margin: 0;
-    border-left: var(
-            --spectrum-selectlist-border-size-key-focus,
-            var(--spectrum-global-dimension-static-size-25)
-        )
-        solid transparent;
     min-height: var(--spectrum-selectlist-option-height);
     font-size: var(
         --spectrum-selectlist-option-text-size,
@@ -77,8 +132,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Menu-item:focus */
     outline: none;
 }
-:host([selected]) #button {
-    /* .spectrum-Menu-item.is-selected */
+:host([dir='ltr'][selected]) #button {
+    /* [dir=ltr] .spectrum-Menu-item.is-selected */
     padding-right: calc(
         var(
                 --spectrum-selectlist-option-padding,
@@ -88,10 +143,19 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 --spectrum-popover-border-size,
                 var(--spectrum-alias-border-size-thin)
             )
-    ); /* .spectrum-Menu-item.is-selected */
-    color: var(
-        --spectrum-selectlist-option-text-color-selected,
-        var(--spectrum-alias-text-color)
+    );
+}
+:host([dir='rtl'][selected]) #button {
+    /* [dir=rtl] .spectrum-Menu-item.is-selected */
+    padding-left: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
     );
 }
 :host([selected]) #button #selected {
@@ -109,14 +173,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     flex-shrink: 0;
     align-self: flex-start;
 }
-slot[name='icon'] + #label,
-.spectrum-Menu-itemIcon + #label {
-    /* .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
-   * .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+:host([dir='ltr']) #button slot[name='icon'] + #label,
+:host([dir='ltr']) #button .spectrum-Menu-itemIcon + #label {
+    /* [dir=ltr] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=ltr] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
     margin-left: var(
         --spectrum-selectlist-thumbnail-image-padding-x,
         var(--spectrum-global-dimension-size-100)
     );
+}
+:host([dir='rtl']) #button slot[name='icon'] + #label,
+:host([dir='rtl']) #button .spectrum-Menu-itemIcon + #label {
+    /* [dir=rtl] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=rtl] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-right: var(
+        --spectrum-selectlist-thumbnail-image-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+slot[name='icon'] + #label,
+.spectrum-Menu-itemIcon + #label {
+    /* .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
     width: calc(
         100% - var(--spectrum-icon-checkmark-medium-width) -
             var(
@@ -154,6 +232,46 @@ slot[name='icon'] + #label,
     white-space: nowrap;
     overflow: hidden;
 }
+:host([dir='ltr']) #selected,
+:host([dir='ltr']) .spectrum-Menu-chevron {
+    /* [dir=ltr] .spectrum-Menu-checkmark,
+   * [dir=ltr] .spectrum-Menu-chevron */
+    margin-left: var(
+        --spectrum-selectlist-option-icon-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) #selected,
+:host([dir='rtl']) .spectrum-Menu-chevron {
+    /* [dir=rtl] .spectrum-Menu-checkmark,
+   * [dir=rtl] .spectrum-Menu-chevron */
+    margin-right: var(
+        --spectrum-selectlist-option-icon-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-chevron {
+    /* [dir=rtl] .spectrum-Menu-chevron */
+    transform: matrix(-1, 0, 0, 1, 0, 0);
+}
+:host([dir='ltr']) #button:focus-visible,
+:host([dir='ltr']) #button.is-focused {
+    /* [dir=ltr] .spectrum-Menu-item.focus-ring,
+   * [dir=ltr] .spectrum-Menu-item.is-focused */
+    border-left-color: var(
+        --spectrum-selectlist-option-focus-indicator-color,
+        var(--spectrum-alias-border-color-focus)
+    );
+}
+:host([dir='rtl']) #button:focus-visible,
+:host([dir='rtl']) #button.is-focused {
+    /* [dir=rtl] .spectrum-Menu-item.focus-ring,
+   * [dir=rtl] .spectrum-Menu-item.is-focused */
+    border-right-color: var(
+        --spectrum-selectlist-option-focus-indicator-color,
+        var(--spectrum-alias-border-color-focus)
+    );
+}
 #button:focus-visible,
 #button.is-focused {
     /* .spectrum-Menu-item.focus-ring,
@@ -165,10 +283,6 @@ slot[name='icon'] + #label,
     color: var(
         --spectrum-selectlist-option-text-color-key-focus,
         var(--spectrum-alias-text-color)
-    );
-    border-left-color: var(
-        --spectrum-selectlist-option-focus-indicator-color,
-        var(--spectrum-alias-border-color-focus)
     );
 }
 #button.is-highlighted,
@@ -185,6 +299,13 @@ slot[name='icon'] + #label,
     );
     color: var(
         --spectrum-selectlist-option-text-color-hover,
+        var(--spectrum-alias-text-color)
+    );
+}
+:host([selected]) #button {
+    /* .spectrum-Menu-item.is-selected */
+    color: var(
+        --spectrum-selectlist-option-text-color-selected,
         var(--spectrum-alias-text-color)
     );
 }

--- a/packages/menu/src/spectrum-menu-sectionHeading.css
+++ b/packages/menu/src/spectrum-menu-sectionHeading.css
@@ -10,6 +10,152 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host([dir='ltr']) .spectrum-Menu.is-selectable .spectrum-Menu-item {
+    /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+    padding-right: calc(
+        var(--spectrum-global-dimension-size-100) +
+            var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-selectlist-option-icon-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl']) .spectrum-Menu.is-selectable .spectrum-Menu-item {
+    /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+    padding-left: calc(
+        var(--spectrum-global-dimension-size-100) +
+            var(--spectrum-icon-checkmark-medium-width) +
+            var(
+                --spectrum-selectlist-option-icon-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='ltr'])
+    .spectrum-Menu.is-selectable
+    .spectrum-Menu-item.is-selected {
+    /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
+    padding-right: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='rtl'])
+    .spectrum-Menu.is-selectable
+    .spectrum-Menu-item.is-selected {
+    /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
+    padding-left: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='ltr']) .spectrum-Menu-item {
+    /* [dir=ltr] .spectrum-Menu-item */
+    border-left: var(
+            --spectrum-selectlist-border-size-key-focus,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        solid transparent;
+}
+:host([dir='rtl']) .spectrum-Menu-item {
+    /* [dir=rtl] .spectrum-Menu-item */
+    border-right: var(
+            --spectrum-selectlist-border-size-key-focus,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        solid transparent;
+}
+:host([dir='ltr']) .spectrum-Menu-item.is-selected {
+    /* [dir=ltr] .spectrum-Menu-item.is-selected */
+    padding-right: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-item.is-selected {
+    /* [dir=rtl] .spectrum-Menu-item.is-selected */
+    padding-left: calc(
+        var(
+                --spectrum-selectlist-option-padding,
+                var(--spectrum-global-dimension-static-size-150)
+            ) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+}
+:host([dir='ltr'])
+    .spectrum-Menu-item
+    .spectrum-Icon
+    + .spectrum-Menu-itemLabel,
+:host([dir='ltr'])
+    .spectrum-Menu-item
+    .spectrum-Menu-itemIcon
+    + .spectrum-Menu-itemLabel {
+    /* [dir=ltr] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=ltr] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-left: var(
+        --spectrum-selectlist-thumbnail-image-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl'])
+    .spectrum-Menu-item
+    .spectrum-Icon
+    + .spectrum-Menu-itemLabel,
+:host([dir='rtl'])
+    .spectrum-Menu-item
+    .spectrum-Menu-itemIcon
+    + .spectrum-Menu-itemLabel {
+    /* [dir=rtl] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=rtl] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-right: var(
+        --spectrum-selectlist-thumbnail-image-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='ltr']) .spectrum-Menu-checkmark,
+:host([dir='ltr']) .spectrum-Menu-chevron {
+    /* [dir=ltr] .spectrum-Menu-checkmark,
+   * [dir=ltr] .spectrum-Menu-chevron */
+    margin-left: var(
+        --spectrum-selectlist-option-icon-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-checkmark,
+:host([dir='rtl']) .spectrum-Menu-chevron {
+    /* [dir=rtl] .spectrum-Menu-checkmark,
+   * [dir=rtl] .spectrum-Menu-chevron */
+    margin-right: var(
+        --spectrum-selectlist-option-icon-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-chevron {
+    /* [dir=rtl] .spectrum-Menu-chevron */
+    transform: matrix(-1, 0, 0, 1, 0, 0);
+}
 .header {
     /* .spectrum-Menu-sectionHeading */
     display: block;
@@ -27,5 +173,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     color: var(
         --spectrum-heading-subtitle3-text-color,
         var(--spectrum-global-color-gray-700)
+    );
+}
+:host([dir='ltr']) .spectrum-Menu-item:focus-visible,
+:host([dir='ltr']) .spectrum-Menu-item.is-focused {
+    /* [dir=ltr] .spectrum-Menu-item.focus-ring,
+   * [dir=ltr] .spectrum-Menu-item.is-focused */
+    border-left-color: var(
+        --spectrum-selectlist-option-focus-indicator-color,
+        var(--spectrum-alias-border-color-focus)
+    );
+}
+:host([dir='rtl']) .spectrum-Menu-item:focus-visible,
+:host([dir='rtl']) .spectrum-Menu-item.is-focused {
+    /* [dir=rtl] .spectrum-Menu-item.focus-ring,
+   * [dir=rtl] .spectrum-Menu-item.is-focused */
+    border-right-color: var(
+        --spectrum-selectlist-option-focus-indicator-color,
+        var(--spectrum-alias-border-color-focus)
     );
 }

--- a/packages/menu/src/spectrum-menu.css
+++ b/packages/menu/src/spectrum-menu.css
@@ -14,11 +14,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Menu */
     display: inline-block;
     box-sizing: border-box;
-    margin: var(
-            --spectrum-popover-padding-y,
-            var(--spectrum-global-dimension-size-50)
-        )
-        0;
+    margin-top: var(
+        --spectrum-popover-padding-y,
+        var(--spectrum-global-dimension-size-50)
+    );
+    margin-bottom: var(
+        --spectrum-popover-padding-y,
+        var(--spectrum-global-dimension-size-50)
+    );
+    margin-left: 0;
+    margin-right: 0;
     padding: 0;
     list-style-type: none;
     overflow: auto; /* .spectrum-Menu .spectrum-Menu */

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -47,12 +47,11 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/popover": "^2.0.6"
+        "@spectrum-css/popover": "^3.0.0-beta.3"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/overlay": "^0.5.1",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/popover/src/Popover.ts
+++ b/packages/popover/src/Popover.ts
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     property,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { nothing } from 'lit-html';
 
 import {
@@ -30,7 +30,7 @@ import popoverStyles from './popover.css.js';
  * @attr {Boolean} dialog - Adds some padding to the popover
  */
 
-export class Popover extends LitElement {
+export class Popover extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [popoverStyles];
     }

--- a/packages/popover/src/spectrum-popover.css
+++ b/packages/popover/src/spectrum-popover.css
@@ -112,6 +112,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
+:host([dir='ltr']) #tip:after {
+    /* [dir=ltr] .spectrum-Popover-tip:after */
+    left: -1px;
+}
+:host([dir='rtl']) #tip:after {
+    /* [dir=rtl] .spectrum-Popover-tip:after */
+    right: -1px;
+}
 #tip:after {
     /* .spectrum-Popover-tip:after */
     content: '';
@@ -130,8 +138,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border-style: solid;
     position: absolute;
     transform: rotate(45deg);
-    top: -18px;
-    left: -1px; /* .spectrum-Popover .spectrum-Popover-tip:after */
+    top: -18px; /* .spectrum-Popover .spectrum-Popover-tip:after */
     background-color: var(
         --spectrum-popover-background-color,
         var(--spectrum-global-color-gray-50)
@@ -147,22 +154,44 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     min-width: 270px;
     padding: 30px 29px;
 }
-:host([placement*='left'][tip]) {
-    /* .spectrum-Popover--left.spectrum-Popover--withTip */
+:host([dir='ltr'][placement*='left'][tip]) {
+    /* [dir=ltr] .spectrum-Popover--left.spectrum-Popover--withTip */
     margin-right: 13px;
+}
+:host([dir='rtl'][placement*='left'][tip]) {
+    /* [dir=rtl] .spectrum-Popover--left.spectrum-Popover--withTip */
+    margin-left: 13px;
+}
+:host([dir='ltr'][placement*='left']) #tip {
+    /* [dir=ltr] .spectrum-Popover--left .spectrum-Popover-tip */
+    right: -16px;
+}
+:host([dir='rtl'][placement*='left']) #tip {
+    /* [dir=rtl] .spectrum-Popover--left .spectrum-Popover-tip */
+    left: -16px;
 }
 :host([placement*='left']) #tip {
     /* .spectrum-Popover--left .spectrum-Popover-tip */
-    right: -16px;
     transform: rotate(-90deg);
 }
-:host([placement*='right'][tip]) {
-    /* .spectrum-Popover--right.spectrum-Popover--withTip */
+:host([dir='ltr'][placement*='right'][tip]) {
+    /* [dir=ltr] .spectrum-Popover--right.spectrum-Popover--withTip */
     margin-left: 13px;
+}
+:host([dir='rtl'][placement*='right'][tip]) {
+    /* [dir=rtl] .spectrum-Popover--right.spectrum-Popover--withTip */
+    margin-right: 13px;
+}
+:host([dir='ltr'][placement*='right']) #tip {
+    /* [dir=ltr] .spectrum-Popover--right .spectrum-Popover-tip */
+    left: -16px;
+}
+:host([dir='rtl'][placement*='right']) #tip {
+    /* [dir=rtl] .spectrum-Popover--right .spectrum-Popover-tip */
+    right: -16px;
 }
 :host([placement*='right']) #tip {
     /* .spectrum-Popover--right .spectrum-Popover-tip */
-    left: -16px;
     transform: rotate(90deg);
 }
 :host([placement*='left']) #tip,
@@ -189,16 +218,37 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Popover--top .spectrum-Popover-tip */
     bottom: -11px;
 }
-:host([placement*='bottom']) #tip,
-:host([placement*='top']) #tip {
-    /* .spectrum-Popover--bottom .spectrum-Popover-tip,
-   * .spectrum-Popover--top .spectrum-Popover-tip */
+:host([dir='ltr'][placement*='bottom']) #tip,
+:host([dir='ltr'][placement*='top']) #tip {
+    /* [dir=ltr] .spectrum-Popover--bottom .spectrum-Popover-tip,
+   * [dir=ltr] .spectrum-Popover--top .spectrum-Popover-tip */
     left: 50%;
+}
+:host([dir='rtl'][placement*='bottom']) #tip,
+:host([dir='rtl'][placement*='top']) #tip {
+    /* [dir=rtl] .spectrum-Popover--bottom .spectrum-Popover-tip,
+   * [dir=rtl] .spectrum-Popover--top .spectrum-Popover-tip */
+    right: 50%;
+}
+:host([dir='ltr'][placement*='bottom']) #tip,
+:host([dir='ltr'][placement*='top']) #tip {
+    /* [dir=ltr] .spectrum-Popover--bottom .spectrum-Popover-tip,
+   * [dir=ltr] .spectrum-Popover--top .spectrum-Popover-tip */
     margin-left: -12px;
 }
-:host([dialog]) .spectrum-Dialog-typeIcon {
-    /* .spectrum-Popover.spectrum-Popover--dialog .spectrum-Dialog-typeIcon */
+:host([dir='rtl'][placement*='bottom']) #tip,
+:host([dir='rtl'][placement*='top']) #tip {
+    /* [dir=rtl] .spectrum-Popover--bottom .spectrum-Popover-tip,
+   * [dir=rtl] .spectrum-Popover--top .spectrum-Popover-tip */
+    margin-right: -12px;
+}
+:host([dir='ltr'][dialog]) .spectrum-Dialog-typeIcon {
+    /* [dir=ltr] .spectrum-Popover.spectrum-Popover--dialog .spectrum-Dialog-typeIcon */
     margin-left: var(--spectrum-global-dimension-size-200);
+}
+:host([dir='rtl'][dialog]) .spectrum-Dialog-typeIcon {
+    /* [dir=rtl] .spectrum-Popover.spectrum-Popover--dialog .spectrum-Dialog-typeIcon */
+    margin-right: var(--spectrum-global-dimension-size-200);
 }
 .spectrum-Dialog-footer,
 .spectrum-Dialog-header,

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -51,12 +51,11 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/radio": "^2.1.0"
+        "@spectrum-css/radio": "^3.0.0-beta.2"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/shared": "^0.6.0",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -16,7 +16,7 @@ import {
     query,
     CSSResultArray,
     TemplateResult,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import radioStyles from './radio.css.js';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
@@ -66,18 +66,17 @@ export class Radio extends Focusable {
 
     protected render(): TemplateResult {
         return html`
-            <label id="root">
-                <input
-                    id="input"
-                    type="radio"
-                    name=${this.name}
-                    value=${this.value}
-                    .checked=${this.checked}
-                    @change=${this.handleChange}
-                />
-                <span id="button"></span>
-                <span id="label"><slot></slot></span>
-            </label>
+            <input
+                id="input"
+                aria-labelledby="label"
+                type="radio"
+                name=${this.name}
+                value=${this.value}
+                .checked=${this.checked}
+                @change=${this.handleChange}
+            />
+            <span id="button"></span>
+            <label id="label"><slot></slot></label>
         `;
     }
 }

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -12,12 +12,12 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     property,
     CSSResultArray,
     TemplateResult,
     queryAssignedNodes,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import radioGroupStyles from './radio-group.css.js';
 import { Radio } from '@spectrum-web-components/radio';
@@ -27,7 +27,7 @@ import { Radio } from '@spectrum-web-components/radio';
  *
  * @attr column - arranges radio buttons vertically
  */
-export class RadioGroup extends LitElement {
+export class RadioGroup extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [radioGroupStyles];
     }

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -94,41 +94,32 @@ export class RadioGroup extends SpectrumElement {
             list: T[],
             index: number
         ): T => list[(list.length + index) % list.length];
+        const buttonFromDelta = (delta: number): void => {
+            nextIndex += delta;
+            while (circularIndexedElement(this.buttons, nextIndex).disabled) {
+                nextIndex += delta;
+            }
+        };
         switch (code) {
             case 'ArrowUp':
-            case 'ArrowLeft': {
-                nextIndex -= 1;
-                while (
-                    circularIndexedElement(this.buttons, nextIndex).disabled
-                ) {
-                    nextIndex -= 1;
-                }
+                buttonFromDelta(-1);
                 break;
-            }
+            case 'ArrowLeft':
+                buttonFromDelta(this.isDefaultDir ? -1 : 1);
+                break;
             case 'ArrowRight':
+                buttonFromDelta(this.isDefaultDir ? 1 : -1);
+                break;
             case 'ArrowDown':
-                nextIndex += 1;
-                while (
-                    circularIndexedElement(this.buttons, nextIndex).disabled
-                ) {
-                    nextIndex += 1;
-                }
+                buttonFromDelta(1);
                 break;
             case 'End':
-                nextIndex = this.buttons.length - 1;
-                while (
-                    circularIndexedElement(this.buttons, nextIndex).disabled
-                ) {
-                    nextIndex -= 1;
-                }
+                nextIndex = this.buttons.length;
+                buttonFromDelta(-1);
                 break;
             case 'Home':
-                nextIndex = 0;
-                while (
-                    circularIndexedElement(this.buttons, nextIndex).disabled
-                ) {
-                    nextIndex += 1;
-                }
+                nextIndex = -1;
+                buttonFromDelta(1);
                 break;
             case 'PageUp':
             case 'PageDown':

--- a/packages/radio/src/spectrum-config.js
+++ b/packages/radio/src/spectrum-config.js
@@ -17,7 +17,6 @@ module.exports = {
             name: 'radio',
             host: {
                 selector: '.spectrum-Radio',
-                shadowSelector: '#root',
             },
             focus: '#input',
             attributes: [

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -10,7 +10,25 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-#root {
+:host([dir='ltr']) {
+    /* [dir=ltr] .spectrum-Radio */
+    margin-right: calc(
+        var(
+                --spectrum-radio-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * 2
+    );
+}
+:host([dir='rtl']) {
+    /* [dir=rtl] .spectrum-Radio */
+    margin-left: calc(
+        var(
+                --spectrum-radio-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * 2
+    );
+}
+:host {
     /* .spectrum-Radio */
     display: inline-flex;
     align-items: flex-start;
@@ -20,13 +38,25 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-400)
     );
     max-width: 100%;
-    margin-right: calc(
+    vertical-align: top;
+}
+:host([dir='ltr']) #input {
+    /* [dir=ltr] .spectrum-Radio-input */
+    left: calc(
         var(
                 --spectrum-radio-cursor-hit-x,
                 var(--spectrum-global-dimension-size-100)
-            ) * 2
+            ) * -1
     );
-    vertical-align: top;
+}
+:host([dir='rtl']) #input {
+    /* [dir=rtl] .spectrum-Radio-input */
+    right: calc(
+        var(
+                --spectrum-radio-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * -1
+    );
 }
 #input {
     /* .spectrum-Radio-input */
@@ -39,12 +69,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding: 0;
     position: absolute;
     top: 0;
-    left: calc(
-        var(
-                --spectrum-radio-cursor-hit-x,
-                var(--spectrum-global-dimension-size-100)
-            ) * -1
-    );
     width: calc(
         100% +
             var(
@@ -72,7 +96,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 --spectrum-radio-circle-dot-size,
                 var(--spectrum-global-dimension-static-size-50)
             ) / 2
-    ); /* .spectrum-Radio .spectrum-Radio-input:checked+.spectrum-Radio-button:before */
+    ); /* .spectrum-Radio-input:checked+.spectrum-Radio-button:before */
     border-color: var(
         --spectrum-radio-emphasized-circle-border-color-selected,
         var(--spectrum-global-color-blue-500)
@@ -87,12 +111,24 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1
     );
 }
-#label {
-    /* .spectrum-Radio-label */
+:host([dir='ltr']) #label {
+    /* [dir=ltr] .spectrum-Radio-label */
+    text-align: left; /* [dir=ltr] .spectrum-Radio-label */
     margin-left: var(
         --spectrum-radio-text-gap,
         var(--spectrum-global-dimension-size-125)
     );
+}
+:host([dir='rtl']) #label {
+    /* [dir=rtl] .spectrum-Radio-label */
+    text-align: right; /* [dir=rtl] .spectrum-Radio-label */
+    margin-right: var(
+        --spectrum-radio-text-gap,
+        var(--spectrum-global-dimension-size-125)
+    );
+}
+#label {
+    /* .spectrum-Radio-label */
     margin-top: var(--spectrum-global-dimension-size-65);
     font-size: var(
         --spectrum-radio-text-size,
@@ -187,7 +223,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ease-out,
         margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
 }
-:host([label-below]) #root {
+:host([label-below]) {
     /* .spectrum-Radio--labelBelow */
     display: inline-flex;
     flex-direction: column;
@@ -203,7 +239,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Radio--labelBelow .spectrum-Radio-label */
     margin: var(--spectrum-global-dimension-size-40) 0 0 0;
 }
-#root:hover #button:before {
+:host(:hover) #button:before {
     /* .spectrum-Radio:hover .spectrum-Radio-button:before */
     border-color: var(
         --spectrum-radio-emphasized-circle-border-color-hover,
@@ -211,35 +247,35 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     box-shadow: none;
 }
-:host([checked]) #root:hover #input + #button:before {
+:host(:hover[checked]) #input + #button:before {
     /* .spectrum-Radio:hover .spectrum-Radio-input:checked+.spectrum-Radio-button:before */
     border-color: var(
         --spectrum-radio-emphasized-circle-border-color-selected-hover,
         var(--spectrum-global-color-blue-600)
     );
 }
-#root:hover #label {
+:host(:hover) #label {
     /* .spectrum-Radio:hover .spectrum-Radio-label */
     color: var(
         --spectrum-radio-emphasized-text-color-hover,
         var(--spectrum-alias-text-color-hover)
     );
 }
-#root:active #button:before {
+:host(:active) #button:before {
     /* .spectrum-Radio:active .spectrum-Radio-button:before */
     border-color: var(
         --spectrum-radio-emphasized-circle-border-color-down,
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([checked]) #root:active #input + #button:before {
+:host(:active[checked]) #input + #button:before {
     /* .spectrum-Radio:active .spectrum-Radio-input:checked+.spectrum-Radio-button:before */
     border-color: var(
         --spectrum-radio-emphasized-circle-border-color-selected-down,
         var(--spectrum-global-color-blue-700)
     );
 }
-#root:active #label {
+:host(:active) #label {
     /* .spectrum-Radio:active .spectrum-Radio-label */
     color: var(
         --spectrum-radio-emphasized-text-color-down,
@@ -253,22 +289,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host([quiet][checked]) #root:hover #input + #button:before {
+:host([quiet][checked]:hover) #input + #button:before {
     /* .spectrum-Radio--quiet:hover .spectrum-Radio-input:checked+.spectrum-Radio-button:before */
     border-color: var(
         --spectrum-radio-quiet-circle-border-color-selected-hover,
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([quiet][checked]) #root:active #input + #button:before {
+:host([quiet][checked]:active) #input + #button:before {
     /* .spectrum-Radio--quiet:active .spectrum-Radio-input:checked+.spectrum-Radio-button:before */
     border-color: var(
         --spectrum-radio-quiet-circle-border-color-selected-down,
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([quiet][invalid]) #root:hover #input + #button:before,
-:host([invalid]) #root:hover #input + #button:before {
+:host([quiet][invalid]:hover) #input + #button:before,
+:host([invalid]:hover) #input + #button:before {
     /* .spectrum-Radio--quiet.is-invalid:hover .spectrum-Radio-input+.spectrum-Radio-button:before,
    * .spectrum-Radio.is-invalid:hover .spectrum-Radio-input+.spectrum-Radio-button:before */
     border-color: var(
@@ -276,8 +312,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-600)
     );
 }
-:host([quiet][invalid]) #root:hover #label,
-:host([invalid]) #root:hover #label {
+:host([quiet][invalid]:hover) #label,
+:host([invalid]:hover) #label {
     /* .spectrum-Radio--quiet.is-invalid:hover .spectrum-Radio-label,
    * .spectrum-Radio.is-invalid:hover .spectrum-Radio-label */
     color: var(
@@ -285,8 +321,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-600)
     );
 }
-:host([quiet][invalid]) #root:active #input + #button:before,
-:host([invalid]) #root:active #input + #button:before {
+:host([quiet][invalid]:active) #input + #button:before,
+:host([invalid]:active) #input + #button:before {
     /* .spectrum-Radio--quiet.is-invalid:active .spectrum-Radio-input+.spectrum-Radio-button:before,
    * .spectrum-Radio.is-invalid:active .spectrum-Radio-input+.spectrum-Radio-button:before */
     border-color: var(
@@ -294,8 +330,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-700)
     );
 }
-:host([quiet][invalid]) #root:active #label,
-:host([invalid]) #root:active #label {
+:host([quiet][invalid]:active) #label,
+:host([invalid]:active) #label {
     /* .spectrum-Radio--quiet.is-invalid:active .spectrum-Radio-label,
    * .spectrum-Radio.is-invalid:active .spectrum-Radio-label */
     color: var(
@@ -303,10 +339,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-700)
     );
 }
-:host([quiet][invalid]) #root #button:before,
-:host([quiet][invalid][checked]) #root #input + #button:before,
-:host([invalid]) #root #button:before,
-:host([invalid][checked]) #root #input + #button:before {
+:host([quiet][invalid]) #button:before,
+:host([quiet][invalid][checked]) #input + #button:before,
+:host([invalid]) #button:before,
+:host([invalid][checked]) #input + #button:before {
     /* .spectrum-Radio--quiet.is-invalid .spectrum-Radio-button:before,
    * .spectrum-Radio--quiet.is-invalid .spectrum-Radio-input:checked+.spectrum-Radio-button:before,
    * .spectrum-Radio.is-invalid .spectrum-Radio-button:before,
@@ -316,8 +352,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-500)
     );
 }
-:host([quiet][invalid]) #root #label,
-:host([invalid]) #root #label {
+:host([quiet][invalid]) #label,
+:host([invalid]) #label {
     /* .spectrum-Radio--quiet.is-invalid .spectrum-Radio-label,
    * .spectrum-Radio.is-invalid .spectrum-Radio-label */
     color: var(
@@ -325,24 +361,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-500)
     );
 }
+:host([checked][disabled]) #input + #button:before,
 :host([disabled]) #input + #button:before {
-    /* .spectrum-Radio-input:disabled+.spectrum-Radio-button:before */
+    /* .spectrum-Radio .spectrum-Radio-input:checked:disabled+.spectrum-Radio-button:before,
+   * .spectrum-Radio .spectrum-Radio-input:disabled+.spectrum-Radio-button:before */
     border-color: var(
         --spectrum-radio-emphasized-circle-border-color-disabled,
         var(--spectrum-global-color-gray-400)
-    ) !important;
+    );
 }
+:host([checked][disabled]) #input ~ #label,
 :host([disabled]) #input ~ #label {
-    /* .spectrum-Radio-input:disabled~.spectrum-Radio-label */
+    /* .spectrum-Radio .spectrum-Radio-input:checked:disabled~.spectrum-Radio-label,
+   * .spectrum-Radio .spectrum-Radio-input:disabled~.spectrum-Radio-label */
     color: var(
         --spectrum-radio-emphasized-text-color-disabled,
         var(--spectrum-alias-text-color-disabled)
-    ) !important;
+    );
 }
 :host([quiet]) #input:focus-visible + #button:before,
-:host([quiet]) #root:hover #input:focus-visible + #button:before,
+:host([quiet]:hover) #input:focus-visible + #button:before,
 #input:focus-visible + #button:before,
-#root:hover #input:focus-visible + #button:before {
+:host(:hover) #input:focus-visible + #button:before {
     /* .spectrum-Radio--quiet .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:before,
    * .spectrum-Radio--quiet:hover .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:before,
    * .spectrum-Radio .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:before,
@@ -353,9 +393,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 :host([quiet]) #input:focus-visible + #button:after,
-:host([quiet]) #root:hover #input:focus-visible + #button:after,
+:host([quiet]:hover) #input:focus-visible + #button:after,
 #input:focus-visible + #button:after,
-#root:hover #input:focus-visible + #button:after {
+:host(:hover) #input:focus-visible + #button:after {
     /* .spectrum-Radio--quiet .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:after,
    * .spectrum-Radio--quiet:hover .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:after,
    * .spectrum-Radio .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:after,
@@ -371,9 +411,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         );
 }
 :host([quiet][checked]) #input:focus-visible + #button:before,
-:host([quiet][checked]) #root:hover #input:focus-visible + #button:before,
+:host([quiet][checked]:hover) #input:focus-visible + #button:before,
 :host([checked]) #input:focus-visible + #button:before,
-:host([checked]) #root:hover #input:focus-visible + #button:before {
+:host(:hover[checked]) #input:focus-visible + #button:before {
     /* .spectrum-Radio--quiet .spectrum-Radio-input.focus-ring:checked+.spectrum-Radio-button:before,
    * .spectrum-Radio--quiet:hover .spectrum-Radio-input.focus-ring:checked+.spectrum-Radio-button:before,
    * .spectrum-Radio .spectrum-Radio-input.focus-ring:checked+.spectrum-Radio-button:before,

--- a/packages/rule/package.json
+++ b/packages/rule/package.json
@@ -49,11 +49,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/rule": "^2.0.6"
+        "@spectrum-css/rule": "^3.0.0-beta.3"
     },
     "dependencies": {
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
+        "@spectrum-web-components/base": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/rule/src/Rule.ts
+++ b/packages/rule/src/Rule.ts
@@ -12,18 +12,18 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     property,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import styles from './rule.css.js';
 
 /**
  * @element sp-rule
  */
-export class Rule extends LitElement {
+export class Rule extends SpectrumElement {
     public static styles: CSSResultArray = [styles];
 
     @property({ type: Boolean, reflect: true })

--- a/packages/search/test/search.test.ts
+++ b/packages/search/test/search.test.ts
@@ -49,7 +49,7 @@ describe('Search', () => {
 
         expect(el.value).to.equal('');
     });
-    it('can be cleared', async () => {
+    it('can be cleared from button', async () => {
         const inputSpy = spy();
         const changeSpy = spy();
         const handleInput = (event: Event): void => {
@@ -81,6 +81,53 @@ describe('Search', () => {
         inputSpy.resetHistory();
         changeSpy.resetHistory();
         clearButton.click();
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal('');
+        expect(inputSpy.calledOnce, 'one input').to.be.true;
+        expect(inputSpy.calledWith(''), 'was blank').to.be.true;
+        expect(changeSpy.calledOnce, 'one change').to.be.true;
+        expect(changeSpy.calledWith(''), 'was blank').to.be.true;
+    });
+    it('can be cleared via "Escape"', async () => {
+        const inputSpy = spy();
+        const changeSpy = spy();
+        const handleInput = (event: Event): void => {
+            const target = event.target as HTMLInputElement;
+            inputSpy(target.value);
+        };
+        const handleChange = (event: Event): void => {
+            const target = event.target as HTMLInputElement;
+            changeSpy(target.value);
+        };
+        const el = await litFixture<Search>(
+            html`
+                <sp-search
+                    value="Test"
+                    @change=${handleChange}
+                    @input=${handleInput}
+                ></sp-search>
+            `
+        );
+
+        await elementUpdated(el);
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
+
+        expect(el.value).to.equal('Test');
+        expect(el).shadowDom.to.equalSnapshot();
+
+        inputSpy.resetHistory();
+        changeSpy.resetHistory();
+        el.focusElement.dispatchEvent(
+            new KeyboardEvent('keydown', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                key: 'Escape',
+                code: 'Escape',
+            })
+        );
 
         await elementUpdated(el);
 

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -55,12 +55,11 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/sidenav": "^2.0.5"
+        "@spectrum-css/sidenav": "^3.0.0-beta.2"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/shared": "^0.6.0",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/sidenav/src/Sidenav.ts
+++ b/packages/sidenav/src/Sidenav.ts
@@ -16,7 +16,7 @@ import {
     TemplateResult,
     property,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import sidenavStyles from './sidenav.css.js';
 import { Focusable, getActiveElement } from '@spectrum-web-components/shared';

--- a/packages/sidenav/src/SidenavHeading.ts
+++ b/packages/sidenav/src/SidenavHeading.ts
@@ -12,16 +12,16 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     property,
     CSSResultArray,
     TemplateResult,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import sidenavItemStyles from './sidenav-item.css.js';
 import sidenavHeadingStyles from './sidenav-heading.css.js';
 
-export class SideNavHeading extends LitElement {
+export class SideNavHeading extends SpectrumElement {
     @property({ reflect: true })
     public label = '';
 

--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -16,7 +16,7 @@ import {
     TemplateResult,
     property,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { LikeAnchor } from '@spectrum-web-components/shared/src/like-anchor.js';
 import { Focusable } from '@spectrum-web-components/shared';
 import { ifDefined } from 'lit-html/directives/if-defined.js';

--- a/packages/sidenav/src/spectrum-config.js
+++ b/packages/sidenav/src/spectrum-config.js
@@ -27,6 +27,7 @@ module.exports = {
                 /^\.spectrum-SideNav-(item|heading)/,
                 // We cannot do global matches like this with shadow DOM
                 /^\.spectrum-SideNav--multiLevel\s\.spectrum-SideNav/,
+                /\.spectrum-SideNav\s\.spectrum-SideNav/,
             ],
         },
         {

--- a/packages/sidenav/src/spectrum-sidenav-heading.css
+++ b/packages/sidenav/src/spectrum-sidenav-heading.css
@@ -16,6 +16,48 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin: 0;
     padding: 0;
 }
+:host([dir='ltr']) .spectrum-SideNav-itemLink:focus-visible:before {
+    /* [dir=ltr] .spectrum-SideNav-itemLink.focus-ring:before */
+    left: 0;
+}
+:host([dir='ltr']) .spectrum-SideNav-itemLink:focus-visible:before,
+:host([dir='rtl']) .spectrum-SideNav-itemLink:focus-visible:before {
+    /* [dir=ltr] .spectrum-SideNav-itemLink.focus-ring:before,
+   * [dir=rtl] .spectrum-SideNav-itemLink.focus-ring:before */
+    right: 0;
+}
+:host([dir='rtl']) .spectrum-SideNav-itemLink:focus-visible:before {
+    /* [dir=rtl] .spectrum-SideNav-itemLink.focus-ring:before */
+    left: 0;
+}
+:host([dir='ltr']) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
+    /* [dir=ltr] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+    margin-right: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl']) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
+    /* [dir=rtl] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+    margin-left: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='ltr']) #heading {
+    /* [dir=ltr] .spectrum-SideNav-heading */
+    margin-right: 0;
+}
+:host([dir='ltr']) #heading,
+:host([dir='rtl']) #heading {
+    /* [dir=ltr] .spectrum-SideNav-heading,
+   * [dir=rtl] .spectrum-SideNav-heading */
+    margin-left: 0;
+}
+:host([dir='rtl']) #heading {
+    /* [dir=rtl] .spectrum-SideNav-heading */
+    margin-right: 0;
+}
 #heading {
     /* .spectrum-SideNav-heading */
     height: var(
@@ -26,21 +68,24 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-sidenav-header-height,
         var(--spectrum-alias-single-line-height)
     );
-    margin: var(
-            --spectrum-sidenav-header-gap-top,
-            var(--spectrum-global-dimension-size-200)
-        )
-        0
-        var(
-            --spectrum-sidenav-header-gap-bottom,
-            var(--spectrum-global-dimension-size-50)
-        )
-        0;
-    padding: 0
-        var(
-            --spectrum-sidenav-header-padding-x,
-            var(--spectrum-global-dimension-size-150)
-        );
+    margin-top: var(
+        --spectrum-sidenav-header-gap-top,
+        var(--spectrum-global-dimension-size-200)
+    );
+    margin-bottom: var(
+        --spectrum-sidenav-header-gap-bottom,
+        var(--spectrum-global-dimension-size-50)
+    );
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: var(
+        --spectrum-sidenav-header-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
+    padding-right: var(
+        --spectrum-sidenav-header-padding-x,
+        var(--spectrum-global-dimension-size-150)
+    );
     border-radius: var(
         --spectrum-sidenav-header-border-radius,
         var(--spectrum-alias-border-radius-regular)
@@ -62,5 +107,71 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     color: var(
         --spectrum-sidenav-header-text-color,
         var(--spectrum-global-color-gray-700)
+    );
+}
+:host([dir='ltr'])
+    .spectrum-SideNav--multiLevel
+    #list
+    .spectrum-SideNav-itemLink {
+    /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level1,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl'])
+    .spectrum-SideNav--multiLevel
+    #list
+    .spectrum-SideNav-itemLink {
+    /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level1,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='ltr'])
+    .spectrum-SideNav--multiLevel
+    #list
+    #list
+    .spectrum-SideNav-itemLink {
+    /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level2,
+                var(--spectrum-global-dimension-size-300)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl'])
+    .spectrum-SideNav--multiLevel
+    #list
+    #list
+    .spectrum-SideNav-itemLink {
+    /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level2,
+                var(--spectrum-global-dimension-size-300)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
     );
 }

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -19,11 +19,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     /* .spectrum-SideNav-item */
     list-style-type: none;
-    margin: var(
-            --spectrum-sidenav-item-gap,
-            var(--spectrum-global-dimension-size-50)
-        )
-        0;
+    margin-top: var(
+        --spectrum-sidenav-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    );
+    margin-bottom: var(
+        --spectrum-sidenav-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    );
+    margin-left: 0;
+    margin-right: 0;
 }
 #itemLink {
     /* .spectrum-SideNav-itemLink */
@@ -76,15 +81,32 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-SideNav-itemLink:focus */
     outline: none;
 }
+:host([dir='ltr']) #itemLink:focus-visible:before {
+    /* [dir=ltr] .spectrum-SideNav-itemLink.focus-ring:before */
+    left: 0;
+}
+:host([dir='ltr']) #itemLink:focus-visible:before,
+:host([dir='rtl']) #itemLink:focus-visible:before {
+    /* [dir=ltr] .spectrum-SideNav-itemLink.focus-ring:before,
+   * [dir=rtl] .spectrum-SideNav-itemLink.focus-ring:before */
+    right: 0;
+}
+:host([dir='rtl']) #itemLink:focus-visible:before {
+    /* [dir=rtl] .spectrum-SideNav-itemLink.focus-ring:before */
+    left: 0;
+}
 #itemLink:focus-visible:before {
     /* .spectrum-SideNav-itemLink.focus-ring:before */
     content: '';
     position: absolute;
     top: 0;
-    left: 0;
-    right: 0;
     bottom: 0;
-    border: var(
+    border-top: var(
+            --spectrum-tabs-focus-ring-size,
+            var(--spectrum-alias-border-size-thick)
+        )
+        solid transparent;
+    border-bottom: var(
             --spectrum-tabs-focus-ring-size,
             var(--spectrum-alias-border-size-thick)
         )
@@ -98,11 +120,84 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-focus)
     );
 }
-#itemLink ::slotted([slot='icon']) {
-    /* .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+:host([dir='ltr']) #itemLink ::slotted([slot='icon']) {
+    /* [dir=ltr] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
     margin-right: var(
         --spectrum-sidenav-icon-gap,
         var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl']) #itemLink ::slotted([slot='icon']) {
+    /* [dir=rtl] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+    margin-left: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='ltr']) .spectrum-SideNav-heading {
+    /* [dir=ltr] .spectrum-SideNav-heading */
+    margin-right: 0;
+}
+:host([dir='ltr']) .spectrum-SideNav-heading,
+:host([dir='rtl']) .spectrum-SideNav-heading {
+    /* [dir=ltr] .spectrum-SideNav-heading,
+   * [dir=rtl] .spectrum-SideNav-heading */
+    margin-left: 0;
+}
+:host([dir='rtl']) .spectrum-SideNav-heading {
+    /* [dir=rtl] .spectrum-SideNav-heading */
+    margin-right: 0;
+}
+:host([dir='ltr']) .spectrum-SideNav--multiLevel #list #itemLink {
+    /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level1,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl']) .spectrum-SideNav--multiLevel #list #itemLink {
+    /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level1,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='ltr']) .spectrum-SideNav--multiLevel #list #list #itemLink {
+    /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level2,
+                var(--spectrum-global-dimension-size-300)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+:host([dir='rtl']) .spectrum-SideNav--multiLevel #list #list #itemLink {
+    /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level2,
+                var(--spectrum-global-dimension-size-300)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
     );
 }
 :host([selected]) > #itemLink {

--- a/packages/sidenav/src/spectrum-sidenav.css
+++ b/packages/sidenav/src/spectrum-sidenav.css
@@ -16,3 +16,45 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin: 0;
     padding: 0;
 }
+:host([dir='ltr']) .spectrum-SideNav-itemLink:focus-visible:before {
+    /* [dir=ltr] .spectrum-SideNav-itemLink.focus-ring:before */
+    left: 0;
+}
+:host([dir='ltr']) .spectrum-SideNav-itemLink:focus-visible:before,
+:host([dir='rtl']) .spectrum-SideNav-itemLink:focus-visible:before {
+    /* [dir=ltr] .spectrum-SideNav-itemLink.focus-ring:before,
+   * [dir=rtl] .spectrum-SideNav-itemLink.focus-ring:before */
+    right: 0;
+}
+:host([dir='rtl']) .spectrum-SideNav-itemLink:focus-visible:before {
+    /* [dir=rtl] .spectrum-SideNav-itemLink.focus-ring:before */
+    left: 0;
+}
+:host([dir='ltr']) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
+    /* [dir=ltr] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+    margin-right: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl']) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
+    /* [dir=rtl] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+    margin-left: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='ltr']) .spectrum-SideNav-heading {
+    /* [dir=ltr] .spectrum-SideNav-heading */
+    margin-right: 0;
+}
+:host([dir='ltr']) .spectrum-SideNav-heading,
+:host([dir='rtl']) .spectrum-SideNav-heading {
+    /* [dir=ltr] .spectrum-SideNav-heading,
+   * [dir=rtl] .spectrum-SideNav-heading */
+    margin-left: 0;
+}
+:host([dir='rtl']) .spectrum-SideNav-heading {
+    /* [dir=rtl] .spectrum-SideNav-heading */
+    margin-right: 0;
+}

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -47,12 +47,11 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/slider": "^2.1.0"
+        "@spectrum-css/slider": "^3.0.0-beta.2"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/shared": "^0.6.0",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -17,7 +17,7 @@ import {
     TemplateResult,
     query,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import spectrumSliderStyles from './spectrum-slider.css.js';
 import sliderStyles from './slider.css.js';
@@ -442,7 +442,7 @@ export class Slider extends Focusable {
         const percent = (offset - minOffset) / size;
         const value = this.min + (this.max - this.min) * percent;
 
-        return value;
+        return this.isDefaultDir ? value : 100 - value;
     }
 
     private dispatchInputEvent(): void {
@@ -485,7 +485,7 @@ export class Slider extends Focusable {
     private get trackRightStyle(): string {
         const width = `width: ${(1 - this.trackProgress) * 100}%;`;
         const halfHandleWidth = `var(--spectrum-slider-handle-width, var(--spectrum-global-dimension-size-200)) / 2`;
-        const offset = `left: calc(${
+        const offset = `${this.isDefaultDir ? 'left' : 'right'}: calc(${
             this.trackProgress * 100
         }% + ${halfHandleWidth})`;
 
@@ -493,6 +493,8 @@ export class Slider extends Focusable {
     }
 
     private get handleStyle(): string {
-        return `left: ${this.trackProgress * 100}%`;
+        return `${this.isDefaultDir ? 'left' : 'right'}: ${
+            this.trackProgress * 100
+        }%`;
     }
 }

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -13,8 +13,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     /* .spectrum-Dial,
    * .spectrum-Slider */
+    position: relative;
     z-index: 1;
     display: block;
+    min-height: var(
+        --spectrum-slider-height,
+        var(--spectrum-alias-single-line-height)
+    );
     min-width: var(
         --spectrum-slider-min-width,
         var(--spectrum-global-dimension-size-1250)
@@ -23,16 +28,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     -moz-user-select: none;
     user-select: none;
 }
-:host,
-#controls {
-    /* .spectrum-Dial,
-   * .spectrum-Dial-controls,
-   * .spectrum-Slider,
-   * .spectrum-Slider-controls */
-    position: relative;
-    min-height: var(
-        --spectrum-slider-height,
-        var(--spectrum-alias-single-line-height)
+:host([dir='ltr']) .spectrum-Dial-controls,
+:host([dir='ltr']) #controls {
+    /* [dir=ltr] .spectrum-Dial-controls,
+   * [dir=ltr] .spectrum-Slider-controls */
+    margin-left: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2
+    );
+}
+:host([dir='rtl']) .spectrum-Dial-controls,
+:host([dir='rtl']) #controls {
+    /* [dir=rtl] .spectrum-Dial-controls,
+   * [dir=rtl] .spectrum-Slider-controls */
+    margin-right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2
     );
 }
 #controls {
@@ -40,6 +55,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Slider-controls */
     display: inline-block;
     box-sizing: border-box;
+    position: relative;
     z-index: auto;
     width: calc(
         100% -
@@ -48,13 +64,51 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-200)
             ) / 2 * 2
     );
-    margin-left: calc(
-        var(
-                --spectrum-slider-handle-width,
-                var(--spectrum-global-dimension-size-200)
-            ) / 2
+    min-height: var(
+        --spectrum-slider-height,
+        var(--spectrum-alias-single-line-height)
     );
     vertical-align: top;
+}
+:host([dir='ltr']) #buffer,
+:host([dir='ltr']) #fill,
+:host([dir='ltr']) #ramp,
+:host([dir='ltr']) .track {
+    /* [dir=ltr] .spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-fill,
+   * [dir=ltr] .spectrum-Slider-ramp,
+   * [dir=ltr] .spectrum-Slider-track */
+    left: 0;
+}
+:host([dir='rtl']) #buffer,
+:host([dir='rtl']) #fill,
+:host([dir='rtl']) #ramp,
+:host([dir='rtl']) .track {
+    /* [dir=rtl] .spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-fill,
+   * [dir=rtl] .spectrum-Slider-ramp,
+   * [dir=rtl] .spectrum-Slider-track */
+    right: 0;
+}
+:host([dir='ltr']) #buffer,
+:host([dir='ltr']) #fill,
+:host([dir='ltr']) #ramp,
+:host([dir='ltr']) .track {
+    /* [dir=ltr] .spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-fill,
+   * [dir=ltr] .spectrum-Slider-ramp,
+   * [dir=ltr] .spectrum-Slider-track */
+    right: auto;
+}
+:host([dir='rtl']) #buffer,
+:host([dir='rtl']) #fill,
+:host([dir='rtl']) #ramp,
+:host([dir='rtl']) .track {
+    /* [dir=rtl] .spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-fill,
+   * [dir=rtl] .spectrum-Slider-ramp,
+   * [dir=rtl] .spectrum-Slider-track */
+    left: auto;
 }
 #buffer,
 #fill,
@@ -75,8 +129,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-slider-height, var(--spectrum-alias-single-line-height)) /
             2
     );
-    left: 0;
-    right: auto;
     margin-top: calc(
         var(
                 --spectrum-slider-fill-track-height,
@@ -85,24 +137,64 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     pointer-events: none;
 }
-#buffer,
-#fill,
-.track {
-    /* .spectrum-Slider-buffer,
-   * .spectrum-Slider-fill,
-   * .spectrum-Slider-track */
-    padding: 0
-        var(
-            --spectrum-slider-handle-gap,
-            var(--spectrum-alias-border-size-thicker)
-        )
-        0 0;
+:host([dir='ltr']) #buffer,
+:host([dir='ltr']) #fill,
+:host([dir='ltr']) .track {
+    /* [dir=ltr] .spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-fill,
+   * [dir=ltr] .spectrum-Slider-track */
+    padding-left: 0;
+    padding-right: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    );
+}
+:host([dir='rtl']) #buffer,
+:host([dir='rtl']) #fill,
+:host([dir='rtl']) .track {
+    /* [dir=rtl] .spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-fill,
+   * [dir=rtl] .spectrum-Slider-track */
+    padding-right: 0;
+    padding-left: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    );
+}
+:host([dir='ltr']) #buffer,
+:host([dir='ltr']) #fill,
+:host([dir='ltr']) .track {
+    /* [dir=ltr] .spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-fill,
+   * [dir=ltr] .spectrum-Slider-track */
     margin-left: calc(
         var(
                 --spectrum-slider-handle-width,
                 var(--spectrum-global-dimension-size-200)
             ) / 2 * -1
     );
+}
+:host([dir='rtl']) #buffer,
+:host([dir='rtl']) #fill,
+:host([dir='rtl']) .track {
+    /* [dir=rtl] .spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-fill,
+   * [dir=rtl] .spectrum-Slider-track */
+    margin-right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 * -1
+    );
+}
+#buffer,
+#fill,
+.track {
+    /* .spectrum-Slider-buffer,
+   * .spectrum-Slider-fill,
+   * .spectrum-Slider-track */
+    padding-top: 0;
+    padding-bottom: 0;
 }
 #buffer:before,
 #fill:before,
@@ -118,58 +210,156 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-static-size-10)
     );
 }
+:host([dir='ltr']) #fill {
+    /* [dir=ltr] .spectrum-Slider-fill */
+    margin-left: 0; /* [dir=ltr] .spectrum-Slider-fill */
+    padding-left: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 +
+            var(
+                --spectrum-slider-handle-gap,
+                var(--spectrum-alias-border-size-thicker)
+            )
+    );
+    padding-right: 0;
+}
+:host([dir='rtl']) #fill {
+    /* [dir=rtl] .spectrum-Slider-fill */
+    margin-right: 0; /* [dir=rtl] .spectrum-Slider-fill */
+    padding-right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 +
+            var(
+                --spectrum-slider-handle-gap,
+                var(--spectrum-alias-border-size-thicker)
+            )
+    );
+    padding-left: 0;
+}
 #fill {
     /* .spectrum-Slider-fill */
-    margin-left: 0;
-    padding: 0 0 0
-        calc(
+    padding-top: 0;
+    padding-bottom: 0;
+}
+:host([dir='ltr']) .spectrum-Slider-fill--right {
+    /* [dir=ltr] .spectrum-Slider-fill--right */
+    padding-left: 0;
+    padding-right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 +
             var(
-                    --spectrum-slider-handle-width,
-                    var(--spectrum-global-dimension-size-200)
-                ) / 2 +
-                var(
-                    --spectrum-slider-handle-gap,
-                    var(--spectrum-alias-border-size-thicker)
-                )
-        );
+                --spectrum-slider-handle-gap,
+                var(--spectrum-alias-border-size-thicker)
+            )
+    );
+}
+:host([dir='rtl']) .spectrum-Slider-fill--right {
+    /* [dir=rtl] .spectrum-Slider-fill--right */
+    padding-right: 0;
+    padding-left: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 +
+            var(
+                --spectrum-slider-handle-gap,
+                var(--spectrum-alias-border-size-thicker)
+            )
+    );
 }
 .spectrum-Slider-fill--right {
     /* .spectrum-Slider-fill--right */
-    padding: 0
-        calc(
-            var(
-                    --spectrum-slider-handle-width,
-                    var(--spectrum-global-dimension-size-200)
-                ) / 2 +
-                var(
-                    --spectrum-slider-handle-gap,
-                    var(--spectrum-alias-border-size-thicker)
-                )
-        )
-        0 0;
+    padding-top: 0;
+    padding-bottom: 0;
+}
+:host([dir='ltr']) #buffer {
+    /* [dir=ltr] .spectrum-Slider-buffer */
+    padding-left: 0;
+    padding-right: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    );
+}
+:host([dir='rtl']) #buffer {
+    /* [dir=rtl] .spectrum-Slider-buffer */
+    padding-right: 0;
+    padding-left: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    );
 }
 #buffer {
     /* .spectrum-Slider-buffer */
-    padding: 0
-        var(
-            --spectrum-slider-handle-gap,
-            var(--spectrum-alias-border-size-thicker)
-        )
-        0 0; /* .spectrum-Slider-buffer */
+    padding-top: 0;
+    padding-bottom: 0; /* .spectrum-Slider-buffer */
     z-index: 2;
 }
-#buffer ~ #buffer,
-.track ~ .track {
-    /* .spectrum-Slider-buffer~.spectrum-Slider-buffer,
-   * .spectrum-Slider-track~.spectrum-Slider-track */
+:host([dir='ltr']) #buffer ~ #buffer,
+:host([dir='ltr']) .track ~ .track {
+    /* [dir=ltr] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
     left: auto;
+}
+:host([dir='rtl']) #buffer ~ #buffer,
+:host([dir='rtl']) .track ~ .track {
+    /* [dir=rtl] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+    right: auto;
+}
+:host([dir='ltr']) #buffer ~ #buffer,
+:host([dir='ltr']) .track ~ .track {
+    /* [dir=ltr] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
     right: 0;
-    padding: 0 0 0
-        var(
-            --spectrum-slider-handle-gap,
-            var(--spectrum-alias-border-size-thicker)
-        );
+}
+:host([dir='rtl']) #buffer ~ #buffer,
+:host([dir='rtl']) .track ~ .track {
+    /* [dir=rtl] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+    left: 0;
+}
+:host([dir='ltr']) #buffer ~ #buffer,
+:host([dir='ltr']) .track ~ .track {
+    /* [dir=ltr] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
+    padding-left: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    );
+    padding-right: 0;
+}
+:host([dir='rtl']) #buffer ~ #buffer,
+:host([dir='rtl']) .track ~ .track {
+    /* [dir=rtl] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+    padding-right: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    );
+    padding-left: 0;
+}
+:host([dir='ltr']) #buffer ~ #buffer,
+:host([dir='ltr']) .track ~ .track {
+    /* [dir=ltr] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
     margin-left: 0;
+}
+:host([dir='rtl']) #buffer ~ #buffer,
+:host([dir='rtl']) .track ~ .track {
+    /* [dir=rtl] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+    margin-right: 0;
+}
+:host([dir='ltr']) #buffer ~ #buffer,
+:host([dir='ltr']) .track ~ .track {
+    /* [dir=ltr] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
     margin-right: calc(
         var(
                 --spectrum-slider-handle-width,
@@ -177,20 +367,58 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) / 2 * -1
     );
 }
+:host([dir='rtl']) #buffer ~ #buffer,
+:host([dir='rtl']) .track ~ .track {
+    /* [dir=rtl] .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+    margin-left: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 * -1
+    );
+}
+#buffer ~ #buffer,
+.track ~ .track {
+    /* .spectrum-Slider-buffer~.spectrum-Slider-buffer,
+   * .spectrum-Slider-track~.spectrum-Slider-track */
+    padding-top: 0;
+    padding-bottom: 0;
+}
+:host([dir='ltr']) #buffer ~ #buffer {
+    /* [dir=ltr] .spectrum-Slider-buffer~.spectrum-Slider-buffer */
+    margin-right: 0; /* [dir=ltr] .spectrum-Slider-buffer~.spectrum-Slider-buffer */
+    padding-left: calc(
+        var(
+                --spectrum-slider-handle-gap,
+                var(--spectrum-alias-border-size-thicker)
+            ) +
+            var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2
+    );
+    padding-right: 0;
+}
+:host([dir='rtl']) #buffer ~ #buffer {
+    /* [dir=rtl] .spectrum-Slider-buffer~.spectrum-Slider-buffer */
+    margin-left: 0; /* [dir=rtl] .spectrum-Slider-buffer~.spectrum-Slider-buffer */
+    padding-right: calc(
+        var(
+                --spectrum-slider-handle-gap,
+                var(--spectrum-alias-border-size-thicker)
+            ) +
+            var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2
+    );
+    padding-left: 0;
+}
 #buffer ~ #buffer {
     /* .spectrum-Slider-buffer~.spectrum-Slider-buffer */
-    margin-right: 0;
-    padding: 0 0 0
-        calc(
-            var(
-                    --spectrum-slider-handle-gap,
-                    var(--spectrum-alias-border-size-thicker)
-                ) +
-                var(
-                    --spectrum-slider-handle-width,
-                    var(--spectrum-global-dimension-size-200)
-                ) / 2
-        );
+    padding-top: 0;
+    padding-bottom: 0;
 }
 #buffer ~ #buffer:after {
     /* .spectrum-Slider-buffer~.spectrum-Slider-buffer:after */
@@ -202,16 +430,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     -moz-user-select: text;
     user-select: text;
 }
-:host([variant='range']) .track:first-of-type {
-    /* .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
-    padding: 0
-        var(
-            --spectrum-slider-handle-gap,
-            var(--spectrum-alias-border-size-thicker)
-        )
-        0 0;
-    left: 0;
-    right: auto;
+:host([dir='ltr'][variant='range']) .track:first-of-type {
+    /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    padding-left: 0;
+    padding-right: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    left: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    right: auto; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
     margin-left: calc(
         var(
                 --spectrum-slider-handle-width,
@@ -219,44 +446,137 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) / 2 * -1
     );
 }
-:host([variant='range']) .track {
-    /* .spectrum-Slider--range .spectrum-Slider-track */
-    padding: 0
-        calc(
-            var(
-                    --spectrum-slider-handle-gap,
-                    var(--spectrum-alias-border-size-thicker)
-                ) +
-                var(
-                    --spectrum-slider-handle-width,
-                    var(--spectrum-global-dimension-size-200)
-                ) / 2
-        )
-        0
-        calc(
-            var(
-                    --spectrum-slider-handle-gap,
-                    var(--spectrum-alias-border-size-thicker)
-                ) +
-                var(
-                    --spectrum-slider-handle-width,
-                    var(--spectrum-global-dimension-size-200)
-                ) / 2
-        );
+:host([dir='rtl'][variant='range']) .track:first-of-type {
+    /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    padding-right: 0;
+    padding-left: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    right: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    left: auto; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    margin-right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 * -1
+    );
+}
+:host([variant='range']) .track:first-of-type {
+    /* .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    padding-top: 0;
+    padding-bottom: 0;
+}
+:host([dir='ltr'][variant='range']) [dir='ltr'] .track,
+:host([dir='ltr'][variant='range']) [dir='rtl'] .track {
+    /* [dir=ltr] [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=ltr] [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track */
     left: auto;
+}
+:host([dir='ltr'][variant='range']) [dir='ltr'] .track,
+:host([dir='ltr'][variant='range']) [dir='rtl'] .track,
+:host([dir='ltr'][variant='range']) [dir='rtl'] .track,
+:host([dir='rtl'][variant='range']) [dir='rtl'] .track {
+    /* [dir=ltr] [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=ltr] [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl] [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl] [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track */
     right: auto;
+}
+:host([dir='ltr'][variant='range']) [dir='rtl'] .track,
+:host([dir='rtl'][variant='range']) [dir='rtl'] .track {
+    /* [dir=rtl] [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl] [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track */
+    left: auto;
+}
+:host([dir='ltr'][variant='range']) .track,
+:host([dir='rtl'][variant='range']) .track {
+    /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track */
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: calc(
+        var(
+                --spectrum-slider-handle-gap,
+                var(--spectrum-alias-border-size-thicker)
+            ) +
+            var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2
+    );
+    padding-right: calc(
+        var(
+                --spectrum-slider-handle-gap,
+                var(--spectrum-alias-border-size-thicker)
+            ) +
+            var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2
+    );
     margin: 0;
+}
+:host([dir='ltr'][variant='range']) .track:last-of-type {
+    /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    padding-left: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    );
+    padding-right: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    left: auto; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    right: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    margin-right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 * -1
+    );
+}
+:host([dir='rtl'][variant='range']) .track:last-of-type {
+    /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    padding-right: var(
+        --spectrum-slider-handle-gap,
+        var(--spectrum-alias-border-size-thicker)
+    );
+    padding-left: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    right: auto; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    left: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    margin-left: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 * -1
+    );
 }
 :host([variant='range']) .track:last-of-type {
     /* .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
-    padding: 0 0 0
+    padding-top: 0;
+    padding-bottom: 0;
+}
+:host([dir='ltr']) #ramp {
+    /* [dir=ltr] .spectrum-Slider-ramp */
+    left: calc(
         var(
-            --spectrum-slider-handle-gap,
-            var(--spectrum-alias-border-size-thicker)
-        );
-    left: auto;
-    right: 0;
-    margin-right: calc(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 * -1
+    );
+}
+:host([dir='ltr']) #ramp,
+:host([dir='rtl']) #ramp {
+    /* [dir=ltr] .spectrum-Slider-ramp,
+   * [dir=rtl] .spectrum-Slider-ramp */
+    right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / 2 * -1
+    );
+}
+:host([dir='rtl']) #ramp {
+    /* [dir=rtl] .spectrum-Slider-ramp */
+    left: calc(
         var(
                 --spectrum-slider-handle-width,
                 var(--spectrum-global-dimension-size-200)
@@ -271,18 +591,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-static-size-200)
     );
     position: absolute;
-    left: calc(
-        var(
-                --spectrum-slider-handle-width,
-                var(--spectrum-global-dimension-size-200)
-            ) / 2 * -1
-    );
-    right: calc(
-        var(
-                --spectrum-slider-handle-width,
-                var(--spectrum-global-dimension-size-200)
-            ) / 2 * -1
-    );
     top: calc(
         var(
                 --spectrum-slider-ramp-track-height,
@@ -290,16 +598,55 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) / 2
     );
 }
+:host([dir='rtl']) #ramp svg {
+    /* [dir=rtl] .spectrum-Slider-ramp svg */
+    transform: matrix(-1, 0, 0, 1, 0, 0);
+}
 #ramp svg {
     /* .spectrum-Slider-ramp svg */
     width: 100%;
     height: 100%;
 }
+:host([dir='ltr']) .spectrum-Dial-handle,
+:host([dir='ltr']) #handle {
+    /* [dir=ltr] .spectrum-Dial-handle,
+   * [dir=ltr] .spectrum-Slider-handle */
+    left: 0;
+}
+:host([dir='rtl']) .spectrum-Dial-handle,
+:host([dir='rtl']) #handle {
+    /* [dir=rtl] .spectrum-Dial-handle,
+   * [dir=rtl] .spectrum-Slider-handle */
+    right: 0;
+}
+:host([dir='ltr']) .spectrum-Dial-handle,
+:host([dir='ltr']) #handle {
+    /* [dir=ltr] .spectrum-Dial-handle,
+   * [dir=ltr] .spectrum-Slider-handle */
+    margin-left: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / -2
+    );
+    margin-right: 0;
+}
+:host([dir='rtl']) .spectrum-Dial-handle,
+:host([dir='rtl']) #handle {
+    /* [dir=rtl] .spectrum-Dial-handle,
+   * [dir=rtl] .spectrum-Slider-handle */
+    margin-right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / -2
+    );
+    margin-left: 0;
+}
 #handle {
     /* .spectrum-Dial-handle,
    * .spectrum-Slider-handle */
     position: absolute;
-    left: 0;
     top: calc(
         var(--spectrum-slider-height, var(--spectrum-alias-single-line-height)) /
             2
@@ -315,19 +662,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-slider-handle-height,
         var(--spectrum-global-dimension-size-200)
     );
-    margin: calc(
-            var(
-                    --spectrum-slider-handle-width,
-                    var(--spectrum-global-dimension-size-200)
-                ) / -2
-        )
-        0 0
-        calc(
-            var(
-                    --spectrum-slider-handle-width,
-                    var(--spectrum-global-dimension-size-200)
-                ) / -2
-        );
+    margin-top: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / -2
+    );
+    margin-bottom: 0;
     border-width: var(
         --spectrum-slider-handle-border-size,
         var(--spectrum-alias-border-size-thick)
@@ -431,6 +772,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         )
         var(--spectrum-alias-focus-color, var(--spectrum-global-color-blue-400));
 }
+:host([dir='ltr']) .spectrum-Dial-input,
+:host([dir='ltr']) #input {
+    /* [dir=ltr] .spectrum-Dial-input,
+   * [dir=ltr] .spectrum-Slider-input */
+    left: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / -2 / 4
+    );
+}
+:host([dir='rtl']) .spectrum-Dial-input,
+:host([dir='rtl']) #input {
+    /* [dir=rtl] .spectrum-Dial-input,
+   * [dir=rtl] .spectrum-Slider-input */
+    right: calc(
+        var(
+                --spectrum-slider-handle-width,
+                var(--spectrum-global-dimension-size-200)
+            ) / -2 / 4
+    );
+}
 #input {
     /* .spectrum-Dial-input,
    * .spectrum-Slider-input */
@@ -446,12 +809,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding: 0;
     position: absolute;
     top: calc(
-        var(
-                --spectrum-slider-handle-width,
-                var(--spectrum-global-dimension-size-200)
-            ) / -2 / 4
-    );
-    left: calc(
         var(
                 --spectrum-slider-handle-width,
                 var(--spectrum-global-dimension-size-200)
@@ -495,19 +852,51 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-label-text-color)
     );
 }
+:host([dir='ltr']) .spectrum-Dial-label,
+:host([dir='ltr']) #label {
+    /* [dir=ltr] .spectrum-Dial-label,
+   * [dir=ltr] .spectrum-Slider-label */
+    padding-left: 0;
+}
+:host([dir='rtl']) .spectrum-Dial-label,
+:host([dir='rtl']) #label {
+    /* [dir=rtl] .spectrum-Dial-label,
+   * [dir=rtl] .spectrum-Slider-label */
+    padding-right: 0;
+}
 #label {
     /* .spectrum-Dial-label,
    * .spectrum-Slider-label */
-    padding-left: 0;
     flex-grow: 1;
+}
+:host([dir='ltr']) .spectrum-Dial-value,
+:host([dir='ltr']) #value {
+    /* [dir=ltr] .spectrum-Dial-value,
+   * [dir=ltr] .spectrum-Slider-value */
+    padding-right: 0;
+}
+:host([dir='rtl']) .spectrum-Dial-value,
+:host([dir='rtl']) #value {
+    /* [dir=rtl] .spectrum-Dial-value,
+   * [dir=rtl] .spectrum-Slider-value */
+    padding-left: 0;
 }
 #value {
     /* .spectrum-Dial-value,
    * .spectrum-Slider-value */
     flex-grow: 0;
-    padding-right: 0;
-    cursor: default; /* .spectrum-Slider-value */
+    cursor: default;
+}
+:host([dir='ltr']) #value {
+    /* [dir=ltr] .spectrum-Slider-value */
     margin-left: var(
+        --spectrum-slider-label-gap-x,
+        var(--spectrum-global-dimension-size-200)
+    );
+}
+:host([dir='rtl']) #value {
+    /* [dir=rtl] .spectrum-Slider-value */
+    margin-right: var(
         --spectrum-slider-label-gap-x,
         var(--spectrum-global-dimension-size-200)
     );
@@ -535,21 +924,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .tick {
     /* .spectrum-Slider-tick */
     position: relative;
-}
-.tick,
-.tick:after {
-    /* .spectrum-Slider-tick,
-   * .spectrum-Slider-tick:after */
     width: var(
         --spectrum-slider-tick-mark-width,
         var(--spectrum-alias-border-size-thick)
     );
 }
-.tick:after {
-    /* .spectrum-Slider-tick:after */
-    display: block;
-    position: absolute;
-    top: 0;
+:host([dir='ltr']) .tick:after {
+    /* [dir=ltr] .spectrum-Slider-tick:after */
     left: calc(
         50% -
             var(
@@ -557,7 +938,27 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-alias-border-size-thick)
             ) / 2
     );
+}
+:host([dir='rtl']) .tick:after {
+    /* [dir=rtl] .spectrum-Slider-tick:after */
+    right: calc(
+        50% -
+            var(
+                --spectrum-slider-tick-mark-width,
+                var(--spectrum-alias-border-size-thick)
+            ) / 2
+    );
+}
+.tick:after {
+    /* .spectrum-Slider-tick:after */
+    display: block;
+    position: absolute;
+    top: 0;
     content: '';
+    width: var(
+        --spectrum-slider-tick-mark-width,
+        var(--spectrum-alias-border-size-thick)
+    );
     height: var(--spectrum-slider-tick-mark-height, 10px);
     border-radius: var(
         --spectrum-slider-tick-mark-border-radius,
@@ -573,23 +974,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: flex;
     align-items: center;
     justify-content: center;
-    margin: var(
-            --spectrum-slider-label-gap-x,
-            var(--spectrum-global-dimension-size-200)
-        )
-        calc(
-            var(
-                    --spectrum-slider-label-gap-x,
-                    var(--spectrum-global-dimension-size-200)
-                ) * -1
-        )
-        0
-        calc(
-            var(
-                    --spectrum-slider-label-gap-x,
-                    var(--spectrum-global-dimension-size-200)
-                ) * -1
-        );
+    margin-top: var(
+        --spectrum-slider-label-gap-x,
+        var(--spectrum-global-dimension-size-200)
+    );
+    margin-bottom: 0;
+    margin-left: calc(
+        var(
+                --spectrum-slider-label-gap-x,
+                var(--spectrum-global-dimension-size-200)
+            ) * -1
+    );
+    margin-right: calc(
+        var(
+                --spectrum-slider-label-gap-x,
+                var(--spectrum-global-dimension-size-200)
+            ) * -1
+    );
     font-size: var(
         --spectrum-label-text-size,
         var(--spectrum-global-dimension-font-size-75)
@@ -605,19 +1006,27 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Slider-tick:last-of-type .spectrum-Slider-tickLabel */
     display: block;
     position: absolute;
-    margin: var(
-            --spectrum-slider-label-gap-x,
-            var(--spectrum-global-dimension-size-200)
-        )
-        0 0 0;
+    margin-top: var(
+        --spectrum-slider-label-gap-x,
+        var(--spectrum-global-dimension-size-200)
+    );
+    margin-bottom: 0;
+    margin-left: 0;
+    margin-right: 0;
 }
-.tick:first-of-type .tickLabel {
-    /* .spectrum-Slider-tick:first-of-type .spectrum-Slider-tickLabel */
+:host([dir='ltr']) .tick:first-of-type .tickLabel {
+    /* [dir=ltr] .spectrum-Slider-tick:first-of-type .spectrum-Slider-tickLabel */
     left: 0;
 }
-.tick:last-of-type .tickLabel {
-    /* .spectrum-Slider-tick:last-of-type .spectrum-Slider-tickLabel */
+:host([dir='ltr']) .tick:last-of-type .tickLabel,
+:host([dir='rtl']) .tick:first-of-type .tickLabel {
+    /* [dir=ltr] .spectrum-Slider-tick:last-of-type .spectrum-Slider-tickLabel,
+   * [dir=rtl] .spectrum-Slider-tick:first-of-type .spectrum-Slider-tickLabel */
     right: 0;
+}
+:host([dir='rtl']) .tick:last-of-type .tickLabel {
+    /* [dir=rtl] .spectrum-Slider-tick:last-of-type .spectrum-Slider-tickLabel */
+    left: 0;
 }
 :host([variant='color']) .spectrum-Dial-labelContainer,
 :host([variant='color']) #labelContainer {
@@ -627,6 +1036,30 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-fieldlabel-padding-bottom,
         var(--spectrum-global-dimension-size-65)
     );
+}
+:host([dir='ltr'][variant='color']) .spectrum-Dial-controls,
+:host([dir='ltr'][variant='color']) .spectrum-Dial-controls:before,
+:host([dir='ltr'][variant='color']) #controls,
+:host([dir='ltr'][variant='color']) #controls:before,
+:host([dir='ltr'][variant='color']) .track {
+    /* [dir=ltr] .spectrum-Slider--color .spectrum-Dial-controls,
+   * [dir=ltr] .spectrum-Slider--color .spectrum-Dial-controls:before,
+   * [dir=ltr] .spectrum-Slider--color .spectrum-Slider-controls,
+   * [dir=ltr] .spectrum-Slider--color .spectrum-Slider-controls:before,
+   * [dir=ltr] .spectrum-Slider--color .spectrum-Slider-track */
+    margin-left: 0;
+}
+:host([dir='rtl'][variant='color']) .spectrum-Dial-controls,
+:host([dir='rtl'][variant='color']) .spectrum-Dial-controls:before,
+:host([dir='rtl'][variant='color']) #controls,
+:host([dir='rtl'][variant='color']) #controls:before,
+:host([dir='rtl'][variant='color']) .track {
+    /* [dir=rtl] .spectrum-Slider--color .spectrum-Dial-controls,
+   * [dir=rtl] .spectrum-Slider--color .spectrum-Dial-controls:before,
+   * [dir=rtl] .spectrum-Slider--color .spectrum-Slider-controls,
+   * [dir=rtl] .spectrum-Slider--color .spectrum-Slider-controls:before,
+   * [dir=rtl] .spectrum-Slider--color .spectrum-Slider-track */
+    margin-right: 0;
 }
 :host([variant='color']) .spectrum-Dial-controls,
 :host([variant='color']) .spectrum-Dial-controls:before,
@@ -643,7 +1076,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-slider-color-track-height,
         var(--spectrum-global-dimension-static-size-300)
     );
-    margin-left: 0;
     width: 100%;
 }
 :host([variant='color']) .spectrum-Dial-controls:before,
@@ -652,6 +1084,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Slider--color .spectrum-Slider-controls:before */
     display: block;
     content: '';
+}
+:host([dir='ltr'][variant='color']) .spectrum-Dial-controls:before,
+:host([dir='ltr'][variant='color']) #controls:before,
+:host([dir='ltr'][variant='color']) .track {
+    /* [dir=ltr] .spectrum-Slider--color .spectrum-Dial-controls:before,
+   * [dir=ltr] .spectrum-Slider--color .spectrum-Slider-controls:before,
+   * [dir=ltr] .spectrum-Slider--color .spectrum-Slider-track */
+    margin-right: 0;
+}
+:host([dir='rtl'][variant='color']) .spectrum-Dial-controls:before,
+:host([dir='rtl'][variant='color']) #controls:before,
+:host([dir='rtl'][variant='color']) .track {
+    /* [dir=rtl] .spectrum-Slider--color .spectrum-Dial-controls:before,
+   * [dir=rtl] .spectrum-Slider--color .spectrum-Slider-controls:before,
+   * [dir=rtl] .spectrum-Slider--color .spectrum-Slider-track */
+    margin-left: 0;
 }
 :host([variant='color']) .spectrum-Dial-controls:before,
 :host([variant='color']) #controls:before,
@@ -662,7 +1110,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     top: 0;
     padding: 0;
     margin-top: 0;
-    margin-right: 0;
     border-radius: var(
         --spectrum-alias-border-radius-regular,
         var(--spectrum-global-dimension-size-50)
@@ -673,6 +1120,84 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Slider--color .spectrum-Dial-handle,
    * .spectrum-Slider--color .spectrum-Slider-handle */
     top: 50%;
+}
+:host([dir='ltr']) .spectrum-Dial-controls:before {
+    /* [dir=ltr] .spectrum-Dial-controls:before */
+    left: auto; /* [dir=ltr] .spectrum-Dial-controls:before */
+    right: calc(
+        var(
+                --spectrum-slider-tick-mark-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * -1
+    );
+}
+:host([dir='rtl']) .spectrum-Dial-controls:before {
+    /* [dir=rtl] .spectrum-Dial-controls:before */
+    right: auto; /* [dir=rtl] .spectrum-Dial-controls:before */
+    left: calc(
+        var(
+                --spectrum-slider-tick-mark-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * -1
+    );
+}
+:host([dir='ltr']) .spectrum-Dial-controls:after {
+    /* [dir=ltr] .spectrum-Dial-controls:after */
+    left: calc(
+        var(
+                --spectrum-slider-tick-mark-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * -1
+    );
+}
+:host([dir='rtl']) .spectrum-Dial-controls:after {
+    /* [dir=rtl] .spectrum-Dial-controls:after */
+    right: calc(
+        var(
+                --spectrum-slider-tick-mark-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * -1
+    );
+}
+:host([dir='ltr']) .spectrum-Dial-handle {
+    /* [dir=ltr] .spectrum-Dial-handle */
+    left: var(--spectrum-global-dimension-size-100);
+}
+:host([dir='ltr']) .spectrum-Dial-handle,
+:host([dir='rtl']) .spectrum-Dial-handle {
+    /* [dir=ltr] .spectrum-Dial-handle,
+   * [dir=rtl] .spectrum-Dial-handle */
+    right: var(--spectrum-global-dimension-size-100);
+}
+:host([dir='rtl']) .spectrum-Dial-handle {
+    /* [dir=rtl] .spectrum-Dial-handle */
+    left: var(--spectrum-global-dimension-size-100);
+}
+:host([dir='ltr']) .spectrum-Dial-handle:after {
+    /* [dir=ltr] .spectrum-Dial-handle:after */
+    left: calc(
+        var(
+                --spectrum-slider-tick-mark-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * -1
+    );
+}
+:host([dir='rtl']) .spectrum-Dial-handle:after {
+    /* [dir=rtl] .spectrum-Dial-handle:after */
+    right: calc(
+        var(
+                --spectrum-slider-tick-mark-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * -1
+    );
+}
+:host([dir='ltr']) .spectrum-Dial-input {
+    /* [dir=ltr] .spectrum-Dial-input */
+    left: 0;
+}
+:host([dir='rtl']) .spectrum-Dial-input {
+    /* [dir=rtl] .spectrum-Dial-input */
+    right: 0;
 }
 :host([disabled]) {
     /* .spectrum-Dial.is-disabled,

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -9,11 +9,12 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { html, action, text, number } from '@open-wc/demoing-storybook';
+import { html, action, text, number, select } from '@open-wc/demoing-storybook';
 
 import '../sp-slider.js';
 import { Slider } from '../';
 import { TemplateResult } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export default {
     component: 'sp-slider',
@@ -25,9 +26,20 @@ export const Default = (): TemplateResult => {
         const target = event.target as Slider;
         action(event.type)(target.value);
     };
+    const dir = select(
+        'Text direction',
+        {
+            None: 'none',
+            'Left to right': 'ltr',
+            'Right to left': 'rtl',
+        },
+        'ltr',
+        'Element'
+    );
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
+                dir=${ifDefined(dir === 'none' ? undefined : dir)}
                 label="Opacity"
                 max="100"
                 min="0"

--- a/packages/split-button/stories/split-button.stories.ts
+++ b/packages/split-button/stories/split-button.stories.ts
@@ -119,7 +119,11 @@ moreCta.story = {
 export const moreCtaOpen = (options = {}): TemplateResult => {
     return html`
         <div>
+<<<<<<< HEAD
             <sp-split-button type="more" open>
+=======
+            <sp-split-button open>
+>>>>>>> feat(split-button): add split-button pattern
                 ${menu(options)}
             </sp-split-button>
         </div>

--- a/packages/split-button/stories/split-button.stories.ts
+++ b/packages/split-button/stories/split-button.stories.ts
@@ -119,11 +119,7 @@ moreCta.story = {
 export const moreCtaOpen = (options = {}): TemplateResult => {
     return html`
         <div>
-<<<<<<< HEAD
             <sp-split-button type="more" open>
-=======
-            <sp-split-button open>
->>>>>>> feat(split-button): add split-button pattern
                 ${menu(options)}
             </sp-split-button>
         </div>

--- a/packages/split-button/test/split-button.test.ts
+++ b/packages/split-button/test/split-button.test.ts
@@ -78,7 +78,6 @@ describe('Splitbutton', () => {
         expect(((el as unknown) as TestableSplitButton).isShiftTabbing).to.be
             .true;
         await nextFrame();
-        await nextFrame();
 
         trigger.focus();
 

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -47,11 +47,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/statuslight": "^2.0.6"
+        "@spectrum-css/statuslight": "^3.0.0-beta.2"
     },
     "dependencies": {
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
+        "@spectrum-web-components/base": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/status-light/src/StatusLight.ts
+++ b/packages/status-light/src/StatusLight.ts
@@ -12,19 +12,19 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     property,
     CSSResultArray,
     TemplateResult,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import statusLightStyles from './status-light.css.js';
 
 /**
  * A Spectrum status light control.
  * @element sp-status-light
  */
-export class StatusLight extends LitElement {
+export class StatusLight extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [statusLightStyles];
     }

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -19,8 +19,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: flex;
     flex-direction: row;
     align-items: flex-start;
-    padding: calc(var(--spectrum-global-dimension-size-65) - 1px) 0
-        calc(var(--spectrum-global-dimension-size-65) + 1px) 0;
+    padding-top: calc(var(--spectrum-global-dimension-size-65) - 1px);
+    padding-bottom: calc(var(--spectrum-global-dimension-size-65) + 1px);
+    padding-left: 0;
+    padding-right: 0;
     box-sizing: border-box;
     font-size: var(
         --spectrum-statuslight-text-size,
@@ -56,11 +58,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             --spectrum-statuslight-text-gap,
             var(--spectrum-global-dimension-size-150)
         )
-        calc(var(--spectrum-global-dimension-size-65) - 1px)
-        var(
-            --spectrum-statuslight-text-gap,
-            var(--spectrum-global-dimension-size-150)
-        );
+        calc(var(--spectrum-global-dimension-size-65) - 1px);
     -ms-high-contrast-adjust: none;
     forced-color-adjust: none;
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -47,12 +47,11 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/toggle": "^2.1.0"
+        "@spectrum-css/toggle": "^3.0.0-beta.2"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/checkbox": "^0.4.3",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/switch/src/Switch.ts
+++ b/packages/switch/src/Switch.ts
@@ -15,7 +15,7 @@ import {
     TemplateResult,
     html,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { CheckboxBase } from '@spectrum-web-components/checkbox/src/CheckboxBase.js';
 import switchStyles from './switch.css.js';
 import legacyStyles from './switch-legacy.css.js';

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -10,6 +10,24 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host([dir='ltr']) {
+    /* [dir=ltr] .spectrum-ToggleSwitch */
+    margin-right: calc(
+        var(
+                --spectrum-switch-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * 2
+    );
+}
+:host([dir='rtl']) {
+    /* [dir=rtl] .spectrum-ToggleSwitch */
+    margin-left: calc(
+        var(
+                --spectrum-switch-cursor-hit-x,
+                var(--spectrum-global-dimension-size-100)
+            ) * 2
+    );
+}
 :host {
     /* .spectrum-ToggleSwitch */
     display: inline-flex;
@@ -20,13 +38,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-400)
     );
     max-width: 100%;
-    margin-right: calc(
-        var(
-                --spectrum-switch-cursor-hit-x,
-                var(--spectrum-global-dimension-size-100)
-            ) * 2
-    );
     vertical-align: top;
+}
+:host([dir='ltr']) #input {
+    /* [dir=ltr] .spectrum-ToggleSwitch-input */
+    left: 0;
+}
+:host([dir='rtl']) #input {
+    /* [dir=rtl] .spectrum-ToggleSwitch-input */
+    right: 0;
 }
 #input {
     /* .spectrum-ToggleSwitch-input */
@@ -37,25 +57,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     width: 100%;
     height: 100%;
     top: 0;
-    left: 0;
     opacity: 0.0001;
     z-index: 1;
     cursor: pointer;
 }
-:host([checked]) #input + #switch:before {
-    /* .spectrum-ToggleSwitch-input:checked+.spectrum-ToggleSwitch-switch:before */
+:host([dir='ltr'][checked]) #input + #switch:before {
+    /* [dir=ltr] .spectrum-ToggleSwitch-input:checked+.spectrum-ToggleSwitch-switch:before */
     transform: translateX(
         calc(
-            var(--spectrum-switch-track-width) -
+            100% -
                 var(
-                    --spectrum-switch-handle-size,
-                    var(--spectrum-global-dimension-size-175)
+                    --spectrum-switch-handle-border-size,
+                    var(--spectrum-alias-border-size-thick)
                 )
         )
-    ); /* .spectrum-ToggleSwitch-input:checked+.spectrum-ToggleSwitch-switch:before */
-    border-color: var(
-        --spectrum-switch-emphasized-handle-border-color-selected,
-        var(--spectrum-global-color-blue-500)
+    );
+}
+:host([dir='rtl'][checked]) #input + #switch:before {
+    /* [dir=rtl] .spectrum-ToggleSwitch-input:checked+.spectrum-ToggleSwitch-switch:before */
+    transform: translateX(
+        calc(
+            -100% + var(--spectrum-switch-handle-border-size, var(--spectrum-alias-border-size-thick))
+        )
     );
 }
 :host([disabled]) #input,
@@ -75,12 +98,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 #label {
     /* .spectrum-ToggleSwitch-label */
-    margin: 0
-        var(
-            --spectrum-switch-text-gap,
-            var(--spectrum-global-dimension-size-125)
-        );
+    margin-left: var(
+        --spectrum-switch-text-gap,
+        var(--spectrum-global-dimension-size-125)
+    );
+    margin-right: var(
+        --spectrum-switch-text-gap,
+        var(--spectrum-global-dimension-size-125)
+    );
     margin-top: var(--spectrum-global-dimension-size-65);
+    margin-bottom: 0;
     font-size: var(
         --spectrum-switch-text-size,
         var(--spectrum-alias-font-size-default)
@@ -89,25 +116,52 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     transition: color var(--spectrum-global-animation-duration-200, 0.16s)
         ease-in-out;
 }
+:host([dir='ltr']) #switch {
+    /* [dir=ltr] .spectrum-ToggleSwitch-switch */
+    left: 0;
+}
+:host([dir='ltr']) #switch,
+:host([dir='rtl']) #switch {
+    /* [dir=ltr] .spectrum-ToggleSwitch-switch,
+   * [dir=rtl] .spectrum-ToggleSwitch-switch */
+    right: 0;
+}
+:host([dir='rtl']) #switch {
+    /* [dir=rtl] .spectrum-ToggleSwitch-switch */
+    left: 0;
+}
 #switch {
     /* .spectrum-ToggleSwitch-switch */
     display: inline-block;
     box-sizing: border-box;
     position: relative;
     width: var(--spectrum-switch-track-width);
-    margin: calc(
-            (
+    margin-top: calc(
+        (
+                var(
+                        --spectrum-switch-height,
+                        var(--spectrum-global-dimension-size-400)
+                    ) -
                     var(
-                            --spectrum-switch-height,
-                            var(--spectrum-global-dimension-size-400)
-                        ) -
-                        var(
-                            --spectrum-switch-track-height,
-                            var(--spectrum-global-dimension-size-175)
-                        )
-                ) / 2
-        )
-        0;
+                        --spectrum-switch-track-height,
+                        var(--spectrum-global-dimension-size-175)
+                    )
+            ) / 2
+    );
+    margin-bottom: calc(
+        (
+                var(
+                        --spectrum-switch-height,
+                        var(--spectrum-global-dimension-size-400)
+                    ) -
+                    var(
+                        --spectrum-switch-track-height,
+                        var(--spectrum-global-dimension-size-175)
+                    )
+            ) / 2
+    );
+    margin-left: 0;
+    margin-right: 0;
     flex-grow: 0;
     flex-shrink: 0;
     vertical-align: middle;
@@ -118,8 +172,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-switch-track-height,
         var(--spectrum-global-dimension-size-175)
     );
-    left: 0;
-    right: 0;
     border-radius: calc(
         var(
                 --spectrum-switch-track-height,
@@ -136,7 +188,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: block;
     position: absolute;
     content: '';
-    box-sizing: border-box;
+    box-sizing: border-box; /* .spectrum-ToggleSwitch-switch:before */
     transition: background var(--spectrum-global-animation-duration-100, 0.13s)
             ease-in-out,
         border var(--spectrum-global-animation-duration-100, 0.13s) ease-in-out,
@@ -153,7 +205,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-175)
     );
     top: 0;
-    left: 0;
     border-width: var(
         --spectrum-switch-handle-border-size,
         var(--spectrum-alias-border-size-thick)
@@ -168,6 +219,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-switch-emphasized-handle-border-color,
         var(--spectrum-global-color-gray-600)
     );
+}
+:host([dir='ltr']) #switch:before {
+    /* [dir=ltr] .spectrum-ToggleSwitch-switch:before */
+    left: 0;
+}
+:host([dir='rtl']) #switch:before {
+    /* [dir=rtl] .spectrum-ToggleSwitch-switch:before */
+    right: 0;
+}
+:host([dir='ltr']) #switch:after {
+    /* [dir=ltr] .spectrum-ToggleSwitch-switch:after */
+    left: 0;
+}
+:host([dir='ltr']) #switch:after,
+:host([dir='rtl']) #switch:after {
+    /* [dir=ltr] .spectrum-ToggleSwitch-switch:after,
+   * [dir=rtl] .spectrum-ToggleSwitch-switch:after */
+    right: 0;
+}
+:host([dir='rtl']) #switch:after {
+    /* [dir=rtl] .spectrum-ToggleSwitch-switch:after */
+    left: 0;
 }
 #switch:after {
     /* .spectrum-ToggleSwitch-switch:after */
@@ -184,8 +257,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     content: '';
     display: block;
     position: absolute;
-    left: 0;
-    right: 0;
     bottom: 0;
     top: 0;
     margin: 0;
@@ -204,6 +275,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-ToggleSwitch-input:checked+.spectrum-ToggleSwitch-switch */
     background-color: var(
         --spectrum-switch-emphasized-track-color-selected,
+        var(--spectrum-global-color-blue-500)
+    );
+}
+:host([checked]) #input + #switch:before {
+    /* .spectrum-ToggleSwitch-input:checked+.spectrum-ToggleSwitch-switch:before */
+    border-color: var(
+        --spectrum-switch-emphasized-handle-border-color-selected,
         var(--spectrum-global-color-blue-500)
     );
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -51,12 +51,11 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/tabs": "^2.1.1"
+        "@spectrum-css/tabs": "^3.0.0-beta.3"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/shared": "^0.6.0",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -15,9 +15,9 @@ import {
     property,
     CSSResultArray,
     TemplateResult,
-    LitElement,
+    SpectrumElement,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { FocusVisiblePolyfillMixin } from '@spectrum-web-components/shared/src/focus-visible.js';
 
 import tabItemStyles from './tab.css.js';
@@ -26,7 +26,7 @@ import tabItemStyles from './tab.css.js';
  * @slot icon - The icon that appears on the left of the label
  */
 
-export class Tab extends FocusVisiblePolyfillMixin(LitElement) {
+export class Tab extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public static get styles(): CSSResultArray {
         return [tabItemStyles];
     }

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -16,7 +16,7 @@ import {
     CSSResultArray,
     TemplateResult,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { Tab } from './Tab.js';
 import { Focusable, getActiveElement } from '@spectrum-web-components/shared';
 

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -175,9 +175,12 @@ export class Tabs extends Focusable {
 
     public handleKeydown(event: KeyboardEvent): void {
         const { code } = event;
-        const availableArrows = availableArrowsByDirection[this.direction];
+        const availableArrows = [...availableArrowsByDirection[this.direction]];
         if (!availableArrows.includes(code)) {
             return;
+        }
+        if (!this.isDefaultDir && this.direction === 'horizontal') {
+            availableArrows.reverse();
         }
         event.preventDefault();
         const currentFocusedTab = getActiveElement(this) as Tab;

--- a/packages/tabs/src/spectrum-config.js
+++ b/packages/tabs/src/spectrum-config.js
@@ -45,6 +45,13 @@ module.exports = {
                     selector: '.spectrum-Tabs-item',
                 },
             ],
+            complexSelectors: [
+                {
+                    replacement: '::slotted(sp-tab:not(:first-child))',
+                    selector:
+                        '.spectrum-Tabs-item+:not(.spectrum-Tabs-selectionIndicator)',
+                },
+            ],
             exclude: [/^\.spectrum-Tabs-item/],
         },
         {
@@ -78,6 +85,7 @@ module.exports = {
                     selector: '.spectrum-Icon',
                 },
             ],
+            exclude: [/.spectrum-Tabs(?!-item)/],
         },
     ],
 };

--- a/packages/tabs/src/spectrum-tab.css
+++ b/packages/tabs/src/spectrum-tab.css
@@ -57,11 +57,38 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Tabs-item .spectrum-Icon */
     color: var(--spectrum-tabs-icon-color, var(--spectrum-alias-icon-color));
 }
-slot[name='icon'] + #itemLabel {
-    /* .spectrum-Tabs-item .spectrum-Icon+.spectrum-Tabs-itemLabel */
+:host([dir='ltr']) slot[name='icon'] + #itemLabel {
+    /* [dir=ltr] .spectrum-Tabs-item .spectrum-Icon+.spectrum-Tabs-itemLabel */
     margin-left: calc(
         var(--spectrum-tabs-icon-gap, var(--spectrum-global-dimension-size-100)) -
             var(--spectrum-global-dimension-size-40)
+    );
+}
+:host([dir='rtl']) slot[name='icon'] + #itemLabel {
+    /* [dir=rtl] .spectrum-Tabs-item .spectrum-Icon+.spectrum-Tabs-itemLabel */
+    margin-right: calc(
+        var(--spectrum-tabs-icon-gap, var(--spectrum-global-dimension-size-100)) -
+            var(--spectrum-global-dimension-size-40)
+    );
+}
+:host([dir='ltr']):before {
+    /* [dir=ltr] .spectrum-Tabs-item:before */
+    left: calc(
+        -1 * var(--spectrum-tabs-focus-ring-padding-x, var(--spectrum-global-dimension-size-100))
+    );
+}
+:host([dir='ltr']):before,
+:host([dir='rtl']):before {
+    /* [dir=ltr] .spectrum-Tabs-item:before,
+   * [dir=rtl] .spectrum-Tabs-item:before */
+    right: calc(
+        -1 * var(--spectrum-tabs-focus-ring-padding-x, var(--spectrum-global-dimension-size-100))
+    );
+}
+:host([dir='rtl']):before {
+    /* [dir=rtl] .spectrum-Tabs-item:before */
+    left: calc(
+        -1 * var(--spectrum-tabs-focus-ring-padding-x, var(--spectrum-global-dimension-size-100))
     );
 }
 :host:before {
@@ -84,12 +111,6 @@ slot[name='icon'] + #itemLabel {
                 var(--spectrum-alias-border-size-thick)
             ) / 2
     );
-    left: calc(
-        -1 * var(--spectrum-tabs-focus-ring-padding-x, var(--spectrum-global-dimension-size-100))
-    );
-    right: calc(
-        -1 * var(--spectrum-tabs-focus-ring-padding-x, var(--spectrum-global-dimension-size-100))
-    );
     border: var(
             --spectrum-tabs-focus-ring-size,
             var(--spectrum-alias-border-size-thick)
@@ -111,6 +132,7 @@ slot[name='icon'] + #itemLabel {
         --spectrum-tabs-text-font-weight,
         var(--spectrum-alias-body-text-font-weight)
     );
+    text-decoration: none;
 }
 #itemLabel:empty {
     /* .spectrum-Tabs-itemLabel:empty */

--- a/packages/tabs/src/spectrum-tabs.css
+++ b/packages/tabs/src/spectrum-tabs.css
@@ -16,21 +16,53 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     position: relative;
     z-index: 0;
     margin: 0;
-    padding: 0
-        var(
-            --spectrum-tabs-focus-ring-padding-x,
-            var(--spectrum-global-dimension-size-100)
-        );
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: var(
+        --spectrum-tabs-focus-ring-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+    padding-right: var(
+        --spectrum-tabs-focus-ring-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
     vertical-align: top; /* .spectrum-Tabs */
     border-bottom-color: var(
         --spectrum-tabs-rule-color,
         var(--spectrum-global-color-gray-200)
     );
 }
+:host([dir='ltr']) ::slotted(*):before {
+    /* [dir=ltr] .spectrum-Tabs-item:before */
+    left: calc(
+        -1 * var(--spectrum-tabs-focus-ring-padding-x, var(--spectrum-global-dimension-size-100))
+    );
+}
+:host([dir='ltr']) ::slotted(*):before,
+:host([dir='rtl']) ::slotted(*):before {
+    /* [dir=ltr] .spectrum-Tabs-item:before,
+   * [dir=rtl] .spectrum-Tabs-item:before */
+    right: calc(
+        -1 * var(--spectrum-tabs-focus-ring-padding-x, var(--spectrum-global-dimension-size-100))
+    );
+}
+:host([dir='rtl']) ::slotted(*):before {
+    /* [dir=rtl] .spectrum-Tabs-item:before */
+    left: calc(
+        -1 * var(--spectrum-tabs-focus-ring-padding-x, var(--spectrum-global-dimension-size-100))
+    );
+}
+:host([dir='ltr']) #selectionIndicator {
+    /* [dir=ltr] .spectrum-Tabs-selectionIndicator */
+    left: 0;
+}
+:host([dir='rtl']) #selectionIndicator {
+    /* [dir=rtl] .spectrum-Tabs-selectionIndicator */
+    right: 0;
+}
 #selectionIndicator {
     /* .spectrum-Tabs-selectionIndicator */
     position: absolute;
-    left: 0;
     z-index: 0;
     transition: transform
         var(
@@ -85,9 +117,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Tabs--horizontal .spectrum-Tabs-item */
     vertical-align: top;
 }
-:host([direction='horizontal']) slot + :not(#selectionIndicator) {
-    /* .spectrum-Tabs--horizontal .spectrum-Tabs-item+:not(.spectrum-Tabs-selectionIndicator) */
+:host([dir='ltr'][direction='horizontal']) ::slotted(sp-tab:not(:first-child)) {
+    /* [dir=ltr] .spectrum-Tabs--horizontal .spectrum-Tabs-item+:not(.spectrum-Tabs-selectionIndicator) */
     margin-left: var(
+        --spectrum-tabs-item-gap,
+        var(--spectrum-global-dimension-size-300)
+    );
+}
+:host([dir='rtl'][direction='horizontal']) ::slotted(sp-tab:not(:first-child)) {
+    /* [dir=rtl] .spectrum-Tabs--horizontal .spectrum-Tabs-item+:not(.spectrum-Tabs-selectionIndicator) */
+    margin-right: var(
         --spectrum-tabs-item-gap,
         var(--spectrum-global-dimension-size-300)
     );
@@ -127,32 +166,38 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-transparent)
     );
 }
-:host([direction='vertical']) {
-    /* .spectrum-Tabs--vertical */
-    display: inline-flex;
-    flex-direction: column;
-    padding: 0;
+:host([dir='ltr'][direction='vertical']) {
+    /* [dir=ltr] .spectrum-Tabs--vertical */
     border-left: var(
             --spectrum-tabs-vertical-rule-width,
             var(--spectrum-alias-border-size-thick)
         )
-        solid; /* .spectrum-Tabs--vertical */
+        solid; /* [dir=ltr] .spectrum-Tabs--vertical */
     border-left-color: var(
         --spectrum-tabs-vertical-rule-color,
         var(--spectrum-global-color-gray-200)
     );
 }
-:host([direction='vertical']) ::slotted(*) {
-    /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
-    height: var(
-        --spectrum-tabs-vertical-item-height,
-        var(--spectrum-global-dimension-size-550)
+:host([dir='rtl'][direction='vertical']) {
+    /* [dir=rtl] .spectrum-Tabs--vertical */
+    border-right: var(
+            --spectrum-tabs-vertical-rule-width,
+            var(--spectrum-alias-border-size-thick)
+        )
+        solid; /* [dir=rtl] .spectrum-Tabs--vertical */
+    border-right-color: var(
+        --spectrum-tabs-vertical-rule-color,
+        var(--spectrum-global-color-gray-200)
     );
-    padding: 0
-        var(
-            --spectrum-tabs-focus-ring-padding-x,
-            var(--spectrum-global-dimension-size-100)
-        );
+}
+:host([direction='vertical']) {
+    /* .spectrum-Tabs--vertical */
+    display: inline-flex;
+    flex-direction: column;
+    padding: 0;
+}
+:host([dir='ltr'][direction='vertical']) ::slotted(*) {
+    /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item */
     margin-left: calc(
         var(
                 --spectrum-tabs-vertical-item-margin-left,
@@ -163,19 +208,63 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-100)
             )
     );
+}
+:host([dir='rtl'][direction='vertical']) ::slotted(*) {
+    /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-item */
+    margin-right: calc(
+        var(
+                --spectrum-tabs-vertical-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) -
+            var(
+                --spectrum-tabs-focus-ring-padding-x,
+                var(--spectrum-global-dimension-size-100)
+            )
+    );
+}
+:host([direction='vertical']) ::slotted(*) {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
+    height: var(
+        --spectrum-tabs-vertical-item-height,
+        var(--spectrum-global-dimension-size-550)
+    );
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: var(
+        --spectrum-tabs-focus-ring-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+    padding-right: var(
+        --spectrum-tabs-focus-ring-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
     margin-bottom: var(
         --spectrum-tabs-vertical-item-gap,
         var(--spectrum-global-dimension-size-50)
     );
 }
-:host([direction='vertical']) ::slotted(*):before {
-    /* .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
+:host([dir='ltr'][direction='vertical']) ::slotted(*):before {
+    /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
     left: calc(
         -1 * var(--spectrum-tabs-focus-ring-size, var(--spectrum-alias-border-size-thick))
     );
+}
+:host([dir='ltr'][direction='vertical']) ::slotted(*):before,
+:host([dir='rtl'][direction='vertical']) ::slotted(*):before {
+    /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item:before,
+   * [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
     right: calc(
         -1 * var(--spectrum-tabs-focus-ring-size, var(--spectrum-alias-border-size-thick))
     );
+}
+:host([dir='rtl'][direction='vertical']) ::slotted(*):before {
+    /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
+    left: calc(
+        -1 * var(--spectrum-tabs-focus-ring-size, var(--spectrum-alias-border-size-thick))
+    );
+}
+:host([direction='vertical']) ::slotted(*):before {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
     margin-top: calc(
         var(
                 --spectrum-tabs-focus-ring-height,
@@ -199,16 +288,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-400)
     );
 }
+:host([dir='ltr'][direction='vertical']) #selectionIndicator {
+    /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+    left: 0; /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+    left: calc(
+        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
+    );
+}
+:host([dir='rtl'][direction='vertical']) #selectionIndicator {
+    /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+    right: 0; /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+    right: calc(
+        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
+    );
+}
 :host([direction='vertical']) #selectionIndicator {
     /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
     position: absolute;
-    left: 0;
     width: var(
         --spectrum-tabs-vertical-rule-width,
         var(--spectrum-alias-border-size-thick)
-    );
-    left: calc(
-        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
     );
 }
 :host([quiet]) #selectionIndicator {
@@ -218,11 +317,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([direction='vertical'][compact]),
-:host([direction='vertical'][quiet]) {
-    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
-   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
+:host([dir='ltr'][direction='vertical'][compact]),
+:host([dir='ltr'][direction='vertical'][quiet]) {
+    /* [dir=ltr] .spectrum-Tabs--vertical.spectrum-Tabs--compact,
+   * [dir=ltr] .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
     border-left-color: var(
+        --spectrum-tabs-quiet-vertical-rule-color,
+        var(--spectrum-alias-border-color-transparent)
+    );
+}
+:host([dir='rtl'][direction='vertical'][compact]),
+:host([dir='rtl'][direction='vertical'][quiet]) {
+    /* [dir=rtl] .spectrum-Tabs--vertical.spectrum-Tabs--compact,
+   * [dir=rtl] .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
+    border-right-color: var(
         --spectrum-tabs-quiet-vertical-rule-color,
         var(--spectrum-alias-border-color-transparent)
     );

--- a/packages/tabs/src/tab.css
+++ b/packages/tabs/src/tab.css
@@ -54,7 +54,7 @@ governing permissions and limitations under the License.
     height: auto;
 }
 
-:host([vertical]) #itemLabel {
+:host([dir][vertical]) slot[name='icon'] + #itemLabel {
     font-size: var(
         --spectrum-tabs-text-size,
         var(--spectrum-alias-font-size-default)

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -17,23 +17,6 @@ governing permissions and limitations under the License.
     width: 1px;
 }
 
-/* Original selector from spectrum-css:
- * .spectrum-Tabs--horizontal .spectrum-Tabs-item + *:not(.spectrum-Tabs-selectionIndicator)
- *
- * The original selector matches all elements (excluding the selectionIndicactor) that are adjacent to a tab-item.
- * We can't follow this approach because complex selectors are restricted in ::slotted pseudo elements.
- * The following would not work -- :host([direction='horizontal']) ::slotted(sp-tab-item + *:not(.spectrum-Tabs-selectionIndicator))
- *
- * This revision matches all tabs except for the first, which achieves the same effect.
- */
-
-:host([direction='horizontal']) ::slotted(sp-tab:not(:first-child)) {
-    margin-left: var(
-        --spectrum-tabs-item-gap,
-        var(--spectrum-global-dimension-size-300)
-    );
-}
-
 /*
  * While https://github.com/adobe/spectrum-css/issues/641 goes unaddressed,
  * then we'll need to place this at `top: 0;` ourselves.
@@ -53,13 +36,24 @@ governing permissions and limitations under the License.
     --spectrum-tabs-height: var(--spectrum-tabs-quiet-compact-height);
 }
 
+/* 
+ * The shorthand border declaration in :host([direction='horizontal']) was overiding
+ * the border-bottom-color declared in :host 
+ */
+:host([direction='horizontal']:not([quiet])) {
+    border-bottom-color: var(
+        --spectrum-tabs-rule-color,
+        var(--spectrum-global-color-gray-200)
+    );
+}
+
 /*
  * The following manually add the `vertical-right` direction to sp-tab-list
  * It can be removed after https://github.com/adobe/spectrum-css/issues/637 is resolved
  * In the interim, if there are ever Visual Regression failures to the 'Vertical' tabs story
  * then it is likely that this CSS will need to be updated with changes in @spectrum-css/tabs
  */
-:host([direction='vertical-right']) {
+:host([dir='ltr'][direction='vertical-right']) {
     /* .spectrum-Tabs--vertical */
     display: inline-flex;
     flex-direction: column;
@@ -75,7 +69,23 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-200)
     );
 }
-:host([direction='vertical-right']) ::slotted(*) {
+:host([dir='rtl'][direction='vertical-right']) {
+    /* .spectrum-Tabs--vertical */
+    display: inline-flex;
+    flex-direction: column;
+    padding: 0;
+    border-left: var(
+            --spectrum-tabs-vertical-rule-width,
+            var(--spectrum-alias-border-size-thick)
+        )
+        solid; /* .spectrum-Tabs--vertical */
+
+    border-left-color: var(
+        --spectrum-tabs-vertical-rule-color,
+        var(--spectrum-global-color-gray-200)
+    );
+}
+:host([dir='ltr'][direction='vertical-right']) ::slotted(*) {
     /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
     height: var(
         --spectrum-tabs-vertical-item-height,
@@ -87,6 +97,32 @@ governing permissions and limitations under the License.
             var(--spectrum-global-dimension-size-100)
         );
     margin-right: calc(
+        var(
+                --spectrum-tabs-vertical-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) -
+            var(
+                --spectrum-tabs-focus-ring-padding-x,
+                var(--spectrum-global-dimension-size-100)
+            )
+    );
+    margin-bottom: var(
+        --spectrum-tabs-vertical-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+:host([dir='rtl'][direction='vertical-right']) ::slotted(*) {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
+    height: var(
+        --spectrum-tabs-vertical-item-height,
+        var(--spectrum-global-dimension-size-550)
+    );
+    padding: 0
+        var(
+            --spectrum-tabs-focus-ring-padding-x,
+            var(--spectrum-global-dimension-size-100)
+        );
+    margin-left: calc(
         var(
                 --spectrum-tabs-vertical-item-margin-left,
                 var(--spectrum-global-dimension-size-150)
@@ -118,7 +154,7 @@ governing permissions and limitations under the License.
         var(--spectrum-global-dimension-size-400)
     );
 }
-:host([direction='vertical-right']) #selectionIndicator {
+:host([dir='ltr'][direction='vertical-right']) #selectionIndicator {
     /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
     position: absolute;
     left: auto;
@@ -130,11 +166,32 @@ governing permissions and limitations under the License.
         -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
     );
 }
-:host([direction='vertical-right'][compact]),
-:host([direction='vertical-right'][quiet]) {
+:host([dir='rtl'][direction='vertical-right']) #selectionIndicator {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+    position: absolute;
+    right: auto;
+    width: var(
+        --spectrum-tabs-vertical-rule-width,
+        var(--spectrum-alias-border-size-thick)
+    );
+    left: calc(
+        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
+    );
+}
+:host([dir='ltr'][direction='vertical-right'][compact]),
+:host([dir='ltr'][direction='vertical-right'][quiet]) {
     /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
    * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
     border-right-color: var(
+        --spectrum-tabs-quiet-vertical-rule-color,
+        var(--spectrum-alias-border-color-transparent)
+    );
+}
+:host([dir='rtl'][direction='vertical-right'][compact]),
+:host([dir='rtl'][direction='vertical-right'][quiet]) {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
+    border-left-color: var(
         --spectrum-tabs-quiet-vertical-rule-color,
         var(--spectrum-alias-border-color-transparent)
     );
@@ -146,16 +203,5 @@ governing permissions and limitations under the License.
     background-color: var(
         --spectrum-tabs-quiet-selection-indicator-color,
         var(--spectrum-global-color-gray-900)
-    );
-}
-
-/* 
- * The shorthand border declaration in :host([direction='horizontal']) was overiding
- * the border-bottom-color declared in :host 
- */
-:host([direction='horizontal']:not([quiet])) {
-    border-bottom-color: var(
-        --spectrum-tabs-rule-color,
-        var(--spectrum-global-color-gray-200)
     );
 }

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -12,11 +12,6 @@ governing permissions and limitations under the License.
 
 @import './spectrum-tabs.css';
 
-/* Power scale based indicator transitions */
-:host([direction='horizontal']) #selectionIndicator {
-    width: 1px;
-}
-
 /*
  * While https://github.com/adobe/spectrum-css/issues/641 goes unaddressed,
  * then we'll need to place this at `top: 0;` ourselves.
@@ -45,6 +40,16 @@ governing permissions and limitations under the License.
         --spectrum-tabs-rule-color,
         var(--spectrum-global-color-gray-200)
     );
+}
+
+/*
+ * Power scale based indicator transitions
+ * Enforce left centric positioning to allow for shared position scripting.
+ */
+:host([dir][direction='horizontal']) #selectionIndicator {
+    width: 1px;
+    left: 0;
+    right: auto;
 }
 
 /*

--- a/packages/tabs/stories/tabs.stories.ts
+++ b/packages/tabs/stories/tabs.stories.ts
@@ -9,12 +9,13 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { html, radios } from '@open-wc/demoing-storybook';
+import { html, radios, select } from '@open-wc/demoing-storybook';
 import '@spectrum-web-components/icon/sp-icon.js';
 import '@spectrum-web-components/icons/sp-icons-medium.js';
 import '../sp-tabs.js';
 import '../sp-tab.js';
 import { TemplateResult } from 'lit-html';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export default {
     component: 'sp-tabs',
@@ -22,12 +23,42 @@ export default {
 };
 
 export const Default = (): TemplateResult => {
+    const dir = select(
+        'Text direction',
+        {
+            None: 'none',
+            'Left to right': 'ltr',
+            'Right to left': 'rtl',
+        },
+        'ltr',
+        'Element'
+    );
     return html`
-        <sp-tabs selected="1">
-            <sp-tab label="Tab 2" value="2"></sp-tab>
-            <sp-tab label="Tab 3" value="3"></sp-tab>
-            <sp-tab label="Tab 4" value="4"></sp-tab>
-            <sp-tab label="Really Long Name" value="1" selected></sp-tab>
+        <sp-tabs
+            dir=${ifDefined(dir === 'none' ? undefined : dir)}
+            selected="1"
+        >
+            <sp-tab
+                dir=${ifDefined(dir === 'none' ? undefined : dir)}
+                label="Tab 2"
+                value="2"
+            ></sp-tab>
+            <sp-tab
+                dir=${ifDefined(dir === 'none' ? undefined : dir)}
+                label="Tab 3"
+                value="3"
+            ></sp-tab>
+            <sp-tab
+                dir=${ifDefined(dir === 'none' ? undefined : dir)}
+                label="Tab 4"
+                value="4"
+            ></sp-tab>
+            <sp-tab
+                dir=${ifDefined(dir === 'none' ? undefined : dir)}
+                label="Really Long Name"
+                value="1"
+                selected
+            ></sp-tab>
         </sp-tabs>
     `;
 };

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -51,13 +51,12 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/tags": "^2.0.0"
+        "@spectrum-css/tags": "^3.0.0-beta.3"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/button": "^0.8.3",
         "@spectrum-web-components/shared": "^0.6.0",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -12,12 +12,12 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     property,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/button/sp-clear-button.js';
 
@@ -26,7 +26,7 @@ import styles from './tag.css.js';
 /**
  * @element sp-tags
  */
-export class Tag extends LitElement {
+export class Tag extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [styles];
     }

--- a/packages/tags/src/Tags.ts
+++ b/packages/tags/src/Tags.ts
@@ -12,11 +12,11 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     queryAssignedNodes,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import { FocusVisiblePolyfillMixin } from '@spectrum-web-components/shared/src/focus-visible.js';
 
 import { Tag } from './Tag.js';
@@ -26,7 +26,7 @@ import styles from './tags.css.js';
 /**
  * @element sp-tags
  */
-export class Tags extends FocusVisiblePolyfillMixin(LitElement) {
+export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public static get styles(): CSSResultArray {
         return [styles];
     }

--- a/packages/tags/src/Tags.ts
+++ b/packages/tags/src/Tags.ts
@@ -86,33 +86,32 @@ export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
             list: T[],
             index: number
         ): T => list[(list.length + index) % list.length];
+        const tagFromDelta = (delta: number): void => {
+            nextIndex += delta;
+            while (circularIndexedElement(this.tags, nextIndex).disabled) {
+                nextIndex += delta;
+            }
+        };
         switch (code) {
             case 'ArrowUp':
-            case 'ArrowLeft': {
-                nextIndex -= 1;
-                while (circularIndexedElement(this.tags, nextIndex).disabled) {
-                    nextIndex -= 1;
-                }
+                tagFromDelta(-1);
                 break;
-            }
+            case 'ArrowLeft':
+                tagFromDelta(this.isDefaultDir ? -1 : 1);
+                break;
             case 'ArrowRight':
+                tagFromDelta(this.isDefaultDir ? 1 : -1);
+                break;
             case 'ArrowDown':
-                nextIndex += 1;
-                while (circularIndexedElement(this.tags, nextIndex).disabled) {
-                    nextIndex += 1;
-                }
+                tagFromDelta(1);
                 break;
             case 'End':
-                nextIndex = this.tags.length - 1;
-                while (circularIndexedElement(this.tags, nextIndex).disabled) {
-                    nextIndex -= 1;
-                }
+                nextIndex = this.tags.length;
+                tagFromDelta(-1);
                 break;
             case 'Home':
-                nextIndex = 0;
-                while (circularIndexedElement(this.tags, nextIndex).disabled) {
-                    nextIndex += 1;
-                }
+                nextIndex = -1;
+                tagFromDelta(1);
                 break;
             case 'PageUp':
             case 'PageDown':

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -27,17 +27,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                     var(--spectrum-global-dimension-size-100)
                 ) / 2
         );
-    padding: 0
-        calc(
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-left: calc(
+        var(--spectrum-tag-padding-x, var(--spectrum-global-dimension-size-125)) -
             var(
-                    --spectrum-tag-padding-x,
-                    var(--spectrum-global-dimension-size-125)
-                ) -
-                var(
-                    --spectrum-tag-border-size,
-                    var(--spectrum-alias-border-size-thin)
-                )
-        );
+                --spectrum-tag-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
+    padding-right: calc(
+        var(--spectrum-tag-padding-x, var(--spectrum-global-dimension-size-125)) -
+            var(
+                --spectrum-tag-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    );
     height: var(
         --spectrum-tag-height,
         var(--spectrum-global-dimension-size-300)
@@ -89,14 +94,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-200)
     );
 }
-:host > ::slotted([slot='avatar']),
-:host > ::slotted([slot='icon']) {
-    /* .spectrum-Tags-item>.spectrum-Avatar,
-   * .spectrum-Tags-item>.spectrum-Icon */
+:host([dir='ltr']) > ::slotted([slot='avatar']),
+:host([dir='ltr']) > ::slotted([slot='icon']) {
+    /* [dir=ltr] .spectrum-Tags-item>.spectrum-Avatar,
+   * [dir=ltr] .spectrum-Tags-item>.spectrum-Icon */
     margin-right: var(
         --spectrum-tag-icon-padding-x,
         var(--spectrum-global-dimension-size-100)
     );
+}
+:host([dir='rtl']) > ::slotted([slot='avatar']),
+:host([dir='rtl']) > ::slotted([slot='icon']) {
+    /* [dir=rtl] .spectrum-Tags-item>.spectrum-Avatar,
+   * [dir=rtl] .spectrum-Tags-item>.spectrum-Icon */
+    margin-left: var(
+        --spectrum-tag-icon-padding-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='ltr']) > ::slotted([slot='avatar']),
+:host([dir='ltr']) > ::slotted([slot='icon']) {
+    /* [dir=ltr] .spectrum-Tags-item>.spectrum-Avatar,
+   * [dir=ltr] .spectrum-Tags-item>.spectrum-Icon */
     margin-left: calc(
         var(
                 --spectrum-tag-avatar-padding-x,
@@ -108,10 +127,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
-:host > slot[name='avatar'] ~ .label,
-:host > slot[name='icon'] ~ .label {
-    /* .spectrum-Tags-item>.spectrum-Avatar~.spectrum-Tags-itemLabel,
-   * .spectrum-Tags-item>.spectrum-Icon~.spectrum-Tags-itemLabel */
+:host([dir='ltr']) > slot[name='avatar'] ~ .label,
+:host([dir='ltr']) > slot[name='icon'] ~ .label,
+:host([dir='rtl']) > ::slotted([slot='avatar']),
+:host([dir='rtl']) > ::slotted([slot='icon']) {
+    /* [dir=ltr] .spectrum-Tags-item>.spectrum-Avatar~.spectrum-Tags-itemLabel,
+   * [dir=ltr] .spectrum-Tags-item>.spectrum-Icon~.spectrum-Tags-itemLabel,
+   * [dir=rtl] .spectrum-Tags-item>.spectrum-Avatar,
+   * [dir=rtl] .spectrum-Tags-item>.spectrum-Icon */
     margin-right: calc(
         var(
                 --spectrum-tag-avatar-padding-x,
@@ -123,14 +146,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
-.clear-button {
-    /* .spectrum-Tags-item .spectrum-ClearButton */
+:host([dir='rtl']) > slot[name='avatar'] ~ .label,
+:host([dir='rtl']) > slot[name='icon'] ~ .label {
+    /* [dir=rtl] .spectrum-Tags-item>.spectrum-Avatar~.spectrum-Tags-itemLabel,
+   * [dir=rtl] .spectrum-Tags-item>.spectrum-Icon~.spectrum-Tags-itemLabel */
+    margin-left: calc(
+        var(
+                --spectrum-tag-avatar-padding-x,
+                var(--spectrum-global-dimension-size-100)
+            ) -
+            var(
+                --spectrum-tag-padding-x,
+                var(--spectrum-global-dimension-size-125)
+            )
+    );
+}
+:host([dir='ltr']) .clear-button {
+    /* [dir=ltr] .spectrum-Tags-item .spectrum-ClearButton */
     margin-right: calc(
         -1 * var(--spectrum-tag-padding-x, var(--spectrum-global-dimension-size-125))
-    ); /* .spectrum-Tags-item .spectrum-ClearButton */
-    color: var(
-        --spectrum-tag-deletable-icon-color,
-        var(--spectrum-global-color-gray-600)
+    );
+}
+:host([dir='rtl']) .clear-button {
+    /* [dir=rtl] .spectrum-Tags-item .spectrum-ClearButton */
+    margin-left: calc(
+        -1 * var(--spectrum-tag-padding-x, var(--spectrum-global-dimension-size-125))
     );
 }
 .label {
@@ -152,6 +192,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+}
+.clear-button {
+    /* .spectrum-Tags-item .spectrum-ClearButton */
+    color: var(
+        --spectrum-tag-deletable-icon-color,
+        var(--spectrum-global-color-gray-600)
+    );
 }
 :host(:hover) {
     /* .spectrum-Tags-item:hover */

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -44,14 +44,13 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/toast": "^2.0.2"
+        "@spectrum-css/toast": "^3.0.0-beta.3"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/button": "^0.8.3",
         "@spectrum-web-components/icon": "^0.5.1",
         "@spectrum-web-components/icons-ui": "^0.2.1",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -14,10 +14,10 @@ import {
     html,
     CSSResultArray,
     TemplateResult,
-    LitElement,
+    SpectrumElement,
     property,
     PropertyValues,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import '@spectrum-web-components/button/sp-clear-button.js';
 import '@spectrum-web-components/icon/sp-icon.js';
 import {
@@ -48,7 +48,7 @@ export type ToastVariants =
  * @slot - The toast content
  */
 
-export class Toast extends LitElement {
+export class Toast extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [toastStyles];
     }

--- a/packages/toast/src/spectrum-toast.css
+++ b/packages/toast/src/spectrum-toast.css
@@ -10,6 +10,28 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host([dir='ltr']) {
+    /* [dir=ltr] .spectrum-Toast */
+    padding-right: var(
+        --spectrum-toast-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=ltr] .spectrum-Toast */
+    padding-left: var(
+        --spectrum-toast-padding-left,
+        var(--spectrum-global-dimension-size-200)
+    );
+}
+:host([dir='rtl']) {
+    /* [dir=rtl] .spectrum-Toast */
+    padding-left: var(
+        --spectrum-toast-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=rtl] .spectrum-Toast */
+    padding-right: var(
+        --spectrum-toast-padding-left,
+        var(--spectrum-global-dimension-size-200)
+    );
+}
 :host {
     /* .spectrum-Toast */
     box-sizing: border-box;
@@ -20,22 +42,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-toast-border-radius,
         var(--spectrum-global-dimension-static-size-50)
     );
-    padding: var(
-            --spectrum-toast-padding-y,
-            var(--spectrum-global-dimension-size-100)
-        )
-        var(
-            --spectrum-toast-padding-right,
-            var(--spectrum-global-dimension-size-100)
-        )
-        var(
-            --spectrum-toast-padding-y,
-            var(--spectrum-global-dimension-size-100)
-        )
-        var(
-            --spectrum-toast-padding-left,
-            var(--spectrum-global-dimension-size-200)
-        );
+    padding-top: var(
+        --spectrum-toast-padding-y,
+        var(--spectrum-global-dimension-size-100)
+    );
+    padding-bottom: var(
+        --spectrum-toast-padding-y,
+        var(--spectrum-global-dimension-size-100)
+    );
     font-size: var(
         --spectrum-toast-text-size,
         var(--spectrum-alias-font-size-default)
@@ -54,30 +68,59 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-gray-700)
     );
 }
+:host([dir='ltr']) .type {
+    /* [dir=ltr] .spectrum-Toast-typeIcon */
+    margin-right: var(
+        --spectrum-toast-icon-padding-right,
+        var(--spectrum-global-dimension-size-150)
+    ); /* [dir=ltr] .spectrum-Toast-typeIcon */
+    margin-left: 0;
+}
+:host([dir='rtl']) .type {
+    /* [dir=rtl] .spectrum-Toast-typeIcon */
+    margin-left: var(
+        --spectrum-toast-icon-padding-right,
+        var(--spectrum-global-dimension-size-150)
+    ); /* [dir=rtl] .spectrum-Toast-typeIcon */
+    margin-right: 0;
+}
 .type {
     /* .spectrum-Toast-typeIcon */
     flex-shrink: 0;
     flex-grow: 0;
-    margin: var(--spectrum-global-dimension-size-85)
-        var(
-            --spectrum-toast-icon-padding-right,
-            var(--spectrum-global-dimension-size-150)
-        )
-        var(--spectrum-global-dimension-size-85) 0; /* .spectrum-Toast-typeIcon */
+    margin-top: var(--spectrum-global-dimension-size-85);
+    margin-bottom: var(
+        --spectrum-global-dimension-size-85
+    ); /* .spectrum-Toast-typeIcon */
     color: #fff;
+}
+:host([dir='ltr']) .content {
+    /* [dir=ltr] .spectrum-Toast-content */
+    padding-right: var(
+        --spectrum-toast-content-padding-right,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-Toast-content */
+    padding-left: 0; /* [dir=ltr] .spectrum-Toast-content */
+    text-align: left;
+}
+:host([dir='rtl']) .content {
+    /* [dir=rtl] .spectrum-Toast-content */
+    padding-left: var(
+        --spectrum-toast-content-padding-right,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-Toast-content */
+    padding-right: 0; /* [dir=rtl] .spectrum-Toast-content */
+    text-align: right;
 }
 .content {
     /* .spectrum-Toast-content */
     flex: 1 1 auto;
     display: inline-block;
     box-sizing: border-box;
-    padding: var(--spectrum-global-dimension-size-65)
-        var(
-            --spectrum-toast-content-padding-right,
-            var(--spectrum-global-dimension-size-200)
-        )
-        var(--spectrum-global-dimension-size-65) 0;
-    text-align: left; /* .spectrum-Toast-content */
+    padding-top: var(--spectrum-global-dimension-size-65);
+    padding-bottom: var(
+        --spectrum-global-dimension-size-65
+    ); /* .spectrum-Toast-content */
     color: var(
         --spectrum-toast-text-color,
         var(--spectrum-global-color-static-white)
@@ -87,18 +130,30 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Toast-buttons */
     display: flex;
     flex: 0 0 auto;
-    align-items: flex-start; /* .spectrum-Toast-buttons */
-    border-left-color: hsla(0, 0%, 100%, 0.2);
+    align-items: flex-start;
 }
-.buttons slot[name='action'] + ::slotted([slot='action']),
-.buttons slot[name='action'] + .spectrum-ClearButton,
-.buttons .spectrum-ClearButton + ::slotted([slot='action']),
-.buttons .spectrum-ClearButton + .spectrum-ClearButton {
-    /* .spectrum-Toast-buttons .spectrum-Button+.spectrum-Button,
-   * .spectrum-Toast-buttons .spectrum-Button+.spectrum-ClearButton,
-   * .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-Button,
-   * .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-ClearButton */
+:host([dir='ltr']) .buttons slot[name='action'] + ::slotted([slot='action']),
+:host([dir='ltr']) .buttons slot[name='action'] + .spectrum-ClearButton,
+:host([dir='ltr']) .buttons .spectrum-ClearButton + ::slotted([slot='action']),
+:host([dir='ltr']) .buttons .spectrum-ClearButton + .spectrum-ClearButton {
+    /* [dir=ltr] .spectrum-Toast-buttons .spectrum-Button+.spectrum-Button,
+   * [dir=ltr] .spectrum-Toast-buttons .spectrum-Button+.spectrum-ClearButton,
+   * [dir=ltr] .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-Button,
+   * [dir=ltr] .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-ClearButton */
     margin-left: var(
+        --spectrum-toast-button-gap,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl']) .buttons slot[name='action'] + ::slotted([slot='action']),
+:host([dir='rtl']) .buttons slot[name='action'] + .spectrum-ClearButton,
+:host([dir='rtl']) .buttons .spectrum-ClearButton + ::slotted([slot='action']),
+:host([dir='rtl']) .buttons .spectrum-ClearButton + .spectrum-ClearButton {
+    /* [dir=rtl] .spectrum-Toast-buttons .spectrum-Button+.spectrum-Button,
+   * [dir=rtl] .spectrum-Toast-buttons .spectrum-Button+.spectrum-ClearButton,
+   * [dir=rtl] .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-Button,
+   * [dir=rtl] .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-ClearButton */
+    margin-right: var(
         --spectrum-toast-button-gap,
         var(--spectrum-global-dimension-size-100)
     );
@@ -108,19 +163,41 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     flex: 1 1 auto;
     align-self: center;
 }
-.body ::slotted([slot='action']) {
-    /* .spectrum-Toast-body .spectrum-Button */
-    float: right;
+:host([dir='ltr']) .body ::slotted([slot='action']) {
+    /* [dir=ltr] .spectrum-Toast-body .spectrum-Button */
+    float: right; /* [dir=ltr] .spectrum-Toast-body .spectrum-Button */
     margin-right: var(--spectrum-global-dimension-size-130);
 }
-.body + .buttons {
-    /* .spectrum-Toast-body+.spectrum-Toast-buttons */
+:host([dir='rtl']) .body ::slotted([slot='action']) {
+    /* [dir=rtl] .spectrum-Toast-body .spectrum-Button */
+    float: left; /* [dir=rtl] .spectrum-Toast-body .spectrum-Button */
+    margin-left: var(--spectrum-global-dimension-size-130);
+}
+:host([dir='ltr']) .body + .buttons {
+    /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
     padding-left: var(
         --spectrum-toast-padding-right,
         var(--spectrum-global-dimension-size-100)
-    );
-    border-left-width: 1px;
+    ); /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
+    border-left-width: 1px; /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
     border-left-style: solid;
+}
+:host([dir='rtl']) .body + .buttons {
+    /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
+    padding-right: var(
+        --spectrum-toast-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
+    border-right-width: 1px; /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
+    border-right-style: solid;
+}
+:host([dir='ltr']) .buttons {
+    /* [dir=ltr] .spectrum-Toast-buttons */
+    border-left-color: hsla(0, 0%, 100%, 0.2);
+}
+:host([dir='rtl']) .buttons {
+    /* [dir=rtl] .spectrum-Toast-buttons */
+    border-right-color: hsla(0, 0%, 100%, 0.2);
 }
 :host([variant='warning']) {
     /* .spectrum-Toast--warning */

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -44,12 +44,11 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/tooltip": "^2.0.5"
+        "@spectrum-css/tooltip": "^3.0.0-beta.2"
     },
     "dependencies": {
+        "@spectrum-web-components/base": "^0.0.1",
         "@spectrum-web-components/overlay": "^0.5.1",
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -14,9 +14,9 @@ import {
     html,
     CSSResultArray,
     TemplateResult,
-    LitElement,
+    SpectrumElement,
     property,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 import {
     OverlayDisplayQueryDetail,
     Placement,
@@ -29,7 +29,7 @@ import tooltipStyles from './tooltip.css.js';
  * @slot - The label
  */
 
-export class Tooltip extends LitElement {
+export class Tooltip extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [tooltipStyles];
     }

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -16,6 +16,7 @@ import {
     TemplateResult,
     SpectrumElement,
     property,
+    query,
 } from '@spectrum-web-components/base';
 import {
     OverlayDisplayQueryDetail,
@@ -40,6 +41,9 @@ export class Tooltip extends SpectrumElement {
      */
     @property({ reflect: true })
     public placement: Placement = 'top';
+
+    @query('#tip')
+    private tipElement!: HTMLSpanElement;
 
     /* Ensure that a '' value for `variant` removes the attribute instead of a blank value */
     private _variant = '';
@@ -73,16 +77,13 @@ export class Tooltip extends SpectrumElement {
 
     public onOverlyQuery(event: CustomEvent<OverlayDisplayQueryDetail>): void {
         /* istanbul ignore if */
-        if (!event.target || !this.shadowRoot) return;
+        if (!event.target) return;
 
         const target = event.target as Node;
         /* istanbul ignore if */
         if (!target.isSameNode(this)) return;
 
-        const tipElement = this.shadowRoot.querySelector('#tip') as HTMLElement;
-        if (tipElement) {
-            event.detail.overlayContentTipElement = tipElement;
-        }
+        event.detail.overlayContentTipElement = this.tipElement;
     }
 
     render(): TemplateResult {

--- a/packages/tooltip/src/spectrum-tooltip.css
+++ b/packages/tooltip/src/spectrum-tooltip.css
@@ -200,8 +200,8 @@ p {
         -1 * var(--spectrum-tooltip-tip-height, var(--spectrum-global-dimension-size-50))
     );
 }
-::slotted([slot='icon']) {
-    /* .spectrum-Tooltip-typeIcon */
+:host([dir='ltr']) ::slotted([slot='icon']) {
+    /* [dir=ltr] .spectrum-Tooltip-typeIcon */
     margin-left: calc(
         var(
                 --spectrum-tooltip-icon-margin-x,
@@ -211,11 +211,31 @@ p {
                 --spectrum-tooltip-padding-x,
                 var(--spectrum-global-dimension-size-125)
             )
-    );
+    ); /* [dir=ltr] .spectrum-Tooltip-typeIcon */
     margin-right: var(
         --spectrum-tooltip-icon-margin-x,
         var(--spectrum-global-dimension-size-100)
     );
+}
+:host([dir='rtl']) ::slotted([slot='icon']) {
+    /* [dir=rtl] .spectrum-Tooltip-typeIcon */
+    margin-right: calc(
+        var(
+                --spectrum-tooltip-icon-margin-x,
+                var(--spectrum-global-dimension-size-100)
+            ) -
+            var(
+                --spectrum-tooltip-padding-x,
+                var(--spectrum-global-dimension-size-125)
+            )
+    ); /* [dir=rtl] .spectrum-Tooltip-typeIcon */
+    margin-left: var(
+        --spectrum-tooltip-icon-margin-x,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+::slotted([slot='icon']) {
+    /* .spectrum-Tooltip-typeIcon */
     width: var(
         --spectrum-tooltip-icon-size,
         var(--spectrum-global-dimension-size-175)

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -47,11 +47,10 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@spectrum-css/underlay": "^2.0.0"
+        "@spectrum-css/underlay": "^2.0.7"
     },
     "dependencies": {
-        "lit-element": "^2.1.0",
-        "lit-html": "^1.0.0",
+        "@spectrum-web-components/base": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/underlay/src/Underlay.ts
+++ b/packages/underlay/src/Underlay.ts
@@ -12,18 +12,18 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    LitElement,
+    SpectrumElement,
     CSSResultArray,
     TemplateResult,
     property,
-} from 'lit-element';
+} from '@spectrum-web-components/base';
 
 import styles from './underlay.css.js';
 
 /**
  * @element sp-underlay
  */
-export class Underlay extends LitElement {
+export class Underlay extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [styles];
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,30 +3337,30 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.0-beta.2.tgz#9cf43a1fcf02312da9e45a2849a38d83fe05b262"
   integrity sha512-Vr5MlLUozF93BxIcxpj7Z6ob1B6MrOn/kZzsV0XPPq1DAI4F06glKLtGP1INrD2JndW2YWvuooaa6iWw8Bd0IQ==
 
-"@spectrum-css/avatar@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-2.0.5.tgz#4e4e7cf273ed6b5925b4a8cad05946114790030a"
-  integrity sha512-S76OW1pDpN/PTSHEgq/tpwFC2oyVnn39czP9lXKCnU9KrHFsD5UyyVxssKviD5Lt0l4GiA/LPQhgANUtzlNQ1w==
+"@spectrum-css/avatar@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-3.0.0-beta.2.tgz#38cc761eba57a0176b25610feb6a22d14f729e9f"
+  integrity sha512-r7GwVGwVtGOUDXQRg1GuQhu6vHN7OpvudRpEbFsdh79rBRtbyWCtwWi0rhNV8Z1s5BiMcKVvy7OExJzWFbT6UQ==
 
-"@spectrum-css/banner@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-2.0.5.tgz#c7105efaec10b07e31d7fb3cd216a0d43c928c0b"
-  integrity sha512-c2dDkAWR7YOTUIa7lMyaVX0RdXWCs9NxL6BqujkJpRpPLhHHWSfaERdLO5CMqNDWnijh5vOUZK8ixDN+Hw3mOg==
+"@spectrum-css/banner@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-3.0.0-beta.2.tgz#df448a3dcb8ac63448bd628843a2895cec305780"
+  integrity sha512-NqrT03ItWzj+L0dtqjedhop6wKOspBmaowzp9IOY/2kL561kRqYTLKR9vTteZ3cEDVD3ajKA8y+bKIW0eN+X7A==
 
-"@spectrum-css/barloader@^2.0.0":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/barloader/-/barloader-2.0.5.tgz#7f846b6bbecd45af56710640a423797271d70b3f"
-  integrity sha512-dZ4KvWwCqkbRrA5Fiy9lzOzTaNrD75GOQtZj110Ov6R2TQMz+G2ukDahDoye0sCj0TtqczbBM4UhE5itd+Tj4g==
+"@spectrum-css/barloader@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/barloader/-/barloader-3.0.0-beta.2.tgz#69d3b028f1c29cf65f5c95db7ac7e7ef43ffc347"
+  integrity sha512-q+XWjIlSce81TCDxlhxwGgvixtvPzNBV8UrJojNDrtWHosMFGTpY0cGBOwzZjEli1X8WnF4KZFgJE6+C0QL2mg==
 
 "@spectrum-css/button@^3.0.0-beta.3":
   version "3.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-3.0.0-beta.3.tgz#52ceb42f76fef170f7cd3010df56c1247a80e6b2"
   integrity sha512-C9g1ZJrq0fGs9Vu5z/Ft+Cr/plnSWtsk8rK394yAyOrQQym0zajiTvIMJLDlu764ah6k/4PkyPXmN+28/8vJSw==
 
-"@spectrum-css/buttongroup@^2.0.0":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-2.2.1.tgz#b27f10b1110fda553d301e5ae194dc340f622a7c"
-  integrity sha512-9yMsNuvF9LQVSMOJlkwi2cWY0vAj1Z/ic3xoTcKkm8WTTJHv7lHVwU+XF0L2XpmnYNsMVICLB5YhCzjTu5GEsg==
+"@spectrum-css/buttongroup@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-3.0.0-beta.3.tgz#429a876aa2eb13f3d85b8969dc0833ecded15d3f"
+  integrity sha512-KzgL9xr87Y5nEnYyAvOZWZkRe7wjsteDF4kAcndUXLc5mKv2rIEz1x80vYz6csp2nT20+90RBUqkQSgKVWE8wQ==
 
 "@spectrum-css/card@^3.0.0-beta.2":
   version "3.0.0-beta.2"
@@ -3372,149 +3372,149 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-3.0.0-beta.3.tgz#7789ba8be60b1edb3db99e8e5c94e7122366ab9c"
   integrity sha512-z+BZzGr2/l4g3uZ/Yn/u7gSfKXSLi3MMTKOfSxDBIGbL+3GBVXCMw5iBSrouepAomWCH82nRYl1mqSKWod6pLQ==
 
-"@spectrum-css/circleloader@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/circleloader/-/circleloader-2.0.5.tgz#7d4d248d1cf1257819b1ecc9b04e1a851f0ca459"
-  integrity sha512-LrQn+S7ZwTUfOLi3wDuZQDoh3doQK/oIqMxcIrmSD/A4QAKKsetbv+GVjCYelci+EJrYLG9P4215eOftsooVNA==
+"@spectrum-css/circleloader@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/circleloader/-/circleloader-3.0.0-beta.2.tgz#bd037b15651db9945eb89727b989ae4f3b60c26b"
+  integrity sha512-iifUWDJkp4TpcPgJBpYsM1Z6pONNKDXGb2osBc8cZtQ0i87QX0EssFp9AkdyTObQvQh7wCUrOYLIg7FZTAGLaw==
 
-"@spectrum-css/coachmark@^2.0.0":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-2.0.5.tgz#a8d175c2398146ec9ce8e2e6ce31795774b03267"
-  integrity sha512-jINN4U+XSVnfD0AbHGJ8I3kZYkb/EnR3smdMYZIwAOMQTuh7e86fH8iseErtqy4sfyLxGE6XG0Y8slAX7R0eYw==
+"@spectrum-css/coachmark@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-3.0.0-beta.3.tgz#4909ae08032dd911c59bb42de0f27aebc6e259e3"
+  integrity sha512-SAm5VgjHtPI1vRN4nNPAJxWTIfAuh2ZnkUrHF4UTdqZUXMStzPmOwtOg5ylDIrd2OhXlB3qiu+8SAE0EsvbAzg==
 
 "@spectrum-css/commons@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-2.1.0.tgz#d50726a31631e10fad0d697ac7c0a918b005ec6f"
   integrity sha512-43bFaOOdV312vIo6K/5PI/gAnLoBKWQDRh3M04A2GIBSdSW7ItpqxXgwvlLsMy6cYkQGjcpb/usOBEr83lMIfA==
 
-"@spectrum-css/dialog@^2.0.0":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-2.0.5.tgz#326c77e6c6b5dc21dad788f171ed3d28e3a6a815"
-  integrity sha512-GKyRtwoUCJVu4toMOTtvFo+nH/O5nwaqzaz7Z/R6RznbzhZAyrEuVCdKHQLnfCuhX/kGVSEu54w/H9KWu1UPRg==
+"@spectrum-css/dialog@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-3.0.0-beta.3.tgz#c0d1cd212e7c3fbf8fe742ab1abfc8acf572f55e"
+  integrity sha512-76NMrLqhufI3Y1gv0elCGBZcLryP9ePEGX0mwIgP33sgbypfowkgutBi6agrNb/d7bJT11OIogDLIeDNkOhGMA==
 
-"@spectrum-css/dropdown@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dropdown/-/dropdown-2.1.5.tgz#2097988d0b80797532cdb47e4bbd912269f50d9c"
-  integrity sha512-v1LVDuF0KZBSqmSyv67w2VXCpd9L2hdqFDFuTogQeBMrvvS3A1Go2JPmwnZXZLH0wDKqzuoExNMcG0JAvgJO/A==
+"@spectrum-css/dropdown@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dropdown/-/dropdown-3.0.0-beta.3.tgz#2195714d6aeaafcc43b3ff2984481116de84f537"
+  integrity sha512-KYpcLl/cnxK208hY9tpqoISk3A2piUlqggSu3kS7qNGbIZQgizpT0YxYvN8F2BqnlAI1NL2KYZ8loMiI7sfQgA==
 
-"@spectrum-css/dropzone@^2.1.1":
+"@spectrum-css/dropzone@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-3.0.0-beta.2.tgz#cf8000fdb1b620f698b92aea0556c73044cddcfb"
+  integrity sha512-mVw9iv9WFx6HOfE0lY3UtZdQiobgHtLnV5JElp+WFi3GM65iNmxfzmdTgaOqFYllpqzjAacnTN5EVXyDjzENlw==
+
+"@spectrum-css/icon@^2.1.1":
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-2.1.1.tgz#6e3313b34a1aa5bd875f297f8152b47f92fb6fdb"
-  integrity sha512-VuUDzQH/htrLzW/TsqBbK8KNIUyARM2oP7NWnamMDB2mRs7OWoVN8NLW44s3Z2atcmJQ0kjUHQWPTCwWsAxMDg==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-2.1.1.tgz#53b371b293833e501898472dda8661a07db09fd8"
+  integrity sha512-Ddnjw3YTZiuJC8uVJ9x6i+ufQN+Vp4vibc+YxE7nXn8tWzT8zTRzwv6oHwSG9m+KzonTfnwqPuQx6ZA8vbK9xA==
 
-"@spectrum-css/icon@^2.0.5", "@spectrum-css/icon@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-2.1.0.tgz#99c772516413f7c1063635ac9d7e7472f8c18a4e"
-  integrity sha512-VrNyqo8lfTf1sdSRW1MlUvh4hqc0uxeNWn5xtMBVRuQPkceAyHySfv6k6Stk3oLsfHf0+UMOHP/xPOb9lVgt0Q==
-
-"@spectrum-css/illustratedmessage@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-2.1.1.tgz#d616b447eb9724b679c978115d38083e65548d35"
-  integrity sha512-rINCfMa8oTBmyBE0oggjKuX5LcfrOoUDkhnpexFxFGBibhBvmj75m2d1h7tSoPkKJnQ53NnNC/k60VspA7NeGw==
+"@spectrum-css/illustratedmessage@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-3.0.0-beta.2.tgz#f27ca6fb80f250b3a86775436376ee51f5d348a2"
+  integrity sha512-LHHhD2Ydj7lg+Dn3F+5SnXJICSE2MQN5RVKIV7ry4KYDJkSIHfMeu97J6DqBTZivyMMl+CLKHhRNxMyJjxGhOQ==
 
 "@spectrum-css/link@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.0.0.tgz#544821b3eafec7e89b86254bb42e3d01024095e4"
   integrity sha512-TPWFopMTGWxxO4+Ush9L0dowI+tWRyxdWG8Gqy7/Q9c3emdJ7SA3hCQV9MRBoRRQHlx9lKFPfjZJ+/ErbTW++A==
 
-"@spectrum-css/menu@^2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-2.1.5.tgz#78c60689d1855a66eafe177321cb5589c7090ab0"
-  integrity sha512-NJjiYpCFrBDLs0bjBAZFZO3/4Nz9Z8X/FFebFkbKYbOnECS9ZUe2mXvDhNB1yDRQksBWwo3m76+/OU2VfBYDQg==
+"@spectrum-css/menu@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-3.0.0-beta.2.tgz#5f412c9233a53050f52f5410f36bc26a9013f9c1"
+  integrity sha512-ngUWriDHuqa3r3djBgdV9NjZkzabg8Phw9deq6tdhJkGJHKp6nd8K3nZhLAxCpdcTJBLJBmqatIXgD5xXovDCw==
 
-"@spectrum-css/popover@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-2.0.6.tgz#b7eb8e202d7f3f7736fcdcdbc2e9df5f1738a9c0"
-  integrity sha512-rLs4przzevttfJ732Jdkjc/1SWny7QVlu1waxPh4o+wVcdA78e61BgrwHLDj5xYNkKo3D2qauSuwKXuwCmHnYA==
+"@spectrum-css/popover@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-3.0.0-beta.3.tgz#09a1662935b88a57012db5782a7198c2b0d9b531"
+  integrity sha512-0qoQFbVcGeaqdaKx8KQS5y+7nLZiqR8vIvSkhb86iNBQ8DXEKPEqK7a0Z3iyi63Xtlx04j5y+Z4F3DWd+EEKHQ==
 
 "@spectrum-css/quickaction@^3.0.0-beta.3":
   version "3.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.0-beta.3.tgz#cd85a2bc0b7dd272382423dbeff7a7ef4afc5352"
   integrity sha512-tTTX5ne+zEjicL0/d6tXtzYf1b/TDrBE6rr3az3e4g3Y3yprORUT2CyTi/P0MsJMO5AhWCU3kxlFQ1MzGpVVFw==
 
-"@spectrum-css/radio@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-2.1.0.tgz#7432d0a9d8e7bdf5e1970c787ec97faf87062df7"
-  integrity sha512-FuCnFu8qOZ1IK/vboWv/SBxEy88qmhAj0BWKi5c1KVrYpujPpxJ03QzBy2dd9we3Yh28XOObbnda+6qXVVzyWg==
+"@spectrum-css/radio@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.0-beta.2.tgz#35e39b49d7f7ed4766e76dc6e43e8a021257b6d9"
+  integrity sha512-4aehv3R5lQVxjfMV5nz3eWdzTzPdwBs90QOYSwAYADoQnR3slJx+YPW9EvoEsNzcZ4bootv7tBT0xxFc+vznIA==
 
-"@spectrum-css/rule@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/rule/-/rule-2.0.6.tgz#1b9743d218af250918313f4f631b74ccf69c5638"
-  integrity sha512-JwZyE/RvsCXUXmGD/SxrSMhoJHUILcYN9b2mLFL2wjiTfyiNsQe7epAkotqLHjr3UO2X8tf6SYLVwev/uZP81A==
+"@spectrum-css/rule@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/rule/-/rule-3.0.0-beta.3.tgz#c4999c4b2fc5a39485782dd2b461d9eb7c3ce3fd"
+  integrity sha512-8PRdIsz+V+BFhrug/iGDUwMkvrnwqvsPy71QqxIQZ2P14y9Mw8thI1nuyjPYveFqX859gh0n8JWPGIC9XF+xXw==
   dependencies:
-    "@spectrum-css/vars" "^2.2.0"
+    "@spectrum-css/vars" "^2.3.0"
 
 "@spectrum-css/search@^3.0.0-beta.4":
   version "3.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-3.0.0-beta.4.tgz#4e39f4966c346778c452fe03fe9597e2bcb310b1"
   integrity sha512-s1jJ675+3H64+flXTcVacvdMaavTXEZ0qBRBCbKVk/1iH8iCoMMWjJjQlr5tWZZsilpnzU2QUaB8D3MSa5HU7g==
 
-"@spectrum-css/sidenav@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-2.0.5.tgz#f05b95a92435b3542095c138f875411263cf0219"
-  integrity sha512-V0TbKvnuczSZ2NU7Isn2fjy0pf/fOMoZDVJj01foF4gkUibMSy5+IRtP5bPwDRVb7lAoP7jdbUThnI2owlSP0A==
+"@spectrum-css/sidenav@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.0-beta.2.tgz#b2431fdaaf8ef06d2c4bfbd3c85fb2ebe6eb7816"
+  integrity sha512-0/g/3lROiRnF4fSMBOQyG9V18x8yr49uWFpMeLGTY3pw8dv2LlfQNULAJs3HxXG/egxHmwjVcIlwLbQAziBP1Q==
 
-"@spectrum-css/slider@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-2.1.0.tgz#2bc83c522b07c5ce5b57ba267021fb24984d2a0b"
-  integrity sha512-oROCNx6HMY5nPPXBmH515dDpE/45hssaUleIC/HtgdOdwHiNdbGVFV3IK5xpPgYPCAzNlrB9BRsL8DSz2nDUQw==
+"@spectrum-css/slider@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.0.0-beta.2.tgz#dc4be304b3541b9647fc70a48ba81b6a693dba95"
+  integrity sha512-TZ6qcCsV+VhCF3JvBiM2BXRzoUTlqIS3yOMNkF665pwtVASPRmCXA1WtmJzrEZZT+Lad3MIGncZ5F85fa4/FgQ==
 
 "@spectrum-css/splitbutton@^3.0.0-beta.3":
   version "3.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-3.0.0-beta.3.tgz#22fc6ea20cd5848c67a3a470952a2351915ad77c"
   integrity sha512-W+7mV1G6xeoGI6N6rd4C7BgyaSiVZsR66XUGICgR9SWA52yoNyjkX99ouQf/uHMy0O6oM++Nl1XzZSzoEm3mGw==
 
-"@spectrum-css/statuslight@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-2.0.6.tgz#90073619f29aa67e377dd404cb9b6449d9adb58d"
-  integrity sha512-EqOIS27G66lFU9MU8isewnQ0Mxx6x7SbRaxG0dcSgA4Oo9a100cWTHNA/MRbWUcJ87G1GXT1wjnBDz59O0/lIg==
+"@spectrum-css/statuslight@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-3.0.0-beta.2.tgz#3e71e38621e46502fcff8cc64001d916f0eb5d9c"
+  integrity sha512-5v5tnBy4Ypdm52JwmESsGPWP3aqniWaD6WqHGVik3k4es4yjkVNraQxvkj3ExzT/K3shYrM8mFPf2sEeiZ83cg==
 
-"@spectrum-css/table@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-2.0.6.tgz#2710a3059b4c195d83128cdae760a7c2c548a61f"
-  integrity sha512-di+Lqn5XXqv/ftK3ZCcPzPfw7z1rGLaR9dGXNt6EEUiE2o18A1em+VQJUcgvk2BDC0S/7TGvsMJawVnY3cNncw==
+"@spectrum-css/table@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-3.0.0-beta.3.tgz#ef018d453078f88880f9efb260ce17a8716e1490"
+  integrity sha512-8Cqrrn59+SLYykjsTOX9NH78d9abKmJqu8EC1/aR1Tj5L3cf7nFD8wQSe79sBcn5bLVOjV6gqTyeUfULsJ7isw==
 
-"@spectrum-css/tabs@^2.1.1":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-2.1.5.tgz#5f64eac57b228c3929cfcf25676aa680ec2c3bfe"
-  integrity sha512-k6Gw6cuSPu8DZGS+pGRB/0HsInjFR5TlYeOYcIXMUQ1iQAofqsFkc+RV7aRYpNNYeq+xkBTq8wGEvKVQXzOm9Q==
+"@spectrum-css/tabs@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.0.0-beta.3.tgz#d9dc83cf0c1e310dc39170c1de8dd45cbf36877f"
+  integrity sha512-ulLWE56VL+x2fmb0LfCYPknMCSvmreQMYYECjnvOMncxsJjPaLZ1a9v0mb5K+XTVXumHMkIEHDGHciY5fJiF3w==
 
-"@spectrum-css/tags@^2.0.0":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tags/-/tags-2.0.5.tgz#13b1e4fc5f17e1f70f98959221c215cbc631a84d"
-  integrity sha512-dMba2Bw9oJlOI2JM6CH+sfDQANRh7/J6XYw4PpRlVwNUvL5v6T8Z+8KN6YozE4a3FT3WDKNu9Vg9hF+5fs3rvg==
+"@spectrum-css/tags@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tags/-/tags-3.0.0-beta.3.tgz#ba1ea7edcbf3f194d167c2f60a6d1a8062b4001f"
+  integrity sha512-MpwbMw4fsYkTEHg4gUVROXfSzhEYfy0hOg8OHXUwUNwlCU/kaEP/iGlC9HnpaeAfismi8xCoyPu2ZjslH4qHiA==
 
 "@spectrum-css/textfield@^3.0.0-beta.3":
   version "3.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.0.0-beta.3.tgz#251763260fedd38e256c8a225809b0ecdc70f68f"
   integrity sha512-ihTZKLfnUxBnlSGRH4xdSMwd23EkpunC69uUvVB2LGGw1QAcmUcBNdS9xz7PPSWFw4qkCRXzVVX9tLC/2fQFbQ==
 
-"@spectrum-css/toast@^2.0.2":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-2.0.5.tgz#42df471443b6720d6aa886ea2e2a76a4af50512e"
-  integrity sha512-oXiLO6GdgGy79NRIAuinQNw0IVhklVoAlRj2gjUtXOz1Avik5r2QaZrH31BvjLvlnf56Va3d9XFQg9eXcCby4Q==
+"@spectrum-css/toast@^3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-3.0.0-beta.3.tgz#98eb1320062e299cf5a96fe1c59357073fbee6f4"
+  integrity sha512-W0akUneCrda9Gad12ehOUeOQEYD4ND/S3JAEFKaQyO/4TKK2+70tEBN50w+2cvvvSry6JgSWgRTiU4a/EGbMZg==
 
-"@spectrum-css/toggle@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/toggle/-/toggle-2.1.0.tgz#9b858c0b96eb084894bd37c864bb413540c048c3"
-  integrity sha512-uP/bApkooTY8j+Do4gh73Bc8zP9XnDgG7dhVzacuLaWhFXF2j6jLOUPmYxVZrwhxRZiRSeaVuAdPLw90kvZUXA==
+"@spectrum-css/toggle@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/toggle/-/toggle-3.0.0-beta.2.tgz#5174d620ba9eb42198a6c1040814b53fdc89caff"
+  integrity sha512-OzgUISU9INlouMa7nuxggB89YFBcoJvnz3HGJnim4R2F0l+iZVVdNfPKw1ypbcLYlAUgfV825uzkbdZOjf9jhw==
 
-"@spectrum-css/tooltip@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-2.0.5.tgz#498b90c3102e775a71acd23584b8578a0b020b84"
-  integrity sha512-AmPTbrm54TPzB7hHi0H31EbP0Q0DzZxprQ3xEtWy6ps6TCThIS2GkAOEKg3MdMQxcGu/QwQM9TrgBdALNQp/XA==
+"@spectrum-css/tooltip@^3.0.0-beta.2":
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.0.0-beta.2.tgz#b30538c05eb8edc080e4ab53538ef59bb6a60bc7"
+  integrity sha512-Kpl5rR13M/qlm82W0T6jJ0B9zE1v15onGmoDpntUMqixeNwCJYplVVnxG1qAOQWNoG3rokFD/uP2HfEVOXFWuA==
 
 "@spectrum-css/typography@^2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-2.1.3.tgz#4d7bcf2f75e8d785bdbae098ef0121b73894f3c5"
   integrity sha512-73lu0Le1zt+etNTS+kJsn+0TJzpy8aiTT6TCkVuJyUY9yxLcKXdV7mYRaz4U7jEYn39MKpndGFXkA7Qq0u16dw==
 
-"@spectrum-css/underlay@^2.0.0", "@spectrum-css/underlay@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.6.tgz#daffc597a63b4b1c0d4d5b17b711ae9befd1c5a5"
-  integrity sha512-Qh50ouZOLPHjZnbYGOv+WvPxF7rcCyy5g9t+8Il72PY6jwVoptqKgD9/06jwmp0YOiql2g5kELDK/C43mHvpgg==
+"@spectrum-css/underlay@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.7.tgz#41754825968ecfc2e7cd42117484113e24be8a35"
+  integrity sha512-KF3Yre/y89enQpoaFEwuPCx8tHTYeQJBjpxqAgamo+XS2ENz4Cbxxy+xJJX9AUiGwNe3LNKN5iSTnZ655DBmEA==
 
-"@spectrum-css/vars@^2.2.0", "@spectrum-css/vars@^2.3.0":
+"@spectrum-css/vars@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-2.3.0.tgz#0ce716fb5ee65f4af9e2d2a7aaae55e8ba4d4c8f"
   integrity sha512-k4YwFbv9+7QzBrc3ezvGuHxI3nDTG/6qJsAmhYS1vEyxpxjKmRfiz59P+fqT12PQNjxeNYHyVz1kRgaLA6gw2w==


### PR DESCRIPTION
## Description
Get some of the lower hanging fruit components updated to Spectrum CSS v3.0.0
- table
- avatar
- banner
- bar-loader
- button-group
- circle-loader
- coachmark
- dialog
- dropdown
- dropzone
- illustrated-message
- menu
- popover
- radio
- rule
- sidenav
- slider
- status-light
- toggle
- tabs
- tags
- toast
- tooltip
There's also some added support for Spectrum that you'll see in the card package thanks to updated CSS processing, but the full work there is being tracked in a branch specifically addressing updates to the card element.

## Motivation and Context
Keeping up with Spectrum CSS

## How Has This Been Tested?
- updated Visual regressions

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
