### PR TITLE
docs(overlay): separate overlay and overlay-trigger APIs

### DIFF
--- a/documentation/src/components/side-nav-search.ts
+++ b/documentation/src/components/side-nav-search.ts
@@ -32,6 +32,14 @@ import { search, ResultGroup } from './search-index.js';
 import { Menu } from '@spectrum-web-components/menu';
 import { Popover } from '@spectrum-web-components/popover';
 
+declare global {
+    interface Window {
+        Overlay: typeof Overlay;
+    }
+}
+
+window.Overlay = Overlay;
+
 class SearchComponent extends LitElement {
     private closeOverlay?: () => void;
 

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -93,7 +93,7 @@ type OverlayOptions = {
 
 `offset` defines the distance of the overlay content from the trigger, measured in pixels.
 
-`receivesFocus` tells the overlay stack to through focus into the overlay after it has opened.
+`receivesFocus` tells the overlay stack to throw focus into the overlay after it has opened.
 
 ## Example
 

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-Overlays in Spectrum Web Components are created via the `Overlay` class system which prepares and "overlay stack" that can manage the deployment of one or more overlays onto a page. Whether transient content like tooltip, or extended interactions like selecting a value from a picker, or blocking content like a modal, either the imperative APIs outlined below or the declarative APIs delivered as `<overlay-trigger>` should be able to conver you overlay delivery needs.
+Overlays in Spectrum Web Components are created via the `Overlay` class system, which prepares an "overlay stack" that can manage the deployment of one or more overlays onto a page. Whether it's needed for transient content like a tooltip, for extended interactions like selecting a value from a picker, or for blocking content like a modal, the imperative APIs outlined below or the declarative APIs delivered by `<overlay-trigger>` should cover your overlay delivery needs.
 
 ### Usage
 
@@ -11,7 +11,7 @@ Overlays in Spectrum Web Components are created via the `Overlay` class system w
 yarn add @spectrum-web-components/overlay
 ```
 
-Import the `Overlay` class to leverage its capabilities within you application or custom element:
+Import the `Overlay` class to leverage its capabilities within your application or custom element:
 
 ```js
 import { Overlay } from '@spectrum-web-components/overlay';
@@ -89,9 +89,9 @@ type OverlayOptions = {
 
 `delayed` allows for the overlay to open the overlay with warmup/cooldown behaviors as described at https://spectrum.adobe.com/page/tooltip/#Immediate-or-delayed-appearance
 
-`placement` outlines where the overlay system should attempt to position the overlay in relation to the trigger. When the layout of the page and/or current scroll positioning prevents the successful placement of the content in this way, the `placement` will be automatically applied as the value best suited for those contitions. Placements available include: `"auto" | "auto-start" | "auto-end" | "top" | "bottom" | "right" | "left" | "top-start" | "top-end" | "bottom-start" | "bottom-end" | "right-start" | "right-end" | "left-start" | "left-end" | "none"`.
+`placement` outlines where the overlay system should attempt to position the overlay in relation to the trigger. When the layout of the page and/or current scroll positioning prevents the successful placement of the content in this way, the `placement` will be automatically applied as the value best suited for those conditions. Placements available include: `"auto" | "auto-start" | "auto-end" | "top" | "bottom" | "right" | "left" | "top-start" | "top-end" | "bottom-start" | "bottom-end" | "right-start" | "right-end" | "left-start" | "left-end" | "none"`.
 
-`offset` defined the distance from the trigger that the overlay content should sit in pixels.
+`offset` defines the distance of the overlay content from the trigger, measured in pixels.
 
 `receivesFocus` tells the overlay stack to through focus into the overlay after it has opened.
 
@@ -144,7 +144,7 @@ type OverlayOptions = {
 
 ## Advanced Usage
 
-When working with the DOM based APIs of custom elements, it can sometimes be preferred to project content into an overlay from a different shadow root. Sometimes that could take the form of projecting a single slotted element into the overlay. To ensure that that content can be mashalled through any number of `<slot>` elements being addressed into subsequent `<slot>` elements, be sure to use the `flatten: true` option when querying `slot.asignedNodes()`:
+When working with the DOM-based APIs of custom elements, it is sometimes preferred to project content into an overlay from a different shadow root (eg projecting a single-slotted element into the overlay). To ensure that the content can be marshalled through any number of `<slot>` elements which are addressed into subsequent `<slot>` elements, be sure to use the `flatten: true` option when querying `slot.asignedNodes()`:
 
 ```js
 const trigger = shadowRoot.querySelector('#trigger');
@@ -160,7 +160,7 @@ const options = {
 const closeOverlay = await Overlay.open(trigger, interaction, content, options);
 ```
 
-Othertimes, you may actually want to compose content from multiple shadow roots into a single overlay. This is a pattern that can be seen in the `<sp-dropdown>` element where its `<sp-menu>` light DOM child is wrapped by its `<sp-popover>` shadow DOM child before being projected into an overlay. What follows is a more trivial example where content in the light DOM of an elements is injected into an element in the shadow DOM of the same element and then projected into an overlay. Notice the added work here of setting a comment node into the light DOM as a placeholder for the "stolen" content and then swapping that content back into the light DOM when the overlay is closed.
+Other times, you may want to compose content from multiple shadow roots into a single overlay. This is a pattern seen in the `<sp-dropdown>` element: its `<sp-menu>` light DOM child is wrapped by its `<sp-popover>` shadow DOM child before being projected into an overlay. What follows is a more trivial example, where content in the light DOM of an element is injected into an element in the shadow DOM of the same element and then projected into an overlay. Notice the added work here of setting a comment node into the light DOM as a placeholder for the "stolen" content, and then swapping that content back into the light DOM when the overlay is closed.
 
 ```js
 const trigger = this.shadowRoot.querySelector('#trigger');

--- a/packages/overlay/overlay-trigger.md
+++ b/packages/overlay/overlay-trigger.md
@@ -1,14 +1,14 @@
 ## Description
 
-An `<overlay-trigger>` element supports the delivery of temporary overlay content based on interaction with a persistant trigger element. Address an element prepared to receive accessible interactions (e.g. an `<sp-button>`, or `<button>`, etc.) to `slot="trigger"` and the content for display either via `click` or `hover`/`focus` interactions to `slot="click-content"` or `slot="hover-content"` respectively. A trigger element can be linked to the delivery of content intended for a single interaction or both. Content addressed to `slot="hover-content"` will be made available both when the mouse enters/leaves the target element as well as when focus enters/leaves the target elements to support receiving this content via keyboard and screen reader navigation. Be thoughtful with what content you address to `slot="hover-content"` as the content available via "hover" will be transient and non-interactive.
+An `<overlay-trigger>` element supports the delivery of temporary overlay content based on interaction with a persistent trigger element. An element prepared to receive accessible interactions (e.g. an `<sp-button>`, or `<button>`, etc.) is addressed to `slot="trigger"`, and the content to display (either via `click` or `hover`/`focus` interactions) is addressed to `slot="click-content"` or `slot="hover-content"`, respectively. A trigger element can be linked to the delivery of content, intended for a single interaction, or both. Content addressed to `slot="hover-content"` is made available when the mouse enters or leaves the target element, as well as when focus enters or leaves the target elements to support receiving this content via keyboard and screen reader navigation. Be thoughtful with what content you address to `slot="hover-content"`, as the content available via "hover" will be transient and non-interactive.
 
 ### Placement
 
-When using the `placement` attribute of an `<overlay-trigger>` (`"top-start" | "top-end" | "bottom-start" | "bottom-end" | "right-start" | "right-end" | "left-start" | "left-end"`), you can suggest to the overlay in which direction from the trigger the content should be made visible. When there is adequate room for the content to display in this direction, it will do so. When adequate room is not available, the overlaid content will calculate the direction in which is will have the most room to be displayed in and use that direction.
+When using the `placement` attribute of an `<overlay-trigger>` (`"top-start" | "top-end" | "bottom-start" | "bottom-end" | "right-start" | "right-end" | "left-start" | "left-end"`), you can suggest to the overlay in which direction relative to the trigger that the content should display. When there is adequate room for the content to display in the specified direction, it will do so. When adequate room is not available, the overlaid content will calculate the direction in which it has the most room to be displayed and use that direction.
 
 ### Type
 
-The `type` attribute of an `<overlay-trigger>` element outlines how the element's "click" content should appear in the tab order. `inline` will insert the overlay after the trigger; from here forward tabbing would target the next logical element and backward/shift tabbing to return to the target. `replace` will insert the overlay into the page as if it were the trigger; from here forward tabbing would target the next logical element and backward/shift tabbing would target the logical element prior to the target. Finally, `modal` will open the content in a tab order fully separate from the original content flow and trap the tab order within that content until the required interaction is complete.
+The `type` attribute of an `<overlay-trigger>` element outlines how the element's "click" content should appear in the tab order. `inline` will insert the overlay after the trigger; from here, forward tabbing targets the next logical element, and backward/shift tabbing returns to the target. `replace` will insert the overlay into the page as if it were the trigger; from here, forward tabbing targets the next logical element, and backward/shift tabbing targets the logical element prior to the target. Finally, `modal` will open the content in a tab order fully separate from the original content flow and trap the tab order within that content until the required interaction is complete.
 
 ### Installation
 
@@ -85,7 +85,7 @@ Here a default `<overlay-trigger>` manages content that is triggered by click an
 
 ### Click content only
 
-This example only delivers content via the click interaction and leverages both `placement` and `type` attributes to customize the visual relationship of the content to the page and its position in the tab order.
+This example only delivers content via the "click" interaction and leverages both `placement` and `type` attributes to customize the visual relationship of the content to the page and its position in the tab order.
 
 ```html
 <overlay-trigger placement="top" type="replace">
@@ -111,7 +111,7 @@ This example only delivers content via the click interaction and leverages both 
 
 ### "Hover" content only
 
-Hover content can be customized via the `placement` attribute, however it not allowing secondary interactions the `type` attribute will not further customize its delivery.
+Hover content can be customized via the `placement` attribute. However, it not allowing secondary interactions the `type` attribute will not further customize its delivery.
 
 ```html
 <overlay-trigger placement="right">
@@ -124,4 +124,4 @@ Hover content can be customized via the `placement` attribute, however it not al
 
 ## Accessibility
 
-When using an `<overlay-trigger>` element, it is important to be sure the that content you project into `slot="trigger"` is "interactive". This means that an element within that branch of DOM will be able to receive focus and said element will appropriately convert keyboard interactions to `click` events similar to what you find with `<a href="#">Anchors</a>`, `<button>Buttons</button>`, etc. You can find further reading on the subject of accessible keyboard interactions at [https://www.w3.org/WAI/WCAG21/Understanding/keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard).
+When using an `<overlay-trigger>` element, it is important to be sure the that content you project into `slot="trigger"` is "interactive". This means that an element within that branch of DOM will be able to receive focus, and said element will appropriately convert keyboard interactions to `click` events, similar to what you'd find with `<a href="#">Anchors</a>`, `<button>Buttons</button>`, etc. You can find further reading on the subject of accessible keyboard interactions at [https://www.w3.org/WAI/WCAG21/Understanding/keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard).

--- a/packages/overlay/overlay-trigger.md
+++ b/packages/overlay/overlay-trigger.md
@@ -1,6 +1,6 @@
 ## Description
 
-An `<overlay-trigger>` element supports the delivery of temporary overlay content based on interaction with a persistent trigger element. An element prepared to receive accessible interactions (e.g. an `<sp-button>`, or `<button>`, etc.) is addressed to `slot="trigger"`, and the content to display (either via `click` or `hover`/`focus` interactions) is addressed to `slot="click-content"` or `slot="hover-content"`, respectively. A trigger element can be linked to the delivery of content, intended for a single interaction, or both. Content addressed to `slot="hover-content"` is made available when the mouse enters or leaves the target element, as well as when focus enters or leaves the target elements to support receiving this content via keyboard and screen reader navigation. Be thoughtful with what content you address to `slot="hover-content"`, as the content available via "hover" will be transient and non-interactive.
+An `<overlay-trigger>` element supports the delivery of temporary overlay content based on interaction with a persistent trigger element. An element prepared to receive accessible interactions (e.g. an `<sp-button>`, or `<button>`, etc.) is addressed to `slot="trigger"`, and the content to display (either via `click` or `hover`/`focus` interactions) is addressed to `slot="click-content"` or `slot="hover-content"`, respectively. A trigger element can be linked to the delivery of content, intended for a single interaction, or both. Content addressed to `slot="hover-content"` is made available when the mouse enters or leaves the target element. Keyboard navigation will make this content available when focus enters or leaves the target element. Be thoughtful with what content you address to `slot="hover-content"`, as the content available via "hover" will be transient and non-interactive.
 
 ### Placement
 
@@ -111,7 +111,7 @@ This example only delivers content via the "click" interaction and leverages bot
 
 ### "Hover" content only
 
-Hover content can be customized via the `placement` attribute. However, it not allowing secondary interactions the `type` attribute will not further customize its delivery.
+The delivery of hover content can be customized via the `placement` attribute. However, this content can not be interacted with, so the `type` attribute will not customize its delivery in any way.
 
 ```html
 <overlay-trigger placement="right">

--- a/packages/overlay/overlay-trigger.md
+++ b/packages/overlay/overlay-trigger.md
@@ -1,0 +1,127 @@
+## Description
+
+An `<overlay-trigger>` element supports the delivery of temporary overlay content based on interaction with a persistant trigger element. Address an element prepared to receive accessible interactions (e.g. an `<sp-button>`, or `<button>`, etc.) to `slot="trigger"` and the content for display either via `click` or `hover`/`focus` interactions to `slot="click-content"` or `slot="hover-content"` respectively. A trigger element can be linked to the delivery of content intended for a single interaction or both. Content addressed to `slot="hover-content"` will be made available both when the mouse enters/leaves the target element as well as when focus enters/leaves the target elements to support receiving this content via keyboard and screen reader navigation. Be thoughtful with what content you address to `slot="hover-content"` as the content available via "hover" will be transient and non-interactive.
+
+### Placement
+
+When using the `placement` attribute of an `<overlay-trigger>` (`"top-start" | "top-end" | "bottom-start" | "bottom-end" | "right-start" | "right-end" | "left-start" | "left-end"`), you can suggest to the overlay in which direction from the trigger the content should be made visible. When there is adequate room for the content to display in this direction, it will do so. When adequate room is not available, the overlaid content will calculate the direction in which is will have the most room to be displayed in and use that direction.
+
+### Type
+
+The `type` attribute of an `<overlay-trigger>` element outlines how the element's "click" content should appear in the tab order. `inline` will insert the overlay after the trigger; from here forward tabbing would target the next logical element and backward/shift tabbing to return to the target. `replace` will insert the overlay into the page as if it were the trigger; from here forward tabbing would target the next logical element and backward/shift tabbing would target the logical element prior to the target. Finally, `modal` will open the content in a tab order fully separate from the original content flow and trap the tab order within that content until the required interaction is complete.
+
+### Installation
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/meter?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/overlay)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/meter?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/overlay)
+
+```
+yarn add @spectrum-web-components/overlay
+```
+
+Import the side-effectful registration of `<overlay-trigger>` via:
+
+```
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+```
+
+When looking to leverage the `OverlayTrigger` base class as a type and/or for extension purposes, do so via:
+
+```
+import { OverlayTrigger } from '@spectrum-web-components/overlay';
+```
+
+## Examples
+
+Here a default `<overlay-trigger>` manages content that is triggered by click and "hover" interactions.
+
+```html
+<style>
+    overlay-trigger {
+        flex: none;
+    }
+
+    .tooltip {
+        background-color: var(--spectrum-global-color-gray-800);
+        color: var(--spectrum-global-color-gray-50);
+        padding: 4px 10px;
+        font-size: 10px;
+    }
+</style>
+<overlay-trigger id="trigger" placement="bottom" offset="6">
+    <sp-button variant="primary" slot="trigger">Button popover</sp-button>
+    <sp-popover dialog slot="click-content" direction="bottom" tip>
+        <div class="options-popover-content">
+            <sp-slider
+                value="5"
+                step="0.5"
+                min="0"
+                max="20"
+                label="Awesomeness"
+            ></sp-slider>
+            <sp-button>Press me</sp-button>
+        </div>
+    </sp-popover>
+    <sp-tooltip slot="hover-content" delayed>Tooltip</sp-tooltip>
+    <sp-popover slot="longpress-content" tip>
+        <sp-action-group
+            selects="single"
+            vertical
+            style="margin: calc(var(--spectrum-actiongroup-button-gap-y,var(--spectrum-global-dimension-size-100)) / 2);"
+        >
+            <sp-action-button>
+                <sp-icon-magnify slot="icon"></sp-icon-magnify>
+            </sp-action-button>
+            <sp-action-button>
+                <sp-icon-magnify slot="icon"></sp-icon-magnify>
+            </sp-action-button>
+            <sp-action-button>
+                <sp-icon-magnify slot="icon"></sp-icon-magnify>
+            </sp-action-button>
+        </sp-action-group>
+    </sp-popover>
+</overlay-trigger>
+```
+
+### Click content only
+
+This example only delivers content via the click interaction and leverages both `placement` and `type` attributes to customize the visual relationship of the content to the page and its position in the tab order.
+
+```html
+<overlay-trigger placement="top" type="replace">
+    <sp-button slot="trigger">Overlay Trigger</sp-button>
+    <sp-popover slot="click-content" open>
+        <sp-dialog size="small">
+            <h2 slot="heading">Click content</h2>
+            An &lt;overlay-trigger&gt; can be used to manage either or both of
+            the "click" and "hover" content slots that are made available. Here,
+            content is only addressed to
+            <code>slot="click-content"</code>
+            ...
+            <sp-button
+                slot="button"
+                onclick="javascript: this.dispatchEvent(new Event('close', {bubbles: true, composed: true}));"
+            >
+                I understand
+            </sp-button>
+        </sp-dialog>
+    </sp-popover>
+</overlay-trigger>
+```
+
+### "Hover" content only
+
+Hover content can be customized via the `placement` attribute, however it not allowing secondary interactions the `type` attribute will not further customize its delivery.
+
+```html
+<overlay-trigger placement="right">
+    <sp-button slot="trigger">Overlay Trigger</sp-button>
+    <sp-tooltip slot="hover-content" open placement="right">
+        Hover Content
+    </sp-tooltip>
+</overlay-trigger>
+```
+
+## Accessibility
+
+When using an `<overlay-trigger>` element, it is important to be sure the that content you project into `slot="trigger"` is "interactive". This means that an element within that branch of DOM will be able to receive focus and said element will appropriately convert keyboard interactions to `click` events similar to what you find with `<a href="#">Anchors</a>`, `<button>Buttons</button>`, etc. You can find further reading on the subject of accessible keyboard interactions at [https://www.w3.org/WAI/WCAG21/Understanding/keyboard](https://www.w3.org/WAI/WCAG21/Understanding/keyboard).


### PR DESCRIPTION
## Description
Clarify the usage of both the `Overlay` api and it's `open()` method and the `overlay-trigger` element by disambiguating them in the documentation site.

This might change a bit with @adixon-adobe's changes/additions of a reparenting API, so I wanted to get this out there to help the development there.

## Related Issue
fixes #866 

## Motivation and Context
More, clearer docs are best.

## How Has This Been Tested?
By you, here: https://603591a4ba119117846bd34f--spectrum-web-components.netlify.app/components/overlay and, here: https://603591a4ba119117846bd34f--spectrum-web-components.netlify.app/components/overlay-trigger

## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
