### PR TITLE
feat(button): use synthetic button instead of native

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: bc2b4f3fe51f9edb858dc4c63248cdf0bb06a046
+        default: ec243d1d8b4aaba9eb836964903b36226829dd2a
 commands:
     setup:
         steps:

--- a/packages/action-group/src/action-group.css
+++ b/packages/action-group/src/action-group.css
@@ -13,50 +13,6 @@ governing permissions and limitations under the License.
 @import './spectrum-action-group.css';
 
 /**
- * The following styles translate the Spectrum CSS usage of `border-radius` directly on `.spectrum-ActionGroup-item`
- * to a usage of the `--spectrum-actionbutton-border-radius` custom property so that it pieces the shadow DOM in
- * `<sp-action-button>` appropriately.
- **/
-
-:host([compact]:not([quiet])) ::slotted(*) {
-    /* .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item */
-    --spectrum-actionbutton-border-radius: 0;
-}
-
-:host([compact][vertical]:not([quiet])) ::slotted(*) {
-    /* .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item */
-    --spectrum-actionbutton-border-radius: 0;
-}
-
-:host([dir='ltr'][compact]:not([quiet])) ::slotted(*:first-child),
-:host([dir='rtl'][compact]:not([quiet])) ::slotted(*:last-child) {
-    --spectrum-actionbutton-border-radius: var(
-            --spectrum-alias-border-radius-regular
-        )
-        0 0 var(--spectrum-alias-border-radius-regular);
-}
-
-:host([dir='rtl'][compact]:not([quiet])) ::slotted(*:first-child),
-:host([dir='ltr'][compact]:not([quiet])) ::slotted(*:last-child) {
-    --spectrum-actionbutton-border-radius: 0
-        var(--spectrum-alias-border-radius-regular)
-        var(--spectrum-alias-border-radius-regular) 0;
-}
-
-:host([compact][vertical]:not([quiet])) ::slotted(*:first-child) {
-    --spectrum-actionbutton-border-radius: var(
-            --spectrum-alias-border-radius-regular
-        )
-        var(--spectrum-alias-border-radius-regular) 0 0;
-}
-
-:host([compact][vertical]:not([quiet])) ::slotted(*:last-child) {
-    --spectrum-actionbutton-border-radius: 0 0
-        var(--spectrum-alias-border-radius-regular)
-        var(--spectrum-alias-border-radius-regular);
-}
-
-/**
  * The following styles corrects issues found in the Spectrum CSS output
  * that are tracked via: https://github.com/adobe/spectrum-css/issues/795
  */

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -50,6 +50,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@spectrum-web-components/base": "^0.1.3",
+        "@spectrum-web-components/button": "^0.9.4",
         "@spectrum-web-components/dropdown": "^0.8.5",
         "@spectrum-web-components/icon": "^0.6.3",
         "@spectrum-web-components/icons-workflow": "^0.3.6",

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -13,11 +13,12 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     TemplateResult,
-    property,
     PropertyValues,
     html,
+    ifDefined,
 } from '@spectrum-web-components/base';
 import { DropdownBase } from '@spectrum-web-components/dropdown';
+import '@spectrum-web-components/button/sp-action-button.js';
 import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
 import { MoreIcon } from '@spectrum-web-components/icons-workflow';
 import actionMenuStyles from './action-menu.css.js';
@@ -30,12 +31,6 @@ export class ActionMenu extends ObserveSlotText(DropdownBase, 'label') {
         return [...super.styles, actionMenuStyles];
     }
 
-    @property({ type: Boolean, reflect: true })
-    public selected = false;
-
-    @property({ type: Boolean, reflect: true })
-    public quiet = true;
-
     protected listRole = 'menu';
     protected itemRole = 'menuitem';
     private get hasLabel(): boolean {
@@ -45,32 +40,42 @@ export class ActionMenu extends ObserveSlotText(DropdownBase, 'label') {
     protected get buttonContent(): TemplateResult[] {
         return [
             html`
-                <slot name="icon">
+                <slot name="icon" slot="icon">
                     <sp-icon size="m" class="icon">
                         ${MoreIcon({ hidden: this.hasLabel })}
                     </sp-icon>
                 </slot>
-                <div id="label" ?hidden=${!this.hasLabel}>
-                    <slot
-                        name="label"
-                        id="slot"
-                        @slotchange=${this.manageTextObservedSlot}
-                    ></slot>
-                </div>
+                <slot name="label"></slot>
             `,
         ];
     }
 
+    protected get renderButton(): TemplateResult {
+        return html`
+            <sp-action-button
+                quiet
+                ?selected=${this.open}
+                aria-haspopup="true"
+                aria-controls="popover"
+                aria-expanded=${this.open ? 'true' : 'false'}
+                aria-label=${ifDefined(this.label || undefined)}
+                id="button"
+                class="button"
+                @blur=${this.onButtonBlur}
+                @click=${this.onButtonClick}
+                @focus=${this.onButtonFocus}
+                ?disabled=${this.disabled}
+            >
+                ${this.buttonContent}
+            </sp-action-button>
+        `;
+    }
+
     protected updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
-        if (changedProperties.has('open')) {
-            this.selected = this.open;
-        }
-        if (changedProperties.has('quiet')) {
-            this.quiet = true;
-        }
         if (changedProperties.has('invalid')) {
             this.invalid = false;
         }
+        this.quiet = true;
     }
 }

--- a/packages/button/sp-field-button.ts
+++ b/packages/button/sp-field-button.ts
@@ -9,30 +9,12 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+import { FieldButton } from './src/FieldButton.js';
 
-:host,
-.button {
-    min-width: 0;
-    width: auto;
-}
+customElements.define('sp-field-button', FieldButton);
 
-:host([quiet]) {
-    min-width: 0;
-}
-
-::slotted([slot='icon']) {
-    flex-shrink: 0;
-}
-
-.icon {
-    /**
-     * Because .icon is acting as default content for its slot, the `::slotted([slot="icon"])` styles do not apply.
-     * In the future it may be necessary to add a default content selector to the style processing code.
-     */
-    flex-shrink: 0;
-}
-
-#popover {
-    width: auto;
-    max-width: none;
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-field-button': FieldButton;
+    }
 }

--- a/packages/button/src/FieldButton.ts
+++ b/packages/button/src/FieldButton.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    CSSResultArray,
+    TemplateResult,
+} from '@spectrum-web-components/base';
+import { ButtonBase } from './ButtonBase.js';
+import buttonStyles from './field-button.css.js';
+
+/**
+ * A Spectrum button control.
+ * @element sp-field-button
+ */
+export class FieldButton extends ButtonBase {
+    public static get styles(): CSSResultArray {
+        return [...super.styles, buttonStyles];
+    }
+
+    protected get buttonContent(): TemplateResult[] {
+        const icon = html`
+            <slot name="icon"></slot>
+        `;
+        const content = [
+            html`
+                <slot
+                    ?hidden=${!this.hasLabel}
+                    id="slot"
+                    @slotchange=${this.manageTextObservedSlot}
+                ></slot>
+            `,
+        ];
+        if (!this.hasIcon) {
+            return content;
+        }
+        this.iconRight ? content.push(icon) : content.unshift(icon);
+        return content;
+    }
+}

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -19,14 +19,12 @@ governing permissions and limitations under the License.
 }
 
 #button {
-    display: flex;
-    flex: 1 1 auto;
+    color: inherit;
+    text-decoration: inherit;
+}
 
-    /* spectrum-css uses "-webkit-appearance: button" to workaround an
-     * iOS and Safari issue. However, it results in incorrect styling
-     * when applied in :host
-     */
-    -webkit-appearance: none;
+#button:focus {
+    outline: none;
 }
 
 slot[name='icon']::slotted(:not(sp-icon)) {

--- a/packages/button/src/spectrum-action-button.css
+++ b/packages/button/src/spectrum-action-button.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-.button {
+:host {
     /* .spectrum-ActionButton */
     position: relative;
     height: var(
@@ -49,21 +49,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-body-text-font-weight)
     );
 }
-:host([dir='ltr']) .button slot[name='icon'] + #label {
+:host([dir='ltr']) slot[name='icon'] + #label {
     /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
     padding-left: var(
         --spectrum-actionbutton-icon-padding-x,
         var(--spectrum-global-dimension-size-85)
     );
 }
-:host([dir='rtl']) .button slot[name='icon'] + #label {
+:host([dir='rtl']) slot[name='icon'] + #label {
     /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
     padding-right: var(
         --spectrum-actionbutton-icon-padding-x,
         var(--spectrum-global-dimension-size-85)
     );
 }
-:host([dir='ltr']) .button slot[name='icon'] + #label {
+:host([dir='ltr']) slot[name='icon'] + #label {
     /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
     padding-right: calc(
         var(
@@ -76,7 +76,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
-:host([dir='rtl']) .button slot[name='icon'] + #label {
+:host([dir='rtl']) slot[name='icon'] + #label {
     /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
     padding-left: calc(
         var(
@@ -89,7 +89,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
-:host([dir='ltr']) .button .spectrum-Icon--sizeS:only-child {
+:host([dir='ltr']) .spectrum-Icon--sizeS:only-child {
     /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon--sizeS:only-child */
     left: calc(
         50% -
@@ -99,7 +99,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) / 2
     );
 }
-:host([dir='rtl']) .button .spectrum-Icon--sizeS:only-child {
+:host([dir='rtl']) .spectrum-Icon--sizeS:only-child {
     /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon--sizeS:only-child */
     right: calc(
         50% -
@@ -175,7 +175,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     overflow: hidden;
     text-overflow: ellipsis;
 }
-:host([quiet]) .button {
+:host([quiet]) {
     /* .spectrum-ActionButton--quiet */
     border-width: var(
         --spectrum-actionbutton-quiet-border-size,
@@ -194,7 +194,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-body-text-font-weight)
     );
 }
-.button {
+:host {
     /* .spectrum-ActionButton */
     background-color: var(
         --spectrum-actionbutton-background-color,
@@ -223,7 +223,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color)
     );
 }
-.button:hover {
+:host(:hover) {
     /* .spectrum-ActionButton:hover */
     background-color: var(
         --spectrum-actionbutton-background-color-hover,
@@ -238,21 +238,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-.button:hover ::slotted([slot='icon']) {
+:host(:hover) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton:hover .spectrum-Icon */
     color: var(
         --spectrum-actionbutton-icon-color-hover,
         var(--spectrum-alias-icon-color-hover)
     );
 }
-.button:hover #hold-affordance {
+:host(:hover) #hold-affordance {
     /* .spectrum-ActionButton:hover .spectrum-ActionButton-hold */
     color: var(
         --spectrum-actionbutton-hold-icon-color-hover,
         var(--spectrum-alias-icon-color-hover)
     );
 }
-.button:focus-visible {
+:host(:focus-visible) {
     /* .spectrum-ActionButton.focus-ring */
     background-color: var(
         --spectrum-actionbutton-background-color-key-focus,
@@ -269,8 +269,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-.button:focus-visible,
-.button:focus-visible:active {
+:host(:focus-visible),
+:host(:focus-visible[active]) {
     /* .spectrum-ActionButton.focus-ring,
    * .spectrum-ActionButton.focus-ring:active */
     border-color: var(
@@ -278,21 +278,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-focus)
     );
 }
-.button:focus-visible ::slotted([slot='icon']) {
+:host(:focus-visible) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton.focus-ring .spectrum-Icon */
     color: var(
         --spectrum-actionbutton-icon-color-key-focus,
         var(--spectrum-alias-icon-color-focus)
     );
 }
-.button:focus-visible #hold-affordance {
+:host(:focus-visible) #hold-affordance {
     /* .spectrum-ActionButton.focus-ring .spectrum-ActionButton-hold */
     color: var(
         --spectrum-actionbutton-hold-icon-color-key-focus,
         var(--spectrum-alias-icon-color-hover)
     );
 }
-.button:active {
+:host([active]) {
     /* .spectrum-ActionButton:active */
     background-color: var(
         --spectrum-actionbutton-background-color-down,
@@ -307,14 +307,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-down)
     );
 }
-.button:active #hold-affordance {
+:host([active]) #hold-affordance {
     /* .spectrum-ActionButton:active .spectrum-ActionButton-hold */
     color: var(
         --spectrum-actionbutton-hold-icon-color-down,
         var(--spectrum-alias-icon-color-down)
     );
 }
-:host([disabled]) .button {
+:host([disabled]),
+:host(:disabled) {
     /* .spectrum-ActionButton.is-disabled,
    * .spectrum-ActionButton:disabled */
     background-color: var(
@@ -330,7 +331,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([disabled]) .button ::slotted([slot='icon']) {
+:host([disabled]) ::slotted([slot='icon']),
+:host(:disabled) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton.is-disabled .spectrum-Icon,
    * .spectrum-ActionButton:disabled .spectrum-Icon */
     color: var(
@@ -338,7 +340,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-disabled)
     );
 }
-:host([disabled]) .button #hold-affordance {
+:host([disabled]) #hold-affordance,
+:host(:disabled) #hold-affordance {
     /* .spectrum-ActionButton.is-disabled .spectrum-ActionButton-hold,
    * .spectrum-ActionButton:disabled .spectrum-ActionButton-hold */
     color: var(
@@ -346,7 +349,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-disabled)
     );
 }
-:host([selected]) .button {
+:host([selected]) {
     /* .spectrum-ActionButton.is-selected */
     background-color: var(
         --spectrum-actionbutton-background-color-selected,
@@ -361,14 +364,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color)
     );
 }
-:host([selected]) .button ::slotted([slot='icon']) {
+:host([selected]) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton.is-selected .spectrum-Icon */
     color: var(
         --spectrum-actionbutton-icon-color-selected,
         var(--spectrum-alias-icon-color)
     );
 }
-:host([selected]) .button:focus-visible {
+:host([selected]:focus-visible) {
     /* .spectrum-ActionButton.is-selected.focus-ring */
     background-color: var(
         --spectrum-actionbutton-background-color-selected-key-focus,
@@ -383,21 +386,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([selected]) .button:focus-visible:active {
+:host([selected]:focus-visible[active]) {
     /* .spectrum-ActionButton.is-selected.focus-ring:active */
     border-color: var(
         --spectrum-actionbutton-border-color-key-focus,
         var(--spectrum-alias-border-color-focus)
     );
 }
-:host([selected]) .button:focus-visible ::slotted([slot='icon']) {
+:host([selected]:focus-visible) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton.is-selected.focus-ring .spectrum-Icon */
     color: var(
         --spectrum-actionbutton-icon-color-selected-key-focus,
         var(--spectrum-alias-icon-color-hover)
     );
 }
-:host([selected]) .button:hover {
+:host([selected]:hover) {
     /* .spectrum-ActionButton.is-selected:hover */
     background-color: var(
         --spectrum-actionbutton-background-color-selected-hover,
@@ -412,14 +415,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([selected]) .button:hover ::slotted([slot='icon']) {
+:host([selected]:hover) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton.is-selected:hover .spectrum-Icon */
     color: var(
         --spectrum-actionbutton-icon-color-selected-hover,
         var(--spectrum-alias-icon-color-hover)
     );
 }
-:host([selected]) .button:active {
+:host([selected][active]) {
     /* .spectrum-ActionButton.is-selected:active */
     background-color: var(
         --spectrum-actionbutton-background-color-selected-down,
@@ -434,14 +437,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-down)
     );
 }
-:host([selected]) .button:active ::slotted([slot='icon']) {
+:host([selected][active]) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton.is-selected:active .spectrum-Icon */
     color: var(
         --spectrum-actionbutton-icon-color-selected-down,
         var(--spectrum-alias-icon-color-down)
     );
 }
-:host([selected][disabled]) .button {
+:host([selected][disabled]),
+:host([selected]:disabled) {
     /* .spectrum-ActionButton.is-selected.is-disabled,
    * .spectrum-ActionButton.is-selected:disabled */
     background-color: var(
@@ -457,7 +461,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([selected][disabled]) .button ::slotted([slot='icon']) {
+:host([selected][disabled]) ::slotted([slot='icon']),
+:host([selected]:disabled) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton.is-selected.is-disabled .spectrum-Icon,
    * .spectrum-ActionButton.is-selected:disabled .spectrum-Icon */
     color: var(
@@ -465,7 +470,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-disabled)
     );
 }
-:host([emphasized]) .button {
+:host([emphasized]) {
     /* .spectrum-ActionButton--emphasized */
     background-color: var(
         --spectrum-actionbutton-emphasized-background-color,
@@ -494,21 +499,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color)
     );
 }
-:host([emphasized][selected]) .button #hold-affordance {
+:host([emphasized][selected]) #hold-affordance {
     /* .spectrum-ActionButton--emphasized.is-selected .spectrum-ActionButton-hold */
     color: var(
         --spectrum-actionbutton-emphasized-hold-icon-color-selected,
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected]) .button:hover #hold-affordance {
+:host([emphasized][selected]:hover) #hold-affordance {
     /* .spectrum-ActionButton--emphasized.is-selected:hover .spectrum-ActionButton-hold */
     color: var(
         --spectrum-actionbutton-emphasized-text-color-selected-hover,
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized]) .button:hover {
+:host([emphasized]:hover) {
     /* .spectrum-ActionButton--emphasized:hover */
     background-color: var(
         --spectrum-actionbutton-emphasized-background-color-hover,
@@ -524,21 +529,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([emphasized]) .button:hover ::slotted([slot='icon']) {
+:host([emphasized]:hover) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton--emphasized:hover .spectrum-Icon */
     color: var(
         --spectrum-actionbutton-emphasized-icon-color-hover,
         var(--spectrum-alias-icon-color-hover)
     );
 }
-:host([emphasized]) .button:hover #hold-affordance {
+:host([emphasized]:hover) #hold-affordance {
     /* .spectrum-ActionButton--emphasized:hover .spectrum-ActionButton-hold */
     color: var(
         --spectrum-actionbutton-emphasized-hold-icon-color-hover,
         var(--spectrum-alias-icon-color-hover)
     );
 }
-:host([emphasized]) .button:focus-visible {
+:host([emphasized]:focus-visible) {
     /* .spectrum-ActionButton--emphasized.focus-ring */
     background-color: var(
         --spectrum-actionbutton-emphasized-background-color-key-focus,
@@ -559,21 +564,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([emphasized]) .button:focus-visible ::slotted([slot='icon']) {
+:host([emphasized]:focus-visible) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton--emphasized.focus-ring .spectrum-Icon */
     color: var(
         --spectrum-actionbutton-emphasized-icon-color-key-focus,
         var(--spectrum-alias-icon-color-focus)
     );
 }
-:host([emphasized]) .button:focus-visible #hold-affordance {
+:host([emphasized]:focus-visible) #hold-affordance {
     /* .spectrum-ActionButton--emphasized.focus-ring .spectrum-ActionButton-hold */
     color: var(
         --spectrum-actionbutton-emphasized-hold-icon-color-key-focus,
         var(--spectrum-alias-icon-color-hover)
     );
 }
-:host([emphasized]) .button.is-active {
+:host([emphasized]) .is-active {
     /* .spectrum-ActionButton--emphasized.is-active */
     background-color: var(
         --spectrum-actionbutton-emphasized-background-color-down,
@@ -589,14 +594,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-down)
     );
 }
-:host([emphasized]) .button.is-active #hold-affordance {
+:host([emphasized]) .is-active #hold-affordance {
     /* .spectrum-ActionButton--emphasized.is-active .spectrum-ActionButton-hold */
     color: var(
         --spectrum-actionbutton-emphasized-hold-icon-color-down,
         var(--spectrum-alias-icon-color-down)
     );
 }
-:host([emphasized][disabled]) .button {
+:host([emphasized][disabled]),
+:host([emphasized]:disabled) {
     /* .spectrum-ActionButton--emphasized.is-disabled,
    * .spectrum-ActionButton--emphasized:disabled */
     background-color: var(
@@ -612,7 +618,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([emphasized][disabled]) .button ::slotted([slot='icon']) {
+:host([emphasized][disabled]) ::slotted([slot='icon']),
+:host([emphasized]:disabled) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton--emphasized.is-disabled .spectrum-Icon,
    * .spectrum-ActionButton--emphasized:disabled .spectrum-Icon */
     color: var(
@@ -620,7 +627,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-disabled)
     );
 }
-:host([emphasized][disabled]) .button #hold-affordance {
+:host([emphasized][disabled]) #hold-affordance,
+:host([emphasized]:disabled) #hold-affordance {
     /* .spectrum-ActionButton--emphasized.is-disabled .spectrum-ActionButton-hold,
    * .spectrum-ActionButton--emphasized:disabled .spectrum-ActionButton-hold */
     color: var(
@@ -628,8 +636,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-disabled)
     );
 }
-:host([emphasized][selected]) .button,
-:host([emphasized][quiet][selected]) .button {
+:host([emphasized][selected]),
+:host([emphasized][quiet][selected]) {
     /* .spectrum-ActionButton--emphasized.is-selected,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected */
     background-color: var(
@@ -645,8 +653,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected]) .button ::slotted([slot='icon']),
-:host([emphasized][quiet][selected]) .button ::slotted([slot='icon']) {
+:host([emphasized][selected]) ::slotted([slot='icon']),
+:host([emphasized][quiet][selected]) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton--emphasized.is-selected .spectrum-Icon,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected .spectrum-Icon */
     color: var(
@@ -654,8 +662,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected]) .button:focus-visible,
-:host([emphasized][quiet][selected]) .button:focus-visible {
+:host([emphasized][selected]:focus-visible),
+:host([emphasized][quiet][selected]:focus-visible) {
     /* .spectrum-ActionButton--emphasized.is-selected.focus-ring,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected.focus-ring */
     background-color: var(
@@ -671,10 +679,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected]) .button:focus-visible ::slotted([slot='icon']),
-:host([emphasized][quiet][selected])
-    .button:focus-visible
-    ::slotted([slot='icon']) {
+:host([emphasized][selected]:focus-visible) ::slotted([slot='icon']),
+:host([emphasized][quiet][selected]:focus-visible) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton--emphasized.is-selected.focus-ring .spectrum-Icon,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected.focus-ring .spectrum-Icon */
     color: var(
@@ -682,8 +688,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected]) .button:hover,
-:host([emphasized][quiet][selected]) .button:hover {
+:host([emphasized][selected]:hover),
+:host([emphasized][quiet][selected]:hover) {
     /* .spectrum-ActionButton--emphasized.is-selected:hover,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected:hover */
     background-color: var(
@@ -699,8 +705,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected]) .button:hover ::slotted([slot='icon']),
-:host([emphasized][quiet][selected]) .button:hover ::slotted([slot='icon']) {
+:host([emphasized][selected]:hover) ::slotted([slot='icon']),
+:host([emphasized][quiet][selected]:hover) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton--emphasized.is-selected:hover .spectrum-Icon,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected:hover .spectrum-Icon */
     color: var(
@@ -708,8 +714,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected]) .button.is-active,
-:host([emphasized][quiet][selected]) .button.is-active {
+:host([emphasized][selected]) .is-active,
+:host([emphasized][quiet][selected]) .is-active {
     /* .spectrum-ActionButton--emphasized.is-selected.is-active,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected.is-active */
     background-color: var(
@@ -725,10 +731,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected]) .button.is-active ::slotted([slot='icon']),
-:host([emphasized][quiet][selected])
-    .button.is-active
-    ::slotted([slot='icon']) {
+:host([emphasized][selected]) .is-active ::slotted([slot='icon']),
+:host([emphasized][quiet][selected]) .is-active ::slotted([slot='icon']) {
     /* .spectrum-ActionButton--emphasized.is-selected.is-active .spectrum-Icon,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected.is-active .spectrum-Icon */
     color: var(
@@ -736,8 +740,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([emphasized][selected][disabled]) .button,
-:host([emphasized][quiet][selected][disabled]) .button {
+:host([emphasized][selected][disabled]),
+:host([emphasized][selected]:disabled),
+:host([emphasized][quiet][selected][disabled]),
+:host([emphasized][quiet][selected]:disabled) {
     /* .spectrum-ActionButton--emphasized.is-selected.is-disabled,
    * .spectrum-ActionButton--emphasized.is-selected:disabled,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected.is-disabled,
@@ -755,10 +761,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([emphasized][selected][disabled]) .button ::slotted([slot='icon']),
-:host([emphasized][quiet][selected][disabled])
-    .button
-    ::slotted([slot='icon']) {
+:host([emphasized][selected][disabled]) ::slotted([slot='icon']),
+:host([emphasized][selected]:disabled) ::slotted([slot='icon']),
+:host([emphasized][quiet][selected][disabled]) ::slotted([slot='icon']),
+:host([emphasized][quiet][selected]:disabled) ::slotted([slot='icon']) {
     /* .spectrum-ActionButton--emphasized.is-selected.is-disabled .spectrum-Icon,
    * .spectrum-ActionButton--emphasized.is-selected:disabled .spectrum-Icon,
    * .spectrum-ActionButton--emphasized.spectrum-ActionButton--quiet.is-selected.is-disabled .spectrum-Icon,
@@ -768,7 +774,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-disabled)
     );
 }
-:host([quiet]) .button {
+:host([quiet]) {
     /* .spectrum-ActionButton--quiet */
     background-color: var(
         --spectrum-actionbutton-quiet-background-color,
@@ -783,7 +789,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color)
     );
 }
-:host([quiet]) .button:hover {
+:host([quiet]:hover) {
     /* .spectrum-ActionButton--quiet:hover */
     background-color: var(
         --spectrum-actionbutton-quiet-background-color-hover,
@@ -798,7 +804,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([quiet]) .button:focus-visible {
+:host([quiet]:focus-visible) {
     /* .spectrum-ActionButton--quiet.focus-ring */
     background-color: var(
         --spectrum-actionbutton-quiet-background-color-key-focus,
@@ -818,7 +824,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([quiet]) .button:active {
+:host([quiet][active]) {
     /* .spectrum-ActionButton--quiet:active */
     background-color: var(
         --spectrum-actionbutton-quiet-background-color-down,
@@ -833,7 +839,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-down)
     );
 }
-:host([quiet][disabled]) .button {
+:host([quiet][disabled]),
+:host([quiet]:disabled) {
     /* .spectrum-ActionButton--quiet.is-disabled,
    * .spectrum-ActionButton--quiet:disabled */
     background-color: var(
@@ -849,7 +856,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([quiet][selected]) .button {
+:host([quiet][selected]) {
     /* .spectrum-ActionButton--quiet.is-selected */
     background-color: var(
         --spectrum-actionbutton-quiet-background-color-selected,
@@ -864,7 +871,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color)
     );
 }
-:host([quiet][selected]) .button:focus-visible {
+:host([quiet][selected]:focus-visible) {
     /* .spectrum-ActionButton--quiet.is-selected.focus-ring */
     background-color: var(
         --spectrum-actionbutton-quiet-background-color-selected-key-focus,
@@ -879,7 +886,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([quiet][selected]) .button:hover {
+:host([quiet][selected]:hover) {
     /* .spectrum-ActionButton--quiet.is-selected:hover */
     background-color: var(
         --spectrum-actionbutton-quiet-background-color-selected-hover,
@@ -894,7 +901,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([quiet][selected]) .button:active {
+:host([quiet][selected][active]) {
     /* .spectrum-ActionButton--quiet.is-selected:active */
     background-color: var(
         --spectrum-actionbutton-quiet-background-color-selected-down,
@@ -909,7 +916,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-down)
     );
 }
-:host([quiet][selected][disabled]) .button {
+:host([quiet][selected][disabled]),
+:host([quiet][selected]:disabled) {
     /* .spectrum-ActionButton--quiet.is-selected.is-disabled,
    * .spectrum-ActionButton--quiet.is-selected:disabled */
     background-color: var(

--- a/packages/button/src/spectrum-button-base.css
+++ b/packages/button/src/spectrum-button-base.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-.button {
+:host {
     /* .spectrum-ActionButton,
    * .spectrum-Button,
    * .spectrum-ClearButton,
@@ -47,7 +47,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     touch-action: none;
     cursor: pointer;
 }
-.button:focus {
+:host(:focus) {
     /* .spectrum-ActionButton:focus,
    * .spectrum-Button:focus,
    * .spectrum-ClearButton:focus,
@@ -55,7 +55,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-LogicButton:focus */
     outline: none;
 }
-.button::-moz-focus-inner {
+:host(::-moz-focus-inner) {
     /* .spectrum-ActionButton::-moz-focus-inner,
    * .spectrum-Button::-moz-focus-inner,
    * .spectrum-ClearButton::-moz-focus-inner,
@@ -67,7 +67,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin-top: -2px;
     margin-bottom: -2px;
 }
-.button:disabled {
+:host(:disabled) {
     /* .spectrum-ActionButton:disabled,
    * .spectrum-Button:disabled,
    * .spectrum-ClearButton:disabled,

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-.button:after {
+:host:after {
     /* .spectrum-Button:after,
    * .spectrum-ClearButton:after,
    * .spectrum-LogicButton:after */
@@ -41,7 +41,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ease-out,
         margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
 }
-.button:focus-visible:after {
+:host(:focus-visible):after {
     /* .spectrum-Button.focus-ring:after,
    * .spectrum-ClearButton.focus-ring:after,
    * .spectrum-LogicButton.focus-ring:after */
@@ -52,7 +52,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -2
     );
 }
-.button {
+:host {
     /* .spectrum-Button */
     border-width: var(
         --spectrum-button-primary-border-size,
@@ -91,27 +91,27 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-font-weight-bold)
     );
 }
-.button:active,
-.button:hover {
+:host([active]),
+:host(:hover) {
     /* .spectrum-Button:active,
    * .spectrum-Button:hover */
     box-shadow: none;
 }
-:host([dir='ltr']) .button slot[name='icon'] + #label {
+:host([dir='ltr']) slot[name='icon'] + #label {
     /* [dir=ltr] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
     margin-left: var(
         --spectrum-button-primary-text-gap,
         var(--spectrum-global-dimension-size-100)
     );
 }
-:host([dir='rtl']) .button slot[name='icon'] + #label {
+:host([dir='rtl']) slot[name='icon'] + #label {
     /* [dir=rtl] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
     margin-right: var(
         --spectrum-button-primary-text-gap,
         var(--spectrum-global-dimension-size-100)
     );
 }
-:host([dir='ltr']) .button #label + ::slotted([slot='icon']) {
+:host([dir='ltr']) #label + ::slotted([slot='icon']) {
     /* [dir=ltr] .spectrum-Button .spectrum-Button-label+.spectrum-Icon */
     margin-left: calc(
         var(
@@ -120,7 +120,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) / 2
     );
 }
-:host([dir='rtl']) .button #label + ::slotted([slot='icon']) {
+:host([dir='rtl']) #label + ::slotted([slot='icon']) {
     /* [dir=rtl] .spectrum-Button .spectrum-Button-label+.spectrum-Icon */
     margin-right: calc(
         var(
@@ -141,8 +141,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Button-label:empty */
     display: none;
 }
-.button:focus-visible:after,
-.button.is-focused:after {
+:host(:focus-visible):after,
+:host([focused]):after {
     /* .spectrum-Button.focus-ring:after,
    * .spectrum-Button.is-focused:after,
    * .spectrum-LogicButton.focus-ring:after,
@@ -157,7 +157,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-focus-ring-color)
         );
 }
-:host([variant='cta']) .button {
+:host([variant='cta']) {
     /* .spectrum-Button--cta */
     background-color: var(
         --spectrum-button-cta-background-color,
@@ -172,7 +172,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='cta']) .button:hover {
+:host([variant='cta']:hover) {
     /* .spectrum-Button--cta:hover */
     background-color: var(
         --spectrum-button-cta-background-color-hover,
@@ -187,7 +187,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='cta']) .button:focus-visible {
+:host([variant='cta']:focus-visible) {
     /* .spectrum-Button--cta.focus-ring */
     background-color: var(
         --spectrum-button-cta-background-color-key-focus,
@@ -202,7 +202,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='cta']) .button:active {
+:host([variant='cta'][active]) {
     /* .spectrum-Button--cta:active */
     background-color: var(
         --spectrum-button-cta-background-color-down,
@@ -217,7 +217,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='cta'][disabled]) .button {
+:host([variant='cta'][disabled]),
+:host([variant='cta']:disabled) {
     /* .spectrum-Button--cta.is-disabled,
    * .spectrum-Button--cta:disabled */
     background-color: var(
@@ -233,7 +234,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-500)
     );
 }
-:host([variant='primary']) .button {
+:host([variant='primary']) {
     /* .spectrum-Button--primary */
     background-color: var(
         --spectrum-button-primary-background-color,
@@ -248,7 +249,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([variant='primary']) .button:hover {
+:host([variant='primary']:hover) {
     /* .spectrum-Button--primary:hover */
     background-color: var(
         --spectrum-button-primary-background-color-hover,
@@ -263,7 +264,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='primary']) .button:focus-visible {
+:host([variant='primary']:focus-visible) {
     /* .spectrum-Button--primary.focus-ring */
     background-color: var(
         --spectrum-button-primary-background-color-key-focus,
@@ -278,7 +279,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='primary']) .button:active {
+:host([variant='primary'][active]) {
     /* .spectrum-Button--primary:active */
     background-color: var(
         --spectrum-button-primary-background-color-down,
@@ -293,7 +294,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='primary'][disabled]) .button {
+:host([variant='primary'][disabled]),
+:host([variant='primary']:disabled) {
     /* .spectrum-Button--primary.is-disabled,
    * .spectrum-Button--primary:disabled */
     background-color: var(
@@ -309,7 +311,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-500)
     );
 }
-:host([variant='secondary']) .button {
+:host([variant='secondary']) {
     /* .spectrum-Button--secondary */
     background-color: var(
         --spectrum-button-secondary-background-color,
@@ -324,7 +326,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host([variant='secondary']) .button:hover {
+:host([variant='secondary']:hover) {
     /* .spectrum-Button--secondary:hover */
     background-color: var(
         --spectrum-button-secondary-background-color-hover,
@@ -339,7 +341,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='secondary']) .button:focus-visible {
+:host([variant='secondary']:focus-visible) {
     /* .spectrum-Button--secondary.focus-ring */
     background-color: var(
         --spectrum-button-secondary-background-color-key-focus,
@@ -354,7 +356,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='secondary']) .button:active {
+:host([variant='secondary'][active]) {
     /* .spectrum-Button--secondary:active */
     background-color: var(
         --spectrum-button-secondary-background-color-down,
@@ -369,7 +371,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='secondary'][disabled]) .button {
+:host([variant='secondary'][disabled]),
+:host([variant='secondary']:disabled) {
     /* .spectrum-Button--secondary.is-disabled,
    * .spectrum-Button--secondary:disabled */
     background-color: var(
@@ -385,7 +388,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-500)
     );
 }
-:host([variant='negative']) .button {
+:host([variant='negative']) {
     /* .spectrum-Button--warning */
     background-color: var(
         --spectrum-button-warning-background-color,
@@ -400,7 +403,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-semantic-negative-color-text-small)
     );
 }
-:host([variant='negative']) .button:hover {
+:host([variant='negative']:hover) {
     /* .spectrum-Button--warning:hover */
     background-color: var(
         --spectrum-button-warning-background-color-hover,
@@ -415,7 +418,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='negative']) .button:focus-visible {
+:host([variant='negative']:focus-visible) {
     /* .spectrum-Button--warning.focus-ring */
     background-color: var(
         --spectrum-button-warning-background-color-key-focus,
@@ -430,7 +433,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='negative']) .button:active {
+:host([variant='negative'][active]) {
     /* .spectrum-Button--warning:active */
     background-color: var(
         --spectrum-button-warning-background-color-down,
@@ -445,7 +448,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([variant='negative'][disabled]) .button {
+:host([variant='negative'][disabled]),
+:host([variant='negative']:disabled) {
     /* .spectrum-Button--warning.is-disabled,
    * .spectrum-Button--warning:disabled */
     background-color: var(
@@ -461,7 +465,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-500)
     );
 }
-:host([variant='overBackground']) .button {
+:host([variant='overBackground']) {
     /* .spectrum-Button--overBackground */
     background-color: var(
         --spectrum-button-over-background-background-color,
@@ -476,8 +480,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground']) .button:focus-visible,
-:host([variant='overBackground']) .button:hover {
+:host([variant='overBackground']:focus-visible),
+:host([variant='overBackground']:hover) {
     /* .spectrum-Button--overBackground.focus-ring,
    * .spectrum-Button--overBackground:hover */
     background-color: var(
@@ -490,7 +494,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     color: inherit;
 }
-:host([variant='overBackground']) .button:focus-visible:after {
+:host([variant='overBackground']:focus-visible):after {
     /* .spectrum-Button--overBackground.focus-ring:after */
     box-shadow: 0 0 0
         var(
@@ -502,7 +506,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-global-color-static-white)
         );
 }
-:host([variant='overBackground']) .button:active {
+:host([variant='overBackground'][active]) {
     /* .spectrum-Button--overBackground:active */
     background-color: var(
         --spectrum-button-over-background-background-color-down,
@@ -514,7 +518,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     color: inherit;
 }
-:host([variant='overBackground'][disabled]) .button {
+:host([variant='overBackground'][disabled]),
+:host([variant='overBackground']:disabled) {
     /* .spectrum-Button--overBackground.is-disabled,
    * .spectrum-Button--overBackground:disabled */
     background-color: var(
@@ -530,7 +535,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         hsla(0, 0%, 100%, 0.35)
     );
 }
-:host([variant='overBackground'][quiet]) .button {
+:host([variant='overBackground'][quiet]) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet,
    * .spectrum-ClearButton--overBackground */
     background-color: var(
@@ -546,8 +551,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground'][quiet]) .button:focus-visible,
-:host([variant='overBackground'][quiet]) .button:hover {
+:host([variant='overBackground'][quiet]:focus-visible),
+:host([variant='overBackground'][quiet]:hover) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet.focus-ring,
    * .spectrum-Button--overBackground.spectrum-Button--quiet:hover,
    * .spectrum-ClearButton--overBackground.focus-ring,
@@ -565,12 +570,12 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground'][quiet]) .button:focus-visible {
+:host([variant='overBackground'][quiet]:focus-visible) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet.focus-ring,
    * .spectrum-ClearButton--overBackground.focus-ring */
     box-shadow: none;
 }
-:host([variant='overBackground'][quiet]) .button:focus-visible:after {
+:host([variant='overBackground'][quiet]:focus-visible):after {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet.focus-ring:after,
    * .spectrum-ClearButton--overBackground.focus-ring:after */
     box-shadow: 0 0 0
@@ -583,7 +588,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-global-color-static-white)
         );
 }
-:host([variant='overBackground'][quiet]) .button:active {
+:host([variant='overBackground'][quiet][active]) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet:active,
    * .spectrum-ClearButton--overBackground:active */
     background-color: var(
@@ -599,7 +604,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground'][quiet][disabled]) .button {
+:host([variant='overBackground'][quiet][disabled]),
+:host([variant='overBackground'][quiet]:disabled) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet.is-disabled,
    * .spectrum-Button--overBackground.spectrum-Button--quiet:disabled,
    * .spectrum-ClearButton--overBackground.is-disabled,
@@ -617,7 +623,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         hsla(0, 0%, 100%, 0.15)
     );
 }
-:host([variant='primary'][quiet]) .button {
+:host([variant='primary'][quiet]) {
     /* .spectrum-Button--primary.spectrum-Button--quiet */
     background-color: var(
         --spectrum-button-quiet-primary-background-color,
@@ -632,7 +638,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([variant='primary'][quiet]) .button:hover {
+:host([variant='primary'][quiet]:hover) {
     /* .spectrum-Button--primary.spectrum-Button--quiet:hover */
     background-color: var(
         --spectrum-button-quiet-primary-background-color-hover,
@@ -647,7 +653,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([variant='primary'][quiet]) .button:focus-visible {
+:host([variant='primary'][quiet]:focus-visible) {
     /* .spectrum-Button--primary.spectrum-Button--quiet.focus-ring */
     background-color: var(
         --spectrum-button-quiet-primary-background-color-key-focus,
@@ -662,7 +668,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([variant='primary'][quiet]) .button:active {
+:host([variant='primary'][quiet][active]) {
     /* .spectrum-Button--primary.spectrum-Button--quiet:active */
     background-color: var(
         --spectrum-button-quiet-primary-background-color-down,
@@ -677,7 +683,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([variant='primary'][quiet][disabled]) .button {
+:host([variant='primary'][quiet][disabled]),
+:host([variant='primary'][quiet]:disabled) {
     /* .spectrum-Button--primary.spectrum-Button--quiet.is-disabled,
    * .spectrum-Button--primary.spectrum-Button--quiet:disabled */
     background-color: var(
@@ -693,7 +700,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-500)
     );
 }
-:host([variant='secondary'][quiet]) .button {
+:host([variant='secondary'][quiet]) {
     /* .spectrum-Button--secondary.spectrum-Button--quiet */
     background-color: var(
         --spectrum-button-quiet-secondary-background-color,
@@ -708,7 +715,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host([variant='secondary'][quiet]) .button:hover {
+:host([variant='secondary'][quiet]:hover) {
     /* .spectrum-Button--secondary.spectrum-Button--quiet:hover */
     background-color: var(
         --spectrum-button-quiet-secondary-background-color-hover,
@@ -723,7 +730,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([variant='secondary'][quiet]) .button:focus-visible {
+:host([variant='secondary'][quiet]:focus-visible) {
     /* .spectrum-Button--secondary.spectrum-Button--quiet.focus-ring */
     background-color: var(
         --spectrum-button-quiet-secondary-background-color-key-focus,
@@ -738,7 +745,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([variant='secondary'][quiet]) .button:active {
+:host([variant='secondary'][quiet][active]) {
     /* .spectrum-Button--secondary.spectrum-Button--quiet:active */
     background-color: var(
         --spectrum-button-quiet-secondary-background-color-down,
@@ -753,7 +760,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-800)
     );
 }
-:host([variant='secondary'][quiet][disabled]) .button {
+:host([variant='secondary'][quiet][disabled]),
+:host([variant='secondary'][quiet]:disabled) {
     /* .spectrum-Button--secondary.spectrum-Button--quiet.is-disabled,
    * .spectrum-Button--secondary.spectrum-Button--quiet:disabled */
     background-color: var(
@@ -769,7 +777,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-500)
     );
 }
-:host([variant='negative'][quiet]) .button {
+:host([variant='negative'][quiet]) {
     /* .spectrum-Button--warning.spectrum-Button--quiet */
     background-color: var(
         --spectrum-button-quiet-warning-background-color,
@@ -784,7 +792,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-semantic-negative-color-text-small)
     );
 }
-:host([variant='negative'][quiet]) .button:hover {
+:host([variant='negative'][quiet]:hover) {
     /* .spectrum-Button--warning.spectrum-Button--quiet:hover */
     background-color: var(
         --spectrum-button-quiet-warning-background-color-hover,
@@ -799,7 +807,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-700)
     );
 }
-:host([variant='negative'][quiet]) .button:focus-visible {
+:host([variant='negative'][quiet]:focus-visible) {
     /* .spectrum-Button--warning.spectrum-Button--quiet.focus-ring */
     background-color: var(
         --spectrum-button-quiet-warning-background-color-key-focus,
@@ -814,7 +822,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-700)
     );
 }
-:host([variant='negative'][quiet]) .button:active {
+:host([variant='negative'][quiet][active]) {
     /* .spectrum-Button--warning.spectrum-Button--quiet:active */
     background-color: var(
         --spectrum-button-quiet-warning-background-color-down,
@@ -829,7 +837,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-700)
     );
 }
-:host([variant='negative'][quiet][disabled]) .button {
+:host([variant='negative'][quiet][disabled]),
+:host([variant='negative'][quiet]:disabled) {
     /* .spectrum-Button--warning.spectrum-Button--quiet.is-disabled,
    * .spectrum-Button--warning.spectrum-Button--quiet:disabled */
     background-color: var(

--- a/packages/button/src/spectrum-clear-button.css
+++ b/packages/button/src/spectrum-clear-button.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-.button:after {
+:host:after {
     /* .spectrum-Button:after,
    * .spectrum-ClearButton:after,
    * .spectrum-LogicButton:after */
@@ -41,7 +41,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ease-out,
         margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
 }
-.button:focus-visible:after {
+:host(:focus-visible):after {
     /* .spectrum-Button.focus-ring:after,
    * .spectrum-ClearButton.focus-ring:after,
    * .spectrum-LogicButton.focus-ring:after */
@@ -52,7 +52,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -2
     );
 }
-.button {
+:host {
     /* .spectrum-ClearButton */
     width: var(
         --spectrum-clearbutton-medium-width,
@@ -67,11 +67,11 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin: 0;
     border: none;
 }
-.button > .icon {
+:host > .icon {
     /* .spectrum-ClearButton>.spectrum-Icon */
     margin: 0 auto;
 }
-:host([variant='overBackground']) .button:focus-visible:after {
+:host([variant='overBackground']:focus-visible):after {
     /* .spectrum-ClearButton--overBackground.focus-ring:after */
     margin: calc(
         var(
@@ -81,11 +81,11 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 @media (-ms-high-contrast: none), screen and (-ms-high-contrast: active) {
-    .button > .icon {
+    :host > .icon {
         margin: 0;
     }
 }
-:host([small]) .button {
+:host([small]) {
     /* .spectrum-ClearButton--small */
     width: var(
         --spectrum-clearbutton-small-width,
@@ -96,7 +96,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-300)
     );
 }
-.button {
+:host {
     /* .spectrum-ClearButton */
     background-color: var(
         --spectrum-clearbutton-medium-background-color,
@@ -107,7 +107,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color)
     );
 }
-.button:hover {
+:host(:hover) {
     /* .spectrum-ClearButton:hover */
     background-color: var(
         --spectrum-clearbutton-medium-background-color-hover,
@@ -118,7 +118,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-hover)
     );
 }
-.button:active {
+:host([active]) {
     /* .spectrum-ClearButton:active */
     background-color: var(
         --spectrum-clearbutton-medium-background-color-down,
@@ -129,7 +129,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-down)
     );
 }
-.button:focus-visible {
+:host(:focus-visible) {
     /* .spectrum-ClearButton.focus-ring */
     background-color: var(
         --spectrum-clearbutton-medium-background-color-key-focus,
@@ -140,8 +140,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-focus)
     );
 }
-.button.is-disabled,
-.button:disabled {
+:host([disabled]),
+:host(:disabled) {
     /* .spectrum-ClearButton.is-disabled,
    * .spectrum-ClearButton:disabled */
     background-color: var(
@@ -153,7 +153,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-disabled)
     );
 }
-:host([variant='overBackground']) .button {
+:host([variant='overBackground']) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet,
    * .spectrum-ClearButton--overBackground */
     background-color: var(
@@ -169,8 +169,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground']) .button:focus-visible,
-:host([variant='overBackground']) .button:hover {
+:host([variant='overBackground']:focus-visible),
+:host([variant='overBackground']:hover) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet.focus-ring,
    * .spectrum-Button--overBackground.spectrum-Button--quiet:hover,
    * .spectrum-ClearButton--overBackground.focus-ring,
@@ -188,12 +188,12 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground']) .button:focus-visible {
+:host([variant='overBackground']:focus-visible) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet.focus-ring,
    * .spectrum-ClearButton--overBackground.focus-ring */
     box-shadow: none;
 }
-:host([variant='overBackground']) .button:focus-visible:after {
+:host([variant='overBackground']:focus-visible):after {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet.focus-ring:after,
    * .spectrum-ClearButton--overBackground.focus-ring:after */
     box-shadow: 0 0 0
@@ -206,7 +206,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-global-color-static-white)
         );
 }
-:host([variant='overBackground']) .button:active {
+:host([variant='overBackground'][active]) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet:active,
    * .spectrum-ClearButton--overBackground:active */
     background-color: var(
@@ -222,8 +222,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground']) .button.is-disabled,
-:host([variant='overBackground']) .button:disabled {
+:host([variant='overBackground'][disabled]),
+:host([variant='overBackground']:disabled) {
     /* .spectrum-Button--overBackground.spectrum-Button--quiet.is-disabled,
    * .spectrum-Button--overBackground.spectrum-Button--quiet:disabled,
    * .spectrum-ClearButton--overBackground.is-disabled,

--- a/packages/button/src/spectrum-config.js
+++ b/packages/button/src/spectrum-config.js
@@ -17,9 +17,7 @@ const config = {
             name: 'button-base',
             host: {
                 selector: '.spectrum-Button',
-                shadowSelector: '.button',
             },
-            focus: '.button',
             slots: [
                 {
                     name: 'icon',
@@ -33,14 +31,17 @@ const config = {
             name: 'fieldbutton',
             host: {
                 selector: '.spectrum-FieldButton',
-                shadowSelector: '.button',
             },
-            focus: '.button',
             attributes: [
                 {
                     type: 'boolean',
                     selector: '.is-invalid',
                     name: 'invalid',
+                },
+                {
+                    type: 'boolean',
+                    selector: '.is-active',
+                    name: 'active',
                 },
                 {
                     type: 'boolean',
@@ -72,9 +73,7 @@ const config = {
             name: 'button',
             host: {
                 selector: '.spectrum-Button',
-                shadowSelector: '.button',
             },
-            focus: '.button',
             attributes: [
                 {
                     type: 'boolean',
@@ -82,7 +81,18 @@ const config = {
                 },
                 {
                     type: 'boolean',
-                    selector: ':disabled',
+                    selector: '.is-disabled',
+                    name: 'disabled',
+                },
+                {
+                    type: 'boolean',
+                    selector: '.is-focused',
+                    name: 'focused',
+                },
+                {
+                    type: 'boolean',
+                    selector: ':active',
+                    name: 'active',
                 },
                 {
                     type: 'enum',
@@ -107,20 +117,14 @@ const config = {
                     selector: '.spectrum-Icon',
                 },
             ],
-            exclude: [
-                /\.is-disabled/,
-                /\.spectrum-ActionButton/,
-                /\.spectrum-ClearButton/,
-            ],
+            exclude: [/\.spectrum-ActionButton/, /\.spectrum-ClearButton/],
             excludeSourceSelector: [/^(.*),(.*),(.*),(.*),(.*)$/],
         },
         {
             name: 'action-button',
             host: {
                 selector: '.spectrum-ActionButton',
-                shadowSelector: '.button',
             },
-            focus: '.button',
             attributes: [
                 {
                     type: 'boolean',
@@ -128,12 +132,18 @@ const config = {
                 },
                 {
                     type: 'boolean',
-                    selector: ':disabled',
+                    selector: '.is-disabled',
+                    name: 'disabled',
                 },
                 {
                     type: 'boolean',
                     name: 'selected',
                     selector: '.is-selected',
+                },
+                {
+                    type: 'boolean',
+                    selector: ':active',
+                    name: 'active',
                 },
                 {
                     type: 'boolean',
@@ -154,25 +164,29 @@ const config = {
                     selector: '.spectrum-Icon',
                 },
             ],
-            exclude: [
-                /\.is-disabled/,
-                /\.spectrum-Button/,
-                /\.spectrum-ClearButton/,
-            ],
+            exclude: [/\.spectrum-Button/, /\.spectrum-ClearButton/],
             excludeSourceSelector: [/^(.*),(.*),(.*),(.*),(.*)$/],
         },
         {
             name: 'clear-button',
             host: {
                 selector: '.spectrum-ClearButton',
-                shadowSelector: '.button',
             },
-            focus: '.button',
             attributes: [
                 {
                     selector: '.spectrum-ClearButton--small',
                     type: 'boolean',
                     name: 'small',
+                },
+                {
+                    type: 'boolean',
+                    selector: ':active',
+                    name: 'active',
+                },
+                {
+                    type: 'boolean',
+                    selector: '.is-disabled',
+                    name: 'disabled',
                 },
                 {
                     type: 'enum',

--- a/packages/button/src/spectrum-fieldbutton.css
+++ b/packages/button/src/spectrum-fieldbutton.css
@@ -19,7 +19,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     max-height: 100%;
     flex-shrink: 0;
 }
-.button {
+:host {
     /* .spectrum-FieldButton */
     height: var(
         --spectrum-picker-height,
@@ -62,34 +62,34 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         box-shadow var(--spectrum-global-animation-duration-100, 0.13s),
         border-color var(--spectrum-global-animation-duration-100, 0.13s);
 }
-.button.is-disabled,
-.button:disabled {
+:host(.is-disabled),
+:host(:disabled) {
     /* .spectrum-FieldButton.is-disabled,
    * .spectrum-FieldButton:disabled */
     border-width: 0;
     cursor: default;
 }
-.button.is-open {
+:host(.is-open) {
     /* .spectrum-FieldButton.is-open */
     border-width: var(
         --spectrum-picker-border-size,
         var(--spectrum-alias-border-size-thin)
     );
 }
-:host([quiet]) .button {
+:host([quiet]) {
     /* .spectrum-FieldButton--quiet */
     margin: 0;
     padding: 0;
     border-width: 0;
     border-radius: var(--spectrum-fieldbutton-quiet-border-radius, 0);
 }
-:host([quiet]) .button.is-disabled:focus-visible,
-:host([quiet]) .button:disabled:focus-visible {
+:host([quiet]) .is-disabled:focus-visible,
+:host([quiet]:disabled:focus-visible) {
     /* .spectrum-FieldButton--quiet.is-disabled.focus-ring,
    * .spectrum-FieldButton--quiet:disabled.focus-ring */
     box-shadow: none;
 }
-.button {
+:host {
     /* .spectrum-FieldButton */
     color: var(
         --spectrum-fieldbutton-text-color,
@@ -104,7 +104,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color)
     );
 }
-.button:hover {
+:host(:hover) {
     /* .spectrum-FieldButton:hover */
     color: var(
         --spectrum-fieldbutton-text-color-hover,
@@ -119,8 +119,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-hover)
     );
 }
-.button.is-selected,
-.button:active {
+:host(.is-selected),
+:host(:active) {
     /* .spectrum-FieldButton.is-selected,
    * .spectrum-FieldButton:active */
     background-color: var(
@@ -132,8 +132,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-down)
     );
 }
-.button:focus-visible,
-:host([focused]) .button {
+:host(:focus-visible),
+:host([focused]) {
     /* .spectrum-FieldButton.focus-ring,
    * .spectrum-FieldButton.is-focused */
     background-color: var(
@@ -155,8 +155,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-.button:focus-visible.is-placeholder,
-:host([focused]) .button.is-placeholder {
+:host(:focus-visible.is-placeholder),
+:host([focused].is-placeholder) {
     /* .spectrum-FieldButton.focus-ring.is-placeholder,
    * .spectrum-FieldButton.is-focused.is-placeholder */
     color: var(
@@ -164,22 +164,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-placeholder-text-color-hover)
     );
 }
-:host([invalid]) .button {
+:host([invalid]) {
     /* .spectrum-FieldButton.is-invalid */
     border-color: var(
         --spectrum-fieldbutton-border-color-error,
         var(--spectrum-global-color-red-500)
     );
 }
-:host([invalid]) .button:hover {
+:host([invalid]:hover) {
     /* .spectrum-FieldButton.is-invalid:hover */
     border-color: var(
         --spectrum-fieldbutton-border-color-error-hover,
         var(--spectrum-global-color-red-600)
     );
 }
-:host([invalid]) .button.is-selected,
-:host([invalid]) .button:active {
+:host([invalid].is-selected),
+:host([invalid]:active) {
     /* .spectrum-FieldButton.is-invalid.is-selected,
    * .spectrum-FieldButton.is-invalid:active */
     border-color: var(
@@ -187,8 +187,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-red-600)
     );
 }
-:host([invalid]) .button:focus-visible,
-:host([invalid][focused]) .button {
+:host([invalid]:focus-visible),
+:host([invalid][focused]) {
     /* .spectrum-FieldButton.is-invalid.focus-ring,
    * .spectrum-FieldButton.is-invalid.is-focused */
     border-color: var(
@@ -202,8 +202,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-border-color-focus)
         );
 }
-.button.is-disabled,
-.button:disabled {
+:host(.is-disabled),
+:host(:disabled) {
     /* .spectrum-FieldButton.is-disabled,
    * .spectrum-FieldButton:disabled */
     background-color: var(
@@ -215,8 +215,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-.button.is-disabled .icon,
-.button:disabled .icon {
+:host(.is-disabled) .icon,
+:host(:disabled) .icon {
     /* .spectrum-FieldButton.is-disabled .spectrum-Icon,
    * .spectrum-FieldButton:disabled .spectrum-Icon */
     color: var(
@@ -224,7 +224,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-icon-color-disabled)
     );
 }
-:host([quiet]) .button {
+:host([quiet]) {
     /* .spectrum-FieldButton--quiet */
     color: var(
         --spectrum-fieldbutton-text-color,
@@ -239,7 +239,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-background-color-transparent)
     );
 }
-:host([quiet]) .button:hover {
+:host([quiet]:hover) {
     /* .spectrum-FieldButton--quiet:hover */
     background-color: var(
         --spectrum-fieldbutton-quiet-background-color-hover,
@@ -250,8 +250,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-hover)
     );
 }
-:host([quiet]) .button:focus-visible,
-:host([quiet][focused]) .button {
+:host([quiet]:focus-visible),
+:host([quiet][focused]) {
     /* .spectrum-FieldButton--quiet.focus-ring,
    * .spectrum-FieldButton--quiet.is-focused */
     background-color: var(
@@ -264,8 +264,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-border-color-focus)
         );
 }
-:host([quiet]) .button:focus-visible.is-placeholder,
-:host([quiet][focused]) .button.is-placeholder {
+:host([quiet]:focus-visible) .is-placeholder,
+:host([quiet][focused]) .is-placeholder {
     /* .spectrum-FieldButton--quiet.focus-ring.is-placeholder,
    * .spectrum-FieldButton--quiet.is-focused.is-placeholder */
     color: var(
@@ -273,8 +273,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-placeholder-text-color-hover)
     );
 }
-:host([quiet]) .button.is-selected,
-:host([quiet]) .button:active {
+:host([quiet]) .is-selected,
+:host([quiet]:active) {
     /* .spectrum-FieldButton--quiet.is-selected,
    * .spectrum-FieldButton--quiet:active */
     background-color: var(
@@ -286,10 +286,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-transparent)
     );
 }
-:host([quiet]) .button.is-selected:focus-visible,
-:host([quiet][focused]) .button.is-selected,
-:host([quiet]) .button:active:focus-visible,
-:host([quiet][focused]) .button:active {
+:host([quiet]) .is-selected:focus-visible,
+:host([quiet][focused]) .is-selected,
+:host([quiet]:active:focus-visible),
+:host([quiet][focused]:active) {
     /* .spectrum-FieldButton--quiet.is-selected.focus-ring,
    * .spectrum-FieldButton--quiet.is-selected.is-focused,
    * .spectrum-FieldButton--quiet:active.focus-ring,
@@ -304,8 +304,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-border-color-focus)
         );
 }
-:host([quiet][invalid]) .button:focus-visible,
-:host([quiet][invalid][focused]) .button {
+:host([quiet][invalid]:focus-visible),
+:host([quiet][invalid][focused]) {
     /* .spectrum-FieldButton--quiet.is-invalid.focus-ring,
    * .spectrum-FieldButton--quiet.is-invalid.is-focused */
     box-shadow: 0 2px 0 0
@@ -314,8 +314,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-border-color-focus)
         );
 }
-:host([quiet]) .button.is-disabled,
-:host([quiet]) .button:disabled {
+:host([quiet]) .is-disabled,
+:host([quiet]:disabled) {
     /* .spectrum-FieldButton--quiet.is-disabled,
    * .spectrum-FieldButton--quiet:disabled */
     background-color: var(

--- a/packages/button/test/action-button.test.ts
+++ b/packages/button/test/action-button.test.ts
@@ -27,6 +27,39 @@ describe('Button', () => {
         expect(el.textContent).to.include('Button');
         await expect(el).to.be.accessible();
     });
+    it('loads [hold-affordance]', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button hold-affordance>Button</sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el).to.not.be.undefined;
+        expect(el.textContent).to.include('Button');
+        await expect(el).to.be.accessible();
+    });
+    it(':not([toggles])', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button>Button</sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        const button = el.focusElement;
+
+        expect(el.toggles).to.be.false;
+        expect(el.selected).to.be.false;
+        expect(button.hasAttribute('aria-pressed')).to.be.false;
+
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.toggles).to.be.false;
+        expect(el.selected).to.be.false;
+        expect(button.hasAttribute('aria-pressed')).to.be.false;
+    });
     it('toggles', async () => {
         const el = await fixture<ActionButton>(
             html`

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -20,6 +20,7 @@ import {
     waitUntil,
 } from '@open-wc/testing';
 import { shiftTabEvent } from '../../../test/testing-helpers.js';
+import { spy } from 'sinon';
 
 type TestableButtonType = {
     hasLabel: boolean;
@@ -64,6 +65,23 @@ describe('Button', () => {
         expect(el.textContent).to.include('Button');
         await expect(el).to.be.accessible();
     });
+    it('loads default w/ an icon-right', async () => {
+        const el = await fixture<Button>(
+            html`
+                <sp-button icon-right>
+                    Button
+                    <svg slot="icon"></svg>
+                </sp-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el).to.not.be.undefined;
+        expect(el.textContent).to.include('Button');
+        expect(((el as unknown) as { hasIcon: boolean }).hasIcon);
+        expect(((el as unknown) as { iconRight: boolean }).iconRight);
+        await expect(el).to.be.accessible();
+    });
     it('loads default only icon', async () => {
         const el = await fixture<Button>(
             html`
@@ -76,6 +94,21 @@ describe('Button', () => {
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
         await expect(el).to.be.accessible();
+    });
+    it('manages "role"', async () => {
+        const el = await fixture<Button>(
+            html`
+                <sp-button>Button</sp-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el.getAttribute('role')).to.equal('button');
+
+        el.href = '#';
+
+        await elementUpdated(el);
+        expect(el.hasAttribute('role')).to.be.false;
     });
     it('allows label to be toggled', async () => {
         const testNode = document.createTextNode('Button');
@@ -105,21 +138,6 @@ describe('Button', () => {
         await elementUpdated(el);
 
         expect(labelTestableEl.hasLabel, 'label is returned').to.be.true;
-    });
-    it('loads default w/ an icon on the right', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button icon-right>
-                    Button
-                    <svg slot="icon"></svg>
-                </sp-button>
-            `
-        );
-
-        await elementUpdated(el);
-        expect(el).to.not.be.undefined;
-        expect(el.textContent).to.include('Button');
-        await expect(el).to.be.accessible();
     });
     it('loads with href', async () => {
         const el = await fixture<Button>(
@@ -246,5 +264,185 @@ describe('Button', () => {
         await elementUpdated(el);
 
         expect(el.tabIndex).to.equal(2);
+    });
+    it('swallows `click` interaction when `[disabled]`', async () => {
+        const clickSpy = spy();
+        const el = await fixture<Button>(
+            html`
+                <sp-button disabled @click=${() => clickSpy()}>
+                    Button
+                </sp-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(clickSpy.callCount).to.equal(0);
+
+        el.click();
+
+        await elementUpdated(el);
+        expect(clickSpy.callCount).to.equal(0);
+    });
+    it('translates keyboard interactions to click', async () => {
+        const clickSpy = spy();
+        const el = await fixture<Button>(
+            html`
+                <sp-button @click=${() => clickSpy()}>Button</sp-button>
+            `
+        );
+
+        await elementUpdated(el);
+
+        el.dispatchEvent(
+            new KeyboardEvent('keypress', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'Enter',
+                key: 'Enter',
+            })
+        );
+
+        await elementUpdated(el);
+        expect(clickSpy.callCount).to.equal(1);
+        clickSpy.resetHistory();
+
+        el.dispatchEvent(
+            new KeyboardEvent('keypress', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'Space',
+                key: 'Space',
+            })
+        );
+
+        await elementUpdated(el);
+        expect(clickSpy.callCount).to.equal(0);
+        clickSpy.resetHistory();
+
+        el.dispatchEvent(
+            new KeyboardEvent('keydown', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'Space',
+                key: 'Space',
+            })
+        );
+        el.dispatchEvent(
+            new KeyboardEvent('keyup', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'Space',
+                key: 'Space',
+            })
+        );
+
+        await elementUpdated(el);
+        expect(clickSpy.callCount).to.equal(1);
+        clickSpy.resetHistory();
+
+        el.dispatchEvent(
+            new KeyboardEvent('keydown', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'Space',
+                key: 'Space',
+            })
+        );
+        el.dispatchEvent(
+            new KeyboardEvent('keyup', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'KeyG',
+                key: 'g',
+            })
+        );
+
+        await elementUpdated(el);
+        expect(clickSpy.callCount).to.equal(0);
+
+        el.dispatchEvent(
+            new KeyboardEvent('keyup', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'Space',
+                key: 'Space',
+            })
+        );
+        clickSpy.resetHistory();
+
+        el.dispatchEvent(
+            new KeyboardEvent('keydown', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'KeyG',
+                key: 'g',
+            })
+        );
+        el.dispatchEvent(
+            new KeyboardEvent('keyup', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                code: 'Space',
+                key: 'Space',
+            })
+        );
+
+        await elementUpdated(el);
+        expect(clickSpy.callCount).to.equal(0);
+    });
+    it('proxies clicks by "type"', async () => {
+        const submitSpy = spy();
+        const resetSpy = spy();
+        const test = await fixture<HTMLFormElement>(
+            html`
+                <form
+                    @submit=${(event: Event): void => {
+                        event.preventDefault();
+                        submitSpy();
+                    }}
+                    @reset=${(event: Event): void => {
+                        event.preventDefault();
+                        resetSpy();
+                    }}
+                >
+                    <sp-button>Button</sp-button>
+                </form>
+            `
+        );
+        const el = test.querySelector('sp-button') as Button;
+
+        await elementUpdated(el);
+        el.type = 'submit';
+
+        await elementUpdated(el);
+        el.click();
+
+        expect(submitSpy.callCount).to.equal(1);
+        expect(resetSpy.callCount).to.equal(0);
+
+        el.type = 'reset';
+
+        await elementUpdated(el);
+        el.click();
+
+        expect(submitSpy.callCount).to.equal(1);
+        expect(resetSpy.callCount).to.equal(1);
+
+        el.type = 'button';
+
+        await elementUpdated(el);
+        el.click();
+
+        expect(submitSpy.callCount).to.equal(1);
+        expect(resetSpy.callCount).to.equal(1);
     });
 });

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -100,7 +100,6 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
 
     private handleKeydown(event: KeyboardEvent): void {
         const { code } = event;
-        /* istanbul ignore else */
         if (code === 'Space') {
             this.toggleSelected();
         }

--- a/packages/dropdown/src/Dropdown.ts
+++ b/packages/dropdown/src/Dropdown.ts
@@ -22,9 +22,7 @@ import {
 } from '@spectrum-web-components/base';
 
 import dropdownStyles from './dropdown.css.js';
-import buttonBaseStyles from '@spectrum-web-components/button/src/button-base.css.js';
-import actionButtonStyles from '@spectrum-web-components/button/src/action-button.css.js';
-import fieldButtonStyles from '@spectrum-web-components/button/src/field-button.css.js';
+import '@spectrum-web-components/button/sp-field-button.js';
 import alertSmallStyles from '@spectrum-web-components/icon/src/spectrum-icon-alert-small.css.js';
 import chevronDownMediumStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron-down-medium.css.js';
 
@@ -54,13 +52,7 @@ import {
  */
 export class DropdownBase extends Focusable {
     public static get styles(): CSSResultArray {
-        return [
-            buttonBaseStyles,
-            actionButtonStyles,
-            dropdownStyles,
-            alertSmallStyles,
-            chevronDownMediumStyles,
-        ];
+        return [dropdownStyles, alertSmallStyles, chevronDownMediumStyles];
     }
 
     public static openOverlay = async (
@@ -239,8 +231,6 @@ export class DropdownBase extends Focusable {
         if (this.optionsMenu && this.placeholder) {
             const parentElement =
                 this.placeholder.parentElement ||
-                /* istanbul ignore next */
-
                 this.placeholder.getRootNode();
 
             if (parentElement) {
@@ -269,8 +259,7 @@ export class DropdownBase extends Focusable {
         );
 
         const parentElement =
-            this.optionsMenu.parentElement ||
-            /* istanbul ignore next */ this.optionsMenu.getRootNode();
+            this.optionsMenu.parentElement || this.optionsMenu.getRootNode();
 
         if (parentElement) {
             parentElement.replaceChild(this.placeholder, this.optionsMenu);
@@ -278,9 +267,9 @@ export class DropdownBase extends Focusable {
 
         this.popover.append(this.optionsMenu);
         this.sizePopover(this.popover);
-        const { button, popover } = this;
+        const { popover } = this;
         this.closeOverlay = await Dropdown.openOverlay(
-            button,
+            this,
             'inline',
             popover,
             {
@@ -333,9 +322,9 @@ export class DropdownBase extends Focusable {
         ];
     }
 
-    protected render(): TemplateResult {
+    protected get renderButton(): TemplateResult {
         return html`
-            <button
+            <sp-field-button
                 aria-haspopup="true"
                 aria-controls="popover"
                 aria-expanded=${this.open ? 'true' : 'false'}
@@ -348,7 +337,13 @@ export class DropdownBase extends Focusable {
                 ?disabled=${this.disabled}
             >
                 ${this.buttonContent}
-            </button>
+            </sp-field-button>
+        `;
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            ${this.renderButton}
             <sp-popover
                 open
                 id="popover"
@@ -388,7 +383,7 @@ export class DropdownBase extends Focusable {
     }
 
     private async manageSelection(): Promise<void> {
-        /* istanbul ignore if */
+        /* c8 ignore next 3 */
         if (!this.optionsMenu) {
             return;
         }
@@ -412,7 +407,6 @@ export class DropdownBase extends Focusable {
             return;
         }
         await this.optionsMenu.updateComplete;
-        /* istanbul ignore else */
         if (this.optionsMenu.menuItems.length) {
             this.manageSelection();
         }
@@ -435,6 +429,6 @@ export class DropdownBase extends Focusable {
 
 export class Dropdown extends DropdownBase {
     public static get styles(): CSSResultArray {
-        return [...super.styles, fieldButtonStyles];
+        return [...super.styles];
     }
 }

--- a/packages/dropdown/src/dropdown.css
+++ b/packages/dropdown/src/dropdown.css
@@ -15,6 +15,10 @@ sp-popover {
     display: none;
 }
 
+.dropdown {
+    flex-shrink: 0;
+}
+
 /**
  * The accessibility team would prefer that it be possible to override the :focus-visible
  * heuristics in _some_ cases, like when clicking an `sp-field-label`...

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -48,7 +48,7 @@ export class Search extends Textfield {
     public placeholder = 'Search';
 
     @query('#form')
-    public form?: HTMLFormElement;
+    public form!: HTMLFormElement;
 
     private handleSubmit(event: Event): void {
         const applyDefault = this.dispatchEvent(
@@ -71,12 +71,7 @@ export class Search extends Textfield {
     }
 
     public async reset(): Promise<void> {
-        /* c8 ignore next */
-        if (!this.form) {
-            return;
-        }
         this.value = '';
-        this.form.reset();
         await this.updateComplete;
         this.focusElement.dispatchEvent(
             new InputEvent('input', {
@@ -102,6 +97,7 @@ export class Search extends Textfield {
                 id="form"
                 method=${ifDefined(this.method)}
                 @submit=${this.handleSubmit}
+                @reset=${this.reset}
                 @keydown=${this.handleKeydown}
             >
                 <sp-icon class="icon magnifier icon-workflow" size="s">
@@ -114,7 +110,7 @@ export class Search extends Textfield {
                               id="button"
                               label="Reset"
                               tabindex="-1"
-                              @click=${this.reset}
+                              type="reset"
                               @keydown=${stopPropagation}
                           ></sp-clear-button>
                       `
@@ -125,8 +121,6 @@ export class Search extends Textfield {
 
     public updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
-        if (changedProperties.has('multiline')) {
-            this.multiline = false;
-        }
+        this.multiline = false;
     }
 }

--- a/packages/search/test/search.test.ts
+++ b/packages/search/test/search.test.ts
@@ -15,6 +15,7 @@ import { litFixture, html, elementUpdated, expect } from '@open-wc/testing';
 import {
     waitForPredicate,
     escapeEvent,
+    spaceEvent,
 } from '../../../test/testing-helpers.js';
 import '@spectrum-web-components/shared/src/focus-visible.js';
 import { spy } from 'sinon';
@@ -50,6 +51,26 @@ describe('Search', () => {
         await elementUpdated(el);
 
         expect(el.value).to.equal('');
+    });
+    it('captures keyboard events to the clear button', async () => {
+        const el = await litFixture<Search>(
+            html`
+                <sp-search value="Test"></sp-search>
+            `
+        );
+
+        await elementUpdated(el);
+        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
+
+        expect(el.value).to.equal('Test');
+
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const clearButton = root.querySelector('#button') as HTMLButtonElement;
+        clearButton.dispatchEvent(escapeEvent);
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal('Test');
     });
     it('dispatches events when using the "clear" button', async () => {
         const inputSpy = spy();
@@ -115,6 +136,10 @@ describe('Search', () => {
         await elementUpdated(el);
         await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
+        expect(el.value).to.equal('Test');
+        el.focusElement.dispatchEvent(spaceEvent);
+
+        await elementUpdated(el);
         expect(el.value).to.equal('Test');
 
         inputSpy.resetHistory();

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -44,6 +44,9 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
      */
     @property({ type: Number })
     public get tabIndex(): number {
+        if (this.focusElement === this) {
+            return Number(this.getAttribute('tabindex')) || -1;
+        }
         const tabIndexAttribute = parseFloat(
             this.hasAttribute('tabindex')
                 ? (this.getAttribute('tabindex') as string) || '0'
@@ -64,6 +67,12 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         return this.focusElement.tabIndex;
     }
     public set tabIndex(tabIndex: number) {
+        if (this.focusElement === this) {
+            if (tabIndex !== this.tabIndex) {
+                this.setAttribute('tabindex', '' + tabIndex);
+            }
+            return;
+        }
         // Flipping `manipulatingTabindex` to true before a change
         // allows for that change NOT to effect the cached value of tabindex
         if (this.manipulatingTabindex) {
@@ -117,11 +126,19 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
             return;
         }
 
-        this.focusElement.focus();
+        if (this.focusElement !== this) {
+            this.focusElement.focus();
+        } else {
+            HTMLElement.prototype.focus.apply(this);
+        }
     }
 
     public blur(): void {
-        this.focusElement.blur();
+        if (this.focusElement !== this) {
+            this.focusElement.blur();
+        } else {
+            HTMLElement.prototype.blur.apply(this);
+        }
     }
 
     public click(): void {
@@ -129,7 +146,11 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
             return;
         }
 
-        this.focusElement.click();
+        if (this.focusElement !== this) {
+            this.focusElement.click();
+        } else {
+            HTMLElement.prototype.click.apply(this);
+        }
     }
 
     protected manageAutoFocus(): void {

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -20,14 +20,13 @@ import {
     ifDefined,
 } from '@spectrum-web-components/base';
 
+import '@spectrum-web-components/button/sp-button.js';
 import { ButtonVariants } from '@spectrum-web-components/button';
 import { DropdownBase } from '@spectrum-web-components/dropdown';
 import {
     ChevronDownMediumIcon,
     MoreIcon,
 } from '@spectrum-web-components/icons-ui';
-import buttonBaseStyles from '@spectrum-web-components/button/src/button-base.css.js';
-import buttonStyles from '@spectrum-web-components/button/src/button.css.js';
 import ChevronDownMediumStyle from '@spectrum-web-components/icon/src/spectrum-icon-chevron-down-medium.css.js';
 import styles from './split-button.css.js';
 
@@ -36,7 +35,7 @@ import styles from './split-button.css.js';
  */
 export class SplitButton extends DropdownBase {
     public static get styles(): CSSResultArray {
-        return [buttonBaseStyles, buttonStyles, styles, ChevronDownMediumStyle];
+        return [styles, ChevronDownMediumStyle];
     }
 
     @property({ type: Boolean, reflect: true })
@@ -78,7 +77,7 @@ export class SplitButton extends DropdownBase {
     }
 
     private passClick(): void {
-        /* istanbul ignore if */
+        /* c8 ignore next 3 */
         if (!this.optionsMenu) {
             return;
         }
@@ -87,7 +86,6 @@ export class SplitButton extends DropdownBase {
                 ? this.optionsMenu.menuItems[0]
                 : this.optionsMenu.menuItems.find((el) => el.selected) ||
                   this.optionsMenu.menuItems[0];
-        /* istanbul ignore else */
         if (target) {
             target.click();
         }
@@ -98,6 +96,7 @@ export class SplitButton extends DropdownBase {
             html`
                 <div
                     id="label"
+                    role="presentation"
                     class=${ifDefined(this.value ? undefined : 'placeholder')}
                 >
                     ${this.selectedItemText}
@@ -109,25 +108,27 @@ export class SplitButton extends DropdownBase {
     protected render(): TemplateResult {
         const buttons: TemplateResult[] = [
             html`
-                <button
+                <sp-button
                     aria-haspopup="true"
                     aria-label=${ifDefined(this.label || undefined)}
                     id="button"
                     class="button ${this.variant}"
                     @click=${this.passClick}
                     ?disabled=${this.disabled}
+                    variant=${this.variant}
                 >
                     ${this.buttonContent}
-                </button>
+                </sp-button>
             `,
             html`
-                <button
+                <sp-button
                     class="button trigger ${this.variant}"
                     @blur=${this.onButtonBlur}
                     @click=${this.onButtonClick}
                     @focus=${this.onButtonFocus}
                     ?disabled=${this.disabled}
                     aria-label="More"
+                    variant=${this.variant}
                 >
                     <sp-icon
                         class="icon ${this.type === 'field'
@@ -138,7 +139,7 @@ export class SplitButton extends DropdownBase {
                             ? ChevronDownMediumIcon({ hidden: true })
                             : MoreIcon({ hidden: true })}
                     </sp-icon>
-                </button>
+                </sp-button>
             `,
         ];
         if (this.left) {
@@ -163,7 +164,7 @@ export class SplitButton extends DropdownBase {
     }
 
     private async manageSplitButtonItems(): Promise<void> {
-        /* istanbul ignore if */
+        /* c8 ignore next 3 */
         if (!this.optionsMenu) {
             return;
         }
@@ -185,7 +186,6 @@ export class SplitButton extends DropdownBase {
             return;
         }
         await this.optionsMenu.updateComplete;
-        /* istanbul ignore else */
         if (this.optionsMenu.menuItems.length) {
             this.manageSplitButtonItems();
         }

--- a/packages/split-button/test/split-button.test.ts
+++ b/packages/split-button/test/split-button.test.ts
@@ -42,6 +42,30 @@ describe('Splitbutton', () => {
         await expect(el1).to.be.accessible();
         await expect(el2).to.be.accessible();
     });
+    it('receives "focus()"', async () => {
+        const test = await fixture<HTMLDivElement>(cta());
+        const el1 = test.querySelector('sp-split-button') as SplitButton;
+        const el2 = test.querySelector('sp-split-button[left]') as SplitButton;
+        const el1FocusElement = el1.focusElement;
+        const el2FocusElement = el2.shadowRoot.querySelector(
+            '.trigger'
+        ) as HTMLElement;
+
+        await elementUpdated(el1);
+        await elementUpdated(el2);
+
+        el1.focus();
+        await elementUpdated(el1);
+
+        expect(document.activeElement === el1);
+        expect(el1.shadowRoot.activeElement === el1FocusElement);
+
+        el2.focus();
+        await elementUpdated(el2);
+
+        expect(document.activeElement === el2);
+        expect(el1.shadowRoot.activeElement === el2FocusElement);
+    });
     it('[type="field"] manages `selectedItemText`', async () => {
         const test = await fixture<HTMLDivElement>(cta());
         const el = test.querySelector('sp-split-button') as SplitButton;

--- a/packages/tags/src/spectrum-config.js
+++ b/packages/tags/src/spectrum-config.js
@@ -37,9 +37,19 @@ const config = {
                     name: 'invalid',
                 },
                 {
+                    selector: '.is-selected',
+                    type: 'boolean',
+                    name: 'selected',
+                },
+                {
                     selector: '.spectrum-Tags-item--deletable',
                     type: 'boolean',
                     name: 'deletable',
+                },
+                {
+                    selector: '.spectrum-Tags-item--removable',
+                    type: 'boolean',
+                    name: 'removable',
                 },
             ],
             classes: [
@@ -50,6 +60,10 @@ const config = {
                 {
                     selector: '.spectrum-Tags-itemLabel',
                     name: 'label',
+                },
+                {
+                    selector: '.spectrum-Tags-itemIcon',
+                    name: 'itemIcon',
                 },
             ],
             slots: [

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -244,7 +244,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-:host(.is-selected) {
+:host([selected]) {
     /* .spectrum-Tags-item.is-selected */
     background-color: var(
         --spectrum-tag-background-color-selected,
@@ -259,21 +259,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-transparent)
     );
 }
-:host(.is-selected) .spectrum-Tags-itemIcon {
+:host([selected]) .itemIcon {
     /* .spectrum-Tags-item.is-selected .spectrum-Tags-itemIcon */
     color: var(
         --spectrum-tag-icon-color-selected,
         var(--spectrum-global-color-gray-50)
     );
 }
-:host(.is-selected:hover) {
+:host([selected]:hover) {
     /* .spectrum-Tags-item.is-selected:hover */
     background-color: var(
         --spectrum-tag-background-color-selected-hover,
         var(--spectrum-global-color-gray-800)
     );
 }
-:host(.is-selected:focus-visible) {
+:host([selected]:focus-visible) {
     /* .spectrum-Tags-item.is-selected.focus-ring */
     box-shadow: 0 0 0
         var(
@@ -289,7 +289,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host(.is-selected[invalid]) {
+:host([selected][invalid]) {
     /* .spectrum-Tags-item.is-selected.is-invalid */
     border-color: var(
         --spectrum-tag-border-color-error-selected,
@@ -300,9 +300,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host(.is-selected[invalid]) .spectrum-Tags-itemClearButton,
-:host(.is-selected[invalid]) .spectrum-Tags-itemIcon,
-:host(.is-selected[invalid]) .label {
+:host([selected][invalid]) .spectrum-Tags-itemClearButton,
+:host([selected][invalid]) .itemIcon,
+:host([selected][invalid]) .label {
     /* .spectrum-Tags-item.is-selected.is-invalid .spectrum-Tags-itemClearButton,
    * .spectrum-Tags-item.is-selected.is-invalid .spectrum-Tags-itemIcon,
    * .spectrum-Tags-item.is-selected.is-invalid .spectrum-Tags-itemLabel */
@@ -311,7 +311,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host(.is-selected[invalid]:focus-visible) {
+:host([selected][invalid]:focus-visible) {
     /* .spectrum-Tags-item.is-selected.is-invalid.focus-ring */
     box-shadow: 0 0 0
         var(
@@ -327,7 +327,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-50)
     );
 }
-:host(.is-selected[invalid]:hover) {
+:host([selected][invalid]:hover) {
     /* .spectrum-Tags-item.is-selected.is-invalid:hover */
     border-color: var(
         --spectrum-tag-border-color-selected,
@@ -338,7 +338,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-800)
     );
 }
-:host(.is-selected[invalid]:hover) .spectrum-Tags-itemIcon {
+:host([selected][invalid]:hover) .itemIcon {
     /* .spectrum-Tags-item.is-selected.is-invalid:hover .spectrum-Tags-itemIcon */
     color: var(
         --spectrum-tag-icon-color-selected,
@@ -366,7 +366,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([invalid]:focus-visible),
 :host([invalid]:hover),
 :host([invalid]:hover) .spectrum-Tags-itemClearButton,
-:host([invalid]:hover) .spectrum-Tags-itemIcon {
+:host([invalid]:hover) .itemIcon {
     /* .spectrum-Tags-item.is-invalid.focus-ring,
    * .spectrum-Tags-item.is-invalid:hover,
    * .spectrum-Tags-item.is-invalid:hover .spectrum-Tags-itemClearButton,
@@ -393,7 +393,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         );
 }
 :host([invalid]) .spectrum-Tags-itemClearButton,
-:host([invalid]) .spectrum-Tags-itemIcon {
+:host([invalid]) .itemIcon {
     /* .spectrum-Tags-item.is-invalid .spectrum-Tags-itemClearButton,
    * .spectrum-Tags-item.is-invalid .spectrum-Tags-itemIcon */
     color: var(
@@ -420,42 +420,42 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Tags-item.is-disabled .spectrum-Avatar */
     opacity: var(--spectrum-avatar-size-100-opacity-disabled, 0.3);
 }
-:host([disabled]) .spectrum-Tags-itemIcon {
+:host([disabled]) .itemIcon {
     /* .spectrum-Tags-item.is-disabled .spectrum-Tags-itemIcon */
     color: var(
         --spectrum-tag-icon-color-disabled,
         var(--spectrum-global-color-gray-500)
     );
 }
-.spectrum-Tags-item--removable:hover {
+:host([removable]:hover) {
     /* .spectrum-Tags-item--removable:hover */
     color: var(
         --spectrum-tag-removable-text-color-hover,
         var(--spectrum-global-color-gray-900)
     );
 }
-.spectrum-Tags-item--removable:hover .clear-button {
+:host([removable]:hover) .clear-button {
     /* .spectrum-Tags-item--removable:hover .spectrum-ClearButton */
     color: var(
         --spectrum-tag-removable-icon-color-hover,
         var(--spectrum-global-color-gray-900)
     );
 }
-.spectrum-Tags-item--removable:active {
+:host([removable]:active) {
     /* .spectrum-Tags-item--removable:active */
     color: var(
         --spectrum-tag-removable-text-color-down,
         var(--spectrum-global-color-gray-700)
     );
 }
-.spectrum-Tags-item--removable:active .clear-button {
+:host([removable]:active) .clear-button {
     /* .spectrum-Tags-item--removable:active .spectrum-ClearButton */
     color: var(
         --spectrum-tag-removable-icon-color-down,
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([invalid]) .spectrum-Tags-item--removable:hover {
+:host([removable][invalid]:hover) {
     /* .spectrum-Tags-item--removable.is-invalid:hover */
     border-color: var(
         --spectrum-tag-removable-border-color-error-hover,
@@ -466,14 +466,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host([invalid]) .spectrum-Tags-item--removable:hover .clear-button {
+:host([removable][invalid]:hover) .clear-button {
     /* .spectrum-Tags-item--removable.is-invalid:hover .spectrum-ClearButton */
     color: var(
         --spectrum-tag-removable-icon-color-error-hover,
         var(--spectrum-global-color-red-600)
     );
 }
-:host([invalid]) .spectrum-Tags-item--removable:active {
+:host([removable][invalid]:active) {
     /* .spectrum-Tags-item--removable.is-invalid:active */
     border-color: var(
         --spectrum-tag-removable-border-color-error-down,
@@ -484,64 +484,63 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host([invalid]) .spectrum-Tags-item--removable:active .clear-button {
+:host([removable][invalid]:active) .clear-button {
     /* .spectrum-Tags-item--removable.is-invalid:active .spectrum-ClearButton */
     color: var(
         --spectrum-tag-removable-icon-color-error-down,
         var(--spectrum-global-color-red-700)
     );
 }
-.spectrum-Tags-item--removable:focus-visible {
+:host([removable]:focus-visible) {
     /* .spectrum-Tags-item--removable.focus-ring */
     color: var(
         --spectrum-tag-removable-text-color-key-focus,
         var(--spectrum-global-color-gray-700)
     );
 }
-.spectrum-Tags-item--removable:focus-visible .clear-button {
+:host([removable]:focus-visible) .clear-button {
     /* .spectrum-Tags-item--removable.focus-ring .spectrum-ClearButton */
     color: var(
         --spectrum-tag-removable-icon-color-key-focus,
         var(--spectrum-global-color-gray-900)
     );
 }
-.spectrum-Tags-item--removable.is-selected {
+:host([removable][selected]) {
     /* .spectrum-Tags-item--removable.is-selected */
     color: var(
         --spectrum-tag-removable-text-color-selected,
         var(--spectrum-global-color-gray-50)
     );
 }
-.spectrum-Tags-item--removable.is-selected.is-focused {
+:host([removable][selected]) .is-focused {
     /* .spectrum-Tags-item--removable.is-selected.is-focused */
     color: var(
         --spectrum-tag-removable-text-color-selected-key-focus,
         var(--spectrum-global-color-gray-50)
     );
 }
-.spectrum-Tags-item--removable.is-selected .spectrum-Tags-itemClearButton {
+:host([removable][selected]) .spectrum-Tags-itemClearButton {
     /* .spectrum-Tags-item--removable.is-selected .spectrum-Tags-itemClearButton */
     color: var(
         --spectrum-tag-removable-button-icon-color-selected,
         var(--spectrum-global-color-gray-50)
     );
 }
-.spectrum-Tags-item--removable.is-selected
-    .spectrum-Tags-itemClearButton:hover {
+:host([removable][selected]) .spectrum-Tags-itemClearButton:hover {
     /* .spectrum-Tags-item--removable.is-selected .spectrum-Tags-itemClearButton:hover */
     color: var(
         --spectrum-tag-removable-button-icon-color-selected-hover,
         var(--spectrum-global-color-gray-50)
     );
 }
-:host([invalid]) .spectrum-Tags-item--removable.is-selected {
+:host([removable][selected][invalid]) {
     /* .spectrum-Tags-item--removable.is-selected.is-invalid */
     color: var(
         --spectrum-tag-removable-text-color-error-key-focus,
         var(--spectrum-global-color-gray-700)
     );
 }
-.spectrum-Tags-item--removable .spectrum-Tags-itemClearButton.is-focused {
+:host([removable]) .spectrum-Tags-itemClearButton.is-focused {
     /* .spectrum-Tags-item--removable .spectrum-Tags-itemClearButton.is-focused */
     border-color: var(
         --spectrum-tag-removable-border-color-key-focus,
@@ -556,14 +555,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-.spectrum-Tags-item--removable .spectrum-Tags-itemClearButton:hover {
+:host([removable]) .spectrum-Tags-itemClearButton:hover {
     /* .spectrum-Tags-item--removable .spectrum-Tags-itemClearButton:hover */
     color: var(
         --spectrum-tag-removable-button-icon-color-hover,
         var(--spectrum-global-color-gray-900)
     );
 }
-.spectrum-Tags-item--removable .spectrum-Tags-itemClearButton:active {
+:host([removable]) .spectrum-Tags-itemClearButton:active {
     /* .spectrum-Tags-item--removable .spectrum-Tags-itemClearButton:active */
     background-color: var(
         --spectrum-tag-removable-button-background-color-hover,


### PR DESCRIPTION
## Description
Move the accessible "button" node up from a `<button>` element in the shadow DOM to the a synthetic button at the host.

This _prepares_ both for work on a few existing issues and for an update to `elementInternals` in the future. There's been some coalescence around a polypill, so we might want to move in that direction at some point in the near future.

- synthesize button
  - apply aria attributes
  - apply click and keyboard handling
- update CSS processing for selector correctness
- process `active` styles correctly and broadly
- cascade changes across all button derivative and possessing patterns.

This will collide with #1051, so there will be much hand holding of one of these PRs to get them over the line.

## Related Issue
refs #998 
refs #1042 

## Motivation and Context
Accessibility can be achieved in many ways, but some of those are blocked by browser APIs that haven't been released, so we have to work with the tools we have available.

## How Has This Been Tested?
- added unit tests
- corrected changes for visual regression
- updated some vrts for correctness


## Types of changes
- [x] Refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
