### PR TITLE
docs: make more responsive

### DIFF
--- a/packages/banner/README.md
+++ b/packages/banner/README.md
@@ -62,7 +62,7 @@ In addition to the variant, banners can be placed in the top-right corner of its
 
 ```html
 <div
-    style="width: 300px; height: 100px; background-color: #ba598b; position: relative;"
+    style="width: 300px; max-width: 75%; height: 100px; background-color: #ba598b; position: relative;"
 >
     <sp-banner corner>
         <div slot="header">This banner is in a corner</div>

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -186,7 +186,7 @@ Quiet cards will also accept `actions` via a named slot.
 Gallery cards can contain a heading, a subheading, an image preview, a description, and a footer.
 
 ```html
-<div style="width: 532px; height: 224px">
+<div style="width: 532px; max-width: 100%; height: 224px">
     <sp-card variant="gallery" heading="Card Heading" subheading="JPG Photo">
         <img alt="" slot="preview" src="https://picsum.photos/532/192" />
         <div slot="description">10/15/18</div>

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -32,9 +32,10 @@ import { Popover } from '@spectrum-web-components/popover';
         height: 200px;
         position: relative;
         width: 320px;
+        max-width: 100%;
     "
 >
-    <sp-popover dialog open>
+    <sp-popover dialog open style="--spectrum-popover-dialog-min-width: 0;">
         <div
             style="
             font-size: 18px;
@@ -67,9 +68,14 @@ element by default. The default popover has no padding by default
         height: 200px;
         position: relative;
         width: 320px;
+        max-width: 100%;
     "
 >
-    <sp-popover variant="default" open style="max-width: 320px">
+    <sp-popover
+        variant="default"
+        open
+        style="max-width: 320px; --spectrum-popover-dialog-min-width: 0;"
+    >
         <div style="font-size: 14px; padding: 10px">
             <div
                 style="
@@ -101,9 +107,10 @@ Popovers with padding, ideal for dialogs.
         height: 200px;
         position: relative;
         width: 320px;
+        max-width: 100%;
     "
 >
-    <sp-popover dialog open>
+    <sp-popover dialog open style="--spectrum-popover-dialog-min-width: 0;">
         <div
             style="
             font-size: 18px;
@@ -131,9 +138,16 @@ Popovers with padding, ideal for dialogs.
         height: 200px;
         position: relative;
         width: 320px;
+        max-width: 100%;
     "
 >
-    <sp-popover dialog placement="bottom" tip open>
+    <sp-popover
+        dialog
+        placement="bottom"
+        tip
+        open
+        style="--spectrum-popover-dialog-min-width: 0;"
+    >
         <div
             style="
             font-size: 18px;
@@ -159,9 +173,16 @@ Popovers with padding, ideal for dialogs.
         height: 200px;
         position: relative;
         width: 320px;
+        max-width: 100%;
     "
 >
-    <sp-popover dialog placement="top" tip open>
+    <sp-popover
+        dialog
+        placement="top"
+        tip
+        open
+        style="--spectrum-popover-dialog-min-width: 0;"
+    >
         <div
             style="
             font-size: 18px;
@@ -187,9 +208,16 @@ Popovers with padding, ideal for dialogs.
         height: 200px;
         position: relative;
         width: 320px;
+        max-width: 100%;
     "
 >
-    <sp-popover dialog placement="left" tip open>
+    <sp-popover
+        dialog
+        placement="left"
+        tip
+        open
+        style="--spectrum-popover-dialog-min-width: 0;"
+    >
         <div
             style="
             font-size: 18px;
@@ -215,9 +243,16 @@ Popovers with padding, ideal for dialogs.
         height: 200px;
         position: relative;
         width: 320px;
+        max-width: 100%;
     "
 >
-    <sp-popover dialog placement="right" tip open>
+    <sp-popover
+        dialog
+        placement="right"
+        tip
+        open
+        style="--spectrum-popover-dialog-min-width: 0;"
+    >
         <div
             style="
             font-size: 18px;

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -106,15 +106,18 @@ Emphasized radio buttons are a secondary style for radio buttons. The blue color
 
 ### Label Below
 
-``html
+```html
 <sp-radio label-below>A label</sp-radio>
-
 ```
 
 ### Wrapping behavior
 
-``html
-<sp-radio label-below>Radio with an extraordinarily long label please don't do this but if you did it should wrap text when it gets longer than the container which contains the radio which has an unacceptably long label</sp-radio>
+```html
+<sp-radio label-below>
+    Radio with an extraordinarily long label please don't do this but if you did
+    it should wrap text when it gets longer than the container which contains
+    the radio which has an unacceptably long label
+</sp-radio>
 ```
 
 ### Handling events


### PR DESCRIPTION
## Description
- uses `max-width` et al to support responsive delivery of the banner, card, and popover patterns
- fixes typo in radio
- prefers #1207 for tabs pattern
- radio group seems to have fixed itself with some better wrapping from upstream

## Related Issue
fixes #694

## Motivation and Context
Docs should make us look good.

## How Has This Been Tested?
Manually in the docs: https://6035833901788b0b1983fe8a--spectrum-web-components.netlify.app/components/banner

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/108916572-76300900-75fc-11eb-9f7a-78fbab15b0a9.png)
![image](https://user-images.githubusercontent.com/1156657/108916601-834cf800-75fc-11eb-9077-72f21c2d5847.png)
![image](https://user-images.githubusercontent.com/1156657/108916671-965fc800-75fc-11eb-8d58-0852e0f84546.png)
![image](https://user-images.githubusercontent.com/1156657/108916693-9f509980-75fc-11eb-979a-783777e1092c.png)


## Types of changes
- [x] Docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
