### PR TITLE
docs(toast): use "sp-toast" in the docs site insted of alert

### DIFF
--- a/documentation/src/app.ts
+++ b/documentation/src/app.ts
@@ -12,3 +12,21 @@ governing permissions and limitations under the License.
 import './main.css';
 import './components/page.js';
 import './router.js';
+
+declare global {
+    interface Window {
+        spAlert(el: HTMLElement, message: string): void;
+    }
+}
+
+window.spAlert = (el: HTMLElement, message: string): void => {
+    el.dispatchEvent(
+        new CustomEvent('alert', {
+            composed: true,
+            bubbles: true,
+            detail: {
+                message,
+            },
+        })
+    );
+};

--- a/documentation/src/components/layout.css
+++ b/documentation/src/components/layout.css
@@ -171,3 +171,16 @@ label {
         var(--spectrum-global-dimension-size-100)
     );
 }
+
+.alerts {
+    width: 100vw;
+    text-align: center;
+    position: absolute;
+    bottom: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.alerts sp-toast {
+    margin: 0 auto var(--spectrum-global-dimension-size-300);
+}

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -111,7 +111,7 @@ Events handlers for clicks and other user actions can be registered on a
 `<sp-button>` as on a standard HTML `<button>` element.
 
 ```html
-<sp-button onclick="alert('spectrum-button clicked!')">Click me</sp-button>
+<sp-button onclick="spAlert(this, '<sp-button> clicked!')">Click me</sp-button>
 ```
 
 ### Autofocus

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -82,7 +82,10 @@ checkbox, and also prevents clicks from activating it.
 Event handlers for clicks and other user actions can be registered on an `<sp-checkbox>` as they would a standard `<input type="checkbox">` element.
 
 ```html
-<sp-checkbox id="checkbox-example" onclick="javascript:alert('Click')">
+<sp-checkbox
+    id="checkbox-example"
+    onclick="spAlert(this, '<sp-checkbox> clicked!')"
+>
     Web component
 </sp-checkbox>
 ```

--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -44,7 +44,7 @@ import { DialogWrapper } from '@spectrum-web-components/dialog';
         dialogWrapper.hidden = false;
         dialogWrapper.open = true;
         function handleEvent({type}) {
-            alert(`Handling '${type}' event.`);
+            spAlert(this, `<sp-dialog-wrapper> '${type}' event handled.`);
             dialogWrapper.open = false;
             dialogWrapper.removeEventListener('close', handleEvent);
         }
@@ -77,7 +77,7 @@ import { DialogWrapper } from '@spectrum-web-components/dialog';
         dialogWrapper.hidden = false;
         dialogWrapper.open = true;
         function handleEvent({type}) {
-            alert(`Handling '${type}' event.`);
+            spAlert(this, `<sp-dialog-wrapper> '${type}' event handled.`);
             dialogWrapper.open = false;
             dialogWrapper.removeEventListener('confirm', handleEvent);
             dialogWrapper.removeEventListener('secondary', handleEvent);

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -96,7 +96,7 @@ When the radio button is no longer interactable. The button cannot be checked.
 Event handlers for clicks and other user actions can be registered on an `<sp-radio>` similar to a standard `<input type="radio">` element.
 
 ```html
-<sp-radio id="radio-example" onclick="javascript:alert('Click')">
+<sp-radio id="radio-example" onclick="spAlert(this, '<sp-radio> clicked!')">
     Web component
 </sp-radio>
 ```

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -26,7 +26,9 @@ import { Switch } from '@spectrum-web-components/switch';
 ## Example
 
 ```html
-<sp-switch label="Switch" onclick="javascript:alert('Click')">Switch</sp-switch>
+<sp-switch label="Switch" onclick="spAlert(this, '<sp-switch> clicked!')">
+    Switch
+</sp-switch>
 ```
 
 ## Variants

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -142,6 +142,7 @@ export class Toast extends SpectrumElement {
         }
         if (time - this.countdownStart > (this._timeout as number)) {
             this.open = false;
+            this.countdownStart = 0;
         } else {
             this.countdown();
         }
@@ -179,7 +180,7 @@ export class Toast extends SpectrumElement {
     protected render(): TemplateResult {
         return html`
             ${this.renderIcon(this.variant)}
-            <div class="body">
+            <div class="body" role="alert">
                 <div class="content">
                     <slot></slot>
                 </div>
@@ -197,7 +198,6 @@ export class Toast extends SpectrumElement {
 
     protected firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
-        this.setAttribute('role', 'alert');
         this.open = true;
     }
 


### PR DESCRIPTION
## Description
Use `<sp-toast>` instead of `alert()` in JS notifications in the documentation site.
- catches a scoping change in `<sp-toast>` for the `rel=alert` and associated screen reader interaction. (Reader will no longer say "close" when the alert opens.)
- creates a `window.spAlert()` method for use in the documentation site.
- begins the conversation around what sort of glue code we might want to vend for consumers to be able to leverage this sort of functionality when using `<sp-toast>`

## Related Issue
fixes #825

## Motivation and Context
This dog food is delicious.

## How Has This Been Tested?
https://5f4e825a1305eb00070d9fbc--spectrum-web-components.netlify.app/
- click the "Use Spectrum Web Component buttons" button
- click the "Click me" button
- experience the toastiness...

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/91885986-a5217f80-ec56-11ea-85d9-f0028c87e314.png)

## Types of changes
- [x] Refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
