### PR TITLE
Add open close events to dropdowns and overlay-triggers

### DIFF
--- a/packages/dropdown/src/Dropdown.ts
+++ b/packages/dropdown/src/Dropdown.ts
@@ -45,6 +45,9 @@ import {
 /**
  * @slot label - The placeholder content for the dropdown
  * @slot {"sp-menu"} - The menu of options that will display when the dropdown is open
+ *
+ * @fires sp-open - Announces that the overlay has been opened
+ * @fires sp-close - Announces that the overlay has been closed
  */
 export class DropdownBase extends Focusable {
     public static openOverlay = async (

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -34,6 +34,9 @@ import overlayTriggerStyles from './overlay-trigger.css.js';
  * @slot trigger - The content that will trigger the various overlays
  * @slot hover-content - The content that will be displayed on hover
  * @slot click-content - The content that will be displayed on click
+ *
+ * @fires sp-open - Announces that the overlay has been opened
+ * @fires sp-close - Announces that the overlay has been closed
  */
 export class OverlayTrigger extends LitElement {
     private closeClickOverlay?: () => void;

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { ActiveOverlay } from './ActiveOverlay.js';
-import { OverlayOpenDetail } from './overlay-types';
+import { OverlayOpenDetail, OverlayOpenCloseDetail } from './overlay-types';
 import { OverlayTimer } from './overlay-timer.js';
 import '../active-overlay.js';
 
@@ -192,6 +192,16 @@ export class OverlayStack {
                 if (details.receivesFocus === 'auto') {
                     activeOverlay.focus();
                 }
+                details.trigger.dispatchEvent(
+                    new CustomEvent<OverlayOpenCloseDetail>('sp-opened', {
+                        bubbles: true,
+                        composed: true,
+                        cancelable: true,
+                        detail: {
+                            interaction: details.interaction
+                        },
+                    })
+                );
                 return false;
             }
         );
@@ -351,6 +361,17 @@ export class OverlayStack {
 
             overlay.remove();
             overlay.dispose();
+
+            overlay.trigger.dispatchEvent(
+                new CustomEvent<OverlayOpenCloseDetail>('sp-closed', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                    detail: {
+                        interaction: overlay.interaction,
+                    },
+                })
+            );
         }
     }
 

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -33,6 +33,10 @@ export interface OverlayOpenDetail {
     theme: ThemeData;
 }
 
+export interface OverlayOpenCloseDetail {
+    interaction: TriggerInteractions;
+}
+
 /**
  * Used, via an event, to query details about how an element should be shown in
  * an overlay
@@ -55,5 +59,7 @@ export type OverlayOptions = {
 declare global {
     interface GlobalEventHandlersEventMap {
         'sp-overlay-query': CustomEvent<OverlayDisplayQueryDetail>;
+        'sp-open': CustomEvent<OverlayOpenCloseDetail>;
+        'sp-close': CustomEvent<OverlayOpenCloseDetail>;
     }
 }

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -148,3 +148,17 @@ export class Overlay {
         Overlay.overlayStack.closeOverlay(this.overlayElement);
     }
 }
+
+/**
+* Announces that an overlay-based UI element has opened
+* @event sp-open
+* @type {object}
+* @property {TriggerInteractions} interaction type of interaction that triggered the opening
+*/
+
+/**
+* Announces that an overlay-based UI element has opened
+* @event sp-close
+* @type {object}
+* @property {TriggerInteractions} interaction type of interaction that triggered the closing
+*/


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->

## Related Issue

#1055

## Motivation and Context

I have hit a couple of use cases where it is important to know when an overlay-trigger or a dropdown-related component (e.g. sp-action-menu) opens and closes.

Use cases include:
* Changing the styling of parent control when overlay is open
* Updating menu content on demand

## How Has This Been Tested?

I have added tests to accompany the changes

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
