### PR TITLE
fix(icon): clean up docs and types for available size values

### DIFF
--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -34,7 +34,7 @@ Names icons on this page are provided by the [`<sp-icons-medium>` icon set](comp
 
 ## Variants
 
-Icons are available in various sizes in Spectrum ranging from `xxs` to `xxl`, `m` being the default. We can specify the size via `size` attribute.
+Icons are available in various sizes in Spectrum ranging from `s` to `xxl`. By default an `sp-icon` without a `size` attribute will appear as if it were `size="m"`. We can specify the size via `size` attribute.
 
 ### Size variants
 

--- a/packages/icon/src/IconBase.ts
+++ b/packages/icon/src/IconBase.ts
@@ -29,7 +29,7 @@ export class IconBase extends SpectrumElement {
     public label?: string;
 
     @property({ reflect: true })
-    public size?: 's' | 'm' | 'l' | 'xl';
+    public size?: 's' | 'm' | 'l' | 'xl' | 'xxl';
 
     protected render(): TemplateResult {
         return html`

--- a/packages/icons-ui/stories/icons-ui.stories.ts
+++ b/packages/icons-ui/stories/icons-ui.stories.ts
@@ -27,7 +27,7 @@ export default {
 export const uiElements = (): TemplateResult => {
     const size = select(
         'Icon Size',
-        ['xxs', 'xs', 's', 'm', 'l', 'xl', 'xxl'],
+        ['s', 'm', 'l', 'xl', 'xxl'],
         'm',
         'Element'
     );

--- a/packages/icons-workflow/stories/icons-workflow.stories.ts
+++ b/packages/icons-workflow/stories/icons-workflow.stories.ts
@@ -27,7 +27,7 @@ export default {
 export const workflowElements = (): TemplateResult => {
     const size = select(
         'Icon Size',
-        ['xxs', 'xs', 's', 'm', 'l', 'xl', 'xxl'],
+        ['s', 'm', 'l', 'xl', 'xxl'],
         'm',
         'Element'
     );


### PR DESCRIPTION
## Description
Correct documentation re: `sp-icon` sizes.
- docs site
- workflow/ui icon stories

Incude `xxl` type for `size` property.

## Related Issue
fixes #1086

## Motivation and Context
Documentation correctness.

## How Has This Been Tested?
Docs.

## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
