### PR TITLE
fix(overlay): ensure overlay addition occurs after closing previous

### DIFF
--- a/packages/dropdown/test/dropdown.test.ts
+++ b/packages/dropdown/test/dropdown.test.ts
@@ -124,6 +124,47 @@ describe('Dropdown', () => {
 
         expect(el.open).to.be.false;
     });
+    it('closes when clicking away', async () => {
+        const el = await dropdownFixture();
+        el.id = 'closing';
+        const other = document.createElement('div');
+        document.body.append(other);
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        other.click();
+        await waitUntil(() => !el.open, 'closed');
+
+        other.remove();
+    });
+    it('toggles between dropdowns', async () => {
+        const el2 = await dropdownFixture();
+        const el1 = await dropdownFixture();
+
+        el1.id = 'away';
+        el2.id = 'other';
+
+        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
+
+        expect(el1.open, 'closed 1').to.be.false;
+        expect(el2.open, 'closed 1').to.be.false;
+        el1.click();
+        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
+        await waitUntil(() => el1.open && !el2.open, '1 open, 2 closed');
+
+        el2.click();
+        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
+        await waitUntil(() => !el1.open && el2.open, '1 closed, 2 open');
+
+        el1.click();
+        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
+        await waitUntil(() => el1.open && !el2.open, '1 open, 2 closed: again');
+    });
     it('selects', async () => {
         const el = await dropdownFixture();
 

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -184,6 +184,13 @@ export class ActiveOverlay extends LitElement {
         return [styles];
     }
 
+    public constructor() {
+        super();
+        this.stealOverlayContentPromise = new Promise(
+            (res) => (this.stealOverlayContentResolver = res)
+        );
+    }
+
     public feature(): void {
         this.tabIndex = 0;
         if (this.interaction === 'modal') {
@@ -345,6 +352,8 @@ export class ActiveOverlay extends LitElement {
         this.originalPlacement = this.overlayContent.getAttribute(
             'placement'
         ) as Placement;
+
+        this.stealOverlayContentResolver();
     }
 
     private returnOverlayContent(): void {
@@ -487,5 +496,13 @@ export class ActiveOverlay extends LitElement {
         }
 
         return overlay;
+    }
+
+    private stealOverlayContentPromise = Promise.resolve();
+    private stealOverlayContentResolver!: () => void;
+
+    protected async _getUpdateComplete(): Promise<void> {
+        await super._getUpdateComplete();
+        await this.stealOverlayContentPromise;
     }
 }

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -173,19 +173,22 @@ export class OverlayStack {
         }
 
         const activeOverlay = ActiveOverlay.create(details);
-        this.overlays.push(activeOverlay);
         document.body.appendChild(activeOverlay);
-        let updateComplete = await activeOverlay.updateComplete;
-        while (updateComplete === false) {
-            updateComplete = await activeOverlay.updateComplete;
-        }
 
-        this.addOverlayEventListeners(activeOverlay);
-        if (details.receivesFocus === 'auto') {
-            activeOverlay.focus();
-        }
-
-        return false;
+        /**
+         * The following work to make the new overlay the "top" of the stack
+         * has to happen AFTER the current call stack completes in case there
+         * is work there in to remove the previous "top" overlay.
+         */
+        return Promise.resolve().then(async () => {
+            this.overlays.push(activeOverlay);
+            await activeOverlay.updateComplete;
+            this.addOverlayEventListeners(activeOverlay);
+            if (details.receivesFocus === 'auto') {
+                activeOverlay.focus();
+            }
+            return false;
+        });
     }
 
     public addOverlayEventListeners(activeOverlay: ActiveOverlay): void {

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -433,16 +433,16 @@ describe('Overlay Trigger', () => {
 
         outerButton.click();
 
-        // Wait for the DOM node to be stolen and reparented into the overlay
-        await waitForPredicate(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger)
+        await waitUntil(
+            () => !(outerPopover.parentElement instanceof OverlayTrigger),
+            'outer content stolen and reparented'
         );
 
         innerButton.click();
 
-        // Wait for the DOM node to be stolen and reparented into the overlay
-        await waitForPredicate(
-            () => !(innerPopover.parentElement instanceof OverlayTrigger)
+        await waitUntil(
+            () => !(innerPopover.parentElement instanceof OverlayTrigger),
+            'inner content stolen and reparented'
         );
 
         expect(isVisible(outerPopover)).to.be.true;
@@ -455,9 +455,9 @@ describe('Overlay Trigger', () => {
 
         pressEscape();
 
-        // Wait for the DOM node to be put back in its original place
-        await waitForPredicate(
-            () => innerPopover.parentElement instanceof OverlayTrigger
+        await waitUntil(
+            () => innerPopover.parentElement instanceof OverlayTrigger,
+            'inner content returned'
         );
 
         expect(isVisible(outerPopover)).to.be.true;
@@ -465,9 +465,9 @@ describe('Overlay Trigger', () => {
 
         pressEscape();
 
-        // Wait for the DOM node to be put back in its original place
-        await waitForPredicate(
-            () => outerPopover.parentElement instanceof OverlayTrigger
+        await waitUntil(
+            () => outerPopover.parentElement instanceof OverlayTrigger,
+            'outer content returned'
         );
 
         expect(isVisible(outerPopover)).to.be.false;
@@ -486,16 +486,16 @@ describe('Overlay Trigger', () => {
 
         outerButton.click();
 
-        // Wait for the DOM node to be stolen and reparented into the overlay
-        await waitForPredicate(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger)
+        await waitUntil(
+            () => !(outerPopover.parentElement instanceof OverlayTrigger),
+            'outer content stolen and reparented'
         );
 
         innerButton.click();
 
-        // Wait for the DOM node to be stolen and reparented into the overlay
-        await waitForPredicate(
-            () => !(innerPopover.parentElement instanceof OverlayTrigger)
+        await waitUntil(
+            () => !(innerPopover.parentElement instanceof OverlayTrigger),
+            'inner content stolen and reparented'
         );
 
         expect(isVisible(outerPopover)).to.be.true;
@@ -512,8 +512,9 @@ describe('Overlay Trigger', () => {
         document.body.click();
 
         // Wait for the DOM node to be put back in its original place
-        await waitForPredicate(
-            () => innerPopover.parentElement instanceof OverlayTrigger
+        await waitUntil(
+            () => innerPopover.parentElement instanceof OverlayTrigger,
+            'outer content returned'
         );
 
         expect(isVisible(outerPopover)).to.be.true;
@@ -522,8 +523,9 @@ describe('Overlay Trigger', () => {
         document.body.click();
 
         // Wait for the DOM node to be put back in its original place
-        await waitForPredicate(
-            () => outerPopover.parentElement instanceof OverlayTrigger
+        await waitUntil(
+            () => outerPopover.parentElement instanceof OverlayTrigger,
+            'inner content returned'
         );
 
         expect(isVisible(outerPopover)).to.be.false;


### PR DESCRIPTION
## Description
When an overlay is open when another is triggered, if the previous element isn't closed before the new overlay has opened, then the wrong overlay will be closed returning to the first overlay.

The dynamic import timing by default (and in builds _not_ made by webpack) seems to have managed this fine in the past, this update ensures the timing is correct in all cases and closer to the same between contexts.

## Related Issue
fixes #809

## Motivation and Context
We expect to be able to open successive overlays without issue.

## How Has This Been Tested?
- added new unit tests, passes old ones.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
