### PR TITLE
ci: run commitlint in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,29 @@ commands:
                   path: test/visual/screenshots-current
 
 jobs:
+    commitlint:
+        executor: node
+
+        steps:
+            - checkout
+            - restore_cache:
+                  keys:
+                      - v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+            - run:
+                  name: Installing Dependencies
+                  command: yarn --ignore-scripts
+            - save_cache:
+                  paths:
+                      - node_modules
+                  key: v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+            - run:
+                  name: Define environment variable with lastest commit's message
+                  command: |
+                      echo 'export COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s")' >> $BASH_ENV
+                      source $BASH_ENV
+            - run:
+                  name: Lint commit message
+                  command: echo "$COMMIT_MESSAGE" | npx commitlint
     build:
         executor: node
 
@@ -273,6 +296,9 @@ jobs:
 
 workflows:
     version: 2
+    commitlint:
+        jobs:
+            - commitlint
     build:
         jobs:
             - build


### PR DESCRIPTION
Replace the GH integration with commitlint with a CircleCI workflow. Checkout:

https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/4050/workflows/3f03ce31-823e-4c5a-af2f-686f7236781d/jobs/21246
https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/4056/workflows/38f7a208-7866-4a29-9691-5c997e810770/jobs/21253
https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/4058/workflows/57370172-e67b-40f9-9fd5-9b9db0768163/jobs/21341