### PR TITLE
docs(dialog): add documentation for the slot API

### DIFF
--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -37,6 +37,11 @@ import styles from './dialog.css.js';
 /**
  * @element sp-dialog
  *
+ * @slot hero - Accepts a hero image to display at the top of the dialog
+ * @slot heading - Acts as the heading of the dialog. This should be an actual heading tag `<h1-6 />`
+ * @slot - Content not addressed to a specific slot will be interpreted as the main content of the dialog
+ * @slot footer - Content addressed to the `footer` will be placed below the main content and to the side of any `[slot='button']` content
+ * @slot button - Button elements addressed to this slot may be placed below the content when not delivered in a fullscreen mode
  * @fires close - Announces that the dialog has been closed.
  */
 export class Dialog extends FocusVisiblePolyfillMixin(


### PR DESCRIPTION
## Description
Add slot documentation to the the Dialog listing.

## Related Issue
fixes #1247 

## Motivation and Context
We should inform users how to use out element.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/112365615-3cf7c100-8cae-11eb-9abb-9a2f28e906cd.png)

## Types of changes
- [x] Docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
