### PR TITLE
fix(slider): allow irregular tick spacing and correct RTL value application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 05af03e27962edfbb5c25500ca1806d53f7b70dd
+        default: c7967753617b72f2449a0af5d709da066c3132d2
 commands:
     setup:
         steps:

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -18,6 +18,7 @@ import {
     query,
     PropertyValues,
     styleMap,
+    ifDefined,
 } from '@spectrum-web-components/base';
 
 import spectrumSliderStyles from './spectrum-slider.css.js';
@@ -217,10 +218,18 @@ export class Slider extends Focusable {
         }
         const tickStep = this.tickStep || this.step;
         const tickCount = (this.max - this.min) / tickStep;
-        const ticks = new Array(tickCount + 1);
+        const partialFit = tickCount % 1 !== 0;
+        const ticks = new Array(Math.floor(tickCount + 1));
         ticks.fill(0, 0, tickCount + 1);
         return html`
-            <div class="ticks">
+            <div
+                class="${partialFit ? 'not-exact ' : ''}ticks"
+                style=${ifDefined(
+                    partialFit
+                        ? `--sp-slider-tick-offset: calc(100% / ${this.max} * ${this.tickStep}`
+                        : undefined
+                )}
+            >
                 ${ticks.map(
                     (_tick, i) => html`
                         <div class="tick">
@@ -430,7 +439,7 @@ export class Slider extends Focusable {
         const percent = (offset - minOffset) / size;
         const value = this.min + (this.max - this.min) * percent;
 
-        return this.isLTR ? value : 100 - value;
+        return this.isLTR ? value : this.max - value;
     }
 
     private dispatchInputEvent(): void {

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -25,6 +25,28 @@ governing permissions and limitations under the License.
     touch-action: none;
 }
 
+.not-exact.ticks {
+    justify-content: start;
+}
+
+:host([dir='ltr']) .not-exact .tick {
+    padding-right: var(--sp-slider-tick-offset);
+}
+
+:host([dir='rtl']) .not-exact .tick {
+    padding-left: var(--sp-slider-tick-offset);
+}
+
+:host([dir='ltr']) .not-exact .tick:after {
+    left: auto;
+    transform: translate(-50%, 0);
+}
+
+:host([dir='rtl']) .not-exact .tick:after {
+    right: auto;
+    transform: translate(50%, 0);
+}
+
 /*
  * The following three declarationsa required while https://github.com/adobe/spectrum-css/issues/521
  * waits to be addressed at the Spectrum CSS level.

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -66,6 +66,18 @@ export const Gradient = (): TemplateResult => {
     `;
 };
 
+export const tick = (): TemplateResult => {
+    return html`
+        <sp-slider
+            label="Slider Label"
+            variant="tick"
+            tick-step="5"
+            min="0"
+            max="92"
+        ></sp-slider>
+    `;
+};
+
 export const Disabled = (): TemplateResult => {
     const label = text('Label', 'Intensity');
     return html`

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import '../sp-slider.js';
 import { Slider } from '../';
+import { tick } from '../stories/slider.stories.js';
 import {
     fixture,
     elementUpdated,
@@ -49,6 +50,13 @@ describe('Slider', () => {
                 ></sp-slider>
             `
         );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('loads - [variant="tick"] irregularly', async () => {
+        const el = await fixture<Slider>(tick());
 
         await elementUpdated(el);
 

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -189,6 +189,7 @@ module.exports = [
     'sidenav--hrefs',
     'slider--default',
     'slider--gradient',
+    'slider--tick',
     'slider--disabled',
     'slider--focus-tab-demo',
     'split-button--cta',


### PR DESCRIPTION
## Description 
- allow for ticks to be placed along the track without fitting exactly to the value: e.g. `<sp-slider max=92 tick-step=5>`
- correct a value calculation error in RTL sliders with `max` other than 100

## Related Issue
fixes #726 

## Motivation and Context
Components shouldn't crash, even in edge case usage 

## How Has This Been Tested?
Added visual regression.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/100100628-17a59400-2e2f-11eb-8d19-b9b1bcbcf4e6.png)

## Types of changes]
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
