### PR TITLE
Adixon 1189 menu prep

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "test:visual:clean": "yarn test:visual:clean:baseline && yarn test:visual:clean:current",
         "test:visual:clean:baseline": "rimraf test/visual/screenshots-baseline",
         "test:visual:clean:current": "rimraf test/visual/screenshots-current",
-        "test:watch": "test:watch:focus unit",
+        "test:watch": "yarn test:watch:focus unit",
         "test:watch:focus": "run-p watch:css \"test:build -w\" \"test:start --watch --group {1}\" --",
         "watch:css": "node ./tasks/watch-css.js"
     },

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -56,7 +56,6 @@ export class Menu extends SpectrumElement {
     @query('slot')
     private menuSlot!: HTMLSlotElement;
 
-    @property({ attribute: false, type: String, reflect: true })
     public get menuItems(): MenuItem[] {
         if (this.cachedMenuItems !== undefined) {
             return this.cachedMenuItems;

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -99,6 +99,8 @@ export class Menu extends SpectrumElement {
         }) as MenuItem;
         /* c8 ignore next 3 */
         if (target) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
             this.selectOrToggleItem(target);
         } else {
             return;

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -48,7 +48,7 @@ export class Menu extends SpectrumElement {
 
     // For the multiple select case, we'll join the value strings together
     // for the value property with this separator
-    @property({ type: String })
+    @property({ type: String, attribute: 'value-separator' })
     public valueSeparator = ',';
 
     // TODO: which of these to keep?
@@ -318,8 +318,8 @@ export class Menu extends SpectrumElement {
             // item as the value. Also set the selected array
             // in the order of the menu items.
             let valueSet: boolean = false;
-            let selected: string[] = [];
-            let selectedItems: MenuItem[] = [];
+            const selected: string[] = [];
+            const selectedItems: MenuItem[] = [];
 
             for (const childItem of this.childItems) {
                 if (!childItem.managed) continue;
@@ -346,12 +346,14 @@ export class Menu extends SpectrumElement {
             })
         );
         if (!applyDefault) {
+            // Cancel the event & don't apply the selection
             this.selected = oldSelected;
             this.selectedItems = oldSelectedItems;
             this.selectedItemsMap = oldSelectedItemsMap;
             this.value = oldValue;
             return;
         }
+        // Apply the selection changes to the menu items
         if (resolvedSelects === 'single') {
             for (const oldItem of oldSelectedItemsMap.keys()) {
                 if (oldItem !== item) {

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -23,10 +23,6 @@ import {
 import { MenuItem, MenuItemUpdateEvent } from './MenuItem.js';
 import menuStyles from './menu.css.js';
 
-export interface MenuQueryRoleEventDetail {
-    role: string;
-}
-
 /**
  * Spectrum Menu Component
  * @element sp-menu
@@ -104,7 +100,7 @@ export class Menu extends SpectrumElement {
                 parent = shadowRoot?.host as HTMLElement;
             }
             while (parent != null) {
-                if (parent.tagName === 'SP-MENU') {
+                if (parent.localName === 'sp-menu') {
                     const selects = parent.getAttribute('selects');
                     const role = parent.getAttribute('role');
                     if (selects === 'single' || selects === 'multiple') {
@@ -181,7 +177,6 @@ export class Menu extends SpectrumElement {
             }
             return el.getAttribute('role') === this.childRole;
         }) as MenuItem;
-        /* c8 ignore next 3 */
         if (target && this.selects !== 'inherit') {
             event.preventDefault();
             event.stopImmediatePropagation();
@@ -435,12 +430,6 @@ export class Menu extends SpectrumElement {
     }
 
     private removeItem(itemToRemove: MenuItem) {
-        const newMenuItems: MenuItem[] = [];
-        for (const item of this.menuItems) {
-            if (item !== itemToRemove) {
-                newMenuItems.push(item);
-            }
-        }
         this.menuItemSet.delete(itemToRemove);
         this.updateMenuItems();
     }
@@ -453,7 +442,6 @@ export class Menu extends SpectrumElement {
     }
 
     private forwardFocusVisibleToitem(item: MenuItem): void {
-        console.log('forwarding focus');
         let shouldFocus = false;
         try {
             // Browsers without support for the `:focus-visible`
@@ -501,11 +489,5 @@ export class Menu extends SpectrumElement {
             // TODO: update roles/selection and announce ownership change if
             // we're going to/from inherits
         }
-    }
-}
-
-declare global {
-    interface GlobalEventHandlersEventMap {
-        'sp-menu-query-role': CustomEvent<MenuQueryRoleEventDetail>;
     }
 }

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -57,18 +57,6 @@ export class MenuGroup extends SpectrumElement {
         }
     }
 
-    // Menu defaults to no selection, while MenuGroup defaults to inherit.
-    private get menuSelects(): void | String {
-        switch (this.selects) {
-            case undefined:
-                return 'inherit';
-            case 'none':
-                return undefined;
-            default:
-                return this.selects;
-        }
-    }
-
     public get menuItems(): MenuItem[] {
         return this.menu.menuItems;
     }
@@ -83,12 +71,7 @@ export class MenuGroup extends SpectrumElement {
             <span class="header" id=${labelledby} aria-hidden="true">
                 <slot name="header"></slot>
             </span>
-            <sp-menu
-                selects=${ifDefined(
-                    this.menuSelects ? this.menuSelects : undefined
-                )}
-                role=${this.menuRole}
-            >
+            <sp-menu selects=${ifDefined(this.selects)} role=${this.menuRole}>
                 <slot></slot>
             </sp-menu>
         `;

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -35,7 +35,7 @@ export class MenuGroup extends SpectrumElement {
     }
 
     @property({ type: String, reflect: true })
-    public selects: undefined | 'single' | 'multiple';
+    public selects: undefined | 'none' | 'single' | 'multiple';
 
     private instanceCount = MenuGroup.instances;
 
@@ -54,6 +54,18 @@ export class MenuGroup extends SpectrumElement {
         }
     }
 
+    // Menu defaults to no selection, while MenuGroup defaults to inherit.
+    private get menuSelects(): void | String {
+        switch (this.selects) {
+            case undefined:
+                return 'inherit';
+            case 'none':
+                return undefined;
+            default:
+                return this.selects;
+        }
+    }
+
     public render(): TemplateResult {
         const labelledby = `menu-heading-category-${this.instanceCount}`;
         return html`
@@ -61,7 +73,9 @@ export class MenuGroup extends SpectrumElement {
                 <slot name="header"></slot>
             </span>
             <sp-menu
-                selects=${ifDefined(this.selects ? this.selects : undefined)}
+                selects=${ifDefined(
+                    this.menuSelects ? this.menuSelects : undefined
+                )}
                 role=${this.menuRole}
             >
                 <slot></slot>

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -12,6 +12,8 @@ governing permissions and limitations under the License.
 
 import {
     html,
+    ifDefined,
+    property,
     SpectrumElement,
     CSSResultArray,
     TemplateResult,
@@ -32,6 +34,9 @@ export class MenuGroup extends SpectrumElement {
         return [menuGroupStyles];
     }
 
+    @property({ type: String, reflect: true })
+    public selects: undefined | 'single' | 'multiple';
+
     private instanceCount = MenuGroup.instances;
 
     private static instances = 0;
@@ -41,13 +46,24 @@ export class MenuGroup extends SpectrumElement {
         MenuGroup.instances += 1;
     }
 
+    private get menuRole() {
+        if (this.selects) {
+            return 'menu';
+        } else {
+            return 'presentation';
+        }
+    }
+
     public render(): TemplateResult {
         const labelledby = `menu-heading-category-${this.instanceCount}`;
         return html`
             <span class="header" id=${labelledby} aria-hidden="true">
                 <slot name="header"></slot>
             </span>
-            <sp-menu role="presentation">
+            <sp-menu
+                selects=${ifDefined(this.selects ? this.selects : undefined)}
+                role=${this.menuRole}
+            >
                 <slot></slot>
             </sp-menu>
         `;

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -19,6 +19,8 @@ import {
     TemplateResult,
 } from '@spectrum-web-components/base';
 
+import { MenuItem } from './MenuItem.js';
+import { Menu } from './Menu.js';
 import '../sp-menu.js';
 import menuGroupStyles from './menu-group.css.js';
 
@@ -38,6 +40,7 @@ export class MenuGroup extends SpectrumElement {
     public selects: undefined | 'none' | 'single' | 'multiple';
 
     private instanceCount = MenuGroup.instances;
+    private menu!: Menu;
 
     private static instances = 0;
 
@@ -66,6 +69,14 @@ export class MenuGroup extends SpectrumElement {
         }
     }
 
+    public get menuItems(): MenuItem[] {
+        return this.menu.menuItems;
+    }
+
+    public get selectedItems(): MenuItem[] {
+        return this.menu.selectedItems;
+    }
+
     public render(): TemplateResult {
         const labelledby = `menu-heading-category-${this.instanceCount}`;
         return html`
@@ -85,5 +96,6 @@ export class MenuGroup extends SpectrumElement {
 
     protected firstUpdated(): void {
         this.setAttribute('role', 'none');
+        this.menu = this.shadowRoot.querySelector('sp-menu') as Menu;
     }
 }

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -20,7 +20,7 @@ import {
 } from '@spectrum-web-components/base';
 
 import { MenuItem } from './MenuItem.js';
-import { Menu } from './Menu.js';
+import { Menu, MenuChildItem } from './Menu.js';
 import '../sp-menu.js';
 import menuGroupStyles from './menu-group.css.js';
 
@@ -57,8 +57,8 @@ export class MenuGroup extends SpectrumElement {
         }
     }
 
-    public get menuItems(): MenuItem[] {
-        return this.menu.menuItems;
+    public get childItems(): MenuChildItem[] {
+        return this.menu.childItems;
     }
 
     public get selectedItems(): MenuItem[] {

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -91,7 +91,6 @@ export class MenuItem extends ActionButton {
         // so we need to wait a frame before announcing ourselves
         // or the right menu might not pick this up
         await new Promise((ready) => requestAnimationFrame(ready));
-        await new Promise((ready) => setTimeout(ready, 500));
         const addedEvent = new CustomEvent('sp-menu-item-added', {
             bubbles: true,
             composed: true,

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -138,16 +138,32 @@ export class MenuItem extends ActionButton {
         });
         this.dispatchEvent(removedEvent);
     }
+
+    public async triggerUpdate(): Promise<void> {
+        await new Promise((ready) => requestAnimationFrame(ready));
+        const updatedEvent = new CustomEvent('sp-menu-item-update', {
+            bubbles: true,
+            composed: true,
+            detail: {
+                item: this,
+                inherited: false,
+                owned: false,
+            },
+        });
+        this.dispatchEvent(updatedEvent);
+    }
 }
 
 export interface MenuItemUpdateEvent {
     item: MenuItem;
     inherited: boolean;
+    owned: boolean;
 }
 
 declare global {
     interface GlobalEventHandlersEventMap {
         'sp-menu-item-added': CustomEvent<MenuItemUpdateEvent>;
+        'sp-menu-item-update': CustomEvent<MenuItemUpdateEvent>;
         'sp-menu-item-removed': CustomEvent<MenuItemUpdateEvent>;
     }
 }

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -92,26 +92,41 @@ export class MenuItem extends ActionButton {
 
     protected updated(changes: PropertyValues): void {
         super.updated(changes);
-        if (this.getAttribute('role') === 'option' && changes.has('selected')) {
-            this.setAttribute(
-                'aria-selected',
-                this.selected ? 'true' : 'false'
-            );
+        const role = this.getAttribute('role');
+        if (changes.has('selected')) {
+            if (role === 'option') {
+                this.setAttribute(
+                    'aria-selected',
+                    this.selected ? 'true' : 'false'
+                );
+            } else if (
+                role === 'menuitemcheckbox' ||
+                role === 'menuitemradio'
+            ) {
+                this.setAttribute(
+                    'aria-checked',
+                    this.selected ? 'true' : 'false'
+                );
+            }
         }
+    }
+
+    public updateRole(): void {
+        const queryRoleEvent = new CustomEvent('sp-menu-item-query-role', {
+            bubbles: true,
+            composed: true,
+            detail: {
+                role: '',
+            },
+        });
+        this.dispatchEvent(queryRoleEvent);
+        this.setAttribute('role', queryRoleEvent.detail.role || 'menuitem');
     }
 
     public connectedCallback(): void {
         super.connectedCallback();
         if (!this.hasAttribute('role')) {
-            const queryRoleEvent = new CustomEvent('sp-menu-item-query-role', {
-                bubbles: true,
-                composed: true,
-                detail: {
-                    role: '',
-                },
-            });
-            this.dispatchEvent(queryRoleEvent);
-            this.setAttribute('role', queryRoleEvent.detail.role || 'menuitem');
+            this.updateRole();
         }
     }
 }

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -89,7 +89,8 @@ export class MenuItem extends ActionButton {
 
         // Slot updates happens after the connected callback,
         // so we need to wait a frame before announcing ourselves
-        // or the right menu might not pick this up
+        // or the right menu might not pick this up. E.g. without this
+        // the underlying menu in sp-menu-group won't see this.
         await new Promise((ready) => requestAnimationFrame(ready));
         const addedEvent = new CustomEvent('sp-menu-item-added', {
             bubbles: true,

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -80,13 +80,16 @@ export class MenuItem extends ActionButton {
         `;
     }
 
-    protected async firstUpdated(changes: PropertyValues) {
+    protected firstUpdated(changes: PropertyValues): void {
         this.setAttribute('tabindex', '-1');
         super.firstUpdated(changes);
         if (!this.hasAttribute('id')) {
             this.id = `sp-menu-item-${MenuItem.instanceCount++}`;
         }
+    }
 
+    public async connectedCallback(): Promise<void> {
+        super.connectedCallback();
         // Slot updates happens after the connected callback,
         // so we need to wait a frame before announcing ourselves
         // or the right menu might not pick this up. E.g. without this
@@ -97,7 +100,7 @@ export class MenuItem extends ActionButton {
             composed: true,
             detail: {
                 item: this,
-                inherited: false,
+                owned: false,
             },
         });
         this.dispatchEvent(addedEvent);

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -146,7 +146,6 @@ export class MenuItem extends ActionButton {
             composed: true,
             detail: {
                 item: this,
-                inherited: false,
                 owned: false,
             },
         });
@@ -156,7 +155,6 @@ export class MenuItem extends ActionButton {
 
 export interface MenuItemUpdateEvent {
     item: MenuItem;
-    inherited: boolean;
     owned: boolean;
 }
 

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -30,7 +30,7 @@ const config = {
                 {
                     selector: '.is-selectable',
                     type: 'boolean',
-                    name: 'selectable',
+                    name: 'selects',
                 },
             ],
             slots: [
@@ -55,13 +55,13 @@ const config = {
                 },
                 {
                     replacement:
-                        ':host([dir="ltr"][selectable]) ::slotted(sp-menu-item[selected])',
+                        ':host([dir="ltr"][selects]) ::slotted(sp-menu-item[selected])',
                     selector:
                         '.spectrum-Menu[dir=ltr].is-selectable .spectrum-Menu-item.is-selected',
                 },
                 {
                     replacement:
-                        ':host([dir="rtl"][selectable]) ::slotted(sp-menu-item[selected])',
+                        ':host([dir="rtl"][selects]) ::slotted(sp-menu-item[selected])',
                     selector:
                         '.spectrum-Menu[dir=rtl].is-selectable .spectrum-Menu-item.is-selected',
                 },

--- a/packages/menu/src/spectrum-menu.css
+++ b/packages/menu/src/spectrum-menu.css
@@ -89,15 +89,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     list-style-type: none;
     overflow: auto;
 }
-:host([dir='ltr'][selectable]) ::slotted(sp-menu-item) {
+:host([dir='ltr'][selects]) ::slotted(sp-menu-item) {
     /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item */
     padding-right: var(--spectrum-listitem-selectable-padding-right);
 }
-:host([dir='rtl'][selectable]) ::slotted(sp-menu-item) {
+:host([dir='rtl'][selects]) ::slotted(sp-menu-item) {
     /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item */
     padding-left: var(--spectrum-listitem-selectable-padding-right);
 }
-:host([dir='ltr'][selectable]) ::slotted(sp-menu-item[selected]) {
+:host([dir='ltr'][selects]) ::slotted(sp-menu-item[selected]) {
     /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
     padding-right: calc(
         var(--spectrum-listitem-padding-right) -
@@ -107,7 +107,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     );
 }
-:host([dir='rtl'][selectable]) ::slotted(sp-menu-item[selected]) {
+:host([dir='rtl'][selects]) ::slotted(sp-menu-item[selected]) {
     /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
     padding-left: calc(
         var(--spectrum-listitem-padding-right) -

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -148,7 +148,45 @@ export const Selected = (): TemplateResult => {
                     <sp-menu-item>North Beach</sp-menu-item>
                 </sp-menu-group>
                 <sp-menu-divider></sp-menu-divider>
+                <sp-menu-group selects="single">
+                    <span slot="header">Oakland</span>
+                    <sp-menu-item>City Center</sp-menu-item>
+                    <sp-menu-item disabled>Jack London Square</sp-menu-item>
+                    <sp-menu-item selected>
+                        My best friend's mom's house in the burbs just off
+                        Silverado street
+                    </sp-menu-item>
+                </sp-menu-group>
+            </sp-menu>
+        </sp-popover>
+    `;
+};
+
+export const MenuGroupSelects = (): TemplateResult => {
+    return html`
+        <sp-popover open style="width: 200px;">
+            <sp-menu selects="single">
                 <sp-menu-group>
+                    <span slot="header">Minneapolis</span>
+                    <sp-menu-item>Camden</sp-menu-item>
+                    <sp-menu-item>Cedar Riverside</sp-menu-item>
+                    <sp-menu-item>Downtown</sp-menu-item>
+                    <sp-menu-item>Northeast Arts District</sp-menu-item>
+                    <sp-menu-item>Uptown</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-group>
+                    <span slot="header">St. Paul</span>
+                    <sp-menu-item>Lowertown</sp-menu-item>
+                    <sp-menu-item>Grand Ave</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-group selects="multiple">
+                    <span slot="header">San Francisco</span>
+                    <sp-menu-item>Financial District</sp-menu-item>
+                    <sp-menu-item>South of Market</sp-menu-item>
+                    <sp-menu-item>North Beach</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-group selects="single">
                     <span slot="header">Oakland</span>
                     <sp-menu-item>City Center</sp-menu-item>
                     <sp-menu-item disabled>Jack London Square</sp-menu-item>

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -28,76 +28,93 @@ export default {
 export const Default = (): TemplateResult => {
     return html`
         <sp-menu>
-            <sp-menu-item>
-                Deselect
-            </sp-menu-item>
-            <sp-menu-item>
-                Select Inverse
-            </sp-menu-item>
-            <sp-menu-item>
-                Feather...
-            </sp-menu-item>
-            <sp-menu-item>
-                Select and Mask...
-            </sp-menu-item>
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
             <sp-menu-divider></sp-menu-divider>
-            <sp-menu-item>
-                Save Selection
-            </sp-menu-item>
-            <sp-menu-item disabled>
-                Make Work Path
-            </sp-menu-item>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
         </sp-menu>
 
         <sp-popover open>
             <sp-menu>
-                <sp-menu-item>
-                    Deselect
-                </sp-menu-item>
-                <sp-menu-item>
-                    Select Inverse
-                </sp-menu-item>
-                <sp-menu-item>
-                    Feather...
-                </sp-menu-item>
-                <sp-menu-item>
-                    Select and Mask...
-                </sp-menu-item>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
                 <sp-menu-divider></sp-menu-divider>
-                <sp-menu-item>
-                    Save Selection
-                </sp-menu-item>
-                <sp-menu-item disabled>
-                    Make Work Path
-                </sp-menu-item>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
             </sp-menu>
         </sp-popover>
     `;
 };
 
+export const singleSelect = (): TemplateResult => {
+    return html`
+        <sp-menu selects="single">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-menu>
+
+        <sp-popover open>
+            <sp-menu selects="single">
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-menu>
+        </sp-popover>
+    `;
+};
+
+export const multipleSelect = (): TemplateResult => {
+    return html`
+        <sp-menu selects="multiple">
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item selected>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item selected>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-menu>
+
+        <sp-popover open>
+            <sp-menu selects="multiple">
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item selected>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item selected>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-menu>
+        </sp-popover>
+    `;
+};
 export const headersAndIcons = (): TemplateResult => {
     return html`
         <sp-popover open>
             <sp-menu>
                 <sp-menu-group>
-                    <span slot="header">
-                        Section Heading
-                    </span>
-                    <sp-menu-item>
-                        Action 1
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        Action 2
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        Action 3
-                    </sp-menu-item>
+                    <span slot="header">Section Heading</span>
+                    <sp-menu-item>Action 1</sp-menu-item>
+                    <sp-menu-item>Action 2</sp-menu-item>
+                    <sp-menu-item>Action 3</sp-menu-item>
                 </sp-menu-group>
                 <sp-menu-divider></sp-menu-divider>
                 <sp-menu-group>
-                    <span slot="header">
-                        Section Heading
-                    </span>
+                    <span slot="header">Section Heading</span>
                     <sp-menu-item>
                         <sp-icon-checkmark-circle
                             slot="icon"
@@ -125,30 +142,16 @@ export const Selected = (): TemplateResult => {
         <sp-popover open style="width: 200px;">
             <sp-menu>
                 <sp-menu-group>
-                    <span slot="header">
-                        San Francisco
-                    </span>
-                    <sp-menu-item>
-                        Financial District
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        South of Market
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        North Beach
-                    </sp-menu-item>
+                    <span slot="header">San Francisco</span>
+                    <sp-menu-item>Financial District</sp-menu-item>
+                    <sp-menu-item>South of Market</sp-menu-item>
+                    <sp-menu-item>North Beach</sp-menu-item>
                 </sp-menu-group>
                 <sp-menu-divider></sp-menu-divider>
                 <sp-menu-group>
-                    <span slot="header">
-                        Oakland
-                    </span>
-                    <sp-menu-item>
-                        City Center
-                    </sp-menu-item>
-                    <sp-menu-item disabled>
-                        Jack London Square
-                    </sp-menu-item>
+                    <span slot="header">Oakland</span>
+                    <sp-menu-item>City Center</sp-menu-item>
+                    <sp-menu-item disabled>Jack London Square</sp-menu-item>
                     <sp-menu-item selected>
                         My best friend's mom's house in the burbs just off
                         Silverado street

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -199,3 +199,41 @@ export const MenuGroupSelects = (): TemplateResult => {
         </sp-popover>
     `;
 };
+
+export const MenuGroupSelectsMultiple = (): TemplateResult => {
+    return html`
+        <sp-popover open style="width: 200px;">
+            <sp-menu selects="multiple">
+                <sp-menu-group>
+                    <span slot="header">Minneapolis</span>
+                    <sp-menu-item>Camden</sp-menu-item>
+                    <sp-menu-item>Cedar Riverside</sp-menu-item>
+                    <sp-menu-item>Downtown</sp-menu-item>
+                    <sp-menu-item>Northeast Arts District</sp-menu-item>
+                    <sp-menu-item>Uptown</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-group>
+                    <span slot="header">St. Paul</span>
+                    <sp-menu-item>Lowertown</sp-menu-item>
+                    <sp-menu-item>Grand Ave</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-group selects="none">
+                    <span slot="header">San Francisco</span>
+                    <sp-menu-item>Financial District</sp-menu-item>
+                    <sp-menu-item>South of Market</sp-menu-item>
+                    <sp-menu-item>North Beach</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-group selects="single">
+                    <span slot="header">Oakland</span>
+                    <sp-menu-item>City Center</sp-menu-item>
+                    <sp-menu-item disabled>Jack London Square</sp-menu-item>
+                    <sp-menu-item selected>
+                        My best friend's mom's house in the burbs just off
+                        Silverado street
+                    </sp-menu-item>
+                </sp-menu-group>
+            </sp-menu>
+        </sp-popover>
+    `;
+};

--- a/packages/menu/test/menu-group.test.ts
+++ b/packages/menu/test/menu-group.test.ts
@@ -171,22 +171,18 @@ describe('Menu group', () => {
         expect(secondItem.getAttribute('aria-checked')).to.equal('false');
 
         secondItem.click();
-
         await elementUpdated(el);
         await elementUpdated(firstItem);
         await elementUpdated(secondItem);
-
         expect(firstItem.selected).to.be.false;
         expect(secondItem.selected).to.be.true;
         expect(firstItem.getAttribute('aria-checked')).to.equal('false');
         expect(secondItem.getAttribute('aria-checked')).to.equal('true');
 
         inheritItem1.click();
-
         await elementUpdated(el);
         await elementUpdated(inheritItem1);
         await elementUpdated(secondItem);
-
         expect(secondItem.selected).to.be.false;
         expect(inheritItem1.selected).to.be.true;
         expect(secondItem.getAttribute('aria-checked')).to.equal('false');
@@ -216,5 +212,55 @@ describe('Menu group', () => {
         expect(inheritItem1.selected).to.be.true;
         expect(multiItem1.getAttribute('aria-checked')).to.equal('true');
         expect(multiItem2.getAttribute('aria-checked')).to.equal('true');
+    });
+
+    it('handles changing managed items for selects changes', async () => {
+        const el = await fixture<Menu>(
+            html`
+                <sp-menu selects="multiple">
+                    <sp-menu-item selected>First</sp-menu-item>
+                    <sp-menu-item>Second</sp-menu-item>
+                    <sp-menu-group id="mg-inherit">
+                        <sp-menu-item>Inherit1</sp-menu-item>
+                        <sp-menu-item>Inherit2</sp-menu-item>
+                    </sp-menu-group>
+                </sp-menu>
+            `
+        );
+
+        await waitUntil(
+            () => el.menuItems.length == 4,
+            'expected outer menu to manage 4 items (2 are inherited)'
+        );
+        await waitUntil(
+            () => el.selectedItems.length == 1,
+            'expected 1 selected item'
+        );
+        await elementUpdated(el);
+
+        const inheritGroup = el.querySelector(
+            'sp-menu-group#mg-inherit'
+        ) as MenuGroup;
+        const inheritItem1 = inheritGroup.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const inheritItem2 = inheritGroup.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        expect(inheritItem1.getAttribute('role')).to.equal('menuitemcheckbox');
+        expect(inheritItem2.getAttribute('role')).to.equal('menuitemcheckbox');
+
+        inheritGroup.setAttribute('selects', 'single');
+
+        await elementUpdated(inheritGroup);
+
+        await waitUntil(
+            () => el.menuItems.length == 2,
+            'expected outer menu to manage 2 items and no longer inherit'
+        );
+
+        expect(inheritItem1.getAttribute('role')).to.equal('menuitemradio');
+        expect(inheritItem2.getAttribute('role')).to.equal('menuitemradio');
     });
 });

--- a/packages/menu/test/menu-group.test.ts
+++ b/packages/menu/test/menu-group.test.ts
@@ -13,7 +13,13 @@ import '../sp-menu-group.js';
 import '../sp-menu.js';
 import '../sp-menu-item.js';
 import { Menu, MenuItem, MenuGroup } from '../';
-import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    waitUntil,
+} from '@open-wc/testing';
 
 describe('Menu group', () => {
     it('renders', async () => {
@@ -36,6 +42,10 @@ describe('Menu group', () => {
             `
         );
 
+        await waitUntil(
+            () => el.menuItems.length == 5,
+            'expected menu group to manage 5 children'
+        );
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
@@ -49,6 +59,10 @@ describe('Menu group', () => {
                     <sp-menu-group id="mg-multi" selects="multiple">
                         <sp-menu-item selected>Multi1</sp-menu-item>
                         <sp-menu-item>Multi2</sp-menu-item>
+                        <sp-menu-group id="mg-sub-inherit">
+                            <sp-menu-item>SubInherit1</sp-menu-item>
+                            <sp-menu-item>SubInherit2</sp-menu-item>
+                        </sp-menu-group>
                     </sp-menu-group>
                     <sp-menu-group id="mg-single" selects="single">
                         <sp-menu-item selected>Single1</sp-menu-item>
@@ -66,6 +80,14 @@ describe('Menu group', () => {
             `
         );
 
+        await waitUntil(
+            () => el.menuItems.length == 4,
+            'expected outer menu to manage 4 items (2 are inherited)'
+        );
+        await waitUntil(
+            () => el.selectedItems.length == 1,
+            'expected 1 selected item'
+        );
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -85,16 +107,25 @@ describe('Menu group', () => {
         const multiItem2 = multiGroup.querySelector(
             'sp-menu-item:nth-of-type(2)'
         ) as MenuItem;
+        await waitUntil(
+            () => multiGroup.menuItems.length == 4,
+            'selects="#mg-multi should manage 4 items (2 are inherited)'
+        );
 
         const singleGroup = el.querySelector(
             'sp-menu-group#mg-single'
         ) as MenuGroup;
+
         const singleItem1 = singleGroup.querySelector(
             'sp-menu-item:nth-of-type(1)'
         ) as MenuItem;
         const singleItem2 = singleGroup.querySelector(
             'sp-menu-item:nth-of-type(2)'
         ) as MenuItem;
+        await waitUntil(
+            () => singleGroup.menuItems.length == 2,
+            'selects="#mg-none should manage 4 items (2 are inherited)'
+        );
 
         const noneGroup = el.querySelector(
             'sp-menu-group#mg-none'
@@ -105,6 +136,10 @@ describe('Menu group', () => {
         const noneItem2 = noneGroup.querySelector(
             'sp-menu-item:nth-of-type(2)'
         ) as MenuItem;
+        await waitUntil(
+            () => noneGroup.menuItems.length == 2,
+            'selects="#mg-none should manage 4 items (2 are inherited)'
+        );
 
         const inheritGroup = el.querySelector(
             'sp-menu-group#mg-inherit'
@@ -127,9 +162,11 @@ describe('Menu group', () => {
         expect(inheritItem1.getAttribute('role')).to.equal('menuitemradio');
         expect(inheritItem2.getAttribute('role')).to.equal('menuitemradio');
 
+        await elementUpdated(firstItem);
         expect(singleItem1.selected).to.be.true;
         expect(firstItem.selected).to.be.true;
         expect(secondItem.selected).to.be.false;
+
         expect(firstItem.getAttribute('aria-checked')).to.equal('true');
         expect(secondItem.getAttribute('aria-checked')).to.equal('false');
 
@@ -163,6 +200,7 @@ describe('Menu group', () => {
 
         singleItem2.click();
         await elementUpdated(el);
+        await elementUpdated(singleItem1);
         await elementUpdated(singleItem2);
         expect(singleItem1.selected).to.be.false;
         expect(singleItem2.selected).to.be.true;

--- a/packages/menu/test/menu-group.test.ts
+++ b/packages/menu/test/menu-group.test.ts
@@ -25,7 +25,7 @@ describe('Menu group', () => {
     it('renders', async () => {
         const el = await fixture<Menu>(
             html`
-                <sp-menu>
+                <sp-menu selects="none">
                     <sp-menu-group>
                         <span slot="header">Section Heading</span>
                         <sp-menu-item>Action 1</sp-menu-item>

--- a/packages/menu/test/menu-group.test.ts
+++ b/packages/menu/test/menu-group.test.ts
@@ -223,14 +223,18 @@ describe('Menu group', () => {
                     <sp-menu-group id="mg-inherit">
                         <sp-menu-item>Inherit1</sp-menu-item>
                         <sp-menu-item>Inherit2</sp-menu-item>
+                        <sp-menu-group id="mg-sub-inherit">
+                            <sp-menu-item>SubInherit1</sp-menu-item>
+                            <sp-menu-item>SubInherit2</sp-menu-item>
+                        </sp-menu-group>
                     </sp-menu-group>
                 </sp-menu>
             `
         );
 
         await waitUntil(
-            () => el.menuItems.length == 4,
-            'expected outer menu to manage 4 items (2 are inherited)'
+            () => el.menuItems.length == 6,
+            'expected outer menu to manage 6 items (4 are inherited)'
         );
         await waitUntil(
             () => el.selectedItems.length == 1,
@@ -248,12 +252,33 @@ describe('Menu group', () => {
             'sp-menu-item:nth-of-type(2)'
         ) as MenuItem;
 
+        const subInheritGroup = el.querySelector(
+            'sp-menu-group#mg-sub-inherit'
+        ) as MenuGroup;
+        const subInheritItem1 = subInheritGroup.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const subInheritItem2 = subInheritGroup.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
         expect(inheritItem1.getAttribute('role')).to.equal('menuitemcheckbox');
         expect(inheritItem2.getAttribute('role')).to.equal('menuitemcheckbox');
+        expect(subInheritItem1.getAttribute('role')).to.equal(
+            'menuitemcheckbox'
+        );
+        expect(subInheritItem2.getAttribute('role')).to.equal(
+            'menuitemcheckbox'
+        );
 
         inheritGroup.setAttribute('selects', 'single');
 
         await elementUpdated(inheritGroup);
+
+        await waitUntil(
+            () => inheritGroup.menuItems.length == 4,
+            'expected new single sub-group to manage 4 items'
+        );
 
         await waitUntil(
             () => el.menuItems.length == 2,
@@ -262,5 +287,7 @@ describe('Menu group', () => {
 
         expect(inheritItem1.getAttribute('role')).to.equal('menuitemradio');
         expect(inheritItem2.getAttribute('role')).to.equal('menuitemradio');
+        expect(subInheritItem1.getAttribute('role')).to.equal('menuitemradio');
+        expect(subInheritItem2.getAttribute('role')).to.equal('menuitemradio');
     });
 });

--- a/packages/menu/test/menu-group.test.ts
+++ b/packages/menu/test/menu-group.test.ts
@@ -21,6 +21,10 @@ import {
     waitUntil,
 } from '@open-wc/testing';
 
+const managedItems = (menu: Menu | MenuGroup) => {
+    return menu.childItems.filter((item: any) => item.managed);
+};
+
 describe('Menu group', () => {
     it('renders', async () => {
         const el = await fixture<Menu>(
@@ -43,14 +47,14 @@ describe('Menu group', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 5,
+            () => managedItems(el).length === 5,
             'expected menu group to manage 5 children'
         );
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
     });
-    it('handles selects for nested menu groups', async () => {
+    it.only('handles selects for nested menu groups', async () => {
         const el = await fixture<Menu>(
             html`
                 <sp-menu selects="single">
@@ -81,11 +85,13 @@ describe('Menu group', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 4,
-            'expected outer menu to manage 4 items (2 are inherited)'
+            () => managedItems(el).length === 4,
+            `expected outer menu to manage 4 items (2 are inherited), got ${
+                managedItems(el).length
+            }, with ${el.childItems.length} total`
         );
         await waitUntil(
-            () => el.selectedItems.length == 1,
+            () => el.selectedItems.length === 1,
             'expected 1 selected item'
         );
         await elementUpdated(el);
@@ -108,7 +114,7 @@ describe('Menu group', () => {
             'sp-menu-item:nth-of-type(2)'
         ) as MenuItem;
         await waitUntil(
-            () => multiGroup.menuItems.length == 4,
+            () => managedItems(multiGroup).length === 4,
             'selects="#mg-multi should manage 4 items (2 are inherited)'
         );
 
@@ -123,7 +129,7 @@ describe('Menu group', () => {
             'sp-menu-item:nth-of-type(2)'
         ) as MenuItem;
         await waitUntil(
-            () => singleGroup.menuItems.length == 2,
+            () => managedItems(singleGroup).length === 2,
             'selects="#mg-none should manage 4 items (2 are inherited)'
         );
 
@@ -137,7 +143,7 @@ describe('Menu group', () => {
             'sp-menu-item:nth-of-type(2)'
         ) as MenuItem;
         await waitUntil(
-            () => noneGroup.menuItems.length == 2,
+            () => managedItems(noneGroup).length === 2,
             'selects="#mg-none should manage 4 items (2 are inherited)'
         );
 
@@ -233,8 +239,8 @@ describe('Menu group', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 6,
-            'expected outer menu to manage 6 items (4 are inherited)'
+            () => managedItems(el).length == 6,
+            'expected outer menu to manage 6 items'
         );
         await waitUntil(
             () => el.selectedItems.length == 1,
@@ -276,12 +282,12 @@ describe('Menu group', () => {
         await elementUpdated(inheritGroup);
 
         await waitUntil(
-            () => inheritGroup.menuItems.length == 4,
+            () => managedItems(inheritGroup).length === 4,
             'expected new single sub-group to manage 4 items'
         );
 
         await waitUntil(
-            () => el.menuItems.length == 2,
+            () => managedItems(el).length === 2,
             'expected outer menu to manage 2 items and no longer inherit'
         );
 

--- a/packages/menu/test/menu-group.test.ts
+++ b/packages/menu/test/menu-group.test.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 import '../sp-menu-group.js';
 import '../sp-menu.js';
 import '../sp-menu-item.js';
-import { Menu } from '../';
+import { Menu, MenuItem, MenuGroup } from '../';
 import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
 
 describe('Menu group', () => {
@@ -39,5 +39,144 @@ describe('Menu group', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+    });
+    it('handles selects for nested menu groups', async () => {
+        const el = await fixture<Menu>(
+            html`
+                <sp-menu selects="single">
+                    <sp-menu-item selected>First</sp-menu-item>
+                    <sp-menu-item>Second</sp-menu-item>
+                    <sp-menu-group id="mg-multi" selects="multiple">
+                        <sp-menu-item selected>Multi1</sp-menu-item>
+                        <sp-menu-item>Multi2</sp-menu-item>
+                    </sp-menu-group>
+                    <sp-menu-group id="mg-single" selects="single">
+                        <sp-menu-item selected>Single1</sp-menu-item>
+                        <sp-menu-item>Single2</sp-menu-item>
+                    </sp-menu-group>
+                    <sp-menu-group id="mg-none" selects="none">
+                        <sp-menu-item>Inherit1</sp-menu-item>
+                        <sp-menu-item>Inherit2</sp-menu-item>
+                    </sp-menu-group>
+                    <sp-menu-group id="mg-inherit">
+                        <sp-menu-item>Inherit1</sp-menu-item>
+                        <sp-menu-item>Inherit2</sp-menu-item>
+                    </sp-menu-group>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        const multiGroup = el.querySelector(
+            'sp-menu-group#mg-multi'
+        ) as MenuGroup;
+        const multiItem1 = multiGroup.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const multiItem2 = multiGroup.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        const singleGroup = el.querySelector(
+            'sp-menu-group#mg-single'
+        ) as MenuGroup;
+        const singleItem1 = singleGroup.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const singleItem2 = singleGroup.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        const noneGroup = el.querySelector(
+            'sp-menu-group#mg-none'
+        ) as MenuGroup;
+        const noneItem1 = noneGroup.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const noneItem2 = noneGroup.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        const inheritGroup = el.querySelector(
+            'sp-menu-group#mg-inherit'
+        ) as MenuGroup;
+        const inheritItem1 = inheritGroup.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const inheritItem2 = inheritGroup.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        expect(firstItem.getAttribute('role')).to.equal('menuitemradio');
+        expect(secondItem.getAttribute('role')).to.equal('menuitemradio');
+        expect(multiItem1.getAttribute('role')).to.equal('menuitemcheckbox');
+        expect(multiItem2.getAttribute('role')).to.equal('menuitemcheckbox');
+        expect(singleItem1.getAttribute('role')).to.equal('menuitemradio');
+        expect(singleItem2.getAttribute('role')).to.equal('menuitemradio');
+        expect(noneItem1.getAttribute('role')).to.equal('menuitem');
+        expect(noneItem2.getAttribute('role')).to.equal('menuitem');
+        expect(inheritItem1.getAttribute('role')).to.equal('menuitemradio');
+        expect(inheritItem2.getAttribute('role')).to.equal('menuitemradio');
+
+        expect(singleItem1.selected).to.be.true;
+        expect(firstItem.selected).to.be.true;
+        expect(secondItem.selected).to.be.false;
+        expect(firstItem.getAttribute('aria-checked')).to.equal('true');
+        expect(secondItem.getAttribute('aria-checked')).to.equal('false');
+
+        secondItem.click();
+
+        await elementUpdated(el);
+        await elementUpdated(firstItem);
+        await elementUpdated(secondItem);
+
+        expect(firstItem.selected).to.be.false;
+        expect(secondItem.selected).to.be.true;
+        expect(firstItem.getAttribute('aria-checked')).to.equal('false');
+        expect(secondItem.getAttribute('aria-checked')).to.equal('true');
+
+        inheritItem1.click();
+
+        await elementUpdated(el);
+        await elementUpdated(inheritItem1);
+        await elementUpdated(secondItem);
+
+        expect(secondItem.selected).to.be.false;
+        expect(inheritItem1.selected).to.be.true;
+        expect(secondItem.getAttribute('aria-checked')).to.equal('false');
+        expect(inheritItem1.getAttribute('aria-checked')).to.equal('true');
+
+        noneItem2.click();
+        await elementUpdated(el);
+        await elementUpdated(noneItem2);
+        expect(inheritItem1.selected).to.be.true;
+        expect(noneItem2.selected).to.be.false;
+
+        singleItem2.click();
+        await elementUpdated(el);
+        await elementUpdated(singleItem2);
+        expect(singleItem1.selected).to.be.false;
+        expect(singleItem2.selected).to.be.true;
+        expect(inheritItem1.selected).to.be.true;
+        expect(singleItem1.getAttribute('aria-checked')).to.equal('false');
+        expect(singleItem2.getAttribute('aria-checked')).to.equal('true');
+
+        multiItem2.click();
+        await elementUpdated(el);
+        await elementUpdated(multiItem2);
+        expect(multiItem1.selected).to.be.true;
+        expect(multiItem2.selected).to.be.true;
+        expect(inheritItem1.selected).to.be.true;
+        expect(multiItem1.getAttribute('aria-checked')).to.equal('true');
+        expect(multiItem2.getAttribute('aria-checked')).to.equal('true');
     });
 });

--- a/packages/menu/test/menu-item.test.ts
+++ b/packages/menu/test/menu-item.test.ts
@@ -34,7 +34,7 @@ describe('Menu item', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 1,
+            () => el.childItems.length == 1,
             'expected menu group to manage 1 child'
         );
         await elementUpdated(el);

--- a/packages/menu/test/menu-item.test.ts
+++ b/packages/menu/test/menu-item.test.ts
@@ -15,20 +15,28 @@ import '../sp-menu-item.js';
 import { MenuItem } from '../';
 import '@spectrum-web-components/menu';
 import { Menu } from '@spectrum-web-components/menu';
-import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    waitUntil,
+} from '@open-wc/testing';
 
 describe('Menu item', () => {
     it('renders', async () => {
         const el = await fixture<Menu>(
             html`
                 <sp-menu>
-                    <sp-menu-item selected>
-                        Selected
-                    </sp-menu-item>
+                    <sp-menu-item selected>Selected</sp-menu-item>
                 </sp-menu>
             `
         );
 
+        await waitUntil(
+            () => el.menuItems.length == 1,
+            'expected menu group to manage 1 child'
+        );
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
@@ -47,9 +55,7 @@ describe('Menu item', () => {
     it('no value attribute', async () => {
         const el = await fixture<MenuItem>(
             html`
-                <sp-menu-item selected>
-                    Selected Text
-                </sp-menu-item>
+                <sp-menu-item selected>Selected Text</sp-menu-item>
             `
         );
         expect(el.itemText).to.equal('Selected Text');
@@ -58,9 +64,7 @@ describe('Menu item', () => {
     it('value property', async () => {
         const el = await fixture<MenuItem>(
             html`
-                <sp-menu-item selected>
-                    Selected Text
-                </sp-menu-item>
+                <sp-menu-item selected>Selected Text</sp-menu-item>
             `
         );
         expect(el.itemText).to.equal('Selected Text');

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -126,7 +126,7 @@ describe('Menu', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 6,
+            () => el.childItems.length == 6,
             'expected menu to manage 6 menu items'
         );
         await elementUpdated(el);
@@ -150,7 +150,7 @@ describe('Menu', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 3,
+            () => el.childItems.length == 3,
             'expected menu to manage 3 items'
         );
         await elementUpdated(el);
@@ -176,7 +176,7 @@ describe('Menu', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 6,
+            () => el.childItems.length == 6,
             'expected menu to manage 6 items'
         );
         await elementUpdated(el);
@@ -222,7 +222,7 @@ describe('Menu', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 1,
+            () => el.childItems.length == 1,
             'expected menu to manage 1 item'
         );
         await elementUpdated(el);
@@ -247,7 +247,7 @@ describe('Menu', () => {
         group.append(appendedItem);
 
         await waitUntil(
-            () => el.menuItems.length == 3,
+            () => el.childItems.length == 3,
             'expected menu to manage 3 items'
         );
         await elementUpdated(el);
@@ -278,7 +278,7 @@ describe('Menu', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 3,
+            () => el.childItems.length == 3,
             'expected menu to manage 3 items'
         );
         await elementUpdated(el);
@@ -356,7 +356,7 @@ describe('Menu', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 3,
+            () => el.childItems.length == 3,
             'expected menu to manage 3 items'
         );
         await waitUntil(
@@ -404,7 +404,7 @@ describe('Menu', () => {
         );
 
         await waitUntil(
-            () => el.menuItems.length == 3,
+            () => el.childItems.length == 3,
             'expected menu to manage 3 items'
         );
         await elementUpdated(el);

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -125,6 +125,10 @@ describe('Menu', () => {
             `
         );
 
+        await waitUntil(
+            () => el.menuItems.length == 6,
+            'expected menu to manage 6 menu items'
+        );
         await elementUpdated(el);
 
         const inTabindexElement = el.querySelector(
@@ -145,6 +149,7 @@ describe('Menu', () => {
             `
         );
 
+        await waitUntil(() => el.menuItems.length == 3);
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
@@ -167,6 +172,7 @@ describe('Menu', () => {
             `
         );
 
+        await waitUntil(() => el.menuItems.length == 6);
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -209,6 +215,7 @@ describe('Menu', () => {
             `
         );
 
+        await waitUntil(() => el.menuItems.length == 1);
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -230,6 +237,7 @@ describe('Menu', () => {
         group.prepend(prependedItem);
         group.append(appendedItem);
 
+        await waitUntil(() => el.menuItems.length == 3);
         await elementUpdated(el);
 
         expect(document.activeElement === el).to.be.false;
@@ -257,6 +265,7 @@ describe('Menu', () => {
             `
         );
 
+        await waitUntil(() => el.menuItems.length == 3);
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -331,6 +340,8 @@ describe('Menu', () => {
             `
         );
 
+        await waitUntil(() => el.menuItems.length == 3);
+        await waitUntil(() => el.selectedItems.length == 1);
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -371,6 +382,7 @@ describe('Menu', () => {
             `
         );
 
+        await waitUntil(() => el.menuItems.length == 3);
         await elementUpdated(el);
 
         const firstItem = el.querySelector(

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -149,7 +149,10 @@ describe('Menu', () => {
             `
         );
 
-        await waitUntil(() => el.menuItems.length == 3);
+        await waitUntil(
+            () => el.menuItems.length == 3,
+            'expected menu to manage 3 items'
+        );
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
@@ -172,7 +175,10 @@ describe('Menu', () => {
             `
         );
 
-        await waitUntil(() => el.menuItems.length == 6);
+        await waitUntil(
+            () => el.menuItems.length == 6,
+            'expected menu to manage 6 items'
+        );
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -206,7 +212,7 @@ describe('Menu', () => {
     it('handle focus and late descendent additions', async () => {
         const el = await fixture<Menu>(
             html`
-                <sp-menu>
+                <sp-menu selects="none">
                     <sp-menu-group>
                         <span slot="header">Options</span>
                         <sp-menu-item>Deselect</sp-menu-item>
@@ -215,7 +221,10 @@ describe('Menu', () => {
             `
         );
 
-        await waitUntil(() => el.menuItems.length == 1);
+        await waitUntil(
+            () => el.menuItems.length == 1,
+            'expected menu to manage 1 item'
+        );
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -237,7 +246,10 @@ describe('Menu', () => {
         group.prepend(prependedItem);
         group.append(appendedItem);
 
-        await waitUntil(() => el.menuItems.length == 3);
+        await waitUntil(
+            () => el.menuItems.length == 3,
+            'expected menu to manage 3 items'
+        );
         await elementUpdated(el);
 
         expect(document.activeElement === el).to.be.false;
@@ -265,7 +277,10 @@ describe('Menu', () => {
             `
         );
 
-        await waitUntil(() => el.menuItems.length == 3);
+        await waitUntil(
+            () => el.menuItems.length == 3,
+            'expected menu to manage 3 items'
+        );
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -340,8 +355,14 @@ describe('Menu', () => {
             `
         );
 
-        await waitUntil(() => el.menuItems.length == 3);
-        await waitUntil(() => el.selectedItems.length == 1);
+        await waitUntil(
+            () => el.menuItems.length == 3,
+            'expected menu to manage 3 items'
+        );
+        await waitUntil(
+            () => el.selectedItems.length == 1,
+            'expected menu to have 1 selected item'
+        );
         await elementUpdated(el);
 
         const firstItem = el.querySelector(
@@ -382,7 +403,10 @@ describe('Menu', () => {
             `
         );
 
-        await waitUntil(() => el.menuItems.length == 3);
+        await waitUntil(
+            () => el.menuItems.length == 3,
+            'expected menu to manage 3 items'
+        );
         await elementUpdated(el);
 
         const firstItem = el.querySelector(

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -48,6 +48,8 @@ describe('Menu', () => {
         expect(document.activeElement === anchor, 'child not focused, 1').to.be
             .false;
 
+        expect(el.getAttribute('role')).to.equal('menu');
+
         el.focus();
         await elementUpdated(el);
         expect(document.activeElement === el, 'self not focused, 2').to.be
@@ -135,7 +137,7 @@ describe('Menu', () => {
     it('renders w/ selected', async () => {
         const el = await fixture<Menu>(
             html`
-                <sp-menu>
+                <sp-menu selects="single">
                     <sp-menu-item>Not Selected</sp-menu-item>
                     <sp-menu-item selected>Selected</sp-menu-item>
                     <sp-menu-item>Other</sp-menu-item>
@@ -146,6 +148,8 @@ describe('Menu', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+
+        expect(el.getAttribute('role')).to.equal('menu');
     });
 
     it('handle focus and keyboard input', async () => {
@@ -315,5 +319,96 @@ describe('Menu', () => {
 
         expect(document.activeElement === el);
         expect(firstItem.focused);
+    });
+    it('handles single selection', async () => {
+        const el = await fixture<Menu>(
+            html`
+                <sp-menu selects="single">
+                    <sp-menu-item selected>First</sp-menu-item>
+                    <sp-menu-item>Second</sp-menu-item>
+                    <sp-menu-item>Third</sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        expect(firstItem.getAttribute('role')).to.equal('menuitemradio');
+        expect(secondItem.getAttribute('role')).to.equal('menuitemradio');
+
+        expect(firstItem.selected).to.be.true;
+        expect(secondItem.selected).to.be.false;
+        expect(firstItem.getAttribute('aria-checked')).to.equal('true');
+        expect(secondItem.getAttribute('aria-checked')).to.equal('false');
+
+        secondItem.click();
+
+        await elementUpdated(el);
+        await elementUpdated(firstItem);
+        await elementUpdated(secondItem);
+
+        expect(firstItem.selected).to.be.false;
+        expect(secondItem.selected).to.be.true;
+        expect(firstItem.getAttribute('aria-checked')).to.equal('false');
+        expect(secondItem.getAttribute('aria-checked')).to.equal('true');
+    });
+    it('handles multiple selection', async () => {
+        const el = await fixture<Menu>(
+            html`
+                <sp-menu selects="multiple">
+                    <sp-menu-item selected>First</sp-menu-item>
+                    <sp-menu-item>Second</sp-menu-item>
+                    <sp-menu-item>Third</sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        expect(firstItem.getAttribute('role')).to.equal('menuitemcheckbox');
+        expect(secondItem.getAttribute('role')).to.equal('menuitemcheckbox');
+
+        expect(firstItem.selected).to.be.true;
+        expect(secondItem.selected).to.be.false;
+        expect(firstItem.getAttribute('aria-checked')).to.equal('true');
+        expect(secondItem.getAttribute('aria-checked')).to.equal('false');
+
+        secondItem.click();
+
+        await elementUpdated(el);
+        await elementUpdated(firstItem);
+        await elementUpdated(secondItem);
+
+        expect(firstItem.selected).to.be.true;
+        expect(secondItem.selected).to.be.true;
+        expect(firstItem.getAttribute('aria-checked')).to.equal('true');
+        expect(secondItem.getAttribute('aria-checked')).to.equal('true');
+
+        firstItem.click();
+
+        await elementUpdated(el);
+        await elementUpdated(firstItem);
+        await elementUpdated(secondItem);
+
+        expect(firstItem.selected).to.be.false;
+        expect(secondItem.selected).to.be.true;
+        expect(firstItem.getAttribute('aria-checked')).to.equal('false');
+        expect(secondItem.getAttribute('aria-checked')).to.equal('true');
     });
 });

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -23,6 +23,7 @@ import { reparentChildren } from '@spectrum-web-components/shared';
 import { Color, Scale } from '@spectrum-web-components/theme';
 import styles from './active-overlay.css.js';
 import {
+    OverlayOpenCloseDetail,
     OverlayOpenDetail,
     Placement,
     TriggerInteractions,
@@ -285,6 +286,16 @@ export class ActiveOverlay extends SpectrumElement {
                 if (this.receivesFocus) {
                     this.focus();
                 }
+                this.trigger.dispatchEvent(
+                    new CustomEvent<OverlayOpenCloseDetail>('sp-opened', {
+                        bubbles: true,
+                        composed: true,
+                        cancelable: true,
+                        detail: {
+                            interaction: this.interaction,
+                        },
+                    })
+                );
             });
     }
 

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -237,19 +237,7 @@ export class OverlayStack {
                     const { trigger } = activeOverlay;
                     contentWithLifecycle.overlayOpenCallback({ trigger });
                 }
-                if (details.receivesFocus === 'auto') {
-                    activeOverlay.focus();
-                }
-                details.trigger.dispatchEvent(
-                    new CustomEvent<OverlayOpenCloseDetail>('sp-opened', {
-                        bubbles: true,
-                        composed: true,
-                        cancelable: true,
-                        detail: {
-                            interaction: details.interaction,
-                        },
-                    })
-                );
+                // NOTE: ActiveOverlay will trigger sp-opened after focus has resolved
                 return false;
             }
         );

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -35,7 +35,6 @@ import {
     MenuItem,
     MenuItemUpdateEvent,
     Menu,
-    MenuQueryRoleEventDetail,
 } from '@spectrum-web-components/menu';
 import '@spectrum-web-components/popover/sp-popover.js';
 import { Popover } from '@spectrum-web-components/popover';
@@ -140,15 +139,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             'sp-menu-item-added',
             (event: CustomEvent<MenuItemUpdateEvent>) => {
                 event.stopPropagation();
-                event.detail.item.setAttribute('role', this.itemRole);
-            }
-        );
-
-        this.addEventListener(
-            'sp-menu-query-role',
-            (event: CustomEvent<MenuQueryRoleEventDetail>) => {
-                event.stopPropagation();
-                event.detail.role = this.listRole;
+                event.detail.item.setRole(this.itemRole);
             }
         );
     }

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -281,8 +281,6 @@ export class PickerBase extends SizedMixin(Focusable) {
             };
         });
 
-        this.optionsMenu.selectable = true;
-
         this.sizePopover(this.popover);
         const { popover } = this;
         this.closeOverlay = await Picker.openOverlay(this, 'inline', popover, {
@@ -365,7 +363,11 @@ export class PickerBase extends SizedMixin(Focusable) {
                 @click=${this.onClick}
                 @sp-overlay-closed=${this.onOverlayClosed}
             >
-                <sp-menu id="menu" role="${this.listRole}"></sp-menu>
+                <sp-menu
+                    id="menu"
+                    selects="single"
+                    role="${this.listRole}"
+                ></sp-menu>
             </sp-popover>
         `;
     }

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -358,11 +358,7 @@ export class PickerBase extends SizedMixin(Focusable) {
                 @click=${this.onClick}
                 @sp-overlay-closed=${this.onOverlayClosed}
             >
-                <sp-menu
-                    id="menu"
-                    selects="inherit"
-                    role="${this.listRole}"
-                ></sp-menu>
+                <sp-menu id="menu" role="${this.listRole}"></sp-menu>
             </sp-popover>
         `;
     }

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -355,6 +355,8 @@ export class PickerBase extends SizedMixin(Focusable) {
         `;
     }
 
+    // TODO: switch sp-menu to `selects="inherit"`. This will involve working through
+    // issues around reparenting, selection, & focus.
     protected get renderPopover(): TemplateResult {
         return html`
             <sp-popover
@@ -365,7 +367,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             >
                 <sp-menu
                     id="menu"
-                    selects="single"
+                    selects="inherit"
                     role="${this.listRole}"
                 ></sp-menu>
             </sp-popover>

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -33,7 +33,7 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import '@spectrum-web-components/menu/sp-menu.js';
 import {
     MenuItem,
-    MenuItemQueryRoleEventDetail,
+    MenuItemUpdateEvent,
     Menu,
     MenuQueryRoleEventDetail,
 } from '@spectrum-web-components/menu';
@@ -135,13 +135,15 @@ export class PickerBase extends SizedMixin(Focusable) {
         super();
         this.onKeydown = this.onKeydown.bind(this);
 
+        // TODO: once we switch away from inherits, the underlying sp-menu should manage this.
         this.addEventListener(
-            'sp-menu-item-query-role',
-            (event: CustomEvent<MenuItemQueryRoleEventDetail>) => {
+            'sp-menu-item-added',
+            (event: CustomEvent<MenuItemUpdateEvent>) => {
                 event.stopPropagation();
-                event.detail.role = this.itemRole;
+                event.detail.item.setAttribute('role', this.itemRole);
             }
         );
+
         this.addEventListener(
             'sp-menu-query-role',
             (event: CustomEvent<MenuQueryRoleEventDetail>) => {

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -259,7 +259,7 @@ describe('Picker', () => {
         );
         await elementUpdated(el);
 
-        expect(firstItem.focused, 'not visually focused').to.be.false;
+        expect(firstItem.focused, 'should not visually focused').to.be.false;
 
         el.focus();
         await elementUpdated(el);
@@ -270,7 +270,7 @@ describe('Picker', () => {
         await opened;
 
         expect(el.open).to.be.true;
-        expect(firstItem.focused, 'not visually focused').to.be.true;
+        expect(firstItem.focused, 'should be visually focused').to.be.true;
 
         const closed = oneEvent(el, 'sp-closed');
         await sendKeys({

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -253,6 +253,10 @@ describe('Picker', () => {
 
         const firstItem = el.querySelector('sp-menu-item') as MenuItem;
 
+        await waitUntil(
+            () => el.menuItems.length == 6,
+            'picker should manage 6 menu items'
+        );
         await elementUpdated(el);
 
         expect(firstItem.focused, 'not visually focused').to.be.false;

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -422,15 +422,17 @@ describe('Picker', () => {
         ) as MenuItem;
         const button = el.button as HTMLButtonElement;
 
+        const opened = oneEvent(el, 'sp-opened');
         button.click();
-        await elementUpdated(el);
+        await opened;
 
         expect(el.open).to.be.true;
         expect(el.selectedItem?.itemText).to.be.undefined;
         expect(el.value).to.equal('');
 
+        const closed = oneEvent(el, 'sp-closed');
         secondItem.click();
-        await elementUpdated(el);
+        await closed;
 
         expect(el.open).to.be.false;
         expect(el.selectedItem?.itemText).to.equal('Select Inverse');
@@ -446,15 +448,17 @@ describe('Picker', () => {
         ) as MenuItem;
         const button = el.button as HTMLButtonElement;
 
+        const opened = oneEvent(el, 'sp-opened');
         button.click();
-        await elementUpdated(el);
+        await opened;
 
         expect(el.open).to.be.true;
         expect(el.selectedItem?.itemText).to.be.undefined;
         expect(el.value).to.equal('');
 
+        const closed = oneEvent(el, 'sp-closed');
         secondItem.click();
-        await elementUpdated(el);
+        await closed;
 
         expect(el.open).to.be.false;
         expect(el.selectedItem?.itemText).to.equal('Select Inverse');
@@ -473,29 +477,33 @@ describe('Picker', () => {
         ) as MenuItem;
         const button = el.button as HTMLButtonElement;
 
+        const opened = oneEvent(el, 'sp-opened');
         button.click();
-        await elementUpdated(el);
+        await opened;
 
         expect(el.open).to.be.true;
         expect(el.selectedItem?.itemText).to.be.undefined;
         expect(el.value).to.equal('');
 
+        const closed = oneEvent(el, 'sp-closed');
         secondItem.click();
-        await elementUpdated(el);
+        await closed;
 
         expect(el.open).to.be.false;
         expect(el.selectedItem?.itemText).to.equal('Select Inverse');
         expect(el.value).to.equal('option-2');
 
+        const opened2 = oneEvent(el, 'sp-opened');
         button.click();
-        await elementUpdated(el);
+        await opened2;
 
         expect(el.open).to.be.true;
         expect(el.selectedItem?.itemText).to.equal('Select Inverse');
         expect(el.value).to.equal('option-2');
 
+        const closed2 = oneEvent(el, 'sp-closed');
         firstItem.click();
-        await elementUpdated(el);
+        await closed2;
 
         expect(el.open).to.be.false;
         expect(el.selectedItem?.itemText).to.equal('Deselect');
@@ -512,8 +520,9 @@ describe('Picker', () => {
         ) as MenuItem;
         const button = el.button as HTMLButtonElement;
 
+        const opened = oneEvent(el, 'sp-opened');
         button.click();
-        await elementUpdated(el);
+        await opened;
 
         expect(el.open).to.be.true;
         expect(el.selectedItem?.itemText).to.be.undefined;
@@ -525,8 +534,9 @@ describe('Picker', () => {
             preventChangeSpy();
         });
 
+        const closed = oneEvent(el, 'sp-closed');
         secondItem.click();
-        await elementUpdated(el);
+        await closed;
         await waitUntil(() => el.open, 'reopens picker');
         expect(secondItem.selected, 'selection prevented').to.be.false;
         expect(preventChangeSpy.calledOnce);
@@ -642,7 +652,7 @@ describe('Picker', () => {
         const el = await pickerFixture();
         el.addEventListener('change', (event: Event) => {
             const { value } = event.target as Picker;
-            console.log('change', value);
+            //console.log('change', value);
             selectionSpy(value);
         });
         const button = el.button as HTMLButtonElement;
@@ -679,7 +689,7 @@ describe('Picker', () => {
         const el = await pickerFixture();
         el.addEventListener('change', (event: Event) => {
             const { value } = event.target as Picker;
-            console.log('change', value);
+            //console.log('change', value);
             selectionSpy(value);
         });
         const button = el.button as HTMLButtonElement;
@@ -935,7 +945,7 @@ describe('Picker', () => {
         el.open = true;
 
         await elementUpdated(el);
-        await nextFrame();
+        await waitUntil(() => isMenuActiveElement(), 'first item focused');
         const getParentOffset = (el: HTMLElement): number => {
             const parentScroll = (el.parentElement as HTMLElement).scrollTop;
             const parentOffset = el.offsetTop - parentScroll;


### PR DESCRIPTION
Continued work on **selects** attribute in sp-menu & sp-menu-group

Preview link: https://adixon-1189-menu-prep--spectrum-web-components.netlify.app/

## Description

For this round I've tried to keep the changes as scoped to sp-menu as possible, given that the reparenting in PickerBase is going to be tricky to work through.

I'm stuck on initialization for sub-menus though -- `prepItems` isn't getting called once the slotted items in the underlying `sp-menu-group`'s `sp-menu` are present (meaning that after initializing menu groups always think they have 0 menu items). I've got some new unittests that are failing, and it's pretty easy to see in the storybook for "Menu Group Selects Multiple"

The only (known) work left here outside of that is getting the documentation work.

## Related Issue

Initial work for #1189 
fixes #715

## Motivation and Context

Gets us closer to more useful menus

## How Has This Been Tested?

Storybook & unit tests.

Here's an example of what's failing: the "Oakland" menu group should be single-select but it initializes wrong. If you keep using the menu it eventually starts working properly once `prepItems` has been called correctly.
<img width="222" alt="Screen Shot 2021-05-22 at 11 54 57 AM" src="https://user-images.githubusercontent.com/48841507/119234624-8a4caf00-baf4-11eb-8598-c00f71b358d7.png">

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
