### PR TITLE
feat(action-group): manage "one" and "multiple" selections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 0ad2b513d09c94b6faceec962d8109f3ff945dc8
+        default: f132556d5b14d4e80062013ba42edfafc19d392a
 commands:
     setup:
         steps:

--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -33,8 +33,14 @@ export class ActionButton extends ButtonBase {
         return [buttonStyles, cornerTriangleStyles];
     }
 
+    @property({ type: Boolean, reflect: true })
+    public emphasized = false;
+
     @property({ type: Boolean, reflect: true, attribute: 'hold-affordance' })
     public holdAffordance = false;
+
+    @property({ type: Boolean, reflect: true })
+    public quiet = false;
 
     @property({ type: Boolean, reflect: true })
     public selected = false;
@@ -42,14 +48,32 @@ export class ActionButton extends ButtonBase {
     @property({ type: Boolean, reflect: true })
     public toggles = false;
 
-    @property({ type: Boolean, reflect: true })
-    public quiet = false;
+    @property({ type: String })
+    public get value(): string {
+        return this._value || this.itemText;
+    }
+    public set value(value: string) {
+        if (value === this._value) {
+            return;
+        }
+        this._value = value || '';
+        if (this._value) {
+            this.setAttribute('value', this._value);
+        } else {
+            this.removeAttribute('value');
+        }
+    }
+    private _value = '';
 
     @property({ type: String, reflect: true })
     public size = 'm';
 
-    @property({ type: Boolean, reflect: true })
-    public emphasized = false;
+    /**
+     * @private
+     */
+    public get itemText(): string {
+        return (this.textContent || /* c8 ignore next */ '').trim();
+    }
 
     constructor() {
         super();

--- a/packages/action-button/stories/action-button.stories.ts
+++ b/packages/action-button/stories/action-button.stories.ts
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 import { html, action } from '@open-wc/demoing-storybook';
 import { TemplateResult } from '@spectrum-web-components/base';
+import '@spectrum-web-components/action-group';
 import '@spectrum-web-components/icon/sp-icon.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-more.js';

--- a/packages/action-group/README.md
+++ b/packages/action-group/README.md
@@ -23,7 +23,53 @@ When looking to leverage the `ActionGroup` base class as a type and/or for exten
 import { ActionGroup } from '@spectrum-web-components/action-group';
 ```
 
-## Horizontal
+## Selects
+
+An `<sp-action-group selects="single|multiple">` will manage a `selected` property that consists on an array of the `<sp-action-button>` children that are currently selected. A `change` event is dispatched from the `<sp-action-group>` element when the value of `selected` is updated. This event can be canceled via `event.preventDefault()`, after which the value of `selected` will be returned to what it was previously.
+
+### Single
+
+An `<sp-action-group selects="single">` will manage its `<sp-action-button>` children as "radio buttons" allowing the user to select a _single_ one of the buttons presented. The `<sp-action-button>` children will only be able to turn their `selected` value on while maintaining a single selection after an intial selection is made.
+
+```html
+<sp-action-group selects="single" emphasized>
+    <sp-action-button>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Button 1
+    </sp-action-button>
+    <sp-action-button selected>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Longer Button 2
+    </sp-action-button>
+    <sp-action-button>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Short 3
+    </sp-action-button>
+</sp-action-group>
+```
+
+### Multiple
+
+An `<sp-action-group selects="multiple">` will manage its `<sp-action-button>` children as "chekboxes" allowing the user to select a _multiple_ of the buttons presented. The `<sp-action-button>` children will toggle their `selected` value on and off when clicked sucessively.
+
+```html
+<sp-action-group selects="multiple" emphasized>
+    <sp-action-button selected>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Button 1
+    </sp-action-button>
+    <sp-action-button>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Longer Button 2
+    </sp-action-button>
+    <sp-action-button selected>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Short 3
+    </sp-action-button>
+</sp-action-group>
+```
+
+## Default
 
 ```html
 <sp-action-group>
@@ -56,14 +102,14 @@ import { ActionGroup } from '@spectrum-web-components/action-group';
     </sp-action-button>
 </sp-action-group>
 <br />
-<sp-action-group>
-    <sp-action-button quiet label="Zoom in">
+<sp-action-group quiet>
+    <sp-action-button label="Zoom in">
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
-    <sp-action-button quiet label="Zoom in">
+    <sp-action-button label="Zoom in">
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
-    <sp-action-button quiet label="Zoom in">
+    <sp-action-button label="Zoom in">
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
 </sp-action-group>
@@ -113,14 +159,14 @@ import { ActionGroup } from '@spectrum-web-components/action-group';
             Short 3
         </sp-action-button>
     </sp-action-group>
-    <sp-action-group vertical>
-        <sp-action-button quiet label="Zoom in">
+    <sp-action-group vertical quiet>
+        <sp-action-button label="Zoom in">
             <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
-        <sp-action-button quiet label="Zoom in">
+        <sp-action-button label="Zoom in">
             <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
-        <sp-action-button quiet label="Zoom in">
+        <sp-action-button label="Zoom in">
             <sp-icon-magnify slot="icon"></sp-icon-magnify>
         </sp-action-button>
     </sp-action-group>
@@ -171,14 +217,14 @@ import { ActionGroup } from '@spectrum-web-components/action-group';
     </sp-action-button>
 </sp-action-group>
 <br />
-<sp-action-group justified>
-    <sp-action-button quiet label="Zoom in">
+<sp-action-group justified quiet>
+    <sp-action-button label="Zoom in">
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
-    <sp-action-button quiet label="Zoom in">
+    <sp-action-button label="Zoom in">
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
-    <sp-action-button quiet label="Zoom in">
+    <sp-action-button label="Zoom in">
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
 </sp-action-group>

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -50,12 +50,12 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "@spectrum-css/actiongroup": "^1.0.0-beta.5",
-        "@spectrum-web-components/action-button": "^0.0.1",
         "@spectrum-web-components/icon": "^0.6.3",
         "@spectrum-web-components/icons-workflow": "^0.3.6"
     },
     "dependencies": {
         "@spectrum-web-components/base": "^0.1.3",
+        "@spectrum-web-components/action-button": "^0.0.1",
         "tslib": "^2.0.0"
     }
 }

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -16,9 +16,14 @@ import {
     CSSResultArray,
     TemplateResult,
     property,
+    PropertyValues,
+    queryAssignedNodes,
 } from '@spectrum-web-components/base';
+import type { ActionButton } from '@spectrum-web-components/action-button';
 
 import styles from './action-group.css.js';
+
+const EMPTY_SELECTION: string[] = [];
 
 /**
  * @element sp-action-group
@@ -28,21 +33,314 @@ export class ActionGroup extends SpectrumElement {
         return [styles];
     }
 
+    @queryAssignedNodes('', true)
+    public defaultNodes!: Node[];
+
+    public get buttons(): ActionButton[] {
+        return this.defaultNodes.filter(
+            (node) => (node as HTMLElement).tagName === 'SP-ACTION-BUTTON'
+        ) as ActionButton[];
+    }
+
     @property({ type: Boolean, reflect: true })
     public compact = false;
 
     @property({ type: Boolean, reflect: true })
-    public justified = false;
+    public emphasized = false;
 
     @property({ type: Boolean, reflect: true })
-    public vertical = false;
+    public justified = false;
+
+    @property({ type: String })
+    public label = '';
 
     @property({ type: Boolean, reflect: true })
     public quiet = false;
 
+    @property({ type: String })
+    public selects: undefined | 'single' | 'multiple';
+
+    @property({ type: Boolean, reflect: true })
+    public vertical = false;
+
+    @property({ type: Array })
+    public get selected(): string[] {
+        return this._selected;
+    }
+    public set selected(selected: string[]) {
+        if (selected === this.selected) return;
+        const old = this.selected;
+        this._selected = selected;
+        const applyDefault = this.dispatchEvent(
+            new Event('change', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
+        if (!applyDefault) {
+            this._selected = old;
+            this.buttons.map((button) => {
+                button.selected = this.selected.includes(button.value);
+            });
+        }
+    }
+    private _selected: string[] = EMPTY_SELECTION;
+
+    private handleClick(event: Event): void {
+        const target = event.target as ActionButton;
+        if (typeof target.value === 'undefined') {
+            return;
+        }
+        switch (this.selects) {
+            case 'single': {
+                const selected = [
+                    ...this.querySelectorAll('[selected]'),
+                ] as ActionButton[];
+                selected.forEach((el) => {
+                    el.selected = false;
+                    el.tabIndex = -1;
+                    el.setAttribute('aria-checked', 'false');
+                });
+                target.selected = true;
+                target.tabIndex = 0;
+                target.setAttribute('aria-checked', 'true');
+                this.selected = [target.value];
+                target.focus();
+                break;
+            }
+            case 'multiple': {
+                const selected = [...this.selected];
+                target.selected = !target.selected;
+                target.setAttribute(
+                    'aria-checked',
+                    target.selected ? 'true' : 'false'
+                );
+                if (target.selected) {
+                    selected.push(target.value);
+                } else {
+                    selected.splice(this.selected.indexOf(target.value), 1);
+                }
+                this.selected = selected;
+                break;
+            }
+            default:
+                this.selected = EMPTY_SELECTION;
+                break;
+        }
+    }
+
+    private handleFocusin = (): void => {
+        this.addEventListener('focusout', this.handleFocusout);
+        this.addEventListener('keydown', this.handleKeydown);
+    };
+
+    private handleKeydown = (event: KeyboardEvent): void => {
+        const { code } = event;
+        if (
+            ![
+                'ArrowUp',
+                'ArrowLeft',
+                'ArrowRight',
+                'ArrowDown',
+                'End',
+                'Home',
+                'PageUp',
+                'PageDown',
+            ].includes(code)
+        ) {
+            return;
+        }
+        const activeElement = (this.getRootNode() as Document)
+            .activeElement as ActionButton;
+        /* c8 ignore next 3 */
+        if (!activeElement) {
+            return;
+        }
+        let nextIndex = this.buttons.indexOf(activeElement);
+        /* c8 ignore next 3 */
+        if (nextIndex === -1) {
+            return;
+        }
+        const circularIndexedElement = <T extends HTMLElement>(
+            list: T[],
+            index: number
+        ): T => list[(list.length + index) % list.length];
+        const buttonFromDelta = (delta: number): void => {
+            nextIndex += delta;
+            while (circularIndexedElement(this.buttons, nextIndex).disabled) {
+                nextIndex += delta;
+            }
+        };
+        switch (code) {
+            case 'ArrowUp':
+                buttonFromDelta(-1);
+                break;
+            case 'ArrowLeft':
+                buttonFromDelta(this.isLTR ? -1 : 1);
+                break;
+            case 'ArrowRight':
+                buttonFromDelta(this.isLTR ? 1 : -1);
+                break;
+            case 'ArrowDown':
+                buttonFromDelta(1);
+                break;
+            case 'End':
+                nextIndex = this.buttons.length;
+                buttonFromDelta(-1);
+                break;
+            case 'Home':
+                nextIndex = -1;
+                buttonFromDelta(1);
+                break;
+            case 'PageUp':
+            case 'PageDown':
+            default:
+                const tagsSiblings = [
+                    ...(this.getRootNode() as Document).querySelectorAll<
+                        ActionGroup
+                    >('sp-action-group'),
+                ];
+                if (tagsSiblings.length < 2) {
+                    return;
+                }
+                event.preventDefault();
+                const currentIndex = tagsSiblings.indexOf(this);
+                const offset = code === 'PageUp' ? -1 : 1;
+                let nextRadioGroupIndex = currentIndex + offset;
+                let nextRadioGroup = circularIndexedElement(
+                    tagsSiblings,
+                    nextRadioGroupIndex
+                );
+                while (!nextRadioGroup.buttons.length) {
+                    nextRadioGroupIndex += offset;
+                    nextRadioGroup = circularIndexedElement(
+                        tagsSiblings,
+                        nextRadioGroupIndex
+                    );
+                }
+                nextRadioGroup.focus();
+                return;
+        }
+        event.preventDefault();
+        const nextRadio = circularIndexedElement(this.buttons, nextIndex);
+        activeElement.tabIndex = -1;
+        nextRadio.tabIndex = 0;
+        nextRadio.focus();
+    };
+
+    private handleFocusout = (event: FocusEvent): void => {
+        const { relatedTarget } = event;
+        if (!relatedTarget || !this.contains(relatedTarget as HTMLElement)) {
+            const firstButtonNonDisabled = this.buttons.find((button) => {
+                if (this.selected.length) {
+                    return button.selected;
+                }
+                return !button.disabled;
+            });
+            if (firstButtonNonDisabled) {
+                firstButtonNonDisabled.tabIndex = 0;
+            }
+        }
+        this.removeEventListener('keydown', this.handleKeydown);
+        this.removeEventListener('focusout', this.handleFocusout);
+    };
+
+    private async manageSelects(): Promise<void> {
+        switch (this.selects) {
+            case 'single': {
+                this.setAttribute('role', 'radiogroup');
+                let selection: ActionButton | undefined;
+                const options = this.buttons;
+                const updates = options.map(async (option) => {
+                    await option.updateComplete;
+                    option.setAttribute('role', 'radio');
+                    option.setAttribute(
+                        'aria-checked',
+                        option.selected ? 'true' : 'false'
+                    );
+                    option.tabIndex = option.selected ? 0 : -1;
+                    if (option.selected) {
+                        selection = option;
+                    }
+                });
+                await Promise.all(updates);
+                (selection || options[0]).tabIndex = 0;
+                this.selected = selection ? [selection.value] : EMPTY_SELECTION;
+                break;
+            }
+            case 'multiple': {
+                this.setAttribute('role', 'group');
+                const selection: string[] = [];
+                const options = this.buttons;
+                const updates = options.map(async (option) => {
+                    await option.updateComplete;
+                    option.setAttribute('role', 'checkbox');
+                    option.setAttribute(
+                        'aria-checked',
+                        option.selected ? 'true' : 'false'
+                    );
+                    option.tabIndex = 0;
+                    if (option.selected) {
+                        selection.push(option.value);
+                    }
+                });
+                await Promise.all(updates);
+                this.selected = !!selection.length
+                    ? selection
+                    : EMPTY_SELECTION;
+                break;
+            }
+            default:
+                const options = [
+                    ...this.querySelectorAll('sp-action-button'),
+                ] as ActionButton[];
+                options.forEach((option) => {
+                    option.removeAttribute('role');
+                    option.tabIndex = 0;
+                });
+                this.removeAttribute('role');
+                this.selected = EMPTY_SELECTION;
+                break;
+        }
+    }
+
     protected render(): TemplateResult {
         return html`
-            <slot></slot>
+            <slot @slotchange=${this.manageSelects} role="presentation"></slot>
         `;
+    }
+
+    protected firstUpdated(changes: PropertyValues): void {
+        super.firstUpdated(changes);
+        this.addEventListener('click', this.handleClick);
+        this.addEventListener('focusin', this.handleFocusin);
+    }
+
+    protected updated(changes: PropertyValues): void {
+        super.updated(changes);
+        if (changes.has('selects')) {
+            this.manageSelects();
+        }
+        if (
+            (changes.has('quiet') && this.quiet) ||
+            (changes.has('emphasized') && this.emphasized)
+        ) {
+            [...this.children].forEach((button) => {
+                if (changes.has('quiet')) {
+                    (button as ActionButton).quiet = this.quiet;
+                }
+                if (changes.has('emphasized')) {
+                    (button as ActionButton).emphasized = this.emphasized;
+                }
+            });
+        }
+        if (changes.has('label')) {
+            if (this.label.length) {
+                this.setAttribute('aria-label', this.label);
+            } else {
+                this.removeAttribute('aria-label');
+            }
+        }
     }
 }

--- a/packages/action-group/stories/action-group.stories.ts
+++ b/packages/action-group/stories/action-group.stories.ts
@@ -20,6 +20,7 @@ import {
     InfoIcon,
     ViewAllTagsIcon,
 } from '@spectrum-web-components/icons-workflow';
+import { ActionGroup } from '../src/ActionGroup.js';
 
 export default {
     title: 'Action Group',
@@ -33,6 +34,49 @@ export const Default = (): TemplateResult => {
             <sp-action-button>Longer Button 2</sp-action-button>
             <sp-action-button>Short 3</sp-action-button>
         </sp-action-group>
+    `;
+};
+
+export const selectsSingle = (): TemplateResult => {
+    return html`
+        <sp-action-group
+            label="Favorite Color"
+            selects="single"
+            @change=${({ target }: Event & { target: ActionGroup }) => {
+                const next = target.nextElementSibling as HTMLDivElement;
+                next.textContent = `Selected: ${JSON.stringify(
+                    target.selected
+                )}`;
+            }}
+        >
+            <sp-action-button>Red</sp-action-button>
+            <sp-action-button>Green</sp-action-button>
+            <sp-action-button>Blue</sp-action-button>
+            <sp-action-button selected>Yellow</sp-action-button>
+        </sp-action-group>
+        <div>Selected:</div>
+    `;
+};
+
+export const selectsMultiple = (): TemplateResult => {
+    return html`
+        <sp-action-group
+            label="Favorite Colors"
+            selects="multiple"
+            emphasized
+            @change=${({ target }: Event & { target: ActionGroup }) => {
+                const next = target.nextElementSibling as HTMLDivElement;
+                next.textContent = `Selected: ${JSON.stringify(
+                    target.selected
+                )}`;
+            }}
+        >
+            <sp-action-button>Red</sp-action-button>
+            <sp-action-button selected>Green</sp-action-button>
+            <sp-action-button selected>Blue</sp-action-button>
+            <sp-action-button>Yellow</sp-action-button>
+        </sp-action-group>
+        <div>Selected:</div>
     `;
 };
 
@@ -61,17 +105,17 @@ export const iconsOnly = (): TemplateResult => {
 export const quietIconsOnly = (): TemplateResult => {
     return html`
         <sp-action-group quiet>
-            <sp-action-button quiet label="Properties">
+            <sp-action-button label="Properties">
                 <sp-icon slot="icon" size="m">
                     ${PropertiesIcon({ hidden: true })}
                 </sp-icon>
             </sp-action-button>
-            <sp-action-button quiet label="Info">
+            <sp-action-button label="Info">
                 <sp-icon slot="icon" size="m">
                     ${InfoIcon({ hidden: true })}
                 </sp-icon>
             </sp-action-button>
-            <sp-action-button quiet label="View All Tags">
+            <sp-action-button label="View All Tags">
                 <sp-icon slot="icon" size="m">
                     ${ViewAllTagsIcon({ hidden: true })}
                 </sp-icon>
@@ -115,17 +159,17 @@ export const compactIconsOnly = (): TemplateResult => {
 export const compactQuietIconsOnly = (): TemplateResult => {
     return html`
         <sp-action-group compact quiet>
-            <sp-action-button quiet label="Properties">
+            <sp-action-button label="Properties">
                 <sp-icon slot="icon" size="m">
                     ${PropertiesIcon({ hidden: true })}
                 </sp-icon>
             </sp-action-button>
-            <sp-action-button quiet label="Info">
+            <sp-action-button label="Info">
                 <sp-icon slot="icon" size="m">
                     ${InfoIcon({ hidden: true })}
                 </sp-icon>
             </sp-action-button>
-            <sp-action-button quiet label="View All Tags">
+            <sp-action-button label="View All Tags">
                 <sp-icon slot="icon" size="m">
                     ${ViewAllTagsIcon({ hidden: true })}
                 </sp-icon>
@@ -169,17 +213,17 @@ export const iconsOnlyVertical = (): TemplateResult => {
 export const quietIconsOnlyVertical = (): TemplateResult => {
     return html`
         <sp-action-group vertical quiet>
-            <sp-action-button quiet label="Properties">
+            <sp-action-button label="Properties">
                 <sp-icon slot="icon" size="m">
                     ${PropertiesIcon({ hidden: true })}
                 </sp-icon>
             </sp-action-button>
-            <sp-action-button quiet label="Info">
+            <sp-action-button label="Info">
                 <sp-icon slot="icon" size="m">
                     ${InfoIcon({ hidden: true })}
                 </sp-icon>
             </sp-action-button>
-            <sp-action-button quiet label="View All Tags">
+            <sp-action-button label="View All Tags">
                 <sp-icon slot="icon" size="m">
                     ${ViewAllTagsIcon({ hidden: true })}
                 </sp-icon>
@@ -223,17 +267,17 @@ export const compactIconsOnlyVertical = (): TemplateResult => {
 export const compactQuietIconsOnlyVertical = (): TemplateResult => {
     return html`
         <sp-action-group vertical compact quiet>
-            <sp-action-button quiet label="Properties">
+            <sp-action-button label="Properties">
                 <sp-icon slot="icon" size="m">
                     ${PropertiesIcon({ hidden: true })}
                 </sp-icon>
             </sp-action-button>
-            <sp-action-button quiet label="Info">
+            <sp-action-button label="Info">
                 <sp-icon slot="icon" size="m">
                     ${InfoIcon({ hidden: true })}
                 </sp-icon>
             </sp-action-button>
-            <sp-action-button quiet label="View All Tags">
+            <sp-action-button label="View All Tags">
                 <sp-icon slot="icon" size="m">
                     ${ViewAllTagsIcon({ hidden: true })}
                 </sp-icon>

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -10,13 +10,32 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    expect,
+    html,
+    waitUntil,
+} from '@open-wc/testing';
 
-import '../sp-action-group.js';
+import { ActionButton } from '@spectrum-web-components/action-button';
+import '@spectrum-web-components/action-button/sp-action-button.js';
 import { ActionGroup } from '..';
+import {
+    arrowDownEvent,
+    arrowLeftEvent,
+    arrowRightEvent,
+    arrowUpEvent,
+    endEvent,
+    enterEvent,
+    homeEvent,
+    pageDownEvent,
+    pageUpEvent,
+} from '../../../test/testing-helpers';
+import '../sp-action-group.js';
 
 describe('ActionGroup', () => {
-    it('loads default action-group accessibly', async () => {
+    it('loads empty action-group accessibly', async () => {
         const el = await fixture<ActionGroup>(
             html`
                 <sp-action-group></sp-action-group>
@@ -27,4 +46,438 @@ describe('ActionGroup', () => {
 
         await expect(el).to.be.accessible();
     });
+    it('loads default action-group accessibly', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Default Group">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button>Second</sp-action-button>
+                    <sp-action-button>Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('loads [selects="single"] action-group accessibly', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Selects Single Group" selects="single">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button>Second</sp-action-button>
+                    <sp-action-button>Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('loads [selects="single"] action-group w/ selection accessibly', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Selects Single Group" selects="single">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button>Second</sp-action-button>
+                    <sp-action-button selected>Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('loads [selects="multiple"] action-group accessibly', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Multiple Group"
+                    selects="multiple"
+                >
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button>Second</sp-action-button>
+                    <sp-action-button>Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('loads [selects="multiple"] action-group w/ selection accessibly', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Multiple Group"
+                    selects="multiple"
+                >
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button selected>Second</sp-action-button>
+                    <sp-action-button selected>Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('surfaces [selects="single"] selection', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Selects Single Group" selects="single">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button>Second</sp-action-button>
+                    <sp-action-button selected>Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.selected, '"Third" selected').to.deep.equal(['Third']);
+    });
+    it('surfaces [selects="multiple"] selection', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Multiple Group"
+                    selects="multiple"
+                >
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button selected>Second</sp-action-button>
+                    <sp-action-button selected>Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.selected, '"Second" and "Third" selected').to.deep.equal([
+            'Second',
+            'Third',
+        ]);
+    });
+    it('does not select without [selects]', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="No Selects Group">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button selected>Second</sp-action-button>
+                    <sp-action-button class="third">Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+        const thirdElement = el.querySelector('.third') as ActionButton;
+
+        await elementUpdated(el);
+        expect(el.selected.length === 0);
+
+        thirdElement.click();
+
+        await elementUpdated(el);
+
+        expect(el.selected.length === 0);
+    });
+    it('selects via `click` while [selects="single"]', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Selects Single Group" selects="single">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button selected>Second</sp-action-button>
+                    <sp-action-button class="third">Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+        const thirdElement = el.querySelector('.third') as ActionButton;
+
+        await elementUpdated(el);
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Second'));
+
+        thirdElement.click();
+
+        await elementUpdated(el);
+
+        expect(thirdElement.selected, 'third child selected');
+
+        await waitUntil(
+            () => el.selected.length === 1 && el.selected.includes('Third'),
+            'Updates value of `selected`'
+        );
+    });
+    it('selects via `click` while  [selects="multiple"] selection', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Multiple Group"
+                    selects="multiple"
+                >
+                    <sp-action-button selected class="first">
+                        First
+                    </sp-action-button>
+                    <sp-action-button class="second">Second</sp-action-button>
+                    <sp-action-button class="third">Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+        const firstElement = el.querySelector('.first') as ActionButton;
+        const secondElement = el.querySelector('.second') as ActionButton;
+        const thirdElement = el.querySelector('.third') as ActionButton;
+
+        await elementUpdated(el);
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('First'));
+
+        firstElement.click();
+        secondElement.click();
+        thirdElement.click();
+
+        await elementUpdated(el);
+
+        expect(secondElement.selected, 'second child selected');
+        expect(thirdElement.selected, 'third child selected');
+
+        await waitUntil(
+            () =>
+                el.selected.length === 2 &&
+                el.selected.includes('Second') &&
+                el.selected.includes('Third'),
+            'Updates value of `selected`'
+        );
+    });
+    it('does not respond to clicks on itself', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Selects Single Group" selects="single">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button>Second</sp-action-button>
+                    <sp-action-button class="third">Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+        await elementUpdated(el);
+        expect(el.selected.length).to.equal(0);
+
+        el.click();
+
+        await elementUpdated(el);
+
+        expect(el.selected.length).to.equal(0);
+    });
+    it('selection can be prevented', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Single Group"
+                    selects="single"
+                    @change=${(event: Event): void => {
+                        event.preventDefault();
+                    }}
+                >
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button>Second</sp-action-button>
+                    <sp-action-button class="third">Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+        const thirdElement = el.querySelector('.third') as ActionButton;
+
+        await elementUpdated(el);
+        expect(el.selected.length).to.equal(0);
+
+        thirdElement.click();
+
+        await elementUpdated(el);
+
+        expect(!thirdElement.selected, 'third child not selected');
+        expect(el.selected.length).to.equal(0);
+    });
+    it('accepts keybord input', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Selects Single Group" selects="single">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button selected>Second</sp-action-button>
+                    <sp-action-button class="third">Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+        const thirdElement = el.querySelector('.third') as ActionButton;
+
+        await elementUpdated(el);
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Second'));
+
+        thirdElement.click();
+
+        await elementUpdated(el);
+
+        expect(thirdElement.selected, 'third child selected');
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Third'));
+
+        el.dispatchEvent(arrowRightEvent);
+        let activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(enterEvent);
+
+        await elementUpdated(el);
+
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('First'));
+
+        el.dispatchEvent(arrowLeftEvent);
+        el.dispatchEvent(arrowUpEvent);
+        activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(enterEvent);
+
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Second'));
+
+        el.dispatchEvent(endEvent);
+        activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(enterEvent);
+
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Third'));
+
+        activeElement.dispatchEvent(pageUpEvent);
+        activeElement = document.activeElement as ActionButton;
+        expect(activeElement === thirdElement);
+
+        el.dispatchEvent(homeEvent);
+        activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(enterEvent);
+
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('First'));
+
+        el.dispatchEvent(arrowDownEvent);
+        activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(enterEvent);
+
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Second'));
+    });
+    it('accepts keybord input when [dir="ltr"]', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Single Group"
+                    selects="single"
+                    dir="ltr"
+                >
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button disabled>Second</sp-action-button>
+                    <sp-action-button class="third">Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+        const thirdElement = el.querySelector('.third') as ActionButton;
+
+        await elementUpdated(el);
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Second'));
+
+        thirdElement.click();
+
+        await elementUpdated(el);
+
+        expect(thirdElement.selected, 'third child selected');
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Third'));
+
+        el.dispatchEvent(arrowRightEvent);
+        let activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(enterEvent);
+
+        await elementUpdated(el);
+
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('First'));
+
+        el.dispatchEvent(arrowLeftEvent);
+        el.dispatchEvent(arrowUpEvent);
+        activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(enterEvent);
+
+        expect(el.selected.length === 1);
+        expect(el.selected.includes('Third'));
+    });
+    it('accepts "PageUp" and "PageUp"', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <div>
+                    <sp-action-group
+                        label="Selects Single Group"
+                        selects="single"
+                    >
+                        <sp-action-button>First</sp-action-button>
+                        <sp-action-button class="first">
+                            Second
+                        </sp-action-button>
+                        <sp-action-button>Third</sp-action-button>
+                    </sp-action-group>
+                    <sp-action-group
+                        label="Selects Single Group"
+                        selects="multiple"
+                    >
+                        <sp-action-button>First</sp-action-button>
+                        <sp-action-button selected class="second">
+                            Second
+                        </sp-action-button>
+                        <sp-action-button>Third</sp-action-button>
+                    </sp-action-group>
+                    <sp-action-group></sp-action-group>
+                </div>
+            `
+        );
+        const firstElement = el.querySelector('.first') as ActionButton;
+        const secondElement = el.querySelector('.second') as ActionButton;
+
+        await elementUpdated(firstElement);
+        await elementUpdated(secondElement);
+
+        firstElement.click();
+
+        let activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(pageDownEvent);
+
+        activeElement = document.activeElement as ActionButton;
+        expect(activeElement === secondElement);
+
+        activeElement.dispatchEvent(pageUpEvent);
+
+        activeElement = document.activeElement as ActionButton;
+        expect(activeElement === firstElement);
+
+        activeElement = document.activeElement as ActionButton;
+        activeElement.dispatchEvent(pageDownEvent);
+
+        activeElement = document.activeElement as ActionButton;
+        expect(activeElement === firstElement);
+
+        activeElement.dispatchEvent(pageUpEvent);
+
+        activeElement = document.activeElement as ActionButton;
+        expect(activeElement === secondElement);
+    });
 });
+
+// action with [selected] by default
+// action with [selected] applied
+// action without [selected] clicked
+// group with `selected.length` by default
+// group with `selected.length` applied
+// group with [selects="one"] with `select.length > 1` by default
+// group with [selects="one"] with `select.length > 1` applied
+// tabIndex=-1 managed when tabbing past
+// tabIndex=-1 managed when using arrow keys
+// tabIndex=-1 managed when clicking with "mouse"
+// tabIndex=-1 managed when clicking with "keyboard"
+// selects="multiple"

--- a/packages/action-group/tsconfig.json
+++ b/packages/action-group/tsconfig.json
@@ -5,5 +5,6 @@
         "rootDir": "./"
     },
     "include": ["*.ts", "src/*.ts"],
-    "exclude": ["test/*.ts", "stories/*.ts"]
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../base" }, { "path": "../button" }]
 }

--- a/packages/actionbar/README.md
+++ b/packages/actionbar/README.md
@@ -28,14 +28,14 @@ import { Actionbar } from '@spectrum-web-components/actionbar';
 ```html
 <sp-actionbar open>
     <sp-checkbox indeterminate>228 Selected</sp-checkbox>
-    <div class="spectrum-ButtonGroup">
-        <sp-action-button quiet label="Edit">
+    <sp-action-group quiet>
+        <sp-action-button label="Edit">
             <sp-icon-edit slot="icon"></sp-icon-edit>
         </sp-action-button>
-        <sp-action-button quiet label="More">
+        <sp-action-button label="More">
             <sp-icon-more slot="icon"></sp-icon-more>
         </sp-action-button>
-    </div>
+    </sp-action-group>
 </sp-actionbar>
 ```
 

--- a/packages/actionbar/stories/actionbar.stories.ts
+++ b/packages/actionbar/stories/actionbar.stories.ts
@@ -28,13 +28,13 @@ export const Default = (): TemplateResult => {
     return html`
         <sp-actionbar open>
             <sp-checkbox indeterminate>228 Selected</sp-checkbox>
-            <sp-action-group>
-                <sp-action-button quiet>
+            <sp-action-group quiet>
+                <sp-action-button>
                     <sp-icon size="m" slot="icon">
                         ${EditIcon()}
                     </sp-icon>
                 </sp-action-button>
-                <sp-action-button quiet>
+                <sp-action-button>
                     <sp-icon size="m" slot="icon">
                         ${MoreIcon()}
                     </sp-icon>

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -15,6 +15,12 @@ governing permissions and limitations under the License.
 :host {
     display: inline-flex;
     vertical-align: top;
+
+    /* spectrum-css uses "-webkit-appearance: button" to workaround an
+     * iOS and Safari issue. However, it results in incorrect styling
+     * when applied in :host
+     */
+    -webkit-appearance: none;
 }
 
 :host([disabled]) {

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -41,26 +41,8 @@ export class MenuItem extends ActionButton {
 
     static instanceCount = 0;
 
-    private _value = '';
-
     @property({ type: Boolean, reflect: true })
     public focused = false;
-
-    @property({ type: String })
-    public get value(): string {
-        return this._value || this.itemText;
-    }
-    public set value(value: string) {
-        if (value === this._value) {
-            return;
-        }
-        this._value = value || '';
-        if (this._value) {
-            this.setAttribute('value', this._value);
-        } else {
-            this.removeAttribute('value');
-        }
-    }
 
     /**
      * Hide this getter from web-component-analyzer until

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -15,6 +15,8 @@ module.exports = [
     'accordion--allow-multiple',
     'accordion--disabled',
     'action-group--default',
+    'action-group--selects-single',
+    'action-group--selects-multiple',
     'action-group--icons-only',
     'action-group--quiet-icons-only',
     'action-group--compact',


### PR DESCRIPTION
## Description
This extends the functionality of the `<sp-action-group>` to support the `selects` attribute that manages the collection of `sp-action-button`s internal to the group as either a radio group (`[selects="single"]`) which maintains a single selection or a checkbox group (`[selects="multiple"]`) which can maintain a selection of multiple items in the group.

Additions that support centrally managing `emphasized` and `quiet` delivery to the entire group of buttons have also been made.

This change is negatively effected by the following bug in Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=1158144 Currently, it is targeted for fixed in M89, which would be < 12 weeks from now, but with no actual progress in the issue so far, it's hard to fully rely on that.

## Related Issue
fixes #998 
fixes #1043 

## Motivation and Context
Expanding visual patterns to fulfill their functional goals makes leveraging SWC more enticing. 

## How Has This Been Tested?
- unit tests
- visual regressions

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/103920116-e6331000-50de-11eb-9fab-dffcbd1d0039.png)
![image](https://user-images.githubusercontent.com/1156657/103920140-ed5a1e00-50de-11eb-9037-1a8375a1c85a.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
