### PR TITLE
fix(menu): only scrollIntoView when keyboard navigating

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
         "test:visual:clean": "yarn test:visual:clean:baseline && yarn test:visual:clean:current",
         "test:visual:clean:baseline": "rm -rf test/visual/screenshots-baseline",
         "test:visual:clean:current": "rm -rf test/visual/screenshots-current",
-        "test:watch": "run-p watch 'test:build -w' 'test:start --watch --group unit'",
+        "test:watch": "test:watch:focus unit",
+        "test:watch:focus": "run-p watch 'test:build -w' 'test:start --watch --group {1}' --",
         "watch": "gulp watch"
     },
     "peerDependencies": {

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -138,12 +138,17 @@ export class Menu extends SpectrumElement {
         if (code !== 'ArrowDown' && code !== 'ArrowUp') {
             return;
         }
-        event.preventDefault();
+        const lastFocusedItem = this.menuItems[this.focusedItemIndex];
         const direction = code === 'ArrowDown' ? 1 : -1;
-        this.focusMenuItemByOffset(direction);
+        const itemToFocus = this.focusMenuItemByOffset(direction);
+        if (itemToFocus === lastFocusedItem) {
+            return;
+        }
+        event.preventDefault();
+        itemToFocus.scrollIntoView({ block: 'nearest' });
     }
 
-    public focusMenuItemByOffset(offset: number): void {
+    public focusMenuItemByOffset(offset: number): MenuItem {
         const step = offset || 1;
         const focusedItem = this.menuItems[this.focusedItemIndex] as MenuItem;
         focusedItem.focused = false;
@@ -161,12 +166,11 @@ export class Menu extends SpectrumElement {
             itemToFocus = this.menuItems[this.focusedItemIndex] as MenuItem;
         }
         // if there are no non-disabled items, skip the work to focus a child
-        if (itemToFocus.disabled) {
-            return;
+        if (!itemToFocus.disabled) {
+            itemToFocus.focused = true;
+            this.setAttribute('aria-activedescendant', itemToFocus.id);
         }
-        itemToFocus.focused = true;
-        itemToFocus.scrollIntoView({ block: 'nearest' });
-        this.setAttribute('aria-activedescendant', itemToFocus.id);
+        return itemToFocus;
     }
 
     private prepareToCleanUp(): void {
@@ -251,6 +255,12 @@ export class Menu extends SpectrumElement {
         }
         this.observer.observe(this, { childList: true, subtree: true });
         this.updateComplete.then(() => this.prepItems());
+        const selectedItem = this.querySelector('[selected]');
+        if (selectedItem) {
+            requestAnimationFrame(() => {
+                selectedItem.scrollIntoView({ block: 'nearest' });
+            });
+        }
     }
 
     public disconnectedCallback(): void {


### PR DESCRIPTION
## Description
The `scrollIntoView()` functionality to support keyboard interactions actually moves the `sp-menu-item` when scrolling is possible making the `click` event not trigger correctly. This sequester the `scrollIntoView()` call to _only_ the keyboard workflow to support this.

TODO:
- [x] ensure open/close visibility of selected/focused item
- [x] think through how to capture this functionality in a unit test

## Related Issue
fixes #1361 

## Motivation and Context
Works as expected.

## How Has This Been Tested?
Manually

## Preview:
https://westbrook-menu--spectrum-web-components.netlify.app/storybook/?path=/story/picker--custom

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
