### PR TITLE
feat(sidenav): add a "change" event to track the "value" property

### DIFF
--- a/packages/sidenav/src/sidenav-item.css
+++ b/packages/sidenav/src/sidenav-item.css
@@ -16,6 +16,10 @@ governing permissions and limitations under the License.
     display: block;
 }
 
+:host([disabled]) {
+    pointer-events: none;
+}
+
 :host([multiLevel]) {
     --spectrum-web-component-sidenav-font-weight: var(
         --spectrum-sidenav-item-font-weight,

--- a/packages/sidenav/stories/sidenav.stories.ts
+++ b/packages/sidenav/stories/sidenav.stories.ts
@@ -25,7 +25,7 @@ export default {
 
 export const Default = (): TemplateResult => {
     return html`
-        <sp-sidenav @sidenav-select=${action('select')} value="Section 2">
+        <sp-sidenav @change=${action('select')} value="Section 2">
             <sp-sidenav-item
                 value="Section 1"
                 label="Section 1"
@@ -54,7 +54,7 @@ export const Multilevel = (): TemplateResult => {
         <sp-sidenav
             variant="multilevel"
             value="2.3.1"
-            @sidenav-select=${action('select')}
+            @change=${action('select')}
         >
             <sp-sidenav-item value="foo" label="foo"></sp-sidenav-item>
             <sp-sidenav-item value="baz" label="baz" expanded>
@@ -124,7 +124,7 @@ export const manageTabIndex = (): TemplateResult => {
                     label="Section 2"
                     disabled
                 ></sp-sidenav-item>
-                <sp-sidenav-item value="Section 3" label="Section 3" exoabnd>
+                <sp-sidenav-item value="Section 3" label="Section 3">
                     <sp-sidenav-item
                         value="Section 3a"
                         label="Section 3a"
@@ -137,7 +137,7 @@ export const manageTabIndex = (): TemplateResult => {
 
 export const Hrefs = (): TemplateResult => {
     return html`
-        <sp-sidenav @sidenav-select=${action('select')} value="current">
+        <sp-sidenav @change=${action('select')} value="current">
             <sp-sidenav-heading label="GITHUB">
                 <sp-sidenav-item
                     href=${window.location.href}

--- a/packages/sidenav/test/benchmark/test-basic.ts
+++ b/packages/sidenav/test/benchmark/test-basic.ts
@@ -17,7 +17,42 @@ import { html } from '@spectrum-web-components/base';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
-    <sp-sidenav>
+    <sp-sidenav manage-tab-index>
+        <sp-sidenav-item value="Section 1" label="Section 1"></sp-sidenav-item>
+        <sp-sidenav-item selected expanded value="Section 2" label="Section 2">
+            <sp-sidenav-item
+                value="Section 2a"
+                label="Section 2a"
+            ></sp-sidenav-item>
+            <sp-sidenav-item
+                value="Section 2b"
+                label="Section 2b"
+            ></sp-sidenav-item>
+            <sp-sidenav-item
+                value="Section 2c"
+                label="Section 2c"
+            ></sp-sidenav-item>
+        </sp-sidenav-item>
+        <sp-sidenav-heading label="CATEGORY 1">
+            <sp-sidenav-item
+                value="Section 3"
+                label="Section 3"
+            ></sp-sidenav-item>
+            <sp-sidenav-item value="Section 4" label="Section 4">
+                <sp-sidenav-item
+                    value="Section 4a"
+                    label="Section 4a"
+                ></sp-sidenav-item>
+                <sp-sidenav-item
+                    value="Section 4b"
+                    label="Section 4b"
+                ></sp-sidenav-item>
+                <sp-sidenav-item
+                    value="Section 4c"
+                    label="Section 4c"
+                ></sp-sidenav-item>
+            </sp-sidenav-item>
+        </sp-sidenav-heading>
         <sp-sidenav-item value="Section 1" label="Section 1"></sp-sidenav-item>
         <sp-sidenav-item selected expanded value="Section 2" label="Section 2">
             <sp-sidenav-item

--- a/packages/sidenav/test/sidenav.test.ts
+++ b/packages/sidenav/test/sidenav.test.ts
@@ -53,7 +53,7 @@ describe('Sidenav', () => {
 
         await expect(el).to.be.accessible();
     });
-    it('does not accept focus when empty', async () => {
+    it('does not accept focus/click/blur when empty', async () => {
         const el = await fixture<SideNav>(
             html`
                 <sp-sidenav></sp-sidenav>
@@ -65,6 +65,16 @@ describe('Sidenav', () => {
         expect(document.activeElement === el).to.be.false;
 
         el.focus();
+        await elementUpdated(el);
+
+        expect(document.activeElement === el).to.be.false;
+
+        el.blur();
+        await elementUpdated(el);
+
+        expect(document.activeElement === el).to.be.false;
+
+        el.click();
         await elementUpdated(el);
 
         expect(document.activeElement === el).to.be.false;
@@ -168,9 +178,10 @@ describe('Sidenav', () => {
         expect(typeof outsideFocused).not.to.equal(SideNavItem);
     });
     it('handles select', async () => {
+        const changeSpy = spy();
         const el = await fixture<SideNav>(
             html`
-                <sp-sidenav>
+                <sp-sidenav @change=${() => changeSpy()}>
                     <sp-sidenav-heading label="CATEGORY 1">
                         <sp-sidenav-item
                             value="Section 1"
@@ -206,6 +217,7 @@ describe('Sidenav', () => {
         await elementUpdated(el);
 
         expect(el.value).to.equal('Section 2');
+        expect(changeSpy.callCount).to.equal(1);
 
         sidenavItem.click();
 
@@ -219,6 +231,48 @@ describe('Sidenav', () => {
         await elementUpdated(el);
 
         expect(el.value).to.equal('Section 2a');
+        expect(changeSpy.callCount).to.equal(2);
+    });
+    it('prevents selection', async () => {
+        const changeSpy = spy();
+        const el = await fixture<SideNav>(
+            html`
+                <sp-sidenav
+                    @change=${(event: Event) => {
+                        event.preventDefault();
+                        changeSpy();
+                    }}
+                >
+                    <sp-sidenav-heading label="CATEGORY 1">
+                        <sp-sidenav-item
+                            value="Section 1"
+                            label="Section 1"
+                        ></sp-sidenav-item>
+                        <sp-sidenav-item
+                            value="Section 2"
+                            label="Section 2"
+                            opened
+                        >
+                            <sp-sidenav-item
+                                value="Section 2a"
+                                label="Section 2a"
+                            ></sp-sidenav-item>
+                        </sp-sidenav-item>
+                    </sp-sidenav-heading>
+                </sp-sidenav>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.value).to.be.undefined;
+
+        el.click();
+
+        await elementUpdated(el);
+
+        expect(el.value).to.be.undefined;
+        expect(changeSpy.callCount).to.equal(1);
     });
     it('prevents [tabindex=0] while `focusin`', async () => {
         const el = await fixture<SideNav>(manageTabIndex());
@@ -276,12 +330,12 @@ describe('Sidenav', () => {
         el.dispatchEvent(arrowDownEvent);
         el.dispatchEvent(arrowDownEvent);
         focused = document.activeElement as SideNavItem;
-        expect(focused.expanded).to.be.false;
+        expect(focused.expanded, 'not expanded').to.be.false;
         focused.focusElement.click();
 
         await elementUpdated(el);
 
-        expect(focused.expanded).to.be.true;
+        expect(focused.expanded, 'expanded').to.be.true;
 
         el.dispatchEvent(arrowDownEvent);
         await elementUpdated(el);
@@ -296,7 +350,7 @@ describe('Sidenav', () => {
 
         el.focus();
         focused = document.activeElement as SideNavItem;
-        expect(focused.selected).to.be.true;
+        expect(focused.selected, 'selected').to.be.true;
 
         el.dispatchEvent(shiftTabEvent);
         const outsideFocused = document.activeElement as HTMLElement;
@@ -402,6 +456,6 @@ describe('Sidenav', () => {
         await elementUpdated(item3);
 
         expect(item3.manageTabIndex).to.be.true;
-        expect(item3.tabIndex, 'after').to.equal(-1);
+        await waitUntil(() => item3.tabIndex === -1, 'after');
     });
 });


### PR DESCRIPTION
## Description
Contain the `sidenav-select` within the `sp-sidenav` element, and re-dispatch this update as a `change` event on the root, so that it can be tracked more like a form element. The `sidenav-select` event can still be heard on individual `sp-sidenav-item` elements, which are available in the light DOM (see the documentation site build for continued usage of this).

There was some more in depth event management that was going on with `sidenav-select` and `manage-tab-index` that made sense to centralize on a single interface as part of this update. The most recent build shows a statistically significant preference for the new version.

```
┌─────────────┬────────────────────┐
│   Benchmark │ sidenav:test-basic │
├─────────────┼────────────────────┤
│     Browser │ chrome-headless    │
│             │ 90.0.4430.93       │
├─────────────┼────────────────────┤
│ Sample size │ 50                 │
└─────────────┴────────────────────┘

┌─────────┬────────────┬─────────────────────┬──────────────────┬──────────────────┐
│ Version │ Bytes      │            Avg time │        vs remote │              vs  │
├─────────┼────────────┼─────────────────────┼──────────────────┼──────────────────┤
│ remote  │ 356.74 KiB │ 388.05ms - 395.92ms │                  │           slower │
│         │            │                     │         -        │          1% - 5% │
│         │            │                     │                  │ 2.43ms - 17.27ms │
├─────────┼────────────┼─────────────────────┼──────────────────┼──────────────────┤
│ local   │ 357.13 KiB │ 375.84ms - 388.43ms │           faster │                  │
│         │            │                     │          1% - 4% │         -        │
│         │            │                     │ 2.43ms - 17.27ms │                  │
└─────────┴────────────┴─────────────────────┴──────────────────┴──────────────────┘
```

## Related Issue
fixes #1156 

## Motivation and Context
Understanding the state of our applications is highly important.

## How Has This Been Tested?
Tweaked some unit tests, and ran the performance tests who's results are listed above.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated tests to cover my changes.
- [x] All new and existing tests passed.
