### PR TITLE
fix: remove right click value setting

### DIFF
--- a/packages/base/src/streaming-listener.ts
+++ b/packages/base/src/streaming-listener.ts
@@ -85,11 +85,14 @@ const addEventListeners = (
     };
 
     const handleStart = (event: any): void => {
+        start.fn.call(eventContext || element, event);
+        if (event.defaultPrevented) {
+            return;
+        }
         removeListener(element, start.type, handleStart);
         addListener(element, stream.type, handleStream);
         addListener(element, end.type, handleEnd);
         stateMap.set(part, true);
-        start.fn.call(eventContext || element, event);
     };
 
     if (!isStreaming) {

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -260,6 +260,10 @@ export class ColorArea extends SpectrumElement {
     private boundingClientRect!: DOMRect;
 
     private handlePointerdown(event: PointerEvent): void {
+        if (event.button !== 0) {
+            event.preventDefault();
+            return;
+        }
         this._previousColor = this._color.clone();
         this.boundingClientRect = this.getBoundingClientRect();
 
@@ -333,6 +337,9 @@ export class ColorArea extends SpectrumElement {
     }
 
     private handleAreaPointerdown(event: PointerEvent): void {
+        if (event.button !== 0) {
+            return;
+        }
         event.stopPropagation();
         event.preventDefault();
         this.handle.dispatchEvent(new PointerEvent('pointerdown', event));

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -225,8 +225,44 @@ describe('ColorArea', () => {
         expect(el.x).to.equal(1);
         expect(el.y).to.equal(0);
 
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 1,
+                pointerId: 1,
+                clientX: 100,
+                clientY: 100,
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.hue).to.equal(0);
+        expect(el.x).to.equal(1);
+        expect(el.y).to.equal(0);
+
         const root = el.shadowRoot ? el.shadowRoot : el;
         const gradient = root.querySelector('.gradient') as HTMLElement;
+        gradient.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 1,
+                pointerId: 1,
+                clientX: 100,
+                clientY: 100,
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.hue).to.equal(0);
+        expect(el.x).to.equal(1);
+        expect(el.y).to.equal(0);
+
         gradient.dispatchEvent(
             new PointerEvent('pointerdown', {
                 pointerId: 1,

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -246,6 +246,10 @@ export class ColorSlider extends Focusable {
     private boundingClientRect!: DOMRect;
 
     private handlePointerdown(event: PointerEvent): void {
+        if (event.button !== 0) {
+            event.preventDefault();
+            return;
+        }
         this._previousColor = this._color.clone();
         this.boundingClientRect = this.getBoundingClientRect();
         (event.target as HTMLElement).setPointerCapture(event.pointerId);
@@ -304,6 +308,9 @@ export class ColorSlider extends Focusable {
     }
 
     private handleGradientPointerdown(event: PointerEvent): void {
+        if (event.button !== 0) {
+            return;
+        }
         event.stopPropagation();
         event.preventDefault();
         this.handle.dispatchEvent(new PointerEvent('pointerdown', event));

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -232,8 +232,38 @@ describe('ColorSlider', () => {
 
         expect(el.sliderHandlePosition).to.equal(0);
 
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 1,
+                pointerId: 1,
+                clientX: 100,
+                clientY: 15,
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
+
+        await elementUpdated(el);
+        expect(el.sliderHandlePosition).to.equal(0);
+
         const root = el.shadowRoot ? el.shadowRoot : el;
         const gradient = root.querySelector('.gradient') as HTMLElement;
+        gradient.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 1,
+                pointerId: 1,
+                clientX: 100,
+                clientY: 15,
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
+
+        await elementUpdated(el);
+        expect(el.sliderHandlePosition).to.equal(0);
+
         gradient.dispatchEvent(
             new PointerEvent('pointerdown', {
                 pointerId: 1,

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -224,6 +224,10 @@ export class ColorWheel extends Focusable {
     private boundingClientRect!: DOMRect;
 
     private handlePointerdown(event: PointerEvent): void {
+        if (event.button !== 0) {
+            event.preventDefault();
+            return;
+        }
         this._previousColor = this._color.clone();
         this.boundingClientRect = this.getBoundingClientRect();
         (event.target as HTMLElement).setPointerCapture(event.pointerId);
@@ -280,6 +284,12 @@ export class ColorWheel extends Focusable {
     }
 
     private handleGradientPointerdown(event: PointerEvent): void {
+        if (
+            event.button !== 0 ||
+            (event.target as SVGElement).classList.contains('innerCircle')
+        ) {
+            return;
+        }
         event.stopPropagation();
         event.preventDefault();
         this.handle.dispatchEvent(new PointerEvent('pointerdown', event));

--- a/packages/color-wheel/test/color-wheel.test.ts
+++ b/packages/color-wheel/test/color-wheel.test.ts
@@ -229,8 +229,41 @@ describe('ColorWheel', () => {
         };
 
         expect(el.value).to.equal(0);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 1,
+                pointerId: 1,
+                clientX: 80,
+                clientY: 15,
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(0);
+
         const root = el.shadowRoot ? el.shadowRoot : el;
         const gradient = root.querySelector('[name="gradient"]') as HTMLElement;
+        gradient.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 1,
+                pointerId: 1,
+                clientX: 80,
+                clientY: 15,
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(0);
+
         gradient.dispatchEvent(
             new PointerEvent('pointerdown', {
                 pointerId: 1,


### PR DESCRIPTION
## Description
- remove right click value setting from `sp-color-area`, `sp-color-slider`, `sp-color-wheel`, and `sp-slider`
- normalize `sp-slider` to the use of `streamingListener` and remove support for mouse event fallbacks

## Related Issue
fixes #1291

## Motivation and Context
- setting value from right click means you can't inspect
- normalized code is easier to maintain
- enough safari supports `pointerEvents` now

## How Has This Been Tested?
Unit tests and manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
