### PR TITLE
fix(menu): pass current focus visibility to menu items

### DIFF
--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -167,7 +167,7 @@ export class Menu extends SpectrumElement {
         }
         // if there are no non-disabled items, skip the work to focus a child
         if (!itemToFocus.disabled) {
-            itemToFocus.focused = true;
+            this.forwardFocusVisibleToitem(itemToFocus);
             this.setAttribute('aria-activedescendant', itemToFocus.id);
         }
         return itemToFocus;
@@ -220,9 +220,25 @@ export class Menu extends SpectrumElement {
         this.updateSelectedItemIndex();
         const focusInItem = this.menuItems[this.focusInItemIndex] as MenuItem;
         if ((this.getRootNode() as Document).activeElement === this) {
-            focusInItem.focused = true;
+            this.forwardFocusVisibleToitem(focusInItem);
         }
     };
+
+    private forwardFocusVisibleToitem(item: MenuItem): void {
+        let shouldFocus = false;
+        try {
+            // Browsers without support for the `:focus-visible`
+            // selector will throw on the following test (Safari, older things).
+            // Some won't throw, but will be focusing item rather than the menu and
+            // will rely on the polyfill to know whether focus is "visible" or not.
+            shouldFocus =
+                this.matches(':focus-visible') ||
+                this.matches('.focus-visible');
+        } catch (error) {
+            shouldFocus = this.matches('.focus-visible');
+        }
+        item.focused = shouldFocus;
+    }
 
     public render(): TemplateResult {
         return html`

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -362,17 +362,13 @@ export class ActiveOverlay extends SpectrumElement {
 
     private stealOverlayContent(element: HTMLElement): void {
         this.originalPlacement = element.getAttribute('placement') as Placement;
-        this.restoreContent = reparentChildren(
-            [element],
-            this,
-            (el: Element) => {
-                const slotName = el.slot;
-                el.removeAttribute('slot');
-                return (el: Element) => {
-                    el.slot = slotName;
-                };
-            }
-        );
+        this.restoreContent = reparentChildren([element], this, (el) => {
+            const slotName = el.slot;
+            el.removeAttribute('slot');
+            return (el) => {
+                el.slot = slotName;
+            };
+        });
         this.stealOverlayContentResolver();
     }
 

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -271,10 +271,15 @@ export class PickerBase extends SizedMixin(Focusable) {
             return;
         }
 
-        this.restoreChildren = reparentChildren(
-            reparentableChildren,
-            this.optionsMenu
-        );
+        this.restoreChildren = reparentChildren<
+            Element & { focused?: boolean }
+        >(reparentableChildren, this.optionsMenu, () => {
+            return (el) => {
+                if (typeof el.focused !== 'undefined') {
+                    el.focused = false;
+                }
+            };
+        });
 
         this.optionsMenu.selectable = true;
 

--- a/packages/shared/src/reparent-children.ts
+++ b/packages/shared/src/reparent-children.ts
@@ -9,11 +9,11 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-function restoreChildren(
+function restoreChildren<T extends Element>(
     placeholderItems: Comment[],
-    srcElements: Element[],
-    cleanupCallbacks: ((el: Element) => void)[] = []
-): Element[] {
+    srcElements: T[],
+    cleanupCallbacks: ((el: T) => void)[] = []
+): T[] {
     for (let index = 0; index < srcElements.length; ++index) {
         const srcElement = srcElements[index];
         const placeholderItem = placeholderItems[index];
@@ -28,13 +28,13 @@ function restoreChildren(
     return srcElements;
 }
 
-export const reparentChildren = (
-    srcElements: Element[],
+export const reparentChildren = <T extends Element>(
+    srcElements: T[],
     newParent: Element,
-    prepareCallback?: (el: Element) => ((el: Element) => void) | void
+    prepareCallback?: (el: T) => ((el: T) => void) | void
 ): (() => Element[]) => {
     const placeholderItems: Comment[] = [];
-    const cleanupCallbacks: ((el: Element) => void)[] = [];
+    const cleanupCallbacks: ((el: T) => void)[] = [];
 
     for (let index = 0; index < srcElements.length; ++index) {
         const placeholderItem: Comment = document.createComment(
@@ -58,6 +58,10 @@ export const reparentChildren = (
     }
 
     return function (): Element[] {
-        return restoreChildren(placeholderItems, srcElements, cleanupCallbacks);
+        return restoreChildren<T>(
+            placeholderItems,
+            srcElements,
+            cleanupCallbacks
+        );
     };
 };

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -87,8 +87,6 @@ export default {
         playwrightLauncher({
             product: 'firefox',
             launchOptions: {
-                headless: false,
-                args: ['-headless'],
                 firefoxUserPrefs: {
                     'toolkit.telemetry.reportingpolicy.firstRun': false,
                     'browser.shell.checkDefaultBrowser': false,


### PR DESCRIPTION
## Description
Afford the current `:focus-visible` context from the `<sp-menu>` element to its `<sp-menu-item>` children when navigating through them.
- only show the blue edge highlighting when the `:focus-visible` heuristic has been triggered.
- persist selected and hovered visual states without alteration

## Related Issue
fixes #1136 

## Motivation and Context
Clearer interface delivery.

## How Has This Been Tested?
New unit tests for both sides of the workflow, including some _special_ Firefox conciderations.

## Screenshots (if appropriate):
https://westbrook-menu--spectrum-web-components.netlify.app/components/picker

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
