### PR TITLE
build: hoist CSS Custom Properties from hostShadowSelector to :host

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: dcc6a300af312400b74ae70c13df085a9b5615bb
+        default: 5af92d758864b164ed594bfa3628c9192800a3af
 commands:
     downstream:
         steps:

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -164,6 +164,7 @@ export class Menu extends SpectrumElement {
             return;
         }
         itemToFocus.focused = true;
+        itemToFocus.scrollIntoView({ block: 'nearest' });
         this.setAttribute('aria-activedescendant', itemToFocus.id);
         focusedItem.tabIndex = -1;
     }

--- a/packages/modal/src/spectrum-modal.css
+++ b/packages/modal/src/spectrum-modal.css
@@ -28,7 +28,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     transition-delay: 0ms;
     pointer-events: auto;
 }
-.modal {
+:host {
     /* .spectrum-Modal */
     --spectrum-dialog-confirm-exit-animation-delay: 0ms;
     --spectrum-dialog-fullscreen-margin: 32px;

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -15,6 +15,30 @@ governing permissions and limitations under the License.
 :host {
     display: inline-flex;
     vertical-align: top;
+
+    /**
+     * .spectrum-Picker
+     * Move width management to :host
+     **/
+    max-width: 100%;
+    width: var(--spectrum-picker-width);
+    min-width: var(--spectrum-picker-min-width);
+}
+
+:host([quiet]) {
+    width: auto;
+    min-width: 0;
+}
+
+:host([size]) {
+    /* TODO: https://github.com/adobe/spectrum-css/blob/011ca5408ae5eb32bb55e1cf79c06e40171fd17c/components/picker/index.css#L93 */
+    --spectrum-picker-width: var(--spectrum-global-dimension-size-2400);
+}
+
+#button {
+    width: 100%;
+    min-width: 100%;
+    max-width: 100%;
 }
 
 sp-popover {

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -10,9 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-#button {
+:host {
     /* .spectrum-Picker */
     --spectrum-button-line-height: 1.3;
+}
+#button {
+    /* .spectrum-Picker */
     position: relative;
     display: inline-flex;
     box-sizing: border-box;
@@ -348,7 +351,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-item-padding-xl)
     );
 }
-#button {
+:host {
     /* .spectrum-Picker */
     --spectrum-picker-min-width: var(--spectrum-global-dimension-size-400);
     --spectrum-picker-disabled-border-size: 0;

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -17,6 +17,7 @@ import '../sp-picker.js';
 import { Picker } from '../';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
+import { states } from './states.js';
 
 export default {
     title: 'Picker',
@@ -154,5 +155,35 @@ export const initialValue = (): TemplateResult => {
                 </sp-menu-item>
             </sp-menu>
         </sp-picker>
+    `;
+};
+
+export const custom = (): TemplateResult => {
+    return html`
+        <sp-picker
+            style="width: 400px;"
+            @change="${(event: Event): void => {
+                const picker = event.target as Picker;
+                action(`Change: ${picker.value}`)();
+            }}"
+            label="Pick an state"
+        >
+            <sp-menu style="max-height: 400px;">
+                ${states.map(
+                    (state) => html`
+                        <sp-menu-item id=${state.id} value=${state.id}>
+                            ${state.label}
+                        </sp-menu-item>
+                    `
+                )}
+            </sp-menu>
+        </sp-picker>
+        <p>This is some text.</p>
+        <p>This is some text.</p>
+        <p>
+            This is a
+            <a href="#anchor">link</a>
+            .
+        </p>
     `;
 };

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -166,7 +166,7 @@ export const custom = (): TemplateResult => {
                 const picker = event.target as Picker;
                 action(`Change: ${picker.value}`)();
             }}"
-            label="Pick an state"
+            label="Pick a state"
         >
             <sp-menu style="max-height: 400px;">
                 ${states.map(

--- a/packages/picker/stories/states.ts
+++ b/packages/picker/stories/states.ts
@@ -1,0 +1,240 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+export const states: {
+    id: string;
+    label: string;
+}[] = [
+    {
+        id: 'lb1-al',
+        label: 'Alabama',
+    },
+    {
+        id: 'lb1-ak',
+        label: 'Alaska',
+    },
+    {
+        id: 'lb1-as',
+        label: 'American Samoa',
+    },
+    {
+        id: 'lb1-az',
+        label: 'Arizona',
+    },
+    {
+        id: 'lb1-ar',
+        label: 'Arkansas',
+    },
+    {
+        id: 'lb1-ca',
+        label: 'California',
+    },
+    {
+        id: 'lb1-co',
+        label: 'Colorado',
+    },
+    {
+        id: 'lb1-ct',
+        label: 'Connecticut',
+    },
+    {
+        id: 'lb1-de',
+        label: 'Delaware',
+    },
+    {
+        id: 'lb1-dc',
+        label: 'District of Columbia',
+    },
+    {
+        id: 'lb1-fl',
+        label: 'Florida',
+    },
+    {
+        id: 'lb1-ga',
+        label: 'Georgia',
+    },
+    {
+        id: 'lb1-gm',
+        label: 'Guam',
+    },
+    {
+        id: 'lb1-hi',
+        label: 'Hawaii',
+    },
+    {
+        id: 'lb1-id',
+        label: 'Idaho',
+    },
+    {
+        id: 'lb1-il',
+        label: 'Illinois',
+    },
+    {
+        id: 'lb1-in',
+        label: 'Indiana',
+    },
+    {
+        id: 'lb1-ia',
+        label: 'Iowa',
+    },
+    {
+        id: 'lb1-ks',
+        label: 'Kansas',
+    },
+    {
+        id: 'lb1-ky',
+        label: 'Kentucky',
+    },
+    {
+        id: 'lb1-la',
+        label: 'Louisiana',
+    },
+    {
+        id: 'lb1-me',
+        label: 'Maine',
+    },
+    {
+        id: 'lb1-md',
+        label: 'Maryland',
+    },
+    {
+        id: 'lb1-ma',
+        label: 'Massachusetts',
+    },
+    {
+        id: 'lb1-mi',
+        label: 'Michigan',
+    },
+    {
+        id: 'lb1-mn',
+        label: 'Minnesota',
+    },
+    {
+        id: 'lb1-ms',
+        label: 'Mississippi',
+    },
+    {
+        id: 'lb1-mo',
+        label: 'Missouri',
+    },
+    {
+        id: 'lb1-mt',
+        label: 'Montana',
+    },
+    {
+        id: 'lb1-ne',
+        label: 'Nebraska',
+    },
+    {
+        id: 'lb1-nv',
+        label: 'Nevada',
+    },
+    {
+        id: 'lb1-nh',
+        label: 'New Hampshire',
+    },
+    {
+        id: 'lb1-nj',
+        label: 'New Jersey',
+    },
+    {
+        id: 'lb1-nm',
+        label: 'New Mexico',
+    },
+    {
+        id: 'lb1-ny',
+        label: 'New York',
+    },
+    {
+        id: 'lb1-nc',
+        label: 'North Carolina',
+    },
+    {
+        id: 'lb1-nd',
+        label: 'North Dakota',
+    },
+    {
+        id: 'lb1-mp',
+        label: 'Northern Marianas Islands',
+    },
+    {
+        id: 'lb1-oh',
+        label: 'Ohio',
+    },
+    {
+        id: 'lb1-ok',
+        label: 'Oklahoma',
+    },
+    {
+        id: 'lb1-or',
+        label: 'Oregon',
+    },
+    {
+        id: 'lb1-pa',
+        label: 'Pennsylvania',
+    },
+    {
+        id: 'lb1-pr',
+        label: 'Puerto Rico',
+    },
+    {
+        id: 'lb1-ri',
+        label: 'Rhode Island',
+    },
+    {
+        id: 'lb1-sc',
+        label: 'South Carolina',
+    },
+    {
+        id: 'lb1-sd',
+        label: 'South Dakota',
+    },
+    {
+        id: 'lb1-tn',
+        label: 'Tennessee',
+    },
+    {
+        id: 'lb1-tx',
+        label: 'Texas',
+    },
+    {
+        id: 'lb1-ut',
+        label: 'Utah',
+    },
+    {
+        id: 'lb1-ve',
+        label: 'Vermont',
+    },
+    {
+        id: 'lb1-va',
+        label: 'Virginia',
+    },
+    {
+        id: 'lb1-vi',
+        label: 'Virgin Islands',
+    },
+    {
+        id: 'lb1-wa',
+        label: 'Washington',
+    },
+    {
+        id: 'lb1-wv',
+        label: 'West Virginia',
+    },
+    {
+        id: 'lb1-wi',
+        label: 'Wisconsin',
+    },
+    {
+        id: 'lb1-wy',
+        label: 'Wyoming',
+    },
+];

--- a/packages/styles/fonts.css
+++ b/packages/styles/fonts.css
@@ -14,53 +14,33 @@ governing permissions and limitations under the License.
 
 :host,
 :root {
-    --spectrum-font-fallbacks-sans: -apple-system, BlinkMacSystemFont,
-        'Segoe UI', Roboto, sans-serif;
-    --spectrum-font-family-base: var(--spectrum-alias-body-text-font-family);
-    --spectrum-font-family-ar: var(--spectrum-alias-font-family-ar);
-    --spectrum-font-family-he: var(--spectrum-alias-font-family-he);
-    --spectrum-font-family-zh: var(--spectrum-alias-font-family-zh);
-    --spectrum-font-family-zhhans: var(--spectrum-alias-font-family-zhhans);
-    --spectrum-font-family-ko: var(--spectrum-alias-font-family-ko);
-    --spectrum-font-family-ja: var(--spectrum-alias-font-family-ja);
-    --spectrum-font-family-han: var(--spectrum-alias-font-family-zh);
-    --spectrum-font-family-zhhant: var(--spectrum-alias-font-family-zh);
-    --spectrum-text-size: var(--spectrum-alias-font-size-default);
-    --spectrum-text-body-line-height: var(--spectrum-alias-line-height-medium);
-    --spectrum-text-size-text-label: var(--spectrum-label-text-size);
-    --spectrum-line-height-text-label: var(--spectrum-label-text-line-height);
-}
-:host,
-:root {
-    font-family: var(--spectrum-font-family-base);
-    font-size: var(--spectrum-text-size);
+    font-family: var(--spectrum-alias-body-text-font-family);
+    font-size: var(--spectrum-alias-font-size-default);
 }
 :host:lang(ar),
 :root:lang(ar) {
-    font-family: var(--spectrum-font-family-ar);
+    font-family: var(--spectrum-alias-font-family-ar);
 }
 :host:lang(he),
 :root:lang(he) {
-    font-family: var(--spectrum-font-family-he);
+    font-family: var(--spectrum-alias-font-family-he);
 }
 :host:lang(zh-Hans),
 :root:lang(zh-Hans) {
-    font-family: var(--spectrum-font-family-zhhans);
-}
-:host:lang(zh-Hant),
-:root:lang(zh-Hant) {
-    font-family: var(--spectrum-font-family-zhhant);
+    font-family: var(--spectrum-alias-font-family-zhhans);
 }
 :host:lang(zh),
-:root:lang(zh) {
-    font-family: var(--spectrum-font-family-zh);
+:host:lang(zh-Hant),
+:root:lang(zh),
+:root:lang(zh-Hant) {
+    font-family: var(--spectrum-alias-font-family-zh);
 }
 :host:lang(ko),
 :root:lang(ko) {
-    font-family: var(--spectrum-font-family-ko);
+    font-family: var(--spectrum-alias-font-family-ko);
 }
 :host:lang(ja),
 :root:lang(ja) {
-    font-family: var(--spectrum-font-family-ja);
+    font-family: var(--spectrum-alias-font-family-ja);
 }
 /* stylelint-enable */

--- a/scripts/spectrum-vars.js
+++ b/scripts/spectrum-vars.js
@@ -194,14 +194,21 @@ cores.forEach(async (core) => {
 
         // fonts.css (2 sources so a little tricky)
         {
-            const srcPath1 = path.join(commonsPath, 'fonts.css');
+            // const srcPath1 = path.join(commonsPath, 'fonts.css');
             const srcPath2 = path.join(typographyPath, 'font.css');
             const dstPath = path.resolve(
                 path.join(__dirname, '..', 'packages', 'styles', 'fonts.css')
             );
             console.log(`processing fonts from commons & typography`);
             processes.push(
-                processMultiSourceCSS([srcPath1, srcPath2], dstPath, ':root ')
+                processMultiSourceCSS(
+                    [
+                        // srcPath1,
+                        srcPath2,
+                    ],
+                    dstPath,
+                    ':root '
+                )
             );
         }
     }


### PR DESCRIPTION
## Description
When we point component root style to a `shadowSelector` in `spectrum-config.js` it is possible that CSS Custom Properties meant for the root of an element get pointed to a child element making it impossible to customize or override them from the outside. This alters our process scripts to ensure that those definitions get moved to the actual `:host` allowing for customization. Here I've added an `sp-picker[style="width: 400px;"]` element to the storybook/visual regression suite to ensure this stays possible going foward.

## Related Issue
fixes #1155

## Motivation and Context
Style customization should be addressable without heroic intervention.

## How Has This Been Tested?
- manually
- storybook
- VRT

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/109510643-448dc680-7a70-11eb-824d-5363b98ffb33.png)

## Types of changes
- [x] Build tool expansion

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
