### PR TITLE
docs: remove adoptedStyleSheet dev time workarounds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
-                      - v2-golden-images-d03d62ccb93494ae1bc7ecfc21fe66e1c5bc46a9-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
+                      - v2-golden-images-79d1ceb110a917eb700123a8a557c2ce3edf4958-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
                       - v2-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
             - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
             - run:

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,9 +1,3 @@
-<script>
-    // @TODO: Remove this after user agent stylesheet bug is fixed
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=946975
-    delete Document.prototype.adoptedStyleSheets;
-</script>
-
 <!-- For Adobe Clean font support -->
 <link rel="stylesheet" href="https://use.typekit.net/evk7lzt.css" />
 

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -30,13 +30,13 @@
             // When the single page app is loaded further down in this file,
             // the correct url will be waiting in the browser's history for
             // the single page app to route accordingly.
-            (function(l) {
+            (function (l) {
                 if (l.search) {
                     var q = {};
                     l.search
                         .slice(1)
                         .split('&')
-                        .forEach(function(v) {
+                        .forEach(function (v) {
                             var a = v.split('=');
                             q[a[0]] = a
                                 .slice(1)
@@ -57,11 +57,6 @@
             })(window.location);
         </script>
         <!-- End Single Page Apps for GitHub Pages -->
-        <script>
-            // @TODO: Remove this after user agent stylesheet bug is fixed
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=946975
-            delete Document.prototype.adoptedStyleSheets;
-        </script>
         <script type="module" defer src="./src/main.js"></script>
     </head>
     <body>


### PR DESCRIPTION
## Description 
Chrome allows you to edit these styles in DevTools now, let's revel in the performance boost even at dev time!

## Related Issue
fixes #722

## Motivation and Context
Faster is better!

## Types of changes
- [x] refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
