### PR TITLE
Westbrook/textfield labels

### DIFF
--- a/packages/field-label/README.md
+++ b/packages/field-label/README.md
@@ -23,15 +23,70 @@ When looking to leverage the `FieldLabel` base class as a type and/or for extens
 import { FieldLabel } from '@spectrum-web-components/field-label';
 ```
 
-## Example
+## Sizes
+
+<sp-tabs selected="m">
+    <sp-tab value="s">Small</sp-tab>
+    <sp-tab value="m">Medium</sp-tab>
+    <sp-tab value="l">Large</sp-tab>
+    <sp-tab value="xl">Extra Large</sp-tab>
+</sp-tabs>
+
+<div class="tabs--s">
+
+```html demo
+<sp-field-label for="lifestory-0" size="s">Life Story</sp-field-label>
+<sp-textfield
+    placeholder="Enter your life story"
+    id="lifestory-0"
+></sp-textfield>
+```
+
+</div>
+
+<div class="tabs--m">
+
+```html demo
+<sp-field-label for="lifestory-1" size="m">Life Story</sp-field-label>
+<sp-textfield
+    placeholder="Enter your life story"
+    id="lifestory-1"
+></sp-textfield>
+```
+
+</div>
+
+<div class="tabs--l">
+
+```html demo
+<sp-field-label for="lifestory-2" size="l">Life Story</sp-field-label>
+<sp-textfield
+    placeholder="Enter your life story"
+    id="lifestory-2"
+></sp-textfield>
+```
+
+</div>
+
+<div class="tabs--xl">
+
+```html demo
+<sp-field-label for="lifestory-3" size="xl">Life Story</sp-field-label>
+<sp-textfield
+    placeholder="Enter your life story"
+    id="lifestory-3"
+></sp-textfield>
+```
+
+</div>
+
+## Examples
 
 ```html
 <sp-field-label for="lifestory">
     Life Story
 </sp-field-label>
-<sp-textfield placeholder="Enter your life story" id="lifestory">
-    <input />
-</sp-textfield>
+<sp-textfield placeholder="Enter your life story" id="lifestory"></sp-textfield>
 <sp-field-label for="birth-place">
     Birthplace
 </sp-field-label>

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -17,6 +17,7 @@ import {
     TemplateResult,
     property,
     PropertyValues,
+    SizedMixin,
 } from '@spectrum-web-components/base';
 import type { Focusable } from '@spectrum-web-components/shared';
 import { Asterisk100Icon } from '@spectrum-web-components/icons-ui';
@@ -30,7 +31,7 @@ type AcceptsFocusVisisble = HTMLElement & { forceFocusVisible?(): void };
 /**
  * @element sp-field-label
  */
-export class FieldLabel extends SpectrumElement {
+export class FieldLabel extends SizedMixin(SpectrumElement) {
     public static get styles(): CSSResultArray {
         return [styles, asteriskIconStyles];
     }
@@ -51,9 +52,6 @@ export class FieldLabel extends SpectrumElement {
 
     @property({ type: String, reflect: true, attribute: 'side-aligned' })
     public sideAligned?: 'start' | 'end';
-
-    @property({ type: String, reflect: true })
-    public size = 'm';
 
     private target?: HTMLElement;
 
@@ -77,6 +75,9 @@ export class FieldLabel extends SpectrumElement {
         }
         const parent = this.getRootNode() as HTMLElement;
         const target = parent.querySelector(`#${this.for}`) as Focusable;
+        if (!target) {
+            return;
+        }
         if (typeof target.updateComplete !== 'undefined') {
             await target.updateComplete;
         }

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -93,6 +93,7 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
                 );
             }
         }
+        return Promise.resolve();
     }
 
     protected render(): TemplateResult {

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -26,7 +26,8 @@ import { Textfield } from '@spectrum-web-components/textfield';
 ## Example
 
 ```html
-<sp-textfield placeholder="Enter your name"></sp-textfield>
+<sp-field-label for="name-0">Name</sp-field-label>
+<sp-textfield id="name-0" placeholder="Enter your name"></sp-textfield>
 ```
 
 ## Variants
@@ -36,7 +37,13 @@ import { Textfield } from '@spectrum-web-components/textfield';
 Dictate the validity state of the text entry with the `valid` attribute.
 
 ```html
-<sp-textfield placeholder="Enter your name" valid></sp-textfield>
+<sp-field-label for="name-1" required>Name</sp-field-label>
+<sp-textfield
+    id="name-1"
+    placeholder="Enter your name"
+    valid
+    value="My Name"
+></sp-textfield>
 ```
 
 ### Invalid
@@ -44,7 +51,8 @@ Dictate the validity state of the text entry with the `valid` attribute.
 Dictate the invalidity state of the text entry with the `invalid` attribute.
 
 ```html
-<sp-textfield placeholder="Enter your name" invalid></sp-textfield>
+<sp-field-label for="name-2" required>Name</sp-field-label>
+<sp-textfield id="name-2" invalid placeholder="Enter your name"></sp-textfield>
 ```
 
 ### Quiet
@@ -52,5 +60,6 @@ Dictate the invalidity state of the text entry with the `invalid` attribute.
 The quiet style works best when a clear layout (vertical stack, table, grid) assists in a user's ability to parse the element. Too many quiet components in a small space can be hard to read.
 
 ```html
-<sp-textfield placeholder="Enter your name" quiet></sp-textfield>
+<sp-field-label for="name-3">Name (quietly)</sp-field-label>
+<sp-textfield id="name-3" placeholder="Enter your name" quiet></sp-textfield>
 ```

--- a/packages/textfield/textarea.md
+++ b/packages/textfield/textarea.md
@@ -26,7 +26,12 @@ import { Textfield } from '@spectrum-web-components/textfield';
 ## Example
 
 ```html
-<sp-textfield placeholder="Enter your name" multiline></sp-textfield>
+<sp-field-label for="story-0">Background</sp-field-label>
+<sp-textfield
+    id="story-0"
+    multiline
+    placeholder="Enter your life story"
+></sp-textfield>
 ```
 
 ## Variants
@@ -36,7 +41,13 @@ import { Textfield } from '@spectrum-web-components/textfield';
 Dictate the validity state of the text entry with the `valid` attribute.
 
 ```html
-<sp-textfield placeholder="Enter your name" valid multiline></sp-textfield>
+<sp-field-label for="story-1" required>Background</sp-field-label>
+<sp-textfield
+    id="story-1"
+    multiline
+    placeholder="Enter your name"
+    valid
+></sp-textfield>
 ```
 
 ### Invalid
@@ -44,7 +55,13 @@ Dictate the validity state of the text entry with the `valid` attribute.
 Dictate the invalidity state of the text entry with the `invalid` attribute.
 
 ```html
-<sp-textfield placeholder="Enter your name" invalid multiline></sp-textfield>
+<sp-field-label for="story-2" required>Background</sp-field-label>
+<sp-textfield
+    id="story-2"
+    invalid
+    multiline
+    placeholder="Enter your name"
+></sp-textfield>
 ```
 
 ### Quiet
@@ -52,7 +69,13 @@ Dictate the invalidity state of the text entry with the `invalid` attribute.
 The quiet style works best when a clear layout (vertical stack, table, grid) assists in a user's ability to parse the element. Too many quiet components in a small space can be hard to read.
 
 ```html
-<sp-textfield placeholder="Enter your name" quiet multiline></sp-textfield>
+<sp-field-label for="story-3">Background (quietly)</sp-field-label>
+<sp-textfield
+    id="story-3"
+    multiline
+    placeholder="Enter your name"
+    quiet
+></sp-textfield>
 ```
 
 ### Grows
@@ -62,22 +85,36 @@ By default the text area has a fixed height and will scroll when text entry goes
 Note: When leveraging the `quiet` attribute, the `grows` attribute does not effect the final delivery of the element.
 
 ```html
-<sp-textfield
-    multiline
-    placeholder="Enter your name"
-    value="By default the text area has a fixed height and will scroll when text entry goes beyond the available space. With the use of the `grows` attribute the text area will grow to accomidate the full content of the element."
-></sp-textfield>
-<sp-textfield
-    multiline
-    grows
-    placeholder="Enter your name"
-    value="By default the text area has a fixed height and will scroll when text entry goes beyond the available space. With the use of the `grows` attribute the text area will grow to accomidate the full content of the element."
-></sp-textfield>
-<sp-textfield
-    multiline
-    grows
-    quiet
-    placeholder="Enter your name"
-    value="By default the text area has a fixed height and will scroll when text entry goes beyond the available space. With the use of the `grows` attribute the text area will grow to accomidate the full content of the element."
-></sp-textfield>
+<div style="display: flex; flex-wrap: wrap;">
+    <div>
+        <sp-field-label for="story-4">Background</sp-field-label>
+        <sp-textfield
+            id="story-4"
+            multiline
+            placeholder="Enter your name"
+            value="By default the text area has a fixed height and will scroll when text entry goes beyond the available space. With the use of the `grows` attribute the text area will grow to accomidate the full content of the element."
+        ></sp-textfield>
+    </div>
+    <div>
+        <sp-field-label for="story-5">Background</sp-field-label>
+        <sp-textfield
+            id="story-5"
+            grows
+            multiline
+            placeholder="Enter your name"
+            value="By default the text area has a fixed height and will scroll when text entry goes beyond the available space. With the use of the `grows` attribute the text area will grow to accomidate the full content of the element."
+        ></sp-textfield>
+    </div>
+    <div>
+        <sp-field-label for="story-6">Background (quietly)</sp-field-label>
+        <sp-textfield
+            id="story-6"
+            grows
+            multiline
+            placeholder="Enter your name"
+            value="By default the text area has a fixed height and will scroll when text entry goes beyond the available space. With the use of the `grows` attribute the text area will grow to accomidate the full content of the element."
+            quiet
+        ></sp-textfield>
+    </div>
+</div>
 ```


### PR DESCRIPTION
## Description
All `sp-textfields` and `sp-textfield multiline` usage in our documentation site are now labelled.

- catches an assumption by `sp-field-label` that its `for` element had to be present
- expands delivery to include t-shirt sizing

## Related Issue
fixes #742

## Motivation and Context
Accessibility and availability of features.

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/104763548-0fcde600-5734-11eb-914c-8b80e54c127b.png)

## Types of changes
- [x] documentation
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
