### PR TITLE
fix: allow rendered anchors to be aria-hidden

### DIFF
--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -122,6 +122,7 @@ export class ButtonBase extends LikeAnchor(
             ${this.buttonContent}
             ${super.renderAnchor({
                 id: 'button',
+                ariaHidden: true,
                 className: 'button anchor hidden',
             })}
         `;

--- a/packages/shared/src/like-anchor.ts
+++ b/packages/shared/src/like-anchor.ts
@@ -23,17 +23,20 @@ type Constructor<T = Record<string, unknown>> = {
     prototype: T;
 };
 
+type RenderAnchorOptions = {
+    id: string;
+    className?: string;
+    ariaHidden?: boolean;
+    anchorContent?: TemplateResult | TemplateResult[];
+};
+
 export interface LikeAnchorInterface {
     download?: string;
     label?: string;
     href?: string;
     rel?: string;
     target?: '_blank' | '_parent' | '_self' | '_top';
-    renderAnchor(options: {
-        id: string;
-        className?: string;
-        anchorContent?: TemplateResult | TemplateResult[];
-    }): TemplateResult;
+    renderAnchor(options: RenderAnchorOptions): TemplateResult;
 }
 
 export function LikeAnchor<T extends Constructor<UpdatingElement>>(
@@ -58,13 +61,10 @@ export function LikeAnchor<T extends Constructor<UpdatingElement>>(
         public renderAnchor({
             id,
             className,
+            ariaHidden,
             // prettier-ignore
-            anchorContent = html`<slot></slot>`
-        }: {
-            id: string;
-            className?: string;
-            anchorContent: TemplateResult | TemplateResult[];
-        }): TemplateResult {
+            anchorContent = html`<slot></slot>`,
+        }: RenderAnchorOptions): TemplateResult {
             // prettier-ignore
             return html
                 `<a
@@ -74,6 +74,7 @@ export function LikeAnchor<T extends Constructor<UpdatingElement>>(
                     download=${ifDefined(this.download)}
                     target=${ifDefined(this.target)}
                     aria-label=${ifDefined(this.label)}
+                    aria-hidden=${ifDefined(ariaHidden ? 'true' : undefined)}
                     rel=${ifDefined(this.rel)}
                 >${anchorContent}</a>`;
         }


### PR DESCRIPTION
## Description
Prevent content placed in the proxy link element from being read by screen readers.

## Motivation and Context
Continually expanding use cases

## How Has This Been Tested?
Manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
