### PR TITLE
fix(slider): ensure pointer events on the track and handle act the same

### DIFF
--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -321,27 +321,18 @@ export class Slider extends Focusable {
      * is moused down
      */
     private handleTrackPointerdown(event: PointerEvent): void {
-        if (
-            event.target === this.handle ||
-            this.disabled ||
-            event.button !== 0
-        ) {
+        if (event.target === this.handle) {
             return;
         }
-        this.boundingClientRect = this.getBoundingClientRect();
 
-        this.dragging = true;
-        this.handle.setPointerCapture(event.pointerId);
-
-        /**
-         * Dispatch a synthetic pointerdown event to ensure that pointerdown
-         * handlers attached to the slider are invoked before input handlers
-         */
         event.stopPropagation();
-        const syntheticPointerEvent = new PointerEvent('pointerdown', event);
-        this.dispatchEvent(syntheticPointerEvent);
-
-        this.value = this.calculateHandlePosition(event);
+        event.preventDefault();
+        const applyDefault = this.handle.dispatchEvent(
+            new PointerEvent('pointerdown', event)
+        );
+        if (applyDefault) {
+            this.handlePointermove(event);
+        }
     }
 
     /**

--- a/test/send-mouse-plugin.ts
+++ b/test/send-mouse-plugin.ts
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import type { Page } from 'playwright';
+
+type Step = {
+    type: 'move' | 'down' | 'up' | 'click';
+    position?: [number, number];
+};
+
+export function sendMousePlugin() {
+    return {
+        name: 'send-mouse-command',
+        async executeCommand({
+            command,
+            session,
+            payload,
+        }: {
+            payload: { steps: Step[] };
+            command: string;
+            session: {
+                id: string;
+                browser: { type: string; getPage: (id: string) => Page };
+            };
+        }): Promise<any> {
+            if (command === 'send-mouse') {
+                // handle specific behavior for playwright
+                if (session.browser.type === 'playwright') {
+                    const page = session.browser.getPage(session.id);
+                    for (const step of payload.steps) {
+                        if (step.position) {
+                            await page.mouse[step.type](
+                                step.position[0],
+                                step.position[1]
+                            );
+                        } else {
+                            await page.mouse[step.type as 'down' | 'up']();
+                        }
+                    }
+                    return true;
+                }
+                // you might not be able to support all browser launchers
+                throw new Error(
+                    `Sending mouse commands is not supported for browser type ${session.browser.type}.`
+                );
+            }
+        },
+    };
+}

--- a/test/tsconfig-plugins.json
+++ b/test/tsconfig-plugins.json
@@ -3,6 +3,10 @@
     "compilerOptions": {
         "rootDir": "."
     },
-    "include": ["./send-keys-plugin.ts", "./a11y-snapshot-plugin.ts"],
+    "include": [
+        "./send-keys-plugin.ts",
+        "./send-mouse-plugin.ts",
+        "./a11y-snapshot-plugin.ts"
+    ],
     "exclude": []
 }

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 import { playwrightLauncher } from '@web/test-runner-playwright';
 import { a11ySnapshotPlugin } from './test/a11y-snapshot-plugin.js';
 import { sendKeysPlugin } from './test/send-keys-plugin.js';
+import { sendMousePlugin } from './test/send-mouse-plugin.js';
 import {
     packages,
     vrtGroups,
@@ -21,6 +22,7 @@ import {
 export default {
     plugins: [
         sendKeysPlugin(),
+        sendMousePlugin(),
         a11ySnapshotPlugin(),
         configuredVisualRegressionPlugin(),
     ],


### PR DESCRIPTION
## Description
- bind event handlers correctly so that `dragging` is released and track based value setting associated to drag based value setting
- add `sendMouse` plugin so that we can appropriately line up our test interactions with the slider with the expectations of the `focus-visible` polyfill when testing interaction state

## Related Issue
fixes #1404 

## Motivation and Context
Correct a bug.

## How Has This Been Tested?
- unit tests with new `sendMouse` plugin.

## Screenshots (if appropriate):
https://westbrook-slider--spectrum-web-components.netlify.app/components/slider

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
