### PR TITLE
feat(tree-view): add multiselect support

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -60,6 +60,7 @@ module.exports = {
         '../packages/toast/stories/*.stories.js',
         '../packages/tooltip/stories/*.stories.js',
         '../packages/top-nav/stories/*.stories.js',
+        '../packages/tree-view/stories/*.stories.js',
         '../packages/underlay/stories/*.stories.js',
     ],
 

--- a/packages/tree-view/README.md
+++ b/packages/tree-view/README.md
@@ -1,0 +1,1 @@
+## Overview

--- a/packages/tree-view/package.json
+++ b/packages/tree-view/package.json
@@ -1,0 +1,60 @@
+{
+    "name": "@spectrum-web-components/tree-view",
+    "version": "0.0.1",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adobe/spectrum-web-components.git",
+        "directory": "packages/tree-view"
+    },
+    "author": "",
+    "homepage": "https://adobe.github.io/spectrum-web-components/components/tree-view",
+    "bugs": {
+        "url": "https://github.com/adobe/spectrum-web-components/issues"
+    },
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        ".": "./src/index.js",
+        "./src/*": "./src/*",
+        "./custom-elements.json": "./custom-elements.json",
+        "./package.json": "./package.json",
+        "./sp-tree-view": "./sp-tree-view.js",
+        "./sp-tree-view.js": "./sp-tree-view.js",
+        "./sp-tree-view-item": "./sp-tree-view-item.js",
+        "./sp-tree-view-item.js": "./sp-tree-view-item.js"
+    },
+    "files": [
+        "*.d.ts",
+        "*.js",
+        "*.js.map",
+        "/src/",
+        "custom-elements.json"
+    ],
+    "keywords": [
+        "spectrum css",
+        "web components",
+        "lit-element",
+        "lit-html"
+    ],
+    "dependencies": {
+        "@spectrum-web-components/base": "^0.4.2",
+        "@spectrum-web-components/icons-ui": "^0.6.4",
+        "@spectrum-web-components/shared": "^0.12.1",
+        "@spectrum-web-components/thumbnail": "^0.1.3",
+        "tslib": "^2.0.0"
+    },
+    "devDependencies": {
+        "@spectrum-css/treeview": "^3.0.0"
+    },
+    "types": "src/index.d.ts",
+    "sideEffects": [
+        "./sp-*.js",
+        "./sp-*.ts"
+    ]
+}

--- a/packages/tree-view/sp-tree-view-heading.ts
+++ b/packages/tree-view/sp-tree-view-heading.ts
@@ -1,0 +1,20 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { TreeViewHeading } from './src/TreeViewHeading.js';
+
+customElements.define('sp-tree-view-heading', TreeViewHeading);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-tree-view-heading': TreeViewHeading;
+    }
+}

--- a/packages/tree-view/sp-tree-view-item.ts
+++ b/packages/tree-view/sp-tree-view-item.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { TreeViewItem } from './src/TreeViewItem.js';
+
+customElements.define('sp-tree-view-item', TreeViewItem);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-tree-view-item': TreeViewItem;
+    }
+}

--- a/packages/tree-view/sp-tree-view.ts
+++ b/packages/tree-view/sp-tree-view.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { TreeView } from './src/TreeView.js';
+
+customElements.define('sp-tree-view', TreeView);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-tree-view': TreeView;
+    }
+}

--- a/packages/tree-view/src/TreeView.ts
+++ b/packages/tree-view/src/TreeView.ts
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    CSSResultArray,
+    TemplateResult,
+    SpectrumElement,
+    property,
+    PropertyValues,
+} from '@spectrum-web-components/base';
+
+import { TreeViewItem } from './TreeViewItem.js';
+import treeViewStyles from './tree-view.css.js';
+
+/**
+ * @slot icon - The icon that appears on the left of the label
+ * @slot - The label
+ */
+
+export class TreeView extends SpectrumElement {
+    public static get styles(): CSSResultArray {
+        return [treeViewStyles];
+    }
+
+    @property({ attribute: false })
+    public selectedChild?: TreeViewItem;
+
+    @property({ type: Boolean, reflect: true })
+    public standalone = false;
+
+    @property({ type: Boolean, reflect: true })
+    public quiet = false;
+
+    constructor() {
+        super();
+        this.addEventListener('selected', this.manageSelected);
+        this.addEventListener('deselected', this.manageDeselected);
+    }
+
+    private manageSelected(event: Event): void {
+        const { target } = event;
+        if (!target) {
+            return;
+        }
+        if (this.selectedChild && this.selectedChild !== target) {
+            this.selectedChild.selected = false;
+        }
+        this.selectedChild = target as TreeViewItem;
+    }
+
+    private manageDeselected(event: Event): void {
+        const { target } = event;
+        if (!target) {
+            return;
+        }
+        if (this.selectedChild && this.selectedChild === target) {
+            this.selectedChild = undefined;
+        }
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            <slot></slot>
+        `;
+    }
+
+    protected firstUpdated(changes: PropertyValues): void {
+        super.firstUpdated(changes);
+        const isRoot = this.parentElement?.tagName !== 'SP-TREE-VIEW-ITEM';
+        this.setAttribute('role', isRoot ? 'tree' : 'group');
+    }
+}

--- a/packages/tree-view/src/TreeViewHeading.ts
+++ b/packages/tree-view/src/TreeViewHeading.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2019 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -12,43 +12,27 @@ governing permissions and limitations under the License.
 
 import {
     html,
-    SpectrumElement,
     CSSResultArray,
     TemplateResult,
-    property,
-    SizedMixin,
+    SpectrumElement,
 } from '@spectrum-web-components/base';
 
-import styles from './thumbnail.css.js';
+import treeViewHeadingStyles from './tree-view-heading.css.js';
+import treeViewLabelStyles from './tree-view-label.css.js';
 
 /**
- * @element sp-thumbnail
+ * @slot icon - The icon that appears on the left of the label
+ * @slot - The label
  */
-export class Thumbnail extends SizedMixin(SpectrumElement, {
-    validSizes: ['s', 'm', 'l', 'xl', 'xxl'],
-    noDefaultSize: true,
-}) {
+
+export class TreeViewHeading extends SpectrumElement {
     public static get styles(): CSSResultArray {
-        return [styles];
+        return [treeViewHeadingStyles, treeViewLabelStyles];
     }
-
-    @property({ type: String, reflect: true })
-    public background?: string;
-
-    @property({ type: Boolean, reflect: true })
-    public selected = false;
 
     protected render(): TemplateResult {
         return html`
-            ${this.background
-                ? html`
-                      <div
-                          class="background"
-                          style="background: ${this.background}"
-                      ></div>
-                  `
-                : html``}
-            <slot></slot>
+            <span id="label"><slot></slot></span>
         `;
     }
 }

--- a/packages/tree-view/src/TreeViewItem.ts
+++ b/packages/tree-view/src/TreeViewItem.ts
@@ -1,0 +1,166 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    CSSResultArray,
+    TemplateResult,
+    property,
+    PropertyValues,
+    query,
+    queryAssignedNodes,
+    ifDefined,
+} from '@spectrum-web-components/base';
+
+import {
+    Focusable,
+    ObserveSlotPresence,
+} from '@spectrum-web-components/shared';
+import type { Thumbnail } from '@spectrum-web-components/thumbnail';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron100.js';
+import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
+import treeViewItemStyles from './tree-view-item.css.js';
+import treeViewItemLabelStyles from './tree-view-label.css.js';
+
+/**
+ * @slot icon - The icon that appears on the left of the label
+ * @slot - The label
+ */
+
+export class TreeViewItem extends ObserveSlotPresence(
+    Focusable,
+    '[slot="thumbnail"]'
+) {
+    public static get styles(): CSSResultArray {
+        return [treeViewItemStyles, treeViewItemLabelStyles, chevronStyles];
+    }
+
+    @queryAssignedNodes('thumbnail', true)
+    private assignedThumbnails!: NodeListOf<Thumbnail>;
+
+    @property({ type: Boolean, reflect: true })
+    public disabled = false;
+
+    @property({ type: Boolean, reflect: true, attribute: 'drop-target' })
+    public dropTarget = false;
+
+    public get thumbnail(): Thumbnail | undefined {
+        if (this.assignedThumbnails.length) {
+            return this.assignedThumbnails[0];
+        }
+
+        return undefined;
+    }
+
+    @query('a')
+    public anchorElement!: HTMLAnchorElement;
+
+    public get focusElement(): HTMLAnchorElement {
+        return this.anchorElement;
+    }
+
+    protected get hasThumbnail(): boolean {
+        return this.slotContentIsPresent;
+    }
+
+    @property({ type: Boolean, reflect: true, attribute: 'can-open' })
+    public canOpen = false;
+
+    @property({ type: Number, reflect: true })
+    public indent!: number;
+
+    @property({ type: Boolean, reflect: true })
+    public open = false;
+
+    @property({ type: Boolean, reflect: true })
+    public selected = false;
+
+    private get hasChildren(): boolean {
+        return !!this.querySelector('[slot="children"]');
+    }
+
+    public toggleOpen(event: Event): void {
+        event.preventDefault();
+        event.stopPropagation();
+        this.open = !this.open;
+    }
+
+    public toggleSelected(event: Event): void {
+        event.preventDefault();
+        this.selected = !this.selected;
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            <a
+                href="#"
+                @click=${this.toggleSelected}
+                class=${this.hasThumbnail ? 'has-thumbnail link' : 'link'}
+                aria-hidden=${ifDefined(this.disabled ? 'true' : undefined)}
+            >
+                ${this.hasChildren || this.canOpen
+                    ? html`
+                          <sp-icon-chevron100
+                              id="indicator"
+                              class="spectrum-UIIcon-ChevronRight100"
+                              @click=${this.toggleOpen}
+                          ></sp-icon-chevron100>
+                      `
+                    : html``}
+                <slot name="icon"></slot>
+                <slot name="thumbnail"></slot>
+                <span id="label">
+                    <slot></slot>
+                </span>
+            </a>
+            ${this.open
+                ? html`
+                      <slot name="children"></slot>
+                  `
+                : html``}
+        `;
+    }
+
+    protected firstUpdated(changed: PropertyValues): void {
+        super.firstUpdated(changed);
+        this.setAttribute('role', 'treeitem');
+    }
+
+    protected updated(changed: PropertyValues): void {
+        super.updated(changed);
+        this.setAttribute('aria-expanded', this.open ? 'true' : 'false');
+        if (changed.has('selected')) {
+            if (this.thumbnail) {
+                this.thumbnail.selected = this.selected;
+            }
+            if ('undefined' !== typeof changed.get('selected')) {
+                if (this.selected) {
+                    this.dispatchEvent(
+                        new Event('selected', {
+                            bubbles: true,
+                            composed: true,
+                            cancelable: true,
+                        })
+                    );
+                } else {
+                    this.dispatchEvent(
+                        new Event('deselected', {
+                            bubbles: true,
+                            composed: true,
+                            cancelable: true,
+                        })
+                    );
+                }
+            }
+        }
+    }
+}

--- a/packages/tree-view/src/TreeViewItem.ts
+++ b/packages/tree-view/src/TreeViewItem.ts
@@ -103,7 +103,10 @@ export class TreeViewItem extends ObserveSlotPresence(
                 bubbles: true,
                 composed: true,
                 cancelable: true,
-                detail: { multiselect },
+                detail: {
+                    multiselect,
+                    contiguous: event.shiftKey,
+                },
             })
         );
         if (!applyDefault) this.selected = !this.selected;
@@ -147,7 +150,15 @@ export class TreeViewItem extends ObserveSlotPresence(
 
     protected updated(changed: PropertyValues): void {
         super.updated(changed);
-        this.setAttribute('aria-expanded', this.open ? 'true' : 'false');
+        if (this.hasChildren || this.canOpen) {
+            this.setAttribute('aria-expanded', this.open ? 'true' : 'false');
+        }
+        if (!this.disabled) {
+            this.setAttribute(
+                'aria-selected',
+                this.selected ? 'true' : 'false'
+            );
+        }
         if (changed.has('selected')) {
             if (this.thumbnail) {
                 this.thumbnail.selected = this.selected;

--- a/packages/tree-view/src/TreeViewItem.ts
+++ b/packages/tree-view/src/TreeViewItem.ts
@@ -94,9 +94,19 @@ export class TreeViewItem extends ObserveSlotPresence(
         this.open = !this.open;
     }
 
-    public toggleSelected(event: Event): void {
+    public toggleSelected(event: MouseEvent): void {
         event.preventDefault();
         this.selected = !this.selected;
+        const multiselect = event.shiftKey || event.metaKey;
+        const applyDefault = this.dispatchEvent(
+            new CustomEvent('toggled', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                detail: { multiselect },
+            })
+        );
+        if (!applyDefault) this.selected = !this.selected;
     }
 
     protected render(): TemplateResult {

--- a/packages/tree-view/src/index.ts
+++ b/packages/tree-view/src/index.ts
@@ -1,0 +1,14 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+export * from './TreeView.js';
+export * from './TreeViewHeading.js';
+export * from './TreeViewItem.js';

--- a/packages/tree-view/src/spectrum-config.js
+++ b/packages/tree-view/src/spectrum-config.js
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the 'License');
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const config = {
+    spectrum: 'treeview',
+    components: [
+        {
+            name: 'tree-view',
+            tagName: 'sp-tree-view',
+            host: {
+                selector: '.spectrum-TreeView',
+            },
+            attributes: [
+                {
+                    type: 'boolean',
+                    selector: '.spectrum-TreeView--standalone',
+                    name: 'standalone',
+                },
+            ],
+            slots: [
+                {
+                    selector: '.spectrum-TreeView',
+                    contents: 'sp-tree-view',
+                },
+            ],
+            exclude: [
+                /\.spectrum-TreeView-item/,
+                /\.spectrum-TreeView-heading/,
+            ],
+        },
+        {
+            name: 'tree-view-item-link',
+            host: {
+                selector: '.spectrum-TreeView--thumbnail',
+            },
+            classes: [
+                {
+                    selector: '.spectrum-TreeView-itemLink',
+                    name: 'has-thumbnail',
+                },
+            ],
+            exclude: [
+                /^(?!\.spectrum-TreeView--thumbnail \.spectrum-TreeView-itemLink).*/,
+            ],
+        },
+        {
+            name: 'tree-view-heading',
+            host: {
+                selector: '.spectrum-TreeView-heading',
+            },
+            exclude: [/\.spectrum-TreeView-item/, /\.spectrum-TreeView\s/],
+        },
+        {
+            name: 'tree-view-item-label',
+            host: {
+                selector: '.spectrum-TreeView-item',
+            },
+            ids: [
+                {
+                    selector: '.spectrum-TreeView-itemLabel',
+                    name: 'label',
+                },
+            ],
+            exclude: [/^(?!\.spectrum-TreeView-itemLabel)/],
+        },
+        {
+            name: 'tree-view-item',
+            host: {
+                selector: '.spectrum-TreeView-item',
+            },
+            attributes: [
+                {
+                    type: 'boolean',
+                    selector: '.is-open',
+                    name: 'open',
+                },
+                {
+                    type: 'boolean',
+                    selector: '.is-selected',
+                    name: 'selected',
+                },
+                {
+                    type: 'boolean',
+                    selector: '.is-drop-target',
+                    name: 'drop-target',
+                },
+                {
+                    type: 'boolean',
+                    selector: '.is-disabled',
+                    name: 'disabled',
+                },
+                {
+                    type: 'enum',
+                    name: 'indent',
+                    root: '.spectrum-TreeView-item--indent',
+                    values: [
+                        '.spectrum-TreeView-item--indent1',
+                        '.spectrum-TreeView-item--indent2',
+                        '.spectrum-TreeView-item--indent3',
+                        '.spectrum-TreeView-item--indent4',
+                        '.spectrum-TreeView-item--indent5',
+                        '.spectrum-TreeView-item--indent6',
+                        '.spectrum-TreeView-item--indent7',
+                        '.spectrum-TreeView-item--indent8',
+                        '.spectrum-TreeView-item--indent9',
+                        '.spectrum-TreeView-item--indent10',
+                    ],
+                },
+            ],
+            ids: [
+                {
+                    selector: '.spectrum-TreeView-itemIndicator',
+                    name: 'indicator',
+                },
+            ],
+            slots: [
+                {
+                    name: 'children',
+                    selector: '.spectrum-TreeView',
+                },
+                {
+                    selector: '.spectrum-TreeView-itemIcon',
+                    name: 'icon',
+                },
+            ],
+            classes: [
+                {
+                    selector: '.spectrum-TreeView-itemLink',
+                    name: 'link',
+                },
+            ],
+            exclude: [/\.spectrum-TreeView-itemLabel/],
+            complexSelectors: [
+                {
+                    selector:
+                        '.spectrum-TreeView-item[dir=rtl] .spectrum-TreeView--thumbnail .spectrum-TreeView-itemThumbnail',
+                    replacement:
+                        ':host([dir=rtl]) ::slotted([slot="thumbnail"])',
+                },
+                {
+                    selector:
+                        '.spectrum-TreeView-item[dir=ltr] .spectrum-TreeView--thumbnail .spectrum-TreeView-itemThumbnail',
+                    replacement:
+                        ':host([dir=ltr]) ::slotted([slot="thumbnail"])',
+                },
+            ],
+        },
+    ],
+};
+
+export default config;

--- a/packages/tree-view/src/spectrum-tree-view-heading.css
+++ b/packages/tree-view/src/spectrum-tree-view-heading.css
@@ -1,0 +1,24 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host {
+    /* .spectrum-TreeView-heading */
+    padding: var(
+        --spectrum-treeview-item-padding-y,
+        var(--spectrum-global-dimension-static-size-100)
+    );
+    font-weight: var(--spectrum-treeview-heading-font-weight);
+}
+:host(:not(:first-child)) {
+    /* .spectrum-TreeView-heading:not(:first-child) */
+    margin-top: var(--spectrum-global-dimension-size-200);
+}

--- a/packages/tree-view/src/spectrum-tree-view-item-label.css
+++ b/packages/tree-view/src/spectrum-tree-view-item-label.css
@@ -1,0 +1,17 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+#label {
+    /* .spectrum-TreeView-itemLabel */
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/packages/tree-view/src/spectrum-tree-view-item-link.css
+++ b/packages/tree-view/src/spectrum-tree-view-item-link.css
@@ -1,0 +1,18 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+.has-thumbnail,
+.has-thumbnail:before {
+    /* .spectrum-TreeView--thumbnail .spectrum-TreeView-itemLink,
+   * .spectrum-TreeView--thumbnail .spectrum-TreeView-itemLink:before */
+    height: var(--spectrum-treeview-item-height-layers);
+}

--- a/packages/tree-view/src/spectrum-tree-view-item.css
+++ b/packages/tree-view/src/spectrum-tree-view-item.css
@@ -1,0 +1,340 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host {
+    /* .spectrum-TreeView-item */
+    overflow: hidden;
+}
+:host([dir='ltr'][open]) > .link > #indicator {
+    /* [dir=ltr] .spectrum-TreeView-item.is-open>.spectrum-TreeView-itemLink>.spectrum-TreeView-itemIndicator */
+    transform: rotate(90deg);
+}
+:host([dir='rtl'][open]) > .link > #indicator {
+    /* [dir=rtl] .spectrum-TreeView-item.is-open>.spectrum-TreeView-itemLink>.spectrum-TreeView-itemIndicator */
+    transform: matrix(-1, 0, 0, 1, 0, 0) rotate(90deg);
+}
+:host([open]) > ::slotted([slot='children']) {
+    /* .spectrum-TreeView-item.is-open>.spectrum-TreeView */
+    height: auto;
+    visibility: visible;
+}
+:host([drop-target]) .link:before {
+    /* .spectrum-TreeView-item.is-drop-target .spectrum-TreeView-itemLink:before */
+    border-width: var(
+        --spectrum-treeview-item-border-size,
+        var(--spectrum-global-dimension-static-size-25)
+    );
+}
+:host([selected]) .link:not(:focus-visible):before {
+    /* .spectrum-TreeView-item.is-selected .spectrum-TreeView-itemLink:not(.focus-ring):before */
+    border-width: var(--spectrum-treeview-item-border-size-selected);
+}
+.link {
+    /* .spectrum-TreeView-itemLink */
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    box-sizing: border-box;
+    cursor: pointer;
+    padding: var(
+            --spectrum-treeview-item-padding-y,
+            var(--spectrum-global-dimension-static-size-100)
+        )
+        var(--spectrum-treeview-item-affordance-width);
+    text-decoration: none;
+    height: var(--spectrum-treeview-item-min-height);
+    white-space: nowrap;
+    overflow: hidden;
+    outline: none;
+}
+:host([dir='ltr']) .link ::slotted([slot='icon']) {
+    /* [dir=ltr] .spectrum-TreeView-itemLink .spectrum-TreeView-itemIcon */
+    margin-right: var(--spectrum-treeview-item-icon-margin-right);
+}
+:host([dir='rtl']) .link ::slotted([slot='icon']) {
+    /* [dir=rtl] .spectrum-TreeView-itemLink .spectrum-TreeView-itemIcon */
+    margin-left: var(--spectrum-treeview-item-icon-margin-right);
+}
+.link ::slotted([slot='icon']) {
+    /* .spectrum-TreeView-itemLink .spectrum-TreeView-itemIcon */
+    vertical-align: top;
+}
+:host([dir='ltr']) .link:before {
+    /* [dir=ltr] .spectrum-TreeView-itemLink:before */
+    left: var(
+        --spectrum-treeview-item-border-size,
+        var(--spectrum-global-dimension-static-size-25)
+    );
+}
+:host([dir='rtl']) .link:before {
+    /* [dir=rtl] .spectrum-TreeView-itemLink:before */
+    right: var(
+        --spectrum-treeview-item-border-size,
+        var(--spectrum-global-dimension-static-size-25)
+    );
+}
+:host([dir='ltr']) .link:before {
+    /* [dir=ltr] .spectrum-TreeView-itemLink:before */
+    right: 0;
+}
+:host([dir='rtl']) .link:before {
+    /* [dir=rtl] .spectrum-TreeView-itemLink:before */
+    left: 0;
+}
+.link:before {
+    /* .spectrum-TreeView-itemLink:before */
+    content: '';
+    box-sizing: border-box;
+    position: absolute;
+    height: calc(
+        var(
+                --spectrum-treeview-item-height,
+                var(--spectrum-global-dimension-size-450)
+            ) - var(--spectrum-treeview-item-hover-offset) * 2
+    );
+    border-left: 0 solid transparent;
+    border-bottom: var(
+            --spectrum-treeview-item-border-size,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        solid transparent;
+    border-right: 0 solid transparent;
+    border-top: var(
+            --spectrum-treeview-item-border-size,
+            var(--spectrum-global-dimension-static-size-25)
+        )
+        solid transparent;
+    background-color: initial;
+}
+.link:focus-visible:before {
+    /* .spectrum-TreeView--standalone .spectrum-TreeView-itemLink:before,
+   * .spectrum-TreeView-itemLink.focus-ring:before */
+    border-width: var(
+        --spectrum-treeview-item-border-size,
+        var(--spectrum-global-dimension-static-size-25)
+    );
+}
+:host([dir='ltr']) ::slotted([slot='thumbnail']) {
+    /* [dir=ltr] .spectrum-TreeView--thumbnail .spectrum-TreeView-itemThumbnail */
+    margin-right: var(--spectrum-treeview-item-icon-margin-right);
+}
+:host([dir='rtl']) ::slotted([slot='thumbnail']) {
+    /* [dir=rtl] .spectrum-TreeView--thumbnail .spectrum-TreeView-itemThumbnail */
+    margin-left: var(--spectrum-treeview-item-icon-margin-right);
+}
+:host([dir='ltr']) #indicator {
+    /* [dir=ltr] .spectrum-TreeView-itemIndicator */
+    float: left;
+}
+:host([dir='rtl']) #indicator {
+    /* [dir=rtl] .spectrum-TreeView-itemIndicator */
+    float: right;
+}
+:host([dir='ltr']) #indicator {
+    /* [dir=ltr] .spectrum-TreeView-itemIndicator */
+    left: var(--spectrum-global-dimension-size-125);
+}
+:host([dir='rtl']) #indicator {
+    /* [dir=rtl] .spectrum-TreeView-itemIndicator */
+    right: var(--spectrum-global-dimension-size-125);
+}
+:host([dir='ltr']) #indicator {
+    /* [dir=ltr] .spectrum-TreeView-itemIndicator */
+    margin-left: calc(-1 * var(--spectrum-global-dimension-size-500));
+}
+:host([dir='rtl']) #indicator {
+    /* [dir=rtl] .spectrum-TreeView-itemIndicator */
+    margin-right: calc(-1 * var(--spectrum-global-dimension-size-500));
+}
+:host([dir='ltr']) #indicator {
+    /* [dir=ltr] .spectrum-TreeView-itemIndicator */
+    margin-right: var(--spectrum-global-dimension-size-85);
+}
+:host([dir='rtl']) #indicator {
+    /* [dir=rtl] .spectrum-TreeView-itemIndicator */
+    margin-left: var(--spectrum-global-dimension-size-85);
+    transform: matrix(-1, 0, 0, 1, 0, 0);
+}
+#indicator {
+    /* .spectrum-TreeView-itemIndicator */
+    display: block;
+    box-sizing: initial;
+    position: relative;
+    z-index: 1;
+    top: calc(-1 * var(--spectrum-global-dimension-size-65));
+    margin-bottom: calc(-1 * var(--spectrum-global-dimension-size-125));
+    padding: var(--spectrum-global-dimension-size-125)
+        var(--spectrum-global-dimension-size-150);
+    transition: transform ease
+        var(--spectrum-global-animation-duration-100, 0.13s);
+    pointer-events: all !important;
+}
+:host([dir='ltr'][indent='1']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent1 */
+    padding-left: var(--spectrum-treeview-item-indentation);
+}
+:host([dir='rtl'][indent='1']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent1 */
+    padding-right: var(--spectrum-treeview-item-indentation);
+}
+:host([dir='ltr'][indent='2']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent2 */
+    padding-left: calc(2 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='2']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent2 */
+    padding-right: calc(2 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='ltr'][indent='3']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent3 */
+    padding-left: calc(3 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='3']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent3 */
+    padding-right: calc(3 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='ltr'][indent='4']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent4 */
+    padding-left: calc(4 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='4']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent4 */
+    padding-right: calc(4 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='ltr'][indent='5']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent5 */
+    padding-left: calc(5 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='5']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent5 */
+    padding-right: calc(5 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='ltr'][indent='6']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent6 */
+    padding-left: calc(6 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='6']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent6 */
+    padding-right: calc(6 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='ltr'][indent='7']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent7 */
+    padding-left: calc(7 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='7']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent7 */
+    padding-right: calc(7 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='ltr'][indent='8']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent8 */
+    padding-left: calc(8 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='8']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent8 */
+    padding-right: calc(8 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='ltr'][indent='9']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent9 */
+    padding-left: calc(9 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='9']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent9 */
+    padding-right: calc(9 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='ltr'][indent='10']) {
+    /* [dir=ltr] .spectrum-TreeView-item--indent10 */
+    padding-left: calc(10 * var(--spectrum-treeview-item-indentation));
+}
+:host([dir='rtl'][indent='10']) {
+    /* [dir=rtl] .spectrum-TreeView-item--indent10 */
+    padding-right: calc(10 * var(--spectrum-treeview-item-indentation));
+}
+:host([disabled]) > .link {
+    /* .spectrum-TreeView-item.is-disabled>.spectrum-TreeView-itemLink */
+    color: var(--spectrum-treeview-item-text-color-disabled);
+}
+:host([disabled]) > .link .spectrum-Icon {
+    /* .spectrum-TreeView-item.is-disabled>.spectrum-TreeView-itemLink .spectrum-Icon */
+    color: var(--spectrum-treeview-item-icon-color-disabled);
+}
+:host([selected]) > .link {
+    /* .spectrum-TreeView-item.is-selected>.spectrum-TreeView-itemLink */
+    color: var(--spectrum-treeview-item-text-color-selected);
+}
+:host([selected]) > .link:before {
+    /* .spectrum-TreeView-item.is-selected>.spectrum-TreeView-itemLink:before */
+    background-color: var(--spectrum-treeview-item-background-color-selected);
+    border-color: var(
+        --spectrum-treeview-item-border-color-key-focus,
+        var(--spectrum-alias-focus-color)
+    );
+}
+:host([selected]) > .link ::slotted([slot='icon']) {
+    /* .spectrum-TreeView-item.is-selected>.spectrum-TreeView-itemLink .spectrum-TreeView-itemIcon */
+    color: var(--spectrum-treeview-item-icon-color-selected);
+}
+:host([drop-target]) > .link:before {
+    /* .spectrum-TreeView-item.is-drop-target>.spectrum-TreeView-itemLink:before */
+    background-color: var(--spectrum-alias-highlight-selected);
+    border-color: var(
+        --spectrum-treeview-item-border-color-key-focus,
+        var(--spectrum-alias-focus-color)
+    );
+}
+::slotted([slot='icon']) {
+    /* .spectrum-TreeView-itemIcon */
+    color: var(--spectrum-treeview-item-icon-color);
+}
+.link {
+    /* .spectrum-TreeView-itemLink */
+    color: var(
+        --spectrum-treeview-item-text-color,
+        var(--spectrum-global-color-gray-800)
+    );
+}
+.link:hover {
+    /* .spectrum-TreeView-itemLink:hover */
+    color: var(
+        --spectrum-treeview-item-text-color-hover,
+        var(--spectrum-global-color-gray-900)
+    );
+}
+.link:hover:before {
+    /* .spectrum-TreeView-itemLink:hover:before */
+    background-color: var(
+        --spectrum-treeview-item-background-color-hover,
+        var(--spectrum-alias-background-color-hover-overlay)
+    );
+}
+.link:hover ::slotted([slot='icon']) {
+    /* .spectrum-TreeView-itemLink:hover .spectrum-TreeView-itemIcon */
+    color: var(--spectrum-treeview-item-icon-color-hover);
+}
+.link:focus-visible {
+    /* .spectrum-TreeView-itemLink.focus-ring */
+    color: var(--spectrum-treeview-item-text-color-focus);
+}
+.link:focus-visible:before {
+    /* .spectrum-TreeView-itemLink.focus-ring:before */
+    background-color: var(
+        --spectrum-treeview-item-background-color-key-focus,
+        var(--spectrum-alias-background-color-hover-overlay)
+    );
+    border-color: var(
+        --spectrum-treeview-item-border-color-key-focus,
+        var(--spectrum-alias-focus-color)
+    );
+}
+.link:focus-visible ::slotted([slot='icon']) {
+    /* .spectrum-TreeView-itemLink.focus-ring .spectrum-TreeView-itemIcon */
+    color: var(--spectrum-treeview-item-icon-color-focus);
+}

--- a/packages/tree-view/src/spectrum-tree-view.css
+++ b/packages/tree-view/src/spectrum-tree-view.css
@@ -1,0 +1,106 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host {
+    /* .spectrum-TreeView */
+    --spectrum-treeview-item-min-height: var(
+        --spectrum-global-dimension-size-400
+    );
+    --spectrum-treeview-item-padding-y: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-treeview-item-icon-margin-right: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-treeview-item-affordance-width: var(
+        --spectrum-global-dimension-size-400
+    );
+    --spectrum-treeview-item-indentation: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-treeview-heading-font-weight: var(
+        --spectrum-global-font-weight-bold,
+        700
+    );
+    --spectrum-treeview-item-hover-offset: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-treeview-item-border-size-selected: var(
+        --spectrum-alias-border-size-thin,
+        var(--spectrum-global-dimension-static-size-10)
+    );
+    --spectrum-treeview-item-height-layers: var(
+        --spectrum-global-dimension-size-550
+    );
+    display: block;
+    position: relative;
+    padding: 0;
+    list-style: none;
+    outline: none;
+    -webkit-user-select: none;
+    user-select: none;
+}
+:host([dir='ltr']) ::slotted(sp-tree-view) {
+    /* [dir=ltr] .spectrum-TreeView .spectrum-TreeView */
+    padding-left: var(--spectrum-treeview-item-indentation);
+}
+:host([dir='rtl']) ::slotted(sp-tree-view) {
+    /* [dir=rtl] .spectrum-TreeView .spectrum-TreeView */
+    padding-right: var(--spectrum-treeview-item-indentation);
+}
+sp-tree-view {
+    /* .spectrum-TreeView .spectrum-TreeView */
+    position: static;
+    height: 0;
+    visibility: hidden;
+}
+:host {
+    /* .spectrum-TreeView */
+    --spectrum-treeview-item-background-color-selected: var(
+        --spectrum-alias-highlight-selected
+    );
+    --spectrum-treeview-item-background-color-quiet-selected: var(
+        --spectrum-alias-highlight-hover
+    );
+    --spectrum-treeview-item-icon-color: var(
+        --spectrum-alias-icon-color,
+        var(--spectrum-global-color-gray-700)
+    );
+    --spectrum-treeview-item-icon-color-hover: var(
+        --spectrum-alias-icon-color-hover,
+        var(--spectrum-global-color-gray-900)
+    );
+    --spectrum-treeview-item-icon-color-focus: var(
+        --spectrum-alias-icon-color-focus,
+        var(--spectrum-global-color-gray-900)
+    );
+    --spectrum-treeview-item-icon-color-selected: var(
+        --spectrum-alias-icon-color-selected-neutral,
+        var(--spectrum-global-color-gray-900)
+    );
+    --spectrum-treeview-item-icon-color-disabled: var(
+        --spectrum-alias-icon-color-disabled,
+        var(--spectrum-global-color-gray-400)
+    );
+    --spectrum-treeview-item-text-color-focus: var(
+        --spectrum-alias-text-color-down,
+        var(--spectrum-global-color-gray-900)
+    );
+    --spectrum-treeview-item-text-color-selected: var(
+        --spectrum-alias-text-color-selected-neutral,
+        var(--spectrum-global-color-gray-900)
+    );
+    --spectrum-treeview-item-text-color-disabled: var(
+        --spectrum-alias-text-color-disabled,
+        var(--spectrum-global-color-gray-500)
+    );
+}

--- a/packages/tree-view/src/tree-view-heading.css
+++ b/packages/tree-view/src/tree-view-heading.css
@@ -1,0 +1,17 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import './spectrum-tree-view-heading.css';
+
+:host {
+    display: block;
+}

--- a/packages/tree-view/src/tree-view-item.css
+++ b/packages/tree-view/src/tree-view-item.css
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import './spectrum-tree-view-item.css';
+@import './spectrum-tree-view-item-link.css';
+
+:host {
+    display: list-item;
+    list-style: none;
+}
+
+::slotted(sp-tree-view) {
+    /* .spectrum-TreeView .spectrum-TreeView */
+    position: static;
+    height: 0;
+    visibility: hidden;
+}
+
+:host([dir='ltr']) ::slotted(sp-tree-view) {
+    /* [dir=ltr] .spectrum-TreeView .spectrum-TreeView */
+    padding-left: var(--spectrum-global-dimension-size-200);
+}
+:host([dir='rtl']) ::slotted(sp-tree-view) {
+    /* [dir=rtl] .spectrum-TreeView .spectrum-TreeView */
+    padding-right: var(--spectrum-global-dimension-size-200);
+}
+
+:host([disabled]) {
+    pointer-events: none;
+}
+
+:host([disabled]) #indicator {
+    pointer-events: none !important;
+}
+
+.link:before {
+    border-radius: var(--spectrum-treeview-item-border-radius);
+    border-width: var(--spectrum-treeview-item-border-size);
+}

--- a/packages/tree-view/src/tree-view-label.css
+++ b/packages/tree-view/src/tree-view-label.css
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import './spectrum-tree-view-item-label.css';

--- a/packages/tree-view/src/tree-view.css
+++ b/packages/tree-view/src/tree-view.css
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import './spectrum-tree-view.css';
+
+:host([standalone]) {
+    --spectrum-treeview-item-border-radius: var(
+        --spectrum-alias-border-radius-regular
+    );
+    --spectrum-treeview-item-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+}
+
+:host([quiet]) {
+    --spectrum-treeview-item-background-color-selected: var(
+        --spectrum-treeview-item-background-color-quiet-selected
+    );
+    --spectrum-treeview-item-border-color-key-focus: transparent;
+}
+
+:host([quiet]) ::slotted(sp-tree-view-item:focus-within) {
+    --spectrum-treeview-item-border-color-key-focus: var(
+        --spectrum-alias-focus-color
+    );
+}

--- a/packages/tree-view/stories/tree-view.stories.ts
+++ b/packages/tree-view/stories/tree-view.stories.ts
@@ -1,0 +1,395 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { html, TemplateResult } from '@spectrum-web-components/base';
+
+import '@spectrum-web-components/thumbnail/sp-thumbnail.js';
+import { thumbnail } from '../../thumbnail/stories/images.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-layers.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-folder.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-document.js';
+import '../sp-tree-view.js';
+import '../sp-tree-view-item.js';
+import '../sp-tree-view-heading.js';
+
+export default {
+    component: 'sp-tree-view',
+    title: 'Tree View',
+};
+
+export const Default = (): TemplateResult => {
+    return html`
+        <sp-tree-view>
+            <sp-tree-view-item>Layer 1</sp-tree-view-item>
+            <sp-tree-view-item open>
+                Design Files
+                <sp-tree-view slot="children">
+                    <sp-tree-view-item>Layer 1</sp-tree-view-item>
+                    <sp-tree-view-item>Layer 3</sp-tree-view-item>
+                </sp-tree-view>
+            </sp-tree-view-item>
+            <sp-tree-view-item>Layer 3</sp-tree-view-item>
+            <sp-tree-view-item>Layer 4</sp-tree-view-item>
+            <sp-tree-view-item open>
+                Group 2
+                <sp-tree-view slot="children">
+                    <sp-tree-view-item open>
+                        Group 3
+                        <sp-tree-view slot="children">
+                            <sp-tree-view-item>
+                                Group 4
+                                <sp-tree-view slot="children">
+                                    <sp-tree-view-item>
+                                        Layer 6
+                                        <sp-tree-view slot="children">
+                                            <sp-tree-view-item>
+                                                Group 5
+                                                <sp-tree-view
+                                                    slot="children"
+                                                ></sp-tree-view>
+                                            </sp-tree-view-item>
+                                        </sp-tree-view>
+                                    </sp-tree-view-item>
+                                </sp-tree-view>
+                            </sp-tree-view-item>
+                        </sp-tree-view>
+                    </sp-tree-view-item>
+                </sp-tree-view>
+            </sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
+export const selected = (): TemplateResult => {
+    return html`
+        <sp-tree-view style="width: 250px;">
+            <sp-tree-view-item>Layer 1</sp-tree-view-item>
+            <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
+export const quiet = (): TemplateResult => {
+    return html`
+        <sp-tree-view quiet style="width: 250px;">
+            <sp-tree-view-item>Layer 1</sp-tree-view-item>
+            <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
+export const standalone = (): TemplateResult => {
+    return html`
+        <sp-tree-view standalone style="width: 250px;">
+            <sp-tree-view-item>Layer 1</sp-tree-view-item>
+            <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
+export const standaloneQuiet = (): TemplateResult => {
+    return html`
+        <sp-tree-view standalone quiet style="width: 250px;">
+            <sp-tree-view-item>Layer 1</sp-tree-view-item>
+            <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
+export const filesAndFolders = (): TemplateResult => html`
+    <sp-tree-view>
+        <sp-tree-view-item open>
+            <sp-icon-folder slot="icon"></sp-icon-folder>
+            Design Files
+            <sp-tree-view slot="children">
+                <sp-tree-view-item>
+                    <sp-icon-folder slot="icon"></sp-icon-folder>
+                    Production Ready
+                    <sp-tree-view slot="children">
+                        <sp-tree-view-item>
+                            <sp-icon-folder slot="icon"></sp-icon-folder>
+                            Unopened Child
+                        </sp-tree-view-item>
+                    </sp-tree-view>
+                </sp-tree-view-item>
+                <sp-tree-view-item open>
+                    <sp-icon-folder slot="icon"></sp-icon-folder>
+                    Work in Progress
+                    <sp-tree-view slot="children">
+                        <sp-tree-view-item open>
+                            <sp-icon-folder slot="icon"></sp-icon-folder>
+                            Branding
+                            <sp-tree-view slot="children">
+                                <sp-tree-view-item>
+                                    <sp-icon-folder
+                                        slot="icon"
+                                    ></sp-icon-folder>
+                                    Assets
+                                    <sp-tree-view slot="children">
+                                        <sp-tree-view-item>
+                                            <sp-icon-folder
+                                                slot="icon"
+                                            ></sp-icon-folder>
+                                            Unopened Child
+                                        </sp-tree-view-item>
+                                    </sp-tree-view>
+                                </sp-tree-view-item>
+                                <sp-tree-view-item open>
+                                    <sp-icon-folder
+                                        slot="icon"
+                                    ></sp-icon-folder>
+                                    Explorations
+                                    <sp-tree-view slot="children">
+                                        <sp-tree-view-item>
+                                            <sp-icon-document
+                                                slot="icon"
+                                            ></sp-icon-document>
+                                            CocaCola_01.ai
+                                        </sp-tree-view-item>
+                                        <sp-tree-view-item>
+                                            <sp-icon-document
+                                                slot="icon"
+                                            ></sp-icon-document>
+                                            CocaCola_02.ai
+                                        </sp-tree-view-item>
+                                    </sp-tree-view>
+                                </sp-tree-view-item>
+                            </sp-tree-view>
+                        </sp-tree-view-item>
+                    </sp-tree-view>
+                </sp-tree-view-item>
+                <sp-tree-view-item>
+                    <sp-icon-folder slot="icon"></sp-icon-folder>
+                    Archive
+                    <sp-tree-view slot="children">
+                        <sp-tree-view-item>
+                            <sp-icon-folder slot="icon"></sp-icon-folder>
+                            Unopened Child
+                        </sp-tree-view-item>
+                    </sp-tree-view>
+                </sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+        <sp-tree-view-item>
+            <sp-icon-folder slot="icon"></sp-icon-folder>
+            References
+            <sp-tree-view slot="children">
+                <sp-tree-view-item>
+                    <sp-icon-folder slot="icon"></sp-icon-folder>
+                    Unopened Child
+                </sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+    </sp-tree-view>
+`;
+
+export const thumbnails = (): TemplateResult => {
+    return html`
+        <sp-tree-view>
+            <sp-tree-view-item open>
+                <sp-thumbnail slot="thumbnail">
+                    <img src=${thumbnail} alt="Woman crouching" />
+                </sp-thumbnail>
+                Composition
+                <sp-tree-view slot="children">
+                    <sp-tree-view-item>
+                        <sp-thumbnail slot="thumbnail">
+                            <img src=${thumbnail} alt="Woman crouching" />
+                        </sp-thumbnail>
+                        Flowers
+                    </sp-tree-view-item>
+                    <sp-tree-view-item>
+                        <sp-thumbnail slot="thumbnail">
+                            <img src=${thumbnail} alt="Woman crouching" />
+                        </sp-thumbnail>
+                        Figure
+                    </sp-tree-view-item>
+                </sp-tree-view>
+            </sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
+export const thumbnailsQuiet = (): TemplateResult => {
+    return html`
+        <sp-tree-view quiet>
+            <sp-tree-view-item open>
+                <sp-thumbnail slot="thumbnail">
+                    <img src=${thumbnail} alt="Woman crouching" />
+                </sp-thumbnail>
+                Composition
+                <sp-tree-view slot="children" quiet>
+                    <sp-tree-view-item>
+                        <sp-thumbnail slot="thumbnail">
+                            <img src=${thumbnail} alt="Woman crouching" />
+                        </sp-thumbnail>
+                        Flowers
+                    </sp-tree-view-item>
+                    <sp-tree-view-item>
+                        <sp-thumbnail slot="thumbnail">
+                            <img src=${thumbnail} alt="Woman crouching" />
+                        </sp-thumbnail>
+                        Figure
+                    </sp-tree-view-item>
+                </sp-tree-view>
+            </sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
+export const disabled = (): TemplateResult => html`
+    <sp-tree-view>
+        <sp-tree-view-item>Layer 1</sp-tree-view-item>
+        <sp-tree-view-item disabled>
+            Group 1
+            <sp-tree-view slot="children">
+                <sp-tree-view-item>Layer 2</sp-tree-view-item>
+                <sp-tree-view-item>Layer 3</sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+        <sp-tree-view-item>Layer 4</sp-tree-view-item>
+        <sp-tree-view-item>Layer 5</sp-tree-view-item>
+        <sp-tree-view-item open>
+            Group 2
+            <sp-tree-view slot="children">
+                <sp-tree-view-item open>
+                    Group 3
+                    <sp-tree-view slot="children">
+                        <sp-tree-view-item>
+                            Group 4
+                            <sp-tree-view slot="children">
+                                <sp-tree-view-item>
+                                    Unopened Child
+                                </sp-tree-view-item>
+                            </sp-tree-view>
+                        </sp-tree-view-item>
+                    </sp-tree-view>
+                </sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+    </sp-tree-view>
+`;
+
+export const sections = (): TemplateResult => html`
+    <sp-tree-view>
+        <sp-tree-view-heading>Section 1</sp-tree-view-heading>
+        <sp-tree-view-item>
+            Group 1
+            <sp-tree-view slot="children">
+                <sp-tree-view-item>Layer 2</sp-tree-view-item>
+                <sp-tree-view-item>Layer 3</sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+        <sp-tree-view-item>Layer 4</sp-tree-view-item>
+        <sp-tree-view-item>Layer 5</sp-tree-view-item>
+        <sp-tree-view-heading>Section 2</sp-tree-view-heading>
+        <sp-tree-view-item open>
+            Group 2
+            <sp-tree-view slot="children">
+                <sp-tree-view-item open>
+                    Group 3
+                    <sp-tree-view slot="children">
+                        <sp-tree-view-item>
+                            Group 4
+                            <sp-tree-view slot="children">
+                                <sp-tree-view-item>
+                                    Unopened Child
+                                </sp-tree-view-item>
+                            </sp-tree-view>
+                        </sp-tree-view-item>
+                    </sp-tree-view>
+                </sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+    </sp-tree-view>
+`;
+
+export const dropTarget = (): TemplateResult => {
+    return html`
+        <sp-tree-view style="width: 250px;">
+            <sp-tree-view-item>Layer 1</sp-tree-view-item>
+            <sp-tree-view-item drop-target>Layer 2</sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
+export const icons = (): TemplateResult => html`
+    <sp-tree-view>
+        <sp-tree-view-item>
+            <sp-icon-layers slot="icon"></sp-icon-layers>
+            Layer 1
+        </sp-tree-view-item>
+        <sp-tree-view-item open>
+            <sp-icon-folder slot="icon"></sp-icon-folder>
+            Group 1
+            <sp-tree-view slot="children">
+                <sp-tree-view-item>
+                    <sp-icon-layers slot="icon"></sp-icon-layers>
+                    Layer 2
+                </sp-tree-view-item>
+                <sp-tree-view-item>
+                    <sp-icon-layers slot="icon"></sp-icon-layers>
+                    Layer 3
+                </sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+        <sp-tree-view-item>
+            <sp-icon-layers slot="icon"></sp-icon-layers>
+            Layer 4
+        </sp-tree-view-item>
+        <sp-tree-view-item>
+            <sp-icon-layers slot="icon"></sp-icon-layers>
+            Layer 5
+        </sp-tree-view-item>
+        <sp-tree-view-item open>
+            <sp-icon-folder slot="icon"></sp-icon-folder>
+            Group 2
+            <sp-tree-view slot="children">
+                <sp-tree-view-item open>
+                    <sp-icon-folder slot="icon"></sp-icon-folder>
+                    Group 3
+                    <sp-tree-view slot="children">
+                        <sp-tree-view-item>
+                            <sp-icon-folder slot="icon"></sp-icon-folder>
+                            Group 4
+                            <sp-tree-view slot="children">
+                                <sp-tree-view-item>
+                                    <sp-icon-folder
+                                        slot="icon"
+                                    ></sp-icon-folder>
+                                    Unopened Child
+                                </sp-tree-view-item>
+                            </sp-tree-view>
+                        </sp-tree-view-item>
+                    </sp-tree-view>
+                </sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+    </sp-tree-view>
+`;
+
+export const flat = (): TemplateResult => {
+    return html`
+        <sp-tree-view>
+            <sp-tree-view-item>Layer 1</sp-tree-view-item>
+            <sp-tree-view-item open can-open>Design Files</sp-tree-view-item>
+            <sp-tree-view-item indent="1">Layer 1</sp-tree-view-item>
+            <sp-tree-view-item indent="1">Layer 3</sp-tree-view-item>
+            <sp-tree-view-item>Layer 3</sp-tree-view-item>
+            <sp-tree-view-item>Layer 4</sp-tree-view-item>
+            <sp-tree-view-item open can-open>Group 2</sp-tree-view-item>
+            <sp-tree-view-item open indent="1" can-open>
+                Group 3
+            </sp-tree-view-item>
+            <sp-tree-view-item indent="2" can-open>Group 4</sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};

--- a/packages/tree-view/stories/tree-view.stories.ts
+++ b/packages/tree-view/stories/tree-view.stories.ts
@@ -70,7 +70,7 @@ export const Default = (): TemplateResult => {
 
 export const selected = (): TemplateResult => {
     return html`
-        <sp-tree-view style="width: 250px;">
+        <sp-tree-view selects="single" style="width: 250px;">
             <sp-tree-view-item>Layer 1</sp-tree-view-item>
             <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
         </sp-tree-view>
@@ -79,7 +79,7 @@ export const selected = (): TemplateResult => {
 
 export const allowMultiple = (): TemplateResult => {
     return html`
-        <sp-tree-view allow-multiple style="width: 250px;">
+        <sp-tree-view selects="multiple" style="width: 250px;">
             <sp-tree-view-item>Layer 1</sp-tree-view-item>
             <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
             <sp-tree-view-item selected>Layer 3</sp-tree-view-item>
@@ -96,7 +96,7 @@ export const allowMultiple = (): TemplateResult => {
 
 export const quiet = (): TemplateResult => {
     return html`
-        <sp-tree-view quiet style="width: 250px;">
+        <sp-tree-view quiet selects="single" style="width: 250px;">
             <sp-tree-view-item>Layer 1</sp-tree-view-item>
             <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
         </sp-tree-view>
@@ -105,7 +105,7 @@ export const quiet = (): TemplateResult => {
 
 export const standalone = (): TemplateResult => {
     return html`
-        <sp-tree-view standalone style="width: 250px;">
+        <sp-tree-view standalone selects="single" style="width: 250px;">
             <sp-tree-view-item>Layer 1</sp-tree-view-item>
             <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
         </sp-tree-view>
@@ -114,7 +114,7 @@ export const standalone = (): TemplateResult => {
 
 export const standaloneQuiet = (): TemplateResult => {
     return html`
-        <sp-tree-view standalone quiet style="width: 250px;">
+        <sp-tree-view standalone quiet selects="single" style="width: 250px;">
             <sp-tree-view-item>Layer 1</sp-tree-view-item>
             <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
         </sp-tree-view>

--- a/packages/tree-view/stories/tree-view.stories.ts
+++ b/packages/tree-view/stories/tree-view.stories.ts
@@ -77,6 +77,23 @@ export const selected = (): TemplateResult => {
     `;
 };
 
+export const allowMultiple = (): TemplateResult => {
+    return html`
+        <sp-tree-view allow-multiple style="width: 250px;">
+            <sp-tree-view-item>Layer 1</sp-tree-view-item>
+            <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
+            <sp-tree-view-item selected>Layer 3</sp-tree-view-item>
+            <sp-tree-view-item open>
+                Group 1
+                <sp-tree-view slot="children">
+                    <sp-tree-view-item selected>Layer 2</sp-tree-view-item>
+                    <sp-tree-view-item>Layer 3</sp-tree-view-item>
+                </sp-tree-view>
+            </sp-tree-view-item>
+        </sp-tree-view>
+    `;
+};
+
 export const quiet = (): TemplateResult => {
     return html`
         <sp-tree-view quiet style="width: 250px;">

--- a/packages/tree-view/test/benchmark/test-basic.ts
+++ b/packages/tree-view/test/benchmark/test-basic.ts
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/tree-view/sp-tree-view.js';
+import { html } from 'lit-html';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-tree-view>
+        <sp-tree-view-item>Item 1</sp-tree-view-item>
+        <sp-tree-view-item>
+            Item 2
+            <sp-tree-view slot="children">
+                <sp-tree-view-item>Child Item 1</sp-tree-view-item>
+                <sp-tree-view-item>Child Item 2</sp-tree-view-item>
+            </sp-tree-view>
+        </sp-tree-view-item>
+        <sp-tree-view-item>Item 3</sp-tree-view-item>
+    </sp-tree-view>
+`);

--- a/packages/tree-view/test/treeview.test.ts
+++ b/packages/tree-view/test/treeview.test.ts
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '../sp-tree-view.js';
+import '../sp-tree-view-item.js';
+import { TreeView, TreeViewItem } from '..';
+import { fixture, elementUpdated, expect } from '@open-wc/testing';
+
+import {
+    Default,
+    sections,
+    thumbnailsQuiet,
+} from '../stories/tree-view.stories.js';
+import { html } from '@spectrum-web-components/base';
+import { spy } from 'sinon';
+
+describe('Tooltip', () => {
+    describe('Accessibility', () => {
+        it('Standard', async () => {
+            const el = await fixture<TreeView>(Default());
+
+            await elementUpdated(el);
+
+            await expect(el).to.be.accessible();
+        });
+        it('Sections', async () => {
+            const el = await fixture<TreeView>(sections());
+
+            await elementUpdated(el);
+
+            await expect(el).to.be.accessible();
+        });
+        it('Thumbnails Quiet', async () => {
+            const el = await fixture<TreeView>(thumbnailsQuiet());
+
+            await elementUpdated(el);
+
+            await expect(el).to.be.accessible();
+        });
+    });
+    describe('Item', () => {
+        it('Standard', async () => {
+            const selectedSpy = spy();
+            const deselectedSpy = spy();
+            const el = await fixture<TreeViewItem>(html`
+                <sp-tree-view-item
+                    can-open
+                    @selected=${() => selectedSpy()}
+                    @deselected=${() => deselectedSpy()}
+                ></sp-tree-view-item>
+            `);
+
+            await elementUpdated(el);
+            expect(el.selected).to.be.false;
+
+            el.click();
+
+            await elementUpdated(el);
+            expect(el.selected).to.be.true;
+            expect(selectedSpy.calledOnce);
+
+            el.click();
+
+            await elementUpdated(el);
+            expect(el.selected).to.be.false;
+            expect(selectedSpy.calledOnce);
+        });
+    });
+});

--- a/packages/tree-view/test/treeview.test.ts
+++ b/packages/tree-view/test/treeview.test.ts
@@ -17,13 +17,14 @@ import { fixture, elementUpdated, expect } from '@open-wc/testing';
 
 import {
     Default,
+    selected,
     sections,
     thumbnailsQuiet,
 } from '../stories/tree-view.stories.js';
 import { html } from '@spectrum-web-components/base';
 import { spy } from 'sinon';
 
-describe('Tooltip', () => {
+describe('Treeview', () => {
     describe('Accessibility', () => {
         it('Standard', async () => {
             const el = await fixture<TreeView>(Default());
@@ -74,5 +75,95 @@ describe('Tooltip', () => {
             expect(el.selected).to.be.false;
             expect(selectedSpy.calledOnce);
         });
+    });
+    it('can be initialized with selected children', async () => {
+        const el = await fixture<TreeView>(selected());
+
+        const firstItem = el.querySelector(
+            'sp-tree-view-item:nth-of-type(1)'
+        ) as TreeViewItem;
+        const secondItem = el.querySelector(
+            'sp-tree-view-item:nth-of-type(2)'
+        ) as TreeViewItem;
+
+        const firstButton = firstItem.focusElement;
+
+        firstButton.click();
+        await elementUpdated(firstItem);
+
+        expect(firstItem.selected).to.be.true;
+        expect(secondItem.selected).to.be.false;
+    });
+    it('only allows one item to be selected at a time by default', async () => {
+        const el = await fixture<TreeView>(Default());
+
+        const firstItem = el.querySelector(
+            'sp-tree-view-item:nth-of-type(1)'
+        ) as TreeViewItem;
+        const secondItem = el.querySelector(
+            'sp-tree-view-item:nth-of-type(2)'
+        ) as TreeViewItem;
+
+        const firstButton = firstItem.focusElement;
+        const secondButton = secondItem.focusElement;
+
+        firstButton.click();
+        await elementUpdated(firstItem);
+
+        expect(firstItem.selected).to.be.true;
+        expect(secondItem.selected).to.be.false;
+
+        secondButton.dispatchEvent(
+            new MouseEvent('click', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                shiftKey: true,
+            })
+        );
+        await elementUpdated(secondItem);
+
+        expect(firstItem.selected).to.be.false;
+        expect(secondItem.selected).to.be.true;
+    });
+    it('allows more than one selected item when `[allow-multiple]`', async () => {
+        const el = await fixture<TreeView>(Default());
+        el.allowMultiple = true;
+        await elementUpdated(el);
+
+        const firstItem = el.querySelector(
+            'sp-tree-view-item:nth-of-type(1)'
+        ) as TreeViewItem;
+        const secondItem = el.querySelector(
+            'sp-tree-view-item:nth-of-type(2)'
+        ) as TreeViewItem;
+
+        const firstButton = firstItem.focusElement;
+        const secondButton = secondItem.focusElement;
+
+        firstButton.click();
+        await elementUpdated(firstItem);
+
+        expect(firstItem.selected).to.be.true;
+        expect(secondItem.selected).to.be.false;
+
+        secondButton.dispatchEvent(
+            new MouseEvent('click', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                shiftKey: true,
+            })
+        );
+        await elementUpdated(secondItem);
+
+        expect(firstItem.selected).to.be.true;
+        expect(secondItem.selected).to.be.true;
+
+        secondButton.click();
+        await elementUpdated(secondItem);
+
+        expect(firstItem.selected).to.be.false;
+        expect(secondItem.selected).to.be.false;
     });
 });

--- a/packages/tree-view/tsconfig.json
+++ b/packages/tree-view/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "./"
+    },
+    "include": ["*.ts", "src/*.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3426,6 +3426,11 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.0.3.tgz#26b8ca3b3d30e29630244d85eb4fc11d0c841281"
   integrity sha512-ztRF7WW1FzyNavXBRc+80z67UoOrY9wl3cMYsVD3MpDnyxdzP8cjza1pCcolKBaFqRTcQKkxKw3GWtGICRKR5A==
 
+"@spectrum-css/treeview@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/treeview/-/treeview-3.0.0.tgz#906608cfa4122cbe6c563a604348ef72ab78d043"
+  integrity sha512-W5OwVrXYNfv9b3lTSdIDxWyxGEsjED0OS/tIuNnYLePv+l/zOoxgHHq+WkNuRTl5kInYhYkZ4poqqDjFZBk/zA==
+
 "@spectrum-css/typography@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-3.0.2.tgz#ea3ca0a60e18064527819d48c8c4364cab4fcd38"


### PR DESCRIPTION
Adds multi-select support to the tree-view component.

## Description

Allows the use of shiftKey & metaKey while clicking tree-view-items to allow multi-selecting items within a root-level tree-view component.

## Related Issue

https://github.com/adobe/spectrum-web-components/issues/1222

## Motivation and Context

This change adds similar multi-select functionality highlighted on the spectrum-css site under the standard tree-view section: https://opensource.adobe.com/spectrum-css/treeview.html#standard

## How Has This Been Tested?

Yes. Tested manually with storybook and automated tests.

## Screenshots (if appropriate):

![Screen Shot 2021-04-29 at 11 16 04 AM](https://user-images.githubusercontent.com/478246/116575116-5a86fe80-a8dc-11eb-8c21-3651ae78496d.png)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
