### PR TITLE
fix(split-button): test a11y correctly, find issues, fix them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v2-golden-images-04883393f23a6a239a5328bee879a382b599b9d3-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
+                      - v2-golden-images-08d959d2af82e77a27f4a6fc0d52eb22b07bc230-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
                       - v2-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
             - run:

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -144,6 +144,7 @@ export class SplitButton extends DropdownBase {
                     @click=${this.onButtonClick}
                     @focus=${this.onButtonFocus}
                     ?disabled=${this.disabled}
+                    aria-label="More"
                 >
                     <sp-icon
                         class="icon ${this.type === 'field'

--- a/packages/split-button/test/split-button.test.ts
+++ b/packages/split-button/test/split-button.test.ts
@@ -33,8 +33,8 @@ describe('Splitbutton', () => {
         await elementUpdated(el1);
         await elementUpdated(el2);
 
-        expect(el1).to.be.accessible();
-        expect(el2).to.be.accessible();
+        await expect(el1).to.be.accessible();
+        await expect(el2).to.be.accessible();
     });
     it('loads [type="more"] splitbutton accessibly', async () => {
         const test = await fixture<HTMLDivElement>(moreCta());
@@ -44,8 +44,8 @@ describe('Splitbutton', () => {
         await elementUpdated(el1);
         await elementUpdated(el2);
 
-        expect(el1).to.be.accessible();
-        expect(el2).to.be.accessible();
+        await expect(el1).to.be.accessible();
+        await expect(el2).to.be.accessible();
     });
     it('manages tab interactions', async () => {
         const test = await fixture<HTMLDivElement>(moreCta());


### PR DESCRIPTION
## Description
Realized there was a very quiet "warning" in our testing output that was pointing to not having `await`ed the accessibility testing in `<sp-split-button>`. Fixing that catches an issue, this corrects that issue by giving the "More" button a label...

## How Has This Been Tested?
The tests pass now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
