### PR TITLE
feat: use fully registered icon components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 1e13231992f594dbe9310d2bdc629ac16d08f4a1
+        default: ba8e184319ddb0e9dacdc6d96969e1a578628409
 commands:
     setup:
         steps:

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -7,6 +7,7 @@
     "include": ["../global.d.ts", "../packages/*/stories/**/*.ts"],
     "exclude": [
         "../packages/*/src/**/*.ts",
+        "../packages/*/icons/**/*.ts",
         "../packages/*/node_modules/**/*.ts"
     ]
 }

--- a/documentation/src/components/component.ts
+++ b/documentation/src/components/component.ts
@@ -14,6 +14,16 @@ import '@spectrum-web-components/bundle/elements.js';
 // work around while `top-nav` isn't "officially" in the bundle
 import '@spectrum-web-components/top-nav/sp-top-nav.js';
 import '@spectrum-web-components/top-nav/sp-top-nav-item.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-help.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-star.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-chevron-down.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark-circle.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import { RouteComponent } from './route-component.js';
 import componentStyles from './markdown.css';
 import { AppRouter } from '../router.js';

--- a/documentation/src/components/component.ts
+++ b/documentation/src/components/component.ts
@@ -24,6 +24,8 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark-circle.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-more.js';
 import { RouteComponent } from './route-component.js';
 import componentStyles from './markdown.css';
 import { AppRouter } from '../router.js';

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,11 @@
 {
     "packages": ["packages/*", "projects/*"],
-    "ignoreChanges": ["packages/*/test/**", "**/*.md"],
+    "ignoreChanges": [
+        "packages/*/test/**",
+        "packages/*/stories/**",
+        "**/*.md",
+        "**/tsconfig.json"
+    ],
     "version": "independent",
     "npmClient": "yarn",
     "useWorkspaces": true,

--- a/packages/action-button/README.md
+++ b/packages/action-button/README.md
@@ -45,11 +45,7 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ```html demo
 <sp-action-button>
-    <svg slot="icon" id="spectrum-icon-18-Edit" viewBox="0 0 36 36">
-        <path
-            d="M33.567 8.2L27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945zM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73z"
-        ></path>
-    </svg>
+    <sp-icon-edit slot="icon"></sp-icon-edit>
     This is an action button
 </sp-action-button>
 ```
@@ -58,11 +54,7 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ```html demo
 <sp-action-button label="Edit">
-    <svg slot="icon" id="spectrum-icon-18-Edit" viewBox="0 0 36 36">
-        <path
-            d="M33.567 8.2L27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945zM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73z"
-        ></path>
-    </svg>
+    <sp-icon-edit slot="icon"></sp-icon-edit>
 </sp-action-button>
 ```
 
@@ -70,11 +62,7 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ```html demo
 <sp-action-button label="Edit" emphasized selected>
-    <svg slot="icon" id="spectrum-icon-18-Edit" viewBox="0 0 36 36">
-        <path
-            d="M33.567 8.2L27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945zM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73z"
-        ></path>
-    </svg>
+    <sp-icon-edit slot="icon"></sp-icon-edit>
 </sp-action-button>
 ```
 
@@ -85,33 +73,15 @@ The use of the `hold-affordance` attribute signifies that the `<sp-action-button
 ```html demo
 <sp-action-group>
     <sp-action-button label="Edit" hold-affordance>
-        <svg slot="icon" id="spectrum-icon-18-Edit" viewBox="0 0 36 36">
-            <path
-                d="M33.567 8.2L27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945zM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73z"
-            ></path>
-        </svg>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
     </sp-action-button>
 
     <sp-action-button hold-affordance quiet>
-        <svg
-            slot="icon"
-            xmlns="http://www.w3.org/2000/svg"
-            height="18"
-            viewBox="0 0 18 18"
-            width="18"
-        >
-            <path
-                d="M16.45,7.8965H14.8945a5.97644,5.97644,0,0,0-.921-2.2535L15.076,4.54a.55.55,0,0,0,.00219-.77781L15.076,3.76l-.8365-.836a.55.55,0,0,0-.77781-.00219L13.4595,2.924,12.357,4.0265a5.96235,5.96235,0,0,0-2.2535-.9205V1.55a.55.55,0,0,0-.55-.55H8.45a.55.55,0,0,0-.55.55V3.106a5.96235,5.96235,0,0,0-2.2535.9205l-1.1-1.1025a.55.55,0,0,0-.77781-.00219L3.7665,2.924,2.924,3.76a.55.55,0,0,0-.00219.77781L2.924,4.54,4.0265,5.643a5.97644,5.97644,0,0,0-.921,2.2535H1.55a.55.55,0,0,0-.55.55V9.55a.55.55,0,0,0,.55.55H3.1055a5.967,5.967,0,0,0,.921,2.2535L2.924,13.4595a.55.55,0,0,0-.00219.77782l.00219.00218.8365.8365a.55.55,0,0,0,.77781.00219L4.5405,15.076,5.643,13.9735a5.96235,5.96235,0,0,0,2.2535.9205V16.45a.55.55,0,0,0,.55.55H9.55a.55.55,0,0,0,.55-.55V14.894a5.96235,5.96235,0,0,0,2.2535-.9205L13.456,15.076a.55.55,0,0,0,.77782.00219L14.236,15.076l.8365-.8365a.55.55,0,0,0,.00219-.77781l-.00219-.00219L13.97,12.357a5.967,5.967,0,0,0,.921-2.2535H16.45a.55.55,0,0,0,.55-.55V8.45a.55.55,0,0,0-.54649-.55349ZM11.207,9A2.207,2.207,0,1,1,9,6.793H9A2.207,2.207,0,0,1,11.207,9Z"
-            />
-        </svg>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
     </sp-action-button>
 
     <sp-action-button hold-affordance selected>
-        <svg slot="icon" id="spectrum-icon-18-More" viewBox="0 0 36 36">
-            <circle cx="17.8" cy="18.2" r="3.4"></circle>
-            <circle cx="29.5" cy="18.2" r="3.4"></circle>
-            <circle cx="6.1" cy="18.2" r="3.4"></circle>
-        </svg>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
     </sp-action-button>
 </sp-action-group>
 ```

--- a/packages/action-button/stories/action-button.stories.ts
+++ b/packages/action-button/stories/action-button.stories.ts
@@ -12,11 +12,9 @@ governing permissions and limitations under the License.
 import { html, action } from '@open-wc/demoing-storybook';
 import { TemplateResult } from '@spectrum-web-components/base';
 import '@spectrum-web-components/icon/sp-icon.js';
-import {
-    EditIcon,
-    MoreIcon,
-    SettingsIcon,
-} from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-more.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 
 import '../';
 import '../sp-action-button.js';
@@ -102,9 +100,7 @@ export const toggles = (): TemplateResult => {
 export const wIconButton = (): TemplateResult => {
     return html`
         <sp-action-button>
-            <sp-icon slot="icon">
-                ${EditIcon({ hidden: true })}
-            </sp-icon>
+            <sp-icon-edit slot="icon"></sp-icon-edit>
             This is an action button
         </sp-action-button>
     `;
@@ -117,9 +113,7 @@ wIconButton.story = {
 export const iconOnlyButton = (): TemplateResult => {
     return html`
         <sp-action-button label="Edit">
-            <sp-icon slot="icon">
-                ${EditIcon({ hidden: true })}
-            </sp-icon>
+            <sp-icon-edit slot="icon"></sp-icon-edit>
         </sp-action-button>
     `;
 };
@@ -128,21 +122,15 @@ export const holdAffordance = (): TemplateResult => {
     return html`
         <sp-action-group>
             <sp-action-button label="Edit" hold-affordance>
-                <sp-icon slot="icon">
-                    ${EditIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
             </sp-action-button>
 
             <sp-action-button hold-affordance quiet>
-                <sp-icon slot="icon">
-                    ${SettingsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-settings slot="icon"></sp-icon-settings>
             </sp-action-button>
 
             <sp-action-button hold-affordance selected>
-                <sp-icon slot="icon">
-                    ${MoreIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-more slot="icon"></sp-icon-more>
             </sp-action-button>
         </sp-action-group>
     `;

--- a/packages/action-group/README.md
+++ b/packages/action-group/README.md
@@ -25,60 +25,58 @@ import { ActionGroup } from '@spectrum-web-components/action-group';
 
 ## Horizontal
 
-<sp-icons-medium></sp-icons-medium>
-
 ```html
 <sp-action-group>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Button 1
     </sp-action-button>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Longer Button 2
     </sp-action-button>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Short 3
     </sp-action-button>
 </sp-action-group>
 <br />
 <sp-action-group compact>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Button 1
     </sp-action-button>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Longer Button 2
     </sp-action-button>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Short 3
     </sp-action-button>
 </sp-action-group>
 <br />
 <sp-action-group>
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
 </sp-action-group>
 <br />
 <sp-action-group compact>
     <sp-action-button label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-action-button label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-action-button label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
 </sp-action-group>
 ```
@@ -89,52 +87,52 @@ import { ActionGroup } from '@spectrum-web-components/action-group';
 <div style="display: flex; justify-content: space-around;">
     <sp-action-group vertical>
         <sp-action-button>
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
             Button 1
         </sp-action-button>
         <sp-action-button>
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
             Longer Button 2
         </sp-action-button>
         <sp-action-button>
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
             Short 3
         </sp-action-button>
     </sp-action-group>
     <sp-action-group vertical compact>
         <sp-action-button>
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
             Button 1
         </sp-action-button>
         <sp-action-button>
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
             Longer Button 2
         </sp-action-button>
         <sp-action-button>
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
             Short 3
         </sp-action-button>
     </sp-action-group>
     <sp-action-group vertical>
         <sp-action-button quiet label="Zoom in">
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
         <sp-action-button quiet label="Zoom in">
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
         <sp-action-button quiet label="Zoom in">
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
     </sp-action-group>
     <sp-action-group compact vertical>
         <sp-action-button label="Zoom in">
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
         <sp-action-button label="Zoom in">
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
         <sp-action-button label="Zoom in">
-            <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
     </sp-action-group>
 </div>
@@ -145,55 +143,55 @@ import { ActionGroup } from '@spectrum-web-components/action-group';
 ```html
 <sp-action-group justified>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Button 1
     </sp-action-button>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Longer Button 2
     </sp-action-button>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Short 3
     </sp-action-button>
 </sp-action-group>
 <br />
 <sp-action-group justified compact>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Button 1
     </sp-action-button>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Longer Button 2
     </sp-action-button>
     <sp-action-button>
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Short 3
     </sp-action-button>
 </sp-action-group>
 <br />
 <sp-action-group justified>
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
 </sp-action-group>
 <br />
 <sp-action-group compact justified>
     <sp-action-button label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-action-button label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-action-button label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
 </sp-action-group>
 ```

--- a/packages/actionbar/README.md
+++ b/packages/actionbar/README.md
@@ -30,18 +30,10 @@ import { Actionbar } from '@spectrum-web-components/actionbar';
     <sp-checkbox indeterminate>228 Selected</sp-checkbox>
     <div class="spectrum-ButtonGroup">
         <sp-action-button quiet label="Edit">
-            <svg slot="icon" id="spectrum-icon-18-Edit" viewBox="0 0 36 36">
-                <path
-                    d="M33.567 8.2L27.8 2.432a1.215 1.215 0 0 0-.866-.353H26.9a1.371 1.371 0 0 0-.927.406L5.084 23.372a.99.99 0 0 0-.251.422L2.055 33.1c-.114.377.459.851.783.851a.251.251 0 0 0 .062-.007c.276-.063 7.866-2.344 9.311-2.778a.972.972 0 0 0 .414-.249l20.888-20.889a1.372 1.372 0 0 0 .4-.883 1.221 1.221 0 0 0-.346-.945zM11.4 29.316c-2.161.649-4.862 1.465-6.729 2.022l2.009-6.73z"
-                ></path>
-            </svg>
+            <sp-icon-edit slot="icon"></sp-icon-edit>
         </sp-action-button>
         <sp-action-button quiet label="More">
-            <svg slot="icon" id="spectrum-icon-18-More" viewBox="0 0 36 36">
-                <circle cx="17.8" cy="18.2" r="3.4"></circle>
-                <circle cx="29.5" cy="18.2" r="3.4"></circle>
-                <circle cx="6.1" cy="18.2" r="3.4"></circle>
-            </svg>
+            <sp-icon-more slot="icon"></sp-icon-more>
         </sp-action-button>
     </div>
 </sp-actionbar>

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -71,7 +71,7 @@ SVG.
 <sp-button-group>
     <sp-button variant="primary">Label only</sp-button>
     <sp-button variant="primary">
-        <sp-icon slot="icon" size="m" name="ui:HelpMedium"></sp-icon>
+        <sp-icon-help slot="icon"></sp-icon-help>
         Icon + Label
     </sp-button>
     <sp-button variant="primary">

--- a/packages/button/stories/button.stories.ts
+++ b/packages/button/stories/button.stories.ts
@@ -14,7 +14,7 @@ import { TemplateResult } from '@spectrum-web-components/base';
 
 import '../sp-button.js';
 import '@spectrum-web-components/icon/sp-icon.js';
-import { HelpIcon } from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-help.js';
 
 interface Properties {
     variant?: 'cta' | 'overBackground' | 'primary' | 'secondary' | 'negative';
@@ -176,9 +176,7 @@ export const withIcon = (): TemplateResult => {
                 variant: 'primary',
                 iconRight: iconRight,
                 content: html`
-                    <sp-icon slot="icon" size="m">
-                        ${HelpIcon({ hidden: true })}
-                    </sp-icon>
+                    <sp-icon-help slot="icon"></sp-icon-help>
                     Help
                 `,
             })}

--- a/packages/dropdown/src/dropdown.css
+++ b/packages/dropdown/src/dropdown.css
@@ -20,7 +20,8 @@ sp-popover {
     display: none;
 }
 
-.dropdown {
+.dropdown,
+.validationIcon {
     flex-shrink: 0;
 }
 

--- a/packages/field-label/tsconfig.json
+++ b/packages/field-label/tsconfig.json
@@ -6,5 +6,9 @@
     },
     "include": ["*.ts", "src/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
-    "references": [{ "path": "../base" }]
+    "references": [
+        { "path": "../base" },
+        { "path": "../icons-ui" },
+        { "path": "../shared" }
+    ]
 }

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -29,7 +29,7 @@ Names icons on this page are provided by the [`<sp-icons-medium>` icon set](comp
 
 ```html
 <sp-icons-medium></sp-icons-medium>
-<sp-icon name="ui:Magnifier"></sp-icon>
+<sp-icon name="ui:Arrow100"></sp-icon>
 ```
 
 ## Variants
@@ -39,13 +39,11 @@ Icons are available in various sizes in Spectrum ranging from `xxs` to `xxl`, `m
 ### Size variants
 
 ```html
-<sp-icon size="xxs" name="ui:Magnifier"></sp-icon>
-<sp-icon size="xs" name="ui:Magnifier"></sp-icon>
-<sp-icon size="s" name="ui:Magnifier"></sp-icon>
-<sp-icon size="m" name="ui:Magnifier"></sp-icon>
-<sp-icon size="l" name="ui:Magnifier"></sp-icon>
-<sp-icon size="xl" name="ui:Magnifier"></sp-icon>
-<sp-icon size="xxl" name="ui:Magnifier"></sp-icon>
+<sp-icon size="s" name="ui:Arrow100"></sp-icon>
+<sp-icon size="m" name="ui:Arrow100"></sp-icon>
+<sp-icon size="l" name="ui:Arrow100"></sp-icon>
+<sp-icon size="xl" name="ui:Arrow100"></sp-icon>
+<sp-icon size="xxl" name="ui:Arrow100"></sp-icon>
 ```
 
 ## Color icon
@@ -53,7 +51,7 @@ Icons are available in various sizes in Spectrum ranging from `xxs` to `xxl`, `m
 Icons apply their color as `currentColor` so change the `color` property of the element for customization.
 
 ```html
-<sp-icon name="ui:Magnifier" style="color: red;"></sp-icon>
+<sp-icon name="ui:Arrow100" style="color: red;"></sp-icon>
 ```
 
 ## Image icon
@@ -61,16 +59,6 @@ Icons apply their color as `currentColor` so change the `color` property of the 
 An image icon can be supplied via the `src` attribute. Remember that you cannot style the contents of an image via CSS, so use graphics that are appropriately prepared for including in your applications design requirements.
 
 ```html
-<sp-icon
-    size="xxs"
-    label="Previous"
-    src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0yOTU3Ljk5NSAtNTUzMC4wMzIgNiAxMCI+PGRlZnM+PHN0eWxlPi5he2ZpbGw6bm9uZTtzdHJva2U6IzE0NzNlNjtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHBhdGggY2xhc3M9ImEiIGQ9Ik0yNTEuMywzMzNsNC00LTQtNCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTI3MDEuNjk1IC01MTk2LjAzMikgcm90YXRlKDE4MCkiLz48L3N2Zz4="
-></sp-icon>
-<sp-icon
-    size="xs"
-    label="Previous"
-    src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0yOTU3Ljk5NSAtNTUzMC4wMzIgNiAxMCI+PGRlZnM+PHN0eWxlPi5he2ZpbGw6bm9uZTtzdHJva2U6IzE0NzNlNjtzdHJva2UtbGluZWNhcDpyb3VuZDtzdHJva2UtbGluZWpvaW46cm91bmQ7c3Ryb2tlLW1pdGVybGltaXQ6MTA7c3Ryb2tlLXdpZHRoOjJweDt9PC9zdHlsZT48L2RlZnM+PHBhdGggY2xhc3M9ImEiIGQ9Ik0yNTEuMywzMzNsNC00LTQtNCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTI3MDEuNjk1IC01MTk2LjAzMikgcm90YXRlKDE4MCkiLz48L3N2Zz4="
-></sp-icon>
 <sp-icon
     size="s"
     label="Previous"
@@ -103,7 +91,7 @@ An image icon can be supplied via the `src` attribute. Remember that you cannot 
 Icons can also be supplied as HTML elements to be applied via the default `<slot>`.
 
 ```html
-<sp-icon size="xxs">
+<sp-icon size="s">
     <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 22 22"
@@ -155,5 +143,5 @@ Icons can also be supplied as HTML elements to be applied via the default `<slot
 `aria-hidden` is set to true by default for Icons. The `label` attribute suppresses this and adds the label text as the aria-label of the icon.
 
 ```html
-<sp-icon name="ui:Magnifier" label="Magnify"></sp-icon>
+<sp-icon name="ui:Arrow100" label="Arrow pointing to the right"></sp-icon>
 ```

--- a/packages/icon/src/Icon.ts
+++ b/packages/icon/src/Icon.ts
@@ -12,41 +12,27 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    SpectrumElement,
     property,
     query,
-    CSSResultArray,
     TemplateResult,
     ifDefined,
 } from '@spectrum-web-components/base';
 
 import { IconsetRegistry } from '@spectrum-web-components/iconset/src/iconset-registry.js';
 
-import iconStyles from './icon.css.js';
+import { IconBase } from './IconBase.js';
 
-export class Icon extends SpectrumElement {
-    public static is = 'sp-icon';
-
+export class Icon extends IconBase {
     @property()
     public src?: string;
 
     @property()
     public name?: string;
 
-    @property({ reflect: true })
-    public size = 'm';
-
-    @property()
-    public label?: string;
-
     @query('#container')
     private iconContainer?: HTMLElement;
 
     private updateIconPromise?: Promise<void>;
-
-    public static get styles(): CSSResultArray {
-        return [iconStyles];
-    }
 
     public connectedCallback(): void {
         super.connectedCallback();
@@ -92,9 +78,7 @@ export class Icon extends SpectrumElement {
                 <img src="${this.src}" alt=${ifDefined(this.label)} />
             `;
         }
-        return html`
-            <slot></slot>
-        `;
+        return super.render();
     }
 
     private async updateIcon(): Promise<void> {

--- a/packages/icon/src/IconBase.ts
+++ b/packages/icon/src/IconBase.ts
@@ -9,5 +9,31 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-export * from './IconBase.js';
-export * from './Icon.js';
+
+import {
+    html,
+    SpectrumElement,
+    CSSResultArray,
+    TemplateResult,
+    property,
+} from '@spectrum-web-components/base';
+
+import iconStyles from './icon.css.js';
+
+export class IconBase extends SpectrumElement {
+    public static get styles(): CSSResultArray {
+        return [iconStyles];
+    }
+
+    @property()
+    public label?: string;
+
+    @property({ reflect: true })
+    public size = 'm';
+
+    protected render(): TemplateResult {
+        return html`
+            <slot></slot>
+        `;
+    }
+}

--- a/packages/icon/src/icon.css
+++ b/packages/icon/src/icon.css
@@ -16,12 +16,8 @@ governing permissions and limitations under the License.
     height: 100%;
 }
 
-img {
-    width: 100%;
-    height: auto;
-    vertical-align: top;
-}
-
+img,
+svg,
 ::slotted(*) {
     height: 100%;
     width: 100%;

--- a/packages/icon/src/spectrum-config.js
+++ b/packages/icon/src/spectrum-config.js
@@ -52,6 +52,7 @@ const config = {
                     ],
                 },
             ],
+            exclude: [/img/, /svg/],
         },
         {
             name: 'icon-arrow',

--- a/packages/icon/src/spectrum-icon.css
+++ b/packages/icon/src/spectrum-icon.css
@@ -23,9 +23,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-UIIcon:not(:root) */
     overflow: hidden;
 }
-:host([size='s']),
-:host([size='s']) img,
-:host([size='s']) svg {
+:host([size='s']) {
     /* .spectrum-Icon--sizeS,
    * .spectrum-Icon--sizeS img,
    * .spectrum-Icon--sizeS svg */
@@ -38,9 +36,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     );
 }
-:host([size='m']),
-:host([size='m']) img,
-:host([size='m']) svg {
+:host([size='m']) {
     /* .spectrum-Icon--sizeM,
    * .spectrum-Icon--sizeM img,
    * .spectrum-Icon--sizeM svg */
@@ -53,18 +49,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-225)
     );
 }
-:host([size='l']),
-:host([size='l']) img,
-:host([size='l']) svg {
+:host([size='l']) {
     /* .spectrum-Icon--sizeL,
    * .spectrum-Icon--sizeL img,
    * .spectrum-Icon--sizeL svg */
     height: var(--spectrum-alias-workflow-icon-size-l);
     width: var(--spectrum-alias-workflow-icon-size-l);
 }
-:host([size='xl']),
-:host([size='xl']) img,
-:host([size='xl']) svg {
+:host([size='xl']) {
     /* .spectrum-Icon--sizeXL,
    * .spectrum-Icon--sizeXL img,
    * .spectrum-Icon--sizeXL svg */
@@ -77,9 +69,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-275)
     );
 }
-:host([size='xxl']),
-:host([size='xxl']) img,
-:host([size='xxl']) svg {
+:host([size='xxl']) {
     /* .spectrum-Icon--sizeXXL,
    * .spectrum-Icon--sizeXXL img,
    * .spectrum-Icon--sizeXXL svg */

--- a/packages/icons-ui/.gitignore
+++ b/packages/icons-ui/.gitignore
@@ -1,2 +1,5 @@
 src/icons
 src/icons.ts
+src/elements
+icons/
+stories/icon-manifest.ts

--- a/packages/icons-ui/README.md
+++ b/packages/icons-ui/README.md
@@ -59,7 +59,7 @@ TemplateResult {strings: Array[1], values: Array[0], type: "html", processor: De
 When working in the context of other frameworks, it is possible to import the icons with a generic template tag as follows:
 
 ```js
-import { AsteriskIcon } from '@spectrum-web-components/icons-ui/lib/icons.js';
+import { AsteriskIcon } from '@spectrum-web-components/icons-ui/src/icons.js';
 
 console.log(AsteriskIcon());
 
@@ -85,7 +85,7 @@ What's more, if you're already working with a specific parser in your project, y
 import {
     AsteriskIcon,
     setCustomTemplateLiteralTag,
-} from '@spectrum-web-components/icons-ui/lib/icons.js';
+} from '@spectrum-web-components/icons-ui/src/icons.js';
 import htm from 'htm';
 import { h } from 'preact';
 

--- a/packages/icons-ui/bin/build.js
+++ b/packages/icons-ui/bin/build.js
@@ -42,11 +42,30 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (err, icons) => {
     if (!fs.existsSync(`${rootDir}packages/icons-ui/src/icons`)) {
         fs.mkdirSync(`${rootDir}packages/icons-ui/src/icons`);
     }
+    if (!fs.existsSync(`${rootDir}packages/icons-ui/src/elements`)) {
+        fs.mkdirSync(`${rootDir}packages/icons-ui/src/elements`);
+    }
+    if (!fs.existsSync(`${rootDir}packages/icons-ui/icons`)) {
+        fs.mkdirSync(`${rootDir}packages/icons-ui/icons`);
+    }
     fs.writeFileSync(
         path.join(rootDir, 'packages', 'icons-ui', 'src', 'icons.ts'),
         disclaimer,
         'utf-8'
     );
+    const manifestPath = path.join(
+        rootDir,
+        'packages',
+        'icons-ui',
+        'stories',
+        'icon-manifest.ts'
+    );
+    fs.writeFileSync(manifestPath, disclaimer, 'utf-8');
+    let manifestImports = `import {
+        html,
+        TemplateResult
+    } from '@spectrum-web-components/base';\r\n`;
+    let manifestListings = `\r\nexport const iconManifest = [\r\n`;
 
     icons.forEach((i) => {
         const svg = fs.readFileSync(i, 'utf-8');
@@ -125,12 +144,113 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (err, icons) => {
             exportString,
             'utf-8'
         );
+
+        const iconElement = `
+        ${disclaimer}
+
+        import {
+            html,
+            TemplateResult
+        } from '@spectrum-web-components/base';
+        import {
+            IconBase
+        } from '@spectrum-web-components/icon';
+
+        import {
+            ${ComponentName}Icon
+        } from '../icons/${id}.js';
+        import {
+            setCustomTemplateLiteralTag
+        } from '../custom-tag.js';
+
+        export class Icon${ComponentName} extends IconBase {
+            protected render(): TemplateResult {
+                setCustomTemplateLiteralTag(html);
+                return ${ComponentName}Icon() as TemplateResult;
+            }
+        }
+        `;
+        const iconElementFile = prettier.format(iconElement, {
+            printWidth: 100,
+            tabWidth: 2,
+            useTabs: false,
+            semi: true,
+            singleQuote: true,
+            trailingComma: 'all',
+            bracketSpacing: true,
+            jsxBracketSameLine: false,
+            arrowParens: 'avoid',
+            parser: 'typescript',
+        });
+
+        fs.writeFileSync(
+            path.join(
+                rootDir,
+                'packages',
+                'icons-ui',
+                'src',
+                'elements',
+                `Icon${id}.ts`
+            ),
+            iconElementFile,
+            'utf-8'
+        );
+
+        const iconElementName = `sp-icon-${Case.kebab(ComponentName)}`;
+        const iconRegistration = `
+        ${disclaimer}
+
+        import { Icon${ComponentName} } from '../src/elements/Icon${id}.js';
+
+        customElements.define('${iconElementName}', Icon${ComponentName});
+
+        declare global {
+            interface HTMLElementTagNameMap {
+                '${iconElementName}': Icon${ComponentName};
+            }
+        }
+        `;
+        const iconRegistrationFile = prettier.format(iconRegistration, {
+            printWidth: 100,
+            tabWidth: 2,
+            useTabs: false,
+            semi: true,
+            singleQuote: true,
+            trailingComma: 'all',
+            bracketSpacing: true,
+            jsxBracketSameLine: false,
+            arrowParens: 'avoid',
+            parser: 'typescript',
+        });
+
+        fs.writeFileSync(
+            path.join(
+                rootDir,
+                'packages',
+                'icons-ui',
+                'icons',
+                `${iconElementName}.ts`
+            ),
+            iconRegistrationFile,
+            'utf-8'
+        );
+        const importStatement = `\r\nimport '../icons/${iconElementName}.js';`;
+        const metadata = `{name: '${Case.sentence(
+            ComponentName
+        )}', tag: '<${iconElementName}>', story: (size: string): TemplateResult => html\`<${iconElementName} size=\$\{size\}></${iconElementName}>\`},\r\n`;
+        manifestImports += importStatement;
+        manifestListings += metadata;
     });
 
     const exportString = `\r\nexport { setCustomTemplateLiteralTag } from './custom-tag.js';\r\n`;
     fs.appendFileSync(
         path.join(rootDir, 'packages', 'icons-ui', 'src', 'icons.ts'),
         exportString,
+        'utf-8'
+    );
+    fs.appendFileSync(
+        manifestPath,
+        `${manifestImports}${manifestListings}];\r\n`,
         'utf-8'
     );
 });

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -20,23 +20,26 @@
     ],
     "version": "0.3.3",
     "description": "",
-    "main": "./lib/index.js",
-    "module": "./lib/index.js",
-    "types": "./lib/index.d.ts",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./lib/": "./lib/",
+        "./src/": "./src/",
+        "./icons/": "./icons/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },
     "files": [
         "custom-elements.json",
         "/lib/",
-        "/src/"
+        "/src/",
+        "/icons/"
     ],
     "sideEffects": [
-        "./lib/index.js",
-        "./src/index.ts"
+        "./src/index.js",
+        "./src/index.ts",
+        "./icons/*"
     ],
     "scripts": {
         "build": "node ./bin/build @spectrum-css/icon/medium"
@@ -57,6 +60,7 @@
     },
     "dependencies": {
         "@spectrum-web-components/base": "^0.1.3",
+        "@spectrum-web-components/icon": "^0.6.3",
         "@spectrum-web-components/iconset": "^0.2.5",
         "tslib": "^2.0.0"
     }

--- a/packages/icons-ui/stories/icons-ui.stories.ts
+++ b/packages/icons-ui/stories/icons-ui.stories.ts
@@ -12,15 +12,42 @@ governing permissions and limitations under the License.
 
 import '../';
 import '@spectrum-web-components/icon/sp-icon.js';
-import '@spectrum-web-components/iconset/src/icons-demo.js';
+import '@spectrum-web-components/iconset/stories/icons-demo.js';
 import { html, color, select } from '@open-wc/demoing-storybook';
 import { TemplateResult } from '@spectrum-web-components/base';
 
 import '../';
 import * as icons from '../';
+import { iconManifest } from './icon-manifest.js';
 
 export default {
     title: 'Icons',
+};
+
+export const uiElements = (): TemplateResult => {
+    const size = select(
+        'Icon Size',
+        ['xxs', 'xs', 's', 'm', 'l', 'xl', 'xxl'],
+        'm',
+        'Element'
+    );
+    return html`
+        <style>
+            .icon {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            }
+            sp-icon {
+                margin-bottom: 10px;
+            }
+        </style>
+        <icons-demo
+            style="color: ${color('Color', '#000', 'Element')}"
+            size=${size}
+            .icons=${iconManifest}
+        ></icons-demo>
+    `;
 };
 
 export const ui = (): TemplateResult => {

--- a/packages/icons-ui/test/benchmark/test-attribute-many.ts
+++ b/packages/icons-ui/test/benchmark/test-attribute-many.ts
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icon/sp-icon.js';
+import '@spectrum-web-components/icons/sp-icons-medium.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+const iconset = document.createElement('sp-icons-medium');
+document.body.append(iconset);
+
+measureFixtureCreation(html`
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow200"></sp-icon>
+    <sp-icon name="ui:Arrow300"></sp-icon>
+    <sp-icon name="ui:Arrow400"></sp-icon>
+    <sp-icon name="ui:Arrow500"></sp-icon>
+    <sp-icon name="ui:Arrow600"></sp-icon>
+    <sp-icon name="ui:Arrow75"></sp-icon>
+    <sp-icon name="ui:Asterisk100"></sp-icon>
+    <sp-icon name="ui:Asterisk200"></sp-icon>
+    <sp-icon name="ui:Asterisk300"></sp-icon>
+    <sp-icon name="ui:Asterisk75"></sp-icon>
+    <sp-icon name="ui:Checkmark100"></sp-icon>
+    <sp-icon name="ui:Checkmark200"></sp-icon>
+    <sp-icon name="ui:Checkmark300"></sp-icon>
+    <sp-icon name="ui:Checkmark400"></sp-icon>
+    <sp-icon name="ui:Checkmark50"></sp-icon>
+    <sp-icon name="ui:Checkmark500"></sp-icon>
+    <sp-icon name="ui:Checkmark600"></sp-icon>
+    <sp-icon name="ui:Checkmark75"></sp-icon>
+    <sp-icon name="ui:Chevron100"></sp-icon>
+    <sp-icon name="ui:Chevron200"></sp-icon>
+    <sp-icon name="ui:Chevron300"></sp-icon>
+    <sp-icon name="ui:Chevron400"></sp-icon>
+    <sp-icon name="ui:Chevron500"></sp-icon>
+    <sp-icon name="ui:Chevron600"></sp-icon>
+    <sp-icon name="ui:Chevron75"></sp-icon>
+    <sp-icon name="ui:CornerTriangle100"></sp-icon>
+    <sp-icon name="ui:CornerTriangle200"></sp-icon>
+    <sp-icon name="ui:CornerTriangle300"></sp-icon>
+    <sp-icon name="ui:CornerTriangle75"></sp-icon>
+    <sp-icon name="ui:Cross100"></sp-icon>
+    <sp-icon name="ui:Cross200"></sp-icon>
+    <sp-icon name="ui:Cross300"></sp-icon>
+    <sp-icon name="ui:Cross400"></sp-icon>
+    <sp-icon name="ui:Cross500"></sp-icon>
+    <sp-icon name="ui:Cross600"></sp-icon>
+    <sp-icon name="ui:Cross75"></sp-icon>
+    <sp-icon name="ui:Dash100"></sp-icon>
+    <sp-icon name="ui:Dash200"></sp-icon>
+    <sp-icon name="ui:Dash300"></sp-icon>
+    <sp-icon name="ui:Dash400"></sp-icon>
+    <sp-icon name="ui:Dash50"></sp-icon>
+    <sp-icon name="ui:Dash500"></sp-icon>
+    <sp-icon name="ui:Dash600"></sp-icon>
+    <sp-icon name="ui:Dash75"></sp-icon>
+    <sp-icon name="ui:DoubleGripper"></sp-icon>
+    <sp-icon name="ui:SingleGripper"></sp-icon>
+    <sp-icon name="ui:TripleGripper"></sp-icon>
+`);

--- a/packages/icons-ui/test/benchmark/test-attribute.ts
+++ b/packages/icons-ui/test/benchmark/test-attribute.ts
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icon/sp-icon.js';
+import '@spectrum-web-components/icons/sp-icons-medium.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+const iconset = document.createElement('sp-icons-medium');
+document.body.append(iconset);
+
+measureFixtureCreation(html`
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+`);

--- a/packages/icons-ui/test/benchmark/test-injected-many.ts
+++ b/packages/icons-ui/test/benchmark/test-injected-many.ts
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icon/sp-icon.js';
+import { Arrow75Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow75.js';
+import { Arrow100Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow100.js';
+import { Arrow200Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow200.js';
+import { Arrow300Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow300.js';
+import { Arrow400Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow400.js';
+import { Arrow500Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow500.js';
+import { Arrow600Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow600.js';
+import { Asterisk75Icon } from '@spectrum-web-components/icons-ui/src/icons/Asterisk75.js';
+import { Asterisk100Icon } from '@spectrum-web-components/icons-ui/src/icons/Asterisk100.js';
+import { Asterisk200Icon } from '@spectrum-web-components/icons-ui/src/icons/Asterisk200.js';
+import { Asterisk300Icon } from '@spectrum-web-components/icons-ui/src/icons/Asterisk300.js';
+import { Checkmark50Icon } from '@spectrum-web-components/icons-ui/src/icons/Checkmark50.js';
+import { Checkmark75Icon } from '@spectrum-web-components/icons-ui/src/icons/Checkmark75.js';
+import { Checkmark100Icon } from '@spectrum-web-components/icons-ui/src/icons/Checkmark100.js';
+import { Checkmark200Icon } from '@spectrum-web-components/icons-ui/src/icons/Checkmark200.js';
+import { Checkmark300Icon } from '@spectrum-web-components/icons-ui/src/icons/Checkmark300.js';
+import { Checkmark400Icon } from '@spectrum-web-components/icons-ui/src/icons/Checkmark400.js';
+import { Checkmark500Icon } from '@spectrum-web-components/icons-ui/src/icons/Checkmark500.js';
+import { Checkmark600Icon } from '@spectrum-web-components/icons-ui/src/icons/Checkmark600.js';
+import { Chevron75Icon } from '@spectrum-web-components/icons-ui/src/icons/Chevron75.js';
+import { Chevron100Icon } from '@spectrum-web-components/icons-ui/src/icons/Chevron100.js';
+import { Chevron200Icon } from '@spectrum-web-components/icons-ui/src/icons/Chevron200.js';
+import { Chevron300Icon } from '@spectrum-web-components/icons-ui/src/icons/Chevron300.js';
+import { Chevron400Icon } from '@spectrum-web-components/icons-ui/src/icons/Chevron400.js';
+import { Chevron500Icon } from '@spectrum-web-components/icons-ui/src/icons/Chevron500.js';
+import { Chevron600Icon } from '@spectrum-web-components/icons-ui/src/icons/Chevron600.js';
+import { CornerTriangle75Icon } from '@spectrum-web-components/icons-ui/src/icons/CornerTriangle75.js';
+import { CornerTriangle100Icon } from '@spectrum-web-components/icons-ui/src/icons/CornerTriangle100.js';
+import { CornerTriangle200Icon } from '@spectrum-web-components/icons-ui/src/icons/CornerTriangle200.js';
+import { CornerTriangle300Icon } from '@spectrum-web-components/icons-ui/src/icons/CornerTriangle300.js';
+import { Cross75Icon } from '@spectrum-web-components/icons-ui/src/icons/Cross75.js';
+import { Cross100Icon } from '@spectrum-web-components/icons-ui/src/icons/Cross100.js';
+import { Cross200Icon } from '@spectrum-web-components/icons-ui/src/icons/Cross200.js';
+import { Cross300Icon } from '@spectrum-web-components/icons-ui/src/icons/Cross300.js';
+import { Cross400Icon } from '@spectrum-web-components/icons-ui/src/icons/Cross400.js';
+import { Cross500Icon } from '@spectrum-web-components/icons-ui/src/icons/Cross500.js';
+import { Cross600Icon } from '@spectrum-web-components/icons-ui/src/icons/Cross600.js';
+import { Dash50Icon } from '@spectrum-web-components/icons-ui/src/icons/Dash50.js';
+import { Dash75Icon } from '@spectrum-web-components/icons-ui/src/icons/Dash75.js';
+import { Dash100Icon } from '@spectrum-web-components/icons-ui/src/icons/Dash100.js';
+import { Dash200Icon } from '@spectrum-web-components/icons-ui/src/icons/Dash200.js';
+import { Dash300Icon } from '@spectrum-web-components/icons-ui/src/icons/Dash300.js';
+import { Dash400Icon } from '@spectrum-web-components/icons-ui/src/icons/Dash400.js';
+import { Dash500Icon } from '@spectrum-web-components/icons-ui/src/icons/Dash500.js';
+import { Dash600Icon } from '@spectrum-web-components/icons-ui/src/icons/Dash600.js';
+import { DoubleGripperIcon } from '@spectrum-web-components/icons-ui/src/icons/DoubleGripper.js';
+import { SingleGripperIcon } from '@spectrum-web-components/icons-ui/src/icons/SingleGripper.js';
+import { TripleGripperIcon } from '@spectrum-web-components/icons-ui/src/icons/TripleGripper.js';
+import { setCustomTemplateLiteralTag } from '@spectrum-web-components/icons-ui/src/custom-tag.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+setCustomTemplateLiteralTag(html);
+
+measureFixtureCreation(html`
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow100Icon()}</sp-icon>
+    <sp-icon>${Arrow200Icon()}</sp-icon>
+    <sp-icon>${Arrow300Icon()}</sp-icon>
+    <sp-icon>${Arrow400Icon()}</sp-icon>
+    <sp-icon>${Arrow500Icon()}</sp-icon>
+    <sp-icon>${Arrow600Icon()}</sp-icon>
+    <sp-icon>${Asterisk75Icon()}</sp-icon>
+    <sp-icon>${Asterisk100Icon()}</sp-icon>
+    <sp-icon>${Asterisk200Icon()}</sp-icon>
+    <sp-icon>${Asterisk300Icon()}</sp-icon>
+    <sp-icon>${Checkmark50Icon()}</sp-icon>
+    <sp-icon>${Checkmark75Icon()}</sp-icon>
+    <sp-icon>${Checkmark100Icon()}</sp-icon>
+    <sp-icon>${Checkmark200Icon()}</sp-icon>
+    <sp-icon>${Checkmark300Icon()}</sp-icon>
+    <sp-icon>${Checkmark400Icon()}</sp-icon>
+    <sp-icon>${Checkmark500Icon()}</sp-icon>
+    <sp-icon>${Checkmark600Icon()}</sp-icon>
+    <sp-icon>${Chevron75Icon()}</sp-icon>
+    <sp-icon>${Chevron100Icon()}</sp-icon>
+    <sp-icon>${Chevron200Icon()}</sp-icon>
+    <sp-icon>${Chevron300Icon()}</sp-icon>
+    <sp-icon>${Chevron400Icon()}</sp-icon>
+    <sp-icon>${Chevron500Icon()}</sp-icon>
+    <sp-icon>${Chevron600Icon()}</sp-icon>
+    <sp-icon>${CornerTriangle75Icon()}</sp-icon>
+    <sp-icon>${CornerTriangle100Icon()}</sp-icon>
+    <sp-icon>${CornerTriangle200Icon()}</sp-icon>
+    <sp-icon>${CornerTriangle300Icon()}</sp-icon>
+    <sp-icon>${Cross75Icon()}</sp-icon>
+    <sp-icon>${Cross100Icon()}</sp-icon>
+    <sp-icon>${Cross200Icon()}</sp-icon>
+    <sp-icon>${Cross300Icon()}</sp-icon>
+    <sp-icon>${Cross400Icon()}</sp-icon>
+    <sp-icon>${Cross500Icon()}</sp-icon>
+    <sp-icon>${Cross600Icon()}</sp-icon>
+    <sp-icon>${Dash50Icon()}</sp-icon>
+    <sp-icon>${Dash75Icon()}</sp-icon>
+    <sp-icon>${Dash100Icon()}</sp-icon>
+    <sp-icon>${Dash200Icon()}</sp-icon>
+    <sp-icon>${Dash300Icon()}</sp-icon>
+    <sp-icon>${Dash400Icon()}</sp-icon>
+    <sp-icon>${Dash500Icon()}</sp-icon>
+    <sp-icon>${Dash600Icon()}</sp-icon>
+    <sp-icon>${DoubleGripperIcon()}</sp-icon>
+    <sp-icon>${SingleGripperIcon()}</sp-icon>
+    <sp-icon>${TripleGripperIcon()}</sp-icon>
+`);

--- a/packages/icons-ui/test/benchmark/test-injected.ts
+++ b/packages/icons-ui/test/benchmark/test-injected.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icon/sp-icon.js';
+import { Arrow75Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow75.js';
+import { setCustomTemplateLiteralTag } from '@spectrum-web-components/icons-ui/src/custom-tag.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+setCustomTemplateLiteralTag(html);
+
+measureFixtureCreation(html`
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+    <sp-icon>${Arrow75Icon()}</sp-icon>
+`);

--- a/packages/icons-ui/test/benchmark/test-registered-many.ts
+++ b/packages/icons-ui/test/benchmark/test-registered-many.ts
@@ -1,0 +1,113 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow400.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow500.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow600.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-asterisk75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-asterisk100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-asterisk200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-asterisk300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark50.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark400.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark500.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark600.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron400.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron500.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron600.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-corner-triangle75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-corner-triangle100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-corner-triangle200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-corner-triangle300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross400.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross500.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross600.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash50.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash400.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash500.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash600.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-double-gripper.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-single-gripper.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-triple-gripper.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-icon-arrow75></sp-icon-arrow75>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow200></sp-icon-arrow200>
+    <sp-icon-arrow300></sp-icon-arrow300>
+    <sp-icon-arrow400></sp-icon-arrow400>
+    <sp-icon-arrow500></sp-icon-arrow500>
+    <sp-icon-arrow600></sp-icon-arrow600>
+    <sp-icon-asterisk75></sp-icon-asterisk75>
+    <sp-icon-asterisk100></sp-icon-asterisk100>
+    <sp-icon-asterisk200></sp-icon-asterisk200>
+    <sp-icon-asterisk300></sp-icon-asterisk300>
+    <sp-icon-checkmark50></sp-icon-checkmark50>
+    <sp-icon-checkmark75></sp-icon-checkmark75>
+    <sp-icon-checkmark100></sp-icon-checkmark100>
+    <sp-icon-checkmark200></sp-icon-checkmark200>
+    <sp-icon-checkmark300></sp-icon-checkmark300>
+    <sp-icon-checkmark400></sp-icon-checkmark400>
+    <sp-icon-checkmark500></sp-icon-checkmark500>
+    <sp-icon-checkmark600></sp-icon-checkmark600>
+    <sp-icon-chevron75></sp-icon-chevron75>
+    <sp-icon-chevron100></sp-icon-chevron100>
+    <sp-icon-chevron200></sp-icon-chevron200>
+    <sp-icon-chevron300></sp-icon-chevron300>
+    <sp-icon-chevron400></sp-icon-chevron400>
+    <sp-icon-chevron500></sp-icon-chevron500>
+    <sp-icon-chevron600></sp-icon-chevron600>
+    <sp-icon-corner-triangle75></sp-icon-corner-triangle75>
+    <sp-icon-corner-triangle100></sp-icon-corner-triangle100>
+    <sp-icon-corner-triangle200></sp-icon-corner-triangle200>
+    <sp-icon-corner-triangle300></sp-icon-corner-triangle300>
+    <sp-icon-cross75></sp-icon-cross75>
+    <sp-icon-cross100></sp-icon-cross100>
+    <sp-icon-cross200></sp-icon-cross200>
+    <sp-icon-cross300></sp-icon-cross300>
+    <sp-icon-cross400></sp-icon-cross400>
+    <sp-icon-cross500></sp-icon-cross500>
+    <sp-icon-cross600></sp-icon-cross600>
+    <sp-icon-dash50></sp-icon-dash50>
+    <sp-icon-dash75></sp-icon-dash75>
+    <sp-icon-dash100></sp-icon-dash100>
+    <sp-icon-dash200></sp-icon-dash200>
+    <sp-icon-dash300></sp-icon-dash300>
+    <sp-icon-dash400></sp-icon-dash400>
+    <sp-icon-dash500></sp-icon-dash500>
+    <sp-icon-dash600></sp-icon-dash600>
+    <sp-icon-double-gripper></sp-icon-double-gripper>
+    <sp-icon-single-gripper></sp-icon-single-gripper>
+    <sp-icon-triple-gripper></sp-icon-triple-gripper>
+`);

--- a/packages/icons-ui/test/benchmark/test-registered.ts
+++ b/packages/icons-ui/test/benchmark/test-registered.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow100.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+    <sp-icon-arrow100></sp-icon-arrow100>
+`);

--- a/packages/icons-ui/tsconfig.json
+++ b/packages/icons-ui/tsconfig.json
@@ -2,10 +2,9 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "composite": true,
-        "outDir": "./lib",
-        "rootDir": "./src"
+        "rootDir": "./"
     },
-    "include": ["src/**/*.ts", "../../global.d.ts"],
+    "include": ["icons/**/*.ts", "src/**/*.ts", "../../global.d.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
-    "references": [{ "path": "../base" }]
+    "references": [{ "path": "../base" }, { "path": "../icon" }]
 }

--- a/packages/icons-workflow/.gitignore
+++ b/packages/icons-workflow/.gitignore
@@ -1,2 +1,5 @@
 src/icons
 src/icons.ts
+src/elements
+icons
+stories/icon-manifest.ts

--- a/packages/icons-workflow/README.md
+++ b/packages/icons-workflow/README.md
@@ -59,7 +59,7 @@ TemplateResult {strings: Array[1], values: Array[0], type: "html", processor: De
 When working in the context of other frameworks, it is possible to import the icons with a generic template tag as follows:
 
 ```js
-import { CircleIcon } from '@spectrum-web-components/icons-workflow/lib/icons.js';
+import { CircleIcon } from '@spectrum-web-components/icons-workflow/src/icons.js';
 
 console.log(CircleIcon());
 
@@ -85,7 +85,7 @@ What's more, if you're already working with a specific parser in your project, y
 import {
     CircleIcon,
     setCustomTemplateLiteralTag,
-} from '@spectrum-web-components/icons-workflow/lib/icons.js';
+} from '@spectrum-web-components/icons-workflow/src/icons.js';
 import htm from 'htm';
 import { h } from 'preact';
 

--- a/packages/icons-workflow/bin/build.js
+++ b/packages/icons-workflow/bin/build.js
@@ -42,11 +42,30 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (err, icons) => {
     if (!fs.existsSync(`${rootDir}packages/icons-workflow/src/icons`)) {
         fs.mkdirSync(`${rootDir}packages/icons-workflow/src/icons`);
     }
+    if (!fs.existsSync(`${rootDir}packages/icons-workflow/src/elements`)) {
+        fs.mkdirSync(`${rootDir}packages/icons-workflow/src/elements`);
+    }
+    if (!fs.existsSync(`${rootDir}packages/icons-workflow/icons`)) {
+        fs.mkdirSync(`${rootDir}packages/icons-workflow/icons`);
+    }
     fs.writeFileSync(
         path.join(rootDir, 'packages', 'icons-workflow', 'src', 'icons.ts'),
         disclaimer,
         'utf-8'
     );
+    const manifestPath = path.join(
+        rootDir,
+        'packages',
+        'icons-workflow',
+        'stories',
+        'icon-manifest.ts'
+    );
+    fs.writeFileSync(manifestPath, disclaimer, 'utf-8');
+    let manifestImports = `import {
+        html,
+        TemplateResult
+    } from '@spectrum-web-components/base';\r\n`;
+    let manifestListings = `\r\nexport const iconManifest = [\r\n`;
 
     icons.forEach((i) => {
         const svg = fs.readFileSync(i, 'utf-8');
@@ -143,12 +162,113 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (err, icons) => {
             exportString,
             'utf-8'
         );
+
+        const iconElement = `
+        ${disclaimer}
+
+        import {
+            html,
+            TemplateResult
+        } from '@spectrum-web-components/base';
+        import {
+            IconBase
+        } from '@spectrum-web-components/icon';
+
+        import {
+            ${ComponentName}Icon
+        } from '../icons/${id}.js';
+        import {
+            setCustomTemplateLiteralTag
+        } from '../custom-tag.js';
+
+        export class Icon${ComponentName} extends IconBase {
+            protected render(): TemplateResult {
+                setCustomTemplateLiteralTag(html);
+                return ${ComponentName}Icon({hidden: !this.label, title: this.label}) as TemplateResult;
+            }
+        }
+        `;
+        const iconElementFile = prettier.format(iconElement, {
+            printWidth: 100,
+            tabWidth: 2,
+            useTabs: false,
+            semi: true,
+            singleQuote: true,
+            trailingComma: 'all',
+            bracketSpacing: true,
+            jsxBracketSameLine: false,
+            arrowParens: 'avoid',
+            parser: 'typescript',
+        });
+
+        fs.writeFileSync(
+            path.join(
+                rootDir,
+                'packages',
+                'icons-workflow',
+                'src',
+                'elements',
+                `Icon${id}.ts`
+            ),
+            iconElementFile,
+            'utf-8'
+        );
+
+        const iconElementName = `sp-icon-${Case.kebab(ComponentName)}`;
+        const iconRegistration = `
+        ${disclaimer}
+
+        import { Icon${ComponentName} } from '../src/elements/Icon${id}.js';
+
+        customElements.define('${iconElementName}', Icon${ComponentName});
+
+        declare global {
+            interface HTMLElementTagNameMap {
+                '${iconElementName}': Icon${ComponentName};
+            }
+        }
+        `;
+        const iconRegistrationFile = prettier.format(iconRegistration, {
+            printWidth: 100,
+            tabWidth: 2,
+            useTabs: false,
+            semi: true,
+            singleQuote: true,
+            trailingComma: 'all',
+            bracketSpacing: true,
+            jsxBracketSameLine: false,
+            arrowParens: 'avoid',
+            parser: 'typescript',
+        });
+
+        fs.writeFileSync(
+            path.join(
+                rootDir,
+                'packages',
+                'icons-workflow',
+                'icons',
+                `${iconElementName}.ts`
+            ),
+            iconRegistrationFile,
+            'utf-8'
+        );
+        const importStatement = `\r\nimport '../icons/${iconElementName}.js';`;
+        const metadata = `{name: '${Case.sentence(
+            ComponentName
+        )}', tag: '<${iconElementName}>', story: (size: string): TemplateResult => html\`<${iconElementName} size=\$\{size\}></${iconElementName}>\`},\r\n`;
+        manifestImports += importStatement;
+        manifestListings += metadata;
     });
 
     const exportString = `\r\nexport { setCustomTemplateLiteralTag } from './custom-tag.js';\r\n`;
     fs.appendFileSync(
         path.join(rootDir, 'packages', 'icons-workflow', 'src', 'icons.ts'),
         exportString,
+        'utf-8'
+    );
+    fs.appendFileSync(
+        manifestPath,
+        `${manifestImports}${manifestListings}];\r\n`,
         'utf-8'
     );
 });

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -20,23 +20,26 @@
     ],
     "version": "0.3.6",
     "description": "",
-    "main": "./lib/index.js",
-    "module": "./lib/index.js",
-    "types": "./lib/index.d.ts",
+    "main": "./src/index.js",
+    "module": "./src/index.js",
+    "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./lib/": "./lib/",
+        "./src/": "./src/",
+        "./icons/": "./icons/",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },
     "files": [
         "custom-elements.json",
         "/lib/",
-        "/src/"
+        "/src/",
+        "/icons/"
     ],
     "sideEffects": [
-        "./lib/index.js",
-        "./src/index.ts"
+        "./src/index.js",
+        "./src/index.ts",
+        "./icons/*"
     ],
     "scripts": {
         "build": "node ./bin/build @adobe/spectrum-css-workflow-icons/dist/18"
@@ -45,8 +48,6 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "@adobe/spectrum-css-workflow-icons": "^1.1.0",
-        "@spectrum-web-components/icon": "^0.6.3",
-        "@spectrum-web-components/iconset": "^0.1.7",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fs": "^0.0.1-security",
@@ -57,7 +58,7 @@
     },
     "dependencies": {
         "@spectrum-web-components/base": "^0.1.3",
-        "@spectrum-web-components/iconset": "^0.2.5",
+        "@spectrum-web-components/icon": "^0.6.3",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/icons-workflow/stories/icons-workflow.stories.ts
+++ b/packages/icons-workflow/stories/icons-workflow.stories.ts
@@ -12,15 +12,42 @@ governing permissions and limitations under the License.
 
 import '../';
 import '@spectrum-web-components/icon/sp-icon.js';
-import '@spectrum-web-components/iconset/src/icons-demo.js';
+import '@spectrum-web-components/iconset/stories/icons-demo.js';
 import { html, color, select } from '@open-wc/demoing-storybook';
 import { TemplateResult } from '@spectrum-web-components/base';
 
 import '../';
 import * as icons from '../';
+import { iconManifest } from './icon-manifest.js';
 
 export default {
     title: 'Icons',
+};
+
+export const workflowElements = (): TemplateResult => {
+    const size = select(
+        'Icon Size',
+        ['xxs', 'xs', 's', 'm', 'l', 'xl', 'xxl'],
+        'm',
+        'Element'
+    );
+    return html`
+        <style>
+            .icon {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            }
+            sp-icon {
+                margin-bottom: 10px;
+            }
+        </style>
+        <icons-demo
+            style="color: ${color('Color', '#000', 'Element')}"
+            size=${size}
+            .icons=${iconManifest}
+        ></icons-demo>
+    `;
 };
 
 export const Workflow = (): TemplateResult => {

--- a/packages/icons-workflow/test/benchmark/test-attribute-many.ts
+++ b/packages/icons-workflow/test/benchmark/test-attribute-many.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icon/sp-icon.js';
+import '@spectrum-web-components/icons/sp-icons-medium.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+const iconset = document.createElement('sp-icons-medium');
+document.body.append(iconset);
+
+measureFixtureCreation(html`
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow200"></sp-icon>
+    <sp-icon name="ui:Arrow300"></sp-icon>
+    <sp-icon name="ui:Arrow400"></sp-icon>
+    <sp-icon name="ui:Arrow500"></sp-icon>
+    <sp-icon name="ui:Arrow600"></sp-icon>
+    <sp-icon name="ui:Arrow75"></sp-icon>
+    <sp-icon name="ui:Asterisk100"></sp-icon>
+    <sp-icon name="ui:Asterisk200"></sp-icon>
+    <sp-icon name="ui:Asterisk300"></sp-icon>
+    <sp-icon name="ui:Asterisk75"></sp-icon>
+    <sp-icon name="ui:Checkmark100"></sp-icon>
+    <sp-icon name="ui:Checkmark200"></sp-icon>
+    <sp-icon name="ui:Checkmark300"></sp-icon>
+    <sp-icon name="ui:Checkmark400"></sp-icon>
+    <sp-icon name="ui:Checkmark50"></sp-icon>
+    <sp-icon name="ui:Checkmark500"></sp-icon>
+    <sp-icon name="ui:Checkmark600"></sp-icon>
+    <sp-icon name="ui:Checkmark75"></sp-icon>
+    <sp-icon name="ui:Chevron100"></sp-icon>
+    <sp-icon name="ui:Chevron200"></sp-icon>
+    <sp-icon name="ui:Chevron300"></sp-icon>
+    <sp-icon name="ui:Chevron400"></sp-icon>
+    <sp-icon name="ui:Chevron500"></sp-icon>
+    <sp-icon name="ui:Chevron600"></sp-icon>
+    <sp-icon name="ui:Chevron75"></sp-icon>
+    <sp-icon name="ui:CornerTriangle100"></sp-icon>
+    <sp-icon name="ui:CornerTriangle200"></sp-icon>
+    <sp-icon name="ui:CornerTriangle300"></sp-icon>
+    <sp-icon name="ui:CornerTriangle75"></sp-icon>
+    <sp-icon name="ui:Cross100"></sp-icon>
+    <sp-icon name="ui:Cross200"></sp-icon>
+    <sp-icon name="ui:Cross300"></sp-icon>
+    <sp-icon name="ui:Cross400"></sp-icon>
+    <sp-icon name="ui:Cross500"></sp-icon>
+    <sp-icon name="ui:Cross600"></sp-icon>
+`);

--- a/packages/icons-workflow/test/benchmark/test-attribute.ts
+++ b/packages/icons-workflow/test/benchmark/test-attribute.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icon/sp-icon.js';
+import '@spectrum-web-components/icons/sp-icons-medium.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+const iconset = document.createElement('sp-icons-medium');
+document.body.append(iconset);
+
+measureFixtureCreation(html`
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+    <sp-icon name="ui:Arrow100"></sp-icon>
+`);

--- a/packages/icons-workflow/test/benchmark/test-injected-many.ts
+++ b/packages/icons-workflow/test/benchmark/test-injected-many.ts
@@ -1,0 +1,93 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icon/sp-icon.js';
+import { AbcIcon } from '@spectrum-web-components/icons-workflow/src/icons/ABC.js';
+import { ActionsIcon } from '@spectrum-web-components/icons-workflow/src/icons/Actions.js';
+import { AdDisplayIcon } from '@spectrum-web-components/icons-workflow/src/icons/AdDisplay.js';
+import { AdPrintIcon } from '@spectrum-web-components/icons-workflow/src/icons/AdPrint.js';
+import { AddIcon } from '@spectrum-web-components/icons-workflow/src/icons/Add.js';
+import { AddCircleIcon } from '@spectrum-web-components/icons-workflow/src/icons/AddCircle.js';
+import { AddToIcon } from '@spectrum-web-components/icons-workflow/src/icons/AddTo.js';
+import { AddToSelectionIcon } from '@spectrum-web-components/icons-workflow/src/icons/AddToSelection.js';
+import { AEMScreensIcon } from '@spectrum-web-components/icons-workflow/src/icons/AEMScreens.js';
+import { AirplaneIcon } from '@spectrum-web-components/icons-workflow/src/icons/Airplane.js';
+import { AlertIcon } from '@spectrum-web-components/icons-workflow/src/icons/Alert.js';
+import { AlertAddIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlertAdd.js';
+import { AlertCheckIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlertCheck.js';
+import { AlertCircleIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlertCircle.js';
+import { AlertCircleFilledIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlertCircleFilled.js';
+import { AlgorithmIcon } from '@spectrum-web-components/icons-workflow/src/icons/Algorithm.js';
+import { AliasIcon } from '@spectrum-web-components/icons-workflow/src/icons/Alias.js';
+import { ArrowLeftIcon } from '@spectrum-web-components/icons-workflow/src/icons/ArrowLeft.js';
+import { AlignCenterIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlignCenter.js';
+import { AlignTopIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlignTop.js';
+import { AlignBottomIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlignBottom.js';
+import { AlignLeftIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlignLeft.js';
+import { AlignRightIcon } from '@spectrum-web-components/icons-workflow/src/icons/AlignRight.js';
+import { AnnotateIcon } from '@spectrum-web-components/icons-workflow/src/icons/Annotate.js';
+import { AnnotatePenIcon } from '@spectrum-web-components/icons-workflow/src/icons/AnnotatePen.js';
+import { AssetIcon } from '@spectrum-web-components/icons-workflow/src/icons/Asset.js';
+import { AssetsAddedIcon } from '@spectrum-web-components/icons-workflow/src/icons/AssetsAdded.js';
+import { AssetsDownloadedIcon } from '@spectrum-web-components/icons-workflow/src/icons/AssetsDownloaded.js';
+import { AssetsExpiredIcon } from '@spectrum-web-components/icons-workflow/src/icons/AssetsExpired.js';
+import { AssetsLinkedPublishedIcon } from '@spectrum-web-components/icons-workflow/src/icons/AssetsLinkedPublished.js';
+import { AssetsModifiedIcon } from '@spectrum-web-components/icons-workflow/src/icons/AssetsModified.js';
+import { AssetsPublishedIcon } from '@spectrum-web-components/icons-workflow/src/icons/AssetsPublished.js';
+import { BookIcon } from '@spectrum-web-components/icons-workflow/src/icons/Book.js';
+import { BookmarkIcon } from '@spectrum-web-components/icons-workflow/src/icons/Bookmark.js';
+import { BookmarkSingleIcon } from '@spectrum-web-components/icons-workflow/src/icons/BookmarkSingle.js';
+import { BookmarkSingleOutlineIcon } from '@spectrum-web-components/icons-workflow/src/icons/BookmarkSingleOutline.js';
+import { setCustomTemplateLiteralTag } from '@spectrum-web-components/icons-workflow/src/custom-tag.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+setCustomTemplateLiteralTag(html);
+
+measureFixtureCreation(html`
+    <sp-icon>${AbcIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${ActionsIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AdDisplayIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AdPrintIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AddIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AddCircleIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AddToIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AddToSelectionIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AEMScreensIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AirplaneIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlertIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlertAddIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlertCheckIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlertCircleIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlertCircleFilledIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlgorithmIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AliasIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${ArrowLeftIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlignCenterIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlignTopIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlignBottomIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlignLeftIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AlignRightIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AnnotateIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AnnotatePenIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AssetIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AssetsAddedIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AssetsDownloadedIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AssetsExpiredIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AssetsLinkedPublishedIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AssetsModifiedIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${AssetsPublishedIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${BookIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${BookmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${BookmarkSingleIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${BookmarkSingleOutlineIcon({ hidden: true })}</sp-icon>
+`);

--- a/packages/icons-workflow/test/benchmark/test-injected.ts
+++ b/packages/icons-workflow/test/benchmark/test-injected.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icon/sp-icon.js';
+import { CheckmarkIcon } from '@spectrum-web-components/icons-workflow/src/icons/Checkmark.js';
+import { setCustomTemplateLiteralTag } from '@spectrum-web-components/icons-workflow/src/custom-tag.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+setCustomTemplateLiteralTag(html);
+
+measureFixtureCreation(html`
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+    <sp-icon>${CheckmarkIcon({ hidden: true })}</sp-icon>
+`);

--- a/packages/icons-workflow/test/benchmark/test-registered-many.ts
+++ b/packages/icons-workflow/test/benchmark/test-registered-many.ts
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-abc.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-actions.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-ad-display.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-ad-print.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-add.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-add-circle.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-add-to.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-add-to-selection.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-aemscreens.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-airplane.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert-add.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert-check.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert-circle.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert-circle-filled.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-algorithm.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alias.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-arrow-left.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-align-center.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-align-top.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-align-bottom.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-align-left.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-align-right.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-annotate.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-annotate-pen.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-asset.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-assets-added.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-assets-downloaded.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-assets-expired.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-assets-linked-published.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-assets-modified.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-assets-published.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-book.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-bookmark.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-bookmark-single.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-bookmark-single-outline.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-icon-abc></sp-icon-abc>
+    <sp-icon-actions></sp-icon-actions>
+    <sp-icon-ad-display></sp-icon-ad-display>
+    <sp-icon-ad-print></sp-icon-ad-print>
+    <sp-icon-add></sp-icon-add>
+    <sp-icon-add-circle></sp-icon-add-circle>
+    <sp-icon-add-to></sp-icon-add-to>
+    <sp-icon-add-to-selection></sp-icon-add-to-selection>
+    <sp-icon-aemscreens></sp-icon-aemscreens>
+    <sp-icon-airplane></sp-icon-airplane>
+    <sp-icon-alert></sp-icon-alert>
+    <sp-icon-alert-add></sp-icon-alert-add>
+    <sp-icon-alert-check></sp-icon-alert-check>
+    <sp-icon-alert-circle></sp-icon-alert-circle>
+    <sp-icon-alert-circle-filled></sp-icon-alert-circle-filled>
+    <sp-icon-algorithm></sp-icon-algorithm>
+    <sp-icon-alias></sp-icon-alias>
+    <sp-icon-arrow-left></sp-icon-arrow-left>
+    <sp-icon-align-center></sp-icon-align-center>
+    <sp-icon-align-top></sp-icon-align-top>
+    <sp-icon-align-bottom></sp-icon-align-bottom>
+    <sp-icon-align-left></sp-icon-align-left>
+    <sp-icon-align-right></sp-icon-align-right>
+    <sp-icon-annotate></sp-icon-annotate>
+    <sp-icon-annotate-pen></sp-icon-annotate-pen>
+    <sp-icon-asset></sp-icon-asset>
+    <sp-icon-assets-added></sp-icon-assets-added>
+    <sp-icon-assets-downloaded></sp-icon-assets-downloaded>
+    <sp-icon-assets-expired></sp-icon-assets-expired>
+    <sp-icon-assets-linked-published></sp-icon-assets-linked-published>
+    <sp-icon-assets-modified></sp-icon-assets-modified>
+    <sp-icon-assets-published></sp-icon-assets-published>
+    <sp-icon-book></sp-icon-book>
+    <sp-icon-bookmark></sp-icon-bookmark>
+    <sp-icon-bookmark-single></sp-icon-bookmark-single>
+    <sp-icon-bookmark-single-outline></sp-icon-bookmark-single-outline>
+`);

--- a/packages/icons-workflow/test/benchmark/test-registered.ts
+++ b/packages/icons-workflow/test/benchmark/test-registered.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+    <sp-icon-checkmark></sp-icon-checkmark>
+`);

--- a/packages/icons-workflow/tsconfig.json
+++ b/packages/icons-workflow/tsconfig.json
@@ -2,10 +2,9 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "composite": true,
-        "outDir": "./lib",
-        "rootDir": "./src"
+        "rootDir": "./"
     },
-    "include": ["src/**/*.ts", "../../global.d.ts"],
+    "include": ["icons/**/*.ts", "src/**/*.ts", "../../global.d.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
-    "references": [{ "path": "../base" }]
+    "references": [{ "path": "../base" }, { "path": "../icon" }]
 }

--- a/packages/icons/stories/icons.stories.ts
+++ b/packages/icons/stories/icons.stories.ts
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 import '../sp-icons-large.js';
 import '../sp-icons-medium.js';
-import '@spectrum-web-components/iconset/src/icons-demo.js';
+import '@spectrum-web-components/iconset/stories/icons-demo.js';
 import { html, color } from '@open-wc/demoing-storybook';
 import { TemplateResult } from '@spectrum-web-components/base';
 

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -39,14 +39,20 @@
     "sideEffects": [
         "./src/index.js",
         "./src/index.ts",
-        "./src/icons-demo.js",
-        "./src/icons-demo.ts"
+        "./stories/icons-demo.js",
+        "./stories/icons-demo.ts"
     ],
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
     "author": "",
     "license": "Apache-2.0",
+    "devDependencies": {
+        "@spectrum-web-components/field-label": "^0.0.1",
+        "@spectrum-web-components/icon": "^0.6.3",
+        "@spectrum-web-components/search": "^0.5.4",
+        "@spectrum-web-components/styles": "^0.6.1"
+    },
     "dependencies": {
         "@spectrum-web-components/base": "^0.1.3",
         "tslib": "^2.0.0"

--- a/packages/iconset/stories/icons-demo.ts
+++ b/packages/iconset/stories/icons-demo.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { IconsetAddedDetail } from './';
+import { IconsetAddedDetail } from '../';
 import {
     SpectrumElement,
     css,
@@ -19,12 +19,29 @@ import {
     property,
     customElement,
 } from '@spectrum-web-components/base';
+import { Search } from '@spectrum-web-components/search';
+import '@spectrum-web-components/search/sp-search.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
+import bodyStyles from '@spectrum-web-components/styles/body.js';
 import '@spectrum-web-components/icon/sp-icon.js';
 
 @customElement('icons-demo')
 export class IconsDemo extends SpectrumElement {
     @property()
     public name = 'ui';
+
+    @property()
+    public size = 'm';
+
+    @property()
+    public search = '';
+
+    @property({ attribute: false })
+    public icons: {
+        name: string;
+        story(size: string): TemplateResult;
+        tag: string;
+    }[] = [];
 
     private iconset: string[] = [];
     public constructor() {
@@ -47,6 +64,7 @@ export class IconsDemo extends SpectrumElement {
     }
     public static get styles(): CSSResult[] {
         return [
+            ...bodyStyles,
             css`
                 :host {
                     display: grid;
@@ -61,12 +79,60 @@ export class IconsDemo extends SpectrumElement {
                 sp-icon {
                     margin-bottom: 10px;
                 }
+                .search {
+                    grid-column-start: 1;
+                    grid-column-end: -1;
+                }
             `,
         ];
     }
+    private updateSearch(event: Event & { target: Search }): void {
+        event.stopPropagation();
+        this.search = event.target.value;
+    }
+    private submit(event: Event & { target: Search }): void {
+        event.stopPropagation();
+        this.updateSearch(event);
+    }
+    private renderSearch(): TemplateResult {
+        const matchingIcons = this.search
+            ? this.icons.filter(
+                  (icon) => icon.name.toLowerCase().search(this.search) !== -1
+              )
+            : this.icons;
+        return html`
+            <div class="search">
+                <sp-field-label for="search">Spectrum icons:</sp-field-label>
+                <sp-search
+                    id="search"
+                    @keydown=${this.updateSearch}
+                    @input=${this.updateSearch}
+                    @submit=${this.submit}
+                    .value=${this.search}
+                    label="Search for icons"
+                    autocomplete="off"
+                ></sp-search>
+                <p class="spectrum-Body spectrum-Body--sizeM">
+                    Showing ${matchingIcons.length} of ${this.icons.length}
+                    available icons.
+                </p>
+            </div>
+            ${matchingIcons.map((icon) => {
+                return html`
+                    <div class="icon">
+                        ${icon.story(this.size)} ${icon.tag}
+                    </div>
+                `;
+            })}
+        `;
+    }
     protected render(): TemplateResult {
         return html`
-            <slot></slot>
+            ${this.icons.length
+                ? this.renderSearch()
+                : html`
+                      <slot></slot>
+                  `}
             ${this.iconset.map(
                 (icon) => html`
                     <div class="icon">

--- a/packages/iconset/tsconfig.json
+++ b/packages/iconset/tsconfig.json
@@ -5,5 +5,6 @@
         "rootDir": "./"
     },
     "include": ["*.ts", "src/*.ts"],
-    "exclude": ["test/*.ts", "stories/*.ts"]
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../base" }]
 }

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -18,8 +18,7 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/icon/sp-icon.js';
-import '@spectrum-web-components/icons/sp-icons-medium.js';
-import { CheckmarkCircleIcon } from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark-circle.js';
 
 export default {
     component: 'sp-menu',
@@ -78,7 +77,6 @@ export const Default = (): TemplateResult => {
 
 export const headersAndIcons = (): TemplateResult => {
     return html`
-        <sp-icons-medium></sp-icons-medium>
         <sp-popover open>
             <sp-menu>
                 <sp-menu-group>
@@ -101,15 +99,15 @@ export const headersAndIcons = (): TemplateResult => {
                         Section Heading
                     </span>
                     <sp-menu-item>
-                        <sp-icon size="s" slot="icon">
-                            ${CheckmarkCircleIcon({ hidden: true })}
-                        </sp-icon>
+                        <sp-icon-checkmark-circle
+                            slot="icon"
+                        ></sp-icon-checkmark-circle>
                         Save
                     </sp-menu-item>
                     <sp-menu-item disabled>
-                        <sp-icon size="s" slot="icon">
-                            ${CheckmarkCircleIcon({ hidden: true })}
-                        </sp-icon>
+                        <sp-icon-checkmark-circle
+                            slot="icon"
+                        ></sp-icon-checkmark-circle>
                         Download
                     </sp-menu-item>
                 </sp-menu-group>

--- a/packages/menu/tsconfig.json
+++ b/packages/menu/tsconfig.json
@@ -5,5 +5,6 @@
         "rootDir": "./"
     },
     "include": ["*.ts", "src/*.ts"],
-    "exclude": ["test/*.ts", "stories/*.ts"]
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../button" }]
 }

--- a/packages/quick-actions/README.md
+++ b/packages/quick-actions/README.md
@@ -25,21 +25,19 @@ import { QuickActions } from '@spectrum-web-components/quick-actions';
 
 ## Example
 
-<sp-icons-medium></sp-icons-medium>
-
 ```html
 <div
     style="padding: 2em; background-color: var(--spectrum-quickactions-overlay-color, var(--spectrum-alias-background-color-quickactions-overlay));"
 >
     <sp-quick-actions opened>
         <sp-action-button quiet label="Info">
-            <sp-icon slot="icon" size="s" name="ui:InfoMedium"></sp-icon>
+            <sp-icon-info slot="icon"></sp-icon-info>
         </sp-action-button>
         <sp-action-button quiet label="Magnify">
-            <sp-icon slot="icon" size="s" name="ui:Magnifier"></sp-icon>
+            <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
         <sp-action-button quiet label="Star">
-            <sp-icon slot="icon" size="s" name="ui:Star"></sp-icon>
+            <sp-icon-star slot="icon"></sp-icon-star>
         </sp-action-button>
     </sp-quick-actions>
 </div>

--- a/packages/rule/README.md
+++ b/packages/rule/README.md
@@ -59,14 +59,13 @@ import { Rule } from '@spectrum-web-components/rule';
 When a vertical Rule is used inside of a flex container, use `align-self: stretch; height: auto;` on the Rule.
 
 ```html-live
-<sp-icons-medium></sp-icons-medium>
 <div style="height: 32px; display: flex;">
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-rule size="s" vertical></sp-rule>
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
 </div>
 ```
@@ -76,11 +75,11 @@ When a vertical Rule is used inside of a flex container, use `align-self: stretc
 ```html-live
 <div style="height: 32px; display: flex;">
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
     <sp-rule size="m" vertical></sp-rule>
     <sp-action-button quiet label="Zoom in">
-        <sp-icon slot="icon" size="m" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
 </div>
 ```

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -6,10 +6,5 @@
     },
     "include": ["*.ts", "src/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
-    "references": [
-        { "path": "../button" },
-        { "path": "../icon" },
-        { "path": "../icons-workflow" },
-        { "path": "../textfield" }
-    ]
+    "references": [{ "path": "../textfield" }]
 }

--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -105,13 +105,13 @@ will send the user to the location of the item.
 <sp-icons-medium></sp-icons-medium>
 <sp-sidenav>
     <sp-sidenav-item value="Section Title 1" label="Section Title 1">
-        <sp-icon slot="icon" size="s" name="ui:Star"></sp-icon>
+        <sp-icon-star slot="icon"></sp-icon-star>
     </sp-sidenav-item>
     <sp-sidenav-item value="Section Title 2" label="Section Title 2">
-        <sp-icon slot="icon" size="s" name="ui:Star"></sp-icon>
+        <sp-icon-star slot="icon"></sp-icon-star>
     </sp-sidenav-item>
     <sp-sidenav-item value="Section Title 3" label="Section Title 3">
-        <sp-icon slot="icon" size="s" name="ui:Star"></sp-icon>
+        <sp-icon-star slot="icon"></sp-icon-star>
     </sp-sidenav-item>
 </sp-sidenav>
 ```

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -80,16 +80,16 @@ import {
     <sp-icons-medium></sp-icons-medium>
     <sp-tabs selected="1" direction="horizontal">
         <sp-tab label="Tab 1" value="1">
-            <sp-icon slot="icon" size="m" name="ui:CheckmarkSmall"></sp-icon>
+            <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
         </sp-tab>
         <sp-tab label="Tab 2" value="2">
-            <sp-icon slot="icon" size="m" name="ui:CrossSmall"></sp-icon>
+            <sp-icon-close slot="icon"></sp-icon-close>
         </sp-tab>
         <sp-tab label="Tab 3" value="3">
-            <sp-icon slot="icon" size="m" name="ui:ChevronDownSmall"></sp-icon>
+            <sp-icon-chevron-down slot="icon"></sp-icon-chevron-down>
         </sp-tab>
         <sp-tab label="Tab 4" value="4">
-            <sp-icon slot="icon" size="m" name="ui:HelpSmall"></sp-icon>
+            <sp-icon-help slot="icon"></sp-icon-help>
         </sp-tab>
     </sp-tabs>
 </div>

--- a/packages/tabs/stories/tabs.stories.ts
+++ b/packages/tabs/stories/tabs.stories.ts
@@ -11,15 +11,13 @@ governing permissions and limitations under the License.
 */
 import { html, radios } from '@open-wc/demoing-storybook';
 import '@spectrum-web-components/icon/sp-icon.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-chevron-down.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-help.js';
 import '../sp-tabs.js';
 import '../sp-tab.js';
 import { TemplateResult } from '@spectrum-web-components/base';
-import {
-    AlertIcon,
-    CheckmarkIcon,
-    HelpIcon,
-    InfoIcon,
-} from '@spectrum-web-components/icons-workflow';
 
 export default {
     component: 'sp-tabs',
@@ -109,36 +107,28 @@ export const Icons = (): TemplateResult => {
                 value="1"
                 ?vertical=${tabType === directions.vertical}
             >
-                <sp-icon slot="icon" size="m">
-                    ${CheckmarkIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
             </sp-tab>
             <sp-tab
                 label="Tab 2"
                 value="2"
                 ?vertical=${tabType === directions.vertical}
             >
-                <sp-icon slot="icon" size="m">
-                    ${AlertIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-close slot="icon"></sp-icon-close>
             </sp-tab>
             <sp-tab
                 label="Tab 3"
                 value="3"
                 ?vertical=${tabType === directions.vertical}
             >
-                <sp-icon slot="icon" size="m">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-chevron-down slot="icon"></sp-icon-chevron-down>
             </sp-tab>
             <sp-tab
                 label="Tab 4"
                 value="4"
                 ?vertical=${tabType === directions.vertical}
             >
-                <sp-icon slot="icon" size="m">
-                    ${HelpIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
         </sp-tabs>
     `;
@@ -153,25 +143,33 @@ export const IconsOnly = (): TemplateResult => {
     const tabType = radios('Tab Type', directions, directions.horizontal);
     return html`
         <sp-tabs selected="1" direction="${type}">
-            <sp-tab value="1" ?vertical=${tabType === directions.vertical}>
-                <sp-icon label="Tab 1" slot="icon" size="m">
-                    ${CheckmarkIcon({ hidden: true })}
-                </sp-icon>
+            <sp-tab
+                aria-label="Tab 1"
+                value="1"
+                ?vertical=${tabType === directions.vertical}
+            >
+                <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
             </sp-tab>
-            <sp-tab value="2" ?vertical=${tabType === directions.vertical}>
-                <sp-icon label="Tab 2" slot="icon" size="m">
-                    ${AlertIcon({ hidden: true })}
-                </sp-icon>
+            <sp-tab
+                aria-label="Tab 2"
+                value="2"
+                ?vertical=${tabType === directions.vertical}
+            >
+                <sp-icon-close slot="icon"></sp-icon-close>
             </sp-tab>
-            <sp-tab value="3" ?vertical=${tabType === directions.vertical}>
-                <sp-icon label="Tab 3" slot="icon" size="m">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+            <sp-tab
+                aria-label="Tab 3"
+                value="3"
+                ?vertical=${tabType === directions.vertical}
+            >
+                <sp-icon-chevron-down slot="icon"></sp-icon-chevron-down>
             </sp-tab>
-            <sp-tab value="4" ?vertical=${tabType === directions.vertical}>
-                <sp-icon label="Tab 4" slot="icon" size="m">
-                    ${HelpIcon({ hidden: true })}
-                </sp-icon>
+            <sp-tab
+                aria-label="Tab 4"
+                value="4"
+                ?vertical=${tabType === directions.vertical}
+            >
+                <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
         </sp-tabs>
     `;
@@ -181,24 +179,16 @@ export const iconsIi = (): TemplateResult => {
     return html`
         <sp-tabs selected="1" direction="vertical">
             <sp-tab label="Tab 1" value="1" vertical>
-                <sp-icon slot="icon" size="m">
-                    ${CheckmarkIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
             </sp-tab>
             <sp-tab label="Tab 2" value="2" vertical>
-                <sp-icon slot="icon" size="m">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-close slot="icon"></sp-icon-close>
             </sp-tab>
             <sp-tab label="Tab 3" value="3" vertical>
-                <sp-icon slot="icon" size="m">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-chevron-down slot="icon"></sp-icon-chevron-down>
             </sp-tab>
             <sp-tab label="Tab 4" value="4" vertical>
-                <sp-icon slot="icon" size="m">
-                    ${HelpIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
         </sp-tabs>
     `;
@@ -210,27 +200,18 @@ iconsIi.story = {
 
 export const iconsIii = (): TemplateResult => {
     return html`
-        <sp-icons-medium></sp-icons-medium>
         <sp-tabs selected="1" direction="vertical">
             <sp-tab label="Tab 1" value="1">
-                <sp-icon slot="icon" size="m">
-                    ${CheckmarkIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
             </sp-tab>
             <sp-tab label="Tab 2" value="2">
-                <sp-icon slot="icon" size="m">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-close slot="icon"></sp-icon-close>
             </sp-tab>
             <sp-tab label="Tab 3" value="3">
-                <sp-icon slot="icon" size="m">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-chevron-down slot="icon"></sp-icon-chevron-down>
             </sp-tab>
             <sp-tab label="Tab 4" value="4">
-                <sp-icon slot="icon" size="m">
-                    ${HelpIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
         </sp-tabs>
     `;

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -13,6 +13,7 @@ import '../sp-tabs.js';
 import '../sp-tab.js';
 import { Tabs, Tab } from '../';
 import '@spectrum-web-components/icon/sp-icon.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
 import {
     fixture,
     elementUpdated,
@@ -265,18 +266,10 @@ describe('Tabs', () => {
         const el = await fixture<Tabs>(html`
             <sp-tabs>
                 <sp-tab label="Tab 1" value="first" selected>
-                    <sp-icon
-                        slot="icon"
-                        size="s"
-                        name="ui:CheckmarkSmall"
-                    ></sp-icon>
+                    <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
                 </sp-tab>
                 <sp-tab label="Tab 2" value="second">
-                    <sp-icon
-                        slot="icon"
-                        size="s"
-                        name="ui:CheckmarkSmall"
-                    ></sp-icon>
+                    <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
                 </sp-tab>
             </sp-tabs>
         `);
@@ -315,18 +308,10 @@ describe('Tabs', () => {
         const el = await fixture<Tabs>(html`
             <sp-tabs selected="Unknown">
                 <sp-tab label="Tab 1" value="first">
-                    <sp-icon
-                        slot="icon"
-                        size="s"
-                        name="ui:CheckmarkSmall"
-                    ></sp-icon>
+                    <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
                 </sp-tab>
                 <sp-tab label="Tab 2" value="second">
-                    <sp-icon
-                        slot="icon"
-                        size="s"
-                        name="ui:CheckmarkSmall"
-                    ></sp-icon>
+                    <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
                 </sp-tab>
             </sp-tabs>
         `);
@@ -449,18 +434,10 @@ describe('Tabs', () => {
                 return html`
                     <sp-tabs selected="Unknown">
                         <sp-tab label="Tab 1" value="first">
-                            <sp-icon
-                                slot="icon"
-                                size="s"
-                                name="ui:CheckmarkSmall"
-                            ></sp-icon>
+                            <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
                         </sp-tab>
                         <sp-tab label="Tab 2" value="second">
-                            <sp-icon
-                                slot="icon"
-                                size="s"
-                                name="ui:CheckmarkSmall"
-                            ></sp-icon>
+                            <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
                         </sp-tab>
                     </sp-tabs>
                 `;
@@ -516,18 +493,10 @@ describe('Tabs', () => {
         const el = await fixture<Tabs>(html`
             <sp-tabs selected="Unknown" direction="vertical">
                 <sp-tab label="Tab 1" value="first">
-                    <sp-icon
-                        slot="icon"
-                        size="s"
-                        name="ui:CheckmarkSmall"
-                    ></sp-icon>
+                    <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
                 </sp-tab>
                 <sp-tab label="Tab 2" value="second">
-                    <sp-icon
-                        slot="icon"
-                        size="s"
-                        name="ui:CheckmarkSmall"
-                    ></sp-icon>
+                    <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
                 </sp-tab>
             </sp-tabs>
         `);

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -29,8 +29,6 @@ import {
 
 ## Example
 
-<sp-icons-medium></sp-icons-medium>
-
 ```html-live
 <sp-tags>
     <sp-tag>Tag 1</sp-tag>
@@ -72,15 +70,15 @@ import {
 <sp-tags>
     <sp-tag>
         Tag 1
-        <sp-icon slot="icon" size="s" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
     </sp-tag>
     <sp-tag invalid>
         Tag 2
-        <sp-icon slot="icon" size="s" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
     </sp-tag>
     <sp-tag disabled>
         Tag 3
-        <sp-icon slot="icon" size="s" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
     </sp-tag>
 </sp-tags>
 ```
@@ -130,15 +128,15 @@ Use the `deletable` attribute to signify `sp-tags` elements that can be removed.
 <sp-tags>
     <sp-tag deletable>
         Tag 1
-        <sp-icon slot="icon" size="s" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
     </sp-tag>
     <sp-tag invalid deletable>
         Tag 2
-        <sp-icon slot="icon" size="s" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
     </sp-tag>
     <sp-tag disabled deletable>
         Tag 3
-        <sp-icon slot="icon" size="s" name="ui:Magnifier"></sp-icon>
+        <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
     </sp-tag>
 </sp-tags>
 ```

--- a/packages/tags/stories/tags.stories.ts
+++ b/packages/tags/stories/tags.stories.ts
@@ -17,7 +17,7 @@ import '../sp-tags.js';
 import '@spectrum-web-components/avatar/sp-avatar.js';
 import { avatar } from '@spectrum-web-components/avatar/stories/images';
 import '@spectrum-web-components/icon/sp-icon.js';
-import { MagnifyIcon } from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 
 export default {
     title: 'Tags',
@@ -64,21 +64,15 @@ export const Default = (): TemplateResult => {
         <sp-tags>
             <sp-tag>
                 Tag 1
-                <sp-icon slot="icon" size="s">
-                    ${MagnifyIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
             </sp-tag>
             <sp-tag invalid>
                 Tag 2
-                <sp-icon slot="icon" size="s">
-                    ${MagnifyIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
             </sp-tag>
             <sp-tag disabled>
                 Tag 3
-                <sp-icon slot="icon" size="s">
-                    ${MagnifyIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
             </sp-tag>
         </sp-tags>
     `;
@@ -124,21 +118,15 @@ export const deletable = (): TemplateResult => {
         <sp-tags @delete=${action('delete')}>
             <sp-tag deletable>
                 Tag 1
-                <sp-icon slot="icon" size="s">
-                    ${MagnifyIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
             </sp-tag>
             <sp-tag invalid deletable>
                 Tag 2
-                <sp-icon slot="icon" size="s">
-                    ${MagnifyIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
             </sp-tag>
             <sp-tag disabled deletable>
                 Tag 3
-                <sp-icon slot="icon" size="s">
-                    ${MagnifyIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
             </sp-tag>
         </sp-tags>
     `;

--- a/packages/textfield/tsconfig.json
+++ b/packages/textfield/tsconfig.json
@@ -7,6 +7,7 @@
     "include": ["*.ts", "src/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
     "references": [
+        { "path": "../base" },
         { "path": "../icon" },
         { "path": "../icons-ui" },
         { "path": "../icons-workflow" },

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -45,7 +45,6 @@ Tooltips can be top, bottom, left, or right.
 #### Informative
 
 This is the informative or info variant of Tooltip
-<sp-icons-medium></sp-icons-medium>
 
 ```html
 <sp-tooltip open placement="top" variant="info">Label</sp-tooltip>
@@ -53,11 +52,11 @@ This is the informative or info variant of Tooltip
     Lorem ipsum dolor sit amet, consectetur adipiscing elit
 </sp-tooltip>
 <sp-tooltip open placement="top" variant="info">
-    <sp-icon size="s" name="ui:InfoSmall" slot="icon"></sp-icon>
+    <sp-icon-info slot="icon" size="s"></sp-icon-info>
     Label
 </sp-tooltip>
 <sp-tooltip open placement="top" variant="info">
-    <sp-icon size="s" name="ui:InfoSmall" slot="icon"></sp-icon>
+    <sp-icon-info slot="icon" size="s"></sp-icon-info>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit
 </sp-tooltip>
 ```
@@ -72,11 +71,11 @@ This is the postive (a.k.a.) success variant of Tooltip
     Lorem ipsum dolor sit amet, consectetur adipiscing elit
 </sp-tooltip>
 <sp-tooltip open placement="top" variant="positive">
-    <sp-icon size="s" name="ui:CheckmarkSmall" slot="icon"></sp-icon>
+    <sp-icon-checkmark-circle slot="icon" size="s"></sp-icon-checkmark-circle>
     Label
 </sp-tooltip>
 <sp-tooltip open placement="top" variant="positive">
-    <sp-icon size="s" name="ui:CheckmarkSmall" slot="icon"></sp-icon>
+    <sp-icon-checkmark-circle slot="icon" size="s"></sp-icon-checkmark-circle>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit
 </sp-tooltip>
 ```
@@ -91,11 +90,11 @@ This is the negative a.k.a. error variant of Tooltip
     Lorem ipsum dolor sit amet, consectetur adipiscing elit
 </sp-tooltip>
 <sp-tooltip open placement="top" variant="negative">
-    <sp-icon size="s" name="ui:AlertSmall" slot="icon"></sp-icon>
+    <sp-icon-alert slot="icon" size="s"></sp-icon-alert>
     Label
 </sp-tooltip>
 <sp-tooltip open placement="top" variant="negative">
-    <sp-icon size="s" name="ui:AlertSmall" slot="icon"></sp-icon>
+    <sp-icon-alert slot="icon" size="s"></sp-icon-alert>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit
 </sp-tooltip>
 ```

--- a/test/benchmark/bench-runner.html
+++ b/test/benchmark/bench-runner.html
@@ -11,6 +11,7 @@
             const params = new URLSearchParams(window.location.search);
             const pack = params.get('package');
             const bench = params.get('bench');
+            window.tachometerStart = params.get('start');
             import(`../../packages/${pack}/test/benchmark/${bench}.js`);
         </script>
     </body>

--- a/test/benchmark/helpers.ts
+++ b/test/benchmark/helpers.ts
@@ -1,3 +1,15 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
 import { customElement, html, LitElement, property } from 'lit-element';
 import { TemplateResult, render } from 'lit-html';
 import '@spectrum-web-components/theme/sp-theme.js';
@@ -7,6 +19,7 @@ import '@spectrum-web-components/theme/theme-lightest.js';
 declare global {
     interface Window {
         tachometerResult: undefined | number;
+        tachometerStart: undefined | 'page' | 'element';
     }
 }
 
@@ -114,7 +127,7 @@ export const measureFixtureCreation = async (
     renderContainer.color = 'lightest';
 
     document.body.appendChild(renderContainer);
-    const start = performance.now();
+    const start = window.tachometerStart === 'page' ? 0 : performance.now();
     render(templates, renderContainer);
     const children = renderContainer.querySelectorAll('*');
     const updates = [...children].filter((el) => 'updateComplete' in el);


### PR DESCRIPTION
## Description
Publish a registered component for each of the Spectrum Workflow Icons so that they can be used directly in HTML.
- prepares for the culling of the icons that occurs in the current Spectrum CSS beta where a number of the UI icons are removed
- shows how the icons can be used by updating the documentation and the tests
- reduces the manual use of `size`
- opens the door for deprecating the `iconset` package all together
- separates _individual_ icons from `iconset` which reduces the work needed to finalize the render

If this feels good for people, we could apply this approach to the remaining UI icons as well.

Thoughts?

## Related Issue
refs #155 
refs #669

## Motivation and Context
Make it easier to use Spectrum Icons regardless of your deployment context.

## How Has This Been Tested?
- visual regressions mainly

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
