### PR TITLE
fix: correct dependency graph

### DIFF
--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -64,7 +64,6 @@
         "@spectrum-web-components/coachmark": "^0.5.1",
         "@spectrum-web-components/dialog": "^0.5.3",
         "@spectrum-web-components/divider": "^0.1.1",
-        "@spectrum-web-components/dropdown": "^0.10.1",
         "@spectrum-web-components/dropzone": "^0.6.1",
         "@spectrum-web-components/field-group": "^0.2.3",
         "@spectrum-web-components/field-label": "^0.2.3",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -47,7 +47,6 @@
     "dependencies": {
         "@spectrum-web-components/base": "^0.3.3",
         "@spectrum-web-components/button": "^0.12.0",
-        "@spectrum-web-components/dropdown": "^0.10.1",
         "@spectrum-web-components/icon": "^0.8.3",
         "@spectrum-web-components/icons-ui": "^0.5.3",
         "@spectrum-web-components/icons-workflow": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3162,22 +3162,6 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-3.0.0.tgz#c3ef4c2f07bd4f0d2734e730233ca81cb18106e7"
   integrity sha512-fNXU6qmcCbSiUoWGe/m9A8/THRHbpzwZ+iN8o/27tWIzcQIyZBZgjmV/kIMdF1dHpu5CuWik7mGV1Ex8tlzATg==
 
-"@spectrum-web-components/dropdown@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-web-components/dropdown/-/dropdown-0.10.1.tgz#d292dd561aaf4165c03179b4a48451d75cba6394"
-  integrity sha512-kGeeQqbc2kbTDo9Io7GN/p8iO8Tpb87/LN4ZKjzTFYxIICLb9qMqk57ziLkH0XdPc/8w5Rjo6RubAYChMcDKlg==
-  dependencies:
-    "@spectrum-web-components/base" "^0.3.1"
-    "@spectrum-web-components/button" "^0.11.1"
-    "@spectrum-web-components/icon" "^0.8.1"
-    "@spectrum-web-components/icons-ui" "^0.5.1"
-    "@spectrum-web-components/icons-workflow" "^0.5.1"
-    "@spectrum-web-components/menu" "^0.6.1"
-    "@spectrum-web-components/overlay" "^0.8.1"
-    "@spectrum-web-components/popover" "^0.7.1"
-    "@spectrum-web-components/shared" "^0.9.0"
-    tslib "^2.0.0"
-
 "@stylelint/postcss-css-in-js@^0.37.2":
   version "0.37.2"
   resolved "https://registry.yarnpkg.com/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz#7e5a84ad181f4234a2480803422a47b8749af3d2"


### PR DESCRIPTION
One of these was missed, another seems like it merged weird, but the `dropdown` pattern is no longer part of the library.