### PR TITLE
fix(radio): ensure radio-group first selected value is followed

### DIFF
--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -63,18 +63,14 @@ export class Radio extends Focusable {
         return this.inputElement;
     }
 
-    public handleChange(): void {
+    public handleChange(event: Event): void {
+        event.stopPropagation();
         if (this.readonly) {
             this.inputElement.checked = this.checked;
             return;
         }
         this.checked = this.inputElement.checked;
-        this.dispatchEvent(
-            new Event('change', {
-                bubbles: true,
-                composed: true,
-            })
-        );
+        this.dispatchEvent(new Event('change', event));
     }
 
     protected render(): TemplateResult {

--- a/packages/radio/stories/radio.stories.ts
+++ b/packages/radio/stories/radio.stories.ts
@@ -79,7 +79,7 @@ interface StoryArgs {
     disabled?: boolean;
     emphasized?: boolean;
     invalid?: boolean;
-    readonly?: boolean
+    readonly?: boolean;
 }
 
 function renderRadio(args: StoryArgs): TemplateResult {
@@ -89,10 +89,11 @@ function renderRadio(args: StoryArgs): TemplateResult {
 }
 export const Default = (args: StoryArgs): TemplateResult => renderRadio(args);
 
-export const readonly = (args: StoryArgs): TemplateResult => renderRadio({
-    ...args,
-    readonly: true,
-});
+export const readonly = (args: StoryArgs): TemplateResult =>
+    renderRadio({
+        ...args,
+        readonly: true,
+    });
 readonly.args = {
     checked: true,
 };
@@ -129,13 +130,20 @@ labelBelow.story = {
     name: 'Label below',
 };
 
+const values = {
+    first: 1,
+    second: 2,
+    third: 3,
+    fourth: 4,
+};
+
 export const groupExample = (): TemplateResult => {
     return html`
-        <sp-radio-group vertical selected="first" name="group-example">
-            <sp-radio value="first">Option 1</sp-radio>
-            <sp-radio value="second">Option 2</sp-radio>
-            <sp-radio value="third">Option 3</sp-radio>
-            <sp-radio value="fourth">Option 4</sp-radio>
+        <sp-radio-group vertical selected="1" name="group-example">
+            <sp-radio value=${values.first}>Option 1</sp-radio>
+            <sp-radio value=${values.second}>Option 2</sp-radio>
+            <sp-radio value=${values.third}>Option 3</sp-radio>
+            <sp-radio value=${values.fourth}>Option 4</sp-radio>
         </sp-radio-group>
     `;
 };

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -45,12 +45,13 @@ describe('Radio Group - focus control', () => {
         expect(document.activeElement === el).to.be.false;
     });
     it('focuses selected before first', async () => {
+        const values = ['first', 'second', 'third'];
         const el = await fixture<RadioGroup>(
             html`
                 <sp-radio-group selected="second">
-                    <sp-radio value="first">Option 1</sp-radio>
-                    <sp-radio value="second">Option 2</sp-radio>
-                    <sp-radio value="third">Option 3</sp-radio>
+                    <sp-radio value=${values[0]}>Option 1</sp-radio>
+                    <sp-radio value=${values[1]}>Option 2</sp-radio>
+                    <sp-radio value=${values[2]}>Option 3</sp-radio>
                 </sp-radio-group>
             `
         );
@@ -296,7 +297,7 @@ describe('Radio Group', () => {
                         <sp-radio value="third">Option 3</sp-radio>
                     </sp-radio-group>
                     <sp-radio-group
-                        id="test-selected-prioritized"
+                        id="test-checked-prioritized"
                         selected="second"
                     >
                         <sp-radio value="first" checked>Option 1</sp-radio>
@@ -330,13 +331,14 @@ describe('Radio Group', () => {
         await expect(testDiv).to.be.accessible();
     });
 
-    it('validates selection', () => {
+    it('validates selection', async () => {
         const radioGroup = testDiv.querySelector(
             'sp-radio-group#test-none-selected'
         ) as RadioGroup;
         expect(radioGroup.selected).to.equal('');
 
         radioGroup.selected = 'missing';
+        await elementUpdated(radioGroup);
 
         expect(radioGroup.selected).to.equal('');
     });
@@ -345,18 +347,20 @@ describe('Radio Group', () => {
         const el = testDiv.querySelector(
             'sp-radio-group#test-default'
         ) as RadioGroup;
+        const secondRadio = el.querySelector('sp-radio[value=second]') as Radio;
+        const thirdRadio = el.querySelector('sp-radio[value=third]') as Radio;
 
         await elementUpdated(el);
         expect(el.selected).to.equal('first');
 
-        el.selected = 'second';
+        secondRadio.click();
 
         await elementUpdated(el);
         expect(el.selected).to.equal('second');
 
         el.addEventListener('change', (event) => event.preventDefault());
 
-        el.selected = 'third';
+        thirdRadio.click();
 
         await elementUpdated(el);
         expect(el.selected).to.equal('second');
@@ -460,20 +464,21 @@ describe('Radio Group', () => {
         expect(radioGroup.selected).to.equal('third');
         expect(radio1.checked).to.be.false;
         expect(radio2.checked).to.be.false;
-        expect(radio3.checked).to.be.true;
+        expect(radio3.checked, 'initial').to.be.true;
 
         radioGroup.selected = 'second';
         await elementUpdated(radioGroup);
 
         expect(radioGroup.selected).to.equal('second');
         expect(radio1.checked).to.be.false;
-        expect(radio2.checked).to.be.true;
+        expect(radio2.checked, 'second').to.be.true;
         expect(radio3.checked).to.be.false;
 
         radioGroup.selected = 'first';
+        await elementUpdated(radioGroup);
 
         expect(radioGroup.selected).to.equal('first');
-        expect(radio1.checked).to.be.true;
+        expect(radio1.checked, 'third').to.be.true;
         expect(radio2.checked).to.be.false;
         expect(radio3.checked).to.be.false;
     });
@@ -492,6 +497,7 @@ describe('Radio Group', () => {
             'sp-radio[value=third]'
         ) as Radio;
 
+        expect(radioGroup.selected).to.equal('third');
         inputForRadio(radio2).click();
         await elementUpdated(radioGroup);
 
@@ -504,14 +510,14 @@ describe('Radio Group', () => {
         await elementUpdated(radioGroup);
 
         expect(radioGroup.selected).to.equal('first');
-        expect(radio1.checked).to.be.true;
+        expect(radio1.checked, 'moved to checked').to.be.true;
         expect(radio2.checked).to.be.false;
         expect(radio3.checked).to.be.false;
     });
 
-    it('prioritizes selected over checked on initialization when conflicting', () => {
+    it('prioritizes checked over selected on initialization when conflicting', () => {
         const radioGroup = testDiv.querySelector(
-            'sp-radio-group#test-selected-prioritized'
+            'sp-radio-group#test-checked-prioritized'
         ) as RadioGroup;
         const radio1 = radioGroup.querySelector(
             'sp-radio[value=first]'
@@ -520,9 +526,9 @@ describe('Radio Group', () => {
             'sp-radio[value=second]'
         ) as Radio;
 
-        expect(radioGroup.selected).to.equal('second');
-        expect(radio1.checked).to.be.false;
-        expect(radio2.checked).to.be.true;
+        expect(radioGroup.selected).to.equal('first');
+        expect(radio1.checked).to.be.true;
+        expect(radio2.checked).to.be.false;
     });
 
     it('handles integer values for radio buttons', () => {


### PR DESCRIPTION
## Description
Ensure correct management of bindings on both the `selected` attribute of an `sp-radio-group` element and the `value` attribute of its `sp-radio` children.

## Motivation and Context
Using this pattern in app with enums or similar currently drops the first `selected` value for lack of access to the children at run time.

## How Has This Been Tested?
Updated units and demos.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated tests to cover my changes.
- [x] All new and existing tests passed.
