### PR TITLE
Adixon 1189/menu customization

### DIFF
--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -98,6 +98,8 @@ export class Menu extends SpectrumElement {
         }) as MenuItem;
         /* c8 ignore next 3 */
         if (target) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
             this.selectOrToggleItem(target);
         } else {
             return;

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -29,6 +29,7 @@ export interface MenuQueryRoleEventDetail {
 /**
  * Spectrum Menu Component
  * @element sp-menu
+ * @fires change - Announces that the `value` of the element has changed
  *
  */
 export class Menu extends SpectrumElement {
@@ -36,12 +37,21 @@ export class Menu extends SpectrumElement {
         return [menuStyles];
     }
 
-    @property({ type: Boolean, reflect: true })
-    public selectable = false;
+    @property({ type: String, reflect: true })
+    public selects: undefined | 'single' | 'multiple';
+
+    @property({ type: String })
+    public value = '';
+
+    // TODO: allow setting this in the API to change the values
+    @property({ attribute: false })
+    public selected = [] as string[];
 
     public menuItems = [] as MenuItem[];
     public focusedItemIndex = 0;
     public focusInItemIndex = 0;
+
+    private selectedItemsMap = new Map() as Map<MenuItem, boolean>;
 
     /**
      * Hide this getter from web-component-analyzer until
@@ -87,7 +97,9 @@ export class Menu extends SpectrumElement {
             return el.getAttribute('role') === this.childRole;
         }) as MenuItem;
         /* c8 ignore next 3 */
-        if (!target) {
+        if (target) {
+            this.selectOrToggleItem(target);
+        } else {
             return;
         }
         this.prepareToCleanUp();
@@ -122,6 +134,67 @@ export class Menu extends SpectrumElement {
 
     public stopListeningToKeyboard(): void {
         this.removeEventListener('keydown', this.handleKeydown);
+    }
+
+    public async selectOrToggleItem(item: MenuItem): Promise<void> {
+        if (this.selects == null) {
+            return;
+        }
+
+        const oldSelectedItemsMap = new Map(this.selectedItemsMap);
+        const oldSelected = this.selected.slice();
+        const oldValue = this.value;
+
+        if (this.selects === 'single') {
+            this.selectedItemsMap.clear();
+            this.selectedItemsMap.set(item, true);
+            this.value = item.value;
+        } else {
+            if (this.selectedItemsMap.has(item)) {
+                this.selectedItemsMap.delete(item);
+            } else {
+                this.selectedItemsMap.set(item, true);
+            }
+
+            // Match HTML select and set the first selected
+            // item as the value. Also set the selected array
+            // in the order of the menu items.
+            let valueSet: boolean = false;
+            let selected: string[] = [];
+            for (const menuItem of this.menuItems) {
+                if (this.selectedItemsMap.has(menuItem)) {
+                    if (!valueSet) {
+                        this.value = menuItem.value;
+                        valueSet = true;
+                    }
+                    selected.push(item.value);
+                }
+            }
+            this.selected = selected;
+        }
+
+        await this.updateComplete;
+        const applyDefault = this.dispatchEvent(
+            new Event('change', {
+                cancelable: true,
+            })
+        );
+        if (!applyDefault) {
+            this.selected = oldSelected;
+            this.selectedItemsMap = oldSelectedItemsMap;
+            this.value = oldValue;
+            return;
+        }
+        if (this.selects === 'single' && oldSelected) {
+            for (const oldItem of oldSelectedItemsMap.keys()) {
+                if (oldItem !== item) {
+                    oldItem.selected = false;
+                }
+            }
+            item.selected = true;
+        } else if (this.selects === 'multiple') {
+            item.selected = !item.selected;
+        }
     }
 
     public handleKeydown(event: KeyboardEvent): void {

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -12,6 +12,8 @@ governing permissions and limitations under the License.
 
 import {
     html,
+    ifDefined,
+    property,
     SpectrumElement,
     CSSResultArray,
     TemplateResult,
@@ -32,6 +34,9 @@ export class MenuGroup extends SpectrumElement {
         return [menuGroupStyles];
     }
 
+    @property({ type: String, reflect: true })
+    public selects: undefined | 'single' | 'multiple';
+
     private instanceCount = MenuGroup.instances;
 
     private static instances = 0;
@@ -41,13 +46,24 @@ export class MenuGroup extends SpectrumElement {
         MenuGroup.instances += 1;
     }
 
+    private get menuRole() {
+        if (this.selects) {
+            return 'menu';
+        } else {
+            return 'presentation';
+        }
+    }
+
     public render(): TemplateResult {
         const labelledby = `menu-heading-category-${this.instanceCount}`;
         return html`
             <span class="header" id=${labelledby} aria-hidden="true">
                 <slot name="header"></slot>
             </span>
-            <sp-menu role="presentation">
+            <sp-menu
+                selects=${ifDefined(this.selects ? this.selects : undefined)}
+                role=${this.menuRole}
+            >
                 <slot></slot>
             </sp-menu>
         `;

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -30,7 +30,7 @@ const config = {
                 {
                     selector: '.is-selectable',
                     type: 'boolean',
-                    name: 'selectable',
+                    name: 'selects',
                 },
             ],
             slots: [
@@ -55,13 +55,13 @@ const config = {
                 },
                 {
                     replacement:
-                        ':host([dir="ltr"][selectable]) ::slotted(sp-menu-item[selected])',
+                        ':host([dir="ltr"][selects]) ::slotted(sp-menu-item[selected])',
                     selector:
                         '.spectrum-Menu[dir=ltr].is-selectable .spectrum-Menu-item.is-selected',
                 },
                 {
                     replacement:
-                        ':host([dir="rtl"][selectable]) ::slotted(sp-menu-item[selected])',
+                        ':host([dir="rtl"][selects]) ::slotted(sp-menu-item[selected])',
                     selector:
                         '.spectrum-Menu[dir=rtl].is-selectable .spectrum-Menu-item.is-selected',
                 },

--- a/packages/menu/src/spectrum-menu.css
+++ b/packages/menu/src/spectrum-menu.css
@@ -89,15 +89,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     list-style-type: none;
     overflow: auto;
 }
-:host([dir='ltr'][selectable]) ::slotted(sp-menu-item) {
+:host([dir='ltr'][selects]) ::slotted(sp-menu-item) {
     /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item */
     padding-right: var(--spectrum-listitem-selectable-padding-right);
 }
-:host([dir='rtl'][selectable]) ::slotted(sp-menu-item) {
+:host([dir='rtl'][selects]) ::slotted(sp-menu-item) {
     /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item */
     padding-left: var(--spectrum-listitem-selectable-padding-right);
 }
-:host([dir='ltr'][selectable]) ::slotted(sp-menu-item[selected]) {
+:host([dir='ltr'][selects]) ::slotted(sp-menu-item[selected]) {
     /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
     padding-right: calc(
         var(--spectrum-listitem-padding-right) -
@@ -107,7 +107,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
-:host([dir='rtl'][selectable]) ::slotted(sp-menu-item[selected]) {
+:host([dir='rtl'][selects]) ::slotted(sp-menu-item[selected]) {
     /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
     padding-left: calc(
         var(--spectrum-listitem-padding-right) -

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -148,7 +148,45 @@ export const Selected = (): TemplateResult => {
                     <sp-menu-item>North Beach</sp-menu-item>
                 </sp-menu-group>
                 <sp-menu-divider></sp-menu-divider>
+                <sp-menu-group selects="single">
+                    <span slot="header">Oakland</span>
+                    <sp-menu-item>City Center</sp-menu-item>
+                    <sp-menu-item disabled>Jack London Square</sp-menu-item>
+                    <sp-menu-item selected>
+                        My best friend's mom's house in the burbs just off
+                        Silverado street
+                    </sp-menu-item>
+                </sp-menu-group>
+            </sp-menu>
+        </sp-popover>
+    `;
+};
+
+export const MenuGroupSelects = (): TemplateResult => {
+    return html`
+        <sp-popover open style="width: 200px;">
+            <sp-menu selects="single">
                 <sp-menu-group>
+                    <span slot="header">Minneapolis</span>
+                    <sp-menu-item>Camden</sp-menu-item>
+                    <sp-menu-item>Cedar Riverside</sp-menu-item>
+                    <sp-menu-item>Downtown</sp-menu-item>
+                    <sp-menu-item>Northeast Arts District</sp-menu-item>
+                    <sp-menu-item>Uptown</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-group>
+                    <span slot="header">St. Paul</span>
+                    <sp-menu-item>Lowertown</sp-menu-item>
+                    <sp-menu-item>Grand Ave</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-group selects="multiple">
+                    <span slot="header">San Francisco</span>
+                    <sp-menu-item>Financial District</sp-menu-item>
+                    <sp-menu-item>South of Market</sp-menu-item>
+                    <sp-menu-item>North Beach</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-group selects="single">
                     <span slot="header">Oakland</span>
                     <sp-menu-item>City Center</sp-menu-item>
                     <sp-menu-item disabled>Jack London Square</sp-menu-item>

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -28,76 +28,93 @@ export default {
 export const Default = (): TemplateResult => {
     return html`
         <sp-menu>
-            <sp-menu-item>
-                Deselect
-            </sp-menu-item>
-            <sp-menu-item>
-                Select Inverse
-            </sp-menu-item>
-            <sp-menu-item>
-                Feather...
-            </sp-menu-item>
-            <sp-menu-item>
-                Select and Mask...
-            </sp-menu-item>
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
             <sp-menu-divider></sp-menu-divider>
-            <sp-menu-item>
-                Save Selection
-            </sp-menu-item>
-            <sp-menu-item disabled>
-                Make Work Path
-            </sp-menu-item>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
         </sp-menu>
 
         <sp-popover open>
             <sp-menu>
-                <sp-menu-item>
-                    Deselect
-                </sp-menu-item>
-                <sp-menu-item>
-                    Select Inverse
-                </sp-menu-item>
-                <sp-menu-item>
-                    Feather...
-                </sp-menu-item>
-                <sp-menu-item>
-                    Select and Mask...
-                </sp-menu-item>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
                 <sp-menu-divider></sp-menu-divider>
-                <sp-menu-item>
-                    Save Selection
-                </sp-menu-item>
-                <sp-menu-item disabled>
-                    Make Work Path
-                </sp-menu-item>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
             </sp-menu>
         </sp-popover>
     `;
 };
 
+export const singleSelect = (): TemplateResult => {
+    return html`
+        <sp-menu selects="single">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-menu>
+
+        <sp-popover open>
+            <sp-menu selects="single">
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-menu>
+        </sp-popover>
+    `;
+};
+
+export const multipleSelect = (): TemplateResult => {
+    return html`
+        <sp-menu selects="multiple">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item selected>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item selected>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-menu>
+
+        <sp-popover open>
+            <sp-menu selects="multiple">
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item selected>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item selected>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-menu>
+        </sp-popover>
+    `;
+};
 export const headersAndIcons = (): TemplateResult => {
     return html`
         <sp-popover open>
             <sp-menu>
                 <sp-menu-group>
-                    <span slot="header">
-                        Section Heading
-                    </span>
-                    <sp-menu-item>
-                        Action 1
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        Action 2
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        Action 3
-                    </sp-menu-item>
+                    <span slot="header">Section Heading</span>
+                    <sp-menu-item>Action 1</sp-menu-item>
+                    <sp-menu-item>Action 2</sp-menu-item>
+                    <sp-menu-item>Action 3</sp-menu-item>
                 </sp-menu-group>
                 <sp-menu-divider></sp-menu-divider>
                 <sp-menu-group>
-                    <span slot="header">
-                        Section Heading
-                    </span>
+                    <span slot="header">Section Heading</span>
                     <sp-menu-item>
                         <sp-icon-checkmark-circle
                             slot="icon"
@@ -125,30 +142,16 @@ export const Selected = (): TemplateResult => {
         <sp-popover open style="width: 200px;">
             <sp-menu>
                 <sp-menu-group>
-                    <span slot="header">
-                        San Francisco
-                    </span>
-                    <sp-menu-item>
-                        Financial District
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        South of Market
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        North Beach
-                    </sp-menu-item>
+                    <span slot="header">San Francisco</span>
+                    <sp-menu-item>Financial District</sp-menu-item>
+                    <sp-menu-item>South of Market</sp-menu-item>
+                    <sp-menu-item>North Beach</sp-menu-item>
                 </sp-menu-group>
                 <sp-menu-divider></sp-menu-divider>
                 <sp-menu-group>
-                    <span slot="header">
-                        Oakland
-                    </span>
-                    <sp-menu-item>
-                        City Center
-                    </sp-menu-item>
-                    <sp-menu-item disabled>
-                        Jack London Square
-                    </sp-menu-item>
+                    <span slot="header">Oakland</span>
+                    <sp-menu-item>City Center</sp-menu-item>
+                    <sp-menu-item disabled>Jack London Square</sp-menu-item>
                     <sp-menu-item selected>
                         My best friend's mom's house in the burbs just off
                         Silverado street

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -276,8 +276,6 @@ export class PickerBase extends SizedMixin(Focusable) {
             this.optionsMenu
         );
 
-        this.optionsMenu.selectable = true;
-
         this.sizePopover(this.popover);
         const { popover } = this;
         this.closeOverlay = await Picker.openOverlay(this, 'inline', popover, {
@@ -360,7 +358,11 @@ export class PickerBase extends SizedMixin(Focusable) {
                 @click=${this.onClick}
                 @sp-overlay-closed=${this.onOverlayClosed}
             >
-                <sp-menu id="menu" role="${this.listRole}"></sp-menu>
+                <sp-menu
+                    id="menu"
+                    selects="single"
+                    role="${this.listRole}"
+                ></sp-menu>
             </sp-popover>
         `;
     }


### PR DESCRIPTION
Initial work to add selects support for #1189
refs #715

## Description

I figured I'd just start by adding support to `sp-menu` and `sp-menu-group` and get some feedback on the approach before integrating with our existing menu components. The storybooks for menu should work with the new changes

## Menu work to still be done (not to mention all the integration work)

* add selection get/set to menu group
* add tests!
* update documentation 
* look for low-hanging fruit accessibility issues that can be addressed here

## Checklist:

- [ x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
