### PR TITLE
refactor: use registered icons elements for performance and bundling benefits

### DIFF
--- a/packages/accordion/src/AccordionItem.ts
+++ b/packages/accordion/src/AccordionItem.ts
@@ -19,8 +19,7 @@ import {
     ifDefined,
 } from '@spectrum-web-components/base';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
-import '@spectrum-web-components/icon/sp-icon.js';
-import { Chevron100Icon } from '@spectrum-web-components/icons-ui';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron100.js';
 import chevronIconStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
 
 import styles from './accordion-item.css.js';
@@ -97,9 +96,10 @@ export class AccordionItem extends Focusable {
                 >
                     ${this.label}
                 </button>
-                <sp-icon id="indicator" class="spectrum-UIIcon-ChevronRight100">
-                    ${Chevron100Icon()}
-                </sp-icon>
+                <sp-icon-chevron100
+                    id="indicator"
+                    class="spectrum-UIIcon-ChevronRight100"
+                ></sp-icon-chevron100>
             </h3>
             <div id="content" role="region" aria-labelledby="header">
                 <slot></slot>

--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -21,9 +21,8 @@ import {
 } from '@spectrum-web-components/base';
 import { ButtonBase } from '@spectrum-web-components/button';
 import buttonStyles from './action-button.css.js';
-import '@spectrum-web-components/icon/sp-icon.js';
 import cornerTriangleStyles from '@spectrum-web-components/icon/src/spectrum-icon-corner-triangle.css.js';
-import { CornerTriangle300Icon } from '@spectrum-web-components/icons-ui';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-corner-triangle300.js';
 
 const holdAffordanceClass = {
     s: 'spectrum-UIIcon-CornerTriangle75',
@@ -179,14 +178,12 @@ export class ActionButton extends SizedMixin(ButtonBase) {
         const buttonContent = super.buttonContent;
         if (this.holdAffordance) {
             buttonContent.unshift(html`
-                <sp-icon
+                <sp-icon-corner-triangle300
                     id="hold-affordance"
                     class="${holdAffordanceClass[
                         this.size as ActionButtonSize
                     ]}"
-                >
-                    ${CornerTriangle300Icon()}
-                </sp-icon>
+                ></sp-icon-corner-triangle300>
             `);
         }
         return buttonContent;

--- a/packages/action-menu/src/action-menu.css
+++ b/packages/action-menu/src/action-menu.css
@@ -37,7 +37,7 @@ governing permissions and limitations under the License.
 }
 
 :host([dir='ltr']) ::slotted([slot='icon']),
-:host([dir='ltr']) sp-icon {
+:host([dir='ltr']) .icon {
     /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon */
     margin-left: calc(
         -1 * (var(--spectrum-actionbutton-textonly-padding-left-adjusted) -
@@ -45,7 +45,7 @@ governing permissions and limitations under the License.
     );
 }
 :host([dir='rtl']) ::slotted([slot='icon']),
-:host([dir='rtl']) sp-icon {
+:host([dir='rtl']) .icon {
     /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon */
     margin-right: calc(
         -1 * (var(--spectrum-actionbutton-textonly-padding-left-adjusted) -
@@ -54,7 +54,7 @@ governing permissions and limitations under the License.
 }
 
 :host([dir]) slot[icon-only]::slotted([slot='icon']),
-:host([dir]) slot[icon-only] sp-icon {
+:host([dir]) slot[icon-only] .icon {
     /* .spectrum-ActionButton .spectrum-ActionButton-hold+.spectrum-Icon,
    * .spectrum-ActionButton .spectrum-Icon:only-child */
     margin-left: calc(

--- a/packages/base/src/sizedMixin.ts
+++ b/packages/base/src/sizedMixin.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { UpdatingElement, property, PropertyValues } from './index.js';
+import { UpdatingElement, property, PropertyValues } from 'lit-element';
 
 type Constructor<T = Record<string, unknown>> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/button/src/ClearButton.ts
+++ b/packages/button/src/ClearButton.ts
@@ -18,7 +18,7 @@ import {
 } from '@spectrum-web-components/base';
 import { ButtonBase } from './ButtonBase.js';
 import buttonStyles from './clear-button.css.js';
-import { Cross75Icon } from '@spectrum-web-components/icons-ui';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross75.js';
 import crossMediumStyles from '@spectrum-web-components/icon/src/spectrum-icon-cross.css.js';
 
 export class ClearButton extends ButtonBase {
@@ -35,9 +35,10 @@ export class ClearButton extends ButtonBase {
     protected get buttonContent(): TemplateResult[] {
         return [
             html`
-                <sp-icon slot="icon" class="icon spectrum-UIIcon-Cross75">
-                    ${Cross75Icon()}
-                </sp-icon>
+                <sp-icon-cross75
+                    slot="icon"
+                    class="icon spectrum-UIIcon-Cross75"
+                ></sp-icon-cross75>
             `,
         ];
     }

--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -20,47 +20,70 @@ import {
     ElementSize,
 } from '@spectrum-web-components/base';
 import { CheckboxBase } from './CheckboxBase.js';
-import '@spectrum-web-components/icon/sp-icon.js';
-import {
-    Checkmark75Icon,
-    Checkmark100Icon,
-    Checkmark200Icon,
-    Checkmark300Icon,
-    Dash75Icon,
-    Dash100Icon,
-    Dash200Icon,
-    Dash300Icon,
-} from '@spectrum-web-components/icons-ui';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-dash300.js';
 import checkboxStyles from './checkbox.css.js';
 import checkmarkSmallStyles from '@spectrum-web-components/icon/src/spectrum-icon-checkmark.css.js';
 import dashSmallStyles from '@spectrum-web-components/icon/src/spectrum-icon-dash.css.js';
 
-const checkmarkClass = {
-    s: 'spectrum-UIIcon-Checkmark75',
-    m: 'spectrum-UIIcon-Checkmark100',
-    l: 'spectrum-UIIcon-Checkmark200',
-    xl: 'spectrum-UIIcon-Checkmark300',
-};
-
 const checkmarkIcon = {
-    s: Checkmark75Icon,
-    m: Checkmark100Icon,
-    l: Checkmark200Icon,
-    xl: Checkmark300Icon,
-};
-
-const dashClass = {
-    s: 'spectrum-UIIcon-Dash75',
-    m: 'spectrum-UIIcon-Dash100',
-    l: 'spectrum-UIIcon-Dash200',
-    xl: 'spectrum-UIIcon-Dash300',
+    s: html`
+        <sp-icon-checkmark75
+            id="checkmark"
+            class="spectrum-UIIcon-Checkmark75"
+        ></sp-icon-checkmark75>
+    `,
+    m: html`
+        <sp-icon-checkmark100
+            id="checkmark"
+            class="spectrum-UIIcon-Checkmark100"
+        ></sp-icon-checkmark100>
+    `,
+    l: html`
+        <sp-icon-checkmark200
+            id="checkmark"
+            class="spectrum-UIIcon-Checkmark200"
+        ></sp-icon-checkmark200>
+    `,
+    xl: html`
+        <sp-icon-checkmark300
+            id="checkmark"
+            class="spectrum-UIIcon-Checkmark300"
+        ></sp-icon-checkmark300>
+    `,
 };
 
 const dashIcon = {
-    s: Dash75Icon,
-    m: Dash100Icon,
-    l: Dash200Icon,
-    xl: Dash300Icon,
+    s: html`
+        <sp-icon-dash75
+            id="partialCheckmark"
+            class="spectrum-UIIcon-Dash75"
+        ></sp-icon-dash75>
+    `,
+    m: html`
+        <sp-icon-dash100
+            id="partialCheckmark"
+            class="spectrum-UIIcon-Dash100"
+        ></sp-icon-dash100>
+    `,
+    l: html`
+        <sp-icon-dash200
+            id="partialCheckmark"
+            class="spectrum-UIIcon-Dash200"
+        ></sp-icon-dash200>
+    `,
+    xl: html`
+        <sp-icon-dash300
+            id="partialCheckmark"
+            class="spectrum-UIIcon-Dash300"
+        ></sp-icon-dash300>
+    `,
 };
 
 type CheckboxSize = Exclude<ElementSize, 'xxl'>;
@@ -83,18 +106,8 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
         return html`
             ${super.render()}
             <span id="box">
-                <sp-icon
-                    id="checkmark"
-                    class=${checkmarkClass[this.size as CheckboxSize]}
-                >
-                    ${checkmarkIcon[this.size as CheckboxSize]()}
-                </sp-icon>
-                <sp-icon
-                    id="partialCheckmark"
-                    class=${dashClass[this.size as CheckboxSize]}
-                >
-                    ${dashIcon[this.size as CheckboxSize]()}
-                </sp-icon>
+                ${checkmarkIcon[this.size as CheckboxSize]}
+                ${dashIcon[this.size as CheckboxSize]}
             </span>
             <label id="label"><slot></slot></label>
         `;

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -25,9 +25,8 @@ import '@spectrum-web-components/divider/sp-divider.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/button-group/sp-button-group.js';
 import crossStyles from '@spectrum-web-components/icon/src/spectrum-icon-cross.css.js';
-import '@spectrum-web-components/icon/sp-icon.js';
-import { Cross500Icon } from '@spectrum-web-components/icons-ui';
-import { AlertIcon } from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross500.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import {
     ObserveSlotPresence,
     FocusVisiblePolyfillMixin,
@@ -121,9 +120,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
                 ></slot>
                 ${this.error
                     ? html`
-                          <sp-icon class="type-icon">
-                              ${AlertIcon({ hidden: true })}
-                          </sp-icon>
+                          <sp-icon-alert class="type-icon"></sp-icon-alert>
                       `
                     : html``}
                 ${this.noDivider
@@ -161,12 +158,10 @@ export class Dialog extends FocusVisiblePolyfillMixin(
                               size="m"
                               @click=${this.close}
                           >
-                              <sp-icon
+                              <sp-icon-cross500
                                   class="spectrum-UIIcon-Cross500"
                                   slot="icon"
-                              >
-                                  ${Cross500Icon()}
-                              </sp-icon>
+                              ></sp-icon-cross500>
                           </sp-action-button>
                       `
                     : html``}

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -20,8 +20,7 @@ import {
     SizedMixin,
 } from '@spectrum-web-components/base';
 import type { Focusable } from '@spectrum-web-components/shared';
-import { Asterisk100Icon } from '@spectrum-web-components/icons-ui';
-import '@spectrum-web-components/icon/sp-icon.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-asterisk100.js';
 import asteriskIconStyles from '@spectrum-web-components/icon/src/spectrum-icon-asterisk.css.js';
 
 import styles from './field-label.css.js';
@@ -102,11 +101,9 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
                 <slot></slot>
                 ${this.required
                     ? html`
-                          <sp-icon
+                          <sp-icon-asterisk100
                               class="requiredIcon spectrum-UIIcon-Asterisk100"
-                          >
-                              ${Asterisk100Icon()}
-                          </sp-icon>
+                          ></sp-icon-asterisk100>
                       `
                     : html``}
             </label>

--- a/packages/field-label/stories/field-label.stories.ts
+++ b/packages/field-label/stories/field-label.stories.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import { html, TemplateResult } from '@spectrum-web-components/base';
 import '@spectrum-web-components/textfield/sp-textfield.js';
+import '@spectrum-web-components/picker/sp-picker.js';
 
 import '../sp-field-label.js';
 

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -18,8 +18,7 @@ import {
     PropertyValues,
 } from '@spectrum-web-components/base';
 
-import '@spectrum-web-components/icon/sp-icon.js';
-import { Checkmark100Icon } from '@spectrum-web-components/icons-ui';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark100.js';
 import { ActionButton } from '@spectrum-web-components/action-button';
 
 import menuItemStyles from './menu-item.css.js';
@@ -68,15 +67,23 @@ export class MenuItem extends ActionButton {
         const content = super.buttonContent;
         if (this.selected) {
             content.push(html`
-                <sp-icon
+                <sp-icon-checkmark100
                     id="selected"
                     class="spectrum-UIIcon-Checkmark100 icon"
-                >
-                    ${Checkmark100Icon()}
-                </sp-icon>
+                ></sp-icon-checkmark100>
             `);
         }
         return content;
+    }
+
+    public renderAnchor(): TemplateResult {
+        return html`
+            ${this.buttonContent}
+            ${super.renderAnchor({
+                id: 'button',
+                className: 'button anchor hidden',
+            })}
+        `;
     }
 
     protected renderButton(): TemplateResult {

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -27,8 +27,7 @@ import pickerStyles from './picker.css.js';
 import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
 
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
-import '@spectrum-web-components/icon/sp-icon.js';
-import { Chevron100Icon } from '@spectrum-web-components/icons-ui';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron100.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import {
     MenuItem,
@@ -318,11 +317,9 @@ export class PickerBase extends SizedMixin(Focusable) {
                           <sp-icon-alert class="validationIcon"></sp-icon-alert>
                       `
                     : nothing}
-                <sp-icon
+                <sp-icon-chevron100
                     class="icon picker ${chevronClass[this.size as PickerSize]}"
-                >
-                    ${Chevron100Icon()}
-                </sp-icon>
+                ></sp-icon-chevron100>
             `,
         ];
     }

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -22,8 +22,7 @@ import {
 
 import { Textfield } from '@spectrum-web-components/textfield';
 import '@spectrum-web-components/button/sp-clear-button.js';
-import '@spectrum-web-components/icon/sp-icon.js';
-import { MagnifyIcon } from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 
 import searchStyles from './search.css.js';
 
@@ -99,9 +98,9 @@ export class Search extends Textfield {
                 @reset=${this.reset}
                 @keydown=${this.handleKeydown}
             >
-                <sp-icon class="icon magnifier icon-workflow">
-                    ${MagnifyIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-magnify
+                    class="icon magnifier icon-workflow"
+                ></sp-icon-magnify>
                 ${super.render()}
                 ${this.value
                     ? html`

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -22,12 +22,12 @@ import {
     ElementSize,
 } from '@spectrum-web-components/base';
 
+import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/button/sp-button.js';
-import '@spectrum-web-components/icon/sp-icon.js';
 import { ButtonVariants } from '@spectrum-web-components/button';
 import { PickerBase } from '@spectrum-web-components/picker';
-import { Chevron100Icon } from '@spectrum-web-components/icons-ui';
-import { MoreIcon } from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron100.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-more.js';
 import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
 import styles from './split-button.css.js';
 
@@ -142,15 +142,17 @@ export class SplitButton extends SizedMixin(PickerBase) {
                     variant=${this.variant}
                     size=${this.size}
                 >
-                    <sp-icon
-                        class="icon ${this.type === 'field'
-                            ? chevronClass[this.size as SplitButtonSize]
-                            : ''}"
-                    >
-                        ${this.type === 'field'
-                            ? Chevron100Icon()
-                            : MoreIcon({ hidden: true })}
-                    </sp-icon>
+                    ${this.type === 'field'
+                        ? html`
+                              <sp-icon-chevron100
+                                  class="icon ${chevronClass[
+                                      this.size as SplitButtonSize
+                                  ]}"
+                              ></sp-icon-chevron100>
+                          `
+                        : html`
+                              <sp-icon-more class="icon"></sp-icon-more>
+                          `}
                 </sp-button>
             `,
         ];

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -23,9 +23,8 @@ import {
 } from '@spectrum-web-components/base';
 
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
-import '@spectrum-web-components/icon/sp-icon.js';
-import { Checkmark100Icon } from '@spectrum-web-components/icons-ui';
-import { AlertIcon } from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark100.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 
 import textfieldStyles from './textfield.css.js';
 import checkmarkStyles from '@spectrum-web-components/icon/src/spectrum-icon-checkmark.css.js';
@@ -131,15 +130,14 @@ export class Textfield extends Focusable {
     protected renderStateIcons(): TemplateResult | typeof nothing {
         if (this.invalid) {
             return html`
-                <sp-icon id="invalid" class="icon">
-                    ${AlertIcon()}
-                </sp-icon>
+                <sp-icon-alert id="invalid" class="icon"></sp-icon-alert>
             `;
         } else if (this.valid) {
             return html`
-                <sp-icon id="valid" class="icon spectrum-UIIcon-Checkmark100">
-                    ${Checkmark100Icon()}
-                </sp-icon>
+                <sp-icon-checkmark100
+                    id="valid"
+                    class="icon spectrum-UIIcon-Checkmark100"
+                ></sp-icon-checkmark100>
             `;
         }
         return nothing;

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -19,12 +19,9 @@ import {
     PropertyValues,
 } from '@spectrum-web-components/base';
 import '@spectrum-web-components/button/sp-clear-button.js';
-import '@spectrum-web-components/icon/sp-icon.js';
-import {
-    AlertIcon,
-    InfoIcon,
-    CheckmarkCircleIcon,
-} from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark-circle.js';
 
 import toastStyles from './toast.css.js';
 
@@ -105,32 +102,31 @@ export class Toast extends SpectrumElement {
     private _variant: ToastVariants = '';
 
     private renderIcon(variant: string): TemplateResult {
-        let label = '';
-        let icon;
         switch (variant) {
             case 'info':
-                label = 'Information';
-                icon = InfoIcon;
-                break;
+                return html`
+                    <sp-icon-info
+                        label="Information"
+                        class="type"
+                    ></sp-icon-info>
+                `;
             case 'negative':
             case 'error': // deprecated
             case 'warning': // deprecated
-                label = 'Error';
-                icon = AlertIcon;
-                break;
+                return html`
+                    <sp-icon-alert label="Error" class="type"></sp-icon-alert>
+                `;
             case 'positive':
             case 'success': // deprecated
-                label = 'Success';
-                icon = CheckmarkCircleIcon;
-                break;
+                return html`
+                    <sp-icon-checkmark-circle
+                        label="Success"
+                        class="type"
+                    ></sp-icon-checkmark-circle>
+                `;
             default:
                 return html``;
         }
-        return html`
-            <sp-icon class="type" label=${label}>
-                ${icon({ hidden: true })}
-            </sp-icon>
-        `;
     }
 
     private countdownStart = 0;


### PR DESCRIPTION
## Description
Prefer the tested performance benefits of `<sp-icon-*>` elements over `<sp-icon>${Icon()}></sp-icon>` benefits.

This approach also allows for module based as opposed to tree shake based bundling for smaller builds.

## Motivation and Context
Smaller, faster, easier.

## How Has This Been Tested?
Passes the visual regression!

## Types of changes
- [x] Refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
