### PR TITLE
docs: process anchor tags in markdown as sp-link elements

### DIFF
--- a/documentation/src/utils/posthtml-spectrum-typography.js
+++ b/documentation/src/utils/posthtml-spectrum-typography.js
@@ -119,8 +119,21 @@ const transformations = [
         classes: ['spectrum-Rule', 'spectrum-Rule--large'],
     },
     {
+        // Update `<a>` tags that do not have the `no-js` or `logo` slot
+        // to be `<sp-link>` elements.
         selector: 'a',
-        classes: ['spectrum-Link'],
+        fn: (node) => {
+            if (
+                node.attrs.slot &&
+                (node.attrs.slot === 'no-js' || node.attrs.slot === 'logo')
+            ) {
+                return node;
+            }
+            return {
+                ...node,
+                tag: 'sp-link',
+            };
+        },
     },
 ];
 


### PR DESCRIPTION
## Description
Make sure links in the documentation site are delivered as `sp-link` elements

## Motivation and Context
This doesn't look awesome: 
![image](https://user-images.githubusercontent.com/1156657/107441512-592b0e80-6b03-11eb-8bf8-334f68dbe441.png)


## How Has This Been Tested?
In the local build via the screenshot below...

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/107441556-6c3dde80-6b03-11eb-912b-f69c78c0b693.png)

## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
