### PR TITLE
fix(slider): prevent pointercancel events by container touch-action

### DIFF
--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -21,6 +21,10 @@ governing permissions and limitations under the License.
     outline-width: 0;
 }
 
+#handle {
+    touch-action: none;
+}
+
 /*
  * The following three declarationsa required while https://github.com/adobe/spectrum-css/issues/521
  * waits to be addressed at the Spectrum CSS level.


### PR DESCRIPTION
## Description
Make touch interactions with `sp-slider` more predictable by preventing "scroll/pan" actions from causing `pointercancel`.

## Related Issue
fixes #519

## Motivation and Context
Lots of people touch our sliders.

## How Has This Been Tested?
Manually in iOS via: https://5f8cdd6d084e2f8cbea81c82--spectrum-web-components.netlify.app

## Types of changes
- [x] Bug fix

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
