### PR TITLE
fix: correct specificity of webkit appearance work around

### DIFF
--- a/packages/action-button/src/action-button.css
+++ b/packages/action-button/src/action-button.css
@@ -17,6 +17,14 @@ governing permissions and limitations under the License.
     flex-direction: row;
 }
 
+:host([dir]) {
+    /* spectrum-css uses "-webkit-appearance: button" to workaround an
+     * iOS and Safari issue. However, it results in incorrect styling
+     * when applied in :host
+     */
+    -webkit-appearance: none;
+}
+
 :host(.spectrum-Dropdown-trigger) #button {
     text-align: left;
 }

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -15,7 +15,9 @@ governing permissions and limitations under the License.
 :host {
     display: inline-flex;
     vertical-align: top;
+}
 
+:host([dir]) {
     /* spectrum-css uses "-webkit-appearance: button" to workaround an
      * iOS and Safari issue. However, it results in incorrect styling
      * when applied in :host


### PR DESCRIPTION
## Description
Correct the specificity of the webkit appearance work around selector.

I'll look at advancing the reality of x-browser visual regression to help prevent things like this in the future.

## Related Issue
fixes #1125

## Motivation and Context
Correct x-browser style delivery

## How Has This Been Tested?
Manually.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/105190010-92bfb980-5b03-11eb-92e4-50b29e19bf21.png)
![image](https://user-images.githubusercontent.com/1156657/105190078-a2d79900-5b03-11eb-9155-32bddffef399.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
