### PR TITLE
fix: prevent tabindex=-1 elements from placing focus on their host

### DIFF
--- a/documentation/src/components/code-example.css
+++ b/documentation/src/components/code-example.css
@@ -44,7 +44,7 @@ governing permissions and limitations under the License.
 #markup {
     display: grid;
     grid-template-columns: 100%;
-    grid-template-rows: 100%;
+    grid-template-rows: minmax(60px, 100%);
     padding: 0.75rem 1.5rem;
     border-radius: 0 0 6px 6px;
     border-top: 1px solid var(--spectrum-global-color-gray-100);

--- a/packages/checkbox/src/checkbox.css
+++ b/packages/checkbox/src/checkbox.css
@@ -17,10 +17,14 @@ governing permissions and limitations under the License.
     vertical-align: top;
 }
 
-:host(:empty) label {
-    display: none;
+:host(:focus) {
+    outline: none;
 }
 
 :host([disabled]) {
     pointer-events: none;
+}
+
+:host(:empty) label {
+    display: none;
 }

--- a/packages/color-slider/src/color-slider.css
+++ b/packages/color-slider/src/color-slider.css
@@ -20,6 +20,10 @@ governing permissions and limitations under the License.
     touch-action: none;
 }
 
+:host(:focus) {
+    outline: none;
+}
+
 :host(:not([vertical])) {
     touch-action: pan-y;
 }

--- a/packages/color-wheel/src/color-wheel.css
+++ b/packages/color-wheel/src/color-wheel.css
@@ -15,3 +15,7 @@ governing permissions and limitations under the License.
 :host {
     touch-action: none;
 }
+
+:host(:focus) {
+    outline: none;
+}

--- a/packages/link/src/link.css
+++ b/packages/link/src/link.css
@@ -15,3 +15,7 @@ governing permissions and limitations under the License.
 :host {
     display: inline;
 }
+
+:host(:focus) {
+    outline: none;
+}

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -45,6 +45,7 @@ export class RadioGroup extends FieldGroup {
     }
 
     public focus(): void {
+        debugger;
         if (!this.buttons.length) {
             return;
         }
@@ -148,11 +149,15 @@ export class RadioGroup extends FieldGroup {
         }
         event.preventDefault();
         const nextRadio = circularIndexedElement(this.buttons, nextIndex);
-        nextRadio.focus();
         this._setSelected(nextRadio.value);
+        nextRadio.focus();
     };
 
-    private handleFocusout = (): void => {
+    private handleFocusout = (event: FocusEvent): void => {
+        const nextActiveElement = event.relatedTarget as Node;
+        if (nextActiveElement && this.contains(nextActiveElement)) {
+            return;
+        }
         const firstButtonNonDisabled = this.buttons.find((button) => {
             if (this.selected) {
                 return button.checked;
@@ -200,7 +205,8 @@ export class RadioGroup extends FieldGroup {
         `;
     }
 
-    protected firstUpdated(): void {
+    protected firstUpdated(changes: PropertyValues<this>): void {
+        super.firstUpdated(changes);
         const checkedRadio = this.querySelector('sp-radio[checked]') as Radio;
         const checkedRadioValue = checkedRadio ? checkedRadio.value : '';
         // Prefer the checked item over the selected value
@@ -225,9 +231,6 @@ export class RadioGroup extends FieldGroup {
             const target = event.target as Radio;
             this._setSelected(target.value);
         });
-    }
-
-    protected updated(changes: PropertyValues<this>): void {
         this.buttons.map((button, index) => {
             const focusable = this.selected
                 ? !button.disabled && button.value === this.selected
@@ -238,6 +241,10 @@ export class RadioGroup extends FieldGroup {
                 : '-1';
             button.setAttribute('tabindex', focusable);
         });
+    }
+
+    protected updated(changes: PropertyValues<this>): void {
+        super.updated(changes);
         if (changes.has('selected')) {
             this.validateRadios();
         }

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -7,19 +7,19 @@ Shared mixins, tools, etc. that support developing Spectrum Web Components.
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/shared?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/shared)
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/shared?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/shared)
 
-```
+```bash
 npm install @spectrum-web-components/shared
 ```
 
 Individual base classes and mixins can be imported as follows:
 
-```
+```javascript
 import {
     Focusable,
     FocusVisiblePolyfillMixin,
     getActiveElement,
     LikeAnchor,
-    ObserveSlotText
+    ObserveSlotText,
 } from '@spectrum-web-components/shared';
 ```
 
@@ -27,7 +27,7 @@ import {
 
 The `Focusable` subclass of `LitElement` adds some helpers method and lifecycle coverage in order to support passing focus to a container element inside of a custom element. The Focusable base class handles tabindex setting into shadowed elements automatically and is based heavily on the aybolit delegate-focus-mixin at https://github.com/web-padawan/aybolit/blob/master/packages/core/src/mixins/delegate-focus-mixin.js
 
-```js
+```javascript
 import { Focusable } from '@spectrum-web-components/shared';
 import { html } from 'lit-element';
 
@@ -36,10 +36,6 @@ class FocusableButton extends Focusable {
         return [...super.styles];
     }
     public get focusElement(): HTMLElement {
-        /* c8 ignore next 3 */
-        if (!this.shadowRoot) {
-            return this;
-        }
         return this.shadowRoot.querySelector('#button') as HTMLElement;
     }
 
@@ -71,7 +67,7 @@ Mix `download`, `label`, `href`, and `target` properties into your element to al
 
 When working with styles that are driven by the conditional presence of `<slot>`s in a component's shadow DOM, you will need to track whether light DOM that is meant for that slot exists. Use the `ObserveSlotPresence` mixin to target specific light DOM to observe the presence of and trigger `this.requestUpdate()` calls when content fulfilling that selector comes in and out of availability.
 
-```js
+```javascript
 import { ObserveSlotPresence } from '@spectrum-web-components/shared';
 import { LitElement, html } from 'lit-element';
 class ObserveSlotPresenceElement extends ObserveSlotPresence(LitElement, '[slot="conditional-slot"]') {
@@ -106,7 +102,7 @@ customElements.define('observing-slot-presence-element', ObserveSlotPresenceElem
 
 When working with `<slot>`s and their `slotchange` event, you will have the opportunity to capture when the nodes and/or elements in your element are added or removed. However, if the `textContent` of a text node changes, you will not receive the `slotchange` event because the slot hasn't actually received new nodes and/or elements in the exchange. When working with a lit-html binding `<your-element>${text}</your-element>` that means you will not receive a `slotchange` event when the value of `text` goes from `text = ''` to `text = 'something'` or the other way. In these cases the `ObserveSlotText` can be leverages to apply a mutation observe onto your element that tracks `characterData` mutations so that you can resspond as desired.
 
-```js
+```javascript
 import { ObserveSlotText } from '@spectrum-web-components/shared';
 import { LitElement, html } from 'lit-element';
 

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -87,8 +87,19 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
             }
             return;
         }
-        // All code paths are about to address the host tabindex without side effect.
-        this.manipulatingTabindex = true;
+        if (tabIndex === -1) {
+            this.addEventListener(
+                'pointerdown',
+                this.onPointerdownManagementOfTabIndex
+            );
+        } else {
+            // All code paths are about to address the host tabindex without side effect.
+            this.manipulatingTabindex = true;
+            this.removeEventListener(
+                'pointerdown',
+                this.onPointerdownManagementOfTabIndex
+            );
+        }
         if (tabIndex === -1 || this.disabled) {
             // Do not cange the tabindex of `focusElement` as it is the "old" value cache.
             // Make element NOT focusable.
@@ -111,6 +122,13 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         this.manageFocusElementTabindex(tabIndex);
     }
     private _tabIndex = 0;
+
+    private onPointerdownManagementOfTabIndex(): void {
+        if (this.tabIndex === -1) {
+            this.tabIndex = 0;
+            this.focus();
+        }
+    }
 
     private async manageFocusElementTabindex(tabIndex: number): Promise<void> {
         if (!this.focusElement) {

--- a/packages/sidenav/test/sidenav.test.ts
+++ b/packages/sidenav/test/sidenav.test.ts
@@ -29,6 +29,7 @@ import {
 } from '@open-wc/testing';
 import { TemplateResult, LitElement } from '@spectrum-web-components/base';
 import { spy } from 'sinon';
+import { executeServerCommand } from '@web/test-runner-commands';
 
 describe('Sidenav', () => {
     it('loads', async () => {
@@ -356,6 +357,33 @@ describe('Sidenav', () => {
         const outsideFocused = document.activeElement as HTMLElement;
 
         expect(typeof outsideFocused).not.to.equal(SideNavItem);
+    });
+    it('focuses the child anchor not the root when [tabindex=-1]', async () => {
+        const el = await fixture<SideNav>(manageTabIndex());
+
+        await elementUpdated(el);
+        const firstItem = el.querySelector(
+            '[value="Section 0"]'
+        ) as SideNavItem;
+        const selected = el.querySelector('[selected]') as SideNavItem;
+        expect(selected.tabIndex).to.equal(0);
+        expect(firstItem.tabIndex).to.equal(-1);
+
+        const firstRect = firstItem.getBoundingClientRect();
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [firstRect.x + 2, firstRect.y + 2],
+                },
+                {
+                    type: 'down',
+                },
+            ],
+        });
+        await elementUpdated(el);
+
+        expect(firstItem.focusElement.matches(':focus')).to.be.true;
     });
     it('manage tab index through shadow DOM', async () => {
         class SideNavTestEl extends LitElement {

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -20,7 +20,11 @@ governing permissions and limitations under the License.
  * interacting with the slider via the mouse.
 */
 :host(:focus) {
-    outline-width: 0;
+    outline: 0;
+}
+
+:host([disabled]) {
+    pointer-events: none;
 }
 
 .track {

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -67,3 +67,8 @@ governing permissions and limitations under the License.
     border-right-width: 0;
     border-left-width: 0;
 }
+
+.icon,
+.icon-workflow {
+    pointer-events: none;
+}


### PR DESCRIPTION
## Description
- prevent the presence of a focus outline on element hosts in Safari where the `focusElement` child isn't a "focusable" element
  - Safari doesn't not by default support focusing `input[type="radio"]`, `input[type="checkbox"]`, `input[type="range"]`, or `a` elements, so while "focus" will sometimes resolve to their host the focus outline has been remove from these sorts of elements
- prevent focusing the host when interacting with elements that contain "focusable" children
- correct the time as which `tabindex` is manages for children of a `sp-radio-group` element so that it performs more predictably

## Related Issue
fixes #1426 
fixes #1038

## Motivation and Context
- correct visual delivery in Safari
- correct keyboard interaction when `input[type=radio]` is "focusable"

## How Has This Been Tested?
- unit tests
- manually

## Screenshots (if appropriate):
https://westbrook-focusable--spectrum-web-components.netlify.app/components/radio

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
