### PR TITLE
refactor: update exports listings, exclude custom-elements.json

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-accordion": "./sp-accordion.js",
         "./sp-accordion.js": "./sp-accordion.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "karma start --coverage"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/action-bar/package.json
+++ b/packages/action-bar/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-action-bar": "./sp-action-bar.js",
         "./sp-action-bar.js": "./sp-action-bar.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-action-button": "./sp-action-button.js",
         "./sp-action-button.js": "./sp-action-button.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-action-group": "./sp-action-group.js",
         "./sp-action-group.js": "./sp-action-group.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "karma start --coverage"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-action-menu": "./sp-action-menu.js",
         "./sp-action-menu.js": "./sp-action-menu.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-asset": "./sp-asset.js",
         "./sp-asset.js": "./sp-asset.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-avatar": "./sp-avatar.js",
         "./sp-avatar.js": "./sp-avatar.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-banner": "./sp-banner.js",
         "./sp-banner.js": "./sp-banner.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -24,7 +24,6 @@
         "./src/*": "./src/*",
         "./streaming-listener": "./src/streaming-listener.js",
         "./streaming-listener.js": "./src/streaming-listener.js",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },
     "scripts": {

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-button-group": "./sp-button-group.js",
         "./sp-button-group.js": "./sp-button-group.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-button": "./sp-button.js",
         "./sp-button.js": "./sp-button.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-card": "./sp-card.js",
         "./sp-card.js": "./sp-card.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-checkbox": "./sp-checkbox.js",
         "./sp-checkbox.js": "./sp-checkbox.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-coachmark": "./sp-coachmark.js",
         "./sp-coachmark.js": "./sp-coachmark.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/color-area/package.json
+++ b/packages/color-area/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-color-area": "./sp-color-area.js",
         "./sp-color-area.js": "./sp-color-area.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/color-handle/package.json
+++ b/packages/color-handle/package.json
@@ -20,8 +20,8 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
-        "./src/": "./src/index.js",
-        "./custom-elements.json": "./custom-elements.json",
+        ".": "./src/index.js",
+        "./src/*": "./src/*",
         "./package.json": "./package.json",
         "./sp-color-handle": "./sp-color-handle.js",
         "./sp-color-handle.js": "./sp-color-handle.js"
@@ -29,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/color-loupe/package.json
+++ b/packages/color-loupe/package.json
@@ -20,8 +20,8 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
-        "./src/": "./src/index.js",
-        "./custom-elements.json": "./custom-elements.json",
+        ".": "./src/index.js",
+        "./src/*": "./src/*",
         "./package.json": "./package.json",
         "./sp-color-loupe": "./sp-color-loupe.js",
         "./sp-color-loupe.js": "./sp-color-loupe.js"
@@ -29,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/color-slider/package.json
+++ b/packages/color-slider/package.json
@@ -20,8 +20,8 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
-        "./src/": "./src/index.js",
-        "./custom-elements.json": "./custom-elements.json",
+        ".": "./src/index.js",
+        "./src/*": "./src/*",
         "./package.json": "./package.json",
         "./sp-color-slider": "./sp-color-slider.js",
         "./sp-color-slider.js": "./sp-color-slider.js"
@@ -29,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/color-wheel/package.json
+++ b/packages/color-wheel/package.json
@@ -20,8 +20,8 @@
     "module": "src/index.js",
     "type": "module",
     "exports": {
-        "./src/": "./src/index.js",
-        "./custom-elements.json": "./custom-elements.json",
+        ".": "./src/index.js",
+        "./src/*": "./src/*",
         "./package.json": "./package.json",
         "./sp-color-wheel": "./sp-color-wheel.js",
         "./sp-color-wheel.js": "./sp-color-wheel.js"
@@ -29,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-dialog": "./sp-dialog.js",
         "./sp-dialog.js": "./sp-dialog.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-divider": "./sp-divider.js",
         "./sp-divider.js": "./sp-divider.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-dropzone": "./sp-dropzone.js",
         "./sp-dropzone.js": "./sp-dropzone.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-field-group": "./sp-field-group.js",
         "./sp-field-group.js": "./sp-field-group.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-field-label": "./sp-field-label.js",
         "./sp-field-label.js": "./sp-field-label.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-icon": "./sp-icon.js",
         "./sp-icon.js": "./sp-icon.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -23,12 +23,12 @@
         ".": "./src/index.js",
         "./src/*": "./src/*",
         "./icons/*": "./icons/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },
     "scripts": {
         "build": "node ./bin/build @spectrum-css/icon/medium"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "/icons/",
         "/lib/",

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -23,12 +23,12 @@
         ".": "./src/index.js",
         "./src/*": "./src/*",
         "./icons/*": "./icons/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },
     "scripts": {
         "build": "node ./bin/build @adobe/spectrum-css-workflow-icons/dist/18"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "/icons/",
         "/lib/",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-icons-large": "./sp-icons-large.js",
         "./sp-icons-large.js": "./sp-icons-large.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -21,7 +21,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },
     "scripts": {

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-illustrated-message": "./sp-illustrated-message.js",
         "./sp-illustrated-message.js": "./sp-illustrated-message.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-link": "./sp-link.js",
         "./sp-link.js": "./sp-link.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-menu": "./sp-menu.js",
         "./sp-menu.js": "./sp-menu.js",
@@ -36,6 +35,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-meter": "./sp-meter.js",
         "./sp-meter.js": "./sp-meter.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -20,9 +20,8 @@
     "module": "src/modal.css.js",
     "type": "module",
     "exports": {
-        ".": "./src/index.js",
+        ".": "./src/modal.css.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },
     "scripts": {

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./active-overlay": "./active-overlay.js",
         "./active-overlay.js": "./active-overlay.js",
@@ -34,6 +33,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-picker": "./sp-picker.js",
         "./sp-picker.js": "./sp-picker.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-popover": "./sp-popover.js",
         "./sp-popover.js": "./sp-popover.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-progress-bar": "./sp-progress-bar.js",
         "./sp-progress-bar.js": "./sp-progress-bar.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-progress-circle": "./sp-progress-circle.js",
         "./sp-progress-circle.js": "./sp-progress-circle.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-quick-actions": "./sp-quick-actions.js",
         "./sp-quick-actions.js": "./sp-quick-actions.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "karma start --coverage"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-radio": "./sp-radio.js",
         "./sp-radio.js": "./sp-radio.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-search": "./sp-search.js",
         "./sp-search.js": "./sp-search.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json"
     },
     "scripts": {

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-sidenav": "./sp-sidenav.js",
         "./sp-sidenav.js": "./sp-sidenav.js",
@@ -34,6 +33,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-slider": "./sp-slider.js",
         "./sp-slider.js": "./sp-slider.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-split-button": "./sp-split-button.js",
         "./sp-split-button.js": "./sp-split-button.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "karma start --coverage"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-split-view": "./sp-split-view.js",
         "./sp-split-view.js": "./sp-split-view.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-status-light": "./sp-status-light.js",
         "./sp-status-light.js": "./sp-status-light.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -20,7 +20,8 @@
     "module": "src/spectrum-base.css.js",
     "type": "module",
     "exports": {
-        "./*": "./*"
+        "./*": "./*",
+        "./src/*": "./src/*"
     },
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-switch": "./sp-switch.js",
         "./sp-switch.js": "./sp-switch.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-tabs": "./sp-tabs.js",
         "./sp-tabs.js": "./sp-tabs.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-tags": "./sp-tags.js",
         "./sp-tags.js": "./sp-tags.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-textfield": "./sp-textfield.js",
         "./sp-textfield.js": "./sp-textfield.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-theme": "./sp-theme.js",
         "./sp-theme.js": "./sp-theme.js",
@@ -42,6 +41,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/thumbnail/package.json
+++ b/packages/thumbnail/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-thumbnail": "./sp-thumbnail.js",
         "./sp-thumbnail.js": "./sp-thumbnail.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-toast": "./sp-toast.js",
         "./sp-toast.js": "./sp-toast.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-tooltip": "./sp-tooltip.js",
         "./sp-tooltip.js": "./sp-tooltip.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-top-nav": "./sp-top-nav.js",
         "./sp-top-nav.js": "./sp-top-nav.js",
@@ -32,6 +31,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./sp-underlay": "./sp-underlay.js",
         "./sp-underlay.js": "./sp-underlay.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",

--- a/projects/story-decorator/package.json
+++ b/projects/story-decorator/package.json
@@ -21,7 +21,6 @@
     "type": "module",
     "exports": {
         "./src/*": "./src/*.js",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./decorator": "./decorator.js",
         "./decorator.js": "./decorator.js",
@@ -31,6 +30,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.js",
         "*.js.map",

--- a/projects/templates/plop-templates/package.json.hbs
+++ b/projects/templates/plop-templates/package.json.hbs
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*.js",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./{{> tagnamePartial }}": "./{{> tagnamePartial }}.js",
         "./{{> tagnamePartial }}.js": "./{{> tagnamePartial }}.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "custom-elements.json",
         "*.d.ts",

--- a/projects/vrt-compare/package.json
+++ b/projects/vrt-compare/package.json
@@ -22,7 +22,6 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*.js",
-        "./custom-elements.json": "./custom-elements.json",
         "./package.json": "./package.json",
         "./vrt-compare": "./vrt-compare.js",
         "./vrt-compare.js": "./vrt-compare.js"
@@ -30,6 +29,7 @@
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
+    "customElementsManifest": "custom-elements.json",
     "files": [
         "*.d.ts",
         "*.js",


### PR DESCRIPTION
## Description
Sequesters this change into a stand alone PR so that we can confirm any ecosystem side effects of it specifically.

Let's get the currently open PRs moved through the system and do a canary release once we've rebased this onto those changes and see what we can see in the lint rules that Alex brought up.

## Motivation and Context
CDNs/Node likely shouldn't be building with this directly, so particular to large ones (the icons listings) this can save a lot of trouble at the CDN level.

## Types of changes
- [x] Metadata refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
