### PR TITLE
fix: include the "types" entry in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
         "stylelint-config-standard": "^20.0.0",
         "tachometer": "^0.5.5",
         "ts-loader": "^8.0.0",
-        "typescript": "^4.0.2",
+        "typescript": "^4.0.3",
         "walker": "^1.0.7",
         "web-component-analyzer": "^1.1.6",
         "webpack": "^4.41.6",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.1.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.1.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.6.5",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/actionbar/package.json
+++ b/packages/actionbar/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.1.5",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/bar-loader/package.json
+++ b/packages/bar-loader/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.2.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.1.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -11,7 +11,10 @@ governing permissions and limitations under the License.
 */
 
 import { LitElement, property, UpdatingElement } from 'lit-element';
-import { Theme } from '@spectrum-web-components/theme';
+type ThemeRoot = HTMLElement & {
+    startManagingContentDirection: (el: HTMLElement) => void;
+    stopManagingContentDirection: (el: HTMLElement) => void;
+};
 
 type Constructor<T = Record<string, unknown>> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -89,7 +92,9 @@ export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
                 if (dirParent === document.documentElement) {
                     observedForElements.add(this);
                 } else {
-                    (dirParent as Theme).startManagingContentDirection(this);
+                    (dirParent as ThemeRoot).startManagingContentDirection(
+                        this
+                    );
                 }
                 this._dirParent = dirParent as HTMLElement;
             }
@@ -102,7 +107,7 @@ export function SpectrumMixin<T extends Constructor<UpdatingElement>>(
                 if (this._dirParent === document.documentElement) {
                     observedForElements.delete(this);
                 } else {
-                    (this._dirParent as Theme).stopManagingContentDirection(
+                    (this._dirParent as ThemeRoot).stopManagingContentDirection(
                         this
                     );
                 }

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.15.7",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.9.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.5.5",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.5.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/circle-loader/package.json
+++ b/packages/circle-loader/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.8.5",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.0.1",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         "./": "./src/index.js",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.6.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.3",
     "description": "",
-    "main": "lib/index.js",
-    "module": "lib/index.js",
+    "main": "./lib/index.js",
+    "module": "./lib/index.js",
+    "types": "./lib/index.d.ts",
     "exports": {
         ".": "./src/index.js",
         "./lib/": "./lib/",

--- a/packages/icons-ui/tsconfig.json
+++ b/packages/icons-ui/tsconfig.json
@@ -5,5 +5,7 @@
         "outDir": "./lib",
         "rootDir": "./src"
     },
-    "include": ["src/**/*.ts", "../../global.d.ts"]
+    "include": ["src/**/*.ts", "../../global.d.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../base" }]
 }

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.6",
     "description": "",
-    "main": "lib/index.js",
-    "module": "lib/index.js",
+    "main": "./lib/index.js",
+    "module": "./lib/index.js",
+    "types": "./lib/index.d.ts",
     "exports": {
         ".": "./src/index.js",
         "./lib/": "./lib/",

--- a/packages/icons-workflow/tsconfig.json
+++ b/packages/icons-workflow/tsconfig.json
@@ -5,5 +5,7 @@
         "outDir": "./lib",
         "rootDir": "./src"
     },
-    "include": ["src/**/*.ts", "../../global.d.ts"]
+    "include": ["src/**/*.ts", "../../global.d.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../base" }]
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.5",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.2.5",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
         "./src/": "./src/",

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.5.6",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.6.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/overlay/sync/overlay-trigger.ts
+++ b/packages/overlay/sync/overlay-trigger.ts
@@ -11,11 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { OverlayTrigger } from '../src/OverlayTrigger.js';
-import {
-    Overlay,
-    OverlayOptions,
-    TriggerInteractions,
-} from '@spectrum-web-components/overlay';
+import { Overlay, OverlayOptions, TriggerInteractions } from '../src/index.js';
 import '../overlay-trigger.js';
 
 OverlayTrigger.openOverlay = async (

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.5.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.1.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/rule/package.json
+++ b/packages/rule/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.5.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.7.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.6.0",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.6.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.1.5",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "files": [
         "custom-elements.json",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.4.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.2.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.5.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.6.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -5,5 +5,6 @@
         "rootDir": "./"
     },
     "include": ["*.ts", "src/*.ts"],
-    "exclude": ["test/*.ts", "stories/*.ts"]
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../base" }]
 }

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.5.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.5.4",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.0.5",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -20,8 +20,9 @@
     ],
     "version": "0.3.3",
     "description": "",
-    "main": "src/index.js",
-    "module": "src/index.js",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
         ".": "./src/index.js",

--- a/test/tsconfig-test.json
+++ b/test/tsconfig-test.json
@@ -1,9 +1,9 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-        "composite": true,
         "outDir": "../",
-        "types": ["mocha", "chai", "sinon", "webpack-env", "node"]
+        "types": ["mocha", "chai", "sinon", "webpack-env", "node"],
+        "declaration": false
     },
     "include": [
         "../packages/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23077,10 +23077,10 @@ typescript@^3.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
-typescript@^4.0.2:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+typescript@^4.0.2, typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description 
Leverage the types entry in `package.json`.
Normalize the includes/excludes in `tsconfig.json`

## Motivation and Context
https://www.skypack.dev/view/@spectrum-web-components/bundle is now using the presence of types as a signifier of quality, and apparently even TS thinks this is the "right" way to do things: https://docs.skypack.dev/package-authors/package-checks#types

## How Has This Been Tested?
Hard to fully test, but seems like the right thing to do.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
