### PR TITLE
build: process @media queries in source CSS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c7967753617b72f2449a0af5d709da066c3132d2
+        default: 2ecdb30466ca9cb15b7850ca9827d6fabf69736f
 commands:
     setup:
         steps:

--- a/packages/bar-loader/src/spectrum-bar-loader.css
+++ b/packages/bar-loader/src/spectrum-bar-loader.css
@@ -10,40 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-@keyframes indeterminate-loop-ltr {
-    0% {
-        transform: translate(
-            calc(
-                -1 * var(--spectrum-progressbar-large-indeterminate-fill-width, var(--spectrum-global-dimension-size-1700))
-            )
-        );
-    }
-    to {
-        transform: translate(
-            var(
-                --spectrum-progressbar-large-width,
-                var(--spectrum-global-dimension-size-2400)
-            )
-        );
-    }
-}
-@keyframes indeterminate-loop-rtl {
-    0% {
-        transform: translate(
-            var(
-                --spectrum-progressbar-large-width,
-                var(--spectrum-global-dimension-size-2400)
-            )
-        );
-    }
-    to {
-        transform: translate(
-            calc(
-                -1 * var(--spectrum-progressbar-large-width, var(--spectrum-global-dimension-size-2400))
-            )
-        );
-    }
-}
 :host {
     /* .spectrum-ProgressBar */
     position: relative;
@@ -239,6 +205,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-global-animation-duration-2000)
         )
         infinite;
+}
+@keyframes indeterminate-loop-ltr {
+    0% {
+        transform: translate(
+            calc(
+                -1 * var(--spectrum-progressbar-large-indeterminate-fill-width, var(--spectrum-global-dimension-size-1700))
+            )
+        );
+    }
+    to {
+        transform: translate(
+            var(
+                --spectrum-progressbar-large-width,
+                var(--spectrum-global-dimension-size-2400)
+            )
+        );
+    }
+}
+@keyframes indeterminate-loop-rtl {
+    0% {
+        transform: translate(
+            var(
+                --spectrum-progressbar-large-width,
+                var(--spectrum-global-dimension-size-2400)
+            )
+        );
+    }
+    to {
+        transform: translate(
+            calc(
+                -1 * var(--spectrum-progressbar-large-width, var(--spectrum-global-dimension-size-2400))
+            )
+        );
+    }
 }
 .fill {
     /* .spectrum-ProgressBar .spectrum-ProgressBar-fill */

--- a/packages/button/src/spectrum-clear-button.css
+++ b/packages/button/src/spectrum-clear-button.css
@@ -80,9 +80,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1
     );
 }
-.button > .icon {
-    /* .spectrum-ClearButton>.spectrum-Icon */
-    margin: 0;
+@media (-ms-high-contrast: none), screen and (-ms-high-contrast: active) {
+    .button > .icon {
+        margin: 0;
+    }
 }
 :host([small]) .button {
     /* .spectrum-ClearButton--small */

--- a/packages/button/src/spectrum-config.js
+++ b/packages/button/src/spectrum-config.js
@@ -26,6 +26,7 @@ const config = {
                     selector: '.spectrum-Icon',
                 },
             ],
+            exclude: [/\.spectrum-ClearButton/],
             excludeSourceSelector: [/^(?!(.*),(.*),(.*),(.*),(.*))/],
         },
         {
@@ -53,7 +54,11 @@ const config = {
                     name: 'icon',
                 },
             ],
-            exclude: [/\.spectrum-ActionButton/, /\.spectrum-Button/],
+            exclude: [
+                /\.spectrum-ActionButton/,
+                /\.spectrum-Button/,
+                /\.spectrum-ClearButton/,
+            ],
             excludeSourceSelector: [
                 /^([^\s]*),([^\s]*),([^\s]*),([^\s]*),([^\s]*)$/,
             ],
@@ -97,7 +102,11 @@ const config = {
                     selector: '.spectrum-Icon',
                 },
             ],
-            exclude: [/\.is-disabled/, /\.spectrum-ActionButton/],
+            exclude: [
+                /\.is-disabled/,
+                /\.spectrum-ActionButton/,
+                /\.spectrum-ClearButton/,
+            ],
             excludeSourceSelector: [/^(.*),(.*),(.*),(.*),(.*)$/],
         },
         {
@@ -140,7 +149,11 @@ const config = {
                     selector: '.spectrum-Icon',
                 },
             ],
-            exclude: [/\.is-disabled/, /\.spectrum-Button/],
+            exclude: [
+                /\.is-disabled/,
+                /\.spectrum-Button/,
+                /\.spectrum-ClearButton/,
+            ],
             excludeSourceSelector: [/^(.*),(.*),(.*),(.*),(.*)$/],
         },
         {

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -507,20 +507,55 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-700)
     );
 }
-#input:focus-visible + #box {
-    /* .spectrum-Checkbox-input.focus-ring+.spectrum-Checkbox-box */
-    forced-color-adjust: none;
-    outline-color: var(
-        --spectrum-checkbox-focus-ring-color-key-focus,
-        var(--spectrum-alias-focus-ring-color)
-    );
-    outline-style: auto;
-    outline-offset: var(
-        --spectrum-checkbox-focus-ring-gap-key-focus,
-        var(--spectrum-alias-focus-ring-gap)
-    );
-    outline-width: var(
-        --spectrum-checkbox-focus-ring-size-key-focus,
-        var(--spectrum-alias-focus-ring-size)
-    );
+@media (forced-colors: active) {
+    #input:focus-visible + #box {
+        forced-color-adjust: none;
+        outline-color: var(
+            --spectrum-checkbox-focus-ring-color-key-focus,
+            var(--spectrum-alias-focus-ring-color)
+        );
+        outline-style: auto;
+        outline-offset: var(
+            --spectrum-checkbox-focus-ring-gap-key-focus,
+            var(--spectrum-alias-focus-ring-gap)
+        );
+        outline-width: var(
+            --spectrum-checkbox-focus-ring-size-key-focus,
+            var(--spectrum-alias-focus-ring-size)
+        );
+    }
+    :host {
+        --spectrum-checkbox-emphasized-box-background-color: var(
+            --spectrum-alias-background-color-transparent,
+            transparent
+        );
+        --spectrum-checkbox-emphasized-box-background-color-disabled: var(
+            --spectrum-alias-background-color-transparent,
+            transparent
+        );
+        --spectrum-checkbox-emphasized-box-border-color-disabled: GrayText;
+        --spectrum-checkbox-text-color-disabled: GrayText;
+        --spectrum-checkbox-box-border-color-key-focus: FieldText;
+        --spectrum-checkbox-emphasized-box-border-color: FieldText;
+        --spectrum-checkbox-quiet-box-border-color: FieldText;
+        --spectrum-checkbox-box-border-color-selected-hover: Highlight;
+        --spectrum-checkbox-emphasized-box-border-color-selected-hover: Highlight;
+        --spectrum-checkbox-quiet-box-border-color-selected-hover: Highlight;
+        --spectrum-checkbox-emphasized-box-border-color-selected: Highlight;
+        --spectrum-checkbox-quiet-box-border-color-selected: Highlight;
+        --spectrum-checkbox-checkmark-color: HighlightText;
+        --spectrum-checkbox-focus-ring-color-key-focus: Highlight;
+        --spectrum-checkbox-focus-ring-gap-key-focus: var(
+            --spectrum-global-dimension-static-size-25,
+            2px
+        );
+        --spectrum-checkbox-focus-ring-size-key-focus: var(
+            --spectrum-global-dimension-static-size-40,
+            3px
+        );
+        --spectrum-checkbox-box-border-color-error: FieldText;
+        --spectrum-checkbox-box-border-color-error-hover: FieldText;
+        --spectrum-checkbox-box-border-color-error-selected: FieldText;
+        --spectrum-checkbox-text-color-error: FieldText;
+    }
 }

--- a/packages/circle-loader/src/spectrum-circle-loader.css
+++ b/packages/circle-loader/src/spectrum-circle-loader.css
@@ -10,6 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+.fill-submask-2 {
+    /* .spectrum-ProgressCircle--indeterminate-fill-submask-2 */
+    animation: spectrum-fill-mask-2 1s linear infinite;
+}
 @keyframes spectrum-fill-mask-1 {
     0% {
         transform: rotate(90deg);
@@ -381,10 +385,6 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     to {
         transform: rotate(270deg);
     }
-}
-.fill-submask-2 {
-    /* .spectrum-ProgressCircle--indeterminate-fill-submask-2 */
-    animation: spectrum-fill-mask-2 1s linear infinite;
 }
 :host {
     /* .spectrum-ProgressCircle */

--- a/packages/dialog/src/spectrum-dialog.css
+++ b/packages/dialog/src/spectrum-dialog.css
@@ -56,10 +56,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .grid {
     /* .spectrum-Dialog .spectrum-Dialog-grid */
     display: grid;
-    grid-template-columns: var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(
-            0,
-            auto
-        ) var(--spectrum-dialog-confirm-padding);
+    grid-template-columns:
+        var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(0, auto)
+        var(--spectrum-dialog-confirm-padding);
     grid-template-rows: auto var(--spectrum-dialog-confirm-padding) auto auto 1fr auto var(
             --spectrum-dialog-confirm-padding
         );
@@ -181,12 +180,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dismissable]) .grid {
     /* .spectrum-Dialog.spectrum-Dialog--dismissable .spectrum-Dialog-grid */
-    grid-template-columns: var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(
-            0,
-            auto
-        ) minmax(0, var(--spectrum-global-dimension-size-400)) var(
-            --spectrum-dialog-confirm-padding
-        );
+    grid-template-columns:
+        var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(0, auto)
+        minmax(0, var(--spectrum-global-dimension-size-400)) var(--spectrum-dialog-confirm-padding);
     grid-template-rows: auto var(--spectrum-dialog-confirm-padding) auto auto 1fr auto var(
             --spectrum-dialog-confirm-padding
         );
@@ -285,60 +281,47 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     grid-area: buttonGroup;
     align-self: start;
 }
-.grid {
-    /* .spectrum-Dialog .spectrum-Dialog-grid */
-    grid-template-columns: var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(
-            0,
-            auto
-        ) var(--spectrum-dialog-confirm-padding);
-    grid-template-areas: 'hero hero    hero    hero        hero        hero' '.    .       .       .           .           .' '.    heading heading heading     typeIcon    .' '.    header  header  header      header      .' '.    divider divider divider     divider     .' '.    content content content     content     .' '.    footer  footer  buttonGroup buttonGroup .' '.    .       .       .           .           .';
-}
-:host([dismissable]) .grid,
-.grid {
-    /* .spectrum-Dialog.spectrum-Dialog--dismissable .spectrum-Dialog-grid,
-   * .spectrum-Dialog .spectrum-Dialog-grid */
-    grid-template-rows: auto var(--spectrum-dialog-confirm-padding) auto auto auto 1fr auto var(
-            --spectrum-dialog-confirm-padding
-        );
-}
-:host([dismissable]) .grid {
-    /* .spectrum-Dialog.spectrum-Dialog--dismissable .spectrum-Dialog-grid */
-    grid-template-columns: var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(
-            0,
-            auto
-        ) minmax(0, var(--spectrum-global-dimension-size-400)) var(
-            --spectrum-dialog-confirm-padding
-        );
-    grid-template-areas: 'hero hero    hero    hero        hero        hero        hero' '.    .       .       .           .           closeButton closeButton' '.    heading heading heading     typeIcon    closeButton closeButton' '.    header  header  header      header      header      .' '.    divider divider divider     divider     divider     .' '.    content content content     content     content     .' '.    footer  footer  buttonGroup buttonGroup buttonGroup .' '.    .       .       .           .           .           .';
-}
-.header {
-    /* .spectrum-Dialog .spectrum-Dialog-header */
-    justify-content: flex-start;
-}
-:host([mode='fullscreen']) .grid,
-:host([mode='fullscreenTakeover']) .grid {
-    /* .spectrum-Dialog--fullscreen.spectrum-Dialog .spectrum-Dialog-grid,
-   * .spectrum-Dialog--fullscreenTakeover.spectrum-Dialog .spectrum-Dialog-grid */
-    display: grid;
-    grid-template-columns: var(--spectrum-dialog-confirm-padding) 1fr var(
-            --spectrum-dialog-confirm-padding
-        );
-    grid-template-rows: var(--spectrum-dialog-confirm-padding) auto auto auto 1fr auto var(
-            --spectrum-dialog-confirm-padding
-        );
-    grid-template-areas: '.    .            .' '.    heading      .' '.    header       .' '.    divider      .' '.    content      .' '.    buttonGroup  .' '.    .            .';
-}
-:host([mode='fullscreen']) .buttonGroup,
-:host([mode='fullscreenTakeover']) .buttonGroup {
-    /* .spectrum-Dialog--fullscreen .spectrum-Dialog-buttonGroup,
-   * .spectrum-Dialog--fullscreenTakeover .spectrum-Dialog-buttonGroup */
-    padding-top: var(--spectrum-global-dimension-static-size-500, 40px);
-}
-:host([mode='fullscreen']) ::slotted([slot='heading']),
-:host([mode='fullscreenTakeover']) ::slotted([slot='heading']) {
-    /* .spectrum-Dialog--fullscreen .spectrum-Dialog-heading,
-   * .spectrum-Dialog--fullscreenTakeover .spectrum-Dialog-heading */
-    font-size: var(--spectrum-dialog-confirm-title-text-size);
+@media screen and (max-inline-size: 700px) {
+    .grid {
+        grid-template-columns:
+            var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(0, auto)
+            var(--spectrum-dialog-confirm-padding);
+        grid-template-areas: 'hero hero    hero    hero        hero        hero' '.    .       .       .           .           .' '.    heading heading heading     typeIcon    .' '.    header  header  header      header      .' '.    divider divider divider     divider     .' '.    content content content     content     .' '.    footer  footer  buttonGroup buttonGroup .' '.    .       .       .           .           .';
+    }
+    :host([dismissable]) .grid,
+    .grid {
+        grid-template-rows: auto var(--spectrum-dialog-confirm-padding) auto auto auto 1fr auto var(
+                --spectrum-dialog-confirm-padding
+            );
+    }
+    :host([dismissable]) .grid {
+        grid-template-columns:
+            var(--spectrum-dialog-confirm-padding) auto 1fr auto minmax(0, auto)
+            minmax(0, var(--spectrum-global-dimension-size-400)) var(--spectrum-dialog-confirm-padding);
+        grid-template-areas: 'hero hero    hero    hero        hero        hero        hero' '.    .       .       .           .           closeButton closeButton' '.    heading heading heading     typeIcon    closeButton closeButton' '.    header  header  header      header      header      .' '.    divider divider divider     divider     divider     .' '.    content content content     content     content     .' '.    footer  footer  buttonGroup buttonGroup buttonGroup .' '.    .       .       .           .           .           .';
+    }
+    .header {
+        justify-content: flex-start;
+    }
+    :host([mode='fullscreen']) .grid,
+    :host([mode='fullscreenTakeover']) .grid {
+        display: grid;
+        grid-template-columns: var(--spectrum-dialog-confirm-padding) 1fr var(
+                --spectrum-dialog-confirm-padding
+            );
+        grid-template-rows: var(--spectrum-dialog-confirm-padding) auto auto auto 1fr auto var(
+                --spectrum-dialog-confirm-padding
+            );
+        grid-template-areas: '.    .            .' '.    heading      .' '.    header       .' '.    divider      .' '.    content      .' '.    buttonGroup  .' '.    .            .';
+    }
+    :host([mode='fullscreen']) .buttonGroup,
+    :host([mode='fullscreenTakeover']) .buttonGroup {
+        padding-top: var(--spectrum-global-dimension-static-size-500, 40px);
+    }
+    :host([mode='fullscreen']) ::slotted([slot='heading']),
+    :host([mode='fullscreenTakeover']) ::slotted([slot='heading']) {
+        font-size: var(--spectrum-dialog-confirm-title-text-size);
+    }
 }
 ::slotted([slot='heading']) {
     /* .spectrum-Dialog-heading */

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -10,40 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-@keyframes indeterminate-loop-ltr {
-    0% {
-        transform: translate(
-            calc(
-                -1 * var(--spectrum-progressbar-large-indeterminate-fill-width, var(--spectrum-global-dimension-size-1700))
-            )
-        );
-    }
-    to {
-        transform: translate(
-            var(
-                --spectrum-progressbar-large-width,
-                var(--spectrum-global-dimension-size-2400)
-            )
-        );
-    }
-}
-@keyframes indeterminate-loop-rtl {
-    0% {
-        transform: translate(
-            var(
-                --spectrum-progressbar-large-width,
-                var(--spectrum-global-dimension-size-2400)
-            )
-        );
-    }
-    to {
-        transform: translate(
-            calc(
-                -1 * var(--spectrum-progressbar-large-width, var(--spectrum-global-dimension-size-2400))
-            )
-        );
-    }
-}
 :host {
     /* .spectrum-ProgressBar */
     position: relative;
@@ -239,6 +205,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-global-animation-duration-2000)
         )
         infinite;
+}
+@keyframes indeterminate-loop-ltr {
+    0% {
+        transform: translate(
+            calc(
+                -1 * var(--spectrum-progressbar-large-indeterminate-fill-width, var(--spectrum-global-dimension-size-1700))
+            )
+        );
+    }
+    to {
+        transform: translate(
+            var(
+                --spectrum-progressbar-large-width,
+                var(--spectrum-global-dimension-size-2400)
+            )
+        );
+    }
+}
+@keyframes indeterminate-loop-rtl {
+    0% {
+        transform: translate(
+            var(
+                --spectrum-progressbar-large-width,
+                var(--spectrum-global-dimension-size-2400)
+            )
+        );
+    }
+    to {
+        transform: translate(
+            calc(
+                -1 * var(--spectrum-progressbar-large-width, var(--spectrum-global-dimension-size-2400))
+            )
+        );
+    }
 }
 .fill {
     /* .spectrum-ProgressBar .spectrum-ProgressBar-fill */

--- a/packages/modal/src/spectrum-modal-wrapper.css
+++ b/packages/modal/src/spectrum-modal-wrapper.css
@@ -35,7 +35,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Modal-wrapper.is-open */
     visibility: visible;
 }
-:host([responsive]) {
-    /* .spectrum-Modal-wrapper .spectrum-Modal--responsive */
-    margin-top: 0;
+@media only screen and (max-device-height: 350px),
+    only screen and (max-device-width: 400px) {
+    :host([responsive]) {
+        width: 100%;
+        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
+        border-radius: 0;
+    }
+    :host([responsive]) {
+        margin-top: 0;
+    }
 }

--- a/packages/modal/src/spectrum-modal.css
+++ b/packages/modal/src/spectrum-modal.css
@@ -92,13 +92,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             );
     transform: translateY(0);
 }
-:host([responsive]) .modal {
-    /* .spectrum-Modal--responsive */
-    width: 100%;
-    height: 100%;
-    max-width: 100%;
-    max-height: 100%;
-    border-radius: 0;
+@media only screen and (max-device-height: 350px),
+    only screen and (max-device-width: 400px) {
+    :host([responsive]) .modal {
+        width: 100%;
+        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
+        border-radius: 0;
+    }
 }
 .fullscreen {
     /* .spectrum-Modal--fullscreen */

--- a/packages/styles/src/spectrum-base.css
+++ b/packages/styles/src/spectrum-base.css
@@ -19,7 +19,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     font-size: var(
         --spectrum-alias-font-size-default,
         var(--spectrum-global-dimension-font-size-100)
-    ); /* .spectrum,
+    );
+}
+.spectrum {
+    /* .spectrum,
    * .spectrum-Body */
     color: var(--spectrum-body-m-text-color, var(--spectrum-alias-text-color));
 }

--- a/packages/styles/src/spectrum-body.css
+++ b/packages/styles/src/spectrum-body.css
@@ -34,11 +34,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-body-xxxl-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Body--sizeXXXL */
-    color: var(
-        --spectrum-body-xxxl-text-color,
-        var(--spectrum-alias-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Body--sizeXXL {
     /* .spectrum-Body--sizeXXL */
@@ -64,11 +60,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-body-xxl-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Body--sizeXXL */
-    color: var(
-        --spectrum-body-xxl-text-color,
-        var(--spectrum-alias-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Body--sizeXL {
     /* .spectrum-Body--sizeXL */
@@ -94,8 +86,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-body-xl-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Body--sizeXL */
-    color: var(--spectrum-body-xl-text-color, var(--spectrum-alias-text-color));
+    margin-bottom: 0;
 }
 .spectrum-Body--sizeL {
     /* .spectrum-Body--sizeL */
@@ -121,8 +112,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-body-l-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Body--sizeL */
-    color: var(--spectrum-body-l-text-color, var(--spectrum-alias-text-color));
+    margin-bottom: 0;
 }
 .spectrum-Body--sizeM {
     /* .spectrum-Body--sizeM */
@@ -148,8 +138,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-body-m-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Body--sizeM */
-    color: var(--spectrum-body-m-text-color, var(--spectrum-alias-text-color));
+    margin-bottom: 0;
 }
 .spectrum-Body--sizeS {
     /* .spectrum-Body--sizeS */
@@ -175,8 +164,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-body-s-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Body--sizeS */
-    color: var(--spectrum-body-s-text-color, var(--spectrum-alias-text-color));
+    margin-bottom: 0;
 }
 .spectrum-Body--sizeXS {
     /* .spectrum-Body--sizeXS */
@@ -202,17 +190,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-body-xs-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Body--sizeXS */
-    color: var(--spectrum-body-xs-text-color, var(--spectrum-alias-text-color));
+    margin-bottom: 0;
 }
 .spectrum-Body {
     /* .spectrum-Body */
     font-family: var(
         --spectrum-body-m-text-font-family,
         var(--spectrum-alias-body-text-font-family)
-    ); /* .spectrum,
-   * .spectrum-Body */
-    color: var(--spectrum-body-m-text-color, var(--spectrum-alias-text-color));
+    );
 }
 .spectrum-Body-strong,
 strong {
@@ -238,4 +223,43 @@ em {
         --spectrum-body-serif-m-text-font-family,
         var(--spectrum-alias-serif-text-font-family)
     );
+}
+.spectrum-Body--sizeXXXL {
+    /* .spectrum-Body--sizeXXXL */
+    color: var(
+        --spectrum-body-xxxl-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+.spectrum-Body--sizeXXL {
+    /* .spectrum-Body--sizeXXL */
+    color: var(
+        --spectrum-body-xxl-text-color,
+        var(--spectrum-alias-text-color)
+    );
+}
+.spectrum-Body--sizeXL {
+    /* .spectrum-Body--sizeXL */
+    color: var(--spectrum-body-xl-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Body--sizeL {
+    /* .spectrum-Body--sizeL */
+    color: var(--spectrum-body-l-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Body--sizeM {
+    /* .spectrum-Body--sizeM */
+    color: var(--spectrum-body-m-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Body--sizeS {
+    /* .spectrum-Body--sizeS */
+    color: var(--spectrum-body-s-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Body--sizeXS {
+    /* .spectrum-Body--sizeXS */
+    color: var(--spectrum-body-xs-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Body {
+    /* .spectrum,
+   * .spectrum-Body */
+    color: var(--spectrum-body-m-text-color, var(--spectrum-alias-text-color));
 }

--- a/packages/styles/src/spectrum-code.css
+++ b/packages/styles/src/spectrum-code.css
@@ -69,8 +69,7 @@ em {
     font-family: var(
         --spectrum-code-xl-text-font-family,
         var(--spectrum-alias-code-text-font-family)
-    ); /* .spectrum-Code--sizeXL */
-    color: var(--spectrum-code-xl-text-color, var(--spectrum-alias-text-color));
+    );
 }
 .spectrum-Code--sizeL {
     /* .spectrum-Code--sizeL */
@@ -99,8 +98,7 @@ em {
     font-family: var(
         --spectrum-code-l-text-font-family,
         var(--spectrum-alias-code-text-font-family)
-    ); /* .spectrum-Code--sizeL */
-    color: var(--spectrum-code-l-text-color, var(--spectrum-alias-text-color));
+    );
 }
 .spectrum-Code--sizeM {
     /* .spectrum-Code--sizeM */
@@ -129,8 +127,7 @@ em {
     font-family: var(
         --spectrum-code-m-text-font-family,
         var(--spectrum-alias-code-text-font-family)
-    ); /* .spectrum-Code--sizeM */
-    color: var(--spectrum-code-m-text-color, var(--spectrum-alias-text-color));
+    );
 }
 .spectrum-Code--sizeS {
     /* .spectrum-Code--sizeS */
@@ -159,8 +156,7 @@ em {
     font-family: var(
         --spectrum-code-s-text-font-family,
         var(--spectrum-alias-code-text-font-family)
-    ); /* .spectrum-Code--sizeS */
-    color: var(--spectrum-code-s-text-color, var(--spectrum-alias-text-color));
+    );
 }
 .spectrum-Code--sizeXS {
     /* .spectrum-Code--sizeXS */
@@ -189,6 +185,25 @@ em {
     font-family: var(
         --spectrum-code-xs-text-font-family,
         var(--spectrum-alias-code-text-font-family)
-    ); /* .spectrum-Code--sizeXS */
+    );
+}
+.spectrum-Code--sizeXL {
+    /* .spectrum-Code--sizeXL */
+    color: var(--spectrum-code-xl-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Code--sizeL {
+    /* .spectrum-Code--sizeL */
+    color: var(--spectrum-code-l-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Code--sizeM {
+    /* .spectrum-Code--sizeM */
+    color: var(--spectrum-code-m-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Code--sizeS {
+    /* .spectrum-Code--sizeS */
+    color: var(--spectrum-code-s-text-color, var(--spectrum-alias-text-color));
+}
+.spectrum-Code--sizeXS {
+    /* .spectrum-Code--sizeXS */
     color: var(--spectrum-code-xs-text-color, var(--spectrum-alias-text-color));
 }

--- a/packages/styles/src/spectrum-detail.css
+++ b/packages/styles/src/spectrum-detail.css
@@ -77,11 +77,7 @@ em {
     );
     text-transform: var(--spectrum-detail-xl-text-transform, uppercase);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Detail--sizeXL */
-    color: var(
-        --spectrum-detail-xl-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Detail--sizeXL em {
     /* .spectrum-Detail--sizeXL em */
@@ -162,11 +158,7 @@ em {
     );
     text-transform: var(--spectrum-detail-l-text-transform, uppercase);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Detail--sizeL */
-    color: var(
-        --spectrum-detail-l-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Detail--sizeL em {
     /* .spectrum-Detail--sizeL em */
@@ -244,11 +236,7 @@ em {
     );
     text-transform: var(--spectrum-detail-m-text-transform, uppercase);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Detail--sizeM */
-    color: var(
-        --spectrum-detail-m-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Detail--sizeM em {
     /* .spectrum-Detail--sizeM em */
@@ -326,11 +314,7 @@ em {
     );
     text-transform: var(--spectrum-detail-s-text-transform, uppercase);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Detail--sizeS */
-    color: var(
-        --spectrum-detail-s-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Detail--sizeS em {
     /* .spectrum-Detail--sizeS em */
@@ -383,4 +367,32 @@ em {
     text-transform: var(--spectrum-detail-s-strong-text-transform, uppercase);
     margin-top: 0;
     margin-bottom: 0;
+}
+.spectrum-Detail--sizeXL {
+    /* .spectrum-Detail--sizeXL */
+    color: var(
+        --spectrum-detail-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Detail--sizeL {
+    /* .spectrum-Detail--sizeL */
+    color: var(
+        --spectrum-detail-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Detail--sizeM {
+    /* .spectrum-Detail--sizeM */
+    color: var(
+        --spectrum-detail-m-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Detail--sizeS {
+    /* .spectrum-Detail--sizeS */
+    color: var(
+        --spectrum-detail-s-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
 }

--- a/packages/styles/src/spectrum-heading.css
+++ b/packages/styles/src/spectrum-heading.css
@@ -34,11 +34,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-heading-xxxl-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Heading--sizeXXXL */
-    color: var(
-        --spectrum-heading-xxxl-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Heading--sizeXXL {
     /* .spectrum-Heading--sizeXXL */
@@ -64,11 +60,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-heading-xxl-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Heading--sizeXXL */
-    color: var(
-        --spectrum-heading-xxl-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Heading--sizeXL {
     /* .spectrum-Heading--sizeXL */
@@ -94,11 +86,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-heading-xl-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Heading--sizeXL */
-    color: var(
-        --spectrum-heading-xl-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Heading--sizeL {
     /* .spectrum-Heading--sizeL */
@@ -124,11 +112,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-heading-l-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Heading--sizeL */
-    color: var(
-        --spectrum-heading-l-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Heading--sizeM {
     /* .spectrum-Heading--sizeM */
@@ -154,11 +138,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-heading-m-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Heading--sizeM */
-    color: var(
-        --spectrum-heading-m-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Heading--sizeS {
     /* .spectrum-Heading--sizeS */
@@ -184,11 +164,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-heading-s-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Heading--sizeS */
-    color: var(
-        --spectrum-heading-s-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Heading--sizeXS {
     /* .spectrum-Heading--sizeXS */
@@ -214,11 +190,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-heading-xs-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Heading--sizeXS */
-    color: var(
-        --spectrum-heading-xs-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Heading--sizeXXS {
     /* .spectrum-Heading--sizeXXS */
@@ -244,11 +216,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     text-transform: var(--spectrum-heading-xxs-text-transform, none);
     margin-top: 0;
-    margin-bottom: 0; /* .spectrum-Heading--sizeXXS */
-    color: var(
-        --spectrum-heading-xxs-text-color,
-        var(--spectrum-alias-heading-text-color)
-    );
+    margin-bottom: 0;
 }
 .spectrum-Heading {
     /* .spectrum-Heading */
@@ -334,6 +302,62 @@ strong {
     font-weight: var(
         --spectrum-heading-light-m-strong-text-font-weight,
         var(--spectrum-global-font-weight-bold)
+    );
+}
+.spectrum-Heading--sizeXXXL {
+    /* .spectrum-Heading--sizeXXXL */
+    color: var(
+        --spectrum-heading-xxxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Heading--sizeXXL {
+    /* .spectrum-Heading--sizeXXL */
+    color: var(
+        --spectrum-heading-xxl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Heading--sizeXL {
+    /* .spectrum-Heading--sizeXL */
+    color: var(
+        --spectrum-heading-xl-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Heading--sizeL {
+    /* .spectrum-Heading--sizeL */
+    color: var(
+        --spectrum-heading-l-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Heading--sizeM {
+    /* .spectrum-Heading--sizeM */
+    color: var(
+        --spectrum-heading-m-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Heading--sizeS {
+    /* .spectrum-Heading--sizeS */
+    color: var(
+        --spectrum-heading-s-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Heading--sizeXS {
+    /* .spectrum-Heading--sizeXS */
+    color: var(
+        --spectrum-heading-xs-text-color,
+        var(--spectrum-alias-heading-text-color)
+    );
+}
+.spectrum-Heading--sizeXXS {
+    /* .spectrum-Heading--sizeXXS */
+    color: var(
+        --spectrum-heading-xxs-text-color,
+        var(--spectrum-alias-heading-text-color)
     );
 }
 .spectrum-Heading-sizeXXXL--light {


### PR DESCRIPTION
## Description 
Include `atrule`s in the processing of Spectrum CSS output.
- ensure that it falls in order of the original CSS
- ensure the excluded classes are followed as appropriate

## Related Issue
fixes #593 

## Motivation and Context
We should be delivering CSS correctly to our users.

## How Has This Been Tested?
Visual regression found the output to be the same except for the color of the focus ring on Checkboxes which was adopting the unscoped `atrule` coloring for WHCM.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
