### PR TITLE
feat: use latest exports specification

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-accordion": "./sp-accordion.js",

--- a/packages/action-bar/package.json
+++ b/packages/action-bar/package.json
@@ -26,7 +26,7 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-action-bar": "./sp-action-bar.js",

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -25,7 +25,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-action-button": "./sp-action-button.js",

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-action-group": "./sp-action-group.js",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-action-menu": "./sp-action-menu.js",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-asset": "./sp-asset.js",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-avatar": "./sp-avatar.js",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-banner": "./sp-banner.js",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./elements": "./elements.js",

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-button-group": "./sp-button-group.js",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-button": "./sp-button.js",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-card": "./sp-card.js",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-checkbox": "./sp-checkbox.js",

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-coachmark": "./sp-coachmark.js",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-dialog": "./sp-dialog.js",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -26,7 +26,7 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-divider": "./sp-divider.js",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-dropzone": "./sp-dropzone.js",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-field-group": "./sp-field-group.js",

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -25,7 +25,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-field-label": "./sp-field-label.js",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-icon": "./sp-icon.js",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -25,8 +25,8 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
-        "./icons/": "./icons/",
+        "./src/*": "./src/*",
+        "./icons/*": "./icons/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -25,8 +25,8 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
-        "./icons/": "./icons/",
+        "./src/*": "./src/*",
+        "./icons/*": "./icons/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-icons-large": "./sp-icons-large.js",

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -25,7 +25,7 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-illustrated-message": "./sp-illustrated-message.js",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-link": "./sp-link.js",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-menu": "./sp-menu.js",

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -25,7 +25,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-meter": "./sp-meter.js",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -25,7 +25,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./active-overlay": "./active-overlay.js",

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -26,7 +26,7 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-picker": "./sp-picker.js",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-popover": "./sp-popover.js",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -26,7 +26,7 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-progress-bar": "./sp-progress-bar.js",

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -26,7 +26,7 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-progress-circle": "./sp-progress-circle.js",

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-quick-actions": "./sp-quick-actions.js",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-radio": "./sp-radio.js",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-search": "./sp-search.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-sidenav": "./sp-sidenav.js",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-slider": "./sp-slider.js",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -23,6 +23,14 @@
     "main": "./src/index.js",
     "module": "./src/index.js",
     "types": "./src/index.d.ts",
+    "exports": {
+        ".": "./src/index.js",
+        "./src/*": "./src/*",
+        "./custom-elements.json": "./custom-elements.json",
+        "./package.json": "./package.json",
+        "./sp-split-button": "./sp-split-button.js",
+        "./sp-split-button.js": "./sp-split-button.js"
+    },
     "type": "module",
     "files": [
         "custom-elements.json",

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -26,7 +26,7 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-split-view": "./sp-split-view.js",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-status-light": "./sp-status-light.js",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -25,7 +25,7 @@
     "module": "src/spectrum-base.css.js",
     "type": "module",
     "exports": {
-        "./": "./"
+        "./*": "./*"
     },
     "files": [
         "custom-elements.json",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-switch": "./sp-switch.js",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-tabs": "./sp-tabs.js",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-tags": "./sp-tags.js",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-textfield": "./sp-textfield.js",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-theme": "./sp-theme.js",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-toast": "./sp-toast.js",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-tooltip": "./sp-tooltip.js",

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-top-nav": "./sp-top-nav.js",

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -26,7 +26,7 @@
     "type": "module",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-underlay": "./sp-underlay.js",

--- a/projects/example-project-webpack/src/index.js
+++ b/projects/example-project-webpack/src/index.js
@@ -15,6 +15,6 @@ import './styles.css';
 
 // import the components we'll use in this page
 import '@spectrum-web-components/button/sp-button';
-import '@spectrum-web-components/dropdown/sp-dropdown';
+import '@spectrum-web-components/picker/sp-picker';
 import '@spectrum-web-components/menu/sp-menu';
 import '@spectrum-web-components/menu/sp-menu-item';

--- a/projects/story-decorator/package.json
+++ b/projects/story-decorator/package.json
@@ -25,7 +25,7 @@
     "types": "./src/index.d.ts",
     "type": "module",
     "exports": {
-        "./src/": "./src/",
+        "./src/*": "./src/*.js",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./decorator": "./decorator.js",

--- a/projects/templates/plop-templates/package.json.hbs
+++ b/projects/templates/plop-templates/package.json.hbs
@@ -26,7 +26,7 @@
     "types": "./src/index.d.ts",
     "exports": {
         ".": "./src/index.js",
-        "./src/": "./src/",
+        "./src/*": "./src/*.js",
         "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./{{> tagnamePartial }}": "./{{> tagnamePartial }}.js",


### PR DESCRIPTION
## Description
Support CDN delivery and modern build tools with latest version of the `package.json` `exports` field.

## Related Issue
fixes #1190 

## Motivation and Context
Our getting started docs shouldn't 404, but also people should be able to consume our packages via a number of paths/tools.

## How Has This Been Tested?
Manually in a package pre-release.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
