### PR TITLE
ci: use next docker release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,23 +2,13 @@ version: 2.1
 executors:
     node:
         docker:
-            - image: mcr.microsoft.com/playwright:bionic
+            - image: mcr.microsoft.com/playwright:next
         environment:
             NODE_ENV: development
-            YARN_VERSION: 1.17.3
 commands:
     setup:
         steps:
             - checkout
-            - run:
-                  name: Prepare Yarn Path
-                  command: echo 'export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> $BASH_ENV
-            - run:
-                  command: npm version
-            - run:
-                  name: Install Yarn
-                  command: |
-                      curl --retry 10 --retry-max-time 30 -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
             - restore_cache:
                   keys:
                       - v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
@@ -32,15 +22,6 @@ commands:
     downstream:
         steps:
             - checkout
-            - run:
-                  name: Prepare Yarn Path
-                  command: echo 'export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> $BASH_ENV
-            - run:
-                  command: npm version
-            - run:
-                  name: Install Yarn
-                  command: |
-                      curl --retry 10 --retry-max-time 30 -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
             - attach_workspace:
                   at: ~/
     run-regressions:
@@ -274,7 +255,7 @@ jobs:
             - run: cp documentation/404.html documentation/dist/
             - run: touch documentation/dist/.nojekyll
             - run: git config --global user.email "circleci@adobe.com" && git config --global user.name "CircleCI"
-            - run: yarn gh-pages -d documentation/dist -m "[skip ci] update demonstration site"
+            - run: yarn gh-pages -d documentation/dist -m "[skip ci] update demonstration site" -t
 
 workflows:
     version: 2

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
         "express": "^4.16.4",
         "extract-loader": "^5.0.1",
         "fs-extra": "^9.0.0",
-        "gh-pages": "^2.1.1",
+        "gh-pages": "^3.1.0",
         "globby": "^10.0.1",
         "gulp": "^4.0.0",
         "gulp-cached": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10021,7 +10021,7 @@ find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.2.0:
+find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
@@ -10480,15 +10480,16 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-gh-pages@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-2.2.0.tgz#74ebeaca8d2b9a11279dcbd4a39ddfff3e6caa24"
-  integrity sha512-c+yPkNOPMFGNisYg9r4qvsMIjVYikJv7ImFOhPIVPt0+AcRUamZ7zkGRLHz7FKB0xrlZ+ddSOJsZv9XAFVXLmA==
+gh-pages@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/gh-pages/-/gh-pages-3.1.0.tgz#ec3ed0f6a6e3fc3d888758fa018f08191c96bd55"
+  integrity sha512-3b1rly9kuf3/dXsT8+ZxP0UhNLOo1CItj+3e31yUVcaph/yDsJ9RzD7JOw5o5zpBTJVQLlJAASNkUfepi9fe2w==
   dependencies:
     async "^2.6.1"
     commander "^2.18.0"
     email-addresses "^3.0.1"
     filenamify-url "^1.0.0"
+    find-cache-dir "^3.3.1"
     fs-extra "^8.1.0"
     globby "^6.1.0"
 


### PR DESCRIPTION
## Description
The Docker image we updated to in order to leverage `web-test-runner` was missing a couple of packages to support publishing the docs site from CI. This has now been corrected, and this PR points to that release. We should be able to move back to `bionic` the main line at some point in the next week or two, but this will allow us to avoid manually publishing the docs site in the interim.