### PR TITLE
test: refactor keyboard input testing to shared tooling

### DIFF
--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -14,16 +14,7 @@ import '@spectrum-web-components/button/sp-button.js';
 import { Button } from '@spectrum-web-components/button';
 import { html } from 'lit-element';
 import { fixture, elementUpdated, expect } from '@open-wc/testing';
-
-const keyboardEvent = (code: string, shiftKey: boolean): KeyboardEvent =>
-    new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-        shiftKey,
-    });
-const shiftTabEvent = keyboardEvent('Tab', true);
+import { shiftTabEvent } from '../../../test/testing-helpers.js';
 
 type TestableButtonType = {
     hasLabel: boolean;

--- a/packages/dropdown/test/dropdown.test.ts
+++ b/packages/dropdown/test/dropdown.test.ts
@@ -26,17 +26,11 @@ import {
 } from '@open-wc/testing';
 import '@spectrum-web-components/shared/src/focus-visible.js';
 import { spy } from 'sinon';
-
-const keyboardEvent = (code: string): KeyboardEvent =>
-    new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-    });
-const arrowDownEvent = keyboardEvent('ArrowDown');
-const arrowUpEvent = keyboardEvent('ArrowUp');
-const tabEvent = keyboardEvent('Tab');
+import {
+    arrowDownEvent,
+    arrowUpEvent,
+    tabEvent,
+} from '../../../test/testing-helpers.js';
 
 describe('Dropdown', () => {
     const dropdownFixture = async (): Promise<Dropdown> => {

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -21,18 +21,12 @@ import {
     expect,
     waitUntil,
 } from '@open-wc/testing';
-
-const keyboardEvent = (code: string): KeyboardEvent =>
-    new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-    });
-const arrowUpEvent = keyboardEvent('ArrowUp');
-const arrowDownEvent = keyboardEvent('ArrowDown');
-const tabEvent = keyboardEvent('Tab');
-const tEvent = keyboardEvent('t');
+import {
+    arrowUpEvent,
+    arrowDownEvent,
+    tabEvent,
+    tEvent,
+} from '../../../test/testing-helpers.js';
 
 describe('Menu', () => {
     it('renders empty', async () => {

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -348,7 +348,7 @@ export class OverlayStack {
     };
 
     private handleKeyUp = (event: KeyboardEvent): void => {
-        if (event.key === 'Escape') {
+        if (event.code === 'Escape') {
             const overlay = this.topOverlay as ActiveOverlay;
             this.closeTopOverlay();
             overlay && overlay.trigger.focus();

--- a/packages/overlay/test/overlay.test.ts
+++ b/packages/overlay/test/overlay.test.ts
@@ -24,17 +24,7 @@ import {
     elementUpdated,
     waitUntil,
 } from '@open-wc/testing';
-
-const keyboardEvent = (code: string, shiftKey = false): KeyboardEvent =>
-    new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-        shiftKey,
-    });
-const tabEvent = keyboardEvent('Tab');
-const shiftTabEvent = keyboardEvent('Tab', true);
+import { tabEvent, shiftTabEvent } from '../../../test/testing-helpers.js';
 
 describe('Overlays', () => {
     let testDiv!: HTMLDivElement;

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -15,24 +15,17 @@ import { RadioGroup } from '../';
 import '@spectrum-web-components/radio/sp-radio.js';
 import { Radio } from '@spectrum-web-components/radio';
 import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
-
-const keyboardEvent = (code: string): KeyboardEvent =>
-    new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-        key: code,
-    });
-const arrowUpEvent = keyboardEvent('ArrowUp');
-const arrowDownEvent = keyboardEvent('ArrowDown');
-const arrowLeftEvent = keyboardEvent('ArrowLeft');
-const arrowRightEvent = keyboardEvent('ArrowRight');
-const endEvent = keyboardEvent('End');
-const homeEvent = keyboardEvent('Home');
-const pageUpEvent = keyboardEvent('PageUp');
-const pageDownEvent = keyboardEvent('PageDown');
-const enterEvent = keyboardEvent('Enter');
+import {
+    arrowUpEvent,
+    arrowDownEvent,
+    arrowLeftEvent,
+    arrowRightEvent,
+    endEvent,
+    homeEvent,
+    pageUpEvent,
+    pageDownEvent,
+    enterEvent,
+} from '../../../test/testing-helpers.js';
 
 describe('Radio Group - focus control', () => {
     it('does not accept focus when empty', async () => {
@@ -312,7 +305,7 @@ describe('Radio Group', () => {
 
         expect(radioGroup.selected).to.equal('');
     });
-    
+
     it('can have selection prevented', async () => {
         const el = testDiv.querySelector(
             'sp-radio-group#test-default'

--- a/packages/sidenav/test/sidenav.test.ts
+++ b/packages/sidenav/test/sidenav.test.ts
@@ -15,6 +15,11 @@ import '../sp-sidenav-item.js';
 import '../sp-sidenav-heading.js';
 import { SideNav, SideNavItem } from '../';
 import {
+    arrowDownEvent,
+    arrowUpEvent,
+    shiftTabEvent,
+} from '../../../test/testing-helpers.js';
+import {
     fixture,
     elementUpdated,
     html,
@@ -23,19 +28,6 @@ import {
 } from '@open-wc/testing';
 import { TemplateResult } from 'lit-html';
 import { LitElement } from 'lit-element';
-
-const keyboardEvent = (code: string, eventDetails = {}): KeyboardEvent => {
-    return new KeyboardEvent('keydown', {
-        ...eventDetails,
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-    });
-};
-const arrowDownEvent = keyboardEvent('ArrowDown');
-const arrowUpEvent = keyboardEvent('ArrowUp');
-const shiftTabEvent = keyboardEvent('Tab', { shiftKey: true });
 
 describe('Sidenav', () => {
     it('loads', async () => {

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -203,7 +203,7 @@ export class Tabs extends Focusable {
     };
 
     private onKeyDown = (event: KeyboardEvent): void => {
-        if (event.key === 'Enter' || event.key === ' ') {
+        if (event.code === 'Enter' || event.code === 'Space') {
             event.preventDefault();
             const target = event.target as HTMLElement;
             /* istanbul ignore else */

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -23,21 +23,14 @@ import {
 import { LitElement } from 'lit-element';
 import { TemplateResult } from 'lit-html';
 import { waitForPredicate } from '../../../test/testing-helpers.js';
-
-const keyboardEvent = (code: string): KeyboardEvent =>
-    new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-        key: code,
-    });
-const enterEvent = keyboardEvent('Enter');
-const spaceEvent = keyboardEvent(' ');
-const arrowRightEvent = keyboardEvent('ArrowRight');
-const arrowLeftEvent = keyboardEvent('ArrowLeft');
-const arrowUpEvent = keyboardEvent('ArrowUp');
-const arrowDownEvent = keyboardEvent('ArrowDown');
+import {
+    enterEvent,
+    spaceEvent,
+    arrowRightEvent,
+    arrowLeftEvent,
+    arrowUpEvent,
+    arrowDownEvent,
+} from '../../../test/testing-helpers.js';
 
 const createTabs = async (): Promise<Tabs> =>
     await fixture<Tabs>(

--- a/packages/tags/test/tag.test.ts
+++ b/packages/tags/test/tag.test.ts
@@ -18,19 +18,12 @@ import '../sp-tag.js';
 import '../sp-tags.js';
 import { Tag } from '..';
 import { ClearButton } from '@spectrum-web-components/button';
-
-const keyboardEvent = (code: string): KeyboardEvent =>
-    new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-        key: code,
-    });
-const deleteEvent = keyboardEvent('Delete');
-const spaceEvent = keyboardEvent('Space');
-const backspaceEvent = keyboardEvent('Backspace');
-const enterEvent = keyboardEvent('Enter');
+import {
+    deleteEvent,
+    spaceEvent,
+    backspaceEvent,
+    enterEvent,
+} from '../../../test/testing-helpers.js';
 
 describe('Tag', () => {
     it('loads default tags accessibly', async () => {

--- a/packages/tags/test/tags.test.ts
+++ b/packages/tags/test/tags.test.ts
@@ -16,24 +16,17 @@ import { fixture, elementUpdated, expect } from '@open-wc/testing';
 import '../sp-tag.js';
 import '../sp-tags.js';
 import { Tags, Tag } from '..';
-
-const keyboardEvent = (code: string): KeyboardEvent =>
-    new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-        code,
-        key: code,
-    });
-const arrowUpEvent = keyboardEvent('ArrowUp');
-const arrowDownEvent = keyboardEvent('ArrowDown');
-const arrowLeftEvent = keyboardEvent('ArrowLeft');
-const arrowRightEvent = keyboardEvent('ArrowRight');
-const endEvent = keyboardEvent('End');
-const homeEvent = keyboardEvent('Home');
-const pageUpEvent = keyboardEvent('PageUp');
-const pageDownEvent = keyboardEvent('PageDown');
-const enterEvent = keyboardEvent('Enter');
+import {
+    arrowUpEvent,
+    arrowDownEvent,
+    arrowLeftEvent,
+    arrowRightEvent,
+    endEvent,
+    homeEvent,
+    pageUpEvent,
+    pageDownEvent,
+    enterEvent,
+} from '../../../test/testing-helpers.js';
 
 describe('Tags', () => {
     it('loads default tags accessibly', async () => {

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -32,3 +32,29 @@ export function waitForPredicate(
 export function isVisible(element: HTMLElement) {
     return !!element.offsetParent;
 }
+
+const keyboardEvent = (code: string, eventDetails = {}): KeyboardEvent => {
+    return new KeyboardEvent('keydown', {
+        ...eventDetails,
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        code,
+        key: code,
+    });
+};
+export const shiftTabEvent = keyboardEvent('Tab', { shiftKey: true });
+export const enterEvent = keyboardEvent('Enter');
+export const arrowRightEvent = keyboardEvent('ArrowRight');
+export const arrowLeftEvent = keyboardEvent('ArrowLeft');
+export const arrowUpEvent = keyboardEvent('ArrowUp');
+export const arrowDownEvent = keyboardEvent('ArrowDown');
+export const deleteEvent = keyboardEvent('Delete');
+export const spaceEvent = keyboardEvent('Space');
+export const backspaceEvent = keyboardEvent('Backspace');
+export const endEvent = keyboardEvent('End');
+export const homeEvent = keyboardEvent('Home');
+export const pageUpEvent = keyboardEvent('PageUp');
+export const pageDownEvent = keyboardEvent('PageDown');
+export const tabEvent = keyboardEvent('Tab');
+export const tEvent = keyboardEvent('t');


### PR DESCRIPTION
## Description
Centralizes the keyboard helper code into a single place so we don't need to copy/paste the code into another test file.

## Related Issue
fixes #789

## Motivation and Context
Shared codes is happier code!

## How Has This Been Tested?
- it is tests

## Types of changes
- [x] Refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
