### PR TITLE
docs(overlay): clean up story application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: bb0ab20fcbadf2291fea9417e0a79379b5d297aa
+        default: caa0e4a61aaf05b035c12894028414193e3d6007
 commands:
     downstream:
         steps:

--- a/packages/overlay/stories/overlay-story-components.ts
+++ b/packages/overlay/stories/overlay-story-components.ts
@@ -41,6 +41,8 @@ class OverlayTargetIcon extends LitElement {
                 color: var(--spectrum-global-color-magenta-700);
                 width: 64px;
                 height: 64px;
+                top: 0;
+                left: 0;
             }
         `;
     }

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -20,7 +20,6 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/picker/sp-picker.js';
-import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/popover/sp-popover.js';
@@ -439,6 +438,7 @@ export const updated = (): TemplateResult => {
 
 export const sideHoverDraggable = (): TemplateResult => {
     return html`
+        ${storyStyles}
         <style>
             sp-tooltip {
                 transition: none;
@@ -554,15 +554,13 @@ export const complexModal = (): TemplateResult => {
                     Selection type:
                 </sp-field-label>
                 <sp-picker id="test-picker">
-                    <sp-menu>
-                        <sp-menu-item>Deselect</sp-menu-item>
-                        <sp-menu-item>Select inverse</sp-menu-item>
-                        <sp-menu-item>Feather...</sp-menu-item>
-                        <sp-menu-item>Select and mask...</sp-menu-item>
-                        <sp-menu-divider></sp-menu-divider>
-                        <sp-menu-item>Save selection</sp-menu-item>
-                        <sp-menu-item disabled>Make work path</sp-menu-item>
-                    </sp-menu>
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save selection</sp-menu-item>
+                    <sp-menu-item disabled>Make work path</sp-menu-item>
                 </sp-picker>
             </sp-dialog-wrapper>
             <sp-button slot="trigger" variant="primary">


### PR DESCRIPTION
## Description
- correct style application in the `sideHoverDraggable` story
- update the default styles of `OverlayTargetIcon` to work by default in RTL contexts

## Related Issue
refs #1437 

## Motivation and Context
It's easier to extend stories when they are correct to start with.

## How Has This Been Tested?
- ci VRT
- manual preview
  - https://westbrook-overlay-stories--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--updated
  - https://westbrook-overlay-stories--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--side-hover-draggable

## Types of changes
- [x] Updated demos

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
