### PR TITLE
fix(picker): accept new "value" and new option post first render

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -414,6 +414,9 @@ export class PickerBase extends SizedMixin(Focusable) {
     }
 
     protected manageSelection(): void {
+        if (!this.open) {
+            this.updateMenuItems();
+        }
         /* c8 ignore next 3 */
         if (this.menuItems.length > 0) {
             let selectedItem: MenuItem | undefined;

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -157,6 +157,27 @@ describe('Picker', () => {
         await expect(el).to.be.accessible();
     });
 
+    it('accepts a new item and value at the same time', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        el.value = 'option-2';
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('option-2');
+
+        const item = document.createElement('sp-menu-item');
+        item.value = 'option-new';
+        item.textContent = 'New Option';
+
+        el.append(item);
+        el.value = 'option-new';
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('option-new');
+    });
+
     it('manages its "name" value in the accessibility tree', async () => {
         const el = await pickerFixture();
 


### PR DESCRIPTION
## Description
Ensures that the available options are as up-to-date as possible before validating a change to the picker's `value`.

## Related Issue
refs #1331 maybe fixes, if we chose to follow up on the conversation there with a more specific issue

## Motivation and Context
Users shouldn't have to be precious with our elements.

## How Has This Been Tested?
Unit test added.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
