### PR TITLE
Correct button spelling mistake in readme for button

### DIFF
--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -57,7 +57,7 @@ import { ActionMenu } from '@spectrum-web-components/action-menu';
 
 ### No visible label
 
-The visible label that is be provided via the default `<slot>` interface can be ommitted in preference of an icon only interface. In this context be sure that the `<sp-action-menu>` continued to be accessible to screen readers by applying the `label` attribute. This will apply an `aria-label` attribute of the same value to the `<botton>` element that toggles the menu list.
+The visible label that is be provided via the default `<slot>` interface can be ommitted in preference of an icon only interface. In this context be sure that the `<sp-action-menu>` continued to be accessible to screen readers by applying the `label` attribute. This will apply an `aria-label` attribute of the same value to the `<button>` element that toggles the menu list.
 
 <!-- prettier-ignore -->
 ```html


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spelling mistake. Called a `button` and `botton`

## Related Issue

## Motivation and Context

Documentation spell correct.

## How Has This Been Tested?

Just a readme change, no code change.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Readme doc change.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
