### PR TITLE
docs(menu): split the various elements into individual docs pages

### DIFF
--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -87,6 +87,72 @@ import { Dropdown } from '@spectrum-web-components/dropdown';
 </sp-dropdown>
 ```
 
+### Value
+
+When the `value` of an `<sp-dropdown>` matches the `value` attribute or the trimmed `textContent` (or `itemText`) of a descendent `<sp-menu-item>` element, it will make that element as `selected`.
+
+### Matching `value`
+
+```html
+<sp-dropdown
+    label="Select a Country with a very long label, too long in fact"
+    value="item-2"
+>
+    <sp-menu>
+        <sp-menu-item value="item-1">
+            Deselect
+        </sp-menu-item>
+        <sp-menu-item value="item-2">
+            Select inverse
+        </sp-menu-item>
+        <sp-menu-item value="item-3">
+            Feather...
+        </sp-menu-item>
+        <sp-menu-item value="item-4">
+            Select and mask...
+        </sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item value="item-5">
+            Save selection
+        </sp-menu-item>
+        <sp-menu-item disabled value="item-6">
+            Make work path
+        </sp-menu-item>
+    </sp-menu>
+</sp-dropdown>
+```
+
+### Matching `itemText`
+
+```html
+<sp-dropdown
+    label="Select a Country with a very long label, too long in fact"
+    value="Feather..."
+>
+    <sp-menu>
+        <sp-menu-item>
+            Deselect
+        </sp-menu-item>
+        <sp-menu-item>
+            Select inverse
+        </sp-menu-item>
+        <sp-menu-item>
+            Feather...
+        </sp-menu-item>
+        <sp-menu-item>
+            Select and mask...
+        </sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>
+            Save selection
+        </sp-menu-item>
+        <sp-menu-item>
+            Make work path
+        </sp-menu-item>
+    </sp-menu>
+</sp-dropdown>
+```
+
 ## States
 
 ### Invalid

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -60,22 +60,22 @@ import {
 ```html
 <sp-popover open style="position: relative">
     <sp-menu>
-        <sp-menu-item>
+        <sp-menu-item value="item-1">
             Deselect
         </sp-menu-item>
-        <sp-menu-item>
+        <sp-menu-item value="item-2">
             Select inverse
         </sp-menu-item>
-        <sp-menu-item>
+        <sp-menu-item value="item-3">
             Feather...
         </sp-menu-item>
-        <sp-menu-item>
+        <sp-menu-item value="item-4">
             Select and mask...
         </sp-menu-item>
-        <sp-menu-item>
+        <sp-menu-item value="item-5">
             Save selection
         </sp-menu-item>
-        <sp-menu-item disabled>
+        <sp-menu-item value="item-6" disabled>
             Make work path
         </sp-menu-item>
     </sp-menu>

--- a/packages/menu/menu-group.md
+++ b/packages/menu/menu-group.md
@@ -1,0 +1,54 @@
+## Overview
+
+An `<sp-menu-group>` will gather a collection of `<sp-menu-item>` elements into a group as part of the content delivered in an `<sp-menu>` element.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/menu?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/menu)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/menu?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/menu)
+
+```
+yarn add @spectrum-web-components/menu
+```
+
+Import the side effectful registration of `<sp-menu-group>` as follows:
+
+```
+import '@spectrum-web-components/menu/sp-menu-group.js';
+```
+
+When looking to leverage the `MenuGroup` base class as a type and/or for extension purposes, do so via:
+
+```
+import { MenuGroup } from '@spectrum-web-components/menu';
+```
+
+## Example
+
+An `<sp-menu-group>` can be used to organize `<sp-menu-item>`s in an `<sp-memu>` in to collections with a shared header. Use an element addressed to the `slot="header` to pass the content of that header.
+
+<!-- prettier-ignore -->
+```html
+<sp-popover open style="position: relative">
+    <sp-menu>
+        <sp-menu-group>
+            <span slot="header">New York</span>
+            <sp-menu-item>
+                Central Park
+            </sp-menu-item>
+            <sp-menu-item>
+                Prospect Park
+            </sp-menu-item>
+        </sp-menu-group>
+        <sp-menu-group>
+            <span slot="header">San Fransisco</span>
+            <sp-menu-item>
+                Golden Gate Park
+            </sp-menu-item>
+            <sp-menu-item>
+                Lake Merced Park
+            </sp-menu-item>
+        </sp-menu-group>
+    </sp-menu>
+</sp-popover>
+```

--- a/packages/menu/menu-item.md
+++ b/packages/menu/menu-item.md
@@ -1,0 +1,101 @@
+## Overview
+
+For use within an `<sp-menu>` element, an `<sp-menu-item>` represents a single item in a menu.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/menu?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/menu)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/menu?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/menu)
+
+```
+yarn add @spectrum-web-components/menu
+```
+
+Import the side effectful registration of `<sp-menu-item>` as follows:
+
+```
+import '@spectrum-web-components/menu/sp-menu-item.js';
+```
+
+When looking to leverage the `MenuItem` base class as a type and/or for extension purposes, do so via:
+
+```
+import { MenuItem } from '@spectrum-web-components/menu';
+```
+
+## Example
+
+Menus are a collection of `<sp-menu-item>`s that can be modified via a `disabled` or `selected` attribute to represent an item in that state.
+
+```html
+<sp-menu>
+    <sp-menu-item>
+        Active Menu Item
+    </sp-menu-item>
+    <sp-menu-item disabled>
+        Disabled Menu Item
+    </sp-menu-item>
+    <sp-menu-item selected>
+        Selected Menu Item
+    </sp-menu-item>
+</sp-menu>
+```
+
+### Value
+
+When displayed as a descendent of an element that manages selection (e.g. `<sp-action-menu>`, `<sp-dropdown>`, `<sp-split-button>`, etc.), an `<sp-menu-item>` will represent the "selected" value of that ancestor when its `value` attribute or the trimmed `textContent` (represeted by `el.itemText`) matches the `value` of the ancestor element.
+
+In the following example, the selected `<sp-menu-item>` represents a `value` of `Text that is really long and useful to a visitor, but not exactly good to use in your application or component state.` for the ancestor element.
+
+```html
+<sp-dropdown
+    label="Menu items examples"
+    value="Text that is really long and useful to a visitor, but not exactly good to use in your application or component state."
+>
+    <sp-menu>
+        <sp-menu-item>
+            Text that is really long and useful to a visitor, but not exactly
+            good to use in your application or component state.
+        </sp-menu-item>
+        <sp-menu-item>Not selected</sp-menu-item>
+    </sp-menu>
+</sp-dropdown>
+
+<sp-action-menu
+    value="Text that is really long and useful to a visitor, but not exactly good to use in your application or component state."
+>
+    <span slot="label">Menu items examples</span>
+    <sp-menu>
+        <sp-menu-item>
+            Text that is really long and useful to a visitor, but not exactly
+            good to use in your application or component state.
+        </sp-menu-item>
+        <sp-menu-item>Not selected</sp-menu-item>
+    </sp-menu>
+</sp-action-menu>
+```
+
+When the `value` attribute is leveraged, the selected `<sp-menu-item>` represents a `value` of `short-key` for the `<sp-action-menu>` element.
+
+```html
+<sp-dropdown value="short-key">
+    <span slot="label">Menu items examples</span>
+    <sp-menu>
+        <sp-menu-item value="not-selected">Not selected</sp-menu-item>
+        <sp-menu-item value="short-key">
+            Text that is really long and useful to a visitor, but not exactly
+            good to use in your application or component state.
+        </sp-menu-item>
+    </sp-menu>
+</sp-dropdown>
+<sp-action-menu value="short-key">
+    <span slot="label">Menu items examples</span>
+    <sp-menu>
+        <sp-menu-item value="not-selected">Not selected</sp-menu-item>
+        <sp-menu-item value="short-key">
+            Text that is really long and useful to a visitor, but not exactly
+            good to use in your application or component state.
+        </sp-menu-item>
+    </sp-menu>
+</sp-action-menu>
+```


### PR DESCRIPTION
## Description
Expand `sp-menu-item` documentation to reference usage of the `value` attribute:
- add page listing `sp-menu-group` directly.
- add page listing `sp-menu-item` directly.

## Related Issue
fixes #664

## Motivation and Context
Begin recovering the various elements batch delivered in a single package.

## How Has This Been Tested?
@adixon-adobe checked it out.

## Types of changes
- [x] Documentation

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
