### PR TITLE
docs: add "getting started" content

### DIFF
--- a/documentation/guides/generating-components.md
+++ b/documentation/guides/generating-components.md
@@ -1,4 +1,4 @@
-# Generating a New Component
+# Generating a new component
 
 The fasted way to get started with creating a new component is with our command line generator. Run the following command to have you new component scaffolded for you:
 

--- a/documentation/guides/getting-started.md
+++ b/documentation/guides/getting-started.md
@@ -1,0 +1,52 @@
+# Getting started
+
+For the fastest possible start, check out the `@spectrum-web-components/bundle` package which includes all of the elements defined by Spectrum Web Components in one easy to import entry point. Copy and paste the following HTML sample, and you can be off and running.
+
+```
+<script
+    src="https://jspm.dev/@spectrum-web-components/bundle/elements.js"
+    type="module"
+></script>
+
+<sp-theme scale="large" color="dark">
+    <!-- Insert content requiring theme application here. -->
+    <sp-button
+        onclick="alert('I was clicked');"
+    >Click me!</sp-button>
+    <!-- End content requiring theme application. -->
+</sp-theme>
+```
+
+The code above renders to the browser as follows (be patient while the JS is loaded from the JSPM CDN...):
+
+<style>iframe { width: 100%; border: none; background: var(--spectrum-global-color-gray-75); border-radius: 6px; }</style>
+
+<iframe src="data:text/html;base64,PHNjcmlwdCBzcmM9Imh0dHBzOi8vanNwbS5kZXYvQHNwZWN0cnVtLXdlYi1jb21wb25lbnRzL2J1bmRsZS9lbGVtZW50cy5qcyIgdHlwZT0ibW9kdWxlIj48L3NjcmlwdD4NCg0KPHNwLXRoZW1lIHNjYWxlPSJsYXJnZSIgY29sb3I9ImRhcmsiPg0KICAgPHNwLWJ1dHRvbiBvbmNsaWNrPSJhbGVydCgnSSB3YXMgY2xpY2tlZCcpOyI+Q2xpY2sgbWUhPC9zcC1idXR0b24+DQo8L3NwLXRoZW1lPg=="></iframe>
+
+## What you're getting...
+
+The `@spectrum-web-components/bundle` package is _litterally_ everything that Spectrum Web Components has to offer. This is why bundled it <sp-link href="https://bundlephobia.com/result?p=@spectrum-web-components/bundle">weighs in as (quite) large</sp-link> as it does and is why we DO NOT suggest leveraging this technique in a production application. However, it is the shortest path to getting right into developing with Spectrum Web Components, so dive right. Good luck, have fun!
+
+## What it's doing
+
+Visually, all Spectrum Web Components are an expression of the design tokens that are specified by Spectrum, Adobe's design system. On the web, these tokens are applied as CSS Custom Properties. Not only do they ensure that a component pattern is delivered as specified in a single color/scale/content direction combination, but they ensure this is so in all color/scale/content direction combinations. When you're ready to look into more advanced usage of the components and themes in your application, there are vanilla CSS implementations of these tokens available in the `@spectrum-web-components/styles` package. However, to get started immediately, the `<sp-theme>` element delivers these tokens to a scoped HTML context and is what is applied in the code above. You'll notice the usage of `scale="large"` and `color="dark"` to outline the scale and color applied to this theme context respectively. To make a theme context with `scale="medium"` and `color="lighest"` you can use the following code sample:
+
+```html
+<sp-theme
+    scale="medium"
+    color="lightest"
+    style="background: var(--spectrum-global-color-gray-75); padding: var(--spectrum-global-dimension-size-400);"
+>
+    <!-- Insert content requiring theme application here. -->
+    <sp-button onclick="alert('I was clicked');">Click me!</sp-button>
+    <!-- End content requiring theme application. -->
+</sp-theme>
+```
+
+<sp-link href="components/theme">Read about the full range of style customization provided by `@spectrum-web-components/theme`.</sp-link>
+
+## What you can do
+
+From this baseline, visit the documentation for each individual component package and find one, some, or all of those that are right for your project. Start building today and use rapid, component-based prototyping to bring your designs to life faster than ever.
+
+When you start to find something your happy with, visit our <sp-link href="https://github.com/adobe/spectrum-web-components/tree/main/projects/example-project-rollup" target="_blank">Rollup</sp-link> and/or <sp-link href="https://github.com/adobe/spectrum-web-components/tree/main/projects/example-project-webpack" target="_blank">Webpack</sp-link> example projects for recommendations on how to start preparing your project for production. Leverage the "Usage" listings on each of the individual components to support the patterns you'll find therein. And then, when you're ready... ship, ship, ship. We look forward to seeing what you bring to life!

--- a/documentation/src/components/guide.ts
+++ b/documentation/src/components/guide.ts
@@ -11,6 +11,9 @@ governing permissions and limitations under the License.
 */
 import { html, CSSResultArray } from 'lit-element';
 import '@spectrum-web-components/link/sp-link.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/theme/theme-lightest.js';
+import '@spectrum-web-components/theme/scale-medium.js';
 import './layout.js';
 import { GuideDocs } from '../../guides/index.js';
 import { RouteComponent } from './route-component.js';
@@ -41,7 +44,9 @@ class GuideElement extends RouteComponent {
         if (this.location && this.location.params) {
             result = html`
                 <article class="spectrum-Typography">
-                    ${GuideDocs.get(this.location.params.guide)}
+                    ${GuideDocs.get(
+                        this.location.params.guide || 'getting-started'
+                    )}
                 </article>
             `;
         }

--- a/documentation/src/components/side-nav.ts
+++ b/documentation/src/components/side-nav.ts
@@ -60,6 +60,11 @@ class SideNav extends SpectrumElement {
         this.handleSelect(event, 'guides');
     }
 
+    private handleGettingStartedSelect(): void {
+        const path = AppRouter.urlForPath(`/getting-started`);
+        AppRouter.go(path);
+    }
+
     public toggle() {
         this.open = !this.open;
     }
@@ -98,6 +103,11 @@ class SideNav extends SpectrumElement {
                 </div>
                 <div id="navigation">
                     <sp-sidenav manage-tab-index>
+                        <sp-sidenav-item
+                            label="Getting Started"
+                            value="getting-started"
+                            @sidenav-select=${this.handleGettingStartedSelect}
+                        ></sp-sidenav-item>
                         <sp-sidenav-item
                             label="Components"
                             expanded

--- a/documentation/src/router.ts
+++ b/documentation/src/router.ts
@@ -75,4 +75,11 @@ AppRouter.setRoutes([
             await import('./components/guide.js');
         },
     },
+    {
+        path: '/getting-started',
+        component: 'docs-guide',
+        action: async () => {
+            await import('./components/guide.js');
+        },
+    },
 ]);


### PR DESCRIPTION
## Description 
Add "Getting Started" documentation with information around using Spectrum Web Components via CDN providers.

See: https://5f87af06d161ad3dbd013599--spectrum-web-components.netlify.app/ and the initial sidenav item `Getting Started`

## Related Issue
fixes #878 

## Motivation and Context
Not everything should require the commandline, NPM, or a build.

## How Has This Been Tested?
See preview.

## Types of changes
- [x] documentation

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
