### PR TITLE
chore(icons-workflow): update icon dependency and docs

### DIFF
--- a/packages/icons-workflow/README.md
+++ b/packages/icons-workflow/README.md
@@ -21,7 +21,7 @@ import { CircleIcon } from '@spectrum-web-components/icons-workflow';
 class ElementWithIcon extends LitElement {
     protected render(): TemplateResult {
         return html`
-            <sp-icon slot="icon">
+            <sp-icon>
                 ${CircleIcon()}
             </sp-icon>
         `

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -42,7 +42,7 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
-        "@adobe/spectrum-css-workflow-icons": "^1.0.0",
+        "@adobe/spectrum-css-workflow-icons": "^1.1.0",
         "@spectrum-web-components/icon": "^0.6.0",
         "@spectrum-web-components/iconset": "^0.1.7",
         "case": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adobe/spectrum-css-workflow-icons@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.0.0.tgz#913f3a251ef5ea3154929a7a23d4fbd6de1553da"
-  integrity sha512-aJbk7XhsUNefoufMpneq2aIT3VuD++KUY0C08VKbt5p/WOW0aDX8WYavUxW4oiK5cAgsvapcaPaS+eWpBMwXLg==
+"@adobe/spectrum-css-workflow-icons@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.1.0.tgz#79e97f86130e1a30b84c8524cebff93a600dbb8a"
+  integrity sha512-07ec4Pfr+W5II4a36nto3jShBZTbpe39lB977ULYN436UTQsnAdYupezBwFd7eEvOMUawgKfqnxyR2oPxp1SMQ==
 
 "@analytics/cookie-utils@^0.2.3":
   version "0.2.3"


### PR DESCRIPTION
## Description 
Catch up to the source Workflow Icons dependency.
Correct `slot` usage in the docs.

Checkout the Storybook from the preview build to see the new icons that are included: https://5f6a8be1e17efa165a73b0f1--spectrum-web-components.netlify.app/storybook/?path=/story/icons--workflow

## Motivation and Context
Keep up with the source and don't teach mistakes.

## Types of changes
- [x] Chore

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
