### PR TITLE
docs(top-nav): provisionally include top-nav JS in docs site

### DIFF
--- a/documentation/src/components/component.ts
+++ b/documentation/src/components/component.ts
@@ -11,6 +11,9 @@ governing permissions and limitations under the License.
 */
 import { html, CSSResultArray, TemplateResult } from 'lit-element';
 import '@spectrum-web-components/bundle/elements.js';
+// work around while `top-nav` isn't "officially" in the bundle
+import '@spectrum-web-components/top-nav/sp-top-nav.js';
+import '@spectrum-web-components/top-nav/sp-top-nav-item.js';
 import { RouteComponent } from './route-component.js';
 import componentStyles from './markdown.css';
 import { AppRouter } from '../router.js';

--- a/packages/top-nav/README.md
+++ b/packages/top-nav/README.md
@@ -28,10 +28,11 @@ yarn add @spectrum-web-components/top-nav
     <sp-top-nav-item href="#page-4">
         Page with Really Long Name
     </sp-top-nav-item>
-    <sp-action-menu label="Account" style="margin-inline-start: auto;">
-        <sp-icon size="s" slot="icon">
-            ${SettingsIcon()}
-        </sp-icon>
+    <sp-action-menu
+        label="Account"
+        placement="bottom-end"
+        style="margin-inline-start: auto;"
+    >
         <sp-menu>
             <sp-menu-item>
                 Account Settings


### PR DESCRIPTION
Adds `top-nav` definitions to documentation site provisionally so that they don't need to go into `bundle`, yet.