### PR TITLE
docs: do not use margin on body with position: absolute root

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -13,6 +13,11 @@
             content="Spectrum Web Components provide interface components as custom elements to help teams work more efficiently and to make applications more consistent."
         />
         <link rel="preconnect" href="https://use.typekit.net" />
+        <style>
+            body {
+                margin: 0;
+            }
+        </style>
 
         <!-- Use this to test Adobe Clean UX support (SpectrumCSS dependency) -->
         <!-- NOTE: you'll need to rebuild storybook to test this locally.


### PR DESCRIPTION
This probably deserve better docs somewhere, but wanted to get this fixed first...