### PR TITLE
docs(slider): expand event documentation

### DIFF
--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -23,16 +23,16 @@ When looking to leverage the `Slider` base class as a type and/or for extension 
 import { Slider } from '@spectrum-web-components/slider';
 ```
 
-### Variants
+## Variants
 
-#### Standard
+### Standard
 
 ```html
 <sp-slider label="Slider Label"></sp-slider>
 <sp-slider label="Slider Label - Disabled" disabled></sp-slider>
 ```
 
-#### Filled
+### Filled
 
 ```html
 <sp-slider label="Slider Label" variant="filled"></sp-slider>
@@ -43,7 +43,7 @@ import { Slider } from '@spectrum-web-components/slider';
 ></sp-slider>
 ```
 
-#### Tick
+### Tick
 
 ```html
 <sp-slider label="Slider Label" variant="tick" tick-step="5"></sp-slider>
@@ -55,7 +55,7 @@ import { Slider } from '@spectrum-web-components/slider';
 ></sp-slider>
 ```
 
-#### Tick with Labels
+### Tick with Labels
 
 ```html
 <sp-slider
@@ -73,9 +73,37 @@ import { Slider } from '@spectrum-web-components/slider';
 ></sp-slider>
 ```
 
-#### Ramp
+### Ramp
 
 ```html
 <sp-slider label="Slider Label" variant="ramp"></sp-slider>
 <sp-slider label="Slider Label - Disabled" variant="ramp" disabled></sp-slider>
+```
+
+## Events
+
+Like the `<input type="range">` element after which the `<sp-slider>` is fashioned it will dispatch `input` events in a stream culminating with a `change` event (representing the final comit of the `value` to the element) once the user has discontinued with the element. Both other these events can access the `value` of their dispatching target via `event.target.value`. In this way a steaming listener patters similar to the following can prove useful:
+
+```javascript
+const slider = document.querySelector('sp-slider');
+
+const endListener = ({ target }) => {
+    target.addEventListener('input', startListener);
+    target.removeEventListener('input', streamListener);
+    target.removeEventListener('change', endListener);
+    console.log(target.value);
+};
+
+const streamListener = ({ target }) => {
+    console.log(target.value);
+};
+
+const startListener = ({ target }) => {
+    target.removeEventListener('input', startListener);
+    target.addEventListener('input', streamListener);
+    target.addEventListener('change', endListener);
+    console.log(target.value);
+};
+
+slider.addEventListener('input', startListener);
 ```


### PR DESCRIPTION
## Description
Document usage of `input` and `change` events in `sp-slider`.

Should revisit the content here when we ship the `steamingListener` directive as part of the Color elements work, as it encapsulates the vanilla pattern outlined herein for use in `lit-html`.

## Related Issue
fixes #482

## Motivation and Context
Clarify usage.

## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
