### PR TITLE
Fix(tags): tags should only be focusable if they can be actioned (deleted / selected)

### DIFF
--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -86,7 +86,7 @@ import {
 
 ### Deletable
 
-Use the `deletable` attribute to signify `sp-tags` elements that can be removed. The tags should only be focusable when they have the `deletable` attribute.
+Use the `deletable` attribute to signify `sp-tags` elements that can be removed. The tags will only be focusable when they have the `deletable` attribute.
 
 ```html-live
 <sp-tags>

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -86,7 +86,7 @@ import {
 
 ### Deletable
 
-Use the `deletable` attribute to signify `sp-tags` elements that can be removed.
+Use the `deletable` attribute to signify `sp-tags` elements that can be removed. The tags should only be focusable when they have the `deletable` attribute.
 
 ```html-live
 <sp-tags>

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -129,8 +129,13 @@ export class Tag extends SpectrumElement {
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'listitem');
         }
-        if (!this.disabled) {
-            this.setAttribute('tabindex', this.deletable ? '0' : '-1');
+        if (this.deletable) {
+            this.setAttribute(
+                'tabindex',
+                !this.disabled && this.matches(':first-of-type:not([disabled])')
+                    ? '0'
+                    : '-1'
+            );
         }
     }
 

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -129,12 +129,15 @@ export class Tag extends SpectrumElement {
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'listitem');
         }
-        this.setAttribute(
-            'tabindex',
-            !this.disabled && this.matches(':first-of-type:not([disabled])')
-                ? '0'
-                : '-1'
-        );
+        if (!this.disabled) {
+            this.setAttribute('tabindex', this.deletable ? '0' : '-1');
+        }
+        // this.setAttribute(
+        //     'tabindex',
+        //     !this.disabled && this.matches(':first-of-type:[disabled]')
+        //         ? '0'
+        //         : '-1'
+        // );
     }
 
     protected updated(changes: PropertyValues): void {

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -132,12 +132,6 @@ export class Tag extends SpectrumElement {
         if (!this.disabled) {
             this.setAttribute('tabindex', this.deletable ? '0' : '-1');
         }
-        // this.setAttribute(
-        //     'tabindex',
-        //     !this.disabled && this.matches(':first-of-type:[disabled]')
-        //         ? '0'
-        //         : '-1'
-        // );
     }
 
     protected updated(changes: PropertyValues): void {

--- a/packages/tags/src/Tags.ts
+++ b/packages/tags/src/Tags.ts
@@ -49,9 +49,11 @@ export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
         if (!this.tags.length) {
             return;
         }
-        const firstTagNonDisabled = this.tags.find((tag) => !tag.disabled);
-        if (firstTagNonDisabled) {
-            firstTagNonDisabled.focus();
+        const firstFocusableTag = this.tags.find(
+            (tag) => !tag.disabled && tag.deletable
+        );
+        if (firstFocusableTag) {
+            firstFocusableTag.focus();
         }
     }
 
@@ -87,8 +89,10 @@ export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
         ): T => list[(list.length + index) % list.length];
         const tagFromDelta = (delta: number): void => {
             nextIndex += delta;
-            while (circularIndexedElement(this.tags, nextIndex).disabled) {
+            let nextTag = circularIndexedElement(this.tags, nextIndex);
+            while (nextTag.disabled || !nextTag.deletable) {
                 nextIndex += delta;
+                nextTag = circularIndexedElement(this.tags, nextIndex);
             }
         };
         switch (code) {
@@ -147,9 +151,11 @@ export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
     };
 
     private handleFocusout = (): void => {
-        const firstTagNonDisabled = this.tags.find((tag) => !tag.disabled);
-        if (firstTagNonDisabled) {
-            firstTagNonDisabled.tabIndex = 0;
+        const firstFocusableTag = this.tags.find(
+            (tag) => !tag.disabled && tag.deletable
+        );
+        if (firstFocusableTag) {
+            firstFocusableTag.tabIndex = 0;
         }
         this.removeEventListener('keydown', this.handleKeydown);
         this.removeEventListener('focusout', this.handleFocusout);

--- a/packages/tags/test/tags.test.ts
+++ b/packages/tags/test/tags.test.ts
@@ -177,7 +177,7 @@ describe('Tags', () => {
 
         expect(document.activeElement === tag2).to.be.true;
     });
-    it('will only focus [deletable] children', async () => {
+    it('will only tab index [deletable] children', async () => {
         const el = await fixture<Tags>(
             html`
                 <sp-tags>

--- a/packages/tags/test/tags.test.ts
+++ b/packages/tags/test/tags.test.ts
@@ -177,6 +177,48 @@ describe('Tags', () => {
 
         expect(document.activeElement === tag2).to.be.true;
     });
+    it('will only focus [deletable] children', async () => {
+        const el = await fixture<Tags>(
+            html`
+                <sp-tags>
+                    <sp-tag deletable>Tag 1</sp-tag>
+                    <sp-tag>Tag 2</sp-tag>
+                    <sp-tag>Tag 3</sp-tag>
+                    <sp-tag>Tag 4</sp-tag>
+                    <sp-tag deletable>Tag 5</sp-tag>
+                </sp-tags>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const tag1 = el.querySelector('sp-tag:nth-child(1)') as Tag;
+        const tag5 = el.querySelector('sp-tag:nth-child(5)') as Tag;
+
+        tag1.focus();
+        await elementUpdated(el);
+
+        el.dispatchEvent(enterEvent);
+        el.dispatchEvent(endEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === tag5).to.be.true;
+
+        el.dispatchEvent(homeEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === tag1).to.be.true;
+
+        el.dispatchEvent(arrowUpEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === tag5).to.be.true;
+
+        el.dispatchEvent(arrowDownEvent);
+        await elementUpdated(el);
+
+        expect(document.activeElement === tag1).to.be.true;
+    });
     it('loads accepts "PageUp" and "PageDown" keys', async () => {
         const el = await fixture<HTMLDivElement>(
             html`


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The tabs are now only included in the tab order if they can be actioned (ie deleted). 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes https://github.com/adobe/spectrum-web-components/issues/769 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Our tags could be tab indexed regardless of their ability to be changed by the user. They're not actionable elements, so they shouldn't be included in the tab order. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with added tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
