### PR TITLE
fix(bundle): bundle does not export its own custom-elements.json

### DIFF
--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -27,7 +27,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./elements": "./elements.js",
         "./elements.js": "./elements.js"


### PR DESCRIPTION
The updated `exports` syntax allows bundlers to be more strict with their processing leading to https://cdn.skypack.dev/error/build:@spectrum-web-components/bundle@v0.19.0-7h0wI9m3AxFBcDNYHbyx which is a solid point being `bundle` doesn't actual export any of it's own custom elements and won't ever include this file. 