### PR TITLE
fix(overlay): handle hover/longpress more directly via the "open" attribute

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -162,8 +162,8 @@ export class OverlayStack {
         if (this.findOverlayForContent(details.content)) {
             return false;
         }
-        if (details.interaction === 'longpress') {
-            this.initialLongpressClick = true;
+        if (details.notImmediatelyClosable) {
+            this._doesNotCloseOnFirstClick = true;
         }
         if (details.interaction === 'modal') {
             this.startTabTrapping();
@@ -409,11 +409,16 @@ export class OverlayStack {
         return this.hideAndCloseOverlay(this.topOverlay);
     }
 
-    private initialLongpressClick = false;
+    /**
+     * A "longpress" occurs before the "click" that creates it has occured.
+     * In that way the first click will still be part of the "longpress" and
+     * not part of closing the overlay.
+     */
+    private _doesNotCloseOnFirstClick = false;
 
     private handleMouse = (event: Event): void => {
-        if (this.initialLongpressClick) {
-            this.initialLongpressClick = false;
+        if (this._doesNotCloseOnFirstClick) {
+            this._doesNotCloseOnFirstClick = false;
             return;
         }
         if (this.preventMouseRootClose || event.defaultPrevented) {

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -32,6 +32,7 @@ export interface OverlayOpenDetail {
     trigger: HTMLElement;
     interaction: TriggerInteractions;
     theme: ThemeData;
+    notImmediatelyClosable?: boolean;
 }
 
 export interface OverlayOpenCloseDetail {
@@ -55,6 +56,7 @@ export type OverlayOptions = {
     placement?: Placement;
     offset?: number;
     receivesFocus?: 'auto';
+    notImmediatelyClosable?: boolean;
 };
 
 declare global {

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -94,6 +94,7 @@ export class Overlay {
         offset = 0,
         placement = 'top',
         receivesFocus,
+        notImmediatelyClosable,
     }: OverlayOptions): Promise<boolean> {
         /* c8 ignore next */
         if (this.isOpen) return true;
@@ -115,14 +116,15 @@ export class Overlay {
         this.owner.dispatchEvent(queryThemeEvent);
 
         const overlayDetailQuery: OverlayDisplayQueryDetail = {};
-        const queryOverlayDetailEvent = new CustomEvent<
-            OverlayDisplayQueryDetail
-        >('sp-overlay-query', {
-            bubbles: true,
-            composed: true,
-            detail: overlayDetailQuery,
-            cancelable: true,
-        });
+        const queryOverlayDetailEvent = new CustomEvent<OverlayDisplayQueryDetail>(
+            'sp-overlay-query',
+            {
+                bubbles: true,
+                composed: true,
+                detail: overlayDetailQuery,
+                cancelable: true,
+            }
+        );
         this.overlayElement.dispatchEvent(queryOverlayDetailEvent);
 
         await Overlay.overlayStack.openOverlay({
@@ -135,6 +137,7 @@ export class Overlay {
             interaction: this.interaction,
             theme: queryThemeDetail,
             receivesFocus,
+            notImmediatelyClosable,
             ...overlayDetailQuery,
         });
         this.isOpen = true;
@@ -150,15 +153,15 @@ export class Overlay {
 }
 
 /**
-* Announces that an overlay-based UI element has opened
-* @event sp-open
-* @type {object}
-* @property {TriggerInteractions} interaction type of interaction that triggered the opening
-*/
+ * Announces that an overlay-based UI element has opened
+ * @event sp-open
+ * @type {object}
+ * @property {TriggerInteractions} interaction type of interaction that triggered the opening
+ */
 
 /**
-* Announces that an overlay-based UI element has opened
-* @event sp-close
-* @type {object}
-* @property {TriggerInteractions} interaction type of interaction that triggered the closing
-*/
+ * Announces that an overlay-based UI element has opened
+ * @event sp-close
+ * @type {object}
+ * @property {TriggerInteractions} interaction type of interaction that triggered the closing
+ */

--- a/packages/overlay/test/overlay-trigger-click.test.ts
+++ b/packages/overlay/test/overlay-trigger-click.test.ts
@@ -9,7 +9,13 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { fixture, elementUpdated, waitUntil, html } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    waitUntil,
+    html,
+    expect,
+} from '@open-wc/testing';
 import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
@@ -17,6 +23,7 @@ import '@spectrum-web-components/popover/sp-popover.js';
 import { OverlayTrigger } from '..';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { spy } from 'sinon';
+import { ActionButton } from '@spectrum-web-components/action-button';
 
 describe('Overlay Trigger - Click', () => {
     it('displays `click` declaratively', async () => {
@@ -50,5 +57,47 @@ describe('Overlay Trigger - Click', () => {
         await waitUntil(() => closedSpy.calledOnce, 'click content returned', {
             timeout: 2000,
         });
+    });
+    it('opens a second time', async () => {
+        const openedSpy = spy();
+        const closedSpy = spy();
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger placement="right-start" type="modal" open="click">
+                <sp-action-button
+                    slot="trigger"
+                    @sp-opened=${() => openedSpy()}
+                    @sp-closed=${() => closedSpy()}
+                >
+                    <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                </sp-action-button>
+                <sp-popover slot="click-content" tip></sp-popover>
+            </overlay-trigger>
+        `);
+        await elementUpdated(el);
+        const trigger = el.querySelector('[slot=trigger]') as ActionButton;
+
+        await waitUntil(
+            () => openedSpy.calledOnce,
+            'click content projected to overlay',
+            { timeout: 2000 }
+        );
+        expect(el.open).to.equal('click');
+
+        el.removeAttribute('open');
+        await elementUpdated(el);
+
+        await waitUntil(() => closedSpy.calledOnce, 'click content returned', {
+            timeout: 2000,
+        });
+
+        expect(el.open).to.be.null;
+
+        trigger.click();
+        await waitUntil(
+            () => openedSpy.callCount === 2,
+            'click content projected to overlay, again',
+            { timeout: 2000 }
+        );
+        expect(el.open).to.equal('click');
     });
 });

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -76,9 +76,8 @@ describe('Overlay Trigger - Longpress', () => {
             () => !(content.parentElement instanceof OverlayTrigger)
         );
         await waitUntil(() => content.open, 'opens for `Space`');
-        await executeServerCommand('send-keys', {
-            press: 'Escape',
-        });
+        document.body.click();
+
         await waitUntil(() => !content.open, 'closes for `Space`');
         await elementUpdated(el);
 


### PR DESCRIPTION
## Description
- add state (rather than a workaround) to handle whether a `longpress` overlay has been opened via the mouse or via the keyboard
- correct the management of whether an `sp-closed` event should close ALL overlays or not
- update/add tests to support maintaining this long term

## Related Issue
fixes #1313

## Motivation and Context
Non-hover/longpress (mouse only) overlays wouldn't open a second time.

## How Has This Been Tested?
- manually
- new tests
- updated tests

## Screenshots (if appropriate):
https://westbrook-overlay-trigger--spectrum-web-components.netlify.app/components/dialog-wrapper

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
