### PR TITLE
fix: improve accessibility through aria-label attribute usage

### DIFF
--- a/packages/bar-loader/src/BarLoader.ts
+++ b/packages/bar-loader/src/BarLoader.ts
@@ -91,5 +91,8 @@ export class BarLoader extends SpectrumElement {
         } else if (this.hasAttribute('aria-valuenow')) {
             this.removeAttribute('aria-valuenow');
         }
+        if (this.label && changes.has('label')) {
+            this.setAttribute('aria-label', this.label);
+        }
     }
 }

--- a/packages/circle-loader/src/CircleLoader.ts
+++ b/packages/circle-loader/src/CircleLoader.ts
@@ -30,6 +30,9 @@ export class CircleLoader extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public indeterminate = false;
 
+    @property({ type: String })
+    public label = '';
+
     @property({ type: Boolean, reflect: true, attribute: 'over-background' })
     public overBackground = false;
 
@@ -85,6 +88,9 @@ export class CircleLoader extends SpectrumElement {
             this.setAttribute('aria-valuenow', '' + this.progress);
         } else if (this.hasAttribute('aria-valuenow')) {
             this.removeAttribute('aria-valuenow');
+        }
+        if (this.label && changes.has('label')) {
+            this.setAttribute('aria-label', this.label);
         }
     }
 }


### PR DESCRIPTION
## Description
Ensure the correct visibility of `role=progress` elements in the accessibility tree through passing their `label` property into the `aria-label` attribute.

## Related Issue
fixes #882

## Motivation and Context
Components should be more accessible.

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/1156657/94352335-9fd70b00-0031-11eb-9cf1-4f97d520a9c2.png)
In https://5f6fca092785764a46d086a8--spectrum-web-components.netlify.app/

## Types of changes
- [x] Feature

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
