### PR TITLE
test: queue page queue to accelerate visual regressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
                   keys:
                       - v2-golden-images-<< pipeline.parameters.current_golden_images_hash >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
                       - v2-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
-            - run: yarn test:visual:ci --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
+            - run: yarn test:visual:ci --concurrency=5 --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
             - run:
                   when: on_fail
                   command: cp -RT test/visual/screenshots-current/ci test/visual/screenshots-baseline/ci

--- a/test/visual/ci.js
+++ b/test/visual/ci.js
@@ -11,6 +11,6 @@ governing permissions and limitations under the License.
 */
 const { checkScreenshots } = require('./visual.js');
 
-const { color, scale, dir } = require('yargs').argv;
+const { color, scale, dir, concurrency } = require('yargs').argv;
 
-checkScreenshots('ci', color, scale, dir);
+checkScreenshots('ci', color, scale, dir, concurrency);

--- a/test/visual/local.js
+++ b/test/visual/local.js
@@ -11,6 +11,6 @@ governing permissions and limitations under the License.
 */
 const { checkScreenshots } = require('./visual.js');
 
-const { color, scale, dir } = require('yargs').argv;
+const { color, scale, dir, concurrency } = require('yargs').argv;
 
-checkScreenshots('local', color, scale, dir);
+checkScreenshots('local', color, scale, dir, concurrency);

--- a/test/visual/screenshots-baseline/ci.js
+++ b/test/visual/screenshots-baseline/ci.js
@@ -11,6 +11,6 @@ governing permissions and limitations under the License.
 */
 const { buildScreenshots } = require('./regenerate.js');
 
-const { color, scale, dir } = require('yargs').argv;
+const { color, scale, dir, concurrency } = require('yargs').argv;
 
-buildScreenshots('ci', color, scale, dir);
+buildScreenshots('ci', color, scale, dir, concurrency);

--- a/test/visual/screenshots-baseline/local.js
+++ b/test/visual/screenshots-baseline/local.js
@@ -11,6 +11,6 @@ governing permissions and limitations under the License.
 */
 const { buildScreenshots } = require('./regenerate.js');
 
-const { color, scale, dir } = require('yargs').argv;
+const { color, scale, dir, concurrency } = require('yargs').argv;
 
-buildScreenshots('local', color, scale, dir);
+buildScreenshots('local', color, scale, dir, concurrency);

--- a/test/visual/screenshots-baseline/regenerate.js
+++ b/test/visual/screenshots-baseline/regenerate.js
@@ -10,35 +10,31 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const playwright = require('playwright');
+const expect = require('chai').expect;
 var rimraf = require('rimraf');
 const { startDevServer } = require('@web/dev-server');
 const path = require('path');
 const fs = require('fs');
 const baselineDir = `${process.cwd()}/test/visual/screenshots-baseline`;
-const stories = require('../stories');
+const storiesAll = require('../stories');
 
 module.exports = {
-    buildScreenshots(type, color = 'light', scale = 'medium', dir = 'ltr') {
-        describe('🎁 regenerate screenshots', function () {
-            let server,
-                browser,
-                page,
-                viewport = { width: 800, height: 600 };
+    buildScreenshots(
+        type,
+        color = 'light',
+        scale = 'medium',
+        dir = 'ltr',
+        concurrency = 10
+    ) {
+        let stories = storiesAll, // storiesAll.splice(0, 8),
+            testQueue = [],
+            results = [],
+            server,
+            browser,
+            viewport = { width: 800, height: 600 };
 
+        describe('🎁 regenerate screenshots', function () {
             before(async function () {
-                server = await startDevServer({
-                    config: {
-                        port: 4444,
-                        nodeResolve: true,
-                        appIndex: 'index.html',
-                        rootDir: path.resolve(
-                            process.cwd(),
-                            'documentation',
-                            'dist',
-                            'storybook'
-                        ),
-                    },
-                });
                 // Create the test directory if needed.
                 if (!fs.existsSync(baselineDir)) {
                     fs.mkdirSync(baselineDir);
@@ -52,49 +48,91 @@ module.exports = {
                     rimraf.sync(`${baselineDir}/${type}/userDataDir`);
                 }
                 fs.mkdirSync(`${baselineDir}/${type}/userDataDir`);
-            });
-
-            after(async () => {
-                await Promise.all([browser.close(), server.stop()]);
-            });
-
-            before(async function () {
+                server = await startDevServer({
+                    config: {
+                        port: 4444,
+                        nodeResolve: true,
+                        appIndex: 'index.html',
+                        rootDir: path.resolve(
+                            process.cwd(),
+                            'documentation',
+                            'dist',
+                            'storybook'
+                        ),
+                    },
+                });
                 browser = await playwright[
                     'chromium'
                 ].launchPersistentContext(
                     `${baselineDir}/${type}/userDataDir`,
                     { viewport }
                 );
-                page = await browser.newPage();
+                for (let i = 0; i < concurrency; i += 1) {
+                    (async () => {
+                        const page = await browser.newPage();
+                        // prevent hover based inaccuracies in screenshots by
+                        // moving the mouse off of the screen before loading tests
+                        await page.mouse.move(-5, -5);
+                        releasePage(page);
+                    })();
+                }
+                for (let i = 0; i < stories.length; i++) {
+                    results.push({
+                        test: queueTest(stories[i]),
+                    });
+                }
             });
 
-            it('did it', async function () {
-                return generateBaselineScreenshots(page);
+            after(async () => {
+                await Promise.all([browser.close(), server.stop()]);
+            });
+
+            describe('doing it', async function () {
+                for (let i = 0; i < stories.length; i++) {
+                    it(`capturing: ${stories[i]}`, async function () {
+                        await results[i].test;
+                        expect(true);
+                    });
+                }
             });
         });
 
-        async function generateBaselineScreenshots(page) {
-            for (let i = 0; i < stories.length; i++) {
-                const url = `http://127.0.0.1:4444/iframe.html?id=${stories[i]}&sp_reduceMotion=true&sp_color=${color}&sp_scale=${scale}&sp_dir=${dir}`;
-                console.log('visiting:', url);
-                await page.goto(url, {
-                    waitUntil: 'networkidle',
-                });
-                await page.waitForFunction(
-                    () => !!document.querySelector('#root-inner')
-                );
-                await page.waitForFunction(
-                    () => !!document.querySelector('sp-story-decorator')
-                );
-                await page.waitForFunction(
-                    () =>
-                        !!document.querySelector('sp-story-decorator')
-                            .shadowRoot
-                );
-                await page.screenshot({
-                    path: `${baselineDir}/${type}/${stories[i]}__${color}__${scale}__${dir}.png`,
-                });
+        function releasePage(page) {
+            if (testQueue[0]) {
+                testQueue.shift()(page);
             }
+        }
+
+        async function availablePage() {
+            let resolver;
+            const testPromise = new Promise((res) => (resolver = res));
+            testQueue.push(resolver);
+            return testPromise;
+        }
+
+        async function queueTest(story) {
+            const page = await availablePage();
+            return generateBaselineScreenshots(page, story);
+        }
+
+        async function generateBaselineScreenshots(page, story) {
+            const url = `http://127.0.0.1:4444/iframe.html?id=${story}&sp_reduceMotion=true&sp_color=${color}&sp_scale=${scale}&sp_dir=${dir}`;
+            await page.goto(url, {
+                waitUntil: 'networkidle',
+            });
+            await page.waitForFunction(
+                () => !!document.querySelector('#root-inner')
+            );
+            await page.waitForFunction(
+                () => !!document.querySelector('sp-story-decorator')
+            );
+            await page.waitForFunction(
+                () => !!document.querySelector('sp-story-decorator').shadowRoot
+            );
+            await page.screenshot({
+                path: `${baselineDir}/${type}/${story}__${color}__${scale}__${dir}.png`,
+            });
+            releasePage(page);
         }
     },
 };

--- a/test/visual/stories.js
+++ b/test/visual/stories.js
@@ -330,4 +330,4 @@ module.exports = [
     'tooltip--default',
     'tooltip--w-icon',
     'underlay--default',
-];
+].sort();

--- a/test/visual/visual.js
+++ b/test/visual/visual.js
@@ -17,7 +17,7 @@ const fs = require('fs');
 var rimraf = require('rimraf');
 const PNG = require('pngjs').PNG;
 const pixelmatch = require('pixelmatch');
-const stories = require('./stories');
+const storiesAll = require('./stories');
 
 const currentDir = `${process.cwd()}/test/visual/screenshots-current`;
 const baselineDir = `${process.cwd()}/test/visual/screenshots-baseline`;
@@ -25,14 +25,23 @@ const baselineDir = `${process.cwd()}/test/visual/screenshots-baseline`;
 const PixelDiffThreshold = 0;
 
 module.exports = {
-    checkScreenshots(type, color = 'light', scale = 'medium', dir = 'ltr') {
-        describe('👀 page screenshots are correct', function () {
-            let server,
-                browser,
-                page,
-                viewport = { width: 800, height: 600 };
+    checkScreenshots(
+        type,
+        color = 'light',
+        scale = 'medium',
+        dir = 'ltr',
+        concurrency = 10
+    ) {
+        let stories = storiesAll, // storiesAll.splice(0, 8),
+            testQueue = [],
+            results = [],
+            server,
+            browser,
+            viewport = { width: 800, height: 600 };
 
-            before(async function () {
+        describe('👀 page screenshots are correct', function () {
+            before(async () => {
+                // Prop file system...
                 // Create the test directory if needed.
                 if (!fs.existsSync(currentDir)) {
                     fs.mkdirSync(currentDir);
@@ -54,13 +63,8 @@ module.exports = {
                     rimraf.sync(`${baselineDir}/${type}/userDataDir`);
                 }
                 fs.mkdirSync(`${baselineDir}/${type}/userDataDir`);
-            });
 
-            after(async () => {
-                await Promise.all([browser.close(), server.stop()]);
-            });
-
-            before(async function () {
+                // start server and browser
                 server = await startDevServer({
                     config: {
                         port: 4444,
@@ -74,27 +78,61 @@ module.exports = {
                         ),
                     },
                 });
-                browser = await playwright[
-                    'chromium'
-                ].launchPersistentContext(
+                browser = await playwright['chromium'].launchPersistentContext(
                     `${baselineDir}/${type}/userDataDir`,
-                    { viewport }
+                    {
+                        viewport,
+                    }
                 );
-                page = await browser.newPage();
-                // prevent hover based inaccuracies in screenshots by
-                // moving the mouse off of the screen before loading tests
-                await page.mouse.move(-5, -5);
+                for (let i = 0; i < concurrency; i += 1) {
+                    (async () => {
+                        const page = await browser.newPage();
+                        // prevent hover based inaccuracies in screenshots by
+                        // moving the mouse off of the screen before loading tests
+                        await page.mouse.move(-5, -5);
+                        releasePage(page);
+                    })();
+                }
+                for (let i = 0; i < stories.length; i++) {
+                    results.push({
+                        title: `${stories[i]}__${color}__${scale}__${dir}`,
+                        test: queueTest(stories[i]),
+                    });
+                }
+            });
+
+            after(async () => {
+                await Promise.all([browser.close(), server.stop()]);
             });
 
             describe('default view', function () {
                 for (let i = 0; i < stories.length; i++) {
                     it(`${stories[i]}__${color}__${scale}__${dir}`, async function () {
-                        return takeAndCompareScreenshot(page, stories[i]);
+                        return (await results[i].test)();
                     });
                 }
             });
         });
 
+        function releasePage(page) {
+            if (testQueue[0]) {
+                testQueue.shift()(page);
+            }
+        }
+
+        async function availablePage() {
+            let resolver;
+            const testPromise = new Promise((res) => (resolver = res));
+            testQueue.push(resolver);
+            return testPromise;
+        }
+
+        async function queueTest(story) {
+            const page = await availablePage();
+            return takeAndCompareScreenshot(page, story);
+        }
+
+        //Process methods
         async function takeAndCompareScreenshot(page, test) {
             await page.goto(
                 `http://127.0.0.1:4444/iframe.html?id=${test}&sp_reduceMotion=true&sp_color=${color}&sp_scale=${scale}&sp_dir=${dir}`,
@@ -114,18 +152,19 @@ module.exports = {
             await page.screenshot({
                 path: `${currentDir}/${type}/${test}__${color}__${scale}__${dir}.png`,
             });
-            return compareScreenshots(test);
+            return compareScreenshots(test, page);
         }
 
-        function compareScreenshots(view) {
+        function compareScreenshots(view, page) {
             return new Promise((resolve, reject) => {
+                const testFileName = `${view}__${color}__${scale}__${dir}`;
                 if (
-                    !fs.existsSync(
-                        `${baselineDir}/${type}/${view}__${color}__${scale}__${dir}.png`
-                    )
+                    !fs.existsSync(`${baselineDir}/${type}/${testFileName}.png`)
                 ) {
-                    reject(
-                        `🙅🏼‍♂️ ${view}__${color}__${scale}__${dir}.png does not have a baseline screenshot.`
+                    resolve(() =>
+                        Promise.reject(
+                            `🙅🏼‍♂️ ${testFileName}.png does not have a baseline screenshot.`
+                        )
                     );
                     return;
                 }
@@ -139,13 +178,13 @@ module.exports = {
                 //   });
                 const img1 = fs
                     .createReadStream(
-                        `${currentDir}/${type}/${view}__${color}__${scale}__${dir}.png`
+                        `${currentDir}/${type}/${testFileName}.png`
                     )
                     .pipe(new PNG())
                     .on('parsed', doneReading);
                 const img2 = fs
                     .createReadStream(
-                        `${baselineDir}/${type}/${view}__${color}__${scale}__${dir}.png`
+                        `${baselineDir}/${type}/${testFileName}.png`
                     )
                     .pipe(new PNG())
                     .on('parsed', doneReading);
@@ -181,25 +220,27 @@ module.exports = {
                         (numDiffPixels / (img1.width * img1.height)) * 100;
 
                     const stats = fs.statSync(
-                        `${currentDir}/${type}/${view}__${color}__${scale}__${dir}.png`
+                        `${currentDir}/${type}/${testFileName}.png`
                     );
                     const fileSizeInBytes = stats.size;
-                    console.log(
-                        `📸 ${view}__${color}__${scale}__${dir}.png => ${fileSizeInBytes} bytes, ${percentDiff}% different`
-                    );
 
                     if (numDiffPixels > PixelDiffThreshold) {
                         diff.pack().pipe(
                             fs.createWriteStream(
-                                `${currentDir}/${view}__${color}__${scale}__${dir}-diff.png`
+                                `${currentDir}/${testFileName}-diff.png`
                             )
                         );
                     }
-                    expect(
-                        numDiffPixels,
-                        'number of different pixels'
-                    ).to.equal(PixelDiffThreshold);
-                    resolve();
+                    releasePage(page);
+                    resolve(() => {
+                        console.log(
+                            `📸 ${testFileName}.png => ${fileSizeInBytes} bytes, ${percentDiff}% different`
+                        );
+                        expect(
+                            numDiffPixels,
+                            'number of different pixels'
+                        ).to.equal(PixelDiffThreshold);
+                    });
                 }
             });
         }


### PR DESCRIPTION
## Description
Make visual regression tests run concurrently.
```
yarn test:visual:baseline:local --concurrency=50
yarn test:visual:local --concurrency=10
yarn test:visual:ci --concurrency=5
```
Testing locally can surface the most performant settings for you system.

While variances exist, this update shortens the VRT passes to 2 - 4 minutes each from 4 - 6 minutes each in CI. Locally, you have more cores and can run an entire pass in about 1 minute, making that usage actually reasonable for the first time.

## Motivation and Context
Things should be faster!

## How Has This Been Tested?
In CI.

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/1156657/104188207-dd944f80-53e6-11eb-9a17-145878938763.png)
After:
![image](https://user-images.githubusercontent.com/1156657/104188269-f69d0080-53e6-11eb-9445-fb3f59ab3f93.png)

## Types of changes
- [x] testing refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
