### PR TITLE
fix: ensure that all paths to user change of selected trigger a change event

### DIFF
--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -105,9 +105,11 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    private handleSelectedChange(event: Event & { target: Checkbox }): void {
-        const { target } = event;
-        this.selected = target.checked;
+    private handleSelectedChange({
+        target: { checked },
+    }: Event & { target: Checkbox }): void {
+        this.selected = checked;
+        this.announceChange();
     }
 
     public toggleSelected(): void {
@@ -121,6 +123,10 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
             return;
         }
         this.selected = !this.selected;
+        this.announceChange();
+    }
+
+    private announceChange(): void {
         const applyDefault = this.dispatchEvent(
             new Event('change', {
                 cancelable: true,
@@ -178,9 +184,7 @@ export class Card extends FocusVisiblePolyfillMixin(SpectrumElement) {
         return html`
             ${this.toggles
                 ? html`
-                      <sp-quick-actions
-                          class="spectrum-QuickActions quickActions"
-                      >
+                      <sp-quick-actions class="quickActions">
                           <sp-checkbox
                               tabindex="-1"
                               class="checkbox"

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -163,7 +163,7 @@ describe('card', () => {
         expect(clickSpy.called).to.be.true;
         expect(clickSpy.calledOnce).to.be.true;
     });
-    it('can be `toggles`', async () => {
+    it('can be `[toggles]`', async () => {
         const test = await fixture<HTMLDivElement>(Default());
         const el = test.querySelector('sp-card') as Card;
         el.toggles = true;
@@ -224,7 +224,31 @@ describe('card', () => {
 
         await elementUpdated(el);
         expect(el.focused, 'still not focused, again 2').to.be.false;
-        expect(el.selected, 'still selected, again 3').to.be.false;
+        // change event is prevented
+        expect(el.selected, 'still selected, again 3');
+    });
+
+    it('announces when `[toggles]`', async () => {
+        const changeSpy = spy();
+        const test = await fixture<HTMLDivElement>(Default());
+        const el = test.querySelector('sp-card') as Card;
+        el.toggles = true;
+        el.addEventListener('change', changeSpy);
+
+        await elementUpdated(el);
+
+        const checkbox = el.shadowRoot.querySelector('sp-checkbox') as Checkbox;
+        expect(el.selected, 'default to not selected').to.be.false;
+        checkbox.click();
+        await elementUpdated(el);
+
+        expect(el.selected, 'selected');
+        expect(changeSpy.callCount).to.equal(1);
+        checkbox.click();
+        await elementUpdated(el);
+
+        expect(el.selected, 'no longer selected').to.be.false;
+        expect(changeSpy.callCount).to.equal(2);
     });
     it('displays the `heading` attribute as `.title`', async () => {
         const testHeading = 'This is a test heading';


### PR DESCRIPTION
## Description
- add `change` event dispatches to interactions with the checkbox.

## Related Issue
fixes #1126

## Motivation and Context
Smooth API delivery as currently documented.

## How Has This Been Tested?
- unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
