### PR TITLE
Allow slider label via slot

### DIFF
--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -28,13 +28,6 @@ import { Slider } from '@spectrum-web-components/slider';
 #### Standard
 
 ```html
-<sp-slider></sp-slider>
-<sp-slider disabled></sp-slider>
-```
-
-#### With Label
-
-```html
 <sp-slider label="Slider Label"></sp-slider>
 <sp-slider label="Slider Label - Disabled" disabled></sp-slider>
 ```

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -151,7 +151,7 @@ export class Slider extends Focusable {
     private renderLabel(): TemplateResult {
         return html`
             <div id="labelContainer">
-                <label id="label" for="input">${this.label}</label>
+                <label id="label" for="input"><slot>${this.label}</slot></label>
                 <div
                     id="value"
                     role="textbox"

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -28,13 +28,14 @@ export const Default = (): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
-                label="Opacity"
                 max="100"
                 min="0"
                 value="50"
                 @input=${handleEvent}
                 @change=${handleEvent}
-            ></sp-slider>
+            >
+                Opacity
+            </sp-slider>
         </div>
     `;
 };


### PR DESCRIPTION
## Description
- remove unlabelled slider expamples
- allow slider label through slot

## Related Issue
fixed #739

## Motivation and Context
Support users in ensuring a11y.
Prep for `:not(:defined)` style usage from the outside.

## How Has This Been Tested?
Unit test.

## Types of changes
- [x] docs
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
