### PR TITLE
feat(tabs): add sp-tab-panel element

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 6fad41e8b706afaf6903bcad12271ae6c9c18180
+        default: 1c7fd4ad7a4457e1aa3ec3a4fbb96df389a621bb
 commands:
     downstream:
         steps:

--- a/documentation/src/components/code-example.css
+++ b/documentation/src/components/code-example.css
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 :host {
     display: flex;
-    margin: 1rem -4px 2rem -4px;
+    margin: 1rem 0 2rem 0;
     flex-direction: column;
     border-radius: 6px;
     border: 1px solid var(--spectrum-global-color-gray-100);
@@ -42,19 +42,37 @@ governing permissions and limitations under the License.
 }
 
 #markup {
-    position: relative;
-    max-width: 100%;
+    display: grid;
+    grid-template-columns: 100%;
+    grid-template-rows: 100%;
     padding: 0.75rem 1.5rem;
     border-radius: 0 0 6px 6px;
     border-top: 1px solid var(--spectrum-global-color-gray-100);
     background: var(--spectrum-global-color-gray-75);
-    overflow: hidden;
     line-height: 1.3em;
-    overflow-x: auto;
+    position: relative;
+    overflow: auto;
+}
+
+pre {
+    grid-area: 1/1/1/1;
+}
+
+.copy-holder {
+    grid-area: 1/1/1/1;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    display: grid;
+    position: sticky;
+    left: 0;
+    top: 0;
+    grid-template-columns: 100%;
+    grid-template-rows: 100%;
 }
 
 .copy {
-    position: absolute;
-    bottom: 1px;
-    right: 1px;
+    place-self: end;
+    pointer-events: all;
+    margin: 0 -1em -0.25em 0;
 }

--- a/documentation/src/components/code-example.ts
+++ b/documentation/src/components/code-example.ts
@@ -101,14 +101,16 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
                 : undefined}
             <bdo id="markup" dir="ltr" class=${this.codeTheme}>
                 ${highlightedCode}
-                <sp-action-button
-                    class="copy"
-                    @click=${this.copyToClipboard}
-                    quiet
-                >
-                    <sp-icon-copy slot="icon"></sp-icon-copy>
-                    Copy to Clipboard
-                </sp-action-button>
+                <div class="copy-holder">
+                    <sp-action-button
+                        class="copy"
+                        @click=${this.copyToClipboard}
+                        quiet
+                    >
+                        <sp-icon-copy slot="icon"></sp-icon-copy>
+                        Copy to Clipboard
+                    </sp-action-button>
+                </div>
             </bdo>
         `;
     }

--- a/documentation/src/components/component.css
+++ b/documentation/src/components/component.css
@@ -14,26 +14,27 @@ governing permissions and limitations under the License.
     margin: 1.2em 0 1.5em 0;
 }
 
-[class^='tabs--'] {
-    display: none;
+sp-tab-panel[selected] {
+    display: flex;
 }
 
-sp-tabs[selected='s'] ~ .tabs--s {
-    display: block;
+sp-tab-panel:focus {
+    outline: none;
 }
 
-sp-tabs[selected='m'] ~ .tabs--m {
-    display: block;
-}
-
-sp-tabs[selected='l'] ~ .tabs--l {
-    display: block;
-}
-
-sp-tabs[selected='xl'] ~ .tabs--xl {
-    display: block;
+sp-tab-panel:focus code-example:after {
+    content: '';
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-left: var(--spectrum-global-dimension-static-size-25) solid
+        var(--spectrum-global-color-static-blue-600);
 }
 
 code-example {
+    overflow: hidden;
     --spectrum-dialog-confirm-min-width: 0;
 }

--- a/documentation/src/components/component.ts
+++ b/documentation/src/components/component.ts
@@ -33,6 +33,7 @@ import componentStyles from './component.css';
 import { AppRouter } from '../router.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
 import '@spectrum-web-components/tabs/sp-tabs.js';
+import '@spectrum-web-components/tabs/sp-tab-panel.js';
 import { Tabs } from '@spectrum-web-components/tabs';
 import docs from '../../custom-elements.json';
 
@@ -193,6 +194,7 @@ class ComponentElement extends RouteComponent {
                     <div id="title-header">
                         <h1
                             class="spectrum-Heading spectrum-Heading--sizeXXL spectrum-Heading--serif"
+                            id="component-name"
                         >
                             ${APIdocs ? APIdocs.name : this.componentName}
                         </h1>
@@ -203,6 +205,7 @@ class ComponentElement extends RouteComponent {
                                   selected="${this.tab}"
                                   @change="${this.handleTabChange}"
                                   direction="horizontal"
+                                  aria-labelledby="component-name"
                               >
                                   <sp-tab
                                       value="examples"

--- a/documentation/src/components/layout.css
+++ b/documentation/src/components/layout.css
@@ -19,6 +19,10 @@ governing permissions and limitations under the License.
     height: 100vh;
 }
 
+sp-theme {
+    --swc-header-height: var(--spectrum-global-dimension-size-600);
+}
+
 #app {
     width: 100%;
     height: 100%;
@@ -44,7 +48,7 @@ governing permissions and limitations under the License.
 #body #layout-content {
     background-color: var(--spectrum-global-color-gray-50);
     position: relative;
-    max-height: 100vh;
+    max-height: calc(100vh - var(--swc-header-height) - 1px);
     width: 100%;
     overflow: auto;
 }
@@ -63,7 +67,7 @@ governing permissions and limitations under the License.
 }
 
 header {
-    min-height: var(--spectrum-global-dimension-size-600);
+    min-height: var(--swc-header-height);
     border-bottom: 1px solid var(--spectrum-global-color-gray-200);
     display: flex;
     flex-direction: row;
@@ -102,6 +106,10 @@ header svg {
 }
 
 @media screen and (min-width: 961px) {
+    sp-theme {
+        --swc-header-height: 0;
+    }
+
     header {
         display: none;
     }

--- a/documentation/src/components/layout.ts
+++ b/documentation/src/components/layout.ts
@@ -18,11 +18,11 @@ import {
     PropertyValues,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import './side-nav.js';
-import layoutStyles from './layout.css';
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
 import { Color, Scale } from '@spectrum-web-components/theme';
+import './side-nav.js';
+import layoutStyles from './layout.css';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/picker/sp-picker.js';

--- a/packages/action-button/README.md
+++ b/packages/action-button/README.md
@@ -26,60 +26,56 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html demo
-<sp-button-group>
+<sp-action-group>
     <sp-action-button size="s">Do action</sp-action-button>
     <sp-action-button size="s" selected>Do action</sp-action-button>
     <sp-action-button size="s" disabled>Do action</sp-action-button>
-</sp-button-group>
+</sp-action-group>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html demo
-<sp-button-group>
+<sp-action-group>
     <sp-action-button size="m">Do action</sp-action-button>
     <sp-action-button size="m" selected>Do action</sp-action-button>
     <sp-action-button size="m" disabled>Do action</sp-action-button>
-</sp-button-group>
+</sp-action-group>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html demo
-<sp-button-group>
+<sp-action-group>
     <sp-action-button size="l">Do action</sp-action-button>
     <sp-action-button size="l" selected>Do action</sp-action-button>
     <sp-action-button size="l" disabled>Do action</sp-action-button>
-</sp-button-group>
+</sp-action-group>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html demo
-<sp-button-group>
+<sp-action-group>
     <sp-action-button size="xl">Do action</sp-action-button>
     <sp-action-button size="xl" selected>Do action</sp-action-button>
     <sp-action-button size="xl" disabled>Do action</sp-action-button>
-</sp-button-group>
+</sp-action-group>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Variants
 

--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -24,11 +24,15 @@ When looking to leverage the `ActionMenu` base class as a type and/or for extens
 import { ActionMenu } from '@spectrum-web-components/action-menu';
 ```
 
-## Example
+## Sizes
+
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 <!-- prettier-ignore -->
 ```html
-<sp-action-menu>
+<sp-action-menu size="s">
     <span slot="label">More Actions</span>
     <sp-menu-item>
         Deselect
@@ -51,6 +55,99 @@ import { ActionMenu } from '@spectrum-web-components/action-menu';
     </sp-menu-item>
 </sp-action-menu>
 ```
+
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
+
+<!-- prettier-ignore -->
+```html
+<sp-action-menu size="m">
+    <span slot="label">More Actions</span>
+    <sp-menu-item>
+        Deselect
+    </sp-menu-item>
+    <sp-menu-item>
+        Select inverse
+    </sp-menu-item>
+    <sp-menu-item>
+        Feather...
+    </sp-menu-item>
+    <sp-menu-item>
+        Select and mask...
+    </sp-menu-item>
+    <sp-menu-divider></sp-menu-divider>
+    <sp-menu-item>
+        Save selection
+    </sp-menu-item>
+    <sp-menu-item disabled>
+        Make work path
+    </sp-menu-item>
+</sp-action-menu>
+```
+
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
+
+<!-- prettier-ignore -->
+```html
+<sp-action-menu size="l">
+    <span slot="label">More Actions</span>
+    <sp-menu-item>
+        Deselect
+    </sp-menu-item>
+    <sp-menu-item>
+        Select inverse
+    </sp-menu-item>
+    <sp-menu-item>
+        Feather...
+    </sp-menu-item>
+    <sp-menu-item>
+        Select and mask...
+    </sp-menu-item>
+    <sp-menu-divider></sp-menu-divider>
+    <sp-menu-item>
+        Save selection
+    </sp-menu-item>
+    <sp-menu-item disabled>
+        Make work path
+    </sp-menu-item>
+</sp-action-menu>
+```
+
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
+
+<!-- prettier-ignore -->
+```html
+<sp-action-menu size="xl">
+    <span slot="label">More Actions</span>
+    <sp-menu-item>
+        Deselect
+    </sp-menu-item>
+    <sp-menu-item>
+        Select inverse
+    </sp-menu-item>
+    <sp-menu-item>
+        Feather...
+    </sp-menu-item>
+    <sp-menu-item>
+        Select and mask...
+    </sp-menu-item>
+    <sp-menu-divider></sp-menu-divider>
+    <sp-menu-item>
+        Save selection
+    </sp-menu-item>
+    <sp-menu-item disabled>
+        Make work path
+    </sp-menu-item>
+</sp-action-menu>
+```
+
+</sp-tab-panel>
+</sp-tabs>
 
 ## Variants
 

--- a/packages/bundle/elements.ts
+++ b/packages/bundle/elements.ts
@@ -65,6 +65,7 @@ import '@spectrum-web-components/status-light/sp-status-light.js';
 import '@spectrum-web-components/switch/sp-switch.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
 import '@spectrum-web-components/tabs/sp-tabs.js';
+import '@spectrum-web-components/tabs/sp-tab-panel.js';
 import '@spectrum-web-components/tags/sp-tag.js';
 import '@spectrum-web-components/tags/sp-tags.js';
 import '@spectrum-web-components/textfield/sp-textfield.js';

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -30,44 +30,40 @@ import { Button, ClearButton } from '@spectrum-web-components/button';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html demo
 <sp-button size="s">Small</sp-button>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html demo
 <sp-button size="m">Medium</sp-button>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html demo
 <sp-button size="l">Large</sp-button>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html demo
 <sp-button size="xl">Extra Large</sp-button>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Variants
 

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -30,14 +30,9 @@ import { Checkbox } from '@spectrum-web-components/checkbox';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html demo
 <sp-field-group>
@@ -47,9 +42,9 @@ import { Checkbox } from '@spectrum-web-components/checkbox';
 </sp-field-group>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html demo
 <sp-field-group>
@@ -59,9 +54,9 @@ import { Checkbox } from '@spectrum-web-components/checkbox';
 </sp-field-group>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html demo
 <sp-field-group>
@@ -71,9 +66,9 @@ import { Checkbox } from '@spectrum-web-components/checkbox';
 </sp-field-group>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html demo
 <sp-field-group>
@@ -83,7 +78,8 @@ import { Checkbox } from '@spectrum-web-components/checkbox';
 </sp-field-group>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Variants
 

--- a/packages/field-label/README.md
+++ b/packages/field-label/README.md
@@ -26,14 +26,9 @@ import { FieldLabel } from '@spectrum-web-components/field-label';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html demo
 <sp-field-label for="lifestory-0" size="s">Life Story</sp-field-label>
@@ -43,9 +38,9 @@ import { FieldLabel } from '@spectrum-web-components/field-label';
 ></sp-textfield>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html demo
 <sp-field-label for="lifestory-1" size="m">Life Story</sp-field-label>
@@ -55,9 +50,9 @@ import { FieldLabel } from '@spectrum-web-components/field-label';
 ></sp-textfield>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html demo
 <sp-field-label for="lifestory-2" size="l">Life Story</sp-field-label>
@@ -67,9 +62,9 @@ import { FieldLabel } from '@spectrum-web-components/field-label';
 ></sp-textfield>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html demo
 <sp-field-label for="lifestory-3" size="xl">Life Story</sp-field-label>
@@ -79,7 +74,8 @@ import { FieldLabel } from '@spectrum-web-components/field-label';
 ></sp-textfield>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Examples
 

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -26,14 +26,9 @@ import { Link } from '@spectrum-web-components/link';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html
 This is an
@@ -41,9 +36,9 @@ This is an
 .
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html
 This is an
@@ -51,9 +46,9 @@ This is an
 .
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html
 This is an
@@ -61,9 +56,9 @@ This is an
 .
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html
 This is an
@@ -71,7 +66,8 @@ This is an
 .
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Variants
 

--- a/packages/meter/README.md
+++ b/packages/meter/README.md
@@ -26,44 +26,40 @@ import { Meter } from '@spectrum-web-components/meter';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html
 <sp-meter size="s" progress="71">Tasks Completed</sp-meter>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html
 <sp-meter size="m" progress="71">Tasks Completed</sp-meter>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html
 <sp-meter size="l" progress="71">Tasks Completed</sp-meter>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html
 <sp-meter size="xl" progress="71">Tasks Completed</sp-meter>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Variants
 

--- a/packages/picker/README.md
+++ b/packages/picker/README.md
@@ -32,14 +32,9 @@ import { Picker } from '@spectrum-web-components/picker';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html demo
 <sp-field-group>
@@ -72,9 +67,9 @@ import { Picker } from '@spectrum-web-components/picker';
 </sp-field-group>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html demo
 <sp-field-group>
@@ -107,9 +102,9 @@ import { Picker } from '@spectrum-web-components/picker';
 </sp-field-group>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html demo
 <sp-field-group>
@@ -142,9 +137,9 @@ import { Picker } from '@spectrum-web-components/picker';
 </sp-field-group>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html demo
 <sp-field-group>
@@ -179,7 +174,8 @@ import { Picker } from '@spectrum-web-components/picker';
 </sp-field-group>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Value
 

--- a/packages/progress-bar/README.md
+++ b/packages/progress-bar/README.md
@@ -26,14 +26,9 @@ import { ProgressBar } from '@spectrum-web-components/progress-bar';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html
 <div
@@ -47,9 +42,9 @@ import { ProgressBar } from '@spectrum-web-components/progress-bar';
 </div>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html
 <div
@@ -63,9 +58,9 @@ import { ProgressBar } from '@spectrum-web-components/progress-bar';
 </div>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html
 <div
@@ -79,9 +74,9 @@ import { ProgressBar } from '@spectrum-web-components/progress-bar';
 </div>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html
 <div
@@ -95,7 +90,8 @@ import { ProgressBar } from '@spectrum-web-components/progress-bar';
 </div>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Variants
 

--- a/packages/split-button/README.md
+++ b/packages/split-button/README.md
@@ -26,14 +26,9 @@ import { SplitButton } from '@spectrum-web-components/split-button';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html
 <sp-split-button size="s">
@@ -43,9 +38,9 @@ import { SplitButton } from '@spectrum-web-components/split-button';
 </sp-split-button>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html
 <sp-split-button size="m">
@@ -55,9 +50,9 @@ import { SplitButton } from '@spectrum-web-components/split-button';
 </sp-split-button>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html
 <sp-split-button size="l">
@@ -66,9 +61,9 @@ import { SplitButton } from '@spectrum-web-components/split-button';
 </sp-split-button>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html
 <sp-split-button size="xl">
@@ -77,7 +72,8 @@ import { SplitButton } from '@spectrum-web-components/split-button';
 </sp-split-button>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Variants
 

--- a/packages/status-light/README.md
+++ b/packages/status-light/README.md
@@ -26,44 +26,40 @@ import { StatusLight } from '@spectrum-web-components/status-light';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html
 <sp-status-light size="s" variant="positive">approved</sp-status-light>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html
 <sp-status-light size="m" variant="positive">approved</sp-status-light>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html
 <sp-status-light size="l" variant="positive">approved</sp-status-light>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html
 <sp-status-light size="xl" variant="positive">approved</sp-status-light>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ### Variants
 

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-The `<sp-tabs>` displays a list of `<sp-tab>` element children which accept both a `label` attribute and a `[slot="icon"]` child to define their contents. `<sp-tab>` content can be further customized with the `vertical` attribute which stacks them in the UI rather than listing them in a row. `<sp-tabs>` is typically used as the interface for controlling a set of layered sections of content that display one panel of content at a time
+The `<sp-tabs>` displays a list of `<sp-tab>` element children as `role="tablist"`. An `<sp-tab>` element is associated with a sibling `<sp-tab-panel>` element via their `value` attribute. When an `<sp-tab>` element is `selected`, the associated `<sp-tab-panel>` will also be selected, showing that panel and hiding the others.
 
 ### Usage
 
@@ -12,19 +12,21 @@ The `<sp-tabs>` displays a list of `<sp-tab>` element children which accept both
 yarn add @spectrum-web-components/tabs
 ```
 
-Import the side effectful registration of `<sp-tabs>` or `<sp-tab>` via:
+Import the side effectful registration of `<sp-tabs>`, `<sp-tab>` or `<sp-tab-panel>` via:
 
 ```
 import '@spectrum-web-components/tabs/sp-tabs.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
+import '@spectrum-web-components/tabs/sp-panel.js';
 ```
 
-When looking to leverage the `Tabs` or `Tab` base class as a type and/or for extension purposes, do so via:
+When looking to leverage the `Tabs`, `Tab`, or `TabPanel` base class as a type and/or for extension purposes, do so via:
 
 ```
 import {
     Tabs,
-    Tab
+    Tab,
+    TabPanel
 } from '@spectrum-web-components/tabs';
 ```
 
@@ -36,6 +38,10 @@ import {
     <sp-tab label="Tab 2" value="2"></sp-tab>
     <sp-tab label="Tab 3" value="3"></sp-tab>
     <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
 </sp-tabs>
 ```
 
@@ -47,6 +53,10 @@ import {
     <sp-tab label="Tab 2" value="2"></sp-tab>
     <sp-tab label="Tab 3" value="3"></sp-tab>
     <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
 </sp-tabs>
 ```
 
@@ -60,6 +70,10 @@ import {
     <sp-tab label="Tab 2" value="2"></sp-tab>
     <sp-tab label="Tab 3" value="3"></sp-tab>
     <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
 </sp-tabs>
 ```
 
@@ -71,6 +85,10 @@ import {
     <sp-tab label="Tab 2" value="2"></sp-tab>
     <sp-tab label="Tab 3" value="3"></sp-tab>
     <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
 </sp-tabs>
 ```
 
@@ -92,6 +110,10 @@ import {
         <sp-tab label="Tab 4" value="4">
             <sp-icon-help slot="icon"></sp-icon-help>
         </sp-tab>
+        <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+        <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+        <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+        <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
     </sp-tabs>
 </div>
 ```

--- a/packages/tabs/sp-tab-panel.ts
+++ b/packages/tabs/sp-tab-panel.ts
@@ -10,6 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './Tabs.js';
-export * from './Tab.js';
-export * from './TabPanel.js';
+import { TabPanel } from './src/TabPanel.js';
+
+customElements.define('sp-tab-panel', TabPanel);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-tab-panel': TabPanel;
+    }
+}

--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -37,6 +37,11 @@ export class Tab extends FocusVisiblePolyfillMixin(
         return [tabItemStyles];
     }
 
+    /**
+     * @private
+     */
+    static instanceCount = 0;
+
     protected get hasIcon(): boolean {
         return this.slotContentIsPresent;
     }
@@ -80,6 +85,9 @@ export class Tab extends FocusVisiblePolyfillMixin(
     protected firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.setAttribute('role', 'tab');
+        if (!this.hasAttribute('id')) {
+            this.id = `sp-tab-${Tab.instanceCount++}`;
+        }
     }
 
     protected updated(changes: PropertyValues): void {

--- a/packages/tabs/src/TabPanel.ts
+++ b/packages/tabs/src/TabPanel.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    TemplateResult,
+    SpectrumElement,
+    property,
+    PropertyValues,
+} from '@spectrum-web-components/base';
+
+import panelStyles from './tab-panel.css.js';
+
+/**
+ */
+export class TabPanel extends SpectrumElement {
+    static styles = [panelStyles];
+
+    /**
+     * @private
+     */
+    static instanceCount = 0;
+
+    @property({ type: Boolean, reflect: true })
+    public selected = false;
+
+    @property({ type: String, reflect: true })
+    public value = '';
+
+    protected render(): TemplateResult {
+        return html`
+            <slot></slot>
+        `;
+    }
+
+    protected firstUpdated(): void {
+        this.slot = 'tab-panel';
+        this.setAttribute('role', 'tabpanel');
+        this.tabIndex = 0;
+        if (!this.hasAttribute('id')) {
+            this.id = `sp-tab-panel-${TabPanel.instanceCount++}`;
+        }
+    }
+
+    protected updated(changes: PropertyValues<this>): void {
+        if (changes.has('selected')) {
+            if (this.selected) {
+                this.removeAttribute('aria-hidden');
+                this.tabIndex = 0;
+            } else {
+                this.setAttribute('aria-hidden', 'true');
+                this.tabIndex = -1;
+            }
+        }
+    }
+}

--- a/packages/tabs/src/spectrum-config.js
+++ b/packages/tabs/src/spectrum-config.js
@@ -15,7 +15,10 @@ const config = {
     components: [
         {
             name: 'tabs',
-            host: '.spectrum-Tabs',
+            host: {
+                selector: '.spectrum-Tabs',
+                shadowSelector: '#list',
+            },
             attributes: [
                 {
                     type: 'boolean',
@@ -47,7 +50,7 @@ const config = {
             ],
             complexSelectors: [
                 {
-                    replacement: '::slotted(:not(:first-child))',
+                    replacement: '::slotted(:not([slot]):not(:first-child))',
                     selector:
                         '.spectrum-Tabs-item+:not(.spectrum-Tabs-selectionIndicator)',
                 },

--- a/packages/tabs/src/spectrum-tabs.css
+++ b/packages/tabs/src/spectrum-tabs.css
@@ -106,6 +106,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-alias-font-size-default,
         var(--spectrum-global-dimension-font-size-100)
     );
+}
+#list {
+    /* .spectrum-Tabs */
     display: flex;
     position: relative;
     z-index: 0;
@@ -156,7 +159,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Tabs--compact .spectrum-Tabs-item .spectrum-Icon */
     height: var(--spectrum-tabs-compact-item-height);
 }
-:host([direction='horizontal']) {
+:host([direction='horizontal']) #list {
     /* .spectrum-Tabs--horizontal */
     align-items: center;
     border-bottom: var(--spectrum-tabs-rule-size) solid;
@@ -165,11 +168,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Tabs--horizontal .spectrum-Tabs-item */
     vertical-align: top;
 }
-:host([dir='ltr'][direction='horizontal']) ::slotted(:not(:first-child)) {
+:host([dir='ltr'][direction='horizontal'])
+    ::slotted(:not([slot]):not(:first-child)) {
     /* [dir=ltr] .spectrum-Tabs--horizontal .spectrum-Tabs-item+:not(.spectrum-Tabs-selectionIndicator) */
     margin-left: var(--spectrum-tabs-item-gap);
 }
-:host([dir='rtl'][direction='horizontal']) ::slotted(:not(:first-child)) {
+:host([dir='rtl'][direction='horizontal'])
+    ::slotted(:not([slot]):not(:first-child)) {
     /* [dir=rtl] .spectrum-Tabs--horizontal .spectrum-Tabs-item+:not(.spectrum-Tabs-selectionIndicator) */
     margin-right: var(--spectrum-tabs-item-gap);
 }
@@ -180,25 +185,25 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     height: var(--spectrum-tabs-rule-size);
     bottom: calc(-1 * var(--spectrum-tabs-rule-size));
 }
-:host([direction='horizontal'][compact]) {
+:host([direction='horizontal'][compact]) #list {
     /* .spectrum-Tabs--horizontal.spectrum-Tabs--compact */
     box-sizing: initial;
     height: var(--spectrum-tabs-compact-item-height);
     align-items: end;
 }
-:host([quiet]) {
+:host([quiet]) #list {
     /* .spectrum-Tabs--quiet */
     display: inline-flex;
 }
-:host([dir='ltr'][direction='vertical']) {
+:host([dir='ltr'][direction='vertical']) #list {
     /* [dir=ltr] .spectrum-Tabs--vertical */
     border-left: var(--spectrum-tabs-vertical-rule-size) solid;
 }
-:host([dir='rtl'][direction='vertical']) {
+:host([dir='rtl'][direction='vertical']) #list {
     /* [dir=rtl] .spectrum-Tabs--vertical */
     border-right: var(--spectrum-tabs-vertical-rule-size) solid;
 }
-:host([direction='vertical']) {
+:host([direction='vertical']) #list {
     /* .spectrum-Tabs--vertical */
     display: inline-flex;
     flex-direction: column;
@@ -245,7 +250,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
     margin-top: calc(var(--spectrum-tabs-focus-ring-height) / -2);
 }
-:host([direction='vertical'][compact]) ::slotted(*) {
+:host([direction='vertical'][compact]) #list ::slotted(*) {
     /* .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-item */
     height: var(--spectrum-tabs-compact-vertical-item-height);
     line-height: var(--spectrum-tabs-compact-vertical-item-height);
@@ -272,21 +277,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     position: absolute;
     width: var(--spectrum-tabs-vertical-rule-size);
 }
-:host {
+#list {
     /* .spectrum-Tabs */
     border-bottom-color: var(
         --spectrum-tabs-m-rule-color,
         var(--spectrum-alias-border-color-light)
     );
 }
-:host([dir='ltr'][direction='vertical']) {
+:host([dir='ltr'][direction='vertical']) #list {
     /* [dir=ltr] .spectrum-Tabs--vertical */
     border-left-color: var(
         --spectrum-tabs-m-vertical-rule-color,
         var(--spectrum-alias-border-color-light)
     );
 }
-:host([dir='rtl'][direction='vertical']) {
+:host([dir='rtl'][direction='vertical']) #list {
     /* [dir=rtl] .spectrum-Tabs--vertical */
     border-right-color: var(
         --spectrum-tabs-m-vertical-rule-color,
@@ -300,7 +305,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([quiet]) {
+:host([quiet]) #list {
     /* .spectrum-Tabs--quiet */
     border-bottom-color: var(
         --spectrum-tabs-quiet-m-rule-color,
@@ -314,8 +319,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-900)
     );
 }
-:host([dir='ltr'][direction='vertical'][compact]),
-:host([dir='ltr'][direction='vertical'][quiet]) {
+:host([dir='ltr'][direction='vertical'][compact]) #list,
+:host([dir='ltr'][direction='vertical'][quiet]) #list {
     /* [dir=ltr] .spectrum-Tabs--vertical.spectrum-Tabs--compact,
    * [dir=ltr] .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
     border-left-color: var(
@@ -323,8 +328,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-transparent)
     );
 }
-:host([dir='rtl'][direction='vertical'][compact]),
-:host([dir='rtl'][direction='vertical'][quiet]) {
+:host([dir='rtl'][direction='vertical'][compact]) #list,
+:host([dir='rtl'][direction='vertical'][quiet]) #list {
     /* [dir=rtl] .spectrum-Tabs--vertical.spectrum-Tabs--compact,
    * [dir=rtl] .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
     border-right-color: var(
@@ -332,8 +337,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-color-transparent)
     );
 }
-:host([direction='vertical'][compact]) #selectionIndicator,
-:host([direction='vertical'][quiet]) #selectionIndicator {
+:host([direction='vertical'][compact]) #list #selectionIndicator,
+:host([direction='vertical'][quiet]) #list #selectionIndicator {
     /* .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-selectionIndicator,
    * .spectrum-Tabs--vertical.spectrum-Tabs--quiet .spectrum-Tabs-selectionIndicator */
     background-color: var(

--- a/packages/tabs/src/tab-panel.css
+++ b/packages/tabs/src/tab-panel.css
@@ -10,6 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './Tabs.js';
-export * from './Tab.js';
-export * from './TabPanel.js';
+:host {
+    display: inline-flex;
+}
+
+:host(:not([selected])) {
+    display: none;
+}

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -35,7 +35,7 @@ governing permissions and limitations under the License.
  * The shorthand border declaration in :host([direction='horizontal']) was overiding
  * the border-bottom-color declared in :host 
  */
-:host([direction='horizontal']:not([quiet])) {
+:host([direction='horizontal']:not([quiet])) #list {
     border-bottom-color: var(
         --spectrum-tabs-rule-color,
         var(--spectrum-global-color-gray-200)
@@ -58,7 +58,7 @@ governing permissions and limitations under the License.
  * In the interim, if there are ever Visual Regression failures to the 'Vertical' tabs story
  * then it is likely that this CSS will need to be updated with changes in @spectrum-css/tabs
  */
-:host([dir='ltr'][direction='vertical-right']) {
+:host([dir='ltr'][direction='vertical-right']) #list {
     /* .spectrum-Tabs--vertical */
     display: inline-flex;
     flex-direction: column;
@@ -74,7 +74,7 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-200)
     );
 }
-:host([dir='rtl'][direction='vertical-right']) {
+:host([dir='rtl'][direction='vertical-right']) #list {
     /* .spectrum-Tabs--vertical */
     display: inline-flex;
     flex-direction: column;
@@ -183,8 +183,8 @@ governing permissions and limitations under the License.
         -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
     );
 }
-:host([dir='ltr'][direction='vertical-right'][compact]),
-:host([dir='ltr'][direction='vertical-right'][quiet]) {
+:host([dir='ltr'][direction='vertical-right'][compact]) #list,
+:host([dir='ltr'][direction='vertical-right'][quiet]) #list {
     /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
    * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
     border-right-color: var(
@@ -192,8 +192,8 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-border-color-transparent)
     );
 }
-:host([dir='rtl'][direction='vertical-right'][compact]),
-:host([dir='rtl'][direction='vertical-right'][quiet]) {
+:host([dir='rtl'][direction='vertical-right'][compact]) #list,
+:host([dir='rtl'][direction='vertical-right'][quiet]) #list {
     /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
    * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
     border-left-color: var(

--- a/packages/tabs/stories/tabs.stories.ts
+++ b/packages/tabs/stories/tabs.stories.ts
@@ -16,6 +16,7 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-chevron-down.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-help.js';
 import '../sp-tabs.js';
 import '../sp-tab.js';
+import '../sp-tab-panel.js';
 import { html, TemplateResult } from '@spectrum-web-components/base';
 
 export default {
@@ -24,52 +25,102 @@ export default {
     argTypes: {
         verticalTabs: { control: 'boolean' },
         verticalTab: { control: 'boolean' },
+        auto: { control: 'boolean' },
     },
     args: {
         type: false,
         verticalTab: false,
+        auto: false,
     },
 };
 
 interface Properties {
     verticalTabs?: boolean;
     verticalTab?: boolean;
+    auto?: boolean;
 }
 
-export const Default = (): TemplateResult => {
+const panels = (): TemplateResult => html`
+    <sp-tab-panel value="1">Content for "Really Long Name"</sp-tab-panel>
+    <sp-tab-panel value="2">Content for tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for tab 4</sp-tab-panel>
+`;
+
+export const Default = (args: Properties): TemplateResult => {
     return html`
-        <sp-tabs selected="1">
-            <sp-tab label="Tab 2" value="2"></sp-tab>
-            <sp-tab label="Tab 3" value="3"></sp-tab>
-            <sp-tab label="Tab 4" value="4"></sp-tab>
-            <sp-tab label="Really Long Name" value="1" selected></sp-tab>
+        <style>
+            sp-tabs {
+                display: grid;
+                grid-template-columns: 100%;
+            }
+            sp-tab-panel {
+                grid-area: 2/1/2/1;
+                transition: opacity
+                        var(--spectrum-global-animation-duration-300)
+                        ease-in-out,
+                    transform var(--spectrum-global-animation-duration-300)
+                        ease-in-out;
+            }
+            sp-tab-panel:not([selected]) {
+                display: unset;
+                opacity: 0;
+                height: 0;
+                pointer-events: none;
+                transform: translateY(
+                    var(
+                        --spectrum-dropdown-flyout-menu-offset-y,
+                        var(--spectrum-global-dimension-size-75)
+                    )
+                );
+                transition: opacity
+                        var(--spectrum-global-animation-duration-300)
+                        ease-in-out,
+                    transform var(--spectrum-global-animation-duration-300)
+                        ease-in-out,
+                    height 0s ease var(--spectrum-global-animation-duration-300);
+            }
+        </style>
+        <sp-tabs selected="1" ?auto=${args.auto} label="Demo Tabs">
+            <sp-tab value="2">Tab 2</sp-tab>
+            <sp-tab value="3">Tab 3</sp-tab>
+            <sp-tab value="4">Tab 4</sp-tab>
+            <sp-tab value="1" selected>Really Long Name</sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
 
-export const Autofocus = (): TemplateResult => {
+export const Autofocus = (args: Properties): TemplateResult => {
     return html`
-        <sp-tabs selected="1" autofocus>
+        <sp-tabs selected="1" autofocus ?auto=${args.auto} label="Demo Tabs">
             <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>
             <sp-tab label="Tab 3" value="3"></sp-tab>
             <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
 
-export const Vertical = (): TemplateResult => {
+export const Vertical = (args: Properties): TemplateResult => {
     return html`
-        <sp-tabs selected="1" direction="vertical">
+        <sp-tabs
+            selected="1"
+            direction="vertical"
+            ?auto=${args.auto}
+            label="Demo Tabs"
+        >
             <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>
             <sp-tab label="Tab 3" value="3"></sp-tab>
             <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
 
-export const VerticalSized = (): TemplateResult => {
+export const VerticalSized = (args: Properties): TemplateResult => {
     return html`
         <style>
             sp-tabs {
@@ -78,16 +129,22 @@ export const VerticalSized = (): TemplateResult => {
                 justify-content: center;
             }
         </style>
-        <sp-tabs selected="1" direction="vertical">
+        <sp-tabs
+            selected="1"
+            direction="vertical"
+            ?auto=${args.auto}
+            label="Demo Tabs"
+        >
             <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>
             <sp-tab label="Tab 3" value="3"></sp-tab>
             <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
 
-export const VerticalRight = (): TemplateResult => {
+export const VerticalRight = (args: Properties): TemplateResult => {
     return html`
         <style>
             sp-tabs {
@@ -96,11 +153,17 @@ export const VerticalRight = (): TemplateResult => {
                 justify-content: center;
             }
         </style>
-        <sp-tabs selected="1" direction="vertical-right">
+        <sp-tabs
+            selected="1"
+            direction="vertical-right"
+            ?auto=${args.auto}
+            label="Demo Tabs"
+        >
             <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>
             <sp-tab label="Tab 3" value="3"></sp-tab>
             <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
@@ -108,11 +171,13 @@ export const VerticalRight = (): TemplateResult => {
 export const Icons = ({
     verticalTabs,
     verticalTab,
+    auto,
 }: Properties): TemplateResult => {
     return html`
         <sp-tabs
             selected="1"
             direction="${verticalTabs ? 'vertical' : 'horizontal'}"
+            ?auto=${auto}
         >
             <sp-tab label="Tab 1" value="1" ?vertical=${verticalTab}>
                 <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
@@ -126,6 +191,7 @@ export const Icons = ({
             <sp-tab label="Tab 4" value="4" ?vertical=${verticalTab}>
                 <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
@@ -133,11 +199,13 @@ export const Icons = ({
 export const IconsWithSlottedLabel = ({
     verticalTabs,
     verticalTab,
+    auto,
 }: Properties): TemplateResult => {
     return html`
         <sp-tabs
             selected="1"
             direction="${verticalTabs ? 'vertical' : 'horizontal'}"
+            ?auto=${auto}
         >
             <sp-tab value="1" ?vertical=${verticalTab}>
                 Tab 1
@@ -155,6 +223,7 @@ export const IconsWithSlottedLabel = ({
                 Tab 4
                 <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
@@ -162,11 +231,13 @@ export const IconsWithSlottedLabel = ({
 export const IconsOnly = ({
     verticalTabs,
     verticalTab,
+    auto,
 }: Properties): TemplateResult => {
     return html`
         <sp-tabs
             selected="1"
             direction="${verticalTabs ? 'vertical' : 'horizontal'}"
+            ?auto=${auto}
         >
             <sp-tab aria-label="Tab 1" value="1" ?vertical=${verticalTab}>
                 <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
@@ -180,13 +251,19 @@ export const IconsOnly = ({
             <sp-tab aria-label="Tab 4" value="4" ?vertical=${verticalTab}>
                 <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
 
-export const iconsIi = (): TemplateResult => {
+export const iconsIi = (args: Properties): TemplateResult => {
     return html`
-        <sp-tabs selected="1" direction="vertical">
+        <sp-tabs
+            selected="1"
+            direction="vertical"
+            ?auto=${args.auto}
+            label="Demo Tabs"
+        >
             <sp-tab label="Tab 1" value="1" vertical>
                 <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
             </sp-tab>
@@ -199,6 +276,7 @@ export const iconsIi = (): TemplateResult => {
             <sp-tab label="Tab 4" value="4" vertical>
                 <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
@@ -207,9 +285,14 @@ iconsIi.story = {
     name: 'Icons II',
 };
 
-export const iconsIii = (): TemplateResult => {
+export const iconsIii = (args: Properties): TemplateResult => {
     return html`
-        <sp-tabs selected="1" direction="vertical">
+        <sp-tabs
+            selected="1"
+            direction="vertical"
+            ?auto=${args.auto}
+            label="Demo Tabs"
+        >
             <sp-tab label="Tab 1" value="1">
                 <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
             </sp-tab>
@@ -222,6 +305,7 @@ export const iconsIii = (): TemplateResult => {
             <sp-tab label="Tab 4" value="4">
                 <sp-icon-help slot="icon"></sp-icon-help>
             </sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
@@ -230,48 +314,57 @@ iconsIii.story = {
     name: 'Icons III',
 };
 
-export const Quiet = ({ verticalTabs }: Properties): TemplateResult => {
+export const Quiet = ({ verticalTabs, auto }: Properties): TemplateResult => {
     return html`
         <sp-tabs
             selected="1"
             quiet
             direction="${verticalTabs ? 'vertical' : 'horizontal'}"
+            ?auto=${auto}
         >
             <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>
             <sp-tab label="Tab 3" value="3"></sp-tab>
             <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
 
-export const Compact = ({ verticalTabs }: Properties): TemplateResult => {
+export const Compact = ({ verticalTabs, auto }: Properties): TemplateResult => {
     return html`
         <sp-tabs
             selected="1"
             compact
             direction="${verticalTabs ? 'vertical' : 'horizontal'}"
+            ?auto=${auto}
         >
             <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>
             <sp-tab label="Tab 3" value="3"></sp-tab>
             <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };
 
-export const quietCompact = ({ verticalTabs }: Properties): TemplateResult => {
+export const quietCompact = ({
+    verticalTabs,
+    auto,
+}: Properties): TemplateResult => {
     return html`
         <sp-tabs
             selected="1"
             quiet
             compact
             direction="${verticalTabs ? 'vertical' : 'horizontal'}"
+            ?auto=${auto}
         >
             <sp-tab label="Tab 1" value="1"></sp-tab>
             <sp-tab label="Tab 2" value="2"></sp-tab>
             <sp-tab label="Tab 3" value="3"></sp-tab>
             <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
         </sp-tabs>
     `;
 };

--- a/packages/tabs/tab-panel.md
+++ b/packages/tabs/tab-panel.md
@@ -1,0 +1,83 @@
+## Description
+
+An `<sp-tab-panel>` contains the content that will be displayed when an `<sp-tab>` becomes `selected`. An `<sp-tab-panel>` can be associated with an `<sp-tab>` by sharing the same `value` attribute.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/tabs?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/tabs)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/tabs?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/tabs)
+[![Try it on webcomponents.dev](https://img.shields.io/badge/Try%20it%20on-webcomponents.dev-green?style=for-the-badge)](https://webcomponents.dev/edit/collection/fO75441E1Q5ZlI0e9pgq/2JFFTBPXfCZpePD0wk58/src/index.ts)
+
+```
+yarn add @spectrum-web-components/tabs
+```
+
+Import the side effectful registration of `<sp-tab-panel>` via:
+
+```
+import '@spectrum-web-components/tabs/sp-tab-panel.js';
+```
+
+When looking to leverage the `TabPanel` base class as a type and/or for extension purposes, do so via:
+
+```
+import {
+    TabPanel,
+} from '@spectrum-web-components/tabs';
+```
+
+## Examples
+
+```html
+<sp-tabs selected="1">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
+
+## Customizing transitions
+
+The state of the `<sp-tab-panel>` is reflected to the boolean `selected` attribute, which can be used to customize the transition between panels when the selection changes.
+
+```html
+<style>
+    sp-tabs {
+        display: grid;
+        grid-template-rows: 100%;
+        grid-template-columns: auto 1fr;
+    }
+    sp-tab-panel {
+        grid-area: 1/2/1/2;
+        transition: opacity 0.5s ease-in-out 0s, transform 0.5s ease-in-out 0s;
+        opacity: 1;
+        height: 100%;
+        position: relative;
+        z-index: 2;
+    }
+    sp-tab-panel:not([selected]) {
+        transition: opacity 0.5s ease-in-out 0s, height 0s ease-in-out 0.5s,
+            transform 0.5s ease-in-out 0s;
+        display: block;
+        opacity: 0;
+        height: 0;
+        transform: translateX(20px);
+        z-index: 2;
+    }
+</style>
+<sp-tabs selected="1" direction="vertical">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```

--- a/packages/tabs/tab.md
+++ b/packages/tabs/tab.md
@@ -1,0 +1,93 @@
+## Description
+
+An `<sp-tab>` element surfaces a `label` attribute to serve as its default text content when none is available in the DOM. An icon may be assigned to the element via the `icon` slot; e.g. `<sp-tab><svg slot="icon" aria-label="Tab w/ Icon">...</svg></sp-tab>`. Associate an `<sp-tab>` element with the `<sp-tab-panel>` that represents its content with the `value` attribute.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/tabs?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/tabs)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/tabs?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/tabs)
+[![Try it on webcomponents.dev](https://img.shields.io/badge/Try%20it%20on-webcomponents.dev-green?style=for-the-badge)](https://webcomponents.dev/edit/collection/fO75441E1Q5ZlI0e9pgq/2JFFTBPXfCZpePD0wk58/src/index.ts)
+
+```
+yarn add @spectrum-web-components/tabs
+```
+
+Import the side effectful registration of `<sp-tab>` via:
+
+```
+import '@spectrum-web-components/tabs/sp-tab.js';
+```
+
+When looking to leverage the `Tab` base class as a type and/or for extension purposes, do so via:
+
+```
+import {
+    Tab,
+} from '@spectrum-web-components/tabs';
+```
+
+## Examples
+
+```html
+<sp-tabs selected="1">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab value="2">Tab 2</sp-tab>
+    <sp-tab label="Tab 3" value="3">
+        <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
+    </sp-tab>
+    <sp-tab vertical value="4">
+        Tab 4
+        <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
+    </sp-tab>
+    <sp-tab-panel value="1">
+        Content for Tab 1 which uses an attribute for its content delivery
+    </sp-tab-panel>
+    <sp-tab-panel value="2">
+        Content for Tab 2 which uses its text content directly
+    </sp-tab-panel>
+    <sp-tab-panel value="3">
+        Content for Tab 3 which uses an attribute with a
+        <code>[slot="icon"]</code>
+        child
+    </sp-tab-panel>
+    <sp-tab-panel value="4">
+        Content for Tab 4 which uses both its text content and a
+        <code>[slot="icon"]</code>
+        child displayed using the
+        <code>[vertical]</code>
+        attribute to define their alignment
+    </sp-tab-panel>
+</sp-tabs>
+```
+
+```html
+<sp-tabs selected="1" direction="vertical">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab value="2">Tab 2</sp-tab>
+    <sp-tab label="Tab 3" value="3">
+        <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
+    </sp-tab>
+    <sp-tab vertical value="4">
+        Tab 4
+        <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
+    </sp-tab>
+    <sp-tab-panel value="1">
+        Content for Tab 1 which uses an attribute for its content delivery
+    </sp-tab-panel>
+    <sp-tab-panel value="2">
+        Content for Tab 2 which uses its text content directly
+    </sp-tab-panel>
+    <sp-tab-panel value="3">
+        Content for Tab 3 which uses an attribute with a
+        <code>[slot="icon"]</code>
+        child
+    </sp-tab-panel>
+    <sp-tab-panel value="4">
+        Content for Tab 4 which uses both its text content and a
+        <code>[slot="icon"]</code>
+        child displayed using the
+        <code>[vertical]</code>
+        attribute to define their alignment
+    </sp-tab-panel>
+</sp-tabs>
+```

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -11,7 +11,8 @@ governing permissions and limitations under the License.
 */
 import '../sp-tabs.js';
 import '../sp-tab.js';
-import { Tabs, Tab } from '../';
+import '../sp-tab-panel.js';
+import { Tabs, Tab, TabPanel } from '../';
 import '@spectrum-web-components/icon/sp-icon.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
 import {
@@ -39,6 +40,9 @@ const createTabs = async (): Promise<Tabs> => {
                 <sp-tab label="Tab 1" value="first"></sp-tab>
                 <sp-tab label="Tab 2" value="second"></sp-tab>
                 <sp-tab label="Tab 3" value="third"></sp-tab>
+                <sp-tab-panel value="first">First tab content</sp-tab-panel>
+                <sp-tab-panel value="second">Second tab content</sp-tab-panel>
+                <sp-tab-panel value="third">Third tab content</sp-tab-panel>
             </sp-tabs>
         `
     );
@@ -80,36 +84,49 @@ describe('Tabs', () => {
     it('reflects selected tab with selected property', async () => {
         const tabs = await createTabs();
 
-        const firstTab = tabs.querySelector('sp-tab[value=first]');
-        const secondTab = tabs.querySelector('sp-tab[value=second]');
-        const thirdTab = tabs.querySelector('sp-tab[value=third]');
-
-        if (!(firstTab instanceof Tab))
-            throw new Error('firstTab not of type Tab');
-        if (!(secondTab instanceof Tab))
-            throw new Error('secondTab not of type Tab');
-        if (!(thirdTab instanceof Tab))
-            throw new Error('thirdTab not of type Tab');
+        const firstTab = tabs.querySelector('sp-tab[value=first]') as Tab;
+        const secondTab = tabs.querySelector('sp-tab[value=second]') as Tab;
+        const thirdTab = tabs.querySelector('sp-tab[value=third]') as Tab;
+        const firstPanel = tabs.querySelector(
+            'sp-tab-panel[value=first]'
+        ) as TabPanel;
+        const secondPanel = tabs.querySelector(
+            'sp-tab-panel[value=second]'
+        ) as TabPanel;
+        const thirdPanel = tabs.querySelector(
+            'sp-tab-panel[value=third]'
+        ) as TabPanel;
 
         expect(firstTab.selected, 'first: 1, selected').to.be.true;
+        expect(firstPanel.selected, 'first panel: 1, selected').to.be.true;
         expect(secondTab.selected, 'second: 1, not selected').to.be.false;
+        expect(secondPanel.selected, 'second panel: 1, not selected').to.be
+            .false;
         expect(thirdTab.selected, 'third: 1, not selected').to.be.false;
+        expect(thirdPanel.selected, 'third panel: 1, not selected').to.be.false;
         expect(tabs.selected).to.equal(firstTab.value);
 
         secondTab.click();
         await elementUpdated(tabs);
 
         expect(firstTab.selected, 'first: 2, not selected').to.be.false;
+        expect(firstPanel.selected, 'first panel: 2, not selected').to.be.false;
         expect(secondTab.selected, 'second: 2, selected').to.be.true;
+        expect(secondTab.selected, 'first panel: 2, selected').to.be.true;
         expect(thirdTab.selected, 'third: 2, not selected').to.be.false;
+        expect(thirdTab.selected, 'first panel: 2, not selected').to.be.false;
         expect(tabs.selected).to.equal(secondTab.value);
 
         thirdTab.click();
         await elementUpdated(tabs);
 
         expect(firstTab.selected, 'first: 3, not selected').to.be.false;
+        expect(firstPanel.selected, 'first panel: 3, not selected').to.be.false;
         expect(secondTab.selected, 'second: 3, not selected').to.be.false;
+        expect(secondPanel.selected, 'second panel: 3, not selected').to.be
+            .false;
         expect(thirdTab.selected, 'third: 3, selected').to.be.true;
+        expect(thirdTab.selected, 'first panel: 3, selected').to.be.true;
         expect(tabs.selected).to.equal(thirdTab.value);
     });
 
@@ -302,14 +319,14 @@ describe('Tabs', () => {
         expect(el.selected).to.equal('first');
         expect(selected.tabIndex).to.equal(0);
 
-        el.dispatchEvent(new Event('focusin'));
+        toBeSelected.dispatchEvent(new Event('focusin', { bubbles: true }));
 
         await elementUpdated(el);
 
         expect(el.selected).to.equal('first');
         expect(selected.tabIndex).to.equal(-1);
 
-        el.dispatchEvent(new Event('focusout'));
+        toBeSelected.dispatchEvent(new Event('focusout', { bubbles: true }));
 
         await elementUpdated(el);
 

--- a/packages/thumbnail/README.md
+++ b/packages/thumbnail/README.md
@@ -26,14 +26,9 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ## Sizes
 
-<sp-tabs selected="m">
-    <sp-tab value="s">Small</sp-tab>
-    <sp-tab value="m">Medium</sp-tab>
-    <sp-tab value="l">Large</sp-tab>
-    <sp-tab value="xl">Extra Large</sp-tab>
-</sp-tabs>
-
-<div class="tabs--s">
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
 
 ```html
 <sp-thumbnail size="s">
@@ -41,9 +36,9 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 </sp-thumbnail>
 ```
 
-</div>
-
-<div class="tabs--m">
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
 
 ```html
 <sp-thumbnail size="m">
@@ -51,9 +46,9 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 </sp-thumbnail>
 ```
 
-</div>
-
-<div class="tabs--l">
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
 
 ```html
 <sp-thumbnail size="l">
@@ -61,9 +56,9 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 </sp-thumbnail>
 ```
 
-</div>
-
-<div class="tabs--xl">
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
 
 ```html
 <sp-thumbnail size="xl">
@@ -71,7 +66,8 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 </sp-thumbnail>
 ```
 
-</div>
+</sp-tab-panel>
+</sp-tabs>
 
 ## Focused or selected
 

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -45,11 +45,6 @@ export class TopNav extends SpectrumElement {
     @property()
     public selectionIndicatorStyle = '';
 
-    public constructor() {
-        super();
-        this.addEventListener('click', this.onClick);
-    }
-
     private onClick = (event: Event): void => {
         const target = event.target as TopNavItem;
         this.selectTarget(target);
@@ -90,11 +85,13 @@ export class TopNav extends SpectrumElement {
 
     protected render(): TemplateResult {
         return html`
-            <slot @slotchange=${this.onSlotChange}></slot>
-            <div
-                id="selectionIndicator"
-                style=${this.selectionIndicatorStyle}
-            ></div>
+            <div @click=${this.onClick} id="list">
+                <slot @slotchange=${this.onSlotChange}></slot>
+                <div
+                    id="selectionIndicator"
+                    style=${this.selectionIndicatorStyle}
+                ></div>
+            </div>
         `;
     }
 

--- a/test/visual/story-imports.ts
+++ b/test/visual/story-imports.ts
@@ -15,6 +15,7 @@ export * as ActionBarStories from '../../packages/action-bar/stories/action-bar.
 export * as ActionButtonSizesStories from '../../packages/action-button/stories/action-button-sizes.stories.js';
 export * as ActionButtonStories from '../../packages/action-button/stories/action-button.stories.js';
 export * as ActionGroupStories from '../../packages/action-group/stories/action-group.stories.js';
+export * as ActionMenuSizesStories from '../../packages/action-menu/stories/action-menu-sizes.stories.js';
 export * as ActionMenuStories from '../../packages/action-menu/stories/action-menu.stories.js';
 export * as AssetStories from '../../packages/asset/stories/asset.stories.js';
 export * as AvatarStories from '../../packages/avatar/stories/avatar.stories.js';


### PR DESCRIPTION
## Description
Expand to support the `role="tabpanel"` pattern via `sp-tab-panel`, a la:
```
<sp-tabs selected="1" auto label="Demo Tabs">
    <sp-tab label="Tab 1" value="1"></sp-tab>
    <sp-tab label="Tab 2" value="2"></sp-tab>
    <sp-tab value="3">Tab 3</sp-tab>
    <sp-tab value="4">Tab 4</sp-tab>
    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
</sp-tabs>
```

See #1280 for more information on the decisions that went into this change.

More complete documentation for the usage of this can be found at:
https://westbrook-tab-panel--spectrum-web-components.netlify.app/components/tabs
https://westbrook-tab-panel--spectrum-web-components.netlify.app/components/tab
https://westbrook-tab-panel--spectrum-web-components.netlify.app/components/tab-panel

## Related Issue
fixes #1280 

## Motivation and Context
Fulfill the aria pattern for tab interfaces

## How Has This Been Tested?
Unit tests, storybook demos, addition of `sp-tab-panel` management of docs site content

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/114949937-185fb680-9e20-11eb-9b04-1d064a03edc4.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
