### PR TITLE
fix: use hue normalized color in handle and allow focus

### DIFF
--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -41,22 +41,23 @@ export const joint = (): TemplateResult => {
             <sp-color-area
                 color="#7f3e3e"
                 @input=${({ target }: Event & { target: ColorArea }) => {
-                    const display = (target.nextElementSibling as HTMLElement)
-                        .nextElementSibling as HTMLElement;
+                    const next = target.nextElementSibling as ColorSlider;
+                    const display = next.nextElementSibling as HTMLElement;
                     display.textContent = target.color as string;
                     display.style.color = target.color as string;
+                    next.color = target.color;
                 }}
             ></sp-color-area>
             <sp-color-slider
+                color="#7f3e3e"
                 @input=${({
-                    target: { value, previousElementSibling },
+                    target: { color, previousElementSibling },
                 }: Event & {
                     target: ColorSlider & {
-                        value: number;
                         previousElementSibling: ColorArea;
                     };
                 }): void => {
-                    previousElementSibling.hue = value;
+                    previousElementSibling.color = color;
                 }}
             ></sp-color-slider>
             <div style="color: #7f3e3e">#7f3e3e</div>

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -253,6 +253,9 @@ export class ColorSlider extends Focusable {
         this._previousColor = this._color.clone();
         this.boundingClientRect = this.getBoundingClientRect();
         (event.target as HTMLElement).setPointerCapture(event.pointerId);
+        if (event.pointerType === 'mouse') {
+            this.handleFocus();
+        }
     }
 
     private handlePointermove(event: PointerEvent): void {
@@ -283,6 +286,9 @@ export class ColorSlider extends Focusable {
         );
         if (!applyDefault) {
             this._color = this._previousColor;
+        }
+        if (event.pointerType === 'mouse') {
+            this.handleBlur();
         }
     }
 
@@ -336,7 +342,7 @@ export class ColorSlider extends Focusable {
             </div>
             <sp-color-handle
                 class="handle"
-                color=${this._color.toHslString()}
+                color="hsl(${this._color.toHsl().h}, 100%, 50%)"
                 ?disabled=${this.disabled}
                 style="${this.vertical ? 'top' : 'left'}: ${this
                     .sliderHandlePosition}%"

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -231,6 +231,9 @@ export class ColorWheel extends Focusable {
         this._previousColor = this._color.clone();
         this.boundingClientRect = this.getBoundingClientRect();
         (event.target as HTMLElement).setPointerCapture(event.pointerId);
+        if (event.pointerType === 'mouse') {
+            this.handleFocus();
+        }
     }
 
     private handlePointermove(event: PointerEvent): void {
@@ -259,6 +262,9 @@ export class ColorWheel extends Focusable {
         );
         if (!applyDefault) {
             this._color = this._previousColor;
+        }
+        if (event.pointerType === 'mouse') {
+            this.handleBlur();
         }
     }
 
@@ -313,7 +319,7 @@ export class ColorWheel extends Focusable {
 
             <sp-color-handle
                 class="handle"
-                color=${this._color.toHslString()}
+                color="hsl(${this._color.toHsl().h}, 100%, 50%)"
                 ?disabled=${this.disabled}
                 style=${handleLocationStyles}
                 @manage=${streamingListener(


### PR DESCRIPTION
## Description
- pass a hue normalized color to handles in slider/wheel elements so that when they area associated with saturation/lightness modifying interfaces they do not display that in their handle
- add "focus management" to pointer === mouse controls so that the handle is made larger during interaction

Preview: https://wesbtrook-handle--spectrum-web-components.netlify.app/storybook/index.html?path=/story/color-area--joint

## Related Issue
fixes #1257 

## Motivation and Context
Composed UIs should appear more as expected by default.

## How Has This Been Tested?
Manually as it's a primarily visual change.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/113864798-55211300-9779-11eb-97c2-6224176d22d8.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
