### PR TITLE
fix(overlay): only "tab trap" when you mean to

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -33,10 +33,10 @@ export class OverlayStack {
 
     public constructor() {
         this.addEventListeners();
-        this.initTabTrapping();
     }
 
     private canTabTrap = true;
+    private trappingInited = false;
     private tabTrapper!: HTMLElement;
     private overlayHolder!: HTMLElement;
 
@@ -90,6 +90,11 @@ export class OverlayStack {
     }
 
     private startTabTrapping(): void {
+        if (!this.trappingInited) {
+            this.initTabTrapping();
+            this.trappingInited = true;
+        }
+        /* c8 ignore next 3 */
         if (!this.canTabTrap) {
             return;
         }
@@ -99,7 +104,7 @@ export class OverlayStack {
 
     private stopTabTrapping(): void {
         /* c8 ignore next 3 */
-        if (!this.canTabTrap) {
+        if (!this.canTabTrap || !this.trappingInited) {
             return;
         }
         this.tabTrapper.removeAttribute('tabindex');


### PR DESCRIPTION
## Description 
Safari has issues with WebGL canvas in association with out tab trapping solution. This mitigated the issue by initializing the tab trapping approach _only_ when tab trapping is being used by an element.

I have another idea that is low touch that I want to try, but all of my other ideas in this area haven't been working, so having something proposed as a possible path forward feels nice...

## Related Issue
refs #848 

## Motivation and Context
You should be able to have WebGL canvas AND use SWC.

## How Has This Been Tested?
- exiting tests pass.

## Types of changes
- [x] refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
