### PR TITLE
docs(dialog): clean up responsive delivery

### DIFF
--- a/documentation/src/components/component.css
+++ b/documentation/src/components/component.css
@@ -33,3 +33,7 @@ sp-tabs[selected='l'] ~ .tabs--l {
 sp-tabs[selected='xl'] ~ .tabs--xl {
     display: block;
 }
+
+code-example {
+    --spectrum-dialog-confirm-min-width: 0;
+}


### PR DESCRIPTION
## Description
Sizes the `sp-dialog` element appropriately within the usage context of our documentation site in small screen contexts.

- we specifically place this element in a parent with padding so that it's `min-width` does not apply well to the layout, so use the `--spectrum-dialog-confirm-min-width` CSS Custom Property to correct.
- don't directly address `mode="fullscreenTakeover"` or `mode="fullscreen"` as it needs input from Spectrum CSS, scoped by only apply the size to content inside a `code-example` element.

## Related Issue
fixes #671
refs #1041

## Motivation and Context
Our documentation should look good.

## How Has This Been Tested?
Manually in the docs site: https://603578357fc48b00d8e7122e--spectrum-web-components.netlify.app/components/dialog

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/108912109-28180700-75f6-11eb-8b3c-9c5b80b58495.png)

## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
