### PR TITLE
fix(button): include "pointerleave" in management of the "active" state

### DIFF
--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -212,9 +212,14 @@ export class ButtonBase extends LikeAnchor(
             if (this.active) {
                 this.addEventListener('focusout', this.handleRemoveActive);
                 this.addEventListener('pointerup', this.handleRemoveActive);
+                this.addEventListener('pointerleave', this.handleRemoveActive);
             } else {
                 this.removeEventListener('focusout', this.handleRemoveActive);
                 this.removeEventListener('pointerup', this.handleRemoveActive);
+                this.removeEventListener(
+                    'pointerleave',
+                    this.handleRemoveActive
+                );
             }
         }
         if (this.anchorElement) {


### PR DESCRIPTION
## Description
Add `pointerleave` (`pointercancel` requires capturing the pointer which then requires additional work to make the "click away" not actually click the button) to the events that manage the removal of the `active` state of buttons.

## Related Issue
fix #1219

## Motivation and Context
Correct UI.

## How Has This Been Tested?
Manually, and you can too: https://6037c9264f9c270bfa8db70a--spectrum-web-components.netlify.app/storybook/?path=/story/action-button--toggles

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
