### PR TITLE
refactor: remove sp-icon usage in shipped elements

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -20,7 +20,7 @@ import {
 import { PickerBase } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
-import { MoreIcon } from '@spectrum-web-components/icons-workflow';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-more.js';
 import actionMenuStyles from './action-menu.css.js';
 
 /**
@@ -43,9 +43,7 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
         return [
             html`
                 <slot name="icon" slot="icon" ?icon-only=${!this.hasLabel}>
-                    <sp-icon class="icon">
-                        ${MoreIcon({ hidden: this.hasLabel })}
-                    </sp-icon>
+                    <sp-icon-more class="icon"></sp-icon-more>
                 </slot>
                 <slot name="label" ?hidden=${!this.hasLabel}></slot>
             `,

--- a/packages/action-menu/test/action-menu.test.ts
+++ b/packages/action-menu/test/action-menu.test.ts
@@ -22,7 +22,7 @@ import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
 const deprecatedActionMenuFixture = async (): Promise<ActionMenu> =>
     await fixture<ActionMenu>(
         html`
-            <sp-action-menu>
+            <sp-action-menu label="More Actions">
                 <sp-menu>
                     <sp-menu-item>Deselect</sp-menu-item>
                     <sp-menu-item>Select Inverse</sp-menu-item>
@@ -39,7 +39,7 @@ const deprecatedActionMenuFixture = async (): Promise<ActionMenu> =>
 const actionMenuFixture = async (): Promise<ActionMenu> =>
     await fixture<ActionMenu>(
         html`
-            <sp-action-menu>
+            <sp-action-menu label="More Actions">
                 <sp-menu-item>Deselect</sp-menu-item>
                 <sp-menu-item>Select Inverse</sp-menu-item>
                 <sp-menu-item>Feather...</sp-menu-item>
@@ -60,10 +60,11 @@ describe('Action menu', () => {
 
         await expect(el).to.be.accessible();
     });
-    it('loads - [label]', async () => {
+    it('loads - [slot="label"]', async () => {
         const el = await fixture<ActionMenu>(
             html`
-                <sp-action-menu label="More Actions">
+                <sp-action-menu>
+                    <span slot="label">More Actions</span>
                     <sp-menu-item>Deselect</sp-menu-item>
                     <sp-menu-item>Select Inverse</sp-menu-item>
                     <sp-menu-item>Feather...</sp-menu-item>


### PR DESCRIPTION
## Description
- refactor one last `<sp-icon>` usage to `<sp-icon-*>` for perf and tree shaking simplicity
- prevent `sp-action-menu` from _accidentally_ resolving its accessible content from the default icon and clarify labelling story in demos

## Motivation and Context
Not having to tree shake is a win for no/low-build situations.

## How Has This Been Tested?
- visual regressions
- a11y units

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/110799450-2a5ea000-8249-11eb-842f-ff4bccc883d2.png)


## Types of changes
- [x] refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
