### PR TITLE
fix(slider): allow pointer interactions that start at the very begin/…

### DIFF
--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -283,13 +283,14 @@ export class Slider extends Focusable {
     private renderTrack(): TemplateResult {
         return html`
             <div
-                id="controls"
                 @pointerdown=${this.onTrackPointerDown}
                 @mousedown=${this.onTrackMouseDown}
             >
-                ${this.renderTrackLeft()} ${this.renderRamp()}
-                ${this.renderTicks()} ${this.renderHandle()}
-                ${this.renderTrackRight()}
+                <div id="controls">
+                    ${this.renderTrackLeft()} ${this.renderRamp()}
+                    ${this.renderTicks()} ${this.renderHandle()}
+                    ${this.renderTrackRight()}
+                </div>
             </div>
         `;
     }

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -242,19 +242,23 @@ describe('Slider', () => {
 
         controls.dispatchEvent(
             new PointerEvent('pointerdown', {
-                clientX: 50,
+                // account for 8px <body> margin by default
+                clientX: 9,
                 pointerId: 4,
+                bubbles: true,
             })
         );
         controls.dispatchEvent(
             new MouseEvent('mousedown', {
-                clientX: 50,
+                // account for 8px <body> margin by default
+                clientX: 9,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
 
         expect(pointerId).to.equal(4);
-        expect(el.value).to.equal(1);
+        expect(el.value).to.equal(0);
     });
     it('will fallback to `trackMouseDown` on `#controls`', async () => {
         const el = await fixture<Slider>(
@@ -276,12 +280,14 @@ describe('Slider', () => {
 
         controls.dispatchEvent(
             new MouseEvent('mousedown', {
-                clientX: 50,
+                // account for 8px <body> margin by default
+                clientX: 9,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
 
-        expect(el.value).to.equal(1);
+        expect(el.value).to.equal(0);
         ((el as unknown) as TestableSliderType).supportsPointerEvent = supportsPointerEvent;
     });
     it('can be disabled', async () => {


### PR DESCRIPTION
## Description
Adds a non-design delivering element on which to hand the `pointer` and `mouse` events needed to inform the position of the slider handle when interacting with the track directly.

## Related Issue
fixes #653 

## Motivation and Context
Full access to the slider UI.

## How Has This Been Tested?
Updated tests now interact with the very beginning of the slider track.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
