### PR TITLE
fix(button): no double link clicks

### DIFF
--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -112,7 +112,6 @@ export class ButtonBase extends LikeAnchor(
         if (this.anchorElement) {
             this.anchorElement.click();
             handled = true;
-            this.anchorElement.classList.remove('clicking');
         } else if (this.type !== 'button') {
             const proxy = document.createElement('button');
             proxy.type = this.type;
@@ -193,11 +192,13 @@ export class ButtonBase extends LikeAnchor(
         this.active = true;
     }
 
-    private manageRole(): void {
+    private manageAnchor(): void {
         if (this.href && this.href.length > 0) {
             this.removeAttribute('role');
+            this.removeEventListener('click', this.shouldProxyClick);
         } else if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'button');
+            this.addEventListener('click', this.shouldProxyClick);
         }
     }
 
@@ -206,8 +207,7 @@ export class ButtonBase extends LikeAnchor(
         if (!this.hasAttribute('tabindex')) {
             this.tabIndex = 0;
         }
-        this.manageRole();
-        this.addEventListener('click', this.shouldProxyClick);
+        this.manageAnchor();
         this.addEventListener('keydown', this.handleKeydown);
         this.addEventListener('keypress', this.handleKeypress);
         this.addEventListener('pointerdown', this.handlePointerdown);
@@ -216,7 +216,7 @@ export class ButtonBase extends LikeAnchor(
     protected updated(changed: PropertyValues): void {
         super.updated(changed);
         if (changed.has('href')) {
-            this.manageRole();
+            this.manageAnchor();
         }
         if (changed.has('label')) {
             this.setAttribute('aria-label', this.label || '');


### PR DESCRIPTION
## Description
Commit to one version of surfacing the anchor element in `sp-button href` and derivative elements.
- the single placement of an invisible link over the entire button element prevents the need to proxy a click _unless_ the implementing developer uses `button.click()`
- gate the click event listening to proxy `sp-button type="submit"` on the availability of an `href` value

## Related Issue
fixes #1376 

## Motivation and Context
Should only click once.

## How Has This Been Tested?
Manually in Firefox and with the existing unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
