### PR TITLE
fix(textfield): add 'u' flag to keep consistency with native input el…

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -93,7 +93,7 @@ export class Textfield extends Focusable {
 
     protected onInput(): void {
         if (this.allowedKeys && this.inputElement.value) {
-            const regExp = new RegExp(`^[${this.allowedKeys}]*$`);
+            const regExp = new RegExp(`^[${this.allowedKeys}]*$`, 'u');
             if (!regExp.test(this.inputElement.value)) {
                 const selectionStart = this.inputElement
                     .selectionStart as number;
@@ -228,7 +228,7 @@ export class Textfield extends Focusable {
         let validity = this.inputElement.checkValidity();
         if (this.required || (this.value && this.pattern)) {
             if ((this.disabled || this.multiline) && this.pattern) {
-                const regex = new RegExp(this.pattern);
+                const regex = new RegExp(`^${this.pattern}$`, 'u');
                 validity = regex.test(this.value);
             }
             if (typeof this.minlength !== 'undefined') {

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -157,14 +157,151 @@ describe('Textfield', () => {
             : null;
         expect(input).to.not.be.null;
     });
-    it('invalid', async () => {
+    it('valid - boundary-type assertions', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="^[\\d]+$"
+                    value="123"
+                    required
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#valid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('valid - multiline - boundary-type assertions', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="^[\\d]+$"
+                    value="123"
+                    required
+                    multiline
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#valid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('valid - unicode', async () => {
         const el = await litFixture<Textfield>(
             html`
                 <sp-textfield
                     placeholder="Enter your name"
+                    value="你的名字"
+                    pattern="\\p{L}{4,8}"
+                    required
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#valid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('valid - multiline - unicode', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="\\p{N}+"
+                    value="123"
+                    required
+                    multiline
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#valid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('invalid', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
                     pattern="[\\d]+"
                     required
-                    value="Not a valid input"
+                    value="123 not valid"
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('invalid - multiline', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="[\\d]+"
+                    required
+                    multiline
+                    value="123 not valid"
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('invalid - unicode', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="\\p{N}+"
+                    required
+                    value="123 not valid"
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('invalid - multiline - unicode', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="\\p{N}+"
+                    required
+                    multiline
+                    value="123 not valid"
                 ></sp-textfield>
             `
         );

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -123,8 +123,9 @@ describe('Textfield', () => {
         const el = await litFixture<Textfield>(
             html`
                 <sp-textfield
-                    placeholder="Enter your name"
-                    value="Your name"
+                    placeholder="Enter your number"
+                    pattern="[\\d]+"
+                    value="123"
                     required
                 ></sp-textfield>
             `
@@ -143,6 +144,43 @@ describe('Textfield', () => {
                 <sp-textfield
                     placeholder="Enter your number"
                     pattern="[\\d]+"
+                    value="123"
+                    required
+                    multiline
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#valid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('valid - required', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    value="123"
+                    required
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#valid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('valid - multiline - required', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
                     value="123"
                     required
                     multiline
@@ -201,8 +239,8 @@ describe('Textfield', () => {
             html`
                 <sp-textfield
                     placeholder="Enter your name"
-                    value="你的名字"
                     pattern="\\p{L}{4,8}"
+                    value="你的名字"
                     required
                 ></sp-textfield>
             `
@@ -219,9 +257,9 @@ describe('Textfield', () => {
         const el = await litFixture<Textfield>(
             html`
                 <sp-textfield
-                    placeholder="Enter your number"
-                    pattern="\\p{N}+"
-                    value="123"
+                    placeholder="Enter your name"
+                    pattern="\\p{L}{4,8}"
+                    value="你的名字"
                     required
                     multiline
                 ></sp-textfield>
@@ -241,8 +279,8 @@ describe('Textfield', () => {
                 <sp-textfield
                     placeholder="Enter your number"
                     pattern="[\\d]+"
-                    required
                     value="123 not valid"
+                    required
                 ></sp-textfield>
             `
         );
@@ -260,9 +298,46 @@ describe('Textfield', () => {
                 <sp-textfield
                     placeholder="Enter your number"
                     pattern="[\\d]+"
+                    value="123 not valid"
                     required
                     multiline
-                    value="123 not valid"
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('invalid - required', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    value=""
+                    required
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('invalid - multiline - required', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    value=""
+                    required
+                    multiline
                 ></sp-textfield>
             `
         );
@@ -280,8 +355,8 @@ describe('Textfield', () => {
                 <sp-textfield
                     placeholder="Enter your number"
                     pattern="\\p{N}+"
-                    required
                     value="123 not valid"
+                    required
                 ></sp-textfield>
             `
         );
@@ -299,9 +374,48 @@ describe('Textfield', () => {
                 <sp-textfield
                     placeholder="Enter your number"
                     pattern="\\p{N}+"
+                    value="123 not valid"
                     required
                     multiline
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('invalid - boundary-type assertions', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="^\\p{N}+$"
                     value="123 not valid"
+                    required
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+    });
+    it('invalid - multiline - boundary-type assertions', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="^\\p{N}+$"
+                    value="123 not valid"
+                    required
+                    multiline
                 ></sp-textfield>
             `
         );

--- a/scripts/process-spectrum-css.js
+++ b/scripts/process-spectrum-css.js
@@ -21,7 +21,7 @@ import { postCSSPlugins } from './css-processing.cjs';
 import postcssSpectrumPlugin from './process-spectrum-postcss-plugin.js';
 import reporter from 'postcss-reporter';
 import postcssCustomProperties from 'postcss-custom-properties';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -29,7 +29,7 @@ const componentRoot = path.resolve(__dirname, '../packages');
 
 async function processComponent(componentPath) {
     const configPath = path.join(componentPath, 'spectrum-config.js');
-    const { default: spectrumConfig } = await import(configPath);
+    const { default: spectrumConfig } = await import(pathToFileURL(configPath));
     const inputCssPath = `node_modules/@spectrum-css/${spectrumConfig.spectrum}/dist/index-vars.css`;
     let packageCss = false;
     if (fs.existsSync(inputCssPath)) {


### PR DESCRIPTION
…ement

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
1. Add 'u' flag for both `"pattern"` and `"allowedKeys"`
2. Add boundary-type assertions (`^` and `$`) for pattern testing
3. Add related tests
4. Add `pathToFileURL` for css generation script, see https://github.com/nodejs/node/issues/34765

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #1388 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change updates the behavior of multiline textfield pattern, to be consistant with native `input` element.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
