### PR TITLE
fix: reduce cycles

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -44,7 +44,6 @@
     "author": "",
     "license": "Apache-2.0",
     "dependencies": {
-        "@spectrum-web-components/theme": "^0.7.3",
         "lit-element": "^2.4.0",
         "lit-html": "^1.0.0",
         "tslib": "^2.0.0"


### PR DESCRIPTION
## Description
Looks like this was the only thing that cycled and then _everything_ cycled. We had removed the use of this dependency a while back for TS cycles and forgot to remove the JS dependency.

## Motivation and Context
Actual cycles are bad.

## How Has This Been Tested?
`yarn lerna changed` no longer warns of cycles

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
