### PR TITLE
build: use import linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
     "root": true,
-    "plugins": ["notice", "spectrum-web-components"],
+    "plugins": ["notice", "spectrum-web-components", "import"],
     "env": {
         "browser": true,
         "node": true,
@@ -12,6 +12,8 @@
         "sourceType": "module"
     },
     "rules": {
+        "import/extensions": ["error", "ignorePackages", { "ts": "never" }],
+        "import/prefer-default-export": "off",
         "spectrum-web-components/prevent-argument-names": [
             "error",
             ["e", "ev", "evt", "err"]

--- a/documentation/src/components/home.ts
+++ b/documentation/src/components/home.ts
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { html, CSSResultArray } from 'lit-element';
-import { RouteComponent } from './route-component';
+import { RouteComponent } from './route-component.js';
 import componentStyles from './markdown.css';
 import homeStyles from './home.css';
 import '@spectrum-web-components/button/sp-button.js';

--- a/documentation/src/router.ts
+++ b/documentation/src/router.ts
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { Router, Route, RouterOptions } from '@vaadin/router';
-import { Page } from './components/page';
+import { Page } from './components/page.js';
 
 const githubUrl = 'https://opensource.adobe.com/spectrum-web-components/';
 const baseUrl =

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
         "eslint": "^7.11.0",
         "eslint-config-prettier": "^6.12.0",
         "eslint-formatter-pretty": "^4.0.0",
+        "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-lit-a11y": "^1.0.0",
         "eslint-plugin-notice": "^0.9.10",
         "eslint-plugin-prettier": "^3.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10687,7 +10687,7 @@ eslint-formatter-pretty@^4.0.0:
     string-width "^4.2.0"
     supports-hyperlinks "^2.0.0"
 
-eslint-import-resolver-node@^0.3.3:
+eslint-import-resolver-node@^0.3.3, eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
   integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
@@ -10728,6 +10728,25 @@ eslint-plugin-import@^2.18.2:
     debug "^2.6.9"
     doctrine "1.5.0"
     eslint-import-resolver-node "^0.3.3"
+    eslint-module-utils "^2.6.0"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.1"
+    read-pkg-up "^2.0.0"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
+
+eslint-plugin-import@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
+  integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
+  dependencies:
+    array-includes "^3.1.1"
+    array.prototype.flat "^1.2.3"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.4"
     eslint-module-utils "^2.6.0"
     has "^1.0.3"
     minimatch "^3.0.4"


### PR DESCRIPTION
## Description
Adds import linting to ensure correct usage of file extensions, and discourage anyone from adding any `export default` code to the library. Only one of two situations outside of the `wtr` context that had been catching most of this up-until-now.

## Motivation and Context
Clearer direction on code structure.

## How Has This Been Tested?
The lint processes caught a couple of missed extensions in the documentation site.

## Types of changes
- [x] internal

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
