### PR TITLE
docs(overlay): include event lisings

### DIFF
--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -95,6 +95,10 @@ type OverlayOptions = {
 
 `receivesFocus` tells the overlay stack to throw focus into the overlay after it has opened.
 
+### Events
+
+The work to both open and close an overlay is asynchronous. This asynchrony is surfaced into the application via DOM events dispatched from the `trigger` element of your overlay. An `sp-opened` event will be dispatched once the overlay has finished opening, and an `sp-closed` event will be dispatched once the overlay has finished closing. In both cases, the dispatched event will include a `detail` property with an `interaction: TriggerInteractions` key to support associating the event/overlay with its originating `interaction`.
+
 ## Example
 
 ```html


### PR DESCRIPTION
## Description
A first iteration of event documentation in non-element docs pages. All info, no style... so, happy to take notes if there was something easily attainable that was more informative here. We need to expand on our ability to document non-element content, but I'm not sure where to take this right now. This hopefully gets the information into the world, and we can revisit this page (and bundle/base/styles/etc.) soon.

## Related Issue
fixes #1360

## Motivation and Context
Ensure users know the capabilities made available to them by our APIs.

## Screenshots (if appropriate):
https://westbrook-overlay-events--spectrum-web-components.netlify.app/components/overlay

## Types of changes
- [x] docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
