### PR TITLE
fix(dialog): include all dependencies

### DIFF
--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -56,10 +56,12 @@
     "dependencies": {
         "@spectrum-web-components/action-button": "^0.1.0",
         "@spectrum-web-components/base": "^0.2.0",
+        "@spectrum-web-components/button-group": "^0.4.0",
         "@spectrum-web-components/icon": "^0.7.0",
         "@spectrum-web-components/icons-ui": "^0.4.0",
         "@spectrum-web-components/icons-workflow": "^0.4.0",
         "@spectrum-web-components/modal": "^0.1.0",
+        "@spectrum-web-components/rule": "^0.4.0",
         "@spectrum-web-components/shared": "^0.8.0",
         "@spectrum-web-components/underlay": "^0.4.0",
         "tslib": "^2.0.0"

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -22,6 +22,7 @@ import {
 
 import '@spectrum-web-components/rule/sp-rule.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/button-group/sp-button-group.js';
 import crossStyles from '@spectrum-web-components/icon/src/spectrum-icon-cross.css.js';
 import '@spectrum-web-components/icon/sp-icon.js';
 import { Cross500Icon } from '@spectrum-web-components/icons-ui';


### PR DESCRIPTION
## Description
Ensure that `sp-button-group` and `sp-rule` are appropriately included in the `@spectrum-web-components/dialog` package and module files.

## Related Issue
fixes #1087

## Motivation and Context
Things works more better.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
