### PR TITLE
fix(overlay): reduce the control active-overlay places on its content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: caa0e4a61aaf05b035c12894028414193e3d6007
+        default: 6fad41e8b706afaf6903bcad12271ae6c9c18180
 commands:
     downstream:
         steps:

--- a/packages/overlay/src/active-overlay.css
+++ b/packages/overlay/src/active-overlay.css
@@ -39,20 +39,12 @@ governing permissions and limitations under the License.
     position: absolute;
     display: inline-block;
     pointer-events: none;
-}
-
-:host(:focus) {
-    outline: none;
-}
-
-:host([placement='none']) {
     top: 0;
     left: 0;
 }
 
-:host([placement='none']) ::slotted(*) {
-    /* 0 * 1px is a hack for the linter. It wants no units on 0, but units are needed for calc() */
-    height: calc(100vh - var(--swc-body-margins-block, 0 * 1px));
+:host(:focus) {
+    outline: none;
 }
 
 sp-theme,
@@ -94,6 +86,10 @@ sp-theme,
 
 :host([animating]) ::slotted(*) {
     pointer-events: none;
+}
+
+:host(:not([animating])) ::slotted(*) {
+    pointer-events: initial;
 }
 
 #contents ::slotted(*) {

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -238,18 +238,47 @@ export const replace = (): TemplateResult => {
     `;
 };
 
-export const modal = (): TemplateResult => {
+export const modalLoose = (): TemplateResult => {
+    const closeEvent = new Event('close', { bubbles: true, composed: true });
+    return html`
+        <overlay-trigger type="modal" placement="none">
+            <sp-button slot="trigger">Open</sp-button>
+            <sp-dialog
+                size="small"
+                dismissable
+                slot="click-content"
+                @closed=${(event: Event & { target: DialogWrapper }) =>
+                    event.target.dispatchEvent(closeEvent)}
+            >
+                <h2 slot="heading">Loose Dialog</h2>
+                <p>
+                    The
+                    <code>sp-dialog</code>
+                    element is not "meant" to be a modal alone. In that way it
+                    does not manage its own
+                    <code>open</code>
+                    attribute or outline when it should have
+                    <code>pointer-events: auto</code>
+                    . It's a part of this test suite to prove that content in
+                    this way can be used in an
+                    <code>overlay-trigger</code>
+                    element.
+                </p>
+            </sp-dialog>
+        </overlay-trigger>
+        ${extraText}
+    `;
+};
+
+export const modalManaged = (): TemplateResult => {
     const closeEvent = new Event('close', { bubbles: true, composed: true });
     return html`
         <overlay-trigger type="modal" placement="none">
             <sp-button slot="trigger">Open</sp-button>
             <sp-dialog-wrapper
-                tabindex="0"
                 underlay
-                open
                 slot="click-content"
                 headline="Wrapped Dialog w/ Hero Image"
-                style="width: 100vw; height: 100vh;"
                 confirm-label="Keep Both"
                 secondary-label="Replace"
                 cancel-label="Cancel"
@@ -265,13 +294,15 @@ export const modal = (): TemplateResult => {
                 @cancel=${(event: Event & { target: DialogWrapper }): void => {
                     event.target.dispatchEvent(closeEvent);
                 }}
-                @sp-overlay-closed=${(
-                    event: Event & { target: DialogWrapper }
-                ): void => {
-                    event.target.open = true;
-                }}
             >
-                Content of the dialog
+                <p>
+                    The
+                    <code>sp-dialog-wrapper</code>
+                    element has been prepared for use in an
+                    <code>overlay-trigger</code>
+                    element by it's combination of modal, underlay, etc. styles
+                    and features.
+                </p>
             </sp-dialog-wrapper>
         </overlay-trigger>
         ${extraText}


### PR DESCRIPTION
## Description
- don't force any overlay to have a specific height
- allow content in non-animating overlays to take pointer events
- add story to outline usage of "manually prepares" overlay content

## Related Issue
fixes #1289 

## Motivation and Context
Not everyone is going to use "expected" content in their overlays

## How Has This Been Tested?
Manually in storybook.

## Screenshots (if appropriate):
https://westbrook-active-overlay--spectrum-web-components.netlify.app/storybook/index.html?path=/story/overlay--modal-loose
https://westbrook-active-overlay--spectrum-web-components.netlify.app/storybook/index.html?path=/story/overlay--modal-managed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
