### PR TITLE
fix: expand sized functionality to support no default and returning to default values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
                   keys:
                       - v2-golden-images-<< pipeline.parameters.current_golden_images_hash >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
                       - v2-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
-            - run: yarn test:visual:ci --concurrency=4 --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
+            - run: yarn test:visual:ci --concurrency=2 --color=<< parameters.regression_color >> --scale=<< parameters.regression_scale >> --dir=<< parameters.regression_dir >>
             - run:
                   when: on_fail
                   command: cp -RT test/visual/screenshots-current/ci test/visual/screenshots-baseline/ci

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -47,6 +47,21 @@ describe('ActionButton', () => {
         expect(el.textContent).to.include('Button');
         await expect(el).to.be.accessible();
     });
+    it('maintains a `size` attribute', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button>Button</sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el.size).to.equal('m');
+        expect(el.getAttribute('size')).to.equal('m');
+        el.removeAttribute('size');
+        await elementUpdated(el);
+        expect(el.size).to.equal('m');
+        expect(el.getAttribute('size')).to.equal('m');
+    });
     it('dispatches `longpress` events when [hold-affordance]', async () => {
         const longpressSpy = spy();
         const el = await fixture<ActionButton>(

--- a/packages/divider/src/Divider.ts
+++ b/packages/divider/src/Divider.ts
@@ -24,7 +24,9 @@ import styles from './divider.css.js';
 /**
  * @element sp-divider
  */
-export class Divider extends SizedMixin(SpectrumElement, ['s', 'm', 'l']) {
+export class Divider extends SizedMixin(SpectrumElement, {
+    validSizes: ['s', 'm', 'l'],
+}) {
     public static styles: CSSResultArray = [styles];
 
     @property({ type: Boolean, reflect: true })

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -27,7 +27,9 @@ import linkStyles from './link.css.js';
  * @attr quiet - uses quiet styles or not
  * @attr over-background - uses over background styles or not
  */
-export class Link extends SizedMixin(LikeAnchor(Focusable)) {
+export class Link extends SizedMixin(LikeAnchor(Focusable), {
+    noDefaultSize: true,
+}) {
     public static get styles(): CSSResultArray {
         return [linkStyles];
     }

--- a/packages/link/test/link.test.ts
+++ b/packages/link/test/link.test.ts
@@ -18,9 +18,7 @@ describe('Link', () => {
     it('loads', async () => {
         const el = await fixture<Link>(
             html`
-                <sp-link href="test_url">
-                    Default Link
-                </sp-link>
+                <sp-link href="test_url">Default Link</sp-link>
             `
         );
 
@@ -50,9 +48,7 @@ describe('Link', () => {
     it('loads[rel]', async () => {
         const el = await fixture<Link>(
             html`
-                <sp-link href="test_url" rel="external">
-                    Default Link
-                </sp-link>
+                <sp-link href="test_url" rel="external">Default Link</sp-link>
             `
         );
 
@@ -61,5 +57,32 @@ describe('Link', () => {
         expect(el.focusElement.getAttribute('rel')).to.eq('external');
 
         await expect(el).to.be.accessible();
+    });
+
+    it('manages the `size` atrbute', async () => {
+        const el = await fixture<Link>(
+            html`
+                <sp-link href="test_url">Default Link</sp-link>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el.size, 'property 0: m').to.equal('m');
+        expect(el.getAttribute('size'), 'attribute 0: null').to.be.null;
+
+        el.setAttribute('size', 'xl');
+        await elementUpdated(el);
+        expect(el.size, 'property 1: xl').to.equal('xl');
+        expect(el.getAttribute('size'), 'attribute 1: xl').to.equal('xl');
+
+        el.removeAttribute('size');
+        await elementUpdated(el);
+        expect(el.size, 'property 2: m').to.equal('m');
+        expect(el.getAttribute('size'), 'attribute 2: null').to.be.null;
+
+        el.setAttribute('size', 'm');
+        await elementUpdated(el);
+        expect(el.size, 'property 3: m').to.equal('m');
+        expect(el.getAttribute('size'), 'attribute 3: m').to.equal('m');
     });
 });


### PR DESCRIPTION
## Description
- support "sized" element without a _default_ size
- support forcing element back to a _default_ size when the `size` attribute is removed

## Motivation and Context
Allow links and other sized element to be used more easily.

## How Has This Been Tested?
Unit tests!

## Screenshots (if appropriate):
See the `sp-link` elements displaying appropriately below...
![image](https://user-images.githubusercontent.com/1156657/107437306-cb4c2500-6afc-11eb-9bd9-959cddfe75bd.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
