### PR TITLE
fix(color-area): Fix stuck up and down arrow keys 

### DIFF
--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -27,6 +27,8 @@ import { TinyColor } from '@ctrl/tinycolor';
 
 import styles from './color-area.css.js';
 
+const preventDefault = (event: KeyboardEvent) => event.preventDefault();
+
 /**
  * @element sp-color-area
  */
@@ -197,11 +199,11 @@ export class ColorArea extends SpectrumElement {
             switch (code) {
                 case 'ArrowUp':
                 case 'Up':
-                    deltaY = -this.step;
+                    deltaY = this.step * -1;
                     break;
                 case 'ArrowDown':
                 case 'Down':
-                    deltaY = this.step;
+                    deltaY = this.step * 1;
                     break;
                 case 'ArrowLeft':
                 case 'Left':
@@ -388,7 +390,7 @@ export class ColorArea extends SpectrumElement {
                 step=${this.step}
                 .value=${String(this.x)}
                 @input=${this.handleInput}
-                @keyup=${(event: KeyboardEvent) => event.preventDefault()}
+                @keydown=${preventDefault}
             />
             <input
                 type="range"
@@ -400,7 +402,7 @@ export class ColorArea extends SpectrumElement {
                 step=${this.step}
                 .value=${String(this.y)}
                 @input=${this.handleInput}
-                @keyup=${(event: KeyboardEvent) => event.preventDefault()}
+                @keydown=${preventDefault}
             />
         `;
     }

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -152,10 +152,10 @@ export class ColorArea extends SpectrumElement {
     public step = 0.01;
 
     @query('[name="x"]')
-    private inputX!: HTMLInputElement;
+    public inputX!: HTMLInputElement;
 
     @query('[name="y"]')
-    private inputY!: HTMLInputElement;
+    public inputY!: HTMLInputElement;
 
     private get altered(): number {
         return this._altered;

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -115,11 +115,6 @@ describe('ColorArea', () => {
             press: 'ArrowUp',
         });
 
-        // el.inputY.dispatchEvent(arrowUpEvent);
-        // el.inputY.dispatchEvent(arrowUpKeyupEvent);
-        // el.inputY.dispatchEvent(arrowUpEvent);
-        // el.inputY.dispatchEvent(arrowUpKeyupEvent);
-
         await elementUpdated(el);
 
         expect(el.x).to.equal(0.6666666666666666);

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -27,6 +27,7 @@ import { HSL, HSLA, HSV, HSVA, RGB, RGBA, TinyColor } from '@ctrl/tinycolor';
 
 import '../sp-color-area.js';
 import { ColorArea } from '..';
+import { executeServerCommand } from '@web/test-runner-commands';
 
 describe('ColorArea', () => {
     it('loads default color-area accessibly', async () => {
@@ -105,40 +106,55 @@ describe('ColorArea', () => {
         expect(el.x, 'x').to.equal(0.6666666666666666);
         expect(el.y, 'y').to.equal(0.25);
 
-        el.dispatchEvent(arrowUpEvent);
-        el.dispatchEvent(arrowUpKeyupEvent);
-        el.dispatchEvent(arrowUpEvent);
-        el.dispatchEvent(arrowUpKeyupEvent);
+        el.inputX.focus();
+
+        await executeServerCommand('send-keys', {
+            press: 'ArrowUp',
+        });
+        await executeServerCommand('send-keys', {
+            press: 'ArrowUp',
+        });
+
+        // el.inputY.dispatchEvent(arrowUpEvent);
+        // el.inputY.dispatchEvent(arrowUpKeyupEvent);
+        // el.inputY.dispatchEvent(arrowUpEvent);
+        // el.inputY.dispatchEvent(arrowUpKeyupEvent);
 
         await elementUpdated(el);
 
         expect(el.x).to.equal(0.6666666666666666);
         expect(el.y).to.equal(0.22999999999999998);
 
-        el.dispatchEvent(arrowRightEvent);
-        el.dispatchEvent(arrowRightKeyupEvent);
-        el.dispatchEvent(arrowRightEvent);
-        el.dispatchEvent(arrowRightKeyupEvent);
+        await executeServerCommand('send-keys', {
+            press: 'ArrowRight',
+        });
+        await executeServerCommand('send-keys', {
+            press: 'ArrowRight',
+        });
 
         await elementUpdated(el);
 
         expect(el.x).to.equal(0.6866666666666666);
         expect(el.y).to.equal(0.22999999999999998);
 
-        el.dispatchEvent(arrowDownEvent);
-        el.dispatchEvent(arrowDownKeyupEvent);
-        el.dispatchEvent(arrowDownEvent);
-        el.dispatchEvent(arrowDownKeyupEvent);
+        await executeServerCommand('send-keys', {
+            press: 'ArrowDown',
+        });
+        await executeServerCommand('send-keys', {
+            press: 'ArrowDown',
+        });
 
         await elementUpdated(el);
 
         expect(el.x).to.equal(0.6866666666666666);
         expect(el.y).to.equal(0.25);
 
-        el.dispatchEvent(arrowLeftEvent);
-        el.dispatchEvent(arrowLeftKeyupEvent);
-        el.dispatchEvent(arrowLeftEvent);
-        el.dispatchEvent(arrowLeftKeyupEvent);
+        await executeServerCommand('send-keys', {
+            press: 'ArrowLeft',
+        });
+        await executeServerCommand('send-keys', {
+            press: 'ArrowLeft',
+        });
 
         await elementUpdated(el);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The up and down arrow keys were reported to be stuck in the Colour Area, which is a pretty serious usability issue. Luckily, it is now resolved. 

## Related Issue

Fixes https://github.com/adobe/spectrum-web-components/issues/1255

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Requested by our users. Also, it's just not great to have something that doesn't work.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
