### PR TITLE
fix(action-menu): provide action menu size to action button

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -61,6 +61,7 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
                 aria-label=${ifDefined(this.label || undefined)}
                 id="button"
                 class="button"
+                size=${this.size}
                 @blur=${this.onButtonBlur}
                 @click=${this.onButtonClick}
                 @focus=${this.onButtonFocus}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support the t-shirt sizing API for `<sp-action-menu>` via `size` attribute passthrough to `sp-action-button>` 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1446


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
T-shirt sizing ftw!

## How Has This Been Tested?

New functionality not tested; existing action menu unit tests for regressions.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
