### PR TITLE
fix(dialog): prevent "fullscreen*" dialogs from being "dissmisable"

### DIFF
--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -83,6 +83,8 @@ import { Dialog } from '@spectrum-web-components/dialog';
 
 When supplied with the `dissmissable` attribute an `<sp-dialog>` element will surface a "close" button afordance that will dispatch a DOM event with the name of `close` when pressed.
 
+Note: the `dissmissable` attribute will not be followed when `mode="fullscreen"` or `mode="fullscreenTakeover"` are applies in accordance with the Spectrum specification.
+
 ```html
 <sp-dialog size="medium" dismissable>
     <h2 slot="heading">Disclaimer</h2>

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -18,6 +18,7 @@ import {
     property,
     query,
     ifDefined,
+    PropertyValues,
 } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/rule/sp-rule.js';
@@ -176,6 +177,16 @@ export class Dialog extends ObserveSlotPresence(SpectrumElement, [
             this.contentElement.removeAttribute('tabindex');
         }
     };
+
+    protected shouldUpdate(changes: PropertyValues): boolean {
+        if (changes.has('mode') && !!this.mode) {
+            this.dismissable = false;
+        }
+        if (changes.has('dismissable') && this.dismissable) {
+            this.dismissable = !this.mode;
+        }
+        return super.shouldUpdate(changes);
+    }
 
     protected onContentSlotChange(): void {
         this.shouldManageTabOrderForScrolling();

--- a/packages/dialog/stories/dialog.stories.ts
+++ b/packages/dialog/stories/dialog.stories.ts
@@ -200,7 +200,7 @@ export const alertErrorWithLongTitle = (): TemplateResult => {
 
 export const fullscreen = (): TemplateResult => {
     return html`
-        <sp-dialog mode="fullscreen">
+        <sp-dialog mode="fullscreen" dismissable>
             <h2 slot="heading">Enable Smart Filters?</h2>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do


### PR DESCRIPTION
## Description
Early response from the design team is that these two features do not mix, so I've prepped this PR. If anything changes, we might revisit, but in the currently available CSS this delivery won't work anyways

## Related Issue
fixes #1088

## Motivation and Context
Prevent bad visual delivery.

## How Has This Been Tested?
Added `dismissable` to the "fullscreen" story so we can be sure that the pattern delivers as expected going forward.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
