### PR TITLE
fix: add support for "readonly" attribute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 02cacf9ef4e766ce33b46b7075da37f0a3f11052
+        default: 8b8bbd28de04f4ab2d1f86434be84e98a2ee92d0
 commands:
     downstream:
         steps:

--- a/packages/checkbox/src/CheckboxBase.ts
+++ b/packages/checkbox/src/CheckboxBase.ts
@@ -22,6 +22,9 @@ export class CheckboxBase extends Focusable {
     @property({ type: Boolean, reflect: true })
     public checked = false;
 
+    @property({ type: Boolean, reflect: true })
+    public readonly = false;
+
     @query('#input')
     protected inputElement!: HTMLInputElement;
 
@@ -30,6 +33,10 @@ export class CheckboxBase extends Focusable {
     }
 
     public handleChange(event: Event): void {
+        if (this.readonly) {
+            this.inputElement.checked = this.checked;
+            return;
+        }
         this.checked = this.inputElement.checked;
 
         // Change events from the shadow DOM are not transmitted into

--- a/packages/checkbox/stories/checkbox.stories.ts
+++ b/packages/checkbox/stories/checkbox.stories.ts
@@ -24,6 +24,12 @@ export const Default = (): TemplateResult => {
     `;
 };
 
+export const readonly = (): TemplateResult => {
+    return html`
+        <sp-checkbox checked readonly>Checkbox</sp-checkbox>
+    `;
+};
+
 export const Indeterminate = (): TemplateResult => {
     return html`
         <sp-checkbox indeterminate>Checkbox</sp-checkbox>

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -170,4 +170,16 @@ describe('Checkbox', () => {
 
         expect(el.checked).to.be.false;
     });
+
+    it('maintains its value when [readonly]', async () => {
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox id="checkbox0" checked readonly>Component</sp-checkbox>
+        `);
+        expect(el.checked).to.be.true;
+
+        inputForCheckbox(el).click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.true;
+    });
 });

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -94,6 +94,9 @@ export class PickerBase extends SizedMixin(Focusable) {
     @property({ type: Boolean, reflect: true })
     public open = false;
 
+    @property({ type: Boolean, reflect: true })
+    public readonly = false;
+
     public menuItems: MenuItem[] = [];
     private restoreChildren?: Function;
 
@@ -193,7 +196,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             return;
         }
         event.preventDefault();
-        this.open = true;
+        this.toggle(true);
     };
 
     public async setValueFromItem(item: MenuItem): Promise<void> {
@@ -220,11 +223,17 @@ export class PickerBase extends SizedMixin(Focusable) {
         item.selected = true;
     }
 
-    public toggle(): void {
-        this.open = !this.open;
+    public toggle(target?: boolean): void {
+        if (this.readonly) {
+            return;
+        }
+        this.open = typeof target !== 'undefined' ? target : !this.open;
     }
 
     public close(): void {
+        if (this.readonly) {
+            return;
+        }
         this.open = false;
     }
 
@@ -455,12 +464,12 @@ export class Picker extends PickerBase {
 
     public onKeydown = (event: KeyboardEvent): void => {
         const { code } = event;
-        if (!code.startsWith('Arrow')) {
+        if (!code.startsWith('Arrow') || this.readonly) {
             return;
         }
         event.preventDefault();
         if (code === 'ArrowUp' || code === 'ArrowDown') {
-            this.open = true;
+            this.toggle(true);
             return;
         }
         const selectedIndex = this.selectedItem

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -41,6 +41,10 @@ governing permissions and limitations under the License.
     max-width: 100%;
 }
 
+:host([readonly]) #button {
+    user-select: inherit;
+}
+
 sp-popover {
     display: none;
 }

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -214,6 +214,31 @@ export const initialValue = (args: StoryArgs): TemplateResult => {
     `;
 };
 
+export const readonly = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-picker
+            @change="${(event: Event): void => {
+                const picker = event.target as Picker;
+                console.log(`Change: ${picker.value}`);
+            }}"
+            readonly
+            value="item-2"
+            ...=${spreadProps(args)}
+        >
+            <span slot="label">
+                Select a Country with a very long label, too long in fact
+            </span>
+            <sp-menu-item value="item-1">Deselect</sp-menu-item>
+            <sp-menu-item value="item-2">Select Inverse</sp-menu-item>
+            <sp-menu-item value="item-3">Feather...</sp-menu-item>
+            <sp-menu-item value="item-4">Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item value="item-5">Save Selection</sp-menu-item>
+            <sp-menu-item disabled value="item-6">Make Work Path</sp-menu-item>
+        </sp-picker>
+    `;
+};
+
 export const custom = (args: StoryArgs): TemplateResult => {
     return html`
         <sp-picker

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -703,4 +703,18 @@ describe('Picker', () => {
             .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
         expect(closedEvent.detail.interaction).to.equal('inline');
     });
+    it('does not open when [readonly]', async () => {
+        const el = await pickerFixture();
+
+        el.readonly = true;
+
+        await elementUpdated(el);
+
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+    });
 });

--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -53,6 +53,9 @@ export class Radio extends Focusable {
     @property({ type: Boolean, reflect: true })
     public invalid = false;
 
+    @property({ type: Boolean, reflect: true })
+    public readonly = false;
+
     @query('#input')
     private inputElement!: HTMLInputElement;
 
@@ -61,6 +64,10 @@ export class Radio extends Focusable {
     }
 
     public handleChange(): void {
+        if (this.readonly) {
+            this.inputElement.checked = this.checked;
+            return;
+        }
         this.checked = this.inputElement.checked;
         this.dispatchEvent(
             new Event('change', {

--- a/packages/radio/stories/radio.stories.ts
+++ b/packages/radio/stories/radio.stories.ts
@@ -79,6 +79,7 @@ interface StoryArgs {
     disabled?: boolean;
     emphasized?: boolean;
     invalid?: boolean;
+    readonly?: boolean
 }
 
 function renderRadio(args: StoryArgs): TemplateResult {
@@ -87,6 +88,14 @@ function renderRadio(args: StoryArgs): TemplateResult {
     `;
 }
 export const Default = (args: StoryArgs): TemplateResult => renderRadio(args);
+
+export const readonly = (args: StoryArgs): TemplateResult => renderRadio({
+    ...args,
+    readonly: true,
+});
+readonly.args = {
+    checked: true,
+};
 
 export const Emphasized = (args: StoryArgs): TemplateResult =>
     renderRadio(args);

--- a/packages/radio/test/radio.test.ts
+++ b/packages/radio/test/radio.test.ts
@@ -118,4 +118,16 @@ describe('Radio', () => {
 
         expect(el.checked).to.be.false;
     });
+
+    it('maintains its value when [readonly]', async () => {
+        const el = await fixture<Radio>(html`
+            <sp-radio checked readonly>Component</sp-radio>
+        `);
+        expect(el.checked).to.be.true;
+
+        el.focusElement.click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.true;
+    });
 });

--- a/packages/switch/stories/switch.stories.ts
+++ b/packages/switch/stories/switch.stories.ts
@@ -29,6 +29,12 @@ export const Checked = (): TemplateResult => {
     `;
 };
 
+export const readonly = (): TemplateResult => {
+    return html`
+        <sp-switch checked readonly>Switch</sp-switch>
+    `;
+};
+
 export const emphasized = (): TemplateResult => {
     return html`
         <sp-switch emphasized>Switch</sp-switch>

--- a/packages/switch/test/switch.test.ts
+++ b/packages/switch/test/switch.test.ts
@@ -37,4 +37,16 @@ describe('Switch', () => {
 
         await expect(el).to.be.accessible();
     });
+
+    it('maintains its value when [readonly]', async () => {
+        const el = await fixture<Switch>(html`
+            <sp-switch checked readonly>Component</sp-switch>
+        `);
+        expect(el.checked).to.be.true;
+
+        el.focusElement.click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.true;
+    });
 });

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -37,6 +37,9 @@ export class Tag extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public disabled = false;
 
+    @property({ type: Boolean, reflect: true })
+    public readonly = false;
+
     private get hasIcon(): boolean {
         return !!this.querySelector('[slot="icon"]');
     }
@@ -77,6 +80,9 @@ export class Tag extends SpectrumElement {
     };
 
     private delete(): void {
+        if (this.readonly) {
+            return;
+        }
         this.dispatchEvent(
             new Event('delete', {
                 bubbles: true,

--- a/packages/tags/stories/tags.stories.ts
+++ b/packages/tags/stories/tags.stories.ts
@@ -130,3 +130,22 @@ export const deletable = (): TemplateResult => {
         </sp-tags>
     `;
 };
+
+export const readonly = (): TemplateResult => {
+    return html`
+        <sp-tags>
+            <sp-tag deletable readonly>
+                Tag 1
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
+            </sp-tag>
+            <sp-tag invalid deletable readonly>
+                Tag 2
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
+            </sp-tag>
+            <sp-tag disabled deletable>
+                Tag 3
+                <sp-icon-magnify slot="icon" size="s"></sp-icon-magnify>
+            </sp-tag>
+        </sp-tags>
+    `;
+};

--- a/packages/tags/test/tag.test.ts
+++ b/packages/tags/test/tag.test.ts
@@ -87,6 +87,33 @@ describe('Tag', () => {
         expect(deleteSpy.called).to.be.true;
         expect(deleteSpy.callCount).to.equal(1);
     });
+    it('does not dispatch `delete` events when [readonly]', async () => {
+        const deleteSpy = spy();
+        const handleDelete = (): void => deleteSpy();
+        const el = await fixture<Tag>(
+            html`
+                <sp-tag @delete=${handleDelete} deletable readonly>
+                    Tag 1
+                </sp-tag>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(deleteSpy.called).to.be.false;
+
+        const root: HTMLElement | DocumentFragment = el.shadowRoot
+            ? el.shadowRoot
+            : el;
+        const deleteButton = root.querySelector(
+            'sp-clear-button'
+        ) as ClearButton;
+        deleteButton.click();
+
+        await elementUpdated(el);
+
+        expect(deleteSpy.called).to.be.false;
+    });
     it('dispatches `delete` events on keyboard input', async () => {
         const deleteSpy = spy();
         const handleDelete = (): void => deleteSpy();

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -68,6 +68,9 @@ export class Textfield extends Focusable {
     public multiline = false;
 
     @property({ type: Boolean, reflect: true })
+    public readonly = false;
+
+    @property({ type: Boolean, reflect: true })
     public valid = false;
 
     @property({ type: String })
@@ -169,6 +172,7 @@ export class Textfield extends Focusable {
                 @blur=${this.onBlur}
                 ?disabled=${this.disabled}
                 ?required=${this.required}
+                ?readonly=${this.readonly}
                 autocomplete=${ifDefined(this.autocomplete)}
             ></textarea>
         `;
@@ -196,6 +200,7 @@ export class Textfield extends Focusable {
                 @blur=${this.onBlur}
                 ?disabled=${this.disabled}
                 ?required=${this.required}
+                ?readonly=${this.readonly}
                 autocomplete=${ifDefined(this.autocomplete)}
             />
         `;

--- a/packages/textfield/stories/textarea.stories.ts
+++ b/packages/textfield/stories/textarea.stories.ts
@@ -70,3 +70,13 @@ export const Default = (): TemplateResult => {
         ></sp-textfield>
     `;
 };
+
+export const readonly = (): TemplateResult => html`
+    <sp-textfield
+        multiline
+        label="Enter your life story"
+        value="A readonly textarea"
+        readonly
+        placeholder="Enter your life story"
+    ></sp-textfield>
+`;

--- a/packages/textfield/stories/textfield.stories.ts
+++ b/packages/textfield/stories/textfield.stories.ts
@@ -68,3 +68,12 @@ export const allowedKeys = (): TemplateResult => {
         ></sp-textfield>
     `;
 };
+
+export const readonly = (): TemplateResult => html`
+    <sp-textfield
+        label="Enter your life story"
+        value="A readonly textfield"
+        readonly
+        placeholder="Enter your life story"
+    ></sp-textfield>
+`;


### PR DESCRIPTION
## Description
Currently fails in CI as I'm waiting for #1287 to land before managing the visual regressions added here.

Add `readonly` attribute to:
- [checkbox](https://605204763582c4ac55114e9b--spectrum-web-components.netlify.app/storybook/index.html?path=/story/checkbox--readonly) 
- [picker](https://605204763582c4ac55114e9b--spectrum-web-components.netlify.app/storybook/index.html?path=/story/picker--readonly)
- [radio](https://605204763582c4ac55114e9b--spectrum-web-components.netlify.app/storybook/index.html?path=/story/radio--readonly)
- [switch](https://605204763582c4ac55114e9b--spectrum-web-components.netlify.app/storybook/index.html?path=/story/switch--readonly)
- [tag](https://605204763582c4ac55114e9b--spectrum-web-components.netlify.app/storybook/index.html?path=/story/tags--readonly)
- [textarea](https://605204763582c4ac55114e9b--spectrum-web-components.netlify.app/storybook/index.html?path=/story/textarea--readonly)
- [textfield](https://605204763582c4ac55114e9b--spectrum-web-components.netlify.app/storybook/index.html?path=/story/textfield--readonly)

## Related Issue
fixes #1248 

## Motivation and Context
Spectrum adherence, ability to have readonly content.

## How Has This Been Tested?
VRTs, manually.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
