### PR TITLE
Update Action Group accessibility

### DIFF
--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -295,7 +295,7 @@ export class ActionGroup extends SpectrumElement {
             }
             default:
                 this.buttons.forEach((option) => {
-                    option.removeAttribute('role');
+                    option.setAttribute('role', 'button');
                     option.tabIndex = 0;
                 });
                 this.removeAttribute('role');

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -327,7 +327,11 @@ export class ActionGroup extends SpectrumElement {
         ) {
             this.manageChildren();
         }
-        if (changes.has('label')) {
+        // Update `aria-label` when `label` available or not first `updated`
+        if (
+            changes.has('label') &&
+            (this.label || typeof changes.get('label') !== 'undefined')
+        ) {
             if (this.label.length) {
                 this.setAttribute('aria-label', this.label);
             } else {

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -62,6 +62,9 @@ describe('ActionGroup', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+        expect(el.getAttribute('aria-label')).to.equal('Default Group');
+        expect(el.hasAttribute('role')).to.be.false;
+        expect(el.children[0].getAttribute('role')).to.equal('button');
     });
     it('loads [selects="single"] action-group accessibly', async () => {
         const el = await fixture<ActionGroup>(
@@ -77,6 +80,9 @@ describe('ActionGroup', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+        expect(el.getAttribute('aria-label')).to.equal('Selects Single Group');
+        expect(el.getAttribute('role')).to.equal('radiogroup');
+        expect(el.children[0].getAttribute('role')).to.equal('radio');
     });
     it('loads [selects="single"] action-group w/ selection accessibly', async () => {
         const el = await fixture<ActionGroup>(
@@ -110,6 +116,11 @@ describe('ActionGroup', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+        expect(el.getAttribute('aria-label')).to.equal(
+            'Selects Multiple Group'
+        );
+        expect(el.getAttribute('role')).to.equal('group');
+        expect(el.children[0].getAttribute('role')).to.equal('checkbox');
     });
     it('loads [selects="multiple"] action-group w/ selection accessibly', async () => {
         const el = await fixture<ActionGroup>(

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -51,7 +51,7 @@ describe('ActionGroup', () => {
     it('loads default action-group accessibly', async () => {
         const el = await fixture<ActionGroup>(
             html`
-                <sp-action-group label="Default Group">
+                <sp-action-group aria-label="Default Group">
                     <sp-action-button>First</sp-action-button>
                     <sp-action-button>Second</sp-action-button>
                     <sp-action-button>Third</sp-action-button>

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -19,6 +19,7 @@ import {
     nextFrame,
     elementUpdated,
     waitUntil,
+    oneEvent,
 } from '@open-wc/testing';
 
 import '../overlay-trigger.js';
@@ -427,7 +428,9 @@ describe('Overlay Trigger', () => {
             .false;
 
         expect(button).to.exist;
+        const outerOpen = oneEvent(button, 'sp-opened');
         button.click();
+        await outerOpen;
 
         await waitUntil(
             () => !(outerPopover.parentElement instanceof OverlayTrigger),
@@ -445,7 +448,9 @@ describe('Overlay Trigger', () => {
             '#inner-button'
         ) as HTMLElement;
 
+        const innerOpen = oneEvent(innerButton, 'sp-opened');
         innerButton.click();
+        await innerOpen;
 
         await waitUntil(
             () => !(innerPopover.parentElement instanceof OverlayTrigger),
@@ -455,7 +460,9 @@ describe('Overlay Trigger', () => {
         expect(isVisible(outerPopover), 'outer popover stays open').to.be.true;
         expect(isVisible(innerPopover), 'inner popover opens').to.be.true;
 
+        const innerClose = oneEvent(innerButton, 'sp-closed');
         pressEscape();
+        await innerClose;
 
         await waitUntil(
             () => innerPopover.parentElement instanceof OverlayTrigger,


### PR DESCRIPTION
## Description
- default child role is now `button` when `selects` is not set
- do not allow unset `label` attributes to overwrite the `aria-label` attribute on first render

## Related Issue
refs #1419
refs #1418

## Motivation and Context
Content appearance in the screen reader.

## How Has This Been Tested?
Expanded unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
