### PR TITLE
fix(slider): ensure min/max/value application order

### DIFF
--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -37,26 +37,7 @@ export class Slider extends Focusable {
     public type = '';
 
     @property({ type: Number, reflect: true })
-    public get value(): number {
-        return this._value;
-    }
-
-    public set value(value: number) {
-        const oldValue = this.value;
-        if (this.input) {
-            this.input.value = String(value);
-        }
-        const newValue = this.input ? parseFloat(this.input.value) : value;
-
-        if (newValue === oldValue) {
-            return;
-        }
-
-        this._value = newValue;
-        this.requestUpdate('value', oldValue);
-    }
-
-    private _value = 10;
+    public value = 10;
 
     @property({ type: String })
     public set variant(variant: string) {
@@ -145,7 +126,11 @@ export class Slider extends Focusable {
 
     protected updated(changedProperties: PropertyValues): void {
         if (changedProperties.has('value')) {
-            this.dispatchInputEvent();
+            if (this.value === this.input.valueAsNumber) {
+                this.dispatchInputEvent();
+            } else {
+                this.value = this.input.valueAsNumber;
+            }
         }
     }
 
@@ -261,10 +246,10 @@ export class Slider extends Focusable {
                 <input
                     type="range"
                     id="input"
-                    value=${this.value}
-                    step=${this.step}
                     min=${this.min}
                     max=${this.max}
+                    step=${this.step}
+                    value=${this.value}
                     aria-disabled=${ifDefined(
                         this.disabled ? 'true' : undefined
                     )}

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -555,4 +555,39 @@ describe('Slider', () => {
 
         expect(input.getAttribute('aria-valuetext')).to.equal('50');
     });
+    it('accepts min/max/value in the same timing', async () => {
+        const el = await fixture<Slider>(
+            html`
+                <sp-slider></sp-slider>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(10);
+
+        el.min = 0;
+        el.max = 200;
+        el.value = 200;
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(200);
+
+        el.value = 500;
+        el.min = 0;
+        el.max = 500;
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(500);
+
+        el.value = -100;
+        el.min = -100;
+        el.max = 500;
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(-100);
+    });
 });


### PR DESCRIPTION
## Description
Make sure the `value` is set _after_ `min`, `max`, and `step` in the rendered template and that validation of the `value` happens after the `<input>` element is update, instead of before.

## Related Issue
fixes #1308

## Motivation and Context
Easier, less error prone element usage.

## How Has This Been Tested?
- unit tests updated and passing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
