### PR TITLE
fix(overlay): close when overlay-trigger becomes [disabled]

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -16,6 +16,7 @@ import {
     property,
     CSSResultArray,
     TemplateResult,
+    PropertyValues,
 } from '@spectrum-web-components/base';
 
 import {
@@ -90,6 +91,17 @@ export class OverlayTrigger extends LitElement {
                 ></slot>
             </div>
         `;
+    }
+
+    protected updated(changes: PropertyValues): void {
+        super.updated(changes);
+        if (
+            this.disabled &&
+            this.closeClickOverlay &&
+            changes.has('disabled')
+        ) {
+            this.closeClickOverlay();
+        }
     }
 
     public static openOverlay = async (

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -162,6 +162,38 @@ describe('Overlay Trigger', () => {
         expect(isVisible(outerPopover)).to.be.true;
     });
 
+    it('[disabled] closes a popover', async () => {
+        const el = testDiv.querySelector('#trigger') as OverlayTrigger;
+        const button = testDiv.querySelector('#outer-button') as HTMLElement;
+        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
+
+        expect(isVisible(outerPopover)).to.be.false;
+        expect(el.disabled).to.be.false;
+
+        expect(button).to.exist;
+        button.click();
+
+        await waitUntil(
+            () => !(outerPopover.parentElement instanceof OverlayTrigger),
+            'Wait for the DOM node to be stolen and reparented into the overlay'
+        );
+
+        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
+            OverlayTrigger
+        );
+        expect(isVisible(outerPopover)).to.be.true;
+
+        el.disabled = true;
+
+        await waitUntil(
+            () => outerPopover.parentElement instanceof OverlayTrigger,
+            'Wait for the DOM node to be returned to the overlay trigger'
+        );
+
+        expect(isVisible(outerPopover)).to.be.false;
+        expect(el.disabled).to.be.true;
+    });
+
     it('resizes a popover', async () => {
         const button = testDiv.querySelector('#outer-button') as HTMLElement;
         const outerPopover = testDiv.querySelector('#outer-popover') as Popover;


### PR DESCRIPTION
## Description
Ensure that an `overlay-trigger` will close its overlays when it is given the `disabled` attribute/property.

## Related Issue
fixes #278

## Motivation and Context
State changes at the broader application level should be able to effect lower level UI offering.

## How Has This Been Tested?
- new unit test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
