### PR TITLE
fix(top-nav): initialize nav with an undefined selection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: ea4c1db97e884f6c40eef1a61ad648675ea05188
+        default: 8c2f4e65efa1058daa8c333d9b5ba6245b33507d
 commands:
     setup:
         steps:

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -56,7 +56,7 @@ export class TopNav extends SpectrumElement {
     };
 
     @property({ reflect: true })
-    public set selected(value: string) {
+    public set selected(value: string | undefined) {
         const oldValue = this.selected;
 
         if (value === oldValue) {
@@ -68,11 +68,11 @@ export class TopNav extends SpectrumElement {
         this.requestUpdate('selected', oldValue);
     }
 
-    public get selected(): string {
+    public get selected(): string | undefined {
         return this._selected;
     }
 
-    private _selected = '';
+    private _selected!: string | undefined;
 
     protected items: TopNavItem[] = [];
 
@@ -122,13 +122,13 @@ export class TopNav extends SpectrumElement {
         this.manageItems();
     }
 
-    protected updateCheckedState(value: string): void {
+    protected updateCheckedState(value: string | undefined): void {
         this.items.forEach((item) => {
             item.selected = false;
         });
 
         requestAnimationFrame(() => {
-            if (value.length) {
+            if (value && value.length) {
                 const currentItem = this.items.find(
                     (item) =>
                         item.value === value ||


### PR DESCRIPTION
## Description 
Set the `selected` value in `sp-top-nav` to `undefined` by default so that it doesn't require two renders passes to apply the correct indicator position.

## Motivation and Context
Stabilize out visual regression suite.

## How Has This Been Tested?
Ran it a bunch in CI to make sure things weren't flaky anymore.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
