### PR TITLE
fix(textfield): process ".is-focused" and ".is-keyboardFocused" styles

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -40,6 +40,9 @@ export class Textfield extends Focusable {
     @property({ attribute: 'allowed-keys' })
     allowedKeys = '';
 
+    @property({ type: Boolean, reflect: true })
+    public focused = false;
+
     @query('#input')
     private inputElement!: HTMLInputElement | HTMLTextAreaElement;
 
@@ -119,6 +122,14 @@ export class Textfield extends Focusable {
         );
     }
 
+    private onFocus(): void {
+        this.focused = true;
+    }
+
+    private onBlur(): void {
+        this.focused = false;
+    }
+
     protected renderStateIcons(): TemplateResult | typeof nothing {
         if (this.invalid) {
             return html`
@@ -152,6 +163,8 @@ export class Textfield extends Focusable {
                 .value=${this.value}
                 @change=${this.onChange}
                 @input=${this.onInput}
+                @focus=${this.onFocus}
+                @blur=${this.onBlur}
                 ?disabled=${this.disabled}
                 ?required=${this.required}
                 autocomplete=${ifDefined(this.autocomplete)}
@@ -170,6 +183,8 @@ export class Textfield extends Focusable {
                 .value=${this.value}
                 @change=${this.onChange}
                 @input=${this.onInput}
+                @focus=${this.onFocus}
+                @blur=${this.onBlur}
                 ?disabled=${this.disabled}
                 ?required=${this.required}
                 autocomplete=${ifDefined(this.autocomplete)}

--- a/packages/textfield/src/spectrum-config.js
+++ b/packages/textfield/src/spectrum-config.js
@@ -47,6 +47,16 @@ const config = {
                 },
                 {
                     type: 'boolean',
+                    selector: '.is-focused',
+                    name: 'focused',
+                },
+                {
+                    type: 'boolean',
+                    selector: '.is-keyboardFocused',
+                    name: 'focused',
+                },
+                {
+                    type: 'boolean',
                     selector: '.is-valid',
                     name: 'valid',
                 },

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -589,7 +589,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 #input:focus,
-:host(.is-focused) #input {
+:host([focused]) #input {
     /* .spectrum-Textfield-input:focus,
    * .spectrum-Textfield.is-focused .spectrum-Textfield-input */
     border-color: var(
@@ -598,7 +598,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 #input:focus-visible,
-:host(.is-keyboardFocused) #input {
+:host([focused]) #input {
     /* .spectrum-Textfield-input.focus-ring,
    * .spectrum-Textfield.is-keyboardFocused .spectrum-Textfield-input */
     border-color: var(
@@ -618,7 +618,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-semantic-negative-color-default)
     );
 }
-:host([invalid]) .is-keyboardFocused #input,
+:host([focused][invalid]) #input,
 :host([invalid]) #input:focus-visible {
     /* .is-keyboardFocused.spectrum-Textfield.is-invalid .spectrum-Textfield-input,
    * .spectrum-Textfield.is-invalid .spectrum-Textfield-input.focus-ring */
@@ -666,7 +666,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([quiet]) .is-focused #input,
+:host([focused][quiet]) #input,
 :host([quiet]) #input:focus {
     /* .is-focused.spectrum-Textfield--quiet .spectrum-Textfield-input,
    * .spectrum-Textfield--quiet .spectrum-Textfield-input:focus */
@@ -675,7 +675,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-mouse-focus)
     );
 }
-:host([quiet]) .is-keyboardFocused #input,
+:host([focused][quiet]) #input,
 :host([quiet]) #input:focus-visible {
     /* .is-keyboardFocused.spectrum-Textfield--quiet .spectrum-Textfield-input,
    * .spectrum-Textfield--quiet .spectrum-Textfield-input.focus-ring */
@@ -696,7 +696,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-semantic-negative-color-default)
     );
 }
-:host([invalid][quiet]) .is-focused #input,
+:host([focused][invalid][quiet]) #input,
 :host([invalid][quiet]) #input:focus {
     /* .is-focused.is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input,
    * .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input:focus */
@@ -706,7 +706,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 :host([invalid][quiet]) #input:focus-visible,
-:host([invalid][quiet]) .is-keyboardFocused #input {
+:host([focused][invalid][quiet]) #input {
     /* .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input.focus-ring,
    * .is-keyboardFocused.is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
     border-color: var(


### PR DESCRIPTION
## Description
Ensure correct focus+hover styles by processing `.is-focused` and `.is-keyboardFocused` styles. Note the polyfill that we leverage does not disambiguated between a mouse and a keyboard focus for inputs, so those styles are merged into the `[focused]` attribute rule.

## Related Issue
fixes #988 

## Motivation and Context
Adherence to Spectrum

## How Has This Been Tested?
Manually in storybook. None of our visual regressions have "interactive steps" before capture, so while we could add an "autofocus" story to Textfield it wouldn't technically cover this additions and "autofocus" is something I'd like to remove from other stories at some point as it's back for accessibility.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/97437534-ffa72700-18f9-11eb-995c-4175afa818c9.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
