### PR TITLE
fix(button): relate to this.href correctly

### DIFF
--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -18,6 +18,11 @@ governing permissions and limitations under the License.
     vertical-align: top;
 }
 
+:host([disabled]) {
+    pointer-events: none;
+    cursor: auto;
+}
+
 #button {
     color: inherit;
     text-decoration: inherit;
@@ -25,6 +30,10 @@ governing permissions and limitations under the License.
 
 #button:focus {
     outline: none;
+}
+
+:host:after {
+    pointer-events: none;
 }
 
 slot[name='icon']::slotted(:not(sp-icon)) {

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -17,7 +17,7 @@ describe('Textfield', () => {
     it('loads default textfield accessibly', async () => {
         const el = await litFixture<Textfield>(
             html`
-                <sp-textfield placeholder="Enter Your Name"></sp-textfield>
+                <sp-textfield label="Enter Your Name"></sp-textfield>
             `
         );
 
@@ -28,16 +28,49 @@ describe('Textfield', () => {
     it('loads multiline textfield accessibly', async () => {
         const el = await litFixture<Textfield>(
             html`
-                <sp-textfield
-                    placeholder="Enter your name"
-                    multiline
-                ></sp-textfield>
+                <sp-textfield label="Enter your name" multiline></sp-textfield>
             `
         );
 
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+    });
+
+    it('manages tabIndex while disabled', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield placeholder="Enter Your Name"></sp-textfield>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(0);
+
+        el.disabled = true;
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(-1);
+
+        el.tabIndex = 2;
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(-1);
+
+        el.disabled = false;
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(2);
+    });
+
+    it('manages tabIndex before first render', async () => {
+        const el = document.createElement('sp-textfield') as Textfield;
+
+        expect(el.focusElement).to.be.null;
+        expect(el.tabIndex).to.equal(0);
+
+        el.remove();
     });
     it('loads', async () => {
         const testPlaceholder = 'Enter your name';
@@ -181,6 +214,13 @@ describe('Textfield', () => {
         await elementUpdated(el);
 
         el.focus();
+        await elementUpdated(el);
+
+        expect(activeElement === el.focusElement).to.be.false;
+        expect(document.activeElement === el).to.be.false;
+        document.removeEventListener('focusin', onFocusIn);
+
+        el.click();
         await elementUpdated(el);
 
         expect(activeElement === el.focusElement).to.be.false;


### PR DESCRIPTION
## Description
Use proxy clicking to manage the anchor option of the `ButtonBase` class so that focus/hover/click/etc are managed correctly.

## Motivation and Context
Buttons should still support `likeAnchor` functionality.

## How Has This Been Tested?
Added new unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
