### PR TITLE
fix(radio): select in response to arrow keys not focus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: af71b4f04045c4a48bae7986a7e6aae4cdfac7d0
+        default: d328839a4482138bdb2a119b3bb656ed45f209e3
 commands:
     setup:
         steps:

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -32,6 +32,9 @@ export class RadioGroup extends SpectrumElement {
         return [radioGroupStyles];
     }
 
+    @property({ type: String })
+    public name = '';
+
     @queryAssignedNodes('')
     public defaultNodes!: Node[];
 
@@ -61,9 +64,7 @@ export class RadioGroup extends SpectrumElement {
         }
     }
 
-    private handleFocusin = (event: FocusEvent): void => {
-        const target = event.target as Radio;
-        this.selected = target.value;
+    private handleFocusin = (): void => {
         this.addEventListener('focusout', this.handleFocusout);
         this.addEventListener('keydown', this.handleKeydown);
         requestAnimationFrame(() => {
@@ -151,7 +152,9 @@ export class RadioGroup extends SpectrumElement {
                 return;
         }
         event.preventDefault();
-        circularIndexedElement(this.buttons, nextIndex).focus();
+        const nextRadio = circularIndexedElement(this.buttons, nextIndex);
+        nextRadio.focus();
+        this.selected = nextRadio.value;
     };
 
     private handleFocusout = (): void => {
@@ -167,9 +170,6 @@ export class RadioGroup extends SpectrumElement {
         this.removeEventListener('keydown', this.handleKeydown);
         this.removeEventListener('focusout', this.handleFocusout);
     };
-
-    @property({ type: String, reflect: true })
-    public name = '';
 
     private _selected = '';
 

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -65,6 +65,41 @@ describe('Radio Group - focus control', () => {
 
         expect(document.activeElement === selected).to.be.true;
     });
+    it('does not select on focus', async () => {
+        const el = await fixture<RadioGroup>(
+            html`
+                <sp-radio-group>
+                    <sp-radio value="1">Options 1</sp-radio>
+                    <sp-radio value="2">Options 2</sp-radio>
+                    <sp-radio value="3">Options 3</sp-radio>
+                    <sp-radio value="4">Options 4</sp-radio>
+                    <sp-radio value="5">Options 5</sp-radio>
+                </sp-radio-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const radio1 = el.querySelector('sp-radio:nth-child(1)') as Radio;
+        const radio2 = el.querySelector('sp-radio:nth-child(2)') as Radio;
+
+        expect(el.selected).to.equal('');
+
+        radio1.focus();
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('');
+        el.selected = '1';
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('1');
+        expect(radio1.checked).to.be.true;
+        radio2.focus();
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('1');
+        expect(radio1.checked).to.be.true;
+    });
     it('loads accepts keyboard events while focused', async () => {
         const el = await fixture<RadioGroup>(
             html`
@@ -122,7 +157,7 @@ describe('Radio Group - focus control', () => {
 
         radio1.blur();
     });
-    it('loads accepts keyboard events while focused', async () => {
+    it('acknowledges `disabled` and accepts keyboard events while focused', async () => {
         const el = await fixture<RadioGroup>(
             html`
                 <sp-radio-group>


### PR DESCRIPTION
## Description 
Update selection mechanism so that swipes in iOS Safari with voice over do not change selection. This also updates the response to the `autofocus` attribute to match what we see in native elements, as seen in the visual regression update.

## Related Issue
fixes #766 

## Motivation and Context
Deliver accessibility features on pair with native elements.

## How Has This Been Tested?
Manually in iOS Safari with VO

## Screenshots (if appropriate):
![Image from iOS](https://user-images.githubusercontent.com/1156657/94562404-4d653c80-0233-11eb-82d5-14abb07108ea.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
