### PR TITLE
fix: include default export in the "exports" fields

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
     node:
         docker:
-            - image: mcr.microsoft.com/playwright:next
+            - image: mcr.microsoft.com/playwright:bionic
         environment:
             NODE_ENV: development
 parameters:

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/actionbar/package.json
+++ b/packages/actionbar/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/bar-loader/package.json
+++ b/packages/bar-loader/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/circle-loader/package.json
+++ b/packages/circle-loader/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -23,6 +23,7 @@
     "main": "lib/index.js",
     "module": "lib/index.js",
     "exports": {
+        ".": "./src/index.js",
         "./lib/": "./lib/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -23,6 +23,7 @@
     "main": "lib/index.js",
     "module": "lib/index.js",
     "exports": {
+        ".": "./src/index.js",
         "./lib/": "./lib/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -23,6 +23,7 @@
     "main": "src/index.js",
     "module": "src/index.js",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/rule/package.json
+++ b/packages/rule/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -24,6 +24,7 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
+        ".": "./src/index.js",
         "./src/": "./src/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",


### PR DESCRIPTION
## Description
Prep for usages in `webpack@5` and correct distribution via jspm.dev
- Add `exports` listings for default exports.
- Correct extension usage for `lit-html` directives

## Related Issue
fixes #932
refs #878 
 
## Motivation and Context
Our packages should work in all bundlers out of the box and be available via CDNs.

## How Has This Been Tested?
Manually created a `webpack@5` project locally and installed `@spectrum-web-components/bundle@0.15.4-beta.17` to test. Also tracked https://jspm.dev/npm:@spectrum-web-components/base@0.1.2-alpha.17 to actual file as opposed to what you get from https://jspm.dev/npm:@spectrum-web-components/base@0.1.1

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
