### PR TITLE
fix: correctly apply CSS Custom Props to docs site

### DIFF
--- a/documentation/webpack.config.js
+++ b/documentation/webpack.config.js
@@ -110,13 +110,16 @@ export default merge(openWcConfig, {
                                     }),
                                     postCSSInherit(),
                                     postCSSPresetEnv({
-                                        stage: 0,
                                         browsers: [
                                             'last 2 Chrome versions',
                                             'last 2 Firefox versions',
                                             'last 4 Safari versions',
                                             'last 4 iOS versions',
                                         ],
+                                        stage: 2,
+                                        features: {
+                                            'nesting-rules': true,
+                                        },
                                     }),
                                     // minify the css with cssnano presets
                                     cssnano({

--- a/scripts/add-custom-properties.js
+++ b/scripts/add-custom-properties.js
@@ -17,7 +17,6 @@ import fs from 'fs';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 const { src } = yargs(hideBin(process.argv)).argv;
-// const { src } = require('yargs').argv;
 
 async function main() {
     const inputCEJPath = path.join(process.cwd(), src);
@@ -30,7 +29,8 @@ async function main() {
                 .replace(/sp-[a-z-]*\.d\.ts/, 'src/spectrum-vars.json');
             try {
                 const vars = fs.readFileSync(varsPath, 'utf8');
-                const properties = JSON.parse(vars)['custom-properties'];
+                const varsJSON = JSON.parse(vars);
+                const properties = varsJSON['custom-properties'];
                 const cssProperties = Object.keys(properties).map(
                     (property) => ({
                         name: property,
@@ -48,16 +48,22 @@ async function main() {
                     }
                     return 0;
                 };
-                tag.attributes.sort(sortAlpha);
-                tag.properties.sort(sortAlpha);
-                tag.events.sort(sortAlpha);
-            } catch (error) {}
+                tag.attributes && tag.attributes.sort(sortAlpha);
+                tag.properties && tag.properties.sort(sortAlpha);
+                tag.events && tag.events.sort(sortAlpha);
+            } catch (error) {
+                // Toggle the following commented logging for debuggering the processing herein:
+                // console.log('Package level error:', tag.name, error);
+            }
         });
         customElementJsonString = JSON.stringify(customElementJson);
         fs.writeFileSync(inputCEJPath, customElementJsonString, {
             encoding: 'utf8',
         });
-    } catch (error) {}
+    } catch (error) {
+        // Toggle the following commented logging for debuggering the processing herein:
+        // console.log('Top level error:', error);
+    }
 }
 
 main();

--- a/scripts/css-processing.cjs
+++ b/scripts/css-processing.cjs
@@ -20,13 +20,16 @@ const postCSSPlugins = (resourcePath) => {
         require('postcss-import')(postCSSImportConfig),
         require('postcss-inherit')(),
         require('postcss-preset-env')({
-            stage: 0,
             browsers: [
                 'last 2 Chrome versions',
                 'last 2 Firefox versions',
                 'last 4 Safari versions',
                 'last 4 iOS versions',
             ],
+            stage: 2,
+            features: {
+                'nesting-rules': true,
+            },
         }),
         // minify the css with cssnano presets
         require('cssnano')({

--- a/scripts/process-spectrum-css.js
+++ b/scripts/process-spectrum-css.js
@@ -49,7 +49,7 @@ async function processComponent(componentPath) {
     );
     inputCustomProperties = inputCustomProperties.replace(
         /(.|\n)*\{/,
-        ':root{'
+        ':root {'
     );
     console.log(chalk.bold.green(`- ${spectrumConfig.spectrum}`));
     return Promise.all(
@@ -70,15 +70,14 @@ async function processComponent(componentPath) {
                 from: inputCssPath,
                 to: outputCssPath,
             });
-            await postcss([postcssCustomProperties]).process(
-                inputCustomProperties,
-                {
-                    from: `node_modules/@spectrum-css/${spectrumConfig.spectrum}/dist/vars.css`,
-                },
-                {
+            const srcPath = `node_modules/@spectrum-css/${spectrumConfig.spectrum}/dist/vars.css`;
+            await postcss([
+                postcssCustomProperties({
                     exportTo: [outputJsonPath],
-                }
-            );
+                }),
+            ]).process(inputCustomProperties, {
+                from: srcPath,
+            });
             console.log(chalk.bold.green(`  o ${component.name}`));
             // await fs.writeFile(outputJsonPath, outputJson, { encoding: 'utf8' });
             return fs.writeFile(outputCssPath, outputCss.css, {

--- a/scripts/spectrum-vars.js
+++ b/scripts/spectrum-vars.js
@@ -204,14 +204,7 @@ cores.forEach(async (core) => {
             );
             console.log(`processing fonts from commons & typography`);
             processes.push(
-                processMultiSourceCSS(
-                    [
-                        // srcPath1,
-                        srcPath2,
-                    ],
-                    dstPath,
-                    ':root '
-                )
+                processMultiSourceCSS([srcPath2], dstPath, ':root ')
             );
         }
     }


### PR DESCRIPTION
## Description

Correct the usage of `postcssCustomProperties` so that CSS Custom Properties are published to the documentation site again.

## Motivation and Context
Easier to use.

## How Has This Been Tested?
https://westbrook-custom-props--spectrum-web-components.netlify.app/components/action-button/api

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
