### PR TITLE
fix(menu): prevent infinite loop when focus()

### DIFF
--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -63,7 +63,10 @@ export class Menu extends SpectrumElement {
     }
 
     public focus(): void {
-        if (!this.menuItems.length) {
+        if (
+            !this.menuItems.length ||
+            this.menuItems.every((item) => item.disabled)
+        ) {
             return;
         }
         this.focusMenuItemByOffset(0);

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -59,6 +59,24 @@ describe('Menu', () => {
             .false;
         expect(document.activeElement === anchor, 'anchor').to.be.true;
     });
+    it('renders w/ [disabled] menu items', async () => {
+        const el = await fixture<Menu>(
+            html`
+                <sp-menu tabindex="0">
+                    <sp-menu-item disabled>Disabled item</sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(document.activeElement === el, 'self not focused, 1').to.be
+            .false;
+
+        el.focus();
+        await elementUpdated(el);
+        expect(document.activeElement === el, 'self not focused, 2').to.be
+            .false;
+    });
     it('renders w/ menu items', async () => {
         const el = await fixture<Menu>(
             html`


### PR DESCRIPTION
## Description
Make sure there are active menu items available when focusing items within an `<sp-menu>` element.

## Related Issue
fixes #1009 

## Motivation and Context
Prevent infinite loops.

## How Has This Been Tested?
Unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
