### PR TITLE
fix(overlay): use esm build from popper and point through to types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ packages/**/spectrum-vars.json
 packages/**/*.js.map
 packages/**/*.d.ts
 !packages/*/global.d.ts
+!packages/*/local.d.ts
 packages/*/*/*.d.ts
 !test/global.d.ts
 !packages/*/test/global.d.ts

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -12,13 +12,6 @@ import {
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
 
-// While https://github.com/open-wc/open-wc/issues/1210 and
-// go https://github.com/popperjs/popper-core/issues/933 persist
-// without an acceptable outcome, this allows the built storybook
-// to function with `process.env.NODE_ENV`... :/
-window.process = window.process || {};
-window.process.env = window.process.env || {};
-window.process.env.NODE_ENV = window.process.env.NODE_ENV || 'production';
 window.__swc_hack_knobs__ = window.__swc_hack_knobs__ || {};
 
 addDecorator(withA11y);

--- a/packages/overlay/local.d.ts
+++ b/packages/overlay/local.d.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+declare module '@popperjs/core/dist/esm/popper-lite.js' {
+    import {
+        popperGenerator,
+        defaultModifiers,
+    } from '@popperjs/core/lib/popper-lite';
+
+    export { popperGenerator, defaultModifiers };
+}
+
+declare module '@popperjs/core/dist/esm/types.js' {
+    import { Instance } from '@popperjs/core/lib/types.js';
+
+    export { Instance };
+}
+
+declare module '@popperjs/core/dist/esm/enums.js' {
+    import { Placement } from '@popperjs/core/lib/enums.js';
+
+    export { Placement };
+}
+
+declare module '@popperjs/core/dist/esm/modifiers/flip.js' {
+    import flip from '@popperjs/core/lib/modifiers/flip.js';
+
+    export default flip;
+}
+
+declare module '@popperjs/core/dist/esm/modifiers/preventOverflow.js' {
+    import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow.js';
+
+    export default preventOverflow;
+}
+
+declare module '@popperjs/core/dist/esm/modifiers/arrow.js' {
+    import arrow from '@popperjs/core/lib/modifiers/arrow.js';
+
+    export default arrow;
+}
+
+declare module '@popperjs/core/dist/esm/modifiers/offset.js' {
+    import offset from '@popperjs/core/lib/modifiers/offset.js';
+
+    export default offset;
+}

--- a/packages/overlay/src/popper.ts
+++ b/packages/overlay/src/popper.ts
@@ -13,17 +13,19 @@ governing permissions and limitations under the License.
 // Bundle only what we want from popper
 // See: https://popper.js.org/docs#popper-lite-tree-shaking
 
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../local.d.ts" />
 import {
     popperGenerator,
     defaultModifiers,
-} from '@popperjs/core/lib/popper-lite';
-import type { Instance } from '@popperjs/core/lib/types';
-import type { Placement } from '@popperjs/core/lib/enums';
+} from '@popperjs/core/dist/esm/popper-lite.js';
+import type { Instance } from '@popperjs/core/dist/esm/types.js';
+import type { Placement } from '@popperjs/core/dist/esm/enums.js';
 
-import flip from '@popperjs/core/lib/modifiers/flip.js';
-import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow.js';
-import arrow from '@popperjs/core/lib/modifiers/arrow.js';
-import offset from '@popperjs/core/lib/modifiers/offset.js';
+import flip from '@popperjs/core/dist/esm/modifiers/flip.js';
+import preventOverflow from '@popperjs/core/dist/esm/modifiers/preventOverflow.js';
+import arrow from '@popperjs/core/dist/esm/modifiers/arrow.js';
+import offset from '@popperjs/core/dist/esm/modifiers/offset.js';
 import { computeArrowRotateStyles } from './popper-arrow-rotate.js';
 import maxSize from 'popper-max-size-modifier';
 import { applyMaxSize } from './apply-max-size.js';

--- a/projects/example-project-rollup/src/example-app.ts
+++ b/projects/example-project-rollup/src/example-app.ts
@@ -21,11 +21,3 @@ import '@spectrum-web-components/dropdown/sp-dropdown';
 // import '@spectrum-web-components/dropdown/sync/sp-dropdown';
 import '@spectrum-web-components/menu/sp-menu';
 import '@spectrum-web-components/menu/sp-menu-item';
-
-// While https://github.com/open-wc/open-wc/issues/1210 and
-// go https://github.com/popperjs/popper-core/issues/933 persist
-// without an acceptable outcome, this allows the built storybook
-// to function with `process.env.NODE_ENV`... :/
-window.process = window.process || {};
-window.process.env = window.process.env || {};
-window.process.env.NODE_ENV = window.process.env.NODE_ENV || 'production';


### PR DESCRIPTION
## Description
Move to the ESM build from Popper so as to remove the need to `process.env` workarounds in no build contexts.

I wish that https://github.com/popperjs/popper-core/issues/1188 and https://github.com/popperjs/popper-core/issues/1188 and https://github.com/popperjs/popper-core/issues/933 would have gotten us a better solution. Needing to use an off main entry point build while hand managing the connectivity to the types is not my favorite thing in the world.

## Related Issue
refs 963

## Motivation and Context
`process.env` should be removed from production facing code.

## How Has This Been Tested?
Works locally and in CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
