### PR TITLE
fix: dir should never fall back to null

### DIFF
--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -84,7 +84,8 @@ export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
                         ((dirParent as unknown) as ShadowRoot)
                             .host) as HTMLElement;
                 }
-                this.dir = dirParent.dir === 'rtl' ? dirParent.dir : this.dir;
+                this.dir =
+                    dirParent.dir === 'rtl' ? dirParent.dir : this.dir || 'ltr';
                 if (dirParent === document.documentElement) {
                     observedForElements.add(this);
                 } else {


### PR DESCRIPTION
## Description

Simple fix to the fallback for `dir`

## Related Issue

#894 

## Motivation and Context

For frameworks that re-use elements, this is pretty necessary!

## How Has This Been Tested?

Using the steps in the issue.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
