### PR TITLE
docs: match tab index between site and stories

### DIFF
--- a/packages/dropzone/README.md
+++ b/packages/dropzone/README.md
@@ -28,7 +28,7 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 ## Example
 
 ```html
-<sp-dropzone id="dropzone-1" tabindex="1" style="width: 400px; height: 200px">
+<sp-dropzone id="dropzone-1" tabindex="0" style="width: 400px; height: 200px">
     <sp-illustrated-message heading="Drag and Drop Your File">
         <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -66,7 +66,7 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 ```html
 <sp-dropzone
     id="dropzone"
-    tabindex="1"
+    tabindex="0"
     dragged
     style="width: 400px; height: 200px"
 >

--- a/packages/dropzone/stories/dropzone.stories.ts
+++ b/packages/dropzone/stories/dropzone.stories.ts
@@ -23,7 +23,7 @@ export default {
 
 export const Default = (): TemplateResult => {
     return html`
-        <sp-dropzone id="dropzone">
+        <sp-dropzone id="dropzone" tabindex="0">
             <sp-illustrated-message heading="Drag and Drop Your File">
                 ${illustration}
             </sp-illustrated-message>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Spectrum CSS expects `sp-dropzone` elements to have a tab index so that they can be focused. I'm not sure the functional implications of this, so rather than apply this to the element itself, I've updated the stories to match the manual application of this in the docs site.

## Related Issue
fixes #280

## Motivation and Context
Spectrum adherence.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/91766209-3685e880-eba8-11ea-9fa5-bfb076a3fcc4.png)

## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
