### PR TITLE
fix(action-group): support ActionButtons that are not direct children

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c9c170a484ae18dbeb421e4a9c4548a68f61d823
+        default: 2c46934df99e551733a0c38569216c6b1331eac4
 commands:
     downstream:
         steps:

--- a/packages/action-bar/stories/action-bar.stories.ts
+++ b/packages/action-bar/stories/action-bar.stories.ts
@@ -31,10 +31,10 @@ export const Default = (): TemplateResult => {
             <sp-checkbox indeterminate>228 Selected</sp-checkbox>
             <sp-action-group quiet>
                 <sp-action-button>
-                    <sp-icon-edit slot="icon"></sp-icon-edit>
+                    <sp-icon-edit slot="icon" label="Edit"></sp-icon-edit>
                 </sp-action-button>
                 <sp-action-button>
-                    <sp-icon-more slot="icon"></sp-icon-more>
+                    <sp-icon-more slot="icon" label="More"></sp-icon-more>
                 </sp-action-button>
             </sp-action-group>
         </sp-action-bar>

--- a/packages/action-group/stories/action-group.stories.ts
+++ b/packages/action-group/stories/action-group.stories.ts
@@ -14,12 +14,11 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '../sp-action-group.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
-import '@spectrum-web-components/icon/sp-icon.js';
-import {
-    PropertiesIcon,
-    InfoIcon,
-    ViewAllTagsIcon,
-} from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-properties.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-view-all-tags.js';
 import { ActionGroup } from '../src/ActionGroup.js';
 
 export default {
@@ -58,6 +57,43 @@ export const selectsSingle = (): TemplateResult => {
     `;
 };
 
+export const selectsSingleWithTooltips = (): TemplateResult => {
+    return html`
+        <sp-action-group
+            label="Favorite Color"
+            selects="single"
+            @change=${({ target }: Event & { target: ActionGroup }) => {
+                const next = target.nextElementSibling as HTMLDivElement;
+                next.textContent = `Selected: ${JSON.stringify(
+                    target.selected
+                )}`;
+            }}
+        >
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Red</sp-action-button>
+                <sp-tooltip slot="hover-content">
+                    This is a cool color.
+                </sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Green</sp-action-button>
+                <sp-tooltip slot="hover-content">
+                    You wouldn't be wrong.
+                </sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Blue</sp-action-button>
+                <sp-tooltip slot="hover-content">The sky in spring.</sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Yellow</sp-action-button>
+                <sp-tooltip slot="hover-content">The sun at noon.</sp-tooltip>
+            </overlay-trigger>
+        </sp-action-group>
+        <div>Selected:</div>
+    `;
+};
+
 export const selectsMultiple = (): TemplateResult => {
     return html`
         <sp-action-group
@@ -80,23 +116,54 @@ export const selectsMultiple = (): TemplateResult => {
     `;
 };
 
+export const selectsMultipleWithTooltips = (): TemplateResult => {
+    return html`
+        <sp-action-group
+            label="Favorite Color"
+            selects="multiple"
+            @change=${({ target }: Event & { target: ActionGroup }) => {
+                const next = target.nextElementSibling as HTMLDivElement;
+                next.textContent = `Selected: ${JSON.stringify(
+                    target.selected
+                )}`;
+            }}
+        >
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Red</sp-action-button>
+                <sp-tooltip slot="hover-content">
+                    This is a cool color.
+                </sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Green</sp-action-button>
+                <sp-tooltip slot="hover-content">
+                    You wouldn't be wrong.
+                </sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Blue</sp-action-button>
+                <sp-tooltip slot="hover-content">The sky in spring.</sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Yellow</sp-action-button>
+                <sp-tooltip slot="hover-content">The sun at noon.</sp-tooltip>
+            </overlay-trigger>
+        </sp-action-group>
+        <div>Selected:</div>
+    `;
+};
+
 export const iconsOnly = (): TemplateResult => {
     return html`
         <sp-action-group>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -106,19 +173,13 @@ export const quietIconsOnly = (): TemplateResult => {
     return html`
         <sp-action-group quiet>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -138,19 +199,13 @@ export const compactIconsOnly = (): TemplateResult => {
     return html`
         <sp-action-group compact>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -160,19 +215,13 @@ export const compactQuietIconsOnly = (): TemplateResult => {
     return html`
         <sp-action-group compact quiet>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -192,19 +241,13 @@ export const iconsOnlyVertical = (): TemplateResult => {
     return html`
         <sp-action-group vertical>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -214,19 +257,13 @@ export const quietIconsOnlyVertical = (): TemplateResult => {
     return html`
         <sp-action-group vertical quiet>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -246,19 +283,13 @@ export const compactIconsOnlyVertical = (): TemplateResult => {
     return html`
         <sp-action-group vertical compact>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -268,19 +299,13 @@ export const compactQuietIconsOnlyVertical = (): TemplateResult => {
     return html`
         <sp-action-group vertical compact quiet>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -300,19 +325,13 @@ export const iconsOnlyJustified = (): TemplateResult => {
     return html`
         <sp-action-group justified>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;
@@ -322,19 +341,13 @@ export const compactIconsOnlyJustified = (): TemplateResult => {
     return html`
         <sp-action-group compact justified>
             <sp-action-button label="Properties">
-                <sp-icon slot="icon">
-                    ${PropertiesIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-properties slot="icon"></sp-icon-properties>
             </sp-action-button>
             <sp-action-button label="Info">
-                <sp-icon slot="icon">
-                    ${InfoIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-info slot="icon"></sp-icon-info>
             </sp-action-button>
             <sp-action-button label="View All Tags">
-                <sp-icon slot="icon">
-                    ${ViewAllTagsIcon({ hidden: true })}
-                </sp-icon>
+                <sp-icon-view-all-tags slot="icon"></sp-icon-view-all-tags>
             </sp-action-button>
         </sp-action-group>
     `;

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -20,6 +20,8 @@ import {
 
 import { ActionButton } from '@spectrum-web-components/action-button';
 import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import { ActionGroup } from '..';
 import {
     arrowDownEvent,
@@ -298,16 +300,7 @@ describe('ActionGroup', () => {
         expect(!thirdElement.selected, 'third child not selected');
         expect(el.selected.length).to.equal(0);
     });
-    it('accepts keybord input', async () => {
-        const el = await fixture<ActionGroup>(
-            html`
-                <sp-action-group label="Selects Single Group" selects="single">
-                    <sp-action-button>First</sp-action-button>
-                    <sp-action-button selected>Second</sp-action-button>
-                    <sp-action-button class="third">Third</sp-action-button>
-                </sp-action-group>
-            `
-        );
+    const acceptKeyboardInput = async (el: ActionGroup) => {
         const thirdElement = el.querySelector('.third') as ActionButton;
 
         await elementUpdated(el);
@@ -363,6 +356,49 @@ describe('ActionGroup', () => {
 
         expect(el.selected.length === 1);
         expect(el.selected.includes('Second'));
+    };
+    it('accepts keybord input', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Selects Single Group" selects="single">
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button selected>Second</sp-action-button>
+                    <sp-action-button class="third">Third</sp-action-button>
+                </sp-action-group>
+            `
+        );
+        await acceptKeyboardInput(el);
+    });
+    it('accepts keybord input with tooltip', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group label="Selects Single Group" selects="single">
+                    <overlay-trigger>
+                        <sp-action-button slot="trigger">
+                            First
+                        </sp-action-button>
+                        <sp-tooltip slot="hover-content">
+                            Definitely the first one.
+                        </sp-tooltip>
+                    </overlay-trigger>
+                    <overlay-trigger>
+                        <sp-action-button slot="trigger" selected>
+                            Second
+                        </sp-action-button>
+                        <sp-tooltip slot="hover-content">
+                            Not the first, not the last.
+                        </sp-tooltip>
+                    </overlay-trigger>
+                    <overlay-trigger>
+                        <sp-action-button slot="trigger" class="third">
+                            Third
+                        </sp-action-button>
+                        <sp-tooltip slot="hover-content">Select me.</sp-tooltip>
+                    </overlay-trigger>
+                </sp-action-group>
+            `
+        );
+        await acceptKeyboardInput(el);
     });
     it('accepts keybord input when [dir="ltr"]', async () => {
         const el = await fixture<ActionGroup>(
@@ -468,16 +504,3 @@ describe('ActionGroup', () => {
         expect(activeElement === secondElement);
     });
 });
-
-// action with [selected] by default
-// action with [selected] applied
-// action without [selected] clicked
-// group with `selected.length` by default
-// group with `selected.length` applied
-// group with [selects="one"] with `select.length > 1` by default
-// group with [selects="one"] with `select.length > 1` applied
-// tabIndex=-1 managed when tabbing past
-// tabIndex=-1 managed when using arrow keys
-// tabIndex=-1 managed when clicking with "mouse"
-// tabIndex=-1 managed when clicking with "keyboard"
-// selects="multiple"


### PR DESCRIPTION
## Description
Ensure the `sp-action-group` supports `sp-action-button`s that are not direct children so that buttons with tooltips driven by `overlay-trigger` elements can be leveraged.

## Related Issue
fixes #1230

## Motivation and Context
JS errors are bad. Complex element usage is good.

## How Has This Been Tested?
Unit tests and manually in Storybook

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
