### PR TITLE
fix: prevent infinite loops when all children are [disabled]

### DIFF
--- a/packages/accordion/src/Accordion.ts
+++ b/packages/accordion/src/Accordion.ts
@@ -99,8 +99,15 @@ export class Accordion extends Focusable {
         const items = this.items;
         const focused = items.indexOf(getActiveElement(this) as AccordionItem);
         let next = focused;
-        while (items[next].disabled || next === focused) {
+        let availableItems = items.length;
+        // cycle through the available items in the directions of the offset to find the next non-disabled item
+        while ((items[next].disabled || next === focused) && availableItems) {
+            availableItems -= 1;
             next = (items.length + next + direction) % items.length;
+        }
+        // if there are no non-disabled items, skip the work to focus a child
+        if (items[next].disabled || next === focused) {
+            return;
         }
         items[next].focus();
     }

--- a/packages/accordion/test/accordion.test.ts
+++ b/packages/accordion/test/accordion.test.ts
@@ -45,6 +45,29 @@ describe('Accordion', () => {
 
         expect(document.activeElement === el).to.be.false;
     });
+    it('does not accept focus when all children [disabled]', async () => {
+        const el = await fixture<Accordion>(
+            html`
+                <sp-accordion>
+                    <sp-accordion-item disabled label="Heading 1">
+                        <div>Item 1</div>
+                    </sp-accordion-item>
+                    <sp-accordion-item disabled label="Heading 2">
+                        <div>Item 2</div>
+                    </sp-accordion-item>
+                </sp-accordion>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(document.activeElement === el).to.be.false;
+
+        el.focus();
+        await elementUpdated(el);
+
+        expect(document.activeElement === el).to.be.false;
+    });
     it('only allows one open item by default', async () => {
         const el = await fixture<Accordion>(Default());
         await elementUpdated(el);

--- a/packages/sidenav/src/Sidenav.ts
+++ b/packages/sidenav/src/Sidenav.ts
@@ -133,8 +133,15 @@ export class SideNav extends Focusable {
         const focused = items.indexOf(getActiveElement(this) as SideNavItem);
         let next = focused;
         next = (items.length + next + direction) % items.length;
-        while (this.isDisabledChild(items[next])) {
+        let availableItems = items.length;
+        // cycle through the available items in the directions of the offset to find the next non-disabled item
+        while (this.isDisabledChild(items[next]) && availableItems) {
+            availableItems -= 1;
             next = (items.length + next + direction) % items.length;
+        }
+        // if there are no non-disabled items, skip the work to focus a child
+        if (this.isDisabledChild(items[next])) {
+            return;
         }
         items[next].focus();
     }

--- a/packages/sidenav/test/sidenav.test.ts
+++ b/packages/sidenav/test/sidenav.test.ts
@@ -68,6 +68,34 @@ describe('Sidenav', () => {
 
         expect(document.activeElement === el).to.be.false;
     });
+    it('does not accept focus when all children [disabled]', async () => {
+        const el = await fixture<SideNav>(
+            html`
+                <sp-sidenav>
+                    <sp-sidenav-item
+                        disabled
+                        value="Section 1"
+                        label="Section 1"
+                    ></sp-sidenav-item>
+                    <sp-sidenav-item
+                        disabled
+                        value="Section 2"
+                        label="Section 2"
+                    ></sp-sidenav-item>
+                </sp-sidenav>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(document.activeElement === el).to.be.false;
+
+        el.focus();
+        await elementUpdated(el);
+
+        expect(document.activeElement === el).to.be.false;
+        expect(el.matches(':focus-within')).to.be.false;
+    });
     it('sets manageTabIndex on new children', async () => {
         const el = await fixture<SideNav>(
             html`


### PR DESCRIPTION
## Description
- prevent child searching loops from going infinite by keeping track of available vs disabled item counts
- prevent `sp-menu` from getting stuck on the first item (when `[disabled]`) when focusing programattically
- test these additions.

## Related Issue
ref #1060 
Brought up in Slack

## Motivation and Context
Infinite loops are bad.

## How Has This Been Tested?
- unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
