### PR TITLE
fix(slider): manage focus more like a native rage input

### DIFF
--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -127,6 +127,9 @@ export class Slider extends Focusable {
     @query('#input')
     private input!: HTMLInputElement;
 
+    @query('#label')
+    private labelEl!: HTMLLabelElement;
+
     private supportsPointerEvent = 'setPointerCapture' in this;
     private currentMouseEvent?: MouseEvent;
     private boundingClientRect?: DOMRect;
@@ -299,7 +302,7 @@ export class Slider extends Focusable {
             return;
         }
         this.boundingClientRect = this.getBoundingClientRect();
-        this.focus();
+        this.labelEl.click();
         this.dragging = true;
         this.handle.setPointerCapture(event.pointerId);
     }
@@ -314,7 +317,7 @@ export class Slider extends Focusable {
         this.boundingClientRect = this.getBoundingClientRect();
         document.addEventListener('mousemove', this.onMouseMove);
         document.addEventListener('mouseup', this.onMouseUp);
-        this.focus();
+        this.labelEl.click();
         this.dragging = true;
         this.currentMouseEvent = event;
         this._trackMouseEvent();
@@ -330,7 +333,7 @@ export class Slider extends Focusable {
 
     private onPointerUp(event: PointerEvent): void {
         // Retain focus on input element after mouse up to enable keyboard interactions
-        this.focus();
+        this.labelEl.click();
         this.handleHighlight = false;
         this.dragging = false;
         this.handle.releasePointerCapture(event.pointerId);
@@ -339,7 +342,7 @@ export class Slider extends Focusable {
 
     private onMouseUp = (event: MouseEvent): void => {
         // Retain focus on input element after mouse up to enable keyboard interactions
-        this.focus();
+        this.labelEl.click();
         this.currentMouseEvent = event;
         document.removeEventListener('mousemove', this.onMouseMove);
         document.removeEventListener('mouseup', this.onMouseUp);
@@ -415,7 +418,15 @@ export class Slider extends Focusable {
     }
 
     private onInputFocus(): void {
-        this.handleHighlight = true;
+        let isFocusVisible;
+        try {
+            isFocusVisible =
+                this.input.matches(':focus-visible') ||
+                this.matches('.focus-visible');
+        } catch (error) {
+            isFocusVisible = this.matches('.focus-visible');
+        }
+        this.handleHighlight = isFocusVisible;
     }
 
     private onInputBlur(): void {

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -20,6 +20,7 @@ import {
     expect,
     nextFrame,
 } from '@open-wc/testing';
+import { executeServerCommand } from '@web/test-runner-commands';
 
 type TestableSliderType = {
     supportsPointerEvent: boolean;
@@ -56,7 +57,11 @@ describe('Slider', () => {
         await expect(el).to.be.accessible();
     });
     it('loads - [variant="tick"] irregularly', async () => {
-        const el = await fixture<Slider>(tick());
+        const el = await fixture<Slider>(
+            html`
+                <sp-slider label="Slider"></sp-slider>
+            `
+        );
 
         await elementUpdated(el);
 
@@ -83,6 +88,30 @@ describe('Slider', () => {
 
         expect(el.value).to.equal(20);
     });
+    it('accepts keyboard events', async () => {
+        const el = await fixture<Slider>(tick());
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(10);
+        expect(el.handleHighlight).to.be.false;
+
+        el.focus();
+        await executeServerCommand('send-keys', {
+            press: 'ArrowDown',
+        });
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(9);
+        expect(el.handleHighlight).to.be.true;
+        await executeServerCommand('send-keys', {
+            press: 'ArrowUp',
+        });
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(10);
+        expect(el.handleHighlight).to.be.true;
+    });
     it('accepts pointer events', async () => {
         let pointerId = -1;
         const el = await fixture<Slider>(
@@ -97,9 +126,7 @@ describe('Slider', () => {
         expect(el.handleHighlight).to.be.false;
         expect(pointerId).to.equal(-1);
 
-        const handle = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#handle') as HTMLDivElement)
-            : (el as Slider);
+        const handle = el.shadowRoot.querySelector('#handle') as HTMLDivElement;
         handle.setPointerCapture = (id: number) => (pointerId = id);
         handle.releasePointerCapture = (id: number) => (pointerId = id);
 
@@ -112,7 +139,6 @@ describe('Slider', () => {
         await elementUpdated(el);
 
         expect(el.dragging).to.be.true;
-        expect(el.handleHighlight).to.be.true;
         expect(pointerId).to.equal(1);
 
         handle.dispatchEvent(
@@ -176,9 +202,7 @@ describe('Slider', () => {
         expect(el.value).to.equal(10);
         expect(inputsHandled).to.equal(0);
 
-        const handle = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#handle') as HTMLDivElement)
-            : (el as Slider);
+        const handle = el.shadowRoot.querySelector('#handle') as HTMLDivElement;
 
         handle.dispatchEvent(
             new MouseEvent('mousedown', {
@@ -232,12 +256,10 @@ describe('Slider', () => {
 
         expect(el.value).to.equal(10);
 
-        const controls = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#controls') as HTMLDivElement)
-            : (el as Slider);
-        const handle = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#handle') as HTMLDivElement)
-            : (el as Slider);
+        const controls = el.shadowRoot.querySelector(
+            '#controls'
+        ) as HTMLDivElement;
+        const handle = el.shadowRoot.querySelector('#handle') as HTMLDivElement;
         handle.setPointerCapture = (id: number) => (pointerId = id);
 
         controls.dispatchEvent(
@@ -274,9 +296,9 @@ describe('Slider', () => {
 
         expect(el.value).to.equal(10);
 
-        const controls = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#controls') as HTMLDivElement)
-            : (el as Slider);
+        const controls = el.shadowRoot.querySelector(
+            '#controls'
+        ) as HTMLDivElement;
 
         controls.dispatchEvent(
             new MouseEvent('mousedown', {
@@ -304,9 +326,7 @@ describe('Slider', () => {
         expect(pointerId).to.equal(-1);
         expect(el.value).to.equal(10);
 
-        const handle = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#handle') as HTMLDivElement)
-            : (el as Slider);
+        const handle = el.shadowRoot.querySelector('#handle') as HTMLDivElement;
         handle.setPointerCapture = (id: number) => (pointerId = id);
 
         handle.dispatchEvent(
@@ -319,9 +339,9 @@ describe('Slider', () => {
         expect(el.dragging).to.be.false;
         expect(pointerId).to.equal(-1);
 
-        const controls = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#controls') as HTMLDivElement)
-            : (el as Slider);
+        const controls = el.shadowRoot.querySelector(
+            '#controls'
+        ) as HTMLDivElement;
 
         controls.dispatchEvent(
             new PointerEvent('pointerdown', {
@@ -351,9 +371,7 @@ describe('Slider', () => {
         expect(pointerId).to.equal(-1);
         expect(el.value).to.equal(10);
 
-        const handle = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#handle') as HTMLDivElement)
-            : (el as Slider);
+        const handle = el.shadowRoot.querySelector('#handle') as HTMLDivElement;
         handle.setPointerCapture = (id: number) => (pointerId = id);
 
         handle.dispatchEvent(new MouseEvent('mousedown'));
@@ -362,9 +380,9 @@ describe('Slider', () => {
         expect(el.dragging).to.be.false;
         expect(pointerId).to.equal(-1);
 
-        const controls = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#controls') as HTMLDivElement)
-            : (el as Slider);
+        const controls = el.shadowRoot.querySelector(
+            '#controls'
+        ) as HTMLDivElement;
 
         controls.dispatchEvent(
             new MouseEvent('mousedown', {
@@ -389,9 +407,7 @@ describe('Slider', () => {
 
         expect(el.value).to.equal(10);
 
-        const handle = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#handle') as HTMLDivElement)
-            : (el as Slider);
+        const handle = el.shadowRoot.querySelector('#handle') as HTMLDivElement;
         handle.setPointerCapture = (id: number) => (pointerId = id);
         handle.releasePointerCapture = (id: number) => (pointerId = id);
 
@@ -403,7 +419,7 @@ describe('Slider', () => {
         await elementUpdated(el);
 
         expect(el.dragging).to.be.true;
-        expect(el.handleHighlight).to.be.true;
+        expect(el.handleHighlight).to.be.false;
         expect(pointerId).to.equal(1);
 
         handle.dispatchEvent(
@@ -436,9 +452,7 @@ describe('Slider', () => {
         expect(el.value).to.equal(10);
         expect(inputsHandled).to.equal(0);
 
-        const handle = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#handle') as HTMLDivElement)
-            : (el as Slider);
+        const handle = el.shadowRoot.querySelector('#handle') as HTMLDivElement;
         handle.setPointerCapture = (id: number) => (pointerId = id);
         handle.releasePointerCapture = (id: number) => (pointerId = id);
 
@@ -450,7 +464,7 @@ describe('Slider', () => {
         await elementUpdated(el);
 
         expect(el.dragging).to.be.true;
-        expect(el.handleHighlight).to.be.true;
+        expect(el.handleHighlight).to.be.false;
         expect(pointerId).to.equal(1);
 
         handle.dispatchEvent(
@@ -485,9 +499,7 @@ describe('Slider', () => {
         expect(el.value).to.equal(10);
         expect(el.dragging).to.be.false;
 
-        const handle = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#handle') as HTMLDivElement)
-            : (el as Slider);
+        const handle = el.shadowRoot.querySelector('#handle') as HTMLDivElement;
 
         handle.dispatchEvent(
             new PointerEvent('pointermove', {
@@ -509,11 +521,9 @@ describe('Slider', () => {
 
         expect(el.value).to.equal(10);
 
-        const input = el.shadowRoot
-            ? (el.shadowRoot.querySelector('#input') as HTMLInputElement)
-            : (el as Slider);
+        const input = el.shadowRoot.querySelector('#input') as HTMLInputElement;
 
-        input.value = 0;
+        input.value = '0';
         input.dispatchEvent(new Event('change'));
 
         expect(el.value).to.equal(0);


### PR DESCRIPTION
## Description
Previously throwing focus into the `<input>` element of a majority of interactions left the browser a difficult task of discerning whether a focus event was "focus visible" (keyboard triggered) or not. This meant that if the slider was interacted with (focused) via a pointing device and the the browser tab was blurred/focused again the "focus" would be applied to the slide as "focus visible", igniting the blue focus ring. This throws the focus to the `<label>` element via an imperative `click` event, which under the browser covers throws focus to the `<input>` without directly assigning additional event origin information. This leads to the "focus visible" check being more natural and the focus when returning to the tab active more like an `<input type="range">` element.

## Related Issue
fixes #517 

## Motivation and Context
We want to be "native" element, but _better_.

## How Has This Been Tested?
Manually and with additional and altered unit testing.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/105853138-5a145a00-5fb3-11eb-8465-ec645e0dfc19.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
