### PR TITLE
fix(textfield): add select() API mapping to shadow DOM element

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -163,6 +163,10 @@ export class TextfieldBase extends Focusable {
         return this.value.toString();
     }
 
+    public select(): void {
+        this.inputElement.select();
+    }
+
     private get renderMultiline(): TemplateResult {
         return html`
             ${this.grows && !this.quiet

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -492,6 +492,21 @@ describe('Textfield', () => {
 
         expect(el.value).to.equal(testValue);
     });
+    it('selects', async () => {
+        const testValue = 'Test Name';
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield value=${testValue}></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+        expect(el.value).to.equal(testValue);
+
+        el.focus();
+        el.select();
+        await sendKeys({ press: 'Backspace' });
+        expect(el.value).to.equal('');
+    });
     it('accepts maxlength', async () => {
         const el = await litFixture<Textfield>(
             html`


### PR DESCRIPTION
## Description
Pass the `select()` method from `sp-textfield` hosts to their `input` children in the shadow DOM.

## Related Issue
fixes #1377 

## Motivation and Context
Enable advanced interactions with the textfield.

## How Has This Been Tested?
- unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
