### PR TITLE
feat(shared): conditionally apply focus-visible polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "build": "gulp css && tsc --build packages/**/tsconfig.json",
         "build:watch": "tsc --build packages/**/tsconfig.json -w",
         "build:tests": "tsc --build test/tsconfig.json && tsc --build test/tsconfig-node.json",
-        "build:clear-cache": "rm -rf packages/*/lib && rm -rf packages/*/tsconfig.tsbuildinfo",
+        "build:clear-cache": "rimraf packages/*/lib && rimraf packages/*/tsconfig.tsbuildinfo",
         "watch": "gulp watch",
         "prestorybook": "wca analyze 'packages/*/*.d.ts' --format json --outFile custom-elements.json && node ./scripts/add-custom-properties.js --src='custom-elements.json'",
         "storybook": "yarn storybook:stories:build && run-p watch build:watch storybook:stories:watch storybook:start",

--- a/scripts/css-processing.js
+++ b/scripts/css-processing.js
@@ -22,7 +22,6 @@ const postCSSPlugins = (resourcePath) => {
         require('postcss-preset-env')({
             stage: 0,
         }),
-        require('postcss-focus-visible')({ preserve: false }),
         // minify the css with cssnano presets
         require('cssnano')({
             preset: [
@@ -32,6 +31,7 @@ const postCSSPlugins = (resourcePath) => {
                 },
             ],
         }),
+        require('postcss-focus-visible')(),
     ];
 };
 


### PR DESCRIPTION
## Description 
Conditionally apply the `focus-visible` polyfill only where it is needed:
![image](https://user-images.githubusercontent.com/1156657/97224562-b21aa500-17a7-11eb-9ddb-6e6dd243a56f.png)
While it would be interesting to also support `:-moz-focusring`, I'm not sure it 100% has the same heuristics as `:focus-visible`, so it's not included herein.

This approach builds on #980 where we make the polyfill lazy. While the results below tend to show a small amount of performance win, there seems to be less than I expected. Due to this, it may be too early to take on this change as it is generally powered by the a change in the way we process/deliver CSS for packages.

Previously, the following CSS `a:focus-visible { ... }` would be converted directly to `a.focus-visible { ... }` keeping the support process non-negative. To support both polyfill and no polyfill delivery it is required that the previous sample be processed to (all automatic of course, no developer intervention needed):
```
a:focus-visible { ... }
a.focus-visible { ... }
```
As CSS will throw out all selectors in a rule wherein a single selector is erroneous. This means that there are some small file size alterations that come along with this change to support. 

I'd love to hear your thoughts!


## Motivation and Context
I wanna go faster!

## How Has This Been Tested?

*Accordion* vs 1-6% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230248-00cc3d00-17b0-11eb-8d83-7c94d10eaf46.png)

*ActionMenu* vs 35-37% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230313-1b061b00-17b0-11eb-8086-6d0134ca8ce7.png)

*Button* vs 7-9% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230387-3709bc80-17b0-11eb-9363-a09a06eb42fd.png)

*Link* vs 9-11% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230430-4a1c8c80-17b0-11eb-9794-93278a7a4b4a.png)

*Menu* vs 21-23% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230481-5c96c600-17b0-11eb-9e9e-808504117c44.png)

*Radio* vs 15-16% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230515-733d1d00-17b0-11eb-949a-ecc3c99f1a2b.png)

*Checkbox* vs 4-8% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230559-86e88380-17b0-11eb-9375-b128294fa6bd.png)

*Search* vs 3-5% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230607-97006300-17b0-11eb-882e-07839c26d6c7.png)

*Sidenav* vs 82-86% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230638-a8496f80-17b0-11eb-956b-d2cb86a4ec31.png)

*Slider* vs 4-6% inn #980 
![image](https://user-images.githubusercontent.com/1156657/97230681-c0b98a00-17b0-11eb-8fb5-f1f97c3d7049.png)

*Switch* vs 6-9% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230726-d5961d80-17b0-11eb-8bde-c7d3b42d9e64.png)

*Textfield* vs 3-5% in #980 
![image](https://user-images.githubusercontent.com/1156657/97230768-eba3de00-17b0-11eb-9990-1c2d9a9d0d12.png)

*Dropdown* vs 33-36% in #980
![image](https://user-images.githubusercontent.com/1156657/97230826-024a3500-17b1-11eb-8b79-0486c10221fc.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
