### PR TITLE
fix: correct overlay closure order or operations for manual override

### DIFF
--- a/packages/dropdown/test/dropdown.test.ts
+++ b/packages/dropdown/test/dropdown.test.ts
@@ -252,6 +252,40 @@ describe('Dropdown', () => {
         expect(el.open).to.be.true;
         expect(secondItem.selected).to.be.false;
     });
+
+    it('can throw focus after `change`', async () => {
+        const el = await dropdownFixture();
+        const input = document.createElement('input');
+        document.body.append(input);
+
+        await elementUpdated(el);
+
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        expect(el.selectedItemText).to.equal('');
+        expect(el.value).to.equal('');
+        expect(secondItem.selected).to.be.false;
+
+        el.addEventListener('change', (): void => {
+            input.focus();
+        });
+
+        secondItem.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.value, 'value changed').to.equal('option-2');
+        expect(secondItem.selected, 'selected changed').to.be.true;
+        await waitUntil(() => document.activeElement === input, 'focus throw');
+        input.remove();
+    });
     it('opens on ArrowDown', async () => {
         const el = await dropdownFixture();
 

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -325,6 +325,11 @@ export class ActiveOverlay extends LitElement {
 
         this.returnOverlayContent();
         this.state = 'disposed';
+
+        if (this.willNotifyClosed) {
+            this.overlayContent.dispatchEvent(new Event('sp-overlay-closed'));
+            this.willNotifyClosed = false;
+        }
     }
 
     private stealOverlayContent(element: HTMLElement): void {
@@ -356,6 +361,8 @@ export class ActiveOverlay extends LitElement {
         this.stealOverlayContentResolver();
     }
 
+    private willNotifyClosed = false;
+
     private returnOverlayContent(): void {
         /* istanbul ignore if */
         if (!this.overlayContent) return;
@@ -378,9 +385,7 @@ export class ActiveOverlay extends LitElement {
                     this.overlayContent,
                     this.placeholder
                 );
-                this.overlayContent.dispatchEvent(
-                    new Event('sp-overlay-closed')
-                );
+                this.willNotifyClosed = true;
             }
         }
 

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -307,9 +307,6 @@ export class OverlayStack {
             await overlay.hide(animated);
             if (overlay.state != 'dispose') return;
 
-            overlay.remove();
-            overlay.dispose();
-
             const index = this.overlays.indexOf(overlay);
             /* istanbul ignore else */
             if (index >= 0) {
@@ -335,6 +332,9 @@ export class OverlayStack {
                 }
                 overlay.tabbingAway = false;
             }
+
+            overlay.remove();
+            overlay.dispose();
         }
     }
 


### PR DESCRIPTION
## Description 
Orders the `sp-overlay-close`, `change`, etc events and work appropriately for a user to be able to respond to `change` with their own `focus()` commands without them being overwritten.

## Related Issue
fixes #843

## Motivation and Context
Fix an issue, get a cookie...can I have a cookie?

## How Has This Been Tested?
- with unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
