### PR TITLE
fix: correctly delivery visuals and mouse interactions for likeAnchor and extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 6ae535fd7d55dbd19686605e4cce215c37d993d1
+        default: 0cb810756b37b517b6daa9cbbfbfcd57bd3032e7
 commands:
     downstream:
         steps:

--- a/packages/action-button/src/action-button.css
+++ b/packages/action-button/src/action-button.css
@@ -29,6 +29,11 @@ governing permissions and limitations under the License.
     flex-shrink: 0;
 }
 
+#button {
+    position: absolute;
+    inset: 0;
+}
+
 #label {
     flex-grow: var(--spectrum-actionbutton-label-flex-grow);
     text-align: var(--spectrum-actionbutton-label-text-align);

--- a/packages/action-button/stories/action-button.stories.ts
+++ b/packages/action-button/stories/action-button.stories.ts
@@ -105,6 +105,18 @@ wIconButton.story = {
     name: 'w/ Icon button',
 };
 
+export const likeAnchor = (): TemplateResult => {
+    return html`
+        <sp-action-button
+            href="https://opensource.adobe.com/spectrum-web-components"
+            target="_blank"
+        >
+            <sp-icon-edit slot="icon"></sp-icon-edit>
+            Edit the Documentation Site
+        </sp-action-button>
+    `;
+};
+
 export const iconOnlyButton = (): TemplateResult => {
     return html`
         <sp-action-button label="Edit">

--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -75,6 +75,7 @@ export class ButtonBase extends LikeAnchor(
 
     constructor() {
         super();
+        this.proxyFocus = this.proxyFocus.bind(this);
 
         this.addEventListener('click', this.handleClickCapture, {
             capture: true,
@@ -102,11 +103,16 @@ export class ButtonBase extends LikeAnchor(
         }
     }
 
+    private proxyFocus(): void {
+        this.focus();
+    }
+
     private shouldProxyClick(): boolean {
         let handled = false;
         if (this.anchorElement) {
             this.anchorElement.click();
             handled = true;
+            this.anchorElement.classList.remove('clicking');
         } else if (this.type !== 'button') {
             const proxy = document.createElement('button');
             proxy.type = this.type;
@@ -118,6 +124,16 @@ export class ButtonBase extends LikeAnchor(
         return handled;
     }
 
+    public renderAnchor(): TemplateResult {
+        return html`
+            ${this.buttonContent}
+            ${super.renderAnchor({
+                id: 'button',
+                className: 'button anchor hidden',
+            })}
+        `;
+    }
+
     protected renderButton(): TemplateResult {
         return html`
             ${this.buttonContent}
@@ -126,11 +142,7 @@ export class ButtonBase extends LikeAnchor(
 
     protected render(): TemplateResult {
         return this.href && this.href.length > 0
-            ? this.renderAnchor({
-                  id: 'button',
-                  className: 'button anchor',
-                  anchorContent: this.buttonContent,
-              })
+            ? this.renderAnchor()
             : this.renderButton();
     }
 
@@ -223,6 +235,7 @@ export class ButtonBase extends LikeAnchor(
             }
         }
         if (this.anchorElement) {
+            this.anchorElement.addEventListener('focus', this.proxyFocus);
             this.anchorElement.tabIndex = -1;
         }
     }

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -31,13 +31,8 @@ governing permissions and limitations under the License.
 }
 
 #button {
-    color: inherit;
-    text-decoration: inherit;
-    display: flex;
-}
-
-#button:focus {
-    outline: none;
+    position: absolute;
+    inset: 0;
 }
 
 :host:after {

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -76,16 +76,6 @@ export class MenuItem extends ActionButton {
         return content;
     }
 
-    public renderAnchor(): TemplateResult {
-        return html`
-            ${this.buttonContent}
-            ${super.renderAnchor({
-                id: 'button',
-                className: 'button anchor hidden',
-            })}
-        `;
-    }
-
     protected renderButton(): TemplateResult {
         return html`
             ${this.buttonContent}

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -11,3 +11,8 @@ governing permissions and limitations under the License.
 */
 
 @import './spectrum-menu-item.css';
+
+#button {
+    position: absolute;
+    inset: 0;
+}

--- a/packages/menu/stories/menu-item.stories.ts
+++ b/packages/menu/stories/menu-item.stories.ts
@@ -36,3 +36,17 @@ export const noWrap = (): TemplateResult => {
         </sp-menu>
     `;
 };
+
+export const href = (): TemplateResult => {
+    return html`
+        <sp-menu style="width: 150px;">
+            <sp-menu-item
+                href="https://opensource.adobe.com/spectrum-web-components"
+                target="_blank"
+            >
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit the Documentation Site
+            </sp-menu-item>
+        </sp-menu>
+    `;
+};


### PR DESCRIPTION
## Description
- Relocate handling for likeAnchor content in `ButtonBase` so all of it's derivatives receive the support for this style of delivery
- Enable appropriate right click response in this context
- Add visual regressions to support maintaining this going forward

## Motivation and Context
Buttons with links should look correct, while still working like links.

## How Has This Been Tested?
Manual and visual regressions.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/110480371-6c0a1200-80b4-11eb-8f02-aac4843c7b13.png)
![image](https://user-images.githubusercontent.com/1156657/110480406-762c1080-80b4-11eb-81aa-a6c0182b3d34.png)
![image](https://user-images.githubusercontent.com/1156657/110480483-893ee080-80b4-11eb-9e64-723d89eccb6e.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
