### PR TITLE
feat(toast): default to "open === false", always dispatch "close" event

### DIFF
--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-`sp-toast`s display brief, temporary notifications. They are noticeable but do not disrupt the user experience and do not require an action to be taken.
+`sp-toast` elements display brief, temporary notifications. They are noticeable but do not disrupt the user experience and do not require an action to be taken.
 
 ### Usage
 
@@ -28,13 +28,15 @@ import { Toast } from '@spectrum-web-components/toast';
 ### Default
 
 ```html
-<sp-toast>This is important information that you should read, soon.</sp-toast>
+<sp-toast open>
+    This is important information that you should read, soon.
+</sp-toast>
 ```
 
 ### With actions
 
 ```html
-<sp-toast>
+<sp-toast open>
     This is important information that you should read, soon.
     <sp-button slot="action" variant="overBackground" quiet>
         Do something
@@ -45,7 +47,7 @@ import { Toast } from '@spectrum-web-components/toast';
 ### Wrapping
 
 ```html
-<sp-toast style="width: 300px">
+<sp-toast open style="width: 300px">
     This is important information that you should read, soon.
     <sp-button slot="action" variant="overBackground" quiet>
         Do something
@@ -58,7 +60,7 @@ import { Toast } from '@spectrum-web-components/toast';
 #### Negative
 
 ```html
-<sp-toast variant="negative">
+<sp-toast open variant="negative">
     This is negative information that you should read, soon.
 </sp-toast>
 ```
@@ -66,7 +68,7 @@ import { Toast } from '@spectrum-web-components/toast';
 #### Positive
 
 ```html
-<sp-toast variant="positive">
+<sp-toast open variant="positive">
     This is positive information that you should read, soon.
 </sp-toast>
 ```
@@ -74,7 +76,9 @@ import { Toast } from '@spectrum-web-components/toast';
 #### Info
 
 ```html
-<sp-toast variant="info">This is information that you should read.</sp-toast>
+<sp-toast open variant="info">
+    This is information that you should read.
+</sp-toast>
 ```
 
 ## Accessibility

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -208,18 +208,15 @@ export class Toast extends SpectrumElement {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
-        super.firstUpdated(changes);
-        this.open = true;
-    }
-
     protected updated(changes: PropertyValues): void {
         super.updated(changes);
-        if (changes.has('open') && this.timeout) {
-            if (this.open) {
+        if (changes.has('open')) {
+            if (this.open && this.timeout) {
                 this.startCountdown();
             } else {
-                this.stopCountdown();
+                if (this.timeout) {
+                    this.stopCountdown();
+                }
                 const applyDefault = this.dispatchEvent(
                     new CustomEvent('close', {
                         composed: true,


### PR DESCRIPTION
## Description 
Support easier consumption of `<sp-toast>` elements by:
- not `open`ing them by default
- always dispatching `close` events when they close

## Related Issue
fixes #935 

## Motivation and Context
Ease of use and clarity of purpose.

## How Has This Been Tested?
Updated and added testing.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
