### PR TITLE
docs: clarify label usage in regards to role="progressbar" uis

### DIFF
--- a/packages/progress-bar/README.md
+++ b/packages/progress-bar/README.md
@@ -107,7 +107,11 @@ When a progress bar needs to be placed on top of a colored background, use the o
 <div
     style="width: var(--spectrum-global-dimension-size-3000); height: var(--spectrum-global-dimension-size-2000); display: flex; flex-direction: column; align-items: center; justify-content: space-around; background-color: var(--spectrum-alias-background-color-modal-overlay);"
 >
-    <sp-progress-bar progress="7" over-background></sp-progress-bar>
+    <sp-progress-bar
+        label="Loaded a large amount"
+        progress="77"
+        over-background
+    ></sp-progress-bar>
 </div>
 ```
 
@@ -119,9 +123,14 @@ A progress bar can be either determinate or indeterminate as signified by `[inde
 <div
     style="width: var(--spectrum-global-dimension-size-3000); height: var(--spectrum-global-dimension-size-2000); display: flex; flex-direction: column; align-items: center; justify-content: space-around;"
 >
-    <sp-progress-bar indeterminate></sp-progress-bar>
+    <sp-progress-bar
+        aria-label="Loaded an unclear amount"
+        indeterminate
+    ></sp-progress-bar>
 </div>
 ```
+
+The above `sp-progress-bar` also leverages the `aria-label` attribute in place of the `label` attribute in ensure that the element is labelled correctly without that label appearing visibly in the UI.
 
 ### Side Label
 
@@ -138,3 +147,7 @@ A progress bar can be delivered with its labeling displayed above its visual ind
     ></sp-progress-bar>
 </div>
 ```
+
+## Accessibility
+
+An `sp-progress-bar` element will register itself as a `role="progressbar"` element in the accessibility tree. Any value applied to the `label` attribute will be used both to visibly label the element and to set the `aria-label` attribute on the host. In cases where a visible label is not desired, be sure to include an `aria-label` attribute manually to ensure that the `sp-progress-bar` correctly fulfills its responsibilities to visitors of you site of all abilities.

--- a/packages/progress-circle/README.md
+++ b/packages/progress-circle/README.md
@@ -34,9 +34,20 @@ An `<sp-progress-circle>` is used to visually show the progression of a system o
 <div
     style="width: 250px; height: 150px; display: flex; align-items: center; justify-content: space-around;"
 >
-    <sp-progress-circle progress="71" size="small"></sp-progress-circle>
-    <sp-progress-circle progress="22"></sp-progress-circle>
-    <sp-progress-circle progress="86" size="large"></sp-progress-circle>
+    <sp-progress-circle
+        label="A small representation of a somewhat completed action"
+        progress="71"
+        size="small"
+    ></sp-progress-circle>
+    <sp-progress-circle
+        label="A medium representation of a recently started action"
+        progress="22"
+    ></sp-progress-circle>
+    <sp-progress-circle
+        label="A large representation of an almost completed action"
+        progress="86"
+        size="large"
+    ></sp-progress-circle>
 </div>
 ```
 
@@ -49,12 +60,18 @@ When a loader needs to be placed on top of a colored background, use the over ba
     style="width: 250px; height: 150px; display: flex; align-items: center; justify-content: space-around;  background-color: rgba(0,0,0,0.4);"
 >
     <sp-progress-circle
+        label="A small representation of a partially completed action"
         progress="42"
         over-background
         size="small"
     ></sp-progress-circle>
-    <sp-progress-circle progress="7" over-background></sp-progress-circle>
     <sp-progress-circle
+        label="A medium representation of a barely started action"
+        progress="7"
+        over-background
+    ></sp-progress-circle>
+    <sp-progress-circle
+        label="A large representation of a somewhat completed action"
         progress="68"
         over-background
         size="large"
@@ -70,12 +87,27 @@ A progress circle can be either determinate or indeterminate as signified by `[i
 <div
     style="width: 250px; height: 150px; display: flex; align-items: center; justify-content: space-around;"
 >
-    <sp-progress-circle indeterminate size="small"></sp-progress-circle>
-    <sp-progress-circle indeterminate></sp-progress-circle>
-    <sp-progress-circle indeterminate size="large"></sp-progress-circle>
+    <sp-progress-circle
+        label="A small representation of an unclear amount of work"
+        indeterminate
+        size="small"
+    ></sp-progress-circle>
+    <sp-progress-circle
+        label="A medium representation of an unclear amount of work"
+        indeterminate
+    ></sp-progress-circle>
+    <sp-progress-circle
+        label="A large representation of an unclear amount of work"
+        indeterminate
+        size="large"
+    ></sp-progress-circle>
 </div>
 ```
 
 ### Size
 
 Progress Circles come in 3 sizes: small (`[size="small"]`), medium (default), or large (`[size="large"]`). These are available to fit various contexts. For example, the small loader can be used in place of an icon or in tight spaces, while the large one can be used for full-page loading.
+
+## Accessibility
+
+An `sp-progress-circle` element will register itself as a `role="progressbar"` element in the accessibility tree. Any value applied to the `label` attribute will be set as the `aria-label` attribute on the host. These two attributes can be used interchangably to ensure that the `sp-progress-circle` elements in your UI correctly fulfills its responsibilities to visitors of you site of all abilities.


### PR DESCRIPTION
## Description
Expand and correct documentation of `sp-progress-bar` and `sp-progress-cirlce` to include and outline when/how labels should be applied to the elements.

## Related Issue
fixes #1271
fixes #1274

## Motivation and Context
Accessibility!

## Screenshots (if appropriate):
https://westbrook-progress-bar--spectrum-web-components.netlify.app/components/progress-bar
https://westbrook-progress-bar--spectrum-web-components.netlify.app/components/progress-circle

## Types of changes
- [ ] Documentation

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
