### PR TITLE
fix(styles): update exports listing

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -20,7 +20,18 @@
     "module": "src/spectrum-base.css.js",
     "type": "module",
     "exports": {
-        "./*": "./*",
+        ".": "./src/spectrum-base.css.js",
+        "./*.css": "./*.css",
+        "./body": "./body.js",
+        "./body.js": "./body.js",
+        "./code": "./code.js",
+        "./code.js": "./code.js",
+        "./detail": "./detail.js",
+        "./detail.js": "./detail.js",
+        "./heading": "./heading.js",
+        "./heading.js": "./heading.js",
+        "./typography": "./typography.js",
+        "./typography.js": "./typography.js",
         "./src/*": "./src/*"
     },
     "scripts": {


### PR DESCRIPTION
## Description
Make JSPM happy about our exports listing.

Now: https://jspm.dev/@spectrum-web-components/styles@0.9.5-alpha.1/body.js
Previously: https://jspm.dev/@spectrum-web-components/styles@0.9.4/body.js

Upon thinking this all the way through I can understand why they would choose not to support the `'./*': './*'` listing that we were using, as it cuts off the ability to easily map "entry points" to not root directory sources. It does make me think that maybe we want to move things out of the root directory at some point in the future and rely on exports to map to the right file... something to think about in the future.

## Related Issue
fixes #1190 🤞🏼 

## Motivation and Context
At least one CDN needs to be happy with out bundle package so we can use it on the Getting Started page.

## How Has This Been Tested?
See above links.

## Types of changes
- [x] Metadata

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
