### PR TITLE
fix(menu): clarify menu internal focus management via preventScroll option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 7e1112cb6b23c5806fce1dafc0a001c2baaf0c96
+        default: af2206f0506c49d7127e6ae9070d8f2359b7e12e
 commands:
     downstream:
         steps:

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -64,10 +64,12 @@ export class Menu extends SpectrumElement {
         this.onClick = this.onClick.bind(this);
         this.addEventListener('click', this.onClick);
         this.addEventListener('focusin', this.startListeningToKeyboard);
-        this.addEventListener('focus', this.focus);
+        this.addEventListener('focus', () =>
+            this.focus({ preventScroll: true })
+        );
     }
 
-    public focus(): void {
+    public focus({ preventScroll }: FocusOptions = {}): void {
         if (
             !this.menuItems.length ||
             this.menuItems.every((item) => item.disabled)
@@ -75,7 +77,11 @@ export class Menu extends SpectrumElement {
             return;
         }
         this.focusMenuItemByOffset(0);
-        super.focus();
+        super.focus({ preventScroll });
+        const selectedItem = this.querySelector('[selected]');
+        if (selectedItem && !preventScroll) {
+            selectedItem.scrollIntoView({ block: 'nearest' });
+        }
     }
 
     private onClick(event: Event): void {
@@ -99,7 +105,7 @@ export class Menu extends SpectrumElement {
             | MenuItem
             | Menu;
         if (activeElement !== this) {
-            this.focus();
+            this.focus({ preventScroll: true });
             if (activeElement && this.focusedItemIndex === 0) {
                 const offset = this.menuItems.indexOf(
                     activeElement as MenuItem
@@ -271,12 +277,6 @@ export class Menu extends SpectrumElement {
         }
         this.observer.observe(this, { childList: true, subtree: true });
         this.updateComplete.then(() => this.prepItems());
-        const selectedItem = this.querySelector('[selected]');
-        if (selectedItem) {
-            requestAnimationFrame(() => {
-                selectedItem.scrollIntoView({ block: 'nearest' });
-            });
-        }
     }
 
     public disconnectedCallback(): void {

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -28,48 +28,24 @@ export default {
 export const Default = (): TemplateResult => {
     return html`
         <sp-menu>
-            <sp-menu-item>
-                Deselect
-            </sp-menu-item>
-            <sp-menu-item>
-                Select Inverse
-            </sp-menu-item>
-            <sp-menu-item>
-                Feather...
-            </sp-menu-item>
-            <sp-menu-item>
-                Select and Mask...
-            </sp-menu-item>
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
             <sp-menu-divider></sp-menu-divider>
-            <sp-menu-item>
-                Save Selection
-            </sp-menu-item>
-            <sp-menu-item disabled>
-                Make Work Path
-            </sp-menu-item>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
         </sp-menu>
 
         <sp-popover open>
             <sp-menu>
-                <sp-menu-item>
-                    Deselect
-                </sp-menu-item>
-                <sp-menu-item>
-                    Select Inverse
-                </sp-menu-item>
-                <sp-menu-item>
-                    Feather...
-                </sp-menu-item>
-                <sp-menu-item>
-                    Select and Mask...
-                </sp-menu-item>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
                 <sp-menu-divider></sp-menu-divider>
-                <sp-menu-item>
-                    Save Selection
-                </sp-menu-item>
-                <sp-menu-item disabled>
-                    Make Work Path
-                </sp-menu-item>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
             </sp-menu>
         </sp-popover>
     `;
@@ -80,24 +56,14 @@ export const headersAndIcons = (): TemplateResult => {
         <sp-popover open>
             <sp-menu>
                 <sp-menu-group>
-                    <span slot="header">
-                        Section Heading
-                    </span>
-                    <sp-menu-item>
-                        Action 1
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        Action 2
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        Action 3
-                    </sp-menu-item>
+                    <span slot="header">Section Heading</span>
+                    <sp-menu-item>Action 1</sp-menu-item>
+                    <sp-menu-item>Action 2</sp-menu-item>
+                    <sp-menu-item>Action 3</sp-menu-item>
                 </sp-menu-group>
                 <sp-menu-divider></sp-menu-divider>
                 <sp-menu-group>
-                    <span slot="header">
-                        Section Heading
-                    </span>
+                    <span slot="header">Section Heading</span>
                     <sp-menu-item>
                         <sp-icon-checkmark-circle
                             slot="icon"
@@ -125,30 +91,16 @@ export const Selected = (): TemplateResult => {
         <sp-popover open style="width: 200px;">
             <sp-menu>
                 <sp-menu-group>
-                    <span slot="header">
-                        San Francisco
-                    </span>
-                    <sp-menu-item>
-                        Financial District
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        South of Market
-                    </sp-menu-item>
-                    <sp-menu-item>
-                        North Beach
-                    </sp-menu-item>
+                    <span slot="header">San Francisco</span>
+                    <sp-menu-item>Financial District</sp-menu-item>
+                    <sp-menu-item>South of Market</sp-menu-item>
+                    <sp-menu-item>North Beach</sp-menu-item>
                 </sp-menu-group>
                 <sp-menu-divider></sp-menu-divider>
                 <sp-menu-group>
-                    <span slot="header">
-                        Oakland
-                    </span>
-                    <sp-menu-item>
-                        City Center
-                    </sp-menu-item>
-                    <sp-menu-item disabled>
-                        Jack London Square
-                    </sp-menu-item>
+                    <span slot="header">Oakland</span>
+                    <sp-menu-item>City Center</sp-menu-item>
+                    <sp-menu-item disabled>Jack London Square</sp-menu-item>
                     <sp-menu-item selected>
                         My best friend's mom's house in the burbs just off
                         Silverado street
@@ -156,5 +108,21 @@ export const Selected = (): TemplateResult => {
                 </sp-menu-group>
             </sp-menu>
         </sp-popover>
+    `;
+};
+
+export const selectedOffPage = (): TemplateResult => {
+    return html`
+        <p style="height: 100vh; padding-bottom: 50px;">
+            In this example the \`&lt;sp-menu-item selected&gt;\` element is off
+            the visible page by default, but does not alter the page scroll on
+            load.
+        </p>
+        <sp-menu>
+            <sp-menu-item selected style="padding-bottom: 50px;">
+                My best friend's mom's house in the burbs just off Silverado
+                street
+            </sp-menu-item>
+        </sp-menu>
     `;
 };

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -255,6 +255,7 @@ export const readonly = (args: StoryArgs): TemplateResult => {
 };
 
 export const custom = (args: StoryArgs): TemplateResult => {
+    const initialState = 'lb1-mo';
     return html`
         <sp-field-label for="picker-state">
             What state do you live in?
@@ -268,10 +269,15 @@ export const custom = (args: StoryArgs): TemplateResult => {
             id="picker-state"
             label="Pick a state"
             ...=${spreadProps(args)}
+            value=${initialState}
         >
             ${states.map(
                 (state) => html`
-                    <sp-menu-item id=${state.id} value=${state.id}>
+                    <sp-menu-item
+                        id=${state.id}
+                        value=${state.id}
+                        ?selected=${state.id === initialState}
+                    >
                         ${state.label}
                     </sp-menu-item>
                 `


### PR DESCRIPTION
## Description
Previously we were `scrollIntoView`ing an `sp-menu-item[selected]` every time the `sp-menu` was connected to the DOM. This causes some inadvertent page scrolling when the `sp-menu` in not the featured content or is in, say, an `sp-popover` that is not `[open]` and also not `display: none;`.

This update correctly leverages the `preventScroll` option in the `focus({preventScroll}: FocusOptions)` method to ensure that internal focus management does not move the scroll which allows us to rely only on direct focus calls without this option to `scrollIntoView`, removing the need to do so at connect time.

Oh, linting also get excited about the touched files...

## Related Issue
fixes #1473

## Motivation and Context
Not all usage is contained in our library and we need to be prepared for unexpected usage.

## How Has This Been Tested?
- this is tested in two new VRT tests
  - `sp-picker` ensures the right item is focused on open by not including `preventScroll`
  - `sp-menu-item` ensure that even though there is a selected item the scroll is not updated.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
