### PR TITLE
chore: use latest Spectrum CSS packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a224033903fc62de316fdea7f9c849e0378b4bfc
+        default: 4238e3ae59b254bb41a80c0e0155c290b493b539
 commands:
     downstream:
         steps:

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "@open-wc/testing": "^2.5.32",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^11.2.0",
-        "@spectrum-css/table": "^3.0.1",
+        "@spectrum-css/table": "^3.0.2",
         "@types/chai": "^4.1.7",
         "@types/command-line-args": "^5.0.0",
         "@types/command-line-usage": "^5.0.1",

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -52,7 +52,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/accordion": "^3.0.1"
+        "@spectrum-css/accordion": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/action-bar/package.json
+++ b/packages/action-bar/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbar": "^3.0.1"
+        "@spectrum-css/actionbar": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^1.0.1"
+        "@spectrum-css/actionbutton": "^1.0.2"
     },
     "customElementsManifest": "custom-elements.json",
     "sideEffects": [

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actiongroup": "^1.0.1"
+        "@spectrum-css/actiongroup": "^1.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/asset": "^3.0.1"
+        "@spectrum-css/asset": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/avatar": "^3.0.1"
+        "@spectrum-css/avatar": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/buttongroup": "^3.0.1"
+        "@spectrum-css/buttongroup": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -52,7 +52,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/button": "^3.0.1"
+        "@spectrum-css/button": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -53,7 +53,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/card": "^3.0.1"
+        "@spectrum-css/card": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/checkbox": "^3.0.1"
+        "@spectrum-css/checkbox": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/coachmark": "^3.0.1"
+        "@spectrum-css/coachmark": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/color-area/package.json
+++ b/packages/color-area/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorarea": "^1.0.1"
+        "@spectrum-css/colorarea": "^1.0.2"
     },
     "customElementsManifest": "custom-elements.json",
     "sideEffects": [

--- a/packages/color-handle/package.json
+++ b/packages/color-handle/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorhandle": "^1.0.1"
+        "@spectrum-css/colorhandle": "^1.0.2"
     },
     "customElementsManifest": "custom-elements.json",
     "sideEffects": [

--- a/packages/color-loupe/package.json
+++ b/packages/color-loupe/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorloupe": "^1.0.1"
+        "@spectrum-css/colorloupe": "^1.0.2"
     },
     "customElementsManifest": "custom-elements.json",
     "sideEffects": [

--- a/packages/color-slider/package.json
+++ b/packages/color-slider/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorslider": "^1.0.1"
+        "@spectrum-css/colorslider": "^1.0.2"
     },
     "customElementsManifest": "custom-elements.json",
     "sideEffects": [

--- a/packages/color-wheel/package.json
+++ b/packages/color-wheel/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorwheel": "^1.0.1"
+        "@spectrum-css/colorwheel": "^1.0.2"
     },
     "customElementsManifest": "custom-elements.json",
     "sideEffects": [

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -59,7 +59,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/dialog": "^3.0.1"
+        "@spectrum-css/dialog": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/divider": "^1.0.1"
+        "@spectrum-css/divider": "^1.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/dropzone": "^3.0.1"
+        "@spectrum-css/dropzone": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldgroup": "^3.0.1"
+        "@spectrum-css/fieldgroup": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldlabel": "^3.0.1"
+        "@spectrum-css/fieldlabel": "^3.0.2"
     },
     "customElementsManifest": "custom-elements.json",
     "sideEffects": [

--- a/packages/field-label/src/spectrum-field-label.css
+++ b/packages/field-label/src/spectrum-field-label.css
@@ -171,7 +171,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-left: 0;
     padding-right: var(
         --spectrum-fieldlabel-side-m-padding-right,
-        var(--spectrum-global-dimension-size-100)
+        var(--spectrum-global-dimension-size-150)
     );
 }
 :host([dir='rtl'][side-aligned='start']) {
@@ -179,7 +179,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-right: 0;
     padding-left: var(
         --spectrum-fieldlabel-side-m-padding-right,
-        var(--spectrum-global-dimension-size-100)
+        var(--spectrum-global-dimension-size-150)
     );
 }
 :host([side-aligned='start']) {
@@ -222,7 +222,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-left: 0;
     padding-right: var(
         --spectrum-fieldlabel-side-m-padding-right,
-        var(--spectrum-global-dimension-size-100)
+        var(--spectrum-global-dimension-size-150)
     );
 }
 :host([dir='rtl'][side-aligned='end']) {
@@ -230,7 +230,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-right: 0;
     padding-left: var(
         --spectrum-fieldlabel-side-m-padding-right,
-        var(--spectrum-global-dimension-size-100)
+        var(--spectrum-global-dimension-size-150)
     );
 }
 :host([side-aligned='end']) {

--- a/packages/field-label/stories/field-label.stories.ts
+++ b/packages/field-label/stories/field-label.stories.ts
@@ -84,7 +84,7 @@ export const required = (): TemplateResult => {
         <sp-field-label
             for="lifestory-3"
             side-aligned="start"
-            style="width: 72px;"
+            style="width: 80px;"
             required
         >
             Life Story
@@ -98,7 +98,7 @@ export const required = (): TemplateResult => {
         <sp-field-label
             for="lifestory-4"
             side-aligned="end"
-            style="width: 72px;"
+            style="width: 80px;"
             required
         >
             Life Story

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^3.0.1"
+        "@spectrum-css/icon": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^3.0.1",
+        "@spectrum-css/icon": "^3.0.2",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fs": "^0.0.1-security",

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/illustratedmessage": "^3.0.1"
+        "@spectrum-css/illustratedmessage": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/link": "^3.1.1"
+        "@spectrum-css/link": "^3.1.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -57,7 +57,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/menu": "^3.0.1"
+        "@spectrum-css/menu": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^1.0.1"
+        "@spectrum-css/progressbar": "^1.0.2"
     },
     "customElementsManifest": "custom-elements.json",
     "sideEffects": [

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -37,7 +37,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-fieldlabel-side-padding-right: var(
         --spectrum-fieldlabel-side-s-padding-right,
-        var(--spectrum-global-dimension-size-75)
+        var(--spectrum-global-dimension-size-130)
     );
 }
 :host([size='m']) {
@@ -67,7 +67,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-fieldlabel-side-padding-right: var(
         --spectrum-fieldlabel-side-m-padding-right,
-        var(--spectrum-global-dimension-size-100)
+        var(--spectrum-global-dimension-size-150)
     );
 }
 :host([size='l']) {
@@ -98,7 +98,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-fieldlabel-side-padding-right: var(
         --spectrum-fieldlabel-side-l-padding-right,
-        var(--spectrum-global-dimension-size-150)
+        var(--spectrum-global-dimension-size-175)
     );
 }
 :host([size='xl']) {
@@ -128,7 +128,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-fieldlabel-side-padding-right: var(
         --spectrum-fieldlabel-side-xl-padding-right,
-        var(--spectrum-global-dimension-size-200)
+        var(--spectrum-global-dimension-size-185)
     );
 }
 :host {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -45,7 +45,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/modal": "^3.0.1"
+        "@spectrum-css/modal": "^3.0.2"
     },
     "sideEffects": [
         "./sp-*.js",

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -58,7 +58,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/picker": "^1.0.1"
+        "@spectrum-css/picker": "^1.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/popover": "^3.0.1"
+        "@spectrum-css/popover": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^1.0.1"
+        "@spectrum-css/progressbar": "^1.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/progress-bar/src/spectrum-progress-bar.css
+++ b/packages/progress-bar/src/spectrum-progress-bar.css
@@ -37,7 +37,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-fieldlabel-side-padding-right: var(
         --spectrum-fieldlabel-side-s-padding-right,
-        var(--spectrum-global-dimension-size-75)
+        var(--spectrum-global-dimension-size-130)
     );
 }
 :host([size='m']) {
@@ -67,7 +67,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-fieldlabel-side-padding-right: var(
         --spectrum-fieldlabel-side-m-padding-right,
-        var(--spectrum-global-dimension-size-100)
+        var(--spectrum-global-dimension-size-150)
     );
 }
 :host([size='l']) {
@@ -98,7 +98,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-fieldlabel-side-padding-right: var(
         --spectrum-fieldlabel-side-l-padding-right,
-        var(--spectrum-global-dimension-size-150)
+        var(--spectrum-global-dimension-size-175)
     );
 }
 :host([size='xl']) {
@@ -128,7 +128,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-fieldlabel-side-padding-right: var(
         --spectrum-fieldlabel-side-xl-padding-right,
-        var(--spectrum-global-dimension-size-200)
+        var(--spectrum-global-dimension-size-185)
     );
 }
 :host {

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progresscircle": "^1.0.1"
+        "@spectrum-css/progresscircle": "^1.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/quickaction": "^3.0.1"
+        "@spectrum-css/quickaction": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/radio": "^3.0.1"
+        "@spectrum-css/radio": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/search": "^3.0.1"
+        "@spectrum-css/search": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -52,7 +52,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/sidenav": "^3.0.1"
+        "@spectrum-css/sidenav": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^3.0.1"
+        "@spectrum-css/slider": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -53,7 +53,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/splitbutton": "^3.0.1"
+        "@spectrum-css/splitbutton": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/split-button/src/spectrum-split-button.css
+++ b/packages/split-button/src/spectrum-split-button.css
@@ -31,21 +31,37 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-splitbutton-cta-trigger-flat-edge-padding: calc(
         var(--spectrum-splitbutton-trigger-flat-edge-padding) -
-            var(--spectrum-button-primary-border-size)
+            var(
+                --spectrum-button-primary-m-border-size,
+                var(--spectrum-alias-border-size-thick)
+            )
     );
 }
 #button {
     /* .spectrum-SplitButton-action */
     --spectrum-splitbutton-flat-edge-padding: calc(
-        var(--spectrum-button-primary-padding-left) -
-            var(--spectrum-button-primary-border-size) * 2
+        var(
+                --spectrum-button-primary-m-padding-left,
+                var(--spectrum-alias-item-rounded-workflow-padding-left-m)
+            ) -
+            var(
+                --spectrum-button-primary-m-border-size,
+                var(--spectrum-alias-border-size-thick)
+            ) * 2
     );
     --spectrum-splitbutton-round-edge-padding: var(
-        --spectrum-button-primary-padding-right
+        --spectrum-button-primary-m-padding-right,
+        var(--spectrum-alias-item-rounded-padding-m)
     );
     --spectrum-splitbutton-cta-flat-edge-padding: calc(
-        var(--spectrum-button-primary-padding-left) -
-            var(--spectrum-button-primary-border-size) * 3
+        var(
+                --spectrum-button-primary-m-padding-left,
+                var(--spectrum-alias-item-rounded-workflow-padding-left-m)
+            ) -
+            var(
+                --spectrum-button-primary-m-border-size,
+                var(--spectrum-alias-border-size-thick)
+            ) * 3
     );
 }
 :host {
@@ -65,11 +81,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr']) #button {
     /* [dir=ltr] .spectrum-SplitButton-action */
-    border-top-left-radius: var(--spectrum-button-primary-border-radius);
+    border-top-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl']) #button {
     /* [dir=rtl] .spectrum-SplitButton-action */
-    border-top-right-radius: var(--spectrum-button-primary-border-radius);
+    border-top-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr']) #button {
     /* [dir=ltr] .spectrum-SplitButton-action */
@@ -89,11 +111,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr']) #button {
     /* [dir=ltr] .spectrum-SplitButton-action */
-    border-bottom-left-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl']) #button {
     /* [dir=rtl] .spectrum-SplitButton-action */
-    border-bottom-right-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr']) #button {
     /* [dir=ltr] .spectrum-SplitButton-action */
@@ -121,11 +149,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][variant='cta']) #button {
     /* [dir=ltr] .spectrum-SplitButton-action.spectrum-Button--cta */
-    margin-right: var(--spectrum-button-primary-border-size);
+    margin-right: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='rtl'][variant='cta']) #button {
     /* [dir=rtl] .spectrum-SplitButton-action.spectrum-Button--cta */
-    margin-left: var(--spectrum-button-primary-border-size);
+    margin-left: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='ltr']) #button:after {
     /* [dir=ltr] .spectrum-SplitButton-action:after */
@@ -161,19 +195,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr']) .trigger {
     /* [dir=ltr] .spectrum-SplitButton-trigger */
-    border-top-right-radius: var(--spectrum-button-primary-border-radius);
+    border-top-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl']) .trigger {
     /* [dir=rtl] .spectrum-SplitButton-trigger */
-    border-top-left-radius: var(--spectrum-button-primary-border-radius);
+    border-top-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr']) .trigger {
     /* [dir=ltr] .spectrum-SplitButton-trigger */
-    border-bottom-right-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl']) .trigger {
     /* [dir=rtl] .spectrum-SplitButton-trigger */
-    border-bottom-left-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr']) .trigger {
     /* [dir=ltr] .spectrum-SplitButton-trigger */
@@ -221,11 +267,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][variant='cta']) .trigger {
     /* [dir=ltr] .spectrum-SplitButton-trigger.spectrum-Button--cta */
-    border-left-width: var(--spectrum-button-primary-border-size);
+    border-left-width: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='rtl'][variant='cta']) .trigger {
     /* [dir=rtl] .spectrum-SplitButton-trigger.spectrum-Button--cta */
-    border-right-width: var(--spectrum-button-primary-border-size);
+    border-right-width: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 .trigger:focus-visible {
     /* .spectrum-SplitButton-trigger.focus-ring */
@@ -282,19 +334,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][left]) #button {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
-    border-top-right-radius: var(--spectrum-button-primary-border-radius);
+    border-top-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl'][left]) #button {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
-    border-top-left-radius: var(--spectrum-button-primary-border-radius);
+    border-top-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr'][left]) #button {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
-    border-bottom-right-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl'][left]) #button {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
-    border-bottom-left-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr'][left]) #button {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
@@ -346,11 +410,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][left][variant='cta']) #button {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--cta */
-    margin-left: var(--spectrum-button-primary-border-size);
+    margin-left: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='rtl'][left][variant='cta']) #button {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--cta */
-    margin-right: var(--spectrum-button-primary-border-size);
+    margin-right: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='ltr'][left]) #button:after {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
@@ -362,19 +432,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][left]) #button:after {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
-    border-top-right-radius: var(--spectrum-button-primary-border-radius);
+    border-top-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl'][left]) #button:after {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
-    border-top-left-radius: var(--spectrum-button-primary-border-radius);
+    border-top-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr'][left]) #button:after {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
-    border-bottom-right-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl'][left]) #button:after {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
-    border-bottom-left-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr'][left]) #button:after {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
@@ -394,11 +476,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][left]) .trigger {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
-    border-top-left-radius: var(--spectrum-button-primary-border-radius);
+    border-top-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl'][left]) .trigger {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
-    border-top-right-radius: var(--spectrum-button-primary-border-radius);
+    border-top-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr'][left]) .trigger {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
@@ -418,19 +506,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][left]) .trigger {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
-    border-bottom-left-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl'][left]) .trigger {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
-    border-bottom-right-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr'][left]) .trigger {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
-    border-left-width: var(--spectrum-button-primary-border-size);
+    border-left-width: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='rtl'][left]) .trigger {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
-    border-right-width: var(--spectrum-button-primary-border-size);
+    border-right-width: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='ltr'][left]) .trigger {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
@@ -466,19 +566,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][left][variant='cta']) .trigger {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--cta */
-    border-right-width: var(--spectrum-button-primary-border-size);
+    border-right-width: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='rtl'][left][variant='cta']) .trigger {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--cta */
-    border-left-width: var(--spectrum-button-primary-border-size);
+    border-left-width: var(
+        --spectrum-button-primary-m-border-size,
+        var(--spectrum-alias-border-size-thick)
+    );
 }
 :host([dir='ltr'][left]) .trigger:after {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
-    border-top-left-radius: var(--spectrum-button-primary-border-radius);
+    border-top-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl'][left]) .trigger:after {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
-    border-top-right-radius: var(--spectrum-button-primary-border-radius);
+    border-top-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='ltr'][left]) .trigger:after {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
@@ -498,9 +610,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 }
 :host([dir='ltr'][left]) .trigger:after {
     /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
-    border-bottom-left-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-left-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }
 :host([dir='rtl'][left]) .trigger:after {
     /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
-    border-bottom-right-radius: var(--spectrum-button-primary-border-radius);
+    border-bottom-right-radius: var(
+        --spectrum-button-primary-m-border-radius,
+        var(--spectrum-alias-item-rounded-border-radius-m)
+    );
 }

--- a/packages/split-button/src/split-button.css
+++ b/packages/split-button/src/split-button.css
@@ -13,38 +13,18 @@ governing permissions and limitations under the License.
 @import './spectrum-split-button.css';
 
 /**
- * Begin work around for https://github.com/adobe/spectrum-css/issues/1157
+ * Begin workaround for SplitButton not natively supporting t-shirt sizes.
  */
-:host([size='s']) {
-    --spectrum-button-primary-padding-right: var(
-        --spectrum-button-primary-s-padding-right,
-        var(--spectrum-alias-item-rounded-padding-s)
-    );
-}
-
-:host([size='m']) {
-    --spectrum-button-primary-padding-right: var(
-        --spectrum-button-primary-m-padding-right,
-        var(--spectrum-alias-item-rounded-padding-m)
-    );
-}
-
-:host([size='l']) {
-    --spectrum-button-primary-padding-right: var(
-        --spectrum-button-primary-l-padding-right,
-        var(--spectrum-alias-item-rounded-padding-l)
-    );
-}
-
-:host([size='xl']) {
-    --spectrum-button-primary-padding-right: var(
-        --spectrum-button-primary-xl-padding-right,
-        var(--spectrum-alias-item-rounded-padding-xl)
+sp-button {
+    --spectrum-button-primary-m-border-radius: calc(
+        var(--spectrum-button-padding-y) +
+            var(--spectrum-icon-tshirt-size-height) / 2 +
+            var(--spectrum-alias-border-size-thick)
     );
 }
 
 /**
- * End work around for https://github.com/adobe/spectrum-css/issues/1157
+ * End workaround for SplitButton not natively supporting t-shirt sizes.
  */
 
 sp-popover {

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/splitview": "^3.0.1"
+        "@spectrum-css/splitview": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/statuslight": "^3.0.1"
+        "@spectrum-css/statuslight": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -55,8 +55,8 @@
     },
     "devDependencies": {
         "@spectrum-css/commons": "^3.0.2",
-        "@spectrum-css/typography": "^3.0.1",
-        "@spectrum-css/vars": "^3.0.1"
+        "@spectrum-css/typography": "^3.0.2",
+        "@spectrum-css/vars": "^3.0.2"
     },
     "sideEffects": [
         "./*.css"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/switch": "^1.0.1"
+        "@spectrum-css/switch": "^1.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tabs": "^3.0.1"
+        "@spectrum-css/tabs": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tags": "^3.0.1"
+        "@spectrum-css/tags": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/textfield": "^3.0.1"
+        "@spectrum-css/textfield": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -571,7 +571,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Textfield-input::placeholder */
     color: var(
         --spectrum-textfield-m-placeholder-text-color,
-        var(--spectrum-alias-placeholder-text-color)
+        var(--spectrum-global-color-gray-600)
     );
 }
 #input:focus,

--- a/packages/thumbnail/package.json
+++ b/packages/thumbnail/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/thumbnail": "^1.0.1"
+        "@spectrum-css/thumbnail": "^1.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/toast": "^3.0.1"
+        "@spectrum-css/toast": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/toast/src/spectrum-toast.css
+++ b/packages/toast/src/spectrum-toast.css
@@ -75,7 +75,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     font-weight: var(
         --spectrum-toast-neutral-text-font-weight,
-        var(--spectrum-global-font-weight-bold)
+        var(--spectrum-global-font-weight-regular)
     );
     -webkit-font-smoothing: antialiased;
 }
@@ -154,11 +154,11 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     font-weight: var(
         --spectrum-toast-info-text-font-weight,
-        var(--spectrum-global-font-weight-bold)
+        var(--spectrum-global-font-weight-regular)
     );
     line-height: var(
         --spectrum-toast-info-text-line-height,
-        var(--spectrum-alias-body-text-line-height)
+        var(--spectrum-alias-component-text-line-height)
     );
 }
 .buttons {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tooltip": "^3.0.1"
+        "@spectrum-css/tooltip": "^3.0.2"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -47,7 +47,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/underlay": "^2.0.9"
+        "@spectrum-css/underlay": "^2.0.10"
     },
     "types": "./src/index.d.ts",
     "customElementsManifest": "custom-elements.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,262 +3063,262 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@spectrum-css/accordion@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-3.0.1.tgz#c82bd3cef913a67b52f34ad78e4c3f1451edad93"
-  integrity sha512-ffhQLF1zZhXVTuae7/oFOldRPdI2eq/tiTDKwCP/YkxZ7/GBD+14/DkTaw3QenxViXhRkzB5PJHVNdtln4xhEg==
+"@spectrum-css/accordion@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-3.0.2.tgz#b4213f8ceac20fa90b45ada376dbb8a345b0993b"
+  integrity sha512-boSs+1Eyx4QIPwM4LbfTvjzfhWeUoQAV5cM8KKztVY9WtdLoWUGMBhew0lrqq1b1bD83lq57oI4Na3/kAQ7UWA==
 
-"@spectrum-css/actionbar@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-3.0.1.tgz#1173d9a8199bf210aac431ea12daab9de2b9fa61"
-  integrity sha512-0EDhLvVafY6Bb/0ncE4q2b1Y3ZqVSFOUNpZ/cSRHq+AG8YnSCqjDMfVw9K0pKsJBCvelMB3VoV8hvqwlBU/Gfg==
+"@spectrum-css/actionbar@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-3.0.2.tgz#782a06bd4b9878e94cc1eb700dafbdbe4f1c4f4a"
+  integrity sha512-KNQ/1cy1OmVIZiJ25mRz/vNuftLpLElJjA4W5QsfJkFIuXAduXiup4no8uIFyAbsK5+2h0rV2QYuSt2E/VYsjg==
 
-"@spectrum-css/actionbutton@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-1.0.1.tgz#9c75da37ea6915919fb574c74bd60dacc03b6577"
-  integrity sha512-AUqtyNabHF451Aj9i3xz82TxS5Z6k1dttA68/1hMeU9kbPCSS4P6Viw3vaRGs9CSspuR8xnnhDgrq+F+zMy2Hw==
+"@spectrum-css/actionbutton@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-1.0.2.tgz#7753a94c64cebecfca6749ef20e37a5ea80c59be"
+  integrity sha512-laDWk7PCgy2I0AGsMjTmYKkiMVYVoF1B4tffJf4cIp66znTiqPHEbLDh5EDNU88JLTY2bWoCOY4cJxvXk5gERw==
 
-"@spectrum-css/actiongroup@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-1.0.1.tgz#b95b86e7af229e90fe1e70399d8d4b547b4bd31c"
-  integrity sha512-5Q6uMjzv5BFA2TwGASr/jAtJpTWl26fhWvgGY8kOA0RCSij35l+YJg/FPXf6Nnj2qCOl8DkNycjT9YXJ+bhyVA==
+"@spectrum-css/actiongroup@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-1.0.2.tgz#37f6593c1defdeda682b9e196bcd8cce38c574aa"
+  integrity sha512-YHKYruXsJteXlkCvfOoQ1cqc3tV7LbmMmbRpyp2vh0ah9CF5ImyGmBRYOOROtZx7VqfDJ5645rdwB2YfJcCBMw==
 
-"@spectrum-css/asset@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.1.tgz#24069a1551dfa66126b6f45b834e3a7c4690d8c5"
-  integrity sha512-uEGTQlu3mYP15Z//5aQ+OYUVMt47jg1j41rWRja9L++uo5B7IlWFmHHJVMX7yjcT67O7GhZcWspVPmosPC0dEA==
+"@spectrum-css/asset@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.2.tgz#ee7af73707f8c9bee7cb010dfe15c7720d53e537"
+  integrity sha512-9GSD/3sQkJ+ZsTUQuAarPA3UAGz1BNhn3kYDK+g30hTxEWAUPnRsj9H5rwvj2NZNgfjP4V9YuJOHYuKUyzHv4Q==
 
-"@spectrum-css/avatar@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-3.0.1.tgz#781f4e44272230ded9a010ad2b20e25fbca6dd50"
-  integrity sha512-EEBscpJWgObCiNzM6gW2mbMxl3+bHlFLxTqK1KbYu3NXWe/wv7CQn2x7CUwVsyhlMmO9fx4C+eK9lHN//TJ6ow==
+"@spectrum-css/avatar@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-3.0.2.tgz#4f1826223eae330e64b6d3cc899e9bc2e98dac95"
+  integrity sha512-wEczvSqxttTWSiL3cOvXV/RmGRwSkw2w6+slcHhnf0kb7ovymMM+9oz8vvEpEsSeo5u598bc+7ktrKFpAd6soQ==
 
 "@spectrum-css/banner@^3.0.0-beta.2":
   version "3.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-3.0.0-beta.2.tgz#df448a3dcb8ac63448bd628843a2895cec305780"
   integrity sha512-NqrT03ItWzj+L0dtqjedhop6wKOspBmaowzp9IOY/2kL561kRqYTLKR9vTteZ3cEDVD3ajKA8y+bKIW0eN+X7A==
 
-"@spectrum-css/button@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-3.0.1.tgz#6db8c3e851baecd0f1c2d88fef37d49d01c6e643"
-  integrity sha512-YXrBtjIYisk4Vaxnp0RiE4gdElQX04P2mc4Pi2GlQ27dJKlHmufYcF+kAqGdtiyK5yjdN/vKRcC8y13aA4rusA==
+"@spectrum-css/button@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-3.0.2.tgz#387712641457d3045bcecf77e13854dd59e9c20e"
+  integrity sha512-sUJuYrrmIL0RCkQpTQ9B5AdoWlu4Y6JatrcOB/OOwdzLbQ9bHw1bHj/y0Ua67hEtLOTjODU+2e5K3UM3KGnMTA==
 
-"@spectrum-css/buttongroup@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-3.0.1.tgz#99e59cf32ed9a73dacb0c04d260c830ecbafb181"
-  integrity sha512-/cktRh8N63lCMvcGX/E/8yTBcearuETzZCxm6YDisk3W4Pi68621JVNjxLOB65pf855EHpoZufzLJIRVj+dyOw==
+"@spectrum-css/buttongroup@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-3.0.2.tgz#fd3387973ca3131609e32112de42a1c0400a48d8"
+  integrity sha512-Wu7B4GJ/SAeVHz9SUGAkeIH8pLaZh4t+w2ykSKOPQIRuK2jCBoudkEClVxviNVwqekccf5XLFXg9GpYF1a3Uaw==
 
-"@spectrum-css/card@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-3.0.1.tgz#d81166e00ee5db825d340d18101b64bfdcdd70d4"
-  integrity sha512-Jjormvn5Ejv++iWf0jSaxfnEwCkJTlwpY42s5ec4FngJnJIrVzng8Ij17w9j9KsGuwVlQwULlbMPJ/0QpO1+jg==
+"@spectrum-css/card@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-3.0.2.tgz#853de2cc7e696238a01e70a082ab61a90731f469"
+  integrity sha512-B8NktY3b9gVtVKbZR8VkttxhCP2MlIuFU6FtXJ2FnqiBtGaxSLVZJM6Lrzj1P+u1htxgSgQcO7utovwhr3m6jg==
 
-"@spectrum-css/checkbox@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-3.0.1.tgz#6f36377d8bd556989ddd1dec2506dc295c5fcda8"
-  integrity sha512-fI0q2Cp6yU4ORyE6JWUSMYNgEtGf6AjYViZ2Weg3UPTYBQuWdQd8J0ZTcH38pDMyARFPRdiXgQ3KnyX5Hk5huw==
+"@spectrum-css/checkbox@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-3.0.2.tgz#53ca2fba0d9faa1fead10e7206eb1f6cdcfd6ddd"
+  integrity sha512-hPbGcnm7kJvJS4jp/P/bdaZvbyR1eIE9mteuZqcBgdmyp9m/k6+mW5jmsbtqb3Y4mMPWvOJFfz/sIvWJP0F0Zg==
 
-"@spectrum-css/coachmark@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-3.0.1.tgz#ec94930586f4f5a287888dce6fe03ef37014aab4"
-  integrity sha512-UdwnGLd51jgN9k1mbNT4WM0OLtPAwbF/h6uSTAmUldLKTRIViMLJpQ8UsZdtnurYLMkWmEgc2bwW4khp3SSwBg==
+"@spectrum-css/coachmark@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-3.0.2.tgz#acaeb70476f0388c10c5cd21458755224eea1f80"
+  integrity sha512-C/IUTIBlejqDgZT+2hWiZHe5R4Ya/b1Njk43zBZo8V4zZjAV2ZmwHy8iFSIEMW6JJRJQ1ffyjoaLlzfkUeIKPA==
 
-"@spectrum-css/colorarea@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-1.0.1.tgz#84a8ae88fda6610657937c5864244a1e7acc5c2e"
-  integrity sha512-Ro9vpNjgQc6NbsPP8csZy7hQlskJC0ajyDHy1SyqogwlNoEurguznMrhoPu9gZmPBu1pySE6dRObbaGz7Upeyg==
+"@spectrum-css/colorarea@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-1.0.2.tgz#4bc50bb03ad42e9d3a4c0a430116ac64a6eaaea1"
+  integrity sha512-qS2Y1oH/rttLDHxvGiBErggvkCfXgs95BcGr2u14ltA7Gl/FcmtU8Heu6qAXMnCzH7K9ctvuO//phi7RoBMuGQ==
 
-"@spectrum-css/colorhandle@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-1.0.1.tgz#642238358c80fd93b46f8843ff8d91d32d419a08"
-  integrity sha512-WZgFkpefGL6RGZ45hkkykOj45iXd7CKlAlViYc4lKo9HTfis9rGRQX3GJdi+eij/wZn/CwRMQbq0UwID1kROjw==
+"@spectrum-css/colorhandle@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-1.0.2.tgz#48b7d393b011033a42e29c92eeef7e9a0b7af573"
+  integrity sha512-ke0XWBR0fqwikP03Cfdv6xSPbBlnwFUPwbPZqtjKpb0YJspc4WqtHV5HSJy/kCvJPoAKFzM1XNcN3IO2/tG+Tg==
 
-"@spectrum-css/colorloupe@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-1.0.1.tgz#9af20ffee74cd7d1a96e3f201c787b68c0dad2be"
-  integrity sha512-JtGAvDRRezJg1guwwiVDj34zNm2qN0FDRnebbxksRafrIVnYVUCevwYxYu5/kruTUWX9RO67q7pjKb+CdTmWIw==
+"@spectrum-css/colorloupe@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-1.0.2.tgz#f1802d4606886f6eb8ca3547c80df8207e966eba"
+  integrity sha512-lC6RxSJOzt460FEGgYhDeDhKHbIZLTIlXaAvsenLwrF15bp8eWiXSQ9Apd4j+LhvV1fZ/maY8yauW2a2MvhsFQ==
 
-"@spectrum-css/colorslider@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-1.0.1.tgz#1756cdea2e89030c8b9d4feb6f7b8bbf28ab9259"
-  integrity sha512-9B7H7zdOg66+IdtShQrmWo3+FpIWoG1JOr+6j9hUwPk4T5lYyVg9lNjr/zLvXdxTH9jiwiSS4Trn17PTyL01jQ==
+"@spectrum-css/colorslider@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-1.0.2.tgz#c11c184ab6f5515d886593a708ba74ebd2af28c7"
+  integrity sha512-+OGW+F8refqxTc5RjUq2+Awm4Z4BA/sinEuVykNlyAeYumSM520d6htvXivZM83f7zJCLgvmpBqXe0XBISx/Iw==
 
-"@spectrum-css/colorwheel@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-1.0.1.tgz#ab65d513bb448be899243f00cfd8c254e0b51b70"
-  integrity sha512-EFp+W72LZOTFzb354zFRwxleklq4QdgPhBhFFNIqU3jAwVKnVmVgS7wlpLA93pJLcX6UzzsrsQ5XZTYjhJQEtg==
+"@spectrum-css/colorwheel@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-1.0.2.tgz#9c4e199ab5023e74c06a344f315e052b3d60f0e1"
+  integrity sha512-Jv1ZfFyczHO57R35+df2tHYDYvzAoRBKt04o+PHx2Kq5dcf0NmYr6nAFGiSp2QDYiWOGnnrNUE7DYi2krLuOlg==
 
 "@spectrum-css/commons@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-3.0.2.tgz#9486afffaeb396c706b54669f3a4e645cc8c4890"
   integrity sha512-OO8K5skuX9a0I0HYto5Ajc9xgehFfYRanSYWRR2oPisRStlP6JV340l4GSr3qUfYoYnuHFbrK5bJwA+CjxPjkw==
 
-"@spectrum-css/dialog@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-3.0.1.tgz#33aae036282159f6aa998848b8c0828640a9620a"
-  integrity sha512-hUFbRR6RGT63MNuP7wP+k9KU+uRuICsduMihskh700e+jiQ+Gsv53fBFDlB843FoZYlIXzFQXgtjMUC5a4Qibw==
+"@spectrum-css/dialog@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-3.0.2.tgz#ae4db17c9772d822c538474f66bf838cea02217f"
+  integrity sha512-9aToA1fO5kE3ednoTKGKmaS8+X6noFJ4PvwZD1FgAZIA842PgHNW6e6hPw+MngZvqKqNcZsiuiJeRCq7TRkd4g==
 
-"@spectrum-css/divider@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-1.0.1.tgz#9d2b8d0b6bc05f08249608297e0e179f6510458c"
-  integrity sha512-IjANehC0qwPIrJ4w9zJGMlhtTXW5n7X3yI7ZhjVMgehXE2dbm50QXLOrEOkq5rjTO0T4lQW6OnHSsE3F8Pnv4w==
+"@spectrum-css/divider@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-1.0.2.tgz#40a9d5fba56cbcc3dbad53408886d2d35159ce40"
+  integrity sha512-piNbNcJ4W3lsnhrhru3SBh1et6lfKKexGKSP3gRFFlbjTT1+/AZGeztqYvdBwE523b7A9xJFekl5Fc0VJ1Flow==
   dependencies:
-    "@spectrum-css/vars" "^3.0.1"
+    "@spectrum-css/vars" "^3.0.2"
 
-"@spectrum-css/dropzone@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-3.0.1.tgz#af43feeedf0316ad11acb2c356ab769c65106194"
-  integrity sha512-w6caXN/Qi9Yztx4fCwnEutmZO43sPbigF8m6YR15HPxiV/Xhk2lw6GUB4mBa1U/eZNKWZlOnqvMQMBPsRk7sdQ==
+"@spectrum-css/dropzone@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-3.0.2.tgz#34f137851054442b219fed7f32006b93fc5e0bcf"
+  integrity sha512-BuBBzm5re6lM0AWgd6V+mI5eEGnnmFEtcFiJBEn9jYNEQYgflFhvnERUt89jMX5WmspiecwI2JBWJFrtFsOzug==
 
-"@spectrum-css/fieldgroup@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.0.1.tgz#cff6cdfd5daefeba7939885b3e7545064e7b3a05"
-  integrity sha512-JB4VE7HEpSmk4x68CS4e8cIW4g8aVFBhx2XYZklh9VlPLuWfKSogDyMEfSvgyXIbs1qqI20Wiz25QR6fQP1b0g==
+"@spectrum-css/fieldgroup@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.0.2.tgz#1c1afd3c444d8650fefac275dc66a7a913933846"
+  integrity sha512-Vyw0kQJdLW18J6w4H+YAsoLntvkw5rXmW3CH5H3SDTXkBztxtHSSe3e106Nw5MoZxTfHlom6CxbYXYCTjQfqGw==
 
-"@spectrum-css/fieldlabel@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-3.0.1.tgz#39f7c0f25cc2ff402afeff005341b0832f7c588c"
-  integrity sha512-LMfwrwIq8wEEvxFLobdLvXRwKrp8o9Fty4iJ9aYl2Rj1uXkfRd8qLz9HGZjLEE1OuJgoTBgamYABl7EvoA5PLw==
+"@spectrum-css/fieldlabel@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-3.0.2.tgz#9c6d28e2c43f019cafa2bb75b54c8bc540669912"
+  integrity sha512-mQ1h3Uc6JXVa1nIgQK501GOgvlqqc/2VNSCJrE73I3MPeIt9kRv1ISAsDqUZnuot88BCWnnXfCkU4lSXY1RLog==
 
-"@spectrum-css/icon@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.1.tgz#e300a6fc353c85c6b5d6e7a364408a940c31b177"
-  integrity sha512-cGFtIrcQ/7tthdkHK1npuEFiCdYVHLqwmLxghUYQw8Tb8KgJaw3OBO1tpjgsUizexNgu26BjVRIbGxNWuBXIHQ==
+"@spectrum-css/icon@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.2.tgz#327dcb95ab86368a00eb5a6d898c2c02e4ae04b3"
+  integrity sha512-BdHoO2ttrbsj1+IfHmSCGNS0oEf8i2UW3agfOVtSlYOD+iGykupWwy8ANLB6p4GvjlR7YjPRGzDRGgmDwVqR0Q==
 
-"@spectrum-css/illustratedmessage@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-3.0.1.tgz#55475436e5b1cc9f04bedf2062a5f9e7037859b7"
-  integrity sha512-VF2iUBFzo7NwR56H2cR2fihRU/PXjrqq6vxt9hZECxYlKeDL3pAPNCOBfagY3Us9gNqwnEasacY5dq7kgGHeKQ==
+"@spectrum-css/illustratedmessage@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-3.0.2.tgz#6a480be98b027e050b086e7899e40d87adb0a8c0"
+  integrity sha512-dqnE8X27bGcO0HN8+dYx8O4o0dNNIAqeivOzDHhe2El+V4dTzMrNIerF6G0NLm3GjVf6XliwmitsZK+K6FmbtA==
 
-"@spectrum-css/link@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.1.tgz#cb526a2e10b50ef5a7ae29cca7272e2610d597eb"
-  integrity sha512-Bi88lRhTY7g6nM/ryW1yY4Cji211ZYNtRxkxbV7n2lPvwMAAQtyx0qVD3ru4kTGj/FFVvmPR3XiOE10K13HSNA==
+"@spectrum-css/link@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.2.tgz#b4af145b809ae74b3776ea14ea30b84b329a67ba"
+  integrity sha512-dODJ3fqsZtds2RNcozqUPR/aIqgjaWnFOpUxd8olwyDTMoFJjZ9Ts1WAHSEBM2NwUIr2nm9Hu5AgWH+6cmuowg==
 
-"@spectrum-css/menu@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-3.0.1.tgz#2a376f991acc24e12ec892bb6b9db2650fc41fbe"
-  integrity sha512-Qjg0+1O0eC89sb/bRFq2AGnQ8XqhVy23TUXHyffNM8qdcMssnlny3QmhzjURCZKvx/Y5UytCpzhedPQqSpQwZg==
+"@spectrum-css/menu@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-3.0.2.tgz#1d133a433f71aeb4722ef98be00a11371276821d"
+  integrity sha512-r3Fom1+SB06iv7jxVebiR+rFgqS4qzoPSXiPt41MhdLznQ0L+9FWBid4eX4dLmPfBNsYdWjnK8Py+7uYCLmkAA==
 
-"@spectrum-css/modal@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-3.0.1.tgz#613a6b83d0330a4d38db41a98090800751c56d8d"
-  integrity sha512-F7D99F3cjDGT9DM9sogx/p49jrNYT7a1J6TUoqV73wUf+0gP+dTsskBOo9jB8VbUE+POQPjiDLB+SWLp6iBB+w==
+"@spectrum-css/modal@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-3.0.2.tgz#58b6621cab65f90788d310374f40df1f7090473f"
+  integrity sha512-YnIivJhoaao7Otu+HV7sgebPyFbO6sd/oMvTN/Rb2wwgnaMnIIuIRdGandSrcgotN2uNgs+P0knG6mv/xA1/dg==
 
-"@spectrum-css/picker@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-1.0.1.tgz#98991198576d26bd14160824e7b6f3c278ff930b"
-  integrity sha512-Rv4/UBOdNW1gs7WVBCJnPD5VFly8MqP++psDX6kcugUIcfJy0GC3acvElotmKRlCDk8Qxks2W2A0jKeSgphTmA==
+"@spectrum-css/picker@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-1.0.2.tgz#b49429ae3c89f9c5f2c0530787ce45392c9612ff"
+  integrity sha512-wfOtS6CdSba5GkN/i8WeCHpfROq2jW4MNWmRWc4tjfaBm23ASJYQhPsKINqWLE02Cr8E65kVoXy2EBpPY+w7pg==
 
-"@spectrum-css/popover@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-3.0.1.tgz#5863c1efc53f98f9aba2de9186666780041303fc"
-  integrity sha512-LmOSj/yCwQQ9iGmCYnHiJsJR/HfPiGqI1Jl7pkKxBOCxYBMS/5+ans9vfCN2Qnd0eK7WSbfPg72S6mjye7db2Q==
+"@spectrum-css/popover@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-3.0.2.tgz#b031b07ed4b927aa67d082a71ebed08bd7ab28b3"
+  integrity sha512-5YiZh4iD8Abw02o0bZNccU59nEYzAsP5c8GO1/J5c7/PwxUzcrAlmzGNPXdsqyz5sm7QMeFZcgp4lr44TEnV5A==
 
-"@spectrum-css/progressbar@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-1.0.1.tgz#c46158c6294ddfb5a54244bb1271072270eda379"
-  integrity sha512-UL6zjNukqck0bPmvFK4fHtuavuWxotY1jPGHAQabrmqqZbhVQJsfNSu1tnLWtFfWA5sWS1wID6t4AQbhHYeolg==
+"@spectrum-css/progressbar@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-1.0.2.tgz#b5a59432517f9ae6dad49d9504691bc5ac42b424"
+  integrity sha512-+jExeBLtVCqo3BqtFq5WCtZ028Dzk+oUnX6y4z6ZamKPqOyOELOtFnhYnyhyRndQOqYwKUTXx9zsaWA/lpJOHw==
 
-"@spectrum-css/progresscircle@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-1.0.1.tgz#ae072eb5ca3906a95334c7c5d619cf43175f7b90"
-  integrity sha512-ydMm5WLVyaAqxP7K4iKZD1xObOrCGKGh7Fps1YGW/jhdi4gBWk8rgvPzzVS4DTiy8QT3bnYSzyiLlOXi/+4S8A==
+"@spectrum-css/progresscircle@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-1.0.2.tgz#258ea9170fb70f795edda03e38a61d93bef4487c"
+  integrity sha512-JLULpyzjIY95lzlWR1yE1gv4l1K6p+scQ+edmuZZUHBzwM3pUtkvHJmUlA9TYdResUYW6Uka60VRdY6lZ8gnFQ==
 
-"@spectrum-css/quickaction@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.1.tgz#85c426ac69a64f94f3fc96a0edb91c3a105dce84"
-  integrity sha512-Iqrs5QRxloOCXgWEgOF5+o/mPOFrDqRLSn7hxRO2oFfQqs4L25vnJKkO+mobDtfjcGM/SPA45NxAMZRzzf/FaQ==
+"@spectrum-css/quickaction@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.2.tgz#816ea299229b85a38100b5144acf9de0e48bf988"
+  integrity sha512-KblLofbD3hTnXKbQFCnTHoKHW9/7oZ06oD0RgnkH8wgLhTQxDPIdWyTAQrRxfCLYIeaRyX/jAB2j3VEx8kKebQ==
 
-"@spectrum-css/radio@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.1.tgz#9dd101f13069317177b236408b923c2717b50b28"
-  integrity sha512-GP0TNCcz1rSo8barM6HfmF3LRp87IdyFtWZhYaaVv9pGOl05yAOEjvfuicUHDYAmb8fRlML2SQDCn8zGaBFEEw==
+"@spectrum-css/radio@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.2.tgz#9c1386894920bbed604e4e174fbbd45d9d762152"
+  integrity sha512-0TDdzC9omNXnpKHEXNuuGeXdNh4x8jvTKVUqMRLb7vY4hY94hAdt6X01NBqka+jzK35HxGzpDdPADAz62yZLPQ==
 
-"@spectrum-css/search@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-3.0.1.tgz#7c22821f29dd40dc1ce59fa88af47976cced47bc"
-  integrity sha512-u2tJhaKvc6tZ2eg/SzzA5OpzHWT+q3Xi+wnqaAx9KSoxwuWBweyz8jKkYCMvXsWyMOC5hQGTbNDJ4ttc8myVMQ==
+"@spectrum-css/search@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-3.0.2.tgz#70e93e321032d40b399498b2324e3b70e050551e"
+  integrity sha512-3UbT8yZmNOwrZxq+CUmumE+26ZySZ8OoKNM6U20SLMPLgdx6MrRugVE88r3Bl0sJ0RZX/5bU8nausdiHeX+Jlw==
 
-"@spectrum-css/sidenav@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.1.tgz#d2ce988085b9d0603f0dd0c61727010eb8601542"
-  integrity sha512-bCkVvDoXFx4uvAjDRP+u7pW/6SaxI4oSZ4yd8YadSGsyKd5pskBwimB+NwWL1OajQA6kvYK/3CyeFEyq1QcSFw==
+"@spectrum-css/sidenav@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.2.tgz#9d70f408d588ee79c69857751010333671f32713"
+  integrity sha512-YpIdH/F0jEICYmoduGrnkTmxwJq1kfKxEp0wOs+ZkQOsvKMv1an7nyhsfOKCQqcGNfYzJ9mJAk7/u5+vsxHa8g==
 
-"@spectrum-css/slider@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.0.1.tgz#5281e6f47eb5a4fd3d1816c138bf66d01d7f2e49"
-  integrity sha512-DI2dtMRnQuDM1miVzl3SGyR1khUEKnwdXfO5EHDFwkC3yav43F5QogkfjmjFmWWobMVovdJlAuiaaJ/IHejD0Q==
+"@spectrum-css/slider@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.0.2.tgz#3a2595e6a6f81cb4f1e97081aeeca68bb514ff9f"
+  integrity sha512-ZuBeP+P18tlmWRPh25EitaUDTB/DxqwlMCPepcwt+wwQRGOTPmN5zL8HcMTfNAoW9xPFl3/7WiBMrs0q4Y1uEQ==
 
-"@spectrum-css/splitbutton@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-3.0.1.tgz#dcf68a5784f4e7539ef848e9446d5e4d13966d0a"
-  integrity sha512-TpsRnjD4Widc+Yvre9TsLTXLy3zL7p8DdjSzrJiXsurbDEZgWzJWH1xaWe5DTc1qrsbx9jaUKelcO74Z08yYBQ==
+"@spectrum-css/splitbutton@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-3.0.2.tgz#33736a463d709c2f6308e3ef6c2598c765e94dee"
+  integrity sha512-jKMwUfnYGZ63/NsmrU2D21VAy/KdaeU9xjJr8+s5+U1q3WHe0nTtmnYGQnGSy9HC05jPVFq1aKGzj+1yMbHkHg==
 
-"@spectrum-css/splitview@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.1.tgz#0f3201f68d6f7ada7e6afa3c81fdee4501d1d33f"
-  integrity sha512-dlYkiZeedQmobvC8SiGeuN7CCcNMtwZ8eejEZJYB80d7L7x054CWFsDrh01/dyC8JOFKli49JNrJRV5b8UdT9Q==
+"@spectrum-css/splitview@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.2.tgz#2ecabe947e2222e03b71a68c9b1d5035f240537f"
+  integrity sha512-6nOjAhhkv2zbQwtYN3U3uEn0juroNNd7Uvm6PsNTJtqT7iTnsYJv/swBIAoUyHdYsGkInFF9HjVPrf6pxjlXmQ==
 
-"@spectrum-css/statuslight@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-3.0.1.tgz#07586f3a9c6420a38e70a68f4409d840e64e15e2"
-  integrity sha512-RN+GlDNs3TGeBDaCaWeiyFjLCVEsUkK5whgPzPfVbQDhn+/AeahDhqxQEzWXegEsj5itK9NS87BQJz8MvmulNg==
+"@spectrum-css/statuslight@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-3.0.2.tgz#dc54b6cd113413dcdb909c486b5d7bae60db65c5"
+  integrity sha512-xodB8g8vGJH20XmUj9ZsPlM1jHrGeRbvmVXkz0q7YvQrYAhim8pP3W+XKKZAletPFAuu8cmUOc6SWn6i4X4z6w==
 
-"@spectrum-css/switch@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-1.0.1.tgz#13803d79cf81f809236aaee4016702f2d0e3d2db"
-  integrity sha512-sdAu3kK2l4dZ29vK3G+HaY+sBliydXZHFUtld7KjeqQCxcfcEzde0/Y2yhxIjTfpZPGiYAI/10QcB1BTPr9Nug==
+"@spectrum-css/switch@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-1.0.2.tgz#f0b4c69271964573e02b08e90998096e49e1de44"
+  integrity sha512-zqmHpgWPNg1gEwdUNFYV3CBX5JaeALfIqcJIxE0FLZqr9d1C4+oLE0ItIFzt1bwr4bFAOmkEpvtiY+amluzGxQ==
 
-"@spectrum-css/table@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-3.0.1.tgz#753e0e2498082c0c36b9600828516aff3ac338cd"
-  integrity sha512-XQ+srMTv9hK1H0nctWUtqyzitmvyb5TNR+7mjAmKRdkBRSTQQSipDhenxZp72ekzMtMoSYZVZ77kgo0Iw3Fpug==
+"@spectrum-css/table@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-3.0.2.tgz#c666743d569fef81ddc8810fac8cda53b315f8d7"
+  integrity sha512-nt/QNC7NmUank0wozd4FySEX1UIYXuvuOKDyN1II3sxfwFSpJfp/Df9KVMhrYs4EsmB4XMGcoxp8ND/CrvH3ow==
 
-"@spectrum-css/tabs@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.0.1.tgz#81cebae7a0db0056834c2b8fdf0df3e71aaaa812"
-  integrity sha512-uyWGiSuv+rKY57RVnNkYe0+8fQxgXtQl09JAmqyqUnvlX5b9sHG/R5TP7ExZ8C7BgE8hzVjPVAMH3RMEQERGUQ==
+"@spectrum-css/tabs@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.0.2.tgz#822316672e7b0dfba66faa988e638ddae18c700e"
+  integrity sha512-4RNcmwf0wxLpB7M54H02owlj0mKE8neL1+lytQpxOOhlwTO5zdsD82zjvx9tIc8tRnRKuhCCCwTuBxHYstnBmw==
 
-"@spectrum-css/tags@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tags/-/tags-3.0.1.tgz#ed5af4d83d4d75429fb2792b815b7bd8cf28f02d"
-  integrity sha512-tDBUs9OausSpM1y/6J9oLCgHMXqtD88MDMVYaPzCO3xx1tMC0mN62sRsSMi7CiD6a3UuT+UUkYh5VDKtYabMhg==
+"@spectrum-css/tags@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tags/-/tags-3.0.2.tgz#5bf35fb79c97cd9344de485bd4626ad5b9f07757"
+  integrity sha512-HbvMk+QHvCDD1/ScvSErpKROcpAbXuMD4Hl/Gz/1A1lQ0fJ/CJeCq/MMsL7zjK1nlItU/ySu8r8KIuRF+6F8SQ==
 
-"@spectrum-css/textfield@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.0.1.tgz#e875b8e37817378ad08fc4af7d53026df38911e5"
-  integrity sha512-MUV5q87CVxbkNdSNoxGrFbgyKc51ft/WWf3aVEoPdPw5yBnXqFe1w1YmAit5zYDOOhhs58sCLAlUcCMlOpkgrA==
+"@spectrum-css/textfield@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.0.2.tgz#907f62d2dc82852dd6236a820be99e252b531631"
+  integrity sha512-nkFgAb0cP4jUodkUBErMNfyF78jJLtgL1Mrr9/rvGpGobo10IAbb8zZY4CkZ64o8XmMy/85+wZTKcx+KHatqpg==
 
-"@spectrum-css/thumbnail@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-1.0.1.tgz#37fa4a0c8f9a24d482e9d1d14c0c0f16ec5c9ea6"
-  integrity sha512-O0LN885wFjllchYBE0gbMGc+dfcaz5v6Y1fbeaKvHB/0M+VxMJnYnRvVa4LQzI2ewOHIN2TLEOqIIxkrw75VDQ==
+"@spectrum-css/thumbnail@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-1.0.2.tgz#58488f9b474bead2551c98473097b632c23beebf"
+  integrity sha512-XDhzQL8WxYM6lEVzt3Rsq3+jMu6KKkNiCkJXQd36sqzG69GhR5Hl6svZcZRln5crXtza346vIVlapOWjsnx79A==
 
-"@spectrum-css/toast@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-3.0.1.tgz#36f62ea05302761e59b9d53e05f6c04423861796"
-  integrity sha512-jov++S358BrN2tmMfaoYk1N6u9HojgeuQk61keXrK2m3VE5/n94x7Lg3kIPeSWO0odyDfBlMqT9jacbRey3QTg==
+"@spectrum-css/toast@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-3.0.2.tgz#8e27cce799b1b1d0054a88b135dddf7fbf1bdc78"
+  integrity sha512-sJp8DRsU2iSF67hlOQHFdRkbJHncspoOywHEsqcjh2KFl8gRY12rQL0ORG6J2THUt0LVBWSy48iwph9s4rkwsA==
 
-"@spectrum-css/tooltip@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.0.1.tgz#bc7513c49344f8983c83ad8a0a45bf19470d9e78"
-  integrity sha512-y5OG3lVidizxKrgvaXQrq9+7n6AxqPUoFDBdBEgrngeZnLmZirYgTqA9kB7EDDivStJhSdqLDRFn0ZrYpwdaNA==
+"@spectrum-css/tooltip@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.0.2.tgz#8b1e5083230a74a1adfc5377c3034e303fa0edbf"
+  integrity sha512-LzwtL5KJwuiInXDgFo01vuId4Ht5ok268+nNh0+Va3lXNG/cipI+hBpdunseTVhzwn0o1q4VKn3YEqqPZfW97Q==
 
-"@spectrum-css/typography@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-3.0.1.tgz#957dafd9b18c314fa37a88b549042ba2175f5b3f"
-  integrity sha512-XyR68K2rIZX3u4j7HhMLOqLVHDJZcapp3XUqgYMzMWccBFleA0qPxKpfRWqVIA5DzTMSIw0wEcZPYKWFZ2e6dA==
+"@spectrum-css/typography@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-3.0.2.tgz#ea3ca0a60e18064527819d48c8c4364cab4fcd38"
+  integrity sha512-5ZOLmQe0edzsDMyhghUd4hBb5uxGsFrxzf+WasfcUw9klSfTsRZ09n1BsaaWbgrLjlMQ+EEHS46v5VNo0Ms2CA==
 
-"@spectrum-css/underlay@^2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.9.tgz#fc10f971d1325cc844b727e6260f7217844060e8"
-  integrity sha512-X86xd0PG4QobmUyXA90BFGnyygaI8kW64dA4ysf4z0cOvUWjNbAAl3a/DB/WRyrnp63Zqv83T/cgNbetagTbWg==
+"@spectrum-css/underlay@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.10.tgz#8b75b646605a311850f6620caa18d4996cd64ed7"
+  integrity sha512-PmsmkzeGD/rY4pp3ILXHt9w8BW7uaEqXe08hQRS7rGki7wqCpG4mE0/8N3yEcA3QxWQclmG9gdkg5uz6wMmYzA==
 
-"@spectrum-css/vars@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-3.0.1.tgz#561fd69098f896a647242dd8d6108af603bfa31e"
-  integrity sha512-l4oRcCOqInChYXZN6OQhpe3isk6l4OE6Ys8cgdlsiKp53suNoQxyyd9p/eGRbCjZgH3xQ8nK0t4DHa7QYC0S6w==
+"@spectrum-css/vars@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-3.0.2.tgz#ea9062c3c98dfc6ba59e5df14a03025ad8969999"
+  integrity sha512-vzS9KqYXot4J3AEER/u618MXWAS+IoMvYMNrOoscKiLLKYQWenaueakUWulFonToPd/9vIpqtdbwxznqrK5qDw==
 
 "@spectrum-web-components/shared@^0.11.1":
   version "0.11.1"


### PR DESCRIPTION
## Description
Use the latest releases of Spectrum CSS
- accept the fix for https://github.com/adobe/spectrum-css/issues/1157
- work around Split Button not _actually_ supporting t-shirt sizing yet
- accept updated Golden Images Cache: https://67428-158297197-gh.circle-artifacts.com/0/test/visual/review/index.html#SplitButtonCTASizesStories/XL.png

## Motivation and Context
Keeping closer to latest means less changes when catching up.

## How Has This Been Tested?
https://67428-158297197-gh.circle-artifacts.com/0/test/visual/review/index.html#SplitButtonCTASizesStories/XL.png

## Types of changes
- [x] Chore

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
