### PR TITLE
fix(overlay): add overlay lifecycle methods to stack management

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -23,6 +23,14 @@ function hasModifier(event: MouseEvent): boolean {
     return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 }
 
+interface ManagedOverlayContent {
+    open: boolean;
+    overlayWillOpenCallback?: (args: { trigger: HTMLElement }) => void;
+    overlayOpenCallback?: (args: { trigger: HTMLElement }) => void;
+    overlayOpenCancelledCallback?: (args: { trigger: HTMLElement }) => void;
+    overlayCloseCallback?: (args: { trigger: HTMLElement }) => void;
+}
+
 export class OverlayStack {
     public overlays: ActiveOverlay[] = [];
 
@@ -152,9 +160,7 @@ export class OverlayStack {
 
     private isClickOverlayActiveForTrigger(trigger: HTMLElement): boolean {
         return this.overlays.some(
-            (item) =>
-                trigger === item.trigger &&
-                item.interaction === 'click'
+            (item) => trigger === item.trigger && item.interaction === 'click'
         );
     }
 
@@ -169,11 +175,29 @@ export class OverlayStack {
             this.startTabTrapping();
         }
 
+        const contentWithLifecycle = (details.content as unknown) as ManagedOverlayContent;
+        if (contentWithLifecycle.overlayWillOpenCallback) {
+            const { trigger } = details;
+            contentWithLifecycle.overlayWillOpenCallback({ trigger });
+        }
+
         if (details.delayed) {
-            const promise = this.overlayTimer.openTimer(details.content);
-            const cancelled = await promise;
+            const cancelledPromise = this.overlayTimer.openTimer(
+                details.content
+            );
+            const promises = [cancelledPromise];
+            if (details.abortPromise) {
+                promises.push(details.abortPromise);
+            }
+            const cancelled = await Promise.race(promises);
             if (cancelled) {
-                return promise;
+                if (contentWithLifecycle.overlayOpenCancelledCallback) {
+                    const { trigger } = details;
+                    contentWithLifecycle.overlayOpenCancelledCallback({
+                        trigger,
+                    });
+                }
+                return cancelled;
             }
         }
 
@@ -206,11 +230,12 @@ export class OverlayStack {
                 this.overlays.push(activeOverlay);
                 await activeOverlay.updateComplete;
                 this.addOverlayEventListeners(activeOverlay);
-                const contentWithOpen = (activeOverlay.overlayContent as unknown) as {
-                    open: boolean;
-                };
-                if (typeof contentWithOpen.open !== 'undefined') {
-                    contentWithOpen.open = true;
+                if (typeof contentWithLifecycle.open !== 'undefined') {
+                    contentWithLifecycle.open = true;
+                }
+                if (contentWithLifecycle.overlayOpenCallback) {
+                    const { trigger } = activeOverlay;
+                    contentWithLifecycle.overlayOpenCallback({ trigger });
                 }
                 if (details.receivesFocus === 'auto') {
                     activeOverlay.focus();
@@ -337,11 +362,13 @@ export class OverlayStack {
     ): Promise<void> {
         if (overlay) {
             await overlay.hide(animated);
-            const contentWithOpen = (overlay.overlayContent as unknown) as {
-                open: boolean;
-            };
-            if (typeof contentWithOpen.open !== 'undefined') {
-                contentWithOpen.open = false;
+            const contentWithLifecycle = (overlay.overlayContent as unknown) as ManagedOverlayContent;
+            if (typeof contentWithLifecycle.open !== 'undefined') {
+                contentWithLifecycle.open = false;
+            }
+            if (contentWithLifecycle.overlayCloseCallback) {
+                const { trigger } = overlay;
+                contentWithLifecycle.overlayCloseCallback({ trigger });
             }
             if (overlay.state != 'dispose') return;
 

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -33,6 +33,7 @@ export interface OverlayOpenDetail {
     interaction: TriggerInteractions;
     theme: ThemeData;
     notImmediatelyClosable?: boolean;
+    abortPromise?: Promise<boolean>;
 }
 
 export interface OverlayOpenCloseDetail {
@@ -57,6 +58,7 @@ export type OverlayOptions = {
     offset?: number;
     receivesFocus?: 'auto';
     notImmediatelyClosable?: boolean;
+    abortPromise?: Promise<boolean>;
 };
 
 declare global {

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -90,6 +90,7 @@ export class Overlay {
      * @returns a Promise that resolves to true if this operation was cancelled
      */
     public async open({
+        abortPromise,
         delayed,
         offset = 0,
         placement = 'top',
@@ -128,6 +129,7 @@ export class Overlay {
         this.overlayElement.dispatchEvent(queryOverlayDetailEvent);
 
         await Overlay.overlayStack.openOverlay({
+            abortPromise,
             content: this.overlayElement,
             contentTip: overlayDetailQuery.overlayContentTipElement,
             delayed,

--- a/packages/overlay/test/overlay-lifecycle.test.ts
+++ b/packages/overlay/test/overlay-lifecycle.test.ts
@@ -1,0 +1,127 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    oneEvent,
+    waitUntil,
+} from '@open-wc/testing';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import { OverlayTrigger } from '..';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import { a11ySnapshot, findAccessibilityNode } from '@web/test-runner-commands';
+
+describe('Overlay Trigger - Lifecycle Methods', () => {
+    it('calls the overlay lifecycle (willOpen/Close)', async () => {
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger placement="right-start">
+                <sp-action-button slot="trigger">
+                    Button with Tooltip
+                </sp-action-button>
+                <sp-tooltip slot="hover-content">
+                    Described by this content on focus/hover. 1
+                </sp-tooltip>
+            </overlay-trigger>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.undefined;
+        expect(el.childNodes.length).to.equal(5);
+        const trigger = el.querySelector('[slot="trigger"]') as HTMLElement;
+        type DescribedNode = {
+            name: string;
+            description: string;
+        };
+        let snapshot = ((await a11ySnapshot(
+            {}
+        )) as unknown) as DescribedNode & { children: DescribedNode[] };
+        expect(
+            findAccessibilityNode<DescribedNode>(
+                snapshot,
+                (node) =>
+                    node.name === 'Button with Tooltip' &&
+                    typeof node.description === 'undefined'
+            ),
+            '`name`ed with no `description`'
+        );
+        const opened = oneEvent(el, 'sp-opened');
+        trigger.dispatchEvent(
+            new FocusEvent('focusin', { bubbles: true, composed: true })
+        );
+        await opened;
+
+        expect(el.open).to.equal('hover');
+        snapshot = ((await a11ySnapshot({})) as unknown) as DescribedNode & {
+            children: DescribedNode[];
+        };
+
+        expect(el.childNodes.length).to.equal(6);
+        expect(
+            findAccessibilityNode<DescribedNode>(
+                snapshot,
+                (node) =>
+                    node.name === 'Button with Tooltip' &&
+                    node.description ===
+                        'Described by this content on focus/hover.'
+            ),
+            '`name`ed with `description`'
+        );
+
+        const closed = oneEvent(el, 'sp-closed');
+        trigger.dispatchEvent(
+            new FocusEvent('focusout', { bubbles: true, composed: true })
+        );
+        await closed;
+        await elementUpdated(el);
+
+        await waitUntil(() => el.open === null);
+        expect(el.childNodes.length).to.equal(5);
+    });
+    it('calls the overlay lifecycle (willOpen/openCanceled)', async () => {
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger placement="right-start">
+                <sp-action-button slot="trigger">
+                    Button with Tooltip
+                </sp-action-button>
+                <sp-tooltip slot="hover-content" delayed>
+                    Described by this content on focus/hover. 2
+                </sp-tooltip>
+            </overlay-trigger>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.undefined;
+        expect(el.childNodes.length, 'always').to.equal(5);
+        const trigger = el.querySelector('[slot="trigger"]') as HTMLElement;
+        trigger.dispatchEvent(
+            new FocusEvent('focusin', { bubbles: true, composed: true })
+        );
+        await elementUpdated(el);
+        trigger.dispatchEvent(
+            new FocusEvent('focusout', { bubbles: true, composed: true })
+        );
+        await elementUpdated(el);
+
+        await waitUntil(() => {
+            return el.open === null;
+        }, 'open');
+        await elementUpdated(el);
+        await waitUntil(() => {
+            return el.childNodes.length === 5;
+        }, 'children');
+    });
+});


### PR DESCRIPTION
## Description
- create "Overlay Lifecycle" methods that call into the overlaid element at open and close time:
  - `overlayWillOpenCallback` marks the beginning of the open cycle. by default this is followed in a few short frames with the actual opening of the overlay and in this way can be seen as equivalent to an `overlayOpenedCallback` for most concerns)
  - `overlayOpenCancelledCallback` takes into account overlay content that is `delayed` (usually tooltips) and could have their open process cancelled.
  - `overlayCloseCallback` handles when the entire cycle is complete and only can occur for overlays that had not previously called `overlayOpenCancelledCallback`.
  - each method accept an `options` argument with `{ trigger: HTMLElement }` (to support expanding to more options as needed in the future) and returns `void`
- leverage these lifecycle methods in the `sp-tooltip` element to appropriate hang content in the origin location to be used for accessibility while the actual `sp-tooltip` element is in "overlay" position and not accessible via IDREFs.
  - add hidden content with the `sp-tooltip`'s `textContent` and appropriate `aria` attributes across the overlay experience to ensure that the `trigger` is "described by" the tooltip.
- `overlay-trigger` now handles an `abortOverlay` promise for `hover-content` so that in the likelihood that said content is `delayed` the warmup time can be cancelled appropriately.
- add testing for the above.

### Alternative
Right now we dispatch `sp-opened` and `sp-closed` events on the `trigger` element of the overlay feature. We would be similarly served as the above were we to dispatch the same events on the `content` elements as well and leverage event listeners rather than direct method calls. We could place `bubbles: false` on one of those dispatches to prevent bubble phases on both events, but we would still have capture phases on both which means that elements that might listen to these events above might face challenges disambiguating one event from the other. In this way we could dispatch more specific events `sp-opened` and `sp-content-opened` or more specific `detail` packages:
```
{
    interaction: TriggerInteractions,
    type: 'trigger' | 'content',
    trigger: HTMLElement,
    content: HTMLElement,
}
```
vs:
```
{
    interaction: TriggerInteractions,
}
```
However, there is something to be said about the pseudo "privacy" of this approach, as well as its relation to the custom element and LitElement usage of lifecycle methods.

## Related Issue
fixes #1078 

## Motivation and Context
More accessible tooltips.
More capable overlay system.
World peace?

## How Has This Been Tested?
- manual with both the chrome dev tools accessibility tree and macOS Voiceover x-brower
- unit tests leveraging the accessibility tree across chromium, webkit and firefox.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/115419637-7dbcfa00-a1c8-11eb-9f32-69f26f439d4c.png)
![image](https://user-images.githubusercontent.com/1156657/115420006-cd9bc100-a1c8-11eb-8464-194538d692e9.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - Maybe. But, I think we should keep this sort of API pseudo "private" for a little to shake out the wrinkled before documenting. 
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
