### PR TITLE
fix(picker): add "quick select" action to right/left arrow keys

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -433,4 +433,42 @@ export class Picker extends PickerBase {
     public static get styles(): CSSResultArray {
         return [pickerStyles, chevronStyles];
     }
+
+    public onKeydown = (event: KeyboardEvent): void => {
+        const { code } = event;
+        if (!code.startsWith('Arrow')) {
+            return;
+        }
+        event.preventDefault();
+        /* c8 ignore next 3 */
+        if (!this.optionsMenu) {
+            return;
+        }
+        if (code === 'ArrowUp' || code === 'ArrowDown') {
+            this.open = true;
+            return;
+        }
+        let selectedIndex = -1;
+        this.optionsMenu.menuItems.map((item, i) => {
+            if (this.value === item.value && !item.disabled) {
+                selectedIndex = i;
+            }
+        });
+        // use a positive offset to find the first non-disabled item when no selection is available.
+        const nextOffset = !this.value || code === 'ArrowRight' ? 1 : -1;
+        let nextIndex = selectedIndex + nextOffset;
+        while (
+            this.optionsMenu.menuItems[nextIndex] &&
+            this.optionsMenu.menuItems[nextIndex].disabled
+        ) {
+            nextIndex += nextOffset;
+        }
+        nextIndex = Math.max(
+            Math.min(nextIndex, this.optionsMenu.menuItems.length),
+            0
+        );
+        if (!this.value || nextIndex !== selectedIndex) {
+            this.setValueFromItem(this.optionsMenu.menuItems[nextIndex]);
+        }
+    };
 }

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -108,8 +108,8 @@ export class PickerBase extends SizedMixin(Focusable) {
     @property({ type: String })
     public value = '';
 
-    @property({ type: String })
-    public selectedItemText = '';
+    @property({ attribute: false })
+    public selectedItem?: MenuItem;
 
     private closeOverlay?: () => void;
 
@@ -197,9 +197,9 @@ export class PickerBase extends SizedMixin(Focusable) {
     };
 
     public async setValueFromItem(item: MenuItem): Promise<void> {
-        const oldSelectedItemText = this.selectedItemText;
+        const oldSelectedItem = this.selectedItem;
         const oldValue = this.value;
-        this.selectedItemText = item.itemText;
+        this.selectedItem = item;
         this.value = item.value;
         this.open = false;
         await this.updateComplete;
@@ -209,18 +209,13 @@ export class PickerBase extends SizedMixin(Focusable) {
             })
         );
         if (!applyDefault) {
-            this.selectedItemText = oldSelectedItemText;
+            this.selectedItem = oldSelectedItem;
             this.value = oldValue;
             this.open = true;
             return;
         }
-        const parentElement = item.parentElement as Element;
-        const selectedItem = parentElement.querySelector(
-            '[selected]'
-        ) as MenuItem;
-        /* c8 ignore next 3 */
-        if (selectedItem) {
-            selectedItem.selected = false;
+        if (oldSelectedItem) {
+            oldSelectedItem.selected = false;
         }
         item.selected = true;
     }
@@ -306,8 +301,8 @@ export class PickerBase extends SizedMixin(Focusable) {
                     id="label"
                     class=${ifDefined(this.value ? undefined : 'placeholder')}
                 >
-                    ${this.value
-                        ? this.selectedItemText
+                    ${this.value && this.selectedItem
+                        ? this.selectedItem.itemText
                         : html`
                               <slot name="label">${this.label}</slot>
                           `}
@@ -363,7 +358,11 @@ export class PickerBase extends SizedMixin(Focusable) {
 
     protected updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
-        if (changedProperties.has('value') && this.optionsMenu) {
+        if (
+            changedProperties.has('value') &&
+            !changedProperties.has('selectedItem') &&
+            this.optionsMenu
+        ) {
             this.manageSelection();
         }
         if (changedProperties.has('disabled') && this.disabled) {
@@ -400,10 +399,10 @@ export class PickerBase extends SizedMixin(Focusable) {
             });
             if (selectedItem) {
                 selectedItem.selected = true;
-                this.selectedItemText = selectedItem.itemText;
+                this.selectedItem = selectedItem;
             } else {
                 this.value = '';
-                this.selectedItemText = '';
+                this.selectedItem = undefined;
             }
             this.optionsMenu.updateSelectedItemIndex();
             return;
@@ -448,12 +447,9 @@ export class Picker extends PickerBase {
             this.open = true;
             return;
         }
-        let selectedIndex = -1;
-        this.optionsMenu.menuItems.map((item, i) => {
-            if (this.value === item.value && !item.disabled) {
-                selectedIndex = i;
-            }
-        });
+        const selectedIndex = this.selectedItem
+            ? this.optionsMenu.menuItems.indexOf(this.selectedItem)
+            : -1;
         // use a positive offset to find the first non-disabled item when no selection is available.
         const nextOffset = !this.value || code === 'ArrowRight' ? 1 : -1;
         let nextIndex = selectedIndex + nextOffset;

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -206,14 +206,14 @@ describe('Picker', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
-        expect(el.selectedItemText).to.equal('');
+        expect(el.selectedItem?.itemText).to.be.undefined;
         expect(el.value).to.equal('');
 
         secondItem.click();
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Select Inverse');
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
         expect(el.value).to.equal('option-2');
     });
     it('re-selects', async () => {
@@ -233,28 +233,28 @@ describe('Picker', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
-        expect(el.selectedItemText).to.equal('');
+        expect(el.selectedItem?.itemText).to.be.undefined;
         expect(el.value).to.equal('');
 
         secondItem.click();
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Select Inverse');
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
         expect(el.value).to.equal('option-2');
 
         button.click();
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
-        expect(el.selectedItemText).to.equal('Select Inverse');
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
         expect(el.value).to.equal('option-2');
 
         firstItem.click();
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Deselect');
+        expect(el.selectedItem?.itemText).to.equal('Deselect');
         expect(el.value).to.equal('Deselect');
     });
     it('can have selection prevented', async () => {
@@ -272,7 +272,7 @@ describe('Picker', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
-        expect(el.selectedItemText).to.equal('');
+        expect(el.selectedItem?.itemText).to.be.undefined;
         expect(el.value).to.equal('');
         expect(secondItem.selected).to.be.false;
 
@@ -304,7 +304,7 @@ describe('Picker', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
-        expect(el.selectedItemText).to.equal('');
+        expect(el.selectedItem?.itemText).to.be.undefined;
         expect(el.value).to.equal('');
         expect(secondItem.selected).to.be.false;
 
@@ -383,14 +383,14 @@ describe('Picker', () => {
         await elementUpdated(el);
 
         expect(el.open, 'open by ArrowDown').to.be.true;
-        expect(el.selectedItemText).to.equal('');
+        expect(el.selectedItem?.itemText).to.be.undefined;
         expect(el.value).to.equal('');
 
         firstItem.click();
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Deselect');
+        expect(el.selectedItem?.itemText).to.equal('Deselect');
         expect(el.value).to.equal('Deselect');
     });
     it('quick selects on ArrowLeft/Right', async () => {
@@ -542,8 +542,8 @@ describe('Picker', () => {
 
         await elementUpdated(el);
         await waitUntil(
-            () => el.selectedItemText === 'Select Inverse',
-            `Selected Item Text: ${el.selectedItemText}`
+            () => el.selectedItem?.itemText === 'Select Inverse',
+            `Selected Item Text: ${el.selectedItem?.itemText}`
         );
 
         const menu = el.querySelector('sp-menu') as Menu;
@@ -558,7 +558,7 @@ describe('Picker', () => {
         secondItem.addEventListener('focus', handleSelectedFocus);
 
         expect(el.value).to.equal('inverse');
-        expect(el.selectedItemText).to.equal('Select Inverse');
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
 
         const button = el.button as HTMLButtonElement;
         button.click();
@@ -597,7 +597,7 @@ describe('Picker', () => {
         await waitUntil(() => el.value === '');
 
         expect(el.value).to.equal('');
-        expect(el.selectedItemText).to.equal('');
+        expect(el.selectedItem?.itemText).to.be.undefined;
     });
 
     it('allows event listeners on child items', async () => {

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -31,6 +31,8 @@ import { spy } from 'sinon';
 import {
     arrowDownEvent,
     arrowUpEvent,
+    arrowLeftEvent,
+    arrowRightEvent,
     tabEvent,
     tEvent,
 } from '../../../test/testing-helpers.js';
@@ -390,6 +392,62 @@ describe('Picker', () => {
         expect(el.open).to.be.false;
         expect(el.selectedItemText).to.equal('Deselect');
         expect(el.value).to.equal('Deselect');
+    });
+    it('quick selects on ArrowLeft/Right', async () => {
+        const selectionSpy = spy();
+        const el = await pickerFixture();
+        el.addEventListener('change', (event: Event) => {
+            const { value } = event.target as Picker;
+            console.log('change', value);
+            selectionSpy(value);
+        });
+        const button = el.button as HTMLButtonElement;
+
+        await elementUpdated(el);
+        el.focus();
+        button.dispatchEvent(arrowLeftEvent);
+
+        await elementUpdated(el);
+
+        expect(selectionSpy.callCount).to.equal(1);
+        expect(selectionSpy.calledWith('Deselected'));
+        button.dispatchEvent(arrowLeftEvent);
+
+        await elementUpdated(el);
+        expect(selectionSpy.callCount).to.equal(1);
+        button.dispatchEvent(arrowRightEvent);
+
+        await elementUpdated(el);
+        expect(selectionSpy.calledWith('option-2'));
+
+        button.dispatchEvent(arrowRightEvent);
+        button.dispatchEvent(arrowRightEvent);
+        button.dispatchEvent(arrowRightEvent);
+        button.dispatchEvent(arrowRightEvent);
+
+        await elementUpdated(el);
+        expect(selectionSpy.callCount).to.equal(5);
+        expect(selectionSpy.calledWith('Save Selection'));
+        expect(selectionSpy.calledWith('Make Work Path')).to.be.false;
+    });
+    it('quick selects first item on ArrowRight when no value', async () => {
+        const selectionSpy = spy();
+        const el = await pickerFixture();
+        el.addEventListener('change', (event: Event) => {
+            const { value } = event.target as Picker;
+            console.log('change', value);
+            selectionSpy(value);
+        });
+        const button = el.button as HTMLButtonElement;
+
+        await elementUpdated(el);
+        el.focus();
+        button.dispatchEvent(arrowRightEvent);
+
+        await elementUpdated(el);
+
+        expect(selectionSpy.callCount).to.equal(1);
+        expect(selectionSpy.calledWith('Deselected'));
     });
     it('loads', async () => {
         const el = await pickerFixture();

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -109,7 +109,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
                     role="presentation"
                     class=${ifDefined(this.value ? undefined : 'placeholder')}
                 >
-                    ${this.selectedItemText}
+                    ${this.selectedItem?.itemText || ''}
                 </div>
             `,
         ];
@@ -189,13 +189,11 @@ export class SplitButton extends SizedMixin(PickerBase) {
                     (el) => (el.selected = false)
                 );
                 this.optionsMenu.menuItems[0].selected = true;
-                this.selectedItemText = this.optionsMenu.menuItems[0].itemText;
+                this.selectedItem = this.optionsMenu.menuItems[0];
             } else {
-                const selected =
-                    this.optionsMenu.menuItems.find((el) => el.selected) ||
-                    this.optionsMenu.menuItems[0];
-                selected.selected = true;
-                this.selectedItemText = selected.itemText;
+                this.selectedItem =
+                    this.selectedItem || this.optionsMenu.menuItems[0];
+                this.selectedItem.selected = true;
             }
             return;
         }

--- a/packages/split-button/test/split-button.test.ts
+++ b/packages/split-button/test/split-button.test.ts
@@ -66,13 +66,13 @@ describe('Splitbutton', () => {
         expect(document.activeElement === el2);
         expect(el1.shadowRoot.activeElement === el2FocusElement);
     });
-    it('[type="field"] manages `selectedItemText`', async () => {
+    it('[type="field"] manages `selectedItem`', async () => {
         const test = await fixture<HTMLDivElement>(cta());
         const el = test.querySelector('sp-split-button') as SplitButton;
 
         await elementUpdated(el);
 
-        expect(el.selectedItemText).to.equal('Option 1');
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
         expect(el.open).to.be.false;
 
         const item3 = el.querySelector('sp-menu-item:nth-child(3)') as MenuItem;
@@ -91,15 +91,15 @@ describe('Splitbutton', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Short');
+        expect(el.selectedItem?.itemText).to.equal('Short');
     });
-    it('[type="more"] manages `selectedItemText`', async () => {
+    it('[type="more"] manages `selectedItem.itemText`', async () => {
         const test = await fixture<HTMLDivElement>(moreCta());
         const el = test.querySelector('sp-split-button') as SplitButton;
 
         await elementUpdated(el);
 
-        expect(el.selectedItemText).to.equal('Option 1');
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
         expect(el.open).to.be.false;
 
         const item3 = el.querySelector('sp-menu-item:nth-child(3)') as MenuItem;
@@ -118,7 +118,7 @@ describe('Splitbutton', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Option 1');
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
     });
     it('passes click events as [type="field"]', async () => {
         const firstItemSpy = spy();
@@ -135,7 +135,7 @@ describe('Splitbutton', () => {
 
         await elementUpdated(el);
 
-        expect(el.selectedItemText).to.equal('Option 1');
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
         expect(el.open).to.be.false;
 
         const item1 = el.querySelector('sp-menu-item:nth-child(1)') as MenuItem;
@@ -171,7 +171,7 @@ describe('Splitbutton', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Short');
+        expect(el.selectedItem?.itemText).to.equal('Short');
         expect(thirdItemSpy.called, 'third called, still').to.be.true;
         expect(thirdItemSpy.callCount, 'third callCount').to.equal(2);
         expect(thirdItemSpy.calledTwice, 'third calledTwice').to.be.true;
@@ -192,7 +192,7 @@ describe('Splitbutton', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Option Extended');
+        expect(el.selectedItem?.itemText).to.equal('Option Extended');
         expect(secondItemSpy.called, 'second called').to.be.true;
         expect(secondItemSpy.calledTwice, 'second twice').to.be.true;
 
@@ -209,7 +209,7 @@ describe('Splitbutton', () => {
 
         await elementUpdated(el);
 
-        expect(el.selectedItemText).to.equal('Option 1');
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
         expect(firstItemSpy.called, 'first called, sill').to.be.true;
         expect(firstItemSpy.callCount, 'first callCount').to.equal(3);
     });
@@ -228,7 +228,7 @@ describe('Splitbutton', () => {
 
         await elementUpdated(el);
 
-        expect(el.selectedItemText).to.equal('Option 1');
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
         expect(el.open).to.be.false;
 
         const item2 = el.querySelector('sp-menu-item:nth-child(2)') as MenuItem;
@@ -255,7 +255,7 @@ describe('Splitbutton', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Option 1');
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
         expect(thirdItemSpy.called, '3rd called').to.be.true;
         expect(thirdItemSpy.calledOnce, '3rd called once').to.be.true;
 
@@ -270,7 +270,7 @@ describe('Splitbutton', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
-        expect(el.selectedItemText).to.equal('Option 1');
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
         expect(secondItemSpy.called, '2nd called').to.be.true;
         expect(secondItemSpy.calledOnce, '2nd called once').to.be.true;
 


### PR DESCRIPTION
## Description
Add support for making a "quick selection" when an `sp-picker` element is focused via the right and left arrow keys.

Uses a cached `selectedItem` property to reduce work across the various interactions.

Check it out at: https://6037cd0dd41f080c0b2563ad--spectrum-web-components.netlify.app/components/picker

## Related Issue
fixes #254
refs #1187

## Motivation and Context
Make users lives easier and parity with other Spectrum component offerings.

## How Has This Been Tested?
Manually and unit tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
