### PR TITLE
feat(accordion): allow accordion items to close

### DIFF
--- a/packages/accordion/src/Accordion.ts
+++ b/packages/accordion/src/Accordion.ts
@@ -15,6 +15,8 @@ import {
     CSSResultArray,
     TemplateResult,
     property,
+    PropertyValues,
+    queryAssignedNodes,
 } from '@spectrum-web-components/base';
 
 import { AccordionItem } from './AccordionItem.js';
@@ -30,27 +32,19 @@ export class Accordion extends Focusable {
         return [styles];
     }
 
-    public focusedItemIndex = 0;
-    public focusInItemIndex = 0;
-    protected isShiftTabbing = false;
-
     /**
      * Allows multiple accordion items to be opened at the same time
      */
     @property({ type: Boolean, reflect: true, attribute: 'allow-multiple' })
     public allowMultiple = false;
 
-    public constructor() {
-        super();
-        this.handleKeydown = this.handleKeydown.bind(this);
-        this.startListeningToKeyboard = this.startListeningToKeyboard.bind(
-            this
-        );
-        this.stopListeningToKeyboard = this.stopListeningToKeyboard.bind(this);
+    @queryAssignedNodes()
+    private defaultNodes!: NodeListOf<AccordionItem>;
 
-        this.addEventListener('focusin', this.startListeningToKeyboard);
-        this.addEventListener('focusout', this.stopListeningToKeyboard);
-        this.addEventListener('sp-accordion-item-toggle', this.onToggle);
+    private get items(): AccordionItem[] {
+        return [...(this.defaultNodes || [])].filter(
+            (node: HTMLElement) => typeof node.tagName !== 'undefined'
+        ) as AccordionItem[];
     }
 
     public focus(): void {
@@ -62,8 +56,8 @@ export class Accordion extends Focusable {
     }
 
     public get focusElement(): Accordion | AccordionItem {
-        const items = this.querySelectorAll('sp-accordion-item');
-        if (!items.length) {
+        const items = this.items;
+        if (items && !items.length) {
             return this;
         }
         let index = 0;
@@ -78,9 +72,9 @@ export class Accordion extends Focusable {
     }
 
     public startListeningToKeyboard(): void {
-        const accordionItems = this.querySelectorAll('sp-accordion-item');
+        const items = this.items;
         /* c8 ignore next 3 */
-        if (accordionItems.length === 0) {
+        if (items && !items.length) {
             return;
         }
         this.addEventListener('keydown', this.handleKeydown);
@@ -102,37 +96,29 @@ export class Accordion extends Focusable {
     }
 
     private focusItemByOffset(direction: number): void {
-        const items = [...this.querySelectorAll('sp-accordion-item')];
+        const items = this.items;
         const focused = items.indexOf(getActiveElement(this) as AccordionItem);
         let next = focused;
-        next = (items.length + next + direction) % items.length;
-        while (items[next].disabled) {
+        while (items[next].disabled || next === focused) {
             next = (items.length + next + direction) % items.length;
         }
         items[next].focus();
     }
 
-    protected manageShiftTab(): void {
-        this.addEventListener('keydown', (event: KeyboardEvent) => {
-            const items = [
-                ...this.querySelectorAll('sp-accordion-item'),
-            ] as AccordionItem[];
-            const firstFocusable = items.find(
-                (item) => !item.disabled
-            ) as AccordionItem;
-            if (
-                !event.defaultPrevented &&
-                event.shiftKey &&
-                event.code === 'Tab' &&
-                (event.composedPath() as AccordionItem[]).includes(
-                    firstFocusable
-                )
-            ) {
-                this.isShiftTabbing = true;
-                HTMLElement.prototype.focus.apply(this);
-                setTimeout(() => (this.isShiftTabbing = false), 0);
-            }
-        });
+    private onToggle(event: Event): void {
+        const target = event.target as AccordionItem;
+        const items = [...this.items] as AccordionItem[];
+        /* c8 ignore next 3 */
+        if (items && !items.length) {
+            return;
+        }
+        if (!this.allowMultiple && !event.defaultPrevented) {
+            items.forEach((item) => {
+                if (item.open && item !== target) {
+                    item.open = false;
+                }
+            });
+        }
     }
 
     protected render(): TemplateResult {
@@ -141,22 +127,11 @@ export class Accordion extends Focusable {
         `;
     }
 
-    private onToggle(event: Event): void {
-        const target = event.target as AccordionItem;
-        const accordionItems = this.querySelectorAll('sp-accordion-item');
-        /* c8 ignore next 3 */
-        if (!accordionItems) {
-            return;
-        }
-        if (!this.allowMultiple) {
-            accordionItems.forEach((item: Element) => {
-                const accordionItem = item as AccordionItem;
-                if (accordionItem.open && accordionItem !== target) {
-                    accordionItem.open = false;
-                }
-            });
-        }
+    protected firstUpdated(changed: PropertyValues): void {
+        super.firstUpdated(changed);
 
-        target.open = true;
+        this.addEventListener('focusin', this.startListeningToKeyboard);
+        this.addEventListener('focusout', this.stopListeningToKeyboard);
+        this.addEventListener('sp-accordion-item-toggle', this.onToggle);
     }
 }

--- a/packages/accordion/src/AccordionItem.ts
+++ b/packages/accordion/src/AccordionItem.ts
@@ -49,22 +49,17 @@ export class AccordionItem extends Focusable {
 
     constructor() {
         super();
-
         this.addEventListener('keydown', this.onKeyDown);
     }
 
     private onKeyDown(event: KeyboardEvent): void {
+        /* c8 ignore next 3 */
         if (this.disabled) {
             return;
         }
         if (event.code === 'Enter' || event.code === 'Space') {
             event.preventDefault();
-            this.dispatchEvent(
-                new CustomEvent('sp-accordion-item-toggle', {
-                    bubbles: true,
-                    composed: true,
-                })
-            );
+            this.toggle();
         }
     }
 
@@ -73,12 +68,21 @@ export class AccordionItem extends Focusable {
         if (this.disabled) {
             return;
         }
-        this.dispatchEvent(
+        this.toggle();
+    }
+
+    private toggle(): void {
+        this.open = !this.open;
+        const applyDefault = this.dispatchEvent(
             new CustomEvent('sp-accordion-item-toggle', {
                 bubbles: true,
                 composed: true,
+                cancelable: true,
             })
         );
+        if (!applyDefault) {
+            this.open = !this.open;
+        }
     }
 
     protected render(): TemplateResult {

--- a/packages/accordion/test/accordion.test.ts
+++ b/packages/accordion/test/accordion.test.ts
@@ -55,11 +55,8 @@ describe('Accordion', () => {
             'sp-accordion-item:nth-of-type(2)'
         ) as AccordionItem;
 
-        const firstRoot = firstItem.shadowRoot as ShadowRoot;
-        const secondRoot = secondItem.shadowRoot as ShadowRoot;
-
-        const firstButton = firstRoot.querySelector('button') as HTMLElement;
-        const secondButton = secondRoot.querySelector('button') as HTMLElement;
+        const firstButton = firstItem.focusElement;
+        const secondButton = secondItem.focusElement;
 
         firstButton.click();
         await elementUpdated(el);
@@ -70,6 +67,33 @@ describe('Accordion', () => {
         await elementUpdated(el);
         openItems = el.querySelectorAll('sp-accordion-item[open]');
         expect(openItems.length).to.equal(1);
+    });
+    it('can have `toggle` events canceled', async () => {
+        const el = await fixture<Accordion>(Default());
+        await elementUpdated(el);
+        const firstItem = el.querySelector(
+            'sp-accordion-item:nth-of-type(1)'
+        ) as AccordionItem;
+        const secondItem = el.querySelector(
+            'sp-accordion-item:nth-of-type(2)'
+        ) as AccordionItem;
+
+        const firstButton = firstItem.focusElement;
+        const secondButton = secondItem.focusElement;
+
+        firstButton.click();
+        await elementUpdated(el);
+        expect(firstItem.open);
+        expect(!secondItem.open);
+
+        el.addEventListener('sp-accordion-item-toggle', (event: Event) =>
+            event.preventDefault()
+        );
+
+        secondButton.click();
+        await elementUpdated(el);
+        expect(firstItem.open);
+        expect(!secondItem.open);
     });
     it('allows more than one open item when `[allow-multiple]`', async () => {
         const el = await fixture<Accordion>(AllowMultiple());
@@ -82,11 +106,8 @@ describe('Accordion', () => {
             'sp-accordion-item:nth-of-type(2)'
         ) as AccordionItem;
 
-        const firstRoot = firstItem.shadowRoot as ShadowRoot;
-        const secondRoot = secondItem.shadowRoot as ShadowRoot;
-
-        const firstButton = firstRoot.querySelector('button') as HTMLElement;
-        const secondButton = secondRoot.querySelector('button') as HTMLElement;
+        const firstButton = firstItem.focusElement;
+        const secondButton = secondItem.focusElement;
 
         firstButton.click();
         await elementUpdated(el);
@@ -100,7 +121,7 @@ describe('Accordion', () => {
         expect(firstItem.open).to.be.true;
         expect(secondItem.open).to.be.true;
     });
-    it('ensures that the correct item is open and that items cannot be closed', async () => {
+    it('ensures that the correct item is open and that items can be closed', async () => {
         const el = await fixture<Accordion>(Default());
 
         await elementUpdated(el);
@@ -111,26 +132,53 @@ describe('Accordion', () => {
             'sp-accordion-item:nth-of-type(2)'
         ) as AccordionItem;
 
-        const firstRoot = firstItem.shadowRoot as ShadowRoot;
-        const secondRoot = secondItem.shadowRoot as ShadowRoot;
-
-        const firstButton = firstRoot.querySelector('button') as HTMLElement;
-        const secondButton = secondRoot.querySelector('button') as HTMLElement;
+        const firstButton = firstItem.focusElement;
+        const secondButton = secondItem.focusElement;
 
         firstButton.click();
         await elementUpdated(el);
-        let openItem = el.querySelector('sp-accordion-item[open]');
-        expect(openItem).to.equal(firstItem);
+        expect(firstItem.open);
+        expect(!secondItem.open);
 
         secondButton.click();
         await elementUpdated(el);
-        openItem = el.querySelector('sp-accordion-item[open]');
-        expect(openItem).to.equal(secondItem);
+        expect(!firstItem.open);
+        expect(secondItem.open);
 
         secondButton.click();
         await elementUpdated(el);
-        openItem = el.querySelector('sp-accordion-item[open]');
-        expect(openItem).to.equal(secondItem);
+        expect(!firstItem.open);
+        expect(!secondItem.open);
+    });
+
+    it('ensures that the correct item is open and that items can be closed when [allow-multiple]', async () => {
+        const el = await fixture<Accordion>(AllowMultiple());
+
+        await elementUpdated(el);
+        const firstItem = el.querySelector(
+            'sp-accordion-item:nth-of-type(1)'
+        ) as AccordionItem;
+        const secondItem = el.querySelector(
+            'sp-accordion-item:nth-of-type(2)'
+        ) as AccordionItem;
+
+        const firstButton = firstItem.focusElement;
+        const secondButton = secondItem.focusElement;
+
+        firstButton.click();
+        await elementUpdated(el);
+        expect(firstItem.open);
+        expect(!secondItem.open);
+
+        secondButton.click();
+        await elementUpdated(el);
+        expect(firstItem.open);
+        expect(secondItem.open);
+
+        secondButton.click();
+        await elementUpdated(el);
+        expect(firstItem.open);
+        expect(!secondItem.open);
     });
     it('handles focus and keyboard input and ignores disabled items', async () => {
         const el = await fixture<Accordion>(


### PR DESCRIPTION
## Description
Allow `sp-accordion-item` elements to close.
- allow `sp-accordion-item-toggle` events to be cancelled

## Related Issue
fixes #920 

## Motivation and Context
More broadly usable accordion interactions.

## How Has This Been Tested?
New and updated unit testing

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
