### PR TITLE
fix(tray): add tray pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 07ff631a3f6b6b7ddba54036c473a867cf581e86
+        default: 6c944967d75f6c5304cc96df1ea21060dfc2f0be
 commands:
     downstream:
         steps:

--- a/documentation/src/components/layout.css
+++ b/documentation/src/components/layout.css
@@ -41,7 +41,7 @@ sp-theme {
     display: flex;
     flex-direction: row;
     flex: 1 1 auto;
-    height: 100%;
+    height: calc(100% - var(--spectrum-global-dimension-size-600) - 1px);
     color: var(--spectrum-global-color-gray-800);
 }
 

--- a/packages/bundle/elements.ts
+++ b/packages/bundle/elements.ts
@@ -75,4 +75,5 @@ import '@spectrum-web-components/theme/src/themes.js';
 import '@spectrum-web-components/thumbnail/sp-thumbnail.js';
 import '@spectrum-web-components/toast/sp-toast.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import '@spectrum-web-components/tray/sp-tray.js';
 import '@spectrum-web-components/underlay/sp-underlay.js';

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -98,6 +98,7 @@
         "@spectrum-web-components/thumbnail": "^0.1.5",
         "@spectrum-web-components/toast": "^0.8.7",
         "@spectrum-web-components/tooltip": "^0.8.7",
+        "@spectrum-web-components/tray": "^0.0.1",
         "@spectrum-web-components/underlay": "^0.6.5",
         "tslib": "^2.0.0"
     },

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -60,4 +60,5 @@ export * from '@spectrum-web-components/theme';
 export * from '@spectrum-web-components/thumbnail';
 export * from '@spectrum-web-components/toast';
 export * from '@spectrum-web-components/tooltip';
+export * from '@spectrum-web-components/tray';
 export * from '@spectrum-web-components/underlay';

--- a/packages/bundle/tsconfig.json
+++ b/packages/bundle/tsconfig.json
@@ -61,6 +61,7 @@
         { "path": "../thumbnail" },
         { "path": "../toast" },
         { "path": "../tooltip" },
+        { "path": "../tray" },
         { "path": "../underlay" }
     ]
 }

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -170,11 +170,11 @@ export class ActiveOverlay extends SpectrumElement {
         ) as HTMLElement;
         if (firstFocusable) {
             firstFocusable.focus();
-            this.removeAttribute('tabindex');
             /* c8 ignore next 3 */
         } else {
             super.focus();
         }
+        this.removeAttribute('tabindex');
     }
 
     private get hasTheme(): boolean {
@@ -205,7 +205,7 @@ export class ActiveOverlay extends SpectrumElement {
     }
 
     public feature(): void {
-        this.tabIndex = 0;
+        this.tabIndex = -1;
         const parentOverlay = this.trigger.closest('active-overlay');
         const parentIsModal = parentOverlay && parentOverlay.slot === 'open';
         // If an overlay it triggered from within a "modal" overlay, it needs to continue

--- a/packages/tray/README.md
+++ b/packages/tray/README.md
@@ -1,0 +1,97 @@
+## Description
+
+`<sp-tray>` elements are typically used to portray information on mobile device or smaller screens.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/tray?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/tray)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/tray?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/tray)
+
+```
+yarn add @spectrum-web-components/tray
+```
+
+Import the side effectful registration of `<sp-tray>` via:
+
+```
+import '@spectrum-web-components/tray/sp-tray.js';
+```
+
+When looking to leverage the `Tray` base class as a type and/or for extension purposes, do so via:
+
+```
+import { Tray } from '@spectrum-web-components/tray';
+```
+
+## Dialog
+
+```html
+<sp-button
+    variant="secondary"
+    onclick="
+    const trigger = this;
+    const interaction = 'modal';
+    const content = this.nextElementSibling;
+    const options = {
+        offset: 0,
+        placement: 'none',
+        receivesFocus: 'auto',
+    };
+    Overlay.open(
+        trigger, 
+        interaction,
+        content,
+        options
+    );
+"
+>
+    Toggle tray
+</sp-button>
+<sp-tray>
+    <sp-dialog size="small" dismissable>
+        <h2 slot="heading">New Messages</h2>
+        You have 5 new messages.
+    </sp-dialog>
+</sp-tray>
+```
+
+## Menu
+
+```html
+<sp-button
+    variant="secondary"
+    onclick="
+    const trigger = this;
+    const interaction = 'modal';
+    const content = this.nextElementSibling;
+    const options = {
+        offset: 0,
+        placement: 'none',
+        receivesFocus: 'auto',
+    };
+    Overlay.open(
+        trigger, 
+        interaction,
+        content,
+        options
+    );
+"
+>
+    Toggle menu
+</sp-button>
+<sp-tray>
+    <sp-menu style="width: 100%">
+        <sp-menu-item selected>Deselect</sp-menu-item>
+        <sp-menu-item>Select Inverse</sp-menu-item>
+        <sp-menu-item focused>Feather...</sp-menu-item>
+        <sp-menu-item>Select and Mask...</sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>Save Selection</sp-menu-item>
+        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+    </sp-menu>
+</sp-tray>
+```
+
+## Accessibility
+
+`<sp-tray>` presents a page blocking experience and should be opened with the `Overlay` API using the `modal` interaction to ensure that the content appropriately manages the presence of other content in the tab order of the page and the availability of that content for a screen reader.

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -1,0 +1,60 @@
+{
+    "name": "@spectrum-web-components/tray",
+    "version": "0.0.1",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "Web component implementation of a Spectrum design Tray",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adobe/spectrum-web-components.git",
+        "directory": "packages/tray"
+    },
+    "author": "",
+    "homepage": "https://adobe.github.io/spectrum-web-components/components/tray",
+    "bugs": {
+        "url": "https://github.com/adobe/spectrum-web-components/issues"
+    },
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        ".": "./src/index.js",
+        "./src/*": "./src/*.js",
+        "./package.json": "./package.json",
+        "./sp-tray": "./sp-tray.js",
+        "./sp-tray.js": "./sp-tray.js"
+    },
+    "scripts": {
+        "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
+    },
+    "files": [
+        "*.d.ts",
+        "*.js",
+        "*.js.map",
+        "/src/",
+        "custom-elements.json"
+    ],
+    "keywords": [
+        "spectrum css",
+        "web components",
+        "lit-element",
+        "lit-html"
+    ],
+    "dependencies": {
+        "@spectrum-web-components/base": "^0.4.3",
+        "@spectrum-web-components/modal": "^0.3.5",
+        "@spectrum-web-components/underlay": "^0.6.5",
+        "tslib": "^2.0.0"
+    },
+    "devDependencies": {
+        "@spectrum-css/tray": "^1.0.3"
+    },
+    "types": "./src/index.d.ts",
+    "customElementsManifest": "custom-elements.json",
+    "sideEffects": [
+        "./sp-*.js",
+        "./sp-*.ts"
+    ]
+}

--- a/packages/tray/sp-tray.ts
+++ b/packages/tray/sp-tray.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Tray } from './src/Tray.js';
+
+customElements.define('sp-tray', Tray);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-tray': Tray;
+    }
+}

--- a/packages/tray/src/Tray.ts
+++ b/packages/tray/src/Tray.ts
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    SpectrumElement,
+    CSSResultArray,
+    TemplateResult,
+    property,
+    query,
+} from '@spectrum-web-components/base';
+import '@spectrum-web-components/underlay/sp-underlay.js';
+
+import modalStyles from '@spectrum-web-components/modal/src/modal.css.js';
+import styles from './tray.css.js';
+
+/**
+ * @element sp-tray
+ */
+export class Tray extends SpectrumElement {
+    public static get styles(): CSSResultArray {
+        return [modalStyles, styles];
+    }
+
+    @property({ type: Boolean, reflect: true })
+    public open = false;
+
+    @query('.tray')
+    private tray!: HTMLDivElement;
+
+    public focus(): void {
+        const firstFocusable = this.querySelector(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"]), [focusable]'
+        ) as HTMLElement;
+        if (firstFocusable) {
+            firstFocusable.focus();
+        } else if (this.children.length === 1) {
+            this.tray.focus();
+        } else {
+            super.focus();
+        }
+    }
+
+    public close(): void {
+        this.open = false;
+        this.dispatchEvent(
+            new Event('close', {
+                bubbles: true,
+            })
+        );
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            <sp-underlay ?open=${this.open} @click=${this.close}></sp-underlay>
+            <div class="tray modal" tabindex="-1">
+                <slot></slot>
+            </div>
+        `;
+    }
+}

--- a/packages/tray/src/index.ts
+++ b/packages/tray/src/index.ts
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export * from './Tray.js';

--- a/packages/tray/src/spectrum-config.js
+++ b/packages/tray/src/spectrum-config.js
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const config = {
+    spectrum: 'tray',
+    components: [
+        {
+            name: 'tray',
+            host: {
+                selector: '.spectrum-Tray',
+                shadowSelector: '.tray',
+            },
+            attributes: [
+                {
+                    type: 'boolean',
+                    name: 'open',
+                    selector: '.is-open',
+                },
+            ],
+        },
+    ],
+};
+
+export default config;

--- a/packages/tray/src/spectrum-tray.css
+++ b/packages/tray/src/spectrum-tray.css
@@ -1,0 +1,131 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+.tray {
+    /* .spectrum-Tray */
+    visibility: hidden;
+    opacity: 0;
+    transition: transform var(--spectrum-global-animation-duration-100, 0.13s)
+            ease-in-out,
+        opacity var(--spectrum-global-animation-duration-100, 0.13s) ease-in-out,
+        visibility 0ms linear
+            var(--spectrum-global-animation-duration-100, 0.13s);
+    pointer-events: none;
+}
+:host([open]) .tray {
+    /* .spectrum-Tray.is-open */
+    visibility: visible;
+    opacity: 1;
+    transition-delay: 0ms;
+    pointer-events: auto;
+}
+:host {
+    /* .spectrum-Tray */
+    --spectrum-dialog-confirm-exit-animation-delay: 0ms;
+    --spectrum-tray-margin-top: 64px;
+}
+:host([dir='ltr']) .spectrum-Tray-wrapper {
+    /* [dir=ltr] .spectrum-Tray-wrapper */
+    left: 0;
+}
+:host([dir='rtl']) .spectrum-Tray-wrapper {
+    /* [dir=rtl] .spectrum-Tray-wrapper */
+    right: 0;
+}
+.spectrum-Tray-wrapper {
+    /* .spectrum-Tray-wrapper */
+    position: fixed;
+    bottom: 0;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    z-index: 2;
+}
+.tray {
+    /* .spectrum-Tray */
+    width: var(--spectrum-tray-width, 100%);
+    max-width: var(--spectrum-tray-max-width, 375px);
+    min-height: var(
+        --spectrum-tray-min-height,
+        var(--spectrum-global-dimension-static-size-800)
+    );
+    max-height: calc(100vh - var(--spectrum-tray-margin-top));
+    overflow: auto;
+    outline: none;
+    border-radius: var(
+            --spectrum-tray-full-width-border-radius,
+            var(--spectrum-alias-border-radius-regular)
+        )
+        var(
+            --spectrum-tray-full-width-border-radius,
+            var(--spectrum-alias-border-radius-regular)
+        )
+        var(--spectrum-tray-border-radius, 0)
+        var(--spectrum-tray-border-radius, 0);
+    padding: var(--spectrum-tray-padding-y, 0)
+        var(
+            --spectrum-tray-padding-x,
+            var(--spectrum-global-dimension-static-size-100)
+        );
+    transform: translateY(100%);
+    transition: opacity
+            var(
+                --spectrum-dialog-confirm-exit-animation-duration,
+                var(--spectrum-global-animation-duration-100)
+            )
+            cubic-bezier(0.5, 0, 1, 1)
+            var(--spectrum-dialog-confirm-exit-animation-delay, 0ms),
+        visibility 0ms linear
+            calc(
+                var(--spectrum-dialog-confirm-exit-animation-delay, 0ms) +
+                    var(
+                        --spectrum-dialog-confirm-exit-animation-duration,
+                        var(--spectrum-global-animation-duration-100)
+                    )
+            ),
+        transform
+            var(
+                --spectrum-dialog-confirm-exit-animation-duration,
+                var(--spectrum-global-animation-duration-100)
+            )
+            cubic-bezier(0.5, 0, 1, 1)
+            var(--spectrum-dialog-confirm-exit-animation-delay, 0ms);
+}
+:host([open]) .tray {
+    /* .spectrum-Tray.is-open */
+    transition: transform
+            var(
+                --spectrum-dialog-confirm-entry-animation-duration,
+                var(--spectrum-global-animation-duration-500)
+            )
+            cubic-bezier(0, 0, 0.4, 1)
+            var(
+                --spectrum-dialog-confirm-entry-animation-delay,
+                var(--spectrum-global-animation-duration-200)
+            ),
+        opacity
+            var(
+                --spectrum-dialog-confirm-entry-animation-duration,
+                var(--spectrum-global-animation-duration-500)
+            )
+            cubic-bezier(0, 0, 0.4, 1)
+            var(
+                --spectrum-dialog-confirm-entry-animation-delay,
+                var(--spectrum-global-animation-duration-200)
+            );
+    transform: translateY(0);
+}
+@media (max-inline-size: 375px) {
+    .tray {
+        border-radius: var(--spectrum-tray-border-radius, 0);
+    }
+}

--- a/packages/tray/src/tray.css
+++ b/packages/tray/src/tray.css
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import './spectrum-tray.css';
+
+:host {
+    align-items: flex-end;
+}
+
+/**
+ * Default padding along the x axis causes a weird interaction with inner content,
+ * e.g. dismissable dialogs, that layout children based off of their own width and
+ * can't correct into the larger tray width. Move the default to 0 while still
+ * surfacing the `--spectrum-tray-padding-x` override as needed.
+ **/
+.tray {
+    padding: var(--spectrum-tray-padding-y, 0) var(--spectrum-tray-padding-x, 0);
+}

--- a/packages/tray/stories/tray.stories.ts
+++ b/packages/tray/stories/tray.stories.ts
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, TemplateResult } from '@spectrum-web-components/base';
+
+import '@spectrum-web-components/dialog/sp-dialog.js';
+import '@spectrum-web-components/menu/sp-menu.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/menu/sp-menu-divider.js';
+import '../sp-tray.js';
+
+export default {
+    title: 'Tray',
+    component: 'sp-tray',
+    args: {
+        open: true,
+    },
+    argTypes: {
+        open: {
+            name: 'open',
+            type: { name: 'boolean', required: false },
+            description: 'Whether the tray is open.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+    },
+};
+
+type StoryArgs = {
+    open?: boolean;
+};
+
+export const Default = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-tray ?open=${args.open}>
+            <sp-dialog size="small">
+                <h2 slot="heading">New Messages</h2>
+                You have 5 new messages.
+            </sp-dialog>
+        </sp-tray>
+    `;
+};
+
+export const menu = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-tray ?open=${args.open}>
+            <sp-menu style="width: 100%">
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item selected>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-menu>
+        </sp-tray>
+    `;
+};

--- a/packages/tray/test/benchmark/basic-test.ts
+++ b/packages/tray/test/benchmark/basic-test.ts
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/dialog/sp-dialog.js';
+import '@spectrum-web-components/tray/sp-tray.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-tray open>
+        <sp-dialog size="small">
+            <h2 slot="heading">New Messages</h2>
+            You have 5 new messages.
+        </sp-dialog>
+    </sp-tray>
+`);

--- a/packages/tray/test/tray.test.ts
+++ b/packages/tray/test/tray.test.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
+
+import '../sp-tray.js';
+import { Tray } from '..';
+
+describe('Tray', () => {
+    it('loads default tray accessibly', async () => {
+        const el = await fixture<Tray>(
+            html`
+                <sp-tray></sp-tray>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/tray/tsconfig.json
+++ b/packages/tray/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "./"
+    },
+    "include": ["*.ts", "src/*.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../base" }]
+}

--- a/test/visual/story-imports.ts
+++ b/test/visual/story-imports.ts
@@ -91,4 +91,5 @@ export * as ThumbnailStories from '../../packages/thumbnail/stories/thumbnail.st
 export * as ToastStories from '../../packages/toast/stories/toast.stories.js';
 export * as TooltipStories from '../../packages/tooltip/stories/tooltip.stories.js';
 export * as TopNavStories from '../../packages/top-nav/stories/top-nav.stories.js';
+export * as TrayStories from '../../packages/tray/stories/tray.stories.js';
 export * as UnderlayStories from '../../packages/underlay/stories/underlay.stories.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3473,6 +3473,11 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.0.3.tgz#26b8ca3b3d30e29630244d85eb4fc11d0c841281"
   integrity sha512-ztRF7WW1FzyNavXBRc+80z67UoOrY9wl3cMYsVD3MpDnyxdzP8cjza1pCcolKBaFqRTcQKkxKw3GWtGICRKR5A==
 
+"@spectrum-css/tray@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-1.0.3.tgz#5a1071a561cb339f9f93422c655dccce54201002"
+  integrity sha512-Sw7FUw7bDbSDaEMjnJulZIefFQ2GI+JY+h1Jh6vEgLRzMNAwuGHg2Zjy/B3Znah4NhkEN1033VyEfiGQMxtf3A==
+
 "@spectrum-css/typography@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-3.0.2.tgz#ea3ca0a60e18064527819d48c8c4364cab4fcd38"


### PR DESCRIPTION
## Description
Add the `sp-tray` element.
- update docs so they don't double scroll bar
- simplify the storybook config for easier pattern additions
- tweak the Active Overlay entry process to reduce unneeded focus loops.

### Notes:
- The "mobile" implementation of the stepper UI has yet to be implemented at the Spectrum CSS level and as such in not included in this PR.

## Related Issue
fixes #1461

## Motivation and Context
Better coverage of Spectrum CSS patterns.
Prep for expanded coverage of the Picker pattern in mobile.

## How Has This Been Tested?
- unit tests
- VRTs

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/118573177-0b502300-b750-11eb-8d99-4edc4666a42f.png)
- https://westbrook-tray--spectrum-web-components.netlify.app/components/tray
- https://westbrook-tray--spectrum-web-components.netlify.app/storybook/index.html?path=/story/tray--default

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
