### PR TITLE
fix(slider): update a11y tree and default max value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 034623e8772e4e2b47ce944668fd64c422ec114a
+        default: 0f3e165906e60caafc12753714be46fccc8d7d70
 commands:
     downstream:
         steps:

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -99,7 +99,7 @@ export class Slider extends Focusable {
     public ariaLabel?: string;
 
     @property({ type: Number })
-    public max = 20;
+    public max = 100;
 
     @property({ type: Number })
     public min = 0;
@@ -153,14 +153,9 @@ export class Slider extends Focusable {
         return html`
             <div id="labelContainer">
                 <label id="label" for="input"><slot>${this.label}</slot></label>
-                <div
-                    id="value"
-                    role="textbox"
-                    aria-readonly="true"
-                    aria-labelledby="label"
-                >
+                <output id="value" aria-live="off" for="input">
                     ${this.ariaValueText}
-                </div>
+                </output>
             </div>
         `;
     }
@@ -270,11 +265,9 @@ export class Slider extends Focusable {
                     step=${this.step}
                     min=${this.min}
                     max=${this.max}
-                    aria-disabled=${this.disabled ? 'true' : 'false'}
-                    aria-labelledby="label"
-                    aria-valuenow=${this.value}
-                    aria-valuemin=${this.min}
-                    aria-valuemax=${this.max}
+                    aria-disabled=${ifDefined(
+                        this.disabled ? 'true' : undefined
+                    )}
                     aria-valuetext=${this.ariaValueText}
                     @change=${this.onInputChange}
                     @focus=${this.onInputFocus}

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -31,11 +31,16 @@ export const Default = (): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
-                max="100"
+                max="1"
                 min="0"
-                value="50"
+                value=".5"
+                step="0.01"
                 @input=${handleEvent}
                 @change=${handleEvent}
+                .getAriaValueText=${(value: number) =>
+                    new Intl.NumberFormat('en-US', { style: 'percent' }).format(
+                        value
+                    )}
             >
                 Opacity
             </sp-slider>

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -60,7 +60,7 @@ describe('Slider', () => {
     it('receives value from the outside', async () => {
         const el = await fixture<Slider>(
             html`
-                <sp-slider></sp-slider>
+                <sp-slider max="20"></sp-slider>
             `
         );
 
@@ -321,6 +321,7 @@ describe('Slider', () => {
             html`
                 <sp-slider
                     step="0"
+                    max="20"
                     @input=${handleInput}
                     style="width: 500px; float: left;"
                 ></sp-slider>


### PR DESCRIPTION
## Description
- change the default `max` value to 100 to more closely match that of a native `<input type="range" />` element
- move from `div[ole="textbox"]` to `output` for the value label
- remove superfluous `aria-*` attributes
- update story to demonstrate the use of `Intl.NumberFormat` for managing the value label

## Related Issue
fixes #1308
fixes #1285

## Motivation and Context
Increase predictability, accessibility, and usability of the pattern.

## How Has This Been Tested?
- Manually in the DOM inspector and mac voice over
- Updated some unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
