### PR TITLE
fix(overlay): place return focus element on demand

### DIFF
--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -106,7 +106,6 @@ export class ActiveOverlay extends SpectrumElement {
     public overlayContent!: HTMLElement;
     public overlayContentTip?: HTMLElement;
     public trigger!: HTMLElement;
-    public returnFocusElement?: HTMLSpanElement;
 
     private placeholder?: Comment;
     private popper?: Instance;
@@ -312,14 +311,10 @@ export class ActiveOverlay extends SpectrumElement {
             this.popper.destroy();
             this.popper = undefined;
         }
-
-        if (this.returnFocusElement) {
-            this.returnFocusElement.remove();
-            this.trigger.removeEventListener(
-                'keydown',
-                this.handleInlineTriggerKeydown
-            );
-        }
+        this.trigger.removeEventListener(
+            'keydown',
+            this.handleInlineTriggerKeydown
+        );
 
         this.returnOverlayContent();
         this.state = 'disposed';

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -246,18 +246,6 @@ export class OverlayStack {
     }
 
     public addInlineOverlayEventListeners(activeOverlay: ActiveOverlay): void {
-        if (!activeOverlay.returnFocusElement) {
-            activeOverlay.returnFocusElement = document.createElement('span');
-            activeOverlay.returnFocusElement.tabIndex = -1;
-            if (activeOverlay.trigger.hasAttribute('slot')) {
-                activeOverlay.returnFocusElement.slot =
-                    activeOverlay.trigger.slot;
-            }
-            activeOverlay.trigger.insertAdjacentElement(
-                'afterend',
-                activeOverlay.returnFocusElement
-            );
-        }
         activeOverlay.trigger.addEventListener(
             'keydown',
             activeOverlay.handleInlineTriggerKeydown
@@ -268,8 +256,18 @@ export class OverlayStack {
             if (code !== 'Tab') return;
 
             activeOverlay.tabbingAway = true;
-            if (shiftKey && activeOverlay.returnFocusElement) {
-                activeOverlay.returnFocusElement.focus();
+            if (shiftKey) {
+                const returnFocusElement = document.createElement('span');
+                returnFocusElement.tabIndex = -1;
+                if (activeOverlay.trigger.hasAttribute('slot')) {
+                    returnFocusElement.slot = activeOverlay.trigger.slot;
+                }
+                activeOverlay.trigger.insertAdjacentElement(
+                    'afterend',
+                    returnFocusElement
+                );
+                returnFocusElement.focus();
+                returnFocusElement.remove();
                 return;
             }
 


### PR DESCRIPTION
## Description
- place return focus element on demand
- as a short lived element it no longer needs to be cached on the `ActiveOverlay` element

## Related Issue
fixes #1094

## Motivation and Context
Functional elements should not reposition visual elements

## How Has This Been Tested?
Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/106332390-b77b0600-6254-11eb-9ff7-e7a297fb7d9f.png)
![image](https://user-images.githubusercontent.com/1156657/106332402-bf3aaa80-6254-11eb-9477-3bcd40814ff1.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
