### PR TITLE
[SplitView] Correct calculation of height when using primary-size='auto'

### DIFF
--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -18,7 +18,7 @@
         "lit-element",
         "lit-html"
     ],
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "",
     "main": "src/index.js",
     "module": "src/index.js",

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -18,7 +18,7 @@
         "lit-element",
         "lit-html"
     ],
-    "version": "0.1.1",
+    "version": "0.1.0",
     "description": "",
     "main": "src/index.js",
     "module": "src/index.js",

--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -377,9 +377,9 @@ export class SplitView extends SpectrumElement {
                 const size = window
                     .getComputedStyle(firstEl)
                     .getPropertyValue(this.vertical ? 'height' : 'width');
-                const size_i = parseInt(size, 10);
+                const size_i = parseFloat(size);
                 if (!isNaN(size_i)) {
-                    return this.getLimitedPosition(size_i);
+                    return this.getLimitedPosition(Math.ceil(size_i));
                 }
             }
         }


### PR DESCRIPTION
## Description

This PR fix the calculation of initial height of primary panel when using primary-size="auto".
It replaces the parseInt function by parseFloat and rounding it up to the next full pixel value to prevent shrinking the initial height of the primary panel.

## Related Issue

https://github.com/adobe/spectrum-web-components/issues/1243

## Motivation and Context

it solves the problem of current client experiencing a shrink of initial height when adding a second panel and using the attribute `primary-size="auto"`. It leads to display scrollbars where in that use case it shouldn't be displayed of the first panel content. 

## How Has This Been Tested?

Visual testing, correct behavior already in local installation of the package to verify correct solution.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
