### PR TITLE
fix(styles): move `@spectrum-web-components/base` from devDependencies to dependencies

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -45,7 +45,9 @@
     "devDependencies": {
         "@spectrum-css/commons": "^3.0.1",
         "@spectrum-css/typography": "^3.0.0",
-        "@spectrum-css/vars": "^3.0.0",
+        "@spectrum-css/vars": "^3.0.0"
+    },
+    "dependencies": {
         "@spectrum-web-components/base": "^0.3.3"
     }
 }


### PR DESCRIPTION
## Description

Compiled files like [spectrum-base.css.js](https://unpkg.com/browse/@spectrum-web-components/styles@0.8.0/src/spectrum-base.css.js) reference the `css` directive from the `@spectrum-web-components/base` package at runtime, so needs to be in `dependencies` section of the `package.json` (not `devDependencies`.)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Package managers like yarn in strict mode will complain about not explicitly declaring all of your dependencies.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
