### PR TITLE
ci: update golden image creation process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
         environment:
             NODE_ENV: development
 parameters:
-    current_golden_images_hash:
+    current_golden_images_cache_key:
         type: string
         default: d03d62ccb93494ae1bc7ecfc21fe66e1c5bc46a9
 commands:
@@ -40,7 +40,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v2-golden-images-<< pipeline.parameters.current_golden_images_hash >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
+                      - v2-golden-images-<< pipeline.parameters.current_golden_images_cache_key >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
                       - v2-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
             - run:
@@ -260,7 +260,7 @@ jobs:
                   command: |
                       cd .circleci
                       touch tmp
-                      sed 's/<< pipeline.parameters.current_golden_images_hash >>/<< pipeline.git.revision >>/g' config.yml > tmp 
+                      sed 's/<< pipeline.parameters.current_golden_images_cache_key >>/<< pipeline.git.revision >>/g' config.yml > tmp 
                       rm config.yml
                       mv tmp config.yml
                       git add config.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_cache_key:
         type: string
-        default: d03d62ccb93494ae1bc7ecfc21fe66e1c5bc46a9
+        default: 32a7234fa940873e1849e226dd3a63ad44c00db1
 commands:
     setup:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ executors:
             - image: mcr.microsoft.com/playwright:next
         environment:
             NODE_ENV: development
+parameters:
+    current_golden_images_hash:
+        type: string
+        default: d03d62ccb93494ae1bc7ecfc21fe66e1c5bc46a9
 commands:
     setup:
         steps:
@@ -36,18 +40,18 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v2-golden-images-d03d62ccb93494ae1bc7ecfc21fe66e1c5bc46a9-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
+                      - v2-golden-images-<< pipeline.parameters.current_golden_images_hash >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
                       - v2-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
             - run:
                   when: on_fail
-                  command: cp -RT test/visual/screenshots-current/ci test/visual/screenshots-baseline/ci && exit 1
+                  command: cp -RT test/visual/screenshots-current/ci test/visual/screenshots-baseline/ci
             - save_cache:
                   when: on_fail
                   name: Build Golden Images Revision Cache
                   paths:
                       - test/visual/screenshots-baseline/ci
-                  key: v2-golden-images-{{ .Revision }}-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
+                  key: v2-golden-images-{{ .Revision }}-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-{{ epoch }}
             - save_cache:
                   name: Build Golden Images Branch Cache
                   paths:
@@ -247,6 +251,26 @@ jobs:
                   regression_scale: large
                   regression_dir: rtl
 
+    apply-new-golden-image-cache:
+        executor: node
+
+        steps:
+            - downstream
+            - run:
+                  command: |
+                      cd .circleci
+                      touch tmp
+                      sed 's/<< pipeline.parameters.current_golden_images_hash >>/<< pipeline.git.revision >>/g' config.yml > tmp 
+                      rm config.yml
+                      mv tmp config.yml
+                      git add config.yml
+            - run:
+                  command: |
+                      git config --global user.email "circleci@adobe.com" && git config --global user.name "CircleCI"
+                      git commit -am 'ci: update golden images cache'
+                      git push --set-upstream origin << pipeline.git.branch >>
+                      git push
+
     publish-docs:
         executor: node
 
@@ -273,6 +297,13 @@ jobs:
 
 workflows:
     version: 2
+    manage-golden-images-cache:
+        jobs:
+            - approve-new-golden-image-cache:
+                  type: approval
+            - apply-new-golden-image-cache:
+                  requires:
+                      - approve-new-golden-image-cache
     build:
         jobs:
             - build

--- a/packages/accordion/stories/accordion.stories.ts
+++ b/packages/accordion/stories/accordion.stories.ts
@@ -37,6 +37,22 @@ export const Default = (): TemplateResult => {
     `;
 };
 
+export const Open = (): TemplateResult => {
+    return html`
+        <sp-accordion style="color: var(--spectrum-global-color-gray-800)">
+            <sp-accordion-item label="Heading 1">
+                <div>Item 1</div>
+            </sp-accordion-item>
+            <sp-accordion-item label="Heading 2" open>
+                Item 2
+            </sp-accordion-item>
+            <sp-accordion-item label="Heading 3">
+                Item 3
+            </sp-accordion-item>
+        </sp-accordion>
+    `;
+};
+
 export const AllowMultiple = (): TemplateResult => {
     return html`
         <sp-accordion

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 module.exports = [
     'accordion--default',
+    'accordion--open',
     'accordion--allow-multiple',
     'accordion--disabled',
     'action-group--default',


### PR DESCRIPTION
## Description
- ensure that changes to the golden images revision cache are more unique that _just_ the current commit hash (adding epoch)
- surface an "Approval" step in CircleCI to automatically update the revision cache ID that commits directly into your working branch so that the next CI run will start automatically with that new cache ID

## Motivation and Context
If the process of "building" a golden image revision cache fails procedurally (the run fails not the comparisons) then the cache ID is blown. This allows these fails not to require intervention outside of CircleCI to rerun them and still be able to update the "golden" cache from their output. It affords the same flexibility for bumping the cache ID via the CircleCI cache.

## How Has This Been Tested?
Painstaking running CI over and over to get things working the way I'd hope.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/94462619-cf009000-0189-11eb-992f-c3012d50e3b8.png)
![image](https://user-images.githubusercontent.com/1156657/94462657-d9228e80-0189-11eb-85f4-aec428b59de0.png)

## Types of changes
- [x] CI tooling.

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
