### PR TITLE
fix: correct max size calculation for overlays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: b82025c6d9b74071b9f318730e9201bf757d3f3d
+        default: 60bc4d9927db4a09f8490aa052d30db962d3753c
 commands:
     downstream:
         steps:

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -269,15 +269,13 @@ export const custom = (args: StoryArgs): TemplateResult => {
             label="Pick a state"
             ...=${spreadProps(args)}
         >
-            <sp-menu style="max-height: 400px;">
-                ${states.map(
-                    (state) => html`
-                        <sp-menu-item id=${state.id} value=${state.id}>
-                            ${state.label}
-                        </sp-menu-item>
-                    `
-                )}
-            </sp-menu>
+            ${states.map(
+                (state) => html`
+                    <sp-menu-item id=${state.id} value=${state.id}>
+                        ${state.label}
+                    </sp-menu-item>
+                `
+            )}
         </sp-picker>
         <p>This is some text.</p>
         <p>This is some text.</p>
@@ -287,4 +285,8 @@ export const custom = (args: StoryArgs): TemplateResult => {
             .
         </p>
     `;
+};
+
+custom.args = {
+    open: true,
 };

--- a/packages/popover/src/popover.css
+++ b/packages/popover/src/popover.css
@@ -15,53 +15,18 @@ governing permissions and limitations under the License.
     --sp-popover-tip-size: 24px;
 }
 
-:host([placement*='bottom'][open]) {
-    /* .spectrum-Popover--bottom.is-open */
-    max-height: calc(
-        100vh -
-            var(
-                --spectrum-dropdown-flyout-menu-offset-y,
-                var(--spectrum-global-dimension-size-75)
-            )
-    );
+:host([placement*='top']),
+:host([placement*='bottom']) {
+    max-height: calc(100% - var(--spectrum-overlay-animation-distance));
 }
-:host([placement*='top'][open]) {
-    /* .spectrum-Popover--top.is-open */
-    margin-top: var(
-        --spectrum-dropdown-flyout-menu-offset-y,
-        var(--spectrum-global-dimension-size-75)
-    );
-    max-height: calc(
-        100vh -
-            var(
-                --spectrum-dropdown-flyout-menu-offset-y,
-                var(--spectrum-global-dimension-size-75)
-            )
-    );
+
+:host([placement*='left']),
+:host([placement*='right']) {
+    max-width: calc(100% - var(--spectrum-overlay-animation-distance));
 }
-:host([placement*='right'][open]) {
-    /* .spectrum-Popover--right.is-open */
-    max-width: calc(
-        100vw -
-            var(
-                --spectrum-dropdown-flyout-menu-offset-y,
-                var(--spectrum-global-dimension-size-75)
-            )
-    );
-}
-:host([placement*='left'][open]) {
-    /* .spectrum-Popover--left.is-open */
-    margin-left: var(
-        --spectrum-dropdown-flyout-menu-offset-y,
-        var(--spectrum-global-dimension-size-75)
-    );
-    max-width: calc(
-        100vw -
-            var(
-                --spectrum-dropdown-flyout-menu-offset-y,
-                var(--spectrum-global-dimension-size-75)
-            )
-    );
+
+::slotted(*) {
+    overscroll-behavior: contain;
 }
 
 /* provide dimensions */


### PR DESCRIPTION
## Description
Ensure maintaining the size of an `active-overlay` element is passed down to descendants.

## Related Issue
fixes #1323 

## Motivation and Context
Size management is important to surfacing this functionality.

## How Has This Been Tested?
Manually
New visual regression

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/112387096-db445080-8cc7-11eb-8649-af92253031f4.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated tests to cover my changes.
- [x] All new and existing tests passed.
