### PR TITLE
fix: no scroll update when managing elements outside of the tab order

### DIFF
--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -126,7 +126,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
     private onPointerdownManagementOfTabIndex(): void {
         if (this.tabIndex === -1) {
             this.tabIndex = 0;
-            this.focus();
+            this.focus({ preventScroll: true });
         }
     }
 
@@ -151,15 +151,15 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         throw new Error('Must implement focusElement getter!');
     }
 
-    public focus(): void {
+    public focus(options?: FocusOptions): void {
         if (this.disabled || !this.focusElement) {
             return;
         }
 
         if (this.focusElement !== this) {
-            this.focusElement.focus();
+            this.focusElement.focus(options);
         } else {
-            HTMLElement.prototype.focus.apply(this);
+            HTMLElement.prototype.focus.apply(this, [options]);
         }
     }
 


### PR DESCRIPTION
## Description
Go here: https://opensource.adobe.com/spectrum-web-components/components/tags
- scroll the nav down a bit
- attempt to navigate to another component
- see the scroll update but not the page
Go here: https://westbrook-focus-options--spectrum-web-components.netlify.app/components/tabs
- do the same
- see it work

Yay!

## Motivation and Context
Links should work.

## How Has This Been Tested?
Manually in the docs site

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
