### PR TITLE
fix(tabs): check if current selected value exists before setting selected attr

### DIFF
--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -246,7 +246,7 @@ export class Tabs extends Focusable {
             element.removeAttribute('selected');
         });
 
-        if (value.length) {
+        if (value?.length) {
             const currentChecked = this.querySelector(`[value="${value}"]`);
 
             if (currentChecked) {


### PR DESCRIPTION
When removing the selected attribute on tabs, a typeError was thrown since the passed value was null 

## Description

This is fixed by checking if the value exists before checking for length via optional chaining

## Related Issue

fixes #877 

## Motivation and Context

* This removes the typeError
* It seems tabs behavior worked despite the typeError since the if-condition throwing the error was only relevant for selection, not removal of selection

## How Has This Been Tested?

* This has been tested in storybook.
* No additional unit tests were created since there's no functional changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
