### PR TITLE
Expand overlay stack support of sizing and modal "groups"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 5af92d758864b164ed594bfa3628c9192800a3af
+        default: c9c170a484ae18dbeb421e4a9c4548a68f61d823
 commands:
     downstream:
         steps:

--- a/packages/modal/src/modal.css
+++ b/packages/modal/src/modal.css
@@ -12,3 +12,9 @@ governing permissions and limitations under the License.
 
 @import './spectrum-modal-wrapper.css';
 @import './spectrum-modal.css';
+
+:host {
+    /* 0 * 1px is a hack for the linter. It wants no units on 0, but units are needed for calc() */
+    width: calc(100vw - var(--swc-body-margins-inline, 0 * 1px));
+    height: calc(100vh - var(--swc-body-margins-block, 0 * 1px));
+}

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -37,8 +37,8 @@ import overlayTriggerStyles from './overlay-trigger.css.js';
  * @slot click-content - The content that will be displayed on click
  * @slot longpress-content - The content that will be displayed on click
  *
- * @fires sp-open - Announces that the overlay has been opened
- * @fires sp-close - Announces that the overlay has been closed
+ * @fires sp-opened - Announces that the overlay has been opened
+ * @fires sp-closed - Announces that the overlay has been closed
  */
 export class OverlayTrigger extends LitElement {
     private closeClickOverlay?: () => void;

--- a/packages/overlay/src/active-overlay.css
+++ b/packages/overlay/src/active-overlay.css
@@ -45,8 +45,14 @@ governing permissions and limitations under the License.
     outline: none;
 }
 
+:host([placement='none']) {
+    top: 0;
+    left: 0;
+}
+
 :host([placement='none']) ::slotted(*) {
-    height: 100vh;
+    /* 0 * 1px is a hack for the linter. It wants no units on 0, but units are needed for calc() */
+    height: calc(100vh - var(--swc-body-margins-block, 0 * 1px));
 }
 
 sp-theme,

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -11,13 +11,15 @@ governing permissions and limitations under the License.
 import { html, number, select, radios } from '@open-wc/demoing-storybook';
 import { TemplateResult } from '@spectrum-web-components/base';
 
-import { Placement } from '../';
+import { OverlayTrigger, Placement } from '../';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
 import { DialogWrapper } from '@spectrum-web-components/dialog';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
+import { Picker } from '@spectrum-web-components/picker';
+import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/slider/sp-slider.js';
 import '@spectrum-web-components/radio/sp-radio.js';
@@ -482,6 +484,114 @@ export const longpress = (): TemplateResult => {
                         <sp-icon-magnify slot="icon"></sp-icon-magnify>
                     </sp-action-button>
                 </sp-action-group>
+            </sp-popover>
+        </overlay-trigger>
+    `;
+};
+
+export const complexModal = (): TemplateResult => {
+    requestAnimationFrame(async () => {
+        const overlay = document.querySelector(
+            `overlay-trigger`
+        ) as OverlayTrigger;
+        const trigger = (overlay.shadowRoot as ShadowRoot).querySelector(
+            '#trigger'
+        ) as HTMLElement;
+        trigger.addEventListener('sp-opened', () => {
+            requestAnimationFrame(() => {
+                const picker = document.querySelector('#test-picker') as Picker;
+                picker.open = true;
+            });
+        });
+        trigger.click();
+    });
+    return html`
+        <style>
+            body {
+                --swc-margin-test: 10px;
+                margin: var(--swc-margin-test);
+            }
+            sp-story-decorator::part(container) {
+                min-height: calc(100vh - (2 * var(--swc-margin-test)));
+                padding: 0;
+                display: grid;
+                place-content: center;
+            }
+            active-overlay > * {
+                --spectrum-global-animation-duration-100: 0ms;
+                --spectrum-global-animation-duration-200: 0ms;
+                --spectrum-global-animation-duration-300: 0ms;
+                --spectrum-global-animation-duration-400: 0ms;
+                --spectrum-global-animation-duration-500: 0ms;
+                --spectrum-global-animation-duration-600: 0ms;
+                --spectrum-global-animation-duration-700: 0ms;
+                --spectrum-global-animation-duration-800: 0ms;
+                --spectrum-global-animation-duration-900: 0ms;
+                --spectrum-global-animation-duration-1000: 0ms;
+                --spectrum-global-animation-duration-2000: 0ms;
+                --spectrum-global-animation-duration-4000: 0ms;
+                --spectrum-coachmark-animation-indicator-ring-duration: 0ms;
+            }
+        </style>
+        <overlay-trigger type="modal" placement="none">
+            <sp-dialog-wrapper
+                slot="click-content"
+                headline="Dialog title"
+                dismissable
+                underlay
+                footer="Content for footer"
+            >
+                <sp-picker id="test-picker">
+                    <sp-menu>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item>Select inverse</sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save selection</sp-menu-item>
+                        <sp-menu-item disabled>Make work path</sp-menu-item>
+                    </sp-menu>
+                </sp-picker>
+            </sp-dialog-wrapper>
+            <sp-button slot="trigger" variant="primary">
+                Toggle Dialog
+            </sp-button>
+        </overlay-trigger>
+    `;
+};
+
+export const superComplexModal = (): TemplateResult => {
+    return html`
+        <overlay-trigger type="modal" placement="none">
+            <sp-button slot="trigger" variant="cta">Toggle Dialog</sp-button>
+            <sp-popover dialog slot="click-content">
+                <overlay-trigger>
+                    <sp-button slot="trigger" variant="primary">
+                        Toggle Dialog
+                    </sp-button>
+                    <sp-popover dialog slot="click-content">
+                        <overlay-trigger type="modal">
+                            <sp-button slot="trigger" variant="secondary">
+                                Toggle Dialog
+                            </sp-button>
+                            <sp-popover dialog slot="click-content">
+                                <p>
+                                    When you get this deep, this ActiveOverlay
+                                    should be the only one in [slot="open"].
+                                </p>
+                                <p>
+                                    All of the rest of the ActiveOverlay
+                                    elements should have had their [slot]
+                                    attribute removed.
+                                </p>
+                                <p>
+                                    Closing this ActiveOverlay should replace
+                                    them...
+                                </p>
+                            </sp-popover>
+                        </overlay-trigger>
+                    </sp-popover>
+                </overlay-trigger>
             </sp-popover>
         </overlay-trigger>
     `;


### PR DESCRIPTION
## Description
- take `body { margin: X }` into account when calculating the size of content in not the top layer of the overlay stack
  - add a visual regression test for this
- realize that any one `type="modal"` overlay creates a sub-group in the stack that must be handled similarly
  - add a unit test for this 

## Related Issue
fixes #1234

## Motivation and Context
The overlay stack should be resilient to many application contexts.

## How Has This Been Tested?
- manuall
- visual regression additions
- unit test additions

## Screenshots (if appropriate):
![complexModal-light](https://user-images.githubusercontent.com/1156657/109831314-4e98fc00-7c0d-11eb-9e7a-5980bfb5fff5.png)
![complexModal-dark](https://user-images.githubusercontent.com/1156657/109831325-5193ec80-7c0d-11eb-90a8-a581afed776e.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
