### PR TITLE
fix: switch to heading/subheading instead of title

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 851f063126923cca87b05ab5406de26fa578de10
+        default: 565f50413cf10b49d83fa00f474893568c6137ac
 commands:
     setup:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 565f50413cf10b49d83fa00f474893568c6137ac
+        default: cb80d9c57e1307d31e1d372cafe1da7f84332664
 commands:
     setup:
         steps:

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -29,7 +29,7 @@ import { Card } from '@spectrum-web-components/card';
 ## Example
 
 ```html demo
-<sp-card title="Card Title" subtitle="JPG">
+<sp-card heading="Card Heading" subheading="JPG">
     <img
         slot="cover-photo"
         src="https://picsum.photos/200/300"
@@ -39,13 +39,13 @@ import { Card } from '@spectrum-web-components/card';
 </sp-card>
 ```
 
-## Title
+## Heading
 
-By default, the title for an `sp-card` is applied via the `title` attribute, which is restricted to string content only. When HTML content is desired, a slot named `title` available for applying the title.
+By default, the heading for an `sp-card` is applied via the `heading` attribute, which is restricted to string content only. When HTML content is desired, a slot named `heading` available for applying the heading.
 
 ```html demo
-<sp-card subtitle="JPG" style="--spectrum-card-body-header-height: auto;">
-    <h1 slot="title">Card title</h1>
+<sp-card subheading="JPG" style="--spectrum-card-body-header-height: auto;">
+    <h1 slot="heading">Card Heading</h1>
     <img alt="" slot="cover-photo" src="https://picsum.photos/200/300" />
     <div slot="footer">Footer</div>
 </sp-card>
@@ -58,12 +58,12 @@ attribute controls the main variant of the card.
 
 ### Normal
 
-Normal cards can contain a title, a subtitle, a cover photo, and a footer.
+Normal cards can contain a heading, a subheading, a cover photo, and a footer.
 
 ```html
-<sp-card title="Card title">
+<sp-card heading="Card Heading">
     <img alt="" slot="cover-photo" src="https://picsum.photos/200/300" />
-    <span slot="subtitle">JPG</span>
+    <span slot="subheading">JPG</span>
     <div slot="footer">Footer</div>
 </sp-card>
 ```
@@ -73,7 +73,7 @@ Normal cards can contain a title, a subtitle, a cover photo, and a footer.
 Cards can be supplied an `actions` via a names slot.
 
 ```html
-<sp-card title="Card Title" subtitle="JPG">
+<sp-card heading="Card Heading" subheading="JPG">
     <img
         slot="cover-photo"
         src="https://picsum.photos/200/300"
@@ -116,11 +116,11 @@ An empty card will still fill space in a design.
 
 ### Quiet
 
-Quiet cards can contain a title, a subtitle, a cover photo, a description, and a footer.
+Quiet cards can contain a heading, a subheading, a cover photo, a description, and a footer.
 
 ```html
 <div style="width: 208px; height: 264px">
-    <sp-card variant="quiet" title="Card title" subtitle="JPG">
+    <sp-card variant="quiet" heading="Card Heading" subheading="JPG">
         <img alt="" slot="preview" src="https://picsum.photos/200/300" />
         <div slot="description">10/15/18</div>
         <div slot="footer">Footer</div>
@@ -132,9 +132,14 @@ When leveraging the `asset` attribute, a card can be declared as representing a 
 
 ```html
 <div style="width: 208px; height: 264px">
-    <sp-card variant="quiet" title="Card title" subtitle="JPG" asset="file">
+    <sp-card
+        variant="quiet"
+        heading="Card Heading"
+        subheading="JPG"
+        asset="file"
+    >
         <img alt="" slot="preview" src="https://picsum.photos/200/300" />
-        <div slot="title">File Name</div>
+        <div slot="heading">File Name</div>
         <div slot="description">10/15/18</div>
         <div slot="footer">Footer</div>
     </sp-card>
@@ -145,9 +150,9 @@ Or a `folder`:
 
 ```html
 <div style="width: 208px; height: 264px">
-    <sp-card variant="quiet" subtitle="JPG" asset="folder">
+    <sp-card variant="quiet" subheading="JPG" asset="folder">
         <img alt="" slot="preview" src="https://picsum.photos/200/300" />
-        <div slot="title">Folder Name</div>
+        <div slot="heading">Folder Name</div>
         <div slot="description">10/15/18</div>
         <div slot="footer">Footer</div>
     </sp-card>
@@ -158,7 +163,7 @@ Quiet cards will also accept `actions` via a named slot.
 
 ```html
 <div style="width: 208px; height: 264px">
-    <sp-card variant="quiet" title="Card title" subtitle="JPG">
+    <sp-card variant="quiet" heading="Card Heading" subheading="JPG">
         <img alt="" slot="preview" src="https://picsum.photos/200/300" />
         <div slot="description">10/15/18</div>
         <sp-action-menu slot="actions" placement="bottom-end">
@@ -190,11 +195,11 @@ Quiet cards will also accept `actions` via a named slot.
 
 ### Gallery
 
-Gallery cards can contain a title, a subtitle, an image preview, a description, and a footer.
+Gallery cards can contain a heading, a subheading, an image preview, a description, and a footer.
 
 ```html
 <div style="width: 532px; height: 224px">
-    <sp-card variant="gallery" title="Card title" subtitle="JPG">
+    <sp-card variant="gallery" heading="Card Heading" subheading="JPG">
         <img alt="" slot="preview" src="https://picsum.photos/532/192" />
         <div slot="description">10/15/18</div>
         <div slot="footer">Footer</div>
@@ -208,7 +213,7 @@ The `small` attriibute can be applied to a standard card:
 
 ```html demo
 <div style="width: 208px; height: 264px">
-    <sp-card small title="Card Title" subtitle="JPG">
+    <sp-card small heading="Card Heading" subheading="JPG">
         <img
             slot="cover-photo"
             alt="Demo Image"
@@ -225,7 +230,7 @@ A `horizontal` card:
 <div
     style="color: var(--spectrum-body-text-color, var(--spectrum-alias-text-color));"
 >
-    <sp-card small horizontal title="Card Title" subtitle="JPG">
+    <sp-card small horizontal heading="Card Heading" subheading="JPG">
         <sp-icon slot="preview" style="width: 36px; height: 36px;">
             <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -250,7 +255,7 @@ Or a `quiet` card:
 <div
     style="color: var(--spectrum-body-text-color, var(--spectrum-alias-text-color)); width: 110px;"
 >
-    <sp-card small title="Card Title" subtitle="JPG" variant="quiet">
+    <sp-card small heading="Card Heading" subheading="JPG" variant="quiet">
         <img src="https://picsum.photos/110" alt="Demo Image" slot="preview" />
         <div slot="footer">Footer</div>
         <sp-action-menu slot="actions" placement="bottom-end">

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -34,8 +34,8 @@ import { Checkbox } from '@spectrum-web-components/checkbox/src/Checkbox';
  * @fires change - Announces a change in the `selected` property of a card
  * @slot preview - This is the preview image for Gallery Cards
  * @slot cover-photo - This is the cover photo for Default and Quiet Cards
- * @slot title - HTML content to be listed as the title
- * @slot subtitle - HTML content to be listed as the subtitle
+ * @slot heading - HTML content to be listed as the heading
+ * @slot subheading - HTML content to be listed as the subheading
  * @slot description - A description of the card
  * @slot actions - an `sp-action-menu` element outlining actions to take on the represened object
  * @slot footer - Footer text
@@ -55,7 +55,7 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public selected = false;
 
     @property()
-    public title = '';
+    public heading = '';
 
     @property({ type: Boolean, reflect: true })
     public horizontal = false;
@@ -70,7 +70,7 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public toggles = false;
 
     @property()
-    public subtitle = '';
+    public subheading = '';
 
     public constructor() {
         super();
@@ -131,11 +131,11 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    protected get renderTitle(): TemplateResult {
+    protected get renderHeading(): TemplateResult {
         return html`
             <div class="title">
-                <slot name="title">
-                    ${this.title}
+                <slot name="heading">
+                    ${this.heading}
                 </slot>
             </div>
         `;
@@ -189,12 +189,12 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
             ${this.renderImage()}
             <div class="body">
                 <div class="header">
-                    ${this.renderTitle}
+                    ${this.renderHeading}
                     ${this.variant === 'gallery'
                         ? html`
                               <div class="subtitle">
-                                  <slot name="subtitle">
-                                      ${this.subtitle}
+                                  <slot name="subheading">
+                                      ${this.subheading}
                                   </slot>
                               </div>
                               <slot name="description"></slot>
@@ -212,8 +212,8 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
                     ? html`
                           <div class="content">
                               <div class="subtitle">
-                                  <slot name="subtitle">
-                                      ${this.subtitle}
+                                  <slot name="subheading">
+                                      ${this.subheading}
                                   </slot>
                               </div>
                               <slot name="description"></slot>

--- a/packages/card/src/card.css
+++ b/packages/card/src/card.css
@@ -50,9 +50,9 @@ sp-quick-actions {
 }
 
 /**
- * Allow that the title element will take specified use of the available width whether 
+ * Allow that the heading element will take specified use of the available width whether 
  * "actions" are supplied to the element or not.
  **/
-.title {
+.heading {
     width: var(--spectrum-card-title-width);
 }

--- a/packages/card/src/spectrum-config.js
+++ b/packages/card/src/spectrum-config.js
@@ -26,12 +26,12 @@ const config = {
                     name: 'header',
                 },
                 {
-                    selector: '.spectrum-Card-title',
-                    name: 'title',
+                    selector: '.spectrum-Card-heading',
+                    name: 'heading',
                 },
                 {
-                    selector: '.spectrum-Card-subtitle',
-                    name: 'subtitle',
+                    selector: '.spectrum-Card-subheading',
+                    name: 'subheading',
                 },
                 {
                     selector: '.spectrum-Card-content',

--- a/packages/card/src/spectrum-config.js
+++ b/packages/card/src/spectrum-config.js
@@ -26,12 +26,12 @@ const config = {
                     name: 'header',
                 },
                 {
-                    selector: '.spectrum-Card-heading',
-                    name: 'heading',
+                    selector: '.spectrum-Card-title',
+                    name: 'title',
                 },
                 {
-                    selector: '.spectrum-Card-subheading',
-                    name: 'subheading',
+                    selector: '.spectrum-Card-subtitle',
+                    name: 'subtitle',
                 },
                 {
                     selector: '.spectrum-Card-content',

--- a/packages/card/stories/card.stories.ts
+++ b/packages/card/stories/card.stories.ts
@@ -27,7 +27,7 @@ export default {
 export const Default = (): TemplateResult => {
     return html`
         <div>
-            <sp-card title="Card Title" subtitle="JPG">
+            <sp-card heading="Card Heading" subheading="JPG">
                 <img slot="cover-photo" src=${portrait} alt="Demo Image" />
                 <div slot="footer">Footer</div>
             </sp-card>
@@ -38,7 +38,7 @@ export const Default = (): TemplateResult => {
 export const actions = (): TemplateResult => {
     return html`
         <div>
-            <sp-card title="Card Title" subtitle="JPG">
+            <sp-card heading="Card Heading" subheading="JPG">
                 <img slot="cover-photo" src=${portrait} alt="Demo Image" />
                 <div slot="footer">Footer</div>
                 <sp-action-menu slot="actions" placement="bottom-end">
@@ -80,7 +80,7 @@ export const empty = (): TemplateResult => {
 export const Gallery = (): TemplateResult => {
     return html`
         <div style="width: 532px; height: 224px">
-            <sp-card variant="gallery" title="Card Title" subtitle="JPG">
+            <sp-card variant="gallery" heading="Card Heading" subheading="JPG">
                 <img
                     slot="preview"
                     src=${landscape}
@@ -96,7 +96,7 @@ export const Gallery = (): TemplateResult => {
 export const Quiet = (): TemplateResult => {
     return html`
         <div style="width: 208px; height: 264px">
-            <sp-card variant="quiet" title="Card Title" subtitle="JPG">
+            <sp-card variant="quiet" heading="Card Heading" subheading="JPG">
                 <img src=${portrait} alt="Demo Image" slot="preview" />
                 <div slot="description">10/15/18</div>
             </sp-card>
@@ -107,9 +107,9 @@ export const Quiet = (): TemplateResult => {
 export const quietFile = (): TemplateResult => {
     return html`
         <div style="width: 208px; height: 264px">
-            <sp-card variant="quiet" subtitle="JPG" asset="file">
+            <sp-card variant="quiet" subheading="JPG" asset="file">
                 <img src=${portrait} alt="Demo Image" slot="preview" />
-                <div slot="title">File Name</div>
+                <div slot="heading">File Name</div>
                 <div slot="description">10/15/18</div>
             </sp-card>
         </div>
@@ -119,9 +119,9 @@ export const quietFile = (): TemplateResult => {
 export const quietFolder = (): TemplateResult => {
     return html`
         <div style="width: 208px; height: 264px">
-            <sp-card variant="quiet" subtitle="JPG" asset="folder">
+            <sp-card variant="quiet" subheading="JPG" asset="folder">
                 <img src=${portrait} alt="Demo Image" slot="preview" />
-                <div slot="title">Folder Name</div>
+                <div slot="heading">Folder Name</div>
                 <div slot="description">10/15/18</div>
             </sp-card>
         </div>
@@ -131,7 +131,7 @@ export const quietFolder = (): TemplateResult => {
 export const quietActions = (): TemplateResult => {
     return html`
         <div style="width: 208px; height: 264px">
-            <sp-card variant="quiet" title="Card Title" subtitle="JPG">
+            <sp-card variant="quiet" heading="Card Heading" subheading="JPG">
                 <img src=${portrait} alt="Demo Image" slot="preview" />
                 <div slot="description">10/15/18</div>
                 <sp-action-menu slot="actions" placement="bottom-end">
@@ -169,7 +169,7 @@ quietActions.story = {
 export const small = (): TemplateResult => {
     return html`
         <div style="width: 208px; height: 264px">
-            <sp-card small title="Card Title" subtitle="JPG">
+            <sp-card small heading="Card Heading" subheading="JPG">
                 <img
                     slot="cover-photo"
                     src=${portrait}
@@ -185,7 +185,7 @@ export const small = (): TemplateResult => {
 export const smallHorizontal = (): TemplateResult => {
     return html`
         <div>
-            <sp-card small horizontal title="Card Title" subtitle="JPG">
+            <sp-card small horizontal heading="Card Heading" subheading="JPG">
                 <sp-icon slot="preview" style="width: 36px; height: 36px;">
                     ${FileTxtIcon({ hidden: false })}
                 </sp-icon>
@@ -198,7 +198,12 @@ export const smallHorizontal = (): TemplateResult => {
 export const smallQuiet = (): TemplateResult => {
     return html`
         <div style="width: 115px">
-            <sp-card small title="Card Title" subtitle="JPG" variant="quiet">
+            <sp-card
+                small
+                heading="Card Heading"
+                subheading="JPG"
+                variant="quiet"
+            >
                 <img src=${portrait} alt="Demo Image" slot="preview" />
                 <div slot="footer">Footer</div>
                 <sp-action-menu slot="actions" placement="bottom-end">
@@ -229,18 +234,18 @@ export const smallQuiet = (): TemplateResult => {
     `;
 };
 
-export const SlottedTitle = (): TemplateResult => {
+export const SlottedHeading = (): TemplateResult => {
     return html`
         <style>
-            .slotted-textfield-title {
+            .slotted-textfield-heading {
                 width: 100%;
             }
         </style>
         <div
             style="
             width: 318px;
-            --spectrum-card-title-width: 100%;
-            --spectrum-card-title-padding-right: 0;
+            --spectrum-card-heading-width: 100%;
+            --spectrum-card-heading-padding-right: 0;
             --spectrum-card-body-header-height: auto;
             --spectrum-alias-single-line-width: 100%;
         "
@@ -248,12 +253,12 @@ export const SlottedTitle = (): TemplateResult => {
             <sp-card>
                 <img slot="cover-photo" src=${portrait} alt="Demo Image" />
                 <sp-textfield
-                    class="slotted-textfield-title"
-                    slot="title"
+                    class="slotted-textfield-heading"
+                    slot="heading"
                     value="Apr 23 Project"
                     quiet
                 ></sp-textfield>
-                <div slot="subtitle">LAST MODIFIED ON 6/17/2020, 3:37 PM</div>
+                <div slot="subheading">LAST MODIFIED ON 6/17/2020, 3:37 PM</div>
                 <sp-action-menu slot="actions" placement="bottom-end">
                     <sp-menu>
                         <sp-menu-item>

--- a/packages/card/test/benchmark/test-basic.ts
+++ b/packages/card/test/benchmark/test-basic.ts
@@ -15,7 +15,7 @@ import { html } from '@spectrum-web-components/base';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers';
 
 measureFixtureCreation(html`
-    <sp-card variant="gallery" title="Card Title" subtitle="JPG">
+    <sp-card variant="gallery" heading="Card Heading" subheading="JPG">
         <img slot="preview" src="https://picsum.photos/532/192" />
         <div slot="description">10/15/18</div>
         <div slot="footer">Footer</div>

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -222,7 +222,7 @@ describe('card', () => {
         expect(el.focused, 'still not focused, again 2').to.be.false;
         expect(el.selected, 'still selected, again 3').to.be.false;
     });
-    it('displays the `heading` attribute as `.heading`', async () => {
+    it('displays the `heading` attribute as `.title`', async () => {
         const testHeading = 'This is a test heading';
         const el = await fixture<Card>(
             html`
@@ -240,15 +240,15 @@ describe('card', () => {
         await elementUpdated(el);
 
         const root = el.shadowRoot ? el.shadowRoot : el;
-        const headingEl = root.querySelector('.heading');
+        const headingEl = root.querySelector('.title');
 
-        expect(headingEl, 'did not find heading element').to.not.be.null;
+        expect(headingEl, 'did not find title element').to.not.be.null;
         expect((headingEl as HTMLDivElement).textContent).to.contain(
             testHeading,
             'the heading renders in the element'
         );
     });
-    it('displays the slotted content as `.heading`', async () => {
+    it('displays the slotted content as `.title`', async () => {
         const testHeading = 'This is a test heading';
         const el = await fixture<Card>(
             html`
@@ -268,7 +268,7 @@ describe('card', () => {
 
         const root = el.shadowRoot ? el.shadowRoot : el;
         const headingSlot = root.querySelector(
-            '[name="heading"]'
+            '.title [name="heading"]'
         ) as HTMLSlotElement;
 
         expect(headingSlot, 'did not find slot element').to.not.be.null;

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -23,7 +23,7 @@ describe('card', () => {
     it('loads', async () => {
         const el = await fixture<Card>(
             html`
-                <sp-card title="Card Title" subtitle="JPG">
+                <sp-card heading="Card Heading" subheading="JPG">
                     <img
                         slot="preview"
                         src="https://picsum.photos/532/192"
@@ -41,7 +41,11 @@ describe('card', () => {
     it('loads - [quiet]', async () => {
         const el = await fixture<Card>(
             html`
-                <sp-card variant="quiet" title="Card Title" subtitle="JPG">
+                <sp-card
+                    variant="quiet"
+                    heading="Card Heading"
+                    subheading="JPG"
+                >
                     <img
                         slot="preview"
                         src="https://picsum.photos/532/192"
@@ -63,8 +67,8 @@ describe('card', () => {
             html`
                 <sp-card
                     small
-                    title="Card Title"
-                    subtitle="JPG"
+                    heading="Card Heading"
+                    subheading="JPG"
                     variant="quiet"
                     style="width: 115px;"
                 >
@@ -108,7 +112,11 @@ describe('card', () => {
     it('loads - [gallery]', async () => {
         const el = await fixture<Card>(
             html`
-                <sp-card variant="gallery" title="Card Title" subtitle="JPG">
+                <sp-card
+                    variant="gallery"
+                    heading="Card Heading"
+                    subheading="JPG"
+                >
                     <img
                         slot="preview"
                         src="https://picsum.photos/532/192"
@@ -214,11 +222,11 @@ describe('card', () => {
         expect(el.focused, 'still not focused, again 2').to.be.false;
         expect(el.selected, 'still selected, again 3').to.be.false;
     });
-    it('displays the `title` attribute as `.title`', async () => {
-        const testTitle = 'This is a test title';
+    it('displays the `heading` attribute as `.heading`', async () => {
+        const testHeading = 'This is a test heading';
         const el = await fixture<Card>(
             html`
-                <sp-card title=${testTitle} subtitle="JPG">
+                <sp-card heading=${testHeading} subheading="JPG">
                     <img
                         slot="preview"
                         src="https://picsum.photos/532/192"
@@ -232,20 +240,20 @@ describe('card', () => {
         await elementUpdated(el);
 
         const root = el.shadowRoot ? el.shadowRoot : el;
-        const titleEl = root.querySelector('.title');
+        const headingEl = root.querySelector('.heading');
 
-        expect(titleEl, 'did not find title element').to.not.be.null;
-        expect((titleEl as HTMLDivElement).textContent).to.contain(
-            testTitle,
-            'the title renders in the element'
+        expect(headingEl, 'did not find heading element').to.not.be.null;
+        expect((headingEl as HTMLDivElement).textContent).to.contain(
+            testHeading,
+            'the heading renders in the element'
         );
     });
-    it('displays the slotted content as `.title`', async () => {
-        const testTitle = 'This is a test title';
+    it('displays the slotted content as `.heading`', async () => {
+        const testHeading = 'This is a test heading';
         const el = await fixture<Card>(
             html`
-                <sp-card subtitle="JPG">
-                    <h1 slot="title">${testTitle}</h1>
+                <sp-card subheading="JPG">
+                    <h1 slot="heading">${testHeading}</h1>
                     <img
                         slot="preview"
                         src="https://picsum.photos/532/192"
@@ -259,18 +267,18 @@ describe('card', () => {
         await elementUpdated(el);
 
         const root = el.shadowRoot ? el.shadowRoot : el;
-        const titleSlot = root.querySelector(
-            '[name="title"]'
+        const headingSlot = root.querySelector(
+            '[name="heading"]'
         ) as HTMLSlotElement;
 
-        expect(titleSlot, 'did not find slot element').to.not.be.null;
-        const nodes = titleSlot.assignedNodes();
+        expect(headingSlot, 'did not find slot element').to.not.be.null;
+        const nodes = headingSlot.assignedNodes();
         const h1Element = nodes.find(
             (node) => (node as HTMLElement).tagName === 'H1'
         );
         expect(h1Element, 'did not find H1 element').to.not.be.null;
         expect((h1Element as HTMLHeadingElement).textContent).to.contain(
-            testTitle,
+            testHeading,
             'the slotted content renders in the element'
         );
     });

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -83,7 +83,7 @@ module.exports = [
     'card--small',
     'card--small-horizontal',
     'card--small-quiet',
-    'card--slotted-title',
+    'card--slotted-heading',
     'checkbox--default',
     'checkbox--checked',
     'checkbox--indeterminate',


### PR DESCRIPTION
The spectrum css variables are still title/subtitle, but I tried to
change what I could.

BREAKING CHANGE: renamed title/subtitle attributes and slot.

## Related Issue

fixes #938 - title attribute causes browser tooltip to show,

## How Has This Been Tested?

Unittests plus review of storybook/docs. Oh, and cmd+f 😁 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
