### PR TITLE
Various updates to performance based off of better `tachometer` results.

### DIFF
--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -18,6 +18,7 @@ import {
     triggerBlurFor,
     html,
     expect,
+    waitUntil,
 } from '@open-wc/testing';
 import { waitForPredicate } from '../../../test/testing-helpers.js';
 import '@spectrum-web-components/shared/src/focus-visible.js';
@@ -120,7 +121,10 @@ describe('Checkbox', () => {
         ) as Checkbox;
 
         expect(autoElement).to.exist;
-        expect(document.activeElement).to.equal(autoElement);
+        await waitUntil(
+            () => document.activeElement === autoElement,
+            'Autofocused'
+        );
 
         await triggerBlurFor(autoElement);
 

--- a/packages/radio/test/radio.test.ts
+++ b/packages/radio/test/radio.test.ts
@@ -18,6 +18,7 @@ import {
     triggerBlurFor,
     html,
     expect,
+    waitUntil,
 } from '@open-wc/testing';
 
 function inputForRadio(radio: Radio): HTMLInputElement {
@@ -97,7 +98,10 @@ describe('Radio', () => {
         ) as Radio;
 
         expect(autoElement).to.exist;
-        expect(document.activeElement).to.equal(autoElement);
+        await waitUntil(
+            () => document.activeElement === autoElement,
+            'Autofocused'
+        );
 
         await triggerBlurFor(autoElement);
 

--- a/packages/shared/src/focus-visible.ts
+++ b/packages/shared/src/focus-visible.ts
@@ -114,20 +114,26 @@ export const FocusVisiblePolyfillMixin = <
         // document:
         connectedCallback(): void {
             super.connectedCallback && super.connectedCallback();
-            if (this[$endPolyfillCoordination] == null) {
-                this[$endPolyfillCoordination] = coordinateWithPolyfill(this);
-            }
+            requestAnimationFrame(() => {
+                if (this[$endPolyfillCoordination] == null) {
+                    this[$endPolyfillCoordination] = coordinateWithPolyfill(
+                        this
+                    );
+                }
+            });
         }
 
         disconnectedCallback(): void {
             super.disconnectedCallback && super.disconnectedCallback();
             // It's important to remove the polyfill event listener when we
             // disconnect, otherwise we will leak the whole element via window:
-            if (this[$endPolyfillCoordination] != null) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                this[$endPolyfillCoordination]!();
-                this[$endPolyfillCoordination] = null;
-            }
+            requestAnimationFrame(() => {
+                if (this[$endPolyfillCoordination] != null) {
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    this[$endPolyfillCoordination]!();
+                    this[$endPolyfillCoordination] = null;
+                }
+            });
         }
     }
 

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -135,12 +135,14 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
     protected manageAutoFocus(): void {
         if (this.autofocus) {
             /* Trick :focus-visible polyfill into thinking keyboard based focus */
-            this.dispatchEvent(
-                new KeyboardEvent('keydown', {
-                    code: 'Tab',
-                })
-            );
-            this.focusElement.focus();
+            requestAnimationFrame(() => {
+                this.dispatchEvent(
+                    new KeyboardEvent('keydown', {
+                        code: 'Tab',
+                    })
+                );
+                this.focusElement.focus();
+            });
         }
     }
 

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -135,14 +135,12 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
     protected manageAutoFocus(): void {
         if (this.autofocus) {
             /* Trick :focus-visible polyfill into thinking keyboard based focus */
-            requestAnimationFrame(() => {
-                this.dispatchEvent(
-                    new KeyboardEvent('keydown', {
-                        code: 'Tab',
-                    })
-                );
-                this.focusElement.focus();
-            });
+            this.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    code: 'Tab',
+                })
+            );
+            this.focusElement.focus();
         }
     }
 

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -169,10 +169,8 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
     protected updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
 
-        if (changedProperties.has('disabled')) {
-            if (this.disabled) {
-                this.blur();
-            }
+        if (changedProperties.has('disabled') && this.disabled) {
+            this.blur();
         }
     }
 

--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -132,16 +132,12 @@ export class SideNavItem extends LikeAnchor(Focusable) {
                 ? html`
                       <slot></slot>
                   `
-                : undefined}
+                : html``}
         `;
     }
 
     protected updated(changes: PropertyValues): void {
         super.updated(changes);
-        if (changes.has('manageTabIndex')) {
-            const tabIndexForSelectedState = this.selected ? 0 : -1;
-            this.tabIndex = this.manageTabIndex ? tabIndexForSelectedState : 0;
-        }
         if (changes.has('selected') || changes.has('manageTabIndex')) {
             const tabIndexForSelectedState = this.selected ? 0 : -1;
             this.tabIndex = this.manageTabIndex ? tabIndexForSelectedState : 0;

--- a/packages/sidenav/stories/sidenav.stories.ts
+++ b/packages/sidenav/stories/sidenav.stories.ts
@@ -108,6 +108,35 @@ export const levelsAndDisabled = (): TemplateResult => {
     `;
 };
 
+export const manageTabIndex = (): TemplateResult => {
+    return html`
+        <sp-sidenav manage-tab-index>
+            <sp-sidenav-heading label="CATEGORY 1">
+                <sp-sidenav-item
+                    value="Section 0"
+                    label="Section 0"
+                ></sp-sidenav-item>
+                <sp-sidenav-item
+                    value="Section 1"
+                    label="Section 1"
+                    selected
+                ></sp-sidenav-item>
+                <sp-sidenav-item
+                    value="Section 2"
+                    label="Section 2"
+                    disabled
+                ></sp-sidenav-item>
+                <sp-sidenav-item value="Section 3" label="Section 3">
+                    <sp-sidenav-item
+                        value="Section 3a"
+                        label="Section 3a"
+                    ></sp-sidenav-item>
+                </sp-sidenav-item>
+            </sp-sidenav-heading>
+        </sp-sidenav>
+    `;
+};
+
 export const Hrefs = (): TemplateResult => {
     return html`
         <sp-sidenav @sidenav-select=${action('select')} value="current">

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -108,7 +108,10 @@ describe('Tabs', () => {
 
         const autoElement = tabs.querySelector('[label="Tab 2"]') as Tab;
 
-        expect(document.activeElement).to.equal(autoElement);
+        await waitUntil(
+            () => document.activeElement === autoElement,
+            'Autofocused'
+        );
     });
 
     it('forces only one tab to be selected', async () => {


### PR DESCRIPTION
## Description
- clean up duplicate code in `<sp-sidenav>`
- simplify logic in `focusable`
- make application of the `focus-visble` polyfill lazy. This means that "autofocus" functionality is delayed by a frame, see update to timing in tests.

## Related Issue
refs #815 

## Motivation and Context
Lazy polyfilling leads to perf trends like the following (note: `Remote` is the currently published version):

*Accordion*
![image](https://user-images.githubusercontent.com/1156657/97222481-d9bc3e00-17a4-11eb-93ae-ce882c304e57.png)

*ActionMenu*
![image](https://user-images.githubusercontent.com/1156657/97222547-f35d8580-17a4-11eb-90e8-3eb964953c60.png)

*Button*
![image](https://user-images.githubusercontent.com/1156657/97222569-ff494780-17a4-11eb-9c04-676282087cff.png)

*Link*
![image](https://user-images.githubusercontent.com/1156657/97222598-096b4600-17a5-11eb-88e7-542324ec302f.png)

*Menu*
![image](https://user-images.githubusercontent.com/1156657/97222640-16883500-17a5-11eb-9755-015542e9ec63.png)

*Radio*
![image](https://user-images.githubusercontent.com/1156657/97222669-20119d00-17a5-11eb-9924-2d42a050c00a.png)

*Checkbox*
![image](https://user-images.githubusercontent.com/1156657/97222712-2b64c880-17a5-11eb-8a9f-a3d784201465.png)

*Search*
![image](https://user-images.githubusercontent.com/1156657/97222744-34559a00-17a5-11eb-9039-283e58a65b49.png)

*Sidenav*
![image](https://user-images.githubusercontent.com/1156657/97222788-3fa8c580-17a5-11eb-8c8a-be73093223c4.png)

*Slider*
![image](https://user-images.githubusercontent.com/1156657/97222817-48010080-17a5-11eb-8c85-159d2de5c53d.png)

*Switch*
![image](https://user-images.githubusercontent.com/1156657/97222857-55b68600-17a5-11eb-8b1e-3e2d914942ba.png)

*Textfield*
![image](https://user-images.githubusercontent.com/1156657/97222887-60711b00-17a5-11eb-96be-8ef489270ed1.png)

*Dropdown*
![image](https://user-images.githubusercontent.com/1156657/97223136-bd6cd100-17a5-11eb-947d-631b5f7de0c2.png)

## How Has This Been Tested?
See above. See asynchrony changes to unit tests.

## Screenshots (if appropriate):

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
