### PR TITLE
[RFC] Virtual Target helper "element"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 181d8463d1de8a10c6c47d4bf51eb4024c5ea1b4
+        default: 38d50443c7f6490dccc8f0715f702165eadb7679
 commands:
     downstream:
         steps:

--- a/packages/overlay/src/VirtualTrigger.ts
+++ b/packages/overlay/src/VirtualTrigger.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+type VirtualElement = HTMLElement & { updateBoundingClientRect: void };
+
+export class VirtualTrigger extends HTMLElement {
+    x = 0;
+    y = 0;
+    constructor(host: HTMLElement, x: number, y: number) {
+        super();
+        this.x = x;
+        this.y = y;
+
+        const target = {};
+        const getHandler = (
+            _target: Record<string, unknown>,
+            prop: keyof VirtualElement
+        ): unknown => {
+            if (
+                prop !== 'getBoundingClientRect' &&
+                prop !== 'updateBoundingClientRect'
+            ) {
+                const hostProp = host[prop];
+                if (typeof hostProp === 'function') {
+                    return hostProp.bind(host);
+                }
+                return hostProp;
+            }
+            return this[prop].bind(this);
+        };
+
+        const handler2 = {
+            get: getHandler,
+        };
+        const proxy2 = (new Proxy(
+            target,
+            handler2
+        ) as unknown) as VirtualTrigger;
+
+        return proxy2;
+    }
+
+    updateBoundingClientRect(x: number, y: number): void {
+        this.x = x;
+        this.y = y;
+    }
+
+    getBoundingClientRect(): DOMRect {
+        return {
+            width: 0,
+            height: 0,
+            top: this.y,
+            right: this.x,
+            y: this.y,
+            x: this.x,
+            bottom: this.y,
+            left: this.x,
+            toJSON() {
+                return;
+            },
+        };
+    }
+}
+
+customElements.define('sp-virtual-overlay-target', VirtualTrigger);

--- a/packages/overlay/src/index.ts
+++ b/packages/overlay/src/index.ts
@@ -14,3 +14,4 @@ export * from './OverlayTrigger.js';
 export * from './overlay-types.js';
 export * from './ActiveOverlay.js';
 export * from './loader.js';
+export * from './VirtualTrigger.js';

--- a/packages/overlay/src/popper.ts
+++ b/packages/overlay/src/popper.ts
@@ -25,6 +25,7 @@ import {
     popperGenerator,
 } from '@popperjs/core/dist/esm/popper-lite.js';
 import type { Instance } from '@popperjs/core/dist/esm/types.js';
+import type { VirtualElement } from '@popperjs/core/lib/types';
 import maxSize from 'popper-max-size-modifier';
 import { applyMaxSize } from './apply-max-size.js';
 
@@ -38,5 +39,5 @@ export const createPopper = popperGenerator({
     ],
 });
 
-export type { Instance, Placement };
+export type { Instance, Placement, VirtualElement };
 export { maxSize, applyMaxSize };

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -9,7 +9,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import { html, TemplateResult, ifDefined } from '@spectrum-web-components/base';
-import { OverlayContentTypes, OverlayTrigger, Placement } from '../';
+import {
+    openOverlay,
+    OverlayContentTypes,
+    OverlayTrigger,
+    Placement,
+    VirtualTrigger,
+} from '../';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/action-group/sp-action-group.js';
 import '@spectrum-web-components/button/sp-button.js';
@@ -636,4 +642,56 @@ export const superComplexModal = (): TemplateResult => {
             </sp-popover>
         </overlay-trigger>
     `;
+};
+
+export const virtualElement = (args: Properties): TemplateResult => {
+    let virtualTarget: VirtualTrigger;
+    const pointerenter = async (event: PointerEvent): Promise<void> => {
+        event.preventDefault();
+        const target = event.target as HTMLElement;
+        virtualTarget = new VirtualTrigger(
+            target,
+            event.clientX,
+            event.clientY
+        );
+        openOverlay(
+            virtualTarget,
+            'modal',
+            target.nextElementSibling as HTMLElement,
+            {
+                placement: args.placement,
+                receivesFocus: 'auto',
+            }
+        );
+    };
+    return html`
+        <style>
+            .app-root {
+                position: absolute;
+                inset: 0;
+            }
+        </style>
+        <div class="app-root" @contextmenu=${pointerenter}></div>
+        <sp-popover
+            style="max-width: 33vw;"
+            @click=${(event: Event) =>
+                event.target?.dispatchEvent(
+                    new Event('close', { bubbles: true })
+                )}
+        >
+            <sp-menu>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save selection</sp-menu-item>
+                <sp-menu-item disabled>Make work path</sp-menu-item>
+            </sp-menu>
+        </sp-popover>
+    `;
+};
+
+virtualElement.args = {
+    placement: 'right-end',
 };


### PR DESCRIPTION
## Description
By default overlays are dispatched from element triggers, however some magic around `getBoundingClientRects()` allows for a "virtual" trigger, e.g. https://popper.js.org/docs/v2/virtual-elements/. The ability to do so is useful for the context in the PopperJS docs where you want to overlay to follow your cursor, but also in the context of wanting to replace the `contextmenu` display in conjunction with a user interaction point along a `canvas` element, which that "point" to be the trigger of the overlay not the entire `canvas` element. Herein, you'll find a proposal for making that possible in SWC.

### Requirements
On the PopperJS side, the "VirtualTrigger" object needs to at least include a synthetic implementation of `getBoundingClientRects()` in order to know where to place the overlay. This precipitates the need to be able to easily update the results of that call, for which this PR adds the `updateBoundingClientRect()` method to the `VirtualTrigger` element. This accepts the `x` and `y` coordinates of the virtual element.

On the SWC side there are a few more responsibilities of the trigger in an overlay experience.
- it is the `EventTarget` from which `sp-query-theme` (which resolves the Spectrum theme information), as well as `sp-closed` and `sp-opened` (which announces the state of the overlay) are dispatched
- they take `focus()` in certain contexts
- their `getRootNode()` method is leveraged to resolve `activeElement` information
- their `closest()` method is used to resolve overlay "stacks" or groups of modals demarcated by `type="modal"` overlays
All of these responsibilities stem the the `HTMLElement` typing that they embody, and in relying on their DOM position for the majority of these things raise the bar on a virtual replacement

### Approach
Herein I create a custom element, which directly satisfies the type requirements of `HTMLElement`, that rather than being used as an actual element in the HTML is constructed `new VirtualTrigger()` to be leveraged in a detached state for this functionality. The constructor is passed a `host` and the initial `x` and `y` positional values for the trigger. The host needs to be a DOM element that is attached to the tree and benefits from being a part of the actual application for the sake of resolving themes, etc. but doesn't strictly need to be associated to the actual interaction point. For ease of use, in our default example of triggering an overlay from a point on a `canvas` element, while the `canvas` can't be the target, it can, and likely should, be the host. In the constructor of the `VirtualElement`, the host (and the implementations for `getBoundingClientRects` and `updateBoundingClientRect`) are wrapped in a `Proxy()` and returned so that calls to the cached virtual trigger will be made to the Proxy rather than to an actual element.

### Benefits
Providing a centralized `VirtualTrigger` API will be useful for code sharing and understandability across larger shared app surfaces while covering over foot gun situations like forgetting to resolve themes, etc. On top of adequately addressing the current needs of the `trigger` element being fairly `HTMLElement`-like, the approach of having `VirtualTrigger` extend `HTMLElement` and proxy calls as needed should be that we don't have to think about it too much when addressing future updates to the overlay system. While we could make a more synthetic "HTMLElement" to support this virtualization of the trigger, we'd likely have to take into account every API on a standard `trigger` that we leveraged and add it to the virtual one. Here we can rely fully on the fact that we have an actual `HTMLElement` for making those calls against. If at any point we need to add more virtual functionality then it simply becomes a matter of managing that forking in the Proxy, as well.

## Questions
- The proxy approach seems like a nice win both for the functional requirements, as well as the TypeScript requirements, but are there other patterns that would better serve us here?
- Like any actual element, when this Virtual Trigger is used up and the closure from which it originates the complete, it should just GC, right? I've not thought a lot about leaks in this manner, but an additional benefit of it extending `HTMLElement` should be that the realities that govern there would govern here, right?
- In the current demo, I'm using a fixed menu, which I think applies more cleanly to the initial use case. However, the demo on the PopperJS side points to the power of using this with a moving `trigger`. In that case, we already have the `updateBoundingClientRect()` method, but as outlined in the follow code on their page a consuming developer would subsequently need to update the instance:

  ```js
      document.addEventListener('mousemove', ({ clientX: x, clientY: y }) => {
          virtualElement.getBoundingClientRect = generateGetBoundingClientRect(x, y);
          instance.update();
      });
  ```
  We surface this functionality via `Overlay.update()`, which is a nice helper, but in this case would we better serve our users by closing other that functionality and calling that for them when they update the position of their virtual trigger?
  ```js
      updateBoundingClientRect(x: number, y: number): void {
          this.x = x;
          this.y = y;
          Overlay.update();      
      }
  ```
- Are there use cases that you'd like to be sure are covered by this functionality in particular that you don't think is addressed here in?

## Related Issue
fixes #1437  

## Motivation and Context
It should be easy to leverage the full capability of our overlay system.

## How Has This Been Tested?
- no tests yet, just demos for conversation

## Screenshots (if appropriate):
Demo available here, right click to see the overlay:
https://westbrook-virtual-element--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--virtual-element
This will look particularly nice when we get #1425 merged!

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. <=== ADD ME!
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. <=== ADD ME!
- [x] All new and existing tests passed.
