### PR TITLE
feat(textfield): adding input type to text tield

### DIFF
--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -54,3 +54,11 @@ The quiet style works best when a clear layout (vertical stack, table, grid) ass
 ```html
 <sp-textfield placeholder="Enter your name" quiet></sp-textfield>
 ```
+
+### Type
+
+Define input type `text|email|tel|password|url|number`. This also include the default validation on `email,url,number`.
+
+```html
+<sp-textfield placeholder="Enter your name" type="password"></sp-textfield>
+```

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -84,6 +84,9 @@ export class Textfield extends Focusable {
         | HTMLInputElement['autocomplete']
         | HTMLTextAreaElement['autocomplete'];
 
+    @property({ type: String, reflect: true })
+    public type?: 'text' | 'password' | 'email' | 'tel' | 'url' | 'number';
+
     public get focusElement(): HTMLInputElement | HTMLTextAreaElement {
         return this.inputElement;
     }
@@ -172,6 +175,7 @@ export class Textfield extends Focusable {
                 @input=${this.onInput}
                 ?disabled=${this.disabled}
                 ?required=${this.required}
+                type=${ifDefined(this.type)}
                 autocomplete=${ifDefined(this.autocomplete)}
             />
         `;
@@ -187,7 +191,8 @@ export class Textfield extends Focusable {
     protected updated(changedProperties: PropertyValues): void {
         if (
             changedProperties.has('value') ||
-            (changedProperties.has('required') && this.required)
+            (changedProperties.has('required') && this.required) ||
+            (this.type && ['email', 'number', 'url'].includes(this.type))
         ) {
             this.checkValidity();
         }
@@ -200,9 +205,9 @@ export class Textfield extends Focusable {
                 const regex = new RegExp(this.pattern);
                 validity = regex.test(this.value);
             }
-            this.valid = validity;
-            this.invalid = !validity;
         }
+        this.valid = validity;
+        this.invalid = !validity;
         return validity;
     }
 }

--- a/packages/textfield/stories/textfield.stories.ts
+++ b/packages/textfield/stories/textfield.stories.ts
@@ -68,3 +68,15 @@ export const allowedKeys = (): TemplateResult => {
         ></sp-textfield>
     `;
 };
+
+export const inputType = (): TemplateResult => {
+    return html`
+        <sp-textfield placeholder="Default Text"></sp-textfield>
+        <sp-textfield placeholder="Text" type="text"></sp-textfield>
+        <sp-textfield placeholder="Password" type="password"></sp-textfield>
+        <sp-textfield placeholder="Email" type="email"></sp-textfield>
+        <sp-textfield placeholder="Telephone" type="tel"></sp-textfield>
+        <sp-textfield placeholder="URL" type="url"></sp-textfield>
+        <sp-textfield placeholder="Number" type="number"></sp-textfield>
+    `;
+};

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -298,4 +298,102 @@ describe('Textfield', () => {
         expect(el.value).to.equal('asdff');
         expect(inputElement.selectionStart).to.equal(3);
     });
+    it('test on `input type`', async () => {
+        let el = await litFixture<Textfield>(
+            html`
+                <sp-textfield></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        let input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.getAttribute('type')).to.be.null;
+        }
+
+        el = await litFixture<Textfield>(
+            html`
+                <sp-textfield type="text"></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.getAttribute('type')).to.equal('text');
+        }
+
+        el = await litFixture<Textfield>(
+            html`
+                <sp-textfield type="password"></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.getAttribute('type')).to.equal('password');
+        }
+
+        el = await litFixture<Textfield>(
+            html`
+                <sp-textfield type="email"></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.getAttribute('type')).to.equal('email');
+        }
+        el.value = 'not a valid email';
+        await elementUpdated(el);
+        expect(el.invalid).to.be.true;
+
+        el.value = 'valid@email.com';
+        await elementUpdated(el);
+        expect(el.invalid).to.be.false;
+
+        el = await litFixture<Textfield>(
+            html`
+                <sp-textfield type="number"></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.getAttribute('type')).to.equal('number');
+        }
+        el.value = 'not a valid number';
+        await elementUpdated(el);
+        input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.value).not.equal(el.value);
+        }
+
+        el.value = '123432142';
+        await elementUpdated(el);
+        expect(el.invalid).to.be.false;
+
+        el = await litFixture<Textfield>(
+            html`
+                <sp-textfield type="url"></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        input = el.shadowRoot ? el.shadowRoot.querySelector('input') : null;
+        expect(input).to.exist;
+        if (input) {
+            expect(input.getAttribute('type')).to.equal('url');
+        }
+        el.value = 'not a valid url';
+        await elementUpdated(el);
+        expect(el.invalid).to.be.true;
+
+        el.value = 'https://www.validaurl.com';
+        await elementUpdated(el);
+        expect(el.invalid).to.be.false;
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added type option to textfield. This would contribute to `<input>` type attribute. The attribute only affecting TextField single line.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
I posted the [issue](https://github.com/adobe/spectrum-web-components/issues/926). There weren't enough discussion about it.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I wanted to have password field and did not want to work around with dom manipulation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It pass the coverage test.

The coverage result:
98.49% Statements 12603/1279694.55% Branches 1734/183495.06% Functions 597/62898.49% Lines 12603/12796

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
