### PR TITLE
Avoid use of Node.isSameNode

### DIFF
--- a/packages/accordion/src/Accordion.ts
+++ b/packages/accordion/src/Accordion.ts
@@ -48,7 +48,7 @@ export class Accordion extends Focusable {
     }
 
     public focus(): void {
-        if (this.focusElement.isSameNode(this)) {
+        if (this.focusElement === this) {
             return;
         }
 

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -64,7 +64,7 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
         const target = this.target as AcceptsFocusVisisble;
         const targetParent = target.getRootNode() as ShadowRoot;
         const targetHost = targetParent.host as AcceptsFocusVisisble;
-        if (targetParent.isSameNode(parent) && target.forceFocusVisible) {
+        if (targetParent === parent && target.forceFocusVisible) {
             target.forceFocusVisible();
         } else if (targetHost && targetHost.forceFocusVisible) {
             targetHost.forceFocusVisible();
@@ -86,7 +86,7 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
         this.target = target.focusElement || target;
         if (this.target) {
             const targetParent = this.target.getRootNode() as HTMLElement;
-            if (targetParent.isSameNode(parent)) {
+            if (targetParent === parent) {
                 this.target.setAttribute('aria-labelledby', this.id);
             } else {
                 this.target.setAttribute(

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -136,7 +136,7 @@ export class OverlayStack {
         overlayContent: HTMLElement
     ): ActiveOverlay | undefined {
         for (const item of this.overlays) {
-            if (overlayContent.isSameNode(item.overlayContent as HTMLElement)) {
+            if (overlayContent === item.overlayContent) {
                 return item;
             }
         }
@@ -153,7 +153,7 @@ export class OverlayStack {
     private isClickOverlayActiveForTrigger(trigger: HTMLElement): boolean {
         return this.overlays.some(
             (item) =>
-                trigger.isSameNode(item.trigger as HTMLElement) &&
+                trigger === item.trigger &&
                 item.interaction === 'click'
         );
     }
@@ -381,7 +381,7 @@ export class OverlayStack {
                             .getRootNode()
                             .contains(triggerActiveElement) ||
                         (triggerRoot.host &&
-                            triggerRoot.host.isSameNode(triggerActiveElement))
+                            triggerRoot.host === triggerActiveElement)
                     ) {
                         overlay.trigger.focus();
                     }

--- a/packages/overlay/src/overlay-timer.ts
+++ b/packages/overlay/src/overlay-timer.ts
@@ -38,7 +38,7 @@ export class OverlayTimer {
     public async openTimer(component: HTMLElement): Promise<boolean> {
         this.cancelCooldownTimer();
 
-        if (!this.component || !component.isSameNode(this.component)) {
+        if (!this.component || component !== this.component) {
             if (this.component) {
                 this.close(this.component);
                 this.cancelCooldownTimer();
@@ -68,7 +68,7 @@ export class OverlayTimer {
     }
 
     public close(component: HTMLElement): void {
-        if (this.component && this.component.isSameNode(component)) {
+        if (this.component && this.component === component) {
             this.resetCooldownTimer();
             if (this.timeout > 0) {
                 clearTimeout(this.timeout);

--- a/packages/popover/src/Popover.ts
+++ b/packages/popover/src/Popover.ts
@@ -80,7 +80,7 @@ export class Popover extends SpectrumElement {
 
         const target = event.target as Node;
         /* c8 ignore next */
-        if (!target.isSameNode(this)) return;
+        if (target !== this) return;
 
         const tipElement = this.shadowRoot.querySelector('#tip') as HTMLElement;
         if (tipElement) {

--- a/packages/sidenav/src/Sidenav.ts
+++ b/packages/sidenav/src/Sidenav.ts
@@ -49,7 +49,7 @@ export class SideNav extends Focusable {
     }
 
     public focus(): void {
-        if (this.focusElement.isSameNode(this)) {
+        if (this.focusElement === this) {
             return;
         }
 
@@ -57,7 +57,7 @@ export class SideNav extends Focusable {
     }
 
     public blur(): void {
-        if (this.focusElement.isSameNode(this)) {
+        if (this.focusElement === this) {
             return;
         }
 
@@ -65,7 +65,7 @@ export class SideNav extends Focusable {
     }
 
     public click(): void {
-        if (this.focusElement.isSameNode(this)) {
+        if (this.focusElement === this) {
             return;
         }
 

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -319,7 +319,7 @@ describe('Textfield', () => {
 
         expect(el.value).to.equal(testValue);
         const testSource = eventSource as Textfield;
-        expect(testSource.isSameNode(el)).to.be.true;
+        expect(testSource).to.equal(el);
     });
     it('passes through `autocomplete` attribute', async () => {
         let el = await litFixture<Textfield>(

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -84,7 +84,7 @@ export class Tooltip extends SpectrumElement {
 
         const target = event.target as Node;
         /* c8 ignore next */
-        if (!target.isSameNode(this)) return;
+        if (target !== this) return;
 
         event.detail.overlayContentTipElement = this.tipElement;
     }


### PR DESCRIPTION
Replace `isSameNode` with `===`.

## Description

When the webcomponentsjs polyfills are applied, Node.isSameNode may fail if the argument is not a Node. This failure is not in the spec and is browser-specific. This change removes isSameNode and replaces it with direct comparison, which is equivalent.

## Related Issue

fixes #1369 1367
https://github.com/webcomponents/polyfills/issues/436

## Motivation and Context

Though spectrum-web-components does not officially support old browsers, this change may be a reasonable and low-impact change to make.

## How Has This Been Tested?

I ran `yarn test`.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
