### PR TITLE
docs(tabs): fixed path to sp-tab-panel in import code block

### DIFF
--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -17,7 +17,7 @@ Import the side effectful registration of `<sp-tabs>`, `<sp-tab>` or `<sp-tab-pa
 ```
 import '@spectrum-web-components/tabs/sp-tabs.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
-import '@spectrum-web-components/tabs/sp-panel.js';
+import '@spectrum-web-components/tabs/sp-tab-panel.js';
 ```
 
 When looking to leverage the `Tabs`, `Tab`, or `TabPanel` base class as a type and/or for extension purposes, do so via:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Typo in the documentation for Tabs had the incorrect import for sp-tab-panel. This was corrected to prevent copy-paste errors or other confusion.

<!--- Describe your changes in detail -->

updated documentation saying
import '@spectrum-web-components/tabs/sp-panel.js';
to
import '@spectrum-web-components/tabs/sp-tab-panel.js';

https://github.com/adobe/spectrum-web-components/issues/1490

## Motivation and Context

I copy-pasted the incorrect value and wanted to save others the same misfortune.

## How Has This Been Tested?

Using the "grip" tool to serve and render Github markdown on local server. Also looked correct in the github fork for this fix.

## Screenshots (if appropriate):

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
