### PR TITLE
fix(action-menu): default to not taking a selection

### DIFF
--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -53,6 +53,40 @@ import { ActionMenu } from '@spectrum-web-components/action-menu';
 </sp-action-menu>
 ```
 
+### Selectable
+
+By default an `<sp-action-menu>` will prevent its `<sp-menu-item>` descendents from being selectable, meaning they will not append a checkmark to their visual delivery indicated that the item in question is "selected". With the `selectable` attribute you can turn this functionality on.
+
+NOTE: In both `<sp-action-menu>` and `<sp-action-menu selectable>` contexts the menu will dispatch a `change` event when items are clicked allowing your application to respond to that interaction whether the selection is visually present or not.
+
+<!-- prettier-ignore -->
+```html
+<sp-action-menu selectable value="Save selection">
+    <span slot="label">More Actions</span>
+    <sp-menu>
+        <sp-menu-item>
+            Deselect
+        </sp-menu-item>
+        <sp-menu-item>
+            Select inverse
+        </sp-menu-item>
+        <sp-menu-item>
+            Feather...
+        </sp-menu-item>
+        <sp-menu-item>
+            Select and mask...
+        </sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>
+            Save selection
+        </sp-menu-item>
+        <sp-menu-item disabled>
+            Make work path
+        </sp-menu-item>
+    </sp-menu>
+</sp-action-menu>
+```
+
 ## Variants
 
 ### No visible label
@@ -90,13 +124,45 @@ The visible label that is be provided via the default `<slot>` interface can be 
 
 A custom icon can be supplied via the `icon` slot in order to replace the default meatballs icon.
 
-<sp-icons-medium></sp-icons-medium>
-
 <!-- prettier-ignore -->
 ```html
 <sp-action-menu label="More actions">
     <sp-icon slot="icon" size="s"><svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18"><rect id="Canvas" fill="#ff13dc" opacity="0" width="18" height="18" /><path class="a" d="M16.45,7.8965H14.8945a5.97644,5.97644,0,0,0-.921-2.2535L15.076,4.54a.55.55,0,0,0,.00219-.77781L15.076,3.76l-.8365-.836a.55.55,0,0,0-.77781-.00219L13.4595,2.924,12.357,4.0265a5.96235,5.96235,0,0,0-2.2535-.9205V1.55a.55.55,0,0,0-.55-.55H8.45a.55.55,0,0,0-.55.55V3.106a5.96235,5.96235,0,0,0-2.2535.9205l-1.1-1.1025a.55.55,0,0,0-.77781-.00219L3.7665,2.924,2.924,3.76a.55.55,0,0,0-.00219.77781L2.924,4.54,4.0265,5.643a5.97644,5.97644,0,0,0-.921,2.2535H1.55a.55.55,0,0,0-.55.55V9.55a.55.55,0,0,0,.55.55H3.1055a5.967,5.967,0,0,0,.921,2.2535L2.924,13.4595a.55.55,0,0,0-.00219.77782l.00219.00218.8365.8365a.55.55,0,0,0,.77781.00219L4.5405,15.076,5.643,13.9735a5.96235,5.96235,0,0,0,2.2535.9205V16.45a.55.55,0,0,0,.55.55H9.55a.55.55,0,0,0,.55-.55V14.894a5.96235,5.96235,0,0,0,2.2535-.9205L13.456,15.076a.55.55,0,0,0,.77782.00219L14.236,15.076l.8365-.8365a.55.55,0,0,0,.00219-.77781l-.00219-.00219L13.97,12.357a5.967,5.967,0,0,0,.921-2.2535H16.45a.55.55,0,0,0,.55-.55V8.45a.55.55,0,0,0-.54649-.55349ZM11.207,9A2.207,2.207,0,1,1,9,6.793H9A2.207,2.207,0,0,1,11.207,9Z" /></svg></sp-icon>
     <span slot="label">Actions under the gear</span>
+    <sp-menu>
+        <sp-menu-item>
+            Deselect
+        </sp-menu-item>
+        <sp-menu-item>
+            Select inverse
+        </sp-menu-item>
+        <sp-menu-item>
+            Feather...
+        </sp-menu-item>
+        <sp-menu-item>
+            Select and mask...
+        </sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>
+            Save selection
+        </sp-menu-item>
+        <sp-menu-item disabled>
+            Make work path
+        </sp-menu-item>
+    </sp-menu>
+</sp-action-menu>
+```
+
+## Alternate icon, no visible label
+
+<!-- prettier-ignore -->
+```html
+<sp-action-menu label="More actions">
+    <sp-icon slot="icon" size="s">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" role="img" fill="currentColor" height="24" width="24" aria-hidden="false" aria-label="Menu">
+            <path d="M33 2H3a1 1 0 00-1 1v30a1 1 0 001 1h30a1 1 0 001-1V3a1 1 0 00-1-1zm-5.394 13.707L18 25.314l-9.606-9.607A1 1 0 019.1 14h17.8a1 1 0 01.706 1.707z"></path>
+        </svg>
+    </sp-icon>
     <sp-menu>
         <sp-menu-item>
             Deselect

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -31,7 +31,7 @@ export class ActionMenu extends ObserveSlotText(DropdownBase, 'label') {
     }
 
     @property({ type: Boolean, reflect: true })
-    public selected = false;
+    public selectable = false;
 
     @property({ type: Boolean, reflect: true })
     public quiet = true;
@@ -63,14 +63,29 @@ export class ActionMenu extends ObserveSlotText(DropdownBase, 'label') {
 
     protected updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
-        if (changedProperties.has('open')) {
-            this.selected = this.open;
-        }
         if (changedProperties.has('quiet')) {
             this.quiet = true;
         }
         if (changedProperties.has('invalid')) {
             this.invalid = false;
+        }
+        if (changedProperties.has('open')) {
+            this.manageMenuItems();
+        }
+    }
+
+    private async manageMenuItems(): Promise<void> {
+        if (this.selectable || !this.optionsMenu) {
+            return;
+        }
+        if (this.optionsMenu.menuItems.length) {
+            this.optionsMenu.menuItems.forEach((el) => (el.selected = false));
+            return;
+        }
+        await this.optionsMenu.updateComplete;
+        /* istanbul ignore else */
+        if (this.optionsMenu.menuItems.length) {
+            this.manageMenuItems();
         }
     }
 }

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -39,6 +39,21 @@ export const customIcon = (): TemplateResult => {
     `;
 };
 
+export const open = (): TemplateResult => {
+    return ActionMenuMarkup({
+        open: true,
+        value: 'Select Inverse',
+    });
+};
+
+export const selectableOpen = (): TemplateResult => {
+    return ActionMenuMarkup({
+        selectable: true,
+        open: true,
+        value: 'Select Inverse',
+    });
+};
+
 export const Default = (): TemplateResult => {
     const ariaLabel = text('Arial Label', 'More Actions', 'Component');
     const visibleLabel = text('Visible Label', 'More Actions', 'Component');

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -22,12 +22,18 @@ export const ActionMenuMarkup = ({
     disabled = false,
     visibleLabel = '',
     customIcon = '' as string | TemplateResult,
+    selectable = false,
+    open = false,
+    value = '',
 } = {}): TemplateResult => {
     return html`
         <sp-action-menu
             label=${ariaLabel}
             ?disabled=${disabled}
             @change="${changeHandler}"
+            ?selectable=${selectable}
+            ?open=${open}
+            value=${value}
         >
             ${customIcon
                 ? html`

--- a/packages/action-menu/test/action-menu.test.ts
+++ b/packages/action-menu/test/action-menu.test.ts
@@ -17,7 +17,14 @@ import { SettingsIcon } from '@spectrum-web-components/icons-workflow';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
-import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    waitUntil,
+} from '@open-wc/testing';
+import { MenuItem } from '@spectrum-web-components/menu/src/MenuItem';
 
 const actionMenuFixture = async (): Promise<ActionMenu> =>
     await fixture<ActionMenu>(
@@ -158,5 +165,46 @@ describe('Action menu', () => {
         button.click();
         await elementUpdated(el);
         expect(el.open).to.be.true;
+    });
+    it('prevents menu items from being [selected]', async () => {
+        const el = await actionMenuFixture();
+
+        await elementUpdated(el);
+        const button = el.button as HTMLButtonElement;
+        const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+        const beforeSelectedItems = [...el.querySelectorAll('[selected]')];
+        expect(beforeSelectedItems.length).to.equal(0);
+
+        button.click();
+        await elementUpdated(el);
+
+        firstItem.click();
+        await waitUntil(
+            () => [...el.querySelectorAll('[selected]')].length === 0,
+            'return item to `selected=false`'
+        );
+
+        expect(el.value).to.equal('Deselect');
+    });
+    it('[selectable] allows menu items to be [selected]', async () => {
+        const el = await actionMenuFixture();
+        el.selectable = true;
+
+        await elementUpdated(el);
+        const button = el.button as HTMLButtonElement;
+        const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+        const beforeSelectedItems = [...el.querySelectorAll('[selected]')];
+        expect(beforeSelectedItems.length).to.equal(0);
+
+        button.click();
+        await elementUpdated(el);
+
+        firstItem.click();
+        await waitUntil(
+            () => [...el.querySelectorAll('[selected]')].length === 1,
+            'set item to `selected=true`'
+        );
+
+        expect(el.value).to.equal('Deselect');
     });
 });

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -16,6 +16,10 @@ governing permissions and limitations under the License.
     display: block;
 }
 
+:host([tabindex]:focus) {
+    outline: none;
+}
+
 #selected {
     flex-shrink: 0;
 }

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -32,6 +32,8 @@ module.exports = [
     'action-menu--default',
     'action-menu--custom-icon',
     'action-menu--icon-only',
+    'action-menu--selectable-open',
+    'action-menu--open',
     'actionbar--default',
     'asset--default',
     'asset--file',


### PR DESCRIPTION
## Description
Should likely go AFTER #905 where we are doing other accessibility and VO work on the Dropdown (base class) element that could effect this change. In particular, pre-905 we throw focus into the first/selected menu item when opening the menu, which causes a slight visual bug herein.

Add a `selectable` attribute to the `sp-action-menu` API so that by default the menu does not display a visual selection.

This doesn't alter the `change` event that triggers when the selection is made which will allow actions to be registered against individual `sp-menu-item` children or agains the `sp-action-menu` as a whole. Action on the `click` event of individual children would need to be managed with reverence to `await ActionMenu.updateComplete;` if they chose to throw focus, but I'm not sure if that should be directly documented or if preference should be given to using the `change` event here.

## Related Issue
fixes #350

## Motivation and Context
"Action" menus don't really have a selections.

## How Has This Been Tested?
Visually in storybook.
New unit tests

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
