### PR TITLE
feat: allow dir management by sp-theme elements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v1-golden-images-99319bfe2d3be2e42e332c53d0d21741b4ae9fd4-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
+                      - v1-golden-images-df9bca4e03c69aa6de6c3493f42dc878906f7a1f-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
                       - v1-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
             - run:

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -18,6 +18,7 @@
     }
     /* @TODO: Implement more default storybook styling here using spectrum theme variables */
     #root-theme {
+        overflow-x: hidden;
         display: block;
         padding: 8px;
         box-sizing: border-box;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -51,7 +51,6 @@ addDecorator((story) => {
         'Theme'
     );
     defaultDirection = dir;
-    // document.documentElement.setAttribute('dir', dir);
     return html`
         <sp-theme id="root-theme" color=${color} scale=${scale} dir=${dir}>
             ${story()}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -51,9 +51,9 @@ addDecorator((story) => {
         'Theme'
     );
     defaultDirection = dir;
-    document.documentElement.setAttribute('dir', dir);
+    // document.documentElement.setAttribute('dir', dir);
     return html`
-        <sp-theme id="root-theme" color=${color} scale=${scale}>
+        <sp-theme id="root-theme" color=${color} scale=${scale} dir=${dir}>
             ${story()}
         </sp-theme>
     `;

--- a/documentation/src/components/code-example.ts
+++ b/documentation/src/components/code-example.ts
@@ -147,9 +147,9 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
                       </div>
                   `
                 : undefined}
-            <div id="markup">
+            <bdo id="markup" dir="ltr">
                 ${highlightedCode}
-            </div>
+            </bdo>
         `;
     }
 

--- a/documentation/src/components/layout.ts
+++ b/documentation/src/components/layout.ts
@@ -30,16 +30,23 @@ import '@spectrum-web-components/button/sp-action-button.js';
 
 const SWC_THEME_COLOR_KEY = 'swc-docs:theme:color';
 const SWC_THEME_SCALE_KEY = 'swc-docs:theme:scale';
+const SWC_THEME_DIR_KEY = 'swc-docs:theme:dir';
 const COLOR_FALLBACK = matchMedia('(prefers-color-scheme: dark)').matches
     ? 'dark'
     : 'light';
 const SCALE_MEDIUM = 'medium';
+const DIR_FALLBACK = 'ltr';
 const DEFAULT_COLOR = (window.localStorage
     ? localStorage.getItem(SWC_THEME_COLOR_KEY) || COLOR_FALLBACK
     : COLOR_FALLBACK) as Color;
 const DEFAULT_SCALE = (window.localStorage
     ? localStorage.getItem(SWC_THEME_SCALE_KEY) || SCALE_MEDIUM
     : SCALE_MEDIUM) as Scale;
+const DEFAULT_DIR = (window.localStorage
+    ? localStorage.getItem(SWC_THEME_DIR_KEY) || DIR_FALLBACK
+    : DIR_FALLBACK) as 'ltr' | 'rtl';
+
+console.log(DEFAULT_DIR);
 
 const isNarrowMediaQuery = matchMedia('screen and (max-width: 960px)');
 
@@ -50,6 +57,9 @@ export class LayoutElement extends SpectrumElement {
 
     @property({ attribute: false })
     public color: Color = DEFAULT_COLOR;
+
+    @property({ reflect: true })
+    public dir: 'ltr' | 'rtl' = DEFAULT_DIR;
 
     @property({ type: Boolean })
     public open = false;
@@ -240,6 +250,9 @@ export class LayoutElement extends SpectrumElement {
         }
         if (changes.has('scale') && window.localStorage) {
             localStorage.setItem(SWC_THEME_SCALE_KEY, this.scale);
+        }
+        if (changes.has('dir') && window.localStorage) {
+            localStorage.setItem(SWC_THEME_DIR_KEY, this.dir);
         }
     }
 

--- a/documentation/src/components/layout.ts
+++ b/documentation/src/components/layout.ts
@@ -82,7 +82,7 @@ export class LayoutElement extends SpectrumElement {
 
     private updateDirection(event: Event) {
         const dir = (event.target as Dropdown).value;
-        document.documentElement.dir = dir === 'rtl' ? dir : 'ltr';
+        this.dir = dir === 'rtl' ? dir : 'ltr';
     }
 
     // TODO: remove this manual link relationship when
@@ -104,7 +104,12 @@ export class LayoutElement extends SpectrumElement {
 
     render() {
         return html`
-            <sp-theme color=${this.color} scale=${this.scale} id="app">
+            <sp-theme
+                color=${this.color}
+                scale=${this.scale}
+                dir=${this.dir}
+                id="app"
+            >
                 <header>
                     <sp-action-button
                         quiet

--- a/packages/base/README.md
+++ b/packages/base/README.md
@@ -27,3 +27,17 @@ import { SpectrumMixin } from '@spectrum-web-components/base';
 
 export MyElement extends SpectrumMixin(HTMLElement) {}
 ```
+
+### Features
+
+#### `dir` management
+
+With powerful CSS selectors like `:host(:dir(rtl))` and `:host-content([dir=rtl])` not yet enjoying cross-browser support, reliably delivering content in both "left to right" and "right to left" while relying on Shadow DOM means certain trade offs need to be made. While every custom element build from `SpectrumMixin` could have its `dir` attribute applied to manage this, doing so is not only a pain for apply, it's a pain to maintain over time. To support the flexibility to devlier content in both of these directions, elements built from `SpectrumMixin` will observe the `dir` attribute of either the `document` or a containing `sp-theme`. This will allow your sites and applications to manage content direction in a single place while also opening the possibility of having multiple content directions on the same page by scoping those content sections with `sp-theme` elements.
+
+#### `isLTR`
+
+While CSS offers many powerful solutions for styling content in various directions, sometimes JS functionality depends on the specific of that direction. Elements built from `SpectrumMixin` have the `this.isLTR` getter that will resolve to `true` when `dir === 'ltr'`.
+
+#### public shadowRoot!: ShadowRoot;
+
+Elements built from `SpectrumMixin` assume that you will be using shadow DOM in the resulting custom element. To simplify TypeScript usage the presence of `this.shadowRoot` is asserted as non-null so that you have direct access to it without extended type checking.

--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -25,7 +25,7 @@ type Constructor<T = Record<string, unknown>> = {
 
 export interface SpectrumInterface {
     shadowRoot: ShadowRoot;
-    isDefaultDir: boolean;
+    isLTR: boolean;
     dir: 'ltr' | 'rtl';
 }
 
@@ -64,7 +64,7 @@ export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
         /**
          * @private
          */
-        public get isDefaultDir(): boolean {
+        public get isLTR(): boolean {
             return this.dir === 'ltr';
         }
 

--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -86,7 +86,7 @@ export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
                         | DocumentFragment
                         | ShadowRoot;
                 }
-                this.dir = dirParent.dir === 'rtl' ? dirParent.dir : 'ltr';
+                this.dir = dirParent.dir === 'rtl' ? dirParent.dir : this.dir;
                 if (dirParent === document.documentElement) {
                     observedForElements.add(this);
                 } else {

--- a/packages/base/test/base.test.ts
+++ b/packages/base/test/base.test.ts
@@ -30,6 +30,6 @@ describe('Base', () => {
         await elementUpdated(el);
 
         expect(el.dir).to.equal('rtl');
-        expect(el.isDefaultDir).to.be.false;
+        expect(el.isLTR).to.be.false;
     });
 });

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -210,14 +210,11 @@ export class Menu extends SpectrumElement {
     }
 
     public disconnectedCallback(): void {
-        /* istanbul ignore else */
-        if (this.observer) {
-            this.observer.disconnect();
-        }
+        this.observer.disconnect();
         super.disconnectedCallback();
     }
 
-    private observer?: MutationObserver;
+    private observer!: MutationObserver;
 }
 
 declare global {

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -105,10 +105,10 @@ export class RadioGroup extends SpectrumElement {
                 buttonFromDelta(-1);
                 break;
             case 'ArrowLeft':
-                buttonFromDelta(this.isDefaultDir ? -1 : 1);
+                buttonFromDelta(this.isLTR ? -1 : 1);
                 break;
             case 'ArrowRight':
-                buttonFromDelta(this.isDefaultDir ? 1 : -1);
+                buttonFromDelta(this.isLTR ? 1 : -1);
                 break;
             case 'ArrowDown':
                 buttonFromDelta(1);

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -442,7 +442,7 @@ export class Slider extends Focusable {
         const percent = (offset - minOffset) / size;
         const value = this.min + (this.max - this.min) * percent;
 
-        return this.isDefaultDir ? value : 100 - value;
+        return this.isLTR ? value : 100 - value;
     }
 
     private dispatchInputEvent(): void {
@@ -485,7 +485,7 @@ export class Slider extends Focusable {
     private get trackRightStyle(): string {
         const width = `width: ${(1 - this.trackProgress) * 100}%;`;
         const halfHandleWidth = `var(--spectrum-slider-handle-width, var(--spectrum-global-dimension-size-200)) / 2`;
-        const offset = `${this.isDefaultDir ? 'left' : 'right'}: calc(${
+        const offset = `${this.isLTR ? 'left' : 'right'}: calc(${
             this.trackProgress * 100
         }% + ${halfHandleWidth})`;
 
@@ -493,8 +493,6 @@ export class Slider extends Focusable {
     }
 
     private get handleStyle(): string {
-        return `${this.isDefaultDir ? 'left' : 'right'}: ${
-            this.trackProgress * 100
-        }%`;
+        return `${this.isLTR ? 'left' : 'right'}: ${this.trackProgress * 100}%`;
     }
 }

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -182,7 +182,7 @@ export class Tabs extends Focusable {
         if (!availableArrows.includes(code)) {
             return;
         }
-        if (!this.isDefaultDir && this.direction === 'horizontal') {
+        if (!this.isLTR && this.direction === 'horizontal') {
             availableArrows.reverse();
         }
         event.preventDefault();

--- a/packages/tags/src/Tags.ts
+++ b/packages/tags/src/Tags.ts
@@ -97,10 +97,10 @@ export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
                 tagFromDelta(-1);
                 break;
             case 'ArrowLeft':
-                tagFromDelta(this.isDefaultDir ? -1 : 1);
+                tagFromDelta(this.isLTR ? -1 : 1);
                 break;
             case 'ArrowRight':
-                tagFromDelta(this.isDefaultDir ? 1 : -1);
+                tagFromDelta(this.isLTR ? 1 : -1);
                 break;
             case 'ArrowDown':
                 tagFromDelta(1);

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -194,8 +194,8 @@ The large scale of `<sp-theme>` will switch to using Spectrum's larger mobile [P
 ## Embedding themes
 
 There are a few cases where it is necessary to embed one theme within another.
-For example, if you have an application that is using a dark theme that is
-previewing or editing content that will be displayed in a light theme.
+For example, if you have an application that is using a dark theme with a left to right text direction that is
+previewing or editing content that will be displayed in a light theme with a right to left text direction.
 
 ```html
 <style type="text/css">
@@ -217,7 +217,7 @@ previewing or editing content that will be displayed in a light theme.
         margin-top: 2em;
     }
 </style>
-<sp-theme color="dark">
+<sp-theme color="dark" dir="ltr">
     <div id="outer">
         <div>
             <sp-slider
@@ -234,7 +234,7 @@ previewing or editing content that will be displayed in a light theme.
             <sp-button variant="primary">Cancel</sp-button>
             <sp-button variant="cta">Continue</sp-button>
         </div>
-        <sp-theme color="light">
+        <sp-theme color="light" dir="rtl">
             <div id="inner">
                 <div>
                     <sp-slider

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -2,6 +2,8 @@
 
 `sp-theme` sets the rendering theme for all child components, and also sets a number of default sizes & colors for any child content. The Spectrum design system provides four color themes (`lightest`, `light`, `dark`, and `darkest`) and two different scales (`medium` and `large`) to support desktop & mobile UI.
 
+When leveraging an `sp-theme` element, it will assume the role of managing the content direction applied to elements in its DOM scope from the `document`. By default, an `sp-theme` element will resolve its initial content direction from value of its `dir` attribute or to be e the same as its containing `sp-theme` parent or the `document`. Subsequent customization of content direction for that content will need to happen on the `sp-theme` element to be appropriately tracked by elements in that scope. This means that each part of your document scoped by an `sp-theme` element can specify individual content directions and that decedent `sp-theme` elements can override the content direction applied by ancestor elements.
+
 ### Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/theme?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/theme)

--- a/packages/theme/stories/theme.stories.ts
+++ b/packages/theme/stories/theme.stories.ts
@@ -144,7 +144,7 @@ export const nestedTheme = (): TemplateResult => {
                     <sp-button variant="primary">Cancel</sp-button>
                     <sp-button variant="cta">Continue</sp-button>
                 </div>
-                <sp-theme color="${inner}">
+                <sp-theme color="${inner}" dir="ltr">
                     <div id="inner">
                         <div>
                             <sp-slider
@@ -212,7 +212,7 @@ export const reverseColorNestedTheme = (): TemplateResult => {
                     <sp-button variant="primary">Cancel</sp-button>
                     <sp-button variant="cta">Continue</sp-button>
                 </div>
-                <sp-theme color="${outer}">
+                <sp-theme color="${outer}" dir="rtl">
                     <div id="inner">
                         <div>
                             <sp-slider


### PR DESCRIPTION
## Description 
Use `sp-theme` elements to supply a content direction "scope" in order to support multiple content directions on the same page.
- refactor `isDefaultDir` to `isLTR` for confusion around what "default" is in this case
- add `dir` documentation to `@spectrum-web-components/base`
- add `dir` documentation to `@spectrum-web-compoentns/theme`

## Motivation and Context
Multiple content directions on the same page

## How Has This Been Tested?
- visual regressions updated

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have altered tests to cover my changes.
- [x] All new and existing tests passed.
