### PR TITLE
[rfc] fix(icons-workflow): rename icons/files to avoid ad blocking

### DIFF
--- a/packages/icons-workflow/bin/build.js
+++ b/packages/icons-workflow/bin/build.js
@@ -69,10 +69,14 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (err, icons) => {
 
     icons.forEach((i) => {
         const svg = fs.readFileSync(i, 'utf-8');
-        const id = path
+        let id = path
             .basename(i, '.svg')
             .replace('S_', '')
             .replace('_22_N', '');
+        if (id.search(/^Ad[A-Z]/) !== -1) {
+            id = id.replace(/^Ad/, '');
+            id += 'Advert';
+        }
         const ComponentName = id === 'github' ? 'GitHub' : Case.pascal(id);
         const $ = cheerio.load(svg, {
             xmlMode: true,


### PR DESCRIPTION
## Description
Prevent ad blocking extensions from blocking unbuilt SWC code by renaming `AdPrint` to `PrintAdvert` and `AdDisplay` to `DisplayAdvert`. 

This is a "breaking" change, and I'm also unsure whether it goes far enough for ALL ad blockers and would appreciate feedback on whether there's a better name to use, whether it matters, whether we should do something else...

## Related Issue
fixes #1160

## Motivation and Context
Unbuilt apps should not be blocked by ad blockers.

## How Has This Been Tested?
Locally with adblockplus.org installed in my browser.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
