### PR TITLE
feat(picker): process field-label content for more accurate a11y tree

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 8b8bbd28de04f4ab2d1f86434be84e98a2ee92d0
+        default: 034623e8772e4e2b47ce944668fd64c422ec114a
 commands:
     downstream:
         steps:

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -35,6 +35,9 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
         return [styles, asteriskIconStyles];
     }
 
+    /**
+     * @private
+     */
     static instanceCount = 0;
 
     @property({ type: Boolean, reflect: true })

--- a/packages/menu/menu-item.md
+++ b/packages/menu/menu-item.md
@@ -43,7 +43,9 @@ When displayed as a descendent of an element that manages selection (e.g. `<sp-a
 In the following example, the selected `<sp-menu-item>` represents a `value` of `Text that is really long and useful to a visitor, but not exactly good to use in your application or component state.` for the ancestor element.
 
 ```html
+<sp-field-label for="picker-content">Value attribute usage:</sp-field-label>
 <sp-picker
+    id="picker-content"
     label="Menu items examples"
     value="Text that is really long and useful to a visitor, but not exactly good to use in your application or component state."
 >
@@ -69,7 +71,8 @@ In the following example, the selected `<sp-menu-item>` represents a `value` of 
 When the `value` attribute is leveraged, the selected `<sp-menu-item>` represents a `value` of `short-key` for the `<sp-action-menu>` element.
 
 ```html
-<sp-picker value="short-key">
+<sp-field-label for="picker-value">Value attribute usage:</sp-field-label>
+<sp-picker id="picker-value" value="short-key">
     <span slot="label">Menu items examples</span>
     <sp-menu-item value="not-selected">Not selected</sp-menu-item>
     <sp-menu-item value="short-key">

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -15,6 +15,7 @@ import '@spectrum-web-components/action-group/sp-action-group.js';
 import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
 import { DialogWrapper } from '@spectrum-web-components/dialog';
+import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { Picker } from '@spectrum-web-components/picker';
@@ -560,6 +561,9 @@ export const complexModal = (): TemplateResult => {
                 underlay
                 footer="Content for footer"
             >
+                <sp-field-label for="test-picker">
+                    Selection type:
+                </sp-field-label>
                 <sp-picker id="test-picker">
                     <sp-menu>
                         <sp-menu-item>Deselect</sp-menu-item>

--- a/packages/picker/README.md
+++ b/packages/picker/README.md
@@ -43,24 +43,32 @@ import { Picker } from '@spectrum-web-components/picker';
 
 ```html demo
 <sp-field-group>
-    <sp-picker size="s" label="Selection type">
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save selection</sp-menu-item>
-        <sp-menu-item disabled>Make work path</sp-menu-item>
-    </sp-picker>
-    <sp-picker quiet size="s" label="Selection type">
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save selection</sp-menu-item>
-        <sp-menu-item disabled>Make work path</sp-menu-item>
-    </sp-picker>
+    <div>
+        <sp-field-label for="picker-s" size="s">Selection type:</sp-field-label>
+        <sp-picker id="picker-s" size="s" label="Selection type">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save selection</sp-menu-item>
+            <sp-menu-item disabled>Make work path</sp-menu-item>
+        </sp-picker>
+    </div>
+    <div>
+        <sp-field-label for="picker-s-quiet" size="s">
+            Selection type:
+        </sp-field-label>
+        <sp-picker id="picker-s-quiet" quiet size="s" label="Selection type">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save selection</sp-menu-item>
+            <sp-menu-item disabled>Make work path</sp-menu-item>
+        </sp-picker>
+    </div>
 </sp-field-group>
 ```
 
@@ -70,24 +78,32 @@ import { Picker } from '@spectrum-web-components/picker';
 
 ```html demo
 <sp-field-group>
-    <sp-picker size="m" label="Selection type">
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save selection</sp-menu-item>
-        <sp-menu-item disabled>Make work path</sp-menu-item>
-    </sp-picker>
-    <sp-picker quiet size="m" label="Selection type">
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save selection</sp-menu-item>
-        <sp-menu-item disabled>Make work path</sp-menu-item>
-    </sp-picker>
+    <div>
+        <sp-field-label for="picker-m" size="m">Selection type:</sp-field-label>
+        <sp-picker id="picker-m" size="m" label="Selection type">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save selection</sp-menu-item>
+            <sp-menu-item disabled>Make work path</sp-menu-item>
+        </sp-picker>
+    </div>
+    <div>
+        <sp-field-label for="picker-m-quiet" size="m">
+            Selection type:
+        </sp-field-label>
+        <sp-picker id="picker-m-quiet" quiet size="m" label="Selection type">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save selection</sp-menu-item>
+            <sp-menu-item disabled>Make work path</sp-menu-item>
+        </sp-picker>
+    </div>
 </sp-field-group>
 ```
 
@@ -97,24 +113,32 @@ import { Picker } from '@spectrum-web-components/picker';
 
 ```html demo
 <sp-field-group>
-    <sp-picker size="l" label="Selection type">
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save selection</sp-menu-item>
-        <sp-menu-item disabled>Make work path</sp-menu-item>
-    </sp-picker>
-    <sp-picker quiet size="l" label="Selection type">
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save selection</sp-menu-item>
-        <sp-menu-item disabled>Make work path</sp-menu-item>
-    </sp-picker>
+    <div>
+        <sp-field-label for="picker-l" size="l">Selection type:</sp-field-label>
+        <sp-picker id="picker-l" size="l" label="Selection type">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save selection</sp-menu-item>
+            <sp-menu-item disabled>Make work path</sp-menu-item>
+        </sp-picker>
+    </div>
+    <div>
+        <sp-field-label for="picker-l-quiet" size="l">
+            Selection type:
+        </sp-field-label>
+        <sp-picker id="picker-l-quiet" quiet size="l" label="Selection type">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save selection</sp-menu-item>
+            <sp-menu-item disabled>Make work path</sp-menu-item>
+        </sp-picker>
+    </div>
 </sp-field-group>
 ```
 
@@ -124,24 +148,34 @@ import { Picker } from '@spectrum-web-components/picker';
 
 ```html demo
 <sp-field-group>
-    <sp-picker size="xl" label="Selection type">
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save selection</sp-menu-item>
-        <sp-menu-item disabled>Make work path</sp-menu-item>
-    </sp-picker>
-    <sp-picker quiet size="xl" label="Selection type">
-        <sp-menu-item>Deselect</sp-menu-item>
-        <sp-menu-item>Select inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
-        <sp-menu-item>Select and mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save selection</sp-menu-item>
-        <sp-menu-item disabled>Make work path</sp-menu-item>
-    </sp-picker>
+    <div>
+        <sp-field-label for="picker-xl" size="xl">
+            Selection type:
+        </sp-field-label>
+        <sp-picker id="picker-xl" size="xl" label="Selection type">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save selection</sp-menu-item>
+            <sp-menu-item disabled>Make work path</sp-menu-item>
+        </sp-picker>
+    </div>
+    <div>
+        <sp-field-label for="picker-xl-quiet" size="xl">
+            Selection type:
+        </sp-field-label>
+        <sp-picker id="picker-xl-quiet" quiet size="xl" label="Selection type">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save selection</sp-menu-item>
+            <sp-menu-item disabled>Make work path</sp-menu-item>
+        </sp-picker>
+    </div>
 </sp-field-group>
 ```
 
@@ -154,9 +188,11 @@ When the `value` of an `<sp-picker>` matches the `value` attribute or the trimme
 ### Matching `value`
 
 ```html
+<sp-field-label for="picker-value">Selection type:</sp-field-label>
 <sp-picker
     label="Select a Country with a very long label, too long in fact"
     value="item-2"
+    id="picker-value"
 >
     <sp-menu-item value="item-1">Deselect</sp-menu-item>
     <sp-menu-item value="item-2">Select inverse</sp-menu-item>
@@ -171,9 +207,11 @@ When the `value` of an `<sp-picker>` matches the `value` attribute or the trimme
 ### Matching `itemText`
 
 ```html
+<sp-field-label for="picker-item-text">Selection type:</sp-field-label>
 <sp-picker
     label="Select a Country with a very long label, too long in fact"
     value="Feather..."
+    id="picker-item-text"
 >
     <sp-menu-item>Deselect</sp-menu-item>
     <sp-menu-item>Select inverse</sp-menu-item>
@@ -190,10 +228,11 @@ When the `value` of an `<sp-picker>` matches the `value` attribute or the trimme
 ### Invalid
 
 ```html
-<p><strong>Standard:</strong></p>
+<sp-field-label for="picker-invalid">Standard:</sp-field-label>
 <sp-picker
     label="Select a Country with a very long label, too long in fact"
     invalid
+    id="picker-invalid"
 >
     <sp-menu-item>Deselect</sp-menu-item>
     <sp-menu-item>Select inverse</sp-menu-item>
@@ -205,11 +244,12 @@ When the `value` of an `<sp-picker>` matches the `value` attribute or the trimme
 </sp-picker>
 <br />
 <br />
-<p><strong>Quiet:</strong></p>
+<sp-field-label for="picker-invalid-quiet">Quiet:</sp-field-label>
 <sp-picker
     label="Select a Country with a very long label, too long in fact"
     invalid
     quiet
+    id="picker-invalid-quiet"
 >
     <sp-menu-item>Deselect</sp-menu-item>
     <sp-menu-item>Select inverse</sp-menu-item>
@@ -224,10 +264,11 @@ When the `value` of an `<sp-picker>` matches the `value` attribute or the trimme
 ### Disabled
 
 ```html
-<p><strong>Standard:</strong></p>
+<sp-field-label for="picker-disabled">Standard:</sp-field-label>
 <sp-picker
     label="Select a Country with a very long label, too long in fact"
     disabled
+    id="picker-disabled"
 >
     <sp-menu-item>Deselect</sp-menu-item>
     <sp-menu-item>Select inverse</sp-menu-item>
@@ -239,11 +280,12 @@ When the `value` of an `<sp-picker>` matches the `value` attribute or the trimme
 </sp-picker>
 <br />
 <br />
-<p><strong>Quiet:</strong></p>
+<sp-field-label for="picker-disabled">Quiet:</sp-field-label>
 <sp-picker
     label="Select a Country with a very long label, too long in fact"
     disabled
     quiet
+    id="picker-disabled-quiet"
 >
     <sp-menu-item>Deselect</sp-menu-item>
     <sp-menu-item>Select inverse</sp-menu-item>
@@ -257,4 +299,4 @@ When the `value` of an `<sp-picker>` matches the `value` attribute or the trimme
 
 ## Accessibility
 
-An `<sp-picker>` parent will ensure that the internal `<sp-menu>` features a role of `listbox` and contains children with the role `option`. Upon focusing the `<sp-picker>` using `ArrowDown` will also open the menu while throwing focus into first selected (or unselected when none are selected) menu item to assist in selecting of a new value.
+To render accessibly, an `<sp-picker>` element should be paired with an `<sp-field-label>` element that has a `for` attribute referencing the `id` of the `<sp-picker>` element.

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -59,10 +59,14 @@ type PickerSize = Exclude<ElementSize, 'xxl'>;
  * @element sp-picker
  * @slot label - The placeholder content for the picker
  *
- * @fires sp-open - Announces that the overlay has been opened
- * @fires sp-close - Announces that the overlay has been closed
+ * @fires change - Announces that the `value` of the element has changed
+ * @fires sp-opened - Announces that the overlay has been opened
+ * @fires sp-closed - Announces that the overlay has been closed
  */
 export class PickerBase extends SizedMixin(Focusable) {
+    /**
+     * @private
+     */
     public static openOverlay = async (
         target: HTMLElement,
         interaction: TriggerInteractions,
@@ -191,7 +195,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         }
     }
 
-    public onKeydown = (event: KeyboardEvent): void => {
+    protected onKeydown = (event: KeyboardEvent): void => {
         if (event.code !== 'ArrowDown' && event.code !== 'ArrowUp') {
             return;
         }
@@ -328,9 +332,8 @@ export class PickerBase extends SizedMixin(Focusable) {
         return html`
             <button
                 aria-haspopup="true"
-                aria-controls="popover"
                 aria-expanded=${this.open ? 'true' : 'false'}
-                aria-label=${ifDefined(this.label || undefined)}
+                aria-labelledby="button label"
                 id="button"
                 class="button"
                 @blur=${this.onButtonBlur}
@@ -364,7 +367,7 @@ export class PickerBase extends SizedMixin(Focusable) {
 
     protected updateMenuItems(): void {
         this.menuItems = [
-            ...this.querySelectorAll(`sp-menu-item`),
+            ...this.querySelectorAll('sp-menu-item'),
         ] as MenuItem[];
     }
 
@@ -462,7 +465,7 @@ export class Picker extends PickerBase {
         return [pickerStyles, chevronStyles];
     }
 
-    public onKeydown = (event: KeyboardEvent): void => {
+    protected onKeydown = (event: KeyboardEvent): void => {
         const { code } = event;
         if (!code.startsWith('Arrow') || this.readonly) {
             return;
@@ -484,7 +487,9 @@ export class Picker extends PickerBase {
         ) {
             nextIndex += nextOffset;
         }
-        nextIndex = Math.max(Math.min(nextIndex, this.menuItems.length), 0);
+        if (!this.menuItems[nextIndex] || this.menuItems[nextIndex].disabled) {
+            return;
+        }
         if (!this.value || nextIndex !== selectedIndex) {
             this.setValueFromItem(this.menuItems[nextIndex]);
         }

--- a/packages/picker/stories/picker-sizes.stories.ts
+++ b/packages/picker/stories/picker-sizes.stories.ts
@@ -24,7 +24,11 @@ export default {
 
 const picker = ({ size }: { size: 's' | 'm' | 'l' | 'xl' }): TemplateResult => {
     return html`
+        <sp-field-label for="picker-${size}" size=${size}>
+            Where do you live?
+        </sp-field-label>
         <sp-picker
+            id="picker-${size}"
             size=${size}
             @change="${(event: Event): void => {
                 const picker = event.target as Picker;

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -17,6 +17,7 @@ import { Picker } from '../';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import { states } from './states.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
 import { spreadProps } from '@open-wc/lit-helpers';
 
 export default {
@@ -86,7 +87,9 @@ interface StoryArgs {
 
 export const Default = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="picker-1">Where do you live?</sp-field-label>
         <sp-picker
+            id="picker-1"
             @change="${(event: Event): void => {
                 const picker = event.target as Picker;
                 console.log(`Change: ${picker.value}`);
@@ -114,8 +117,10 @@ export const Default = (args: StoryArgs): TemplateResult => {
 
 export const quiet = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="picker-quiet">Where do you live?</sp-field-label>
         <sp-picker
             ...=${spreadProps(args)}
+            id="picker-quiet"
             @change="${(event: Event): void => {
                 const picker = event.target as Picker;
                 console.log(`Change: ${picker.value}`);
@@ -150,7 +155,11 @@ export const Open = (args: StoryArgs): TemplateResult => {
             }
         </style>
         <fieldset>
+            <sp-field-label for="picker-open">
+                Where do you live?
+            </sp-field-label>
             <sp-picker
+                id="picker-open"
                 label="Open picker"
                 ...=${spreadProps(args)}
                 @change="${(event: Event): void => {
@@ -171,7 +180,11 @@ export const Open = (args: StoryArgs): TemplateResult => {
             </sp-picker>
         </fieldset>
         <fieldset>
+            <sp-field-label for="picker-closed">
+                Where do you live?
+            </sp-field-label>
             <sp-picker
+                id="picker-closed"
                 label="Picker that displays below the options"
                 @change="${(event: Event): void => {
                     const picker = event.target as Picker;
@@ -192,7 +205,9 @@ Open.args = {
 
 export const initialValue = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="picker-initial">Where do you live?</sp-field-label>
         <sp-picker
+            id="picker-initial"
             @change="${(event: Event): void => {
                 const picker = event.target as Picker;
                 console.log(`Change: ${picker.value}`);
@@ -241,12 +256,16 @@ export const readonly = (args: StoryArgs): TemplateResult => {
 
 export const custom = (args: StoryArgs): TemplateResult => {
     return html`
+        <sp-field-label for="picker-state">
+            What state do you live in?
+        </sp-field-label>
         <sp-picker
             style="width: 400px;"
             @change="${(event: Event): void => {
                 const picker = event.target as Picker;
                 console.log(`Change: ${picker.value}`);
             }}"
+            id="picker-state"
             label="Pick a state"
             ...=${spreadProps(args)}
         >

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -18,6 +18,7 @@ import { OverlayOpenCloseDetail } from '@spectrum-web-components/overlay';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
 import { Menu, MenuItem } from '@spectrum-web-components/menu';
 import {
     fixture,
@@ -33,9 +34,11 @@ import {
     arrowUpEvent,
     arrowLeftEvent,
     arrowRightEvent,
+    findAccessibilityNode,
     tabEvent,
     tEvent,
 } from '../../../test/testing-helpers.js';
+import { executeServerCommand } from '@web/test-runner-commands';
 
 const isMenuActiveElement = function (): boolean {
     return document.activeElement instanceof Menu;
@@ -43,36 +46,13 @@ const isMenuActiveElement = function (): boolean {
 
 describe('Picker', () => {
     const pickerFixture = async (): Promise<Picker> => {
-        const el = await fixture<Picker>(
+        const test = await fixture<HTMLDivElement>(
             html`
-                <sp-picker
-                    label="Select a Country with a very long label, too long in fact"
-                >
-                    <sp-menu-item>Deselect</sp-menu-item>
-                    <sp-menu-item value="option-2">Select Inverse</sp-menu-item>
-                    <sp-menu-item>Feather...</sp-menu-item>
-                    <sp-menu-item>Select and Mask...</sp-menu-item>
-                    <sp-menu-divider></sp-menu-divider>
-                    <sp-menu-item>Save Selection</sp-menu-item>
-                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
-                </sp-picker>
-            `
-        );
-
-        await waitUntil(
-            () => !!window.applyFocusVisiblePolyfill,
-            'polyfill loaded'
-        );
-        return el;
-    };
-
-    const deprecatedPickerFixture = async (): Promise<Picker> => {
-        const el = await fixture<Picker>(
-            html`
-                <sp-picker
-                    label="Select a Country with a very long label, too long in fact"
-                >
-                    <sp-menu>
+                <div>
+                    <sp-field-label for="picker">
+                        Where do you live?
+                    </sp-field-label>
+                    <sp-picker id="picker">
                         <sp-menu-item>Deselect</sp-menu-item>
                         <sp-menu-item value="option-2">
                             Select Inverse
@@ -82,8 +62,8 @@ describe('Picker', () => {
                         <sp-menu-divider></sp-menu-divider>
                         <sp-menu-item>Save Selection</sp-menu-item>
                         <sp-menu-item disabled>Make Work Path</sp-menu-item>
-                    </sp-menu>
-                </sp-picker>
+                    </sp-picker>
+                </div>
             `
         );
 
@@ -91,25 +71,68 @@ describe('Picker', () => {
             () => !!window.applyFocusVisiblePolyfill,
             'polyfill loaded'
         );
-        return el;
+
+        return test.querySelector('sp-picker') as Picker;
+    };
+
+    const deprecatedPickerFixture = async (): Promise<Picker> => {
+        const test = await fixture<Picker>(
+            html`
+                <div>
+                    <sp-field-label for="picker-deprecated">
+                        Where do you live?
+                    </sp-field-label>
+                    <sp-picker
+                        id="picker-deprecated"
+                        label="Select a Country with a very long label, too long in fact"
+                    >
+                        <sp-menu>
+                            <sp-menu-item>Deselect</sp-menu-item>
+                            <sp-menu-item value="option-2">
+                                Select Inverse
+                            </sp-menu-item>
+                            <sp-menu-item>Feather...</sp-menu-item>
+                            <sp-menu-item>Select and Mask...</sp-menu-item>
+                            <sp-menu-divider></sp-menu-divider>
+                            <sp-menu-item>Save Selection</sp-menu-item>
+                            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                        </sp-menu>
+                    </sp-picker>
+                </div>
+            `
+        );
+
+        await waitUntil(
+            () => !!window.applyFocusVisiblePolyfill,
+            'polyfill loaded'
+        );
+
+        return test.querySelector('sp-picker') as Picker;
     };
 
     const slottedLabelFixture = async (): Promise<Picker> => {
-        const el = await fixture<Picker>(
+        const test = await fixture<Picker>(
             html`
-                <sp-picker>
-                    <span slot="label">
-                        Select a Country with a very long label, too long in
-                        fact
-                    </span>
-                    <sp-menu-item>Deselect</sp-menu-item>
-                    <sp-menu-item value="option-2">Select Inverse</sp-menu-item>
-                    <sp-menu-item>Feather...</sp-menu-item>
-                    <sp-menu-item>Select and Mask...</sp-menu-item>
-                    <sp-menu-divider></sp-menu-divider>
-                    <sp-menu-item>Save Selection</sp-menu-item>
-                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
-                </sp-picker>
+                <div>
+                    <sp-field-label for="picker-slotted">
+                        Where do you live?
+                    </sp-field-label>
+                    <sp-picker id="picker-slotted">
+                        <span slot="label">
+                            Select a Country with a very long label, too long in
+                            fact
+                        </span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item value="option-2">
+                            Select Inverse
+                        </sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and Mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save Selection</sp-menu-item>
+                        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                    </sp-picker>
+                </div>
             `
         );
 
@@ -117,7 +140,8 @@ describe('Picker', () => {
             () => !!window.applyFocusVisiblePolyfill,
             'polyfill loaded'
         );
-        return el;
+
+        return test.querySelector('sp-picker') as Picker;
     };
 
     afterEach(async () => {
@@ -132,6 +156,41 @@ describe('Picker', () => {
 
         await expect(el).to.be.accessible();
     });
+
+    it('manages its "name" value in the accessibility tree', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+        type NamedNode = { name: string };
+        let snapshot = (await executeServerCommand(
+            'a11y-snapshot'
+        )) as NamedNode & { children: NamedNode[] };
+
+        expect(
+            findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) =>
+                    node.name ===
+                    'Where do you live? Select a Country with a very long label, too long in fact'
+            ),
+            '`name` is the label text'
+        );
+
+        el.value = 'option-2';
+        await elementUpdated(el);
+        snapshot = (await executeServerCommand(
+            'a11y-snapshot'
+        )) as NamedNode & { children: NamedNode[] };
+
+        expect(
+            findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Where do you live? Select Inverse'
+            ),
+            '`name` is the label text plus the selected item text'
+        );
+    });
+
     it('loads accessibly w/ slotted label', async () => {
         const el = await slottedLabelFixture();
 

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -34,6 +34,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
 
     /**
      * When this control is rendered, focus it automatically
+     * @private
      */
     @property({ type: Boolean })
     public autofocus = false;

--- a/projects/example-project-rollup/index.html
+++ b/projects/example-project-rollup/index.html
@@ -18,7 +18,8 @@
     <br /><br />
     <sp-button variant="secondary" quiet>secondary</sp-button>
     <br /><br />
-    <sp-picker>
+    <sp-field-label for="picker">Where do you live?</sp-field-label>
+    <sp-picker id="picker">
       <span slot="label">
         Select a Country with a very long label, too long in fact
       </span>

--- a/projects/example-project-rollup/package.json
+++ b/projects/example-project-rollup/package.json
@@ -44,6 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@spectrum-web-components/button": "^0.13.1",
+    "@spectrum-web-components/field-label": "^0.3.1",
     "@spectrum-web-components/menu": "^0.7.1",
     "@spectrum-web-components/picker": "^0.3.1",
     "@spectrum-web-components/styles": "^0.9.1"

--- a/projects/example-project-rollup/src/example-app.ts
+++ b/projects/example-project-rollup/src/example-app.ts
@@ -15,6 +15,7 @@ import './styles.css';
 
 // import the components we'll use in this page
 import '@spectrum-web-components/button/sp-button';
+import '@spectrum-web-components/field-label/sp-field-label';
 // use the following import to chunk your build at the async boundary infront of the Overlay package
 import '@spectrum-web-components/picker/sp-picker';
 // use the following import to chunk your build as defaulted in the Rollup config.

--- a/projects/example-project-webpack/package.json
+++ b/projects/example-project-webpack/package.json
@@ -13,6 +13,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@spectrum-web-components/button": "^0.13.1",
+        "@spectrum-web-components/field-label": "^0.3.1",
         "@spectrum-web-components/menu": "^0.7.1",
         "@spectrum-web-components/picker": "^0.3.1",
         "@spectrum-web-components/styles": "^0.9.1",

--- a/projects/example-project-webpack/src/index.html
+++ b/projects/example-project-webpack/src/index.html
@@ -21,7 +21,8 @@
         <sp-button variant="secondary" quiet>secondary</sp-button>
         <br />
         <br />
-        <sp-picker>
+        <sp-field-label for="picker">Where do you live?</sp-field-label>
+        <sp-picker id="picker">
             <span slot="label">
                 Select a Country with a very long label, too long in fact
             </span>

--- a/projects/example-project-webpack/src/index.js
+++ b/projects/example-project-webpack/src/index.js
@@ -15,6 +15,7 @@ import './styles.css';
 
 // import the components we'll use in this page
 import '@spectrum-web-components/button/sp-button';
+import '@spectrum-web-components/field-label/sp-field-label';
 import '@spectrum-web-components/picker/sp-picker';
 import '@spectrum-web-components/menu/sp-menu';
 import '@spectrum-web-components/menu/sp-menu-item';

--- a/test/a11y-snapshot-plugin.ts
+++ b/test/a11y-snapshot-plugin.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import type { ElementHandle, Page } from 'playwright';
+
+export function a11ySnapshotPlugin() {
+    return {
+        name: 'a11y-snapshot-command',
+        async executeCommand({
+            command,
+            payload = {},
+            session,
+        }: {
+            payload: { selector?: string };
+            command: string;
+            session: {
+                id: string;
+                browser: { type: string; getPage: (id: string) => Page };
+            };
+        }) {
+            if (command === 'a11y-snapshot') {
+                // handle specific behavior for playwright
+                if (session.browser.type === 'playwright') {
+                    const page = session.browser.getPage(session.id);
+                    const options: {
+                        root?: ElementHandle;
+                    } = {};
+                    if (payload.selector) {
+                        const root = await page.$(payload.selector);
+                        if (root) {
+                            options.root = root;
+                        }
+                    }
+                    const snapshot = await page.accessibility.snapshot(options);
+                    return snapshot;
+                }
+                // you might not be able to support all browser launchers
+                throw new Error(
+                    `Acessibility snapshot is not supported for browser type ${session.browser.type}.`
+                );
+            }
+        },
+    };
+}

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -74,3 +74,18 @@ export const arrowRightKeyupEvent = keyboardEvent('ArrowRight', {}, 'keyup');
 export const arrowLeftKeyupEvent = keyboardEvent('ArrowLeft', {}, 'keyup');
 export const arrowUpKeyupEvent = keyboardEvent('ArrowUp', {}, 'keyup');
 export const arrowDownKeyupEvent = keyboardEvent('ArrowDown', {}, 'keyup');
+
+export const findAccessibilityNode = <TNode>(
+    node: TNode & { children: TNode[] },
+    test: (node: TNode) => boolean
+): TNode | null => {
+    if (test(node)) return node;
+    for (const child of node.children || []) {
+        const foundNode = findAccessibilityNode<TNode>(
+            child as TNode & { children: TNode[] },
+            test
+        );
+        return foundNode;
+    }
+    return null;
+};

--- a/test/tsconfig-plugins.json
+++ b/test/tsconfig-plugins.json
@@ -6,6 +6,6 @@
         "sourceMap": false,
         "strict": true
     },
-    "include": ["./send-keys-plugin.ts"],
+    "include": ["./send-keys-plugin.ts", "./a11y-snapshot-plugin.ts"],
     "exclude": []
 }

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const { playwrightLauncher } = require('@web/test-runner-playwright');
+const { a11ySnapshotPlugin } = require('./test/a11y-snapshot-plugin.js');
 const { sendKeysPlugin } = require('./test/send-keys-plugin.js');
 const {
     packages,
@@ -18,7 +19,11 @@ const {
 } = require('./web-test-runner.utils.js');
 
 module.exports = {
-    plugins: [sendKeysPlugin(), configuredVisualRegressionPlugin()],
+    plugins: [
+        sendKeysPlugin(),
+        a11ySnapshotPlugin(),
+        configuredVisualRegressionPlugin(),
+    ],
     nodeResolve: true,
     concurrency: 4,
     concurrentBrowsers: 1,


### PR DESCRIPTION
## Description
- ensure that both the `field-label` content and the current `value` are represented in the accessibility tree of the picker
- prevent element errors in the "quick select" functionality
- label all of the pickers
- add accessibility snapshot tool for Playwright

## Related Issue
fixes #1077
refs #1269

## Motivation and Context
Screen reader users should have a clear representation of the content otherwise made available when seeing the UI.

## How Has This Been Tested?
- manual review with the accessibility team
- unit tests
- visual regressions

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/110684937-bc17d000-81ab-11eb-8ceb-3632bb92bd82.png)
![image](https://user-images.githubusercontent.com/1156657/110685022-d782db00-81ab-11eb-9327-cb7b07a10918.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
