### PR TITLE
build: allow whitespace in documentation examples

### DIFF
--- a/documentation/webpack.config.js
+++ b/documentation/webpack.config.js
@@ -120,6 +120,19 @@ module.exports = merge(openWcConfig, {
                 use: [
                     {
                         loader: 'html-loader',
+                        options: {
+                            minimize: {
+                                collapseWhitespace: false,
+                                removeComments: true,
+                                caseSensitive: true,
+                                removeRedundantAttributes: true,
+                                removeScriptTypeAttributes: true,
+                                removeStyleLinkTypeAttributes: true,
+                                useShortDoctype: true,
+                                minifyCSS: true,
+                                minifyJS: true,
+                            },
+                        },
                     },
                     {
                         loader: 'posthtml-loader',


### PR DESCRIPTION
## Description
`html-loader` chose to minify HTML by default when it [moved to v1.0](https://github.com/webpack-contrib/html-loader/blob/master/CHANGELOG.md#-breaking-changes) and it started breaking the examples in the docs site. This reduces the amount of processing therein.

## Related Issue
fixes #844 

## Motivation and Context
It should be easy to read out examples.

## How Has This Been Tested?
Visually, locally, with `yarn docs:ci && npx servor documentation/dist` and the base updated, as this wasn't happening in the `yarn docs:start` context, because `development` vs `production`.

## Types of changes
- [c] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
