### PR TITLE
fix(dialog): support "error" in wrapper, prevent underlay closure when not dismissable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a50831ccb066f9605acd066cc49ab19192e47e5f
+        default: 95fc998fe00f901ed1d33392851f36779dac05de
 commands:
     setup:
         steps:

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -113,6 +113,9 @@ export class DialogWrapper extends SpectrumElement {
     }
 
     private dismiss(): void {
+        if (!this.dismissable) {
+            return;
+        }
         this.close();
     }
 
@@ -163,6 +166,7 @@ export class DialogWrapper extends SpectrumElement {
                 <sp-dialog
                     ?dismissable=${this.dismissable}
                     ?no-divider=${this.noDivider}
+                    ?error=${this.error}
                     mode=${ifDefined(this.mode ? this.mode : undefined)}
                     size=${ifDefined(this.size ? this.size : undefined)}
                     @close=${this.close}

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -101,6 +101,33 @@ export const wrapperDismissableUnderlay = (): TemplateResult => {
     `;
 };
 
+export const wrapperDismissableUnderlayError = (): TemplateResult => {
+    const noTransitions = boolean('No Transitions', false, 'Testing');
+    return html`
+        <div>
+            <sp-button
+                onClick="this.nextElementSibling.open = !this.nextElementSibling.open"
+                variant="primary"
+            >
+                Toggle Dialog
+            </sp-button>
+            <sp-dialog-wrapper
+                ?no-transitions=${noTransitions}
+                open
+                hero=${landscape}
+                dismissable
+                error
+                headline="Wrapped Dialog w/ Hero Image"
+                underlay
+                @close=${action('close')}
+                size="small"
+            >
+                Content of the dialog
+            </sp-dialog-wrapper>
+        </div>
+    `;
+};
+
 export const wrapperButtons = ({
     actionTracking = true,
 } = {}): TemplateResult => {

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -23,6 +23,7 @@ import {
     wrapperButtons,
     wrapperFullscreen,
     wrapperButtonsUnderlay,
+    wrapperDismissableUnderlayError,
 } from '../stories/dialog-wrapper.stories.js';
 
 describe('Dialog Wrapper', () => {
@@ -54,16 +55,27 @@ describe('Dialog Wrapper', () => {
         await elementUpdated(el);
         expect(el).to.be.accessible();
     });
-    it('dismisses via clicking the underlay', async () => {
-        const el = await fixture<DialogWrapper>(wrapperButtonsUnderlay());
+    it('dismisses via clicking the underlay when [dismissable]', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapperDismissableUnderlayError()
+        );
+        const el = test.querySelector('sp-dialog-wrapper') as DialogWrapper;
         await elementUpdated(el);
         expect(el.open).to.be.true;
         el.dismissable = true;
-        const root = el.shadowRoot ? el.shadowRoot : el;
-        const underlay = root.querySelector('sp-underlay') as Underlay;
+        const underlay = el.shadowRoot.querySelector('sp-underlay') as Underlay;
         underlay.click();
         await elementUpdated(el);
         expect(el.open).to.be.false;
+    });
+    it('does not dismiss via clicking the underlay :not([dismissable])', async () => {
+        const el = await fixture<DialogWrapper>(wrapperButtonsUnderlay());
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
+        const underlay = el.shadowRoot.querySelector('sp-underlay') as Underlay;
+        underlay.click();
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
     });
     it('dismisses', async () => {
         const el = await fixture<DialogWrapper>(

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -111,6 +111,7 @@ module.exports = [
     'circle-loader--over-background',
     'dialog-wrapped--wrapper-dismissable',
     'dialog-wrapped--wrapper-dismissable-underlay',
+    'dialog-wrapped--wrapper-dismissable-underlay-error',
     'dialog-wrapped--wrapper-buttons',
     'dialog-wrapped--wrapper-buttons-underlay',
     'dialog-wrapped--wrapper-fullscreen',


### PR DESCRIPTION
## Description 
- pass `error` attribute between `sp-dialog-wrapper` and `sp-dialog`
- prevent closing on `sp-underlay` when `sp-dialog:not([dismissable])`

## Related Issue
fixes #992 

## Motivation and Context
Expected delivery of attributes

## How Has This Been Tested?
New unit test.
New visual regression.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/99679702-3defbc00-2a4a-11eb-85f8-52effe5f1f13.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
