### PR TITLE
docs: add component generation documenation

### DIFF
--- a/documentation/guides/developing-components.md
+++ b/documentation/guides/developing-components.md
@@ -1,16 +1,14 @@
-# Adding a New Component
+# Developing a Component
 
-This guide explains how to contribute the implementation of a Spectrum control
-to <sp-link href="https://github.com/adobe/spectrum-web-components">spectrum-web-components</sp-link>
+This guide explains the techniques involved in the ongoing development a Spectrum control
+as a <sp-link href="https://github.com/adobe/spectrum-web-components">spectrum-web-components</sp-link>.
 
 The components in spectrum-web-components are based on the CSS definitions in
 <sp-link href="https://github.com/adobe/spectrum-css">spectrum-css</sp-link>. Typically, component
 implementations contain very little code. The CSS from the `spectrum-css`
-project typically specifies all of the presentation details.
+project typically specifies most, if not all, of the presentation details.
 
 ## What is a web component?
-
----
 
 According to <sp-link href="https://www.webcomponents.org/introduction">webcomponents.org</sp-link>,
 web components are:
@@ -32,8 +30,6 @@ working knowledge of the following technologies:
 -   <sp-link href="https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html">Typescript</sp-link>: A typesafe variant of JavaScript
 
 ## Setting up the styling
-
----
 
 The most complicated part of implementing a Spectrum web component is getting
 the styles set up correctly. The <sp-link href="https://developers.google.com/web/fundamentals/web-components/shadowdom">shadow
@@ -107,19 +103,17 @@ If we wanted to create a button component using this config file, the steps woul
 follows:
 
 1. Make the directory <sp-link href="https://github.com/adobe/spectrum-web-components/tree/master/src/button">`src/components/button`</sp-link>
-2. In that new directory, create a <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/button/spectrum-config.js">`spectrum-config.js`</sp-link>
+2. In that new directory, create a <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/src/spectrum-config.js">`spectrum-config.js`</sp-link>
    file with the above contents
-3. Run the command `npm run process-spectrum` to create the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/button/spectrum-button.css">CSS file</sp-link>
+3. Run the command `npm run process-spectrum` to create the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/src/spectrum-button.css">CSS file</sp-link>
 
-When you do the above, the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/scripts/process-spectrum-postcss-plugin.js">config-driven processor</sp-link>
+When you do the above, the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/scripts/process-spectrum-postcss-plugin.js">config-driven processor</sp-link>
 will look in the <sp-link href="https://github.com/adobe/spectrum-css">`spectrum-css`</sp-link> project
-for the <sp-link href="https://unpkg.com/@adobe/spectrum-css@2.13.0/dist/components/button/index-vars.css">matching CSS file</sp-link>.
+for the <sp-link href="https://unpkg.com/@spectrum-css/button/dist/index-vars.css">matching CSS file</sp-link>.
 It will parse that file and restructure the CSS as per the configuration
 instructions.
 
 ## Structure of a Spectrum Web Component
-
----
 
 If you look at an `sp-button` in the Chrome developer tools, you will see a DOM
 structure that looks like this.
@@ -175,7 +169,7 @@ that CSS to be applied. In many cases, you will want that CSS to be applied to
 the actual web component via the `:host` selector. That is the default behaviour
 of the conversion script. In this case, we wanted to preserve all of the default
 behaviour of the `button` element in HTML. So, we want the main CSS to be
-applied to our `<button>` instead. If you look at the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/button/spectrum-config.js#L18-L21">`host` definition in
+applied to our `<button>` instead. If you look at the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/src/spectrum-config.js">`host` definition in
 `spectrum-config.js`</sp-link>
 you can see that we have supplied a `shadowSelector` option. That tells the
 script to move all of the CSS for `.Spectrum-Button` to the `#button` element in
@@ -197,7 +191,7 @@ component has it's own DOM scope. So, there can never be an id name collision.
 
 Typically, you will reference the <sp-link href="http://opensource.adobe.com/spectrum-css/2.13.0/docs/#checkbox">sample code from the
 `spectrum-css`</sp-link>
-documentation and <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/checkbox/checkbox.ts#L30-L48">recreate that structure in the shadow DOM of your
+documentation and <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/checkbox/src/Checkbox.ts">recreate that structure in the shadow DOM of your
 component</sp-link>.
 
 In the case of `sp-checkbox`, we turn this sample DOM code:
@@ -250,7 +244,7 @@ return html`
 You will notice that many of the `spectrum-css` classes are mapped to ids in the
 web component. For example, `.spectrum-Checkbox-input` and
 `.spectrum-Checkbox-box` become `#input` and `#box`. Those transformations are
-described in the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/checkbox/spectrum-config.js#L43-L64">`ids` section of the `spectrum-config.js`
+described in the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/checkbox/src/spectrum-config.js">`ids` section of the `spectrum-config.js`
 file</sp-link>.
 
 ```javascript
@@ -294,7 +288,7 @@ style button.
 We could conditionally add CSS classes to the elements of the shadow DOM during
 rendering, but it is much easier to just let the attributes on the DOM node
 drive the styling directly. In order to facilitate that, the
-<sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/button/spectrum-config.js#L23-L47">`spectrum-config.js` file lets you specify how to map the various
+<sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/src/spectrum-config.js">`spectrum-config.js` file lets you specify how to map the various
 `spectrum-css` classes to CSS that is based on the attributes on the `:host` of
 the web
 component</sp-link>.
@@ -329,7 +323,7 @@ component</sp-link>.
 
 We support two different kinds of attributes, booleans and enums. Booleans are
 turned on or off by the presence or absence of the attribute. Enum attributes
-must be set to one of the allowed values. The <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/button/spectrum-button.css#L204-L212">CSS generated will reference the
+must be set to one of the allowed values. The <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/src/spectrum-button.css">CSS generated will reference the
 attributes on the `host:` element
 directly</sp-link>.
 
@@ -338,7 +332,7 @@ directly</sp-link>.
 In some cases, you will need to retain the `spectrum-css` classes as classes. An
 example of that is when you need to apply CSS rules to multiple items in the
 shadow DOM. In that case, we simply map class names to shorter classnames. There
-is an <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/slider/spectrum-config.js#L91-L96">example of remapping classes in the slider
+is an <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/slider/src/spectrum-config.js">example of remapping classes in the slider
 component</sp-link>.
 
 ```javacript
@@ -355,7 +349,7 @@ component</sp-link>.
 <sp-link href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">Slot tags</sp-link> are
 how we host our child content (light DOM) in our component's shadow DOM. The
 `spectrum-css` for a component sometimes contains rules for laying out the child
-content. There is a <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/button/spectrum-config.js#L49-L54">`slots`
+content. There is a <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/src/spectrum-config.js">`slots`
 section</sp-link>
 in the `spectrum-config.js` file for mapping those rules to the slotted content.
 
@@ -369,7 +363,7 @@ in the `spectrum-config.js` file for mapping those rules to the slotted content.
 ```
 
 The above section tells our CSS processor to map CSS for the `.spectrum-Icon`
-class to the content that is being hosted in the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/button/spectrum-button.css#L148-L158">slot with the name
+class to the content that is being hosted in the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/src/spectrum-button.css">slot with the name
 `icon`</sp-link>.
 
 ## Coding the Component
@@ -379,7 +373,7 @@ class to the content that is being hosted in the <sp-link href="https://github.c
 All of the `spectrum-web-components` are written using the
 <sp-link href="https://lit-element.polymer-project.org/guide">lit-element</sp-link> framework and
 <sp-link href="https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html">Typescript</sp-link>.
-Your best bet is to look at <sp-link href="https://github.com/adobe/spectrum-web-components/tree/master/packages">similar
+Your best bet is to look at <sp-link href="https://github.com/adobe/spectrum-web-components/tree/main/packages">similar
 components</sp-link>
 and match the style.
 
@@ -389,9 +383,9 @@ the necessary specifications for it.
 
 ### Documenting the component
 
-Each component should have a page in the documentation system. The pages are
+The documentation for each component in the documentation site is adopted from the `README.md` in said package. The pages are
 written in <sp-link href="https://www.markdownguide.org/cheat-sheet">Markdown</sp-link>. See one of
-the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/documentation/components/button.md">existing pages</sp-link> for an example.
+the <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/README.md">existing pages</sp-link> for an example.
 
 To run the local documentation server, use the command:
 
@@ -401,14 +395,14 @@ The documentation automatically extracts the properties and attributes from the
 source code. You should document your component using the <sp-link href="https://github.com/runem/web-component-analyzer#-how-to-document-your-components-using-jsdoc">appropriate jsdoc
 tags</sp-link>.
 See
-<sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/src/button/button.ts">button.ts</sp-link>
+<sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/src/Button.ts">Button.ts</sp-link>
 for an example.
 
 ### Working with Storybook
 
 We use <sp-link href="https://storybook.js.org/">Storybook</sp-link> for developing our components.
 This gives us a rapid way to test our components in various configurations. The
-best way to start is to copy <sp-link href="https://github.com/adobe/spectrum-web-components/blob/master/stories/button.stories.ts">one of the existing
+best way to start is to copy <sp-link href="https://github.com/adobe/spectrum-web-components/blob/main/packages/button/stories/button.stories.ts">one of the existing
 stories</sp-link>.
 
 To run Storybook, use the command:

--- a/documentation/guides/generating-components.md
+++ b/documentation/guides/generating-components.md
@@ -1,0 +1,37 @@
+# Generating a New Component
+
+The fasted way to get started with creating a new component is with our command line generator. Run the following command to have you new component scaffolded for you:
+
+```bash
+yarn new-package
+? component name please _
+```
+
+In response to the above, the component name should be the dashified version of the Spectrum CSS pattern that you are looking to add to the repo. In this way, the `SpectrumPattern` that you want to create will be represented as `spectrum-pattern` in your response. From here the command will generate a new package for you pattern with the following file structure in the `packages` directory:
+
+```
+> spectrum-pattern
+   > src/
+       index.ts
+       SpectrumPattern.ts
+       spectrum-pattern.css
+       spectrum-config.js
+   > test/
+       > benchmark/
+           basic-test.ts
+       spectrum-pattern.test.ts
+   > stories/
+       spectrum-pattern.stories.ts
+   sp-spectrum-pattern.ts
+   README.md
+   tsconfig.json
+   package.json
+```
+
+From here, peek into the `package.json` file and ensure the "devDependency" of `@spectrum-css/spectrumpattern` listed there is of the most current version. Once you have confirmed that run `yarn` in your terminal to get any new packages added to the repository and have the CSS provided therein processed for use in your component using the default configuration. You'll now be able to review your component via the Storybook command `yarn storybook` or see it appear in tests via `yarn test` so that you can dive into fully preparing the patterns for use as a custom element.
+
+From here, the next look when continuing to develop your new component pattern is in `node_modules/@spectrum-css/spectrumpattern/metadata/spectrumpattern.yml`. Here you will find complete Spectrum CSS correct HTML representation of the many states, variants, and capabilities offered by the pattern that you are working with and will support you in ensuring that you have fulfilled the features that are expected of this pattern. The HTML found here is that found in the examples of this pattern made available in the <sp-link href="https://opensource.adobe.com/spectrum-css">Spectrum CSS documentation site</sp-link>.
+
+With this scaffold as a baseline in conjunction with these <sp-link href="guides/developing-components">instructions</sp-link> on working with the web components in general and the Spectrum Web Components repository in specific and the specification for the <sp-link href="guides/spectrum-config">`spectrum-config.js`</sp-link> outlining how to translate the Spectrum CSS source you will be working from into shadow DOM optimized CSS you are well on your way to adding a new package to the project. If you run into any issues with the instructions above of linked to across this documentation site, please feel free to raise <sp-link href="https://github.com/adobe/spectrum-web-components/issues">quesitons and issues</sp-link> on GitHub either as brand new issues when specifically related to the process of generating a component or as comments on the broader issue of adding a specific pattern when in reference to bringing a specific component to live.
+
+Thanks for stopping by, we look forward to your contribution!

--- a/documentation/guides/spectrum-config.md
+++ b/documentation/guides/spectrum-config.md
@@ -1,4 +1,4 @@
-# Specification for .spectrum-config.js files
+# Specification for spectrum-config.js files
 
 The following is an annotated example that serves to document the format
 of the spectrum-config.js file. A higher-level explanation may be found

--- a/documentation/src/components/side-nav.ts
+++ b/documentation/src/components/side-nav.ts
@@ -121,8 +121,12 @@ class SideNav extends SpectrumElement {
                             multilevel
                         >
                             <sp-sidenav-item
-                                value="adding-component"
-                                label="Adding Components"
+                                value="developing-components"
+                                label="Developing Components"
+                            ></sp-sidenav-item>
+                            <sp-sidenav-item
+                                value="generating-components"
+                                label="Generating Components"
                             ></sp-sidenav-item>
                             <sp-sidenav-item
                                 value="spectrum-config"


### PR DESCRIPTION
## Description
Adds documentation on working with the component package generation script and getting started from the Spectrum CSS source CSS/HTML.
- updates some spelling/linking on existing "Guides" pages

## Related Issue
fixes #590

## Motivation and Context
Help external contributors contribute to the project from scratch

## How Has This Been Tested?
Available for live review at https://5f6fbe59b444f53141be1701--spectrum-web-components.netlify.app/
![image](https://user-images.githubusercontent.com/1156657/94690010-8ec21e80-02fd-11eb-9fb6-f39d7b265a68.png)


## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
