### PR TITLE
Westbrook/action group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 6c944967d75f6c5304cc96df1ea21060dfc2f0be
+        default: 181d8463d1de8a10c6c47d4bf51eb4024c5ea1b4
 commands:
     downstream:
         steps:

--- a/packages/action-group/src/action-group.css
+++ b/packages/action-group/src/action-group.css
@@ -21,3 +21,81 @@ governing permissions and limitations under the License.
     margin-right: 0;
     margin-left: 0;
 }
+
+/**
+ * End Spectrum CSS #795 fixes.
+ */
+
+/**
+ * The following styles correct realities outlined in https://github.com/adobe/spectrum-web-components/issues/1434
+ */
+
+:host([justified]) ::slotted(:not([role])),
+:host([vertical]) ::slotted(:not([role])) {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+}
+
+:host([compact]:not([quiet])) ::slotted(:not([role])) {
+    /* .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item */
+    --spectrum-actionbutton-m-border-radius: 0;
+    --spectrum-actionbutton-s-border-radius: var(
+        --spectrum-actionbutton-m-border-radius
+    );
+    --spectrum-actionbutton-l-border-radius: var(
+        --spectrum-actionbutton-m-border-radius
+    );
+    --spectrum-actionbutton-xl-border-radius: var(
+        --spectrum-actionbutton-m-border-radius
+    );
+}
+
+:host([compact][vertical]:not([quiet])) ::slotted(:not([role]):first-child) {
+    /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+    --spectrum-actionbutton-m-border-radius: var(
+            --spectrum-alias-border-radius-regular
+        )
+        var(--spectrum-alias-border-radius-regular) 0 0;
+}
+
+:host([compact][vertical]:not([quiet])) ::slotted(:not([role]):last-child) {
+    /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+    --spectrum-actionbutton-m-border-radius: 0 0
+        var(--spectrum-alias-border-radius-regular)
+        var(--spectrum-alias-border-radius-regular);
+}
+
+:host([dir='ltr'][compact]:not([quiet]):not([vertical]))
+    ::slotted(:not([role]):first-child) {
+    /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+    --spectrum-actionbutton-m-border-radius: var(
+            --spectrum-alias-border-radius-regular
+        )
+        0 0 var(--spectrum-alias-border-radius-regular);
+}
+
+:host([dir='rtl'][compact]:not([quiet]):not([vertical]))
+    ::slotted(:not([role]):first-child) {
+    /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+    --spectrum-actionbutton-m-border-radius: 0
+        var(--spectrum-alias-border-radius-regular)
+        var(--spectrum-alias-border-radius-regular) 0;
+}
+
+:host([dir='ltr'][compact]:not([quiet]):not([vertical]))
+    ::slotted(:not([role]):last-child) {
+    /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+    --spectrum-actionbutton-m-border-radius: 0
+        var(--spectrum-alias-border-radius-regular)
+        var(--spectrum-alias-border-radius-regular) 0;
+}
+
+:host([dir='rtl'][compact]:not([quiet]):not([vertical]))
+    ::slotted(:not([role]):last-child) {
+    /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+    --spectrum-actionbutton-m-border-radius: var(
+            --spectrum-alias-border-radius-regular
+        )
+        0 0 var(--spectrum-alias-border-radius-regular);
+}

--- a/packages/action-group/stories/action-group-tooltips.stories.ts
+++ b/packages/action-group/stories/action-group-tooltips.stories.ts
@@ -1,0 +1,192 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import { spreadProps } from '@open-wc/lit-helpers';
+
+import '../sp-action-group.js';
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-properties.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-view-all-tags.js';
+import { ActionGroup } from '../src/ActionGroup.js';
+
+export default {
+    title: 'Action Group/Tooltips',
+    component: 'sp-action-group',
+    args: {
+        compact: false,
+        emphasized: false,
+        justified: false,
+        quiet: false,
+        vertical: false,
+        selects: 'none',
+    },
+    argTypes: {
+        compact: {
+            name: 'compact',
+            description:
+                'Visually joins the buttons together to clarify their relationship to one another.',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        emphasized: {
+            name: 'emphasized',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        justified: {
+            name: 'justified',
+            description:
+                'Aligns the action group items to use all the available space on that line.',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        quiet: {
+            name: 'quiet',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        vertical: {
+            name: 'vertical',
+            description: 'Changes the orientation of the action group.',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        selects: {
+            name: 'selects',
+            description:
+                'Whether the elements selects its children and how many it can select at a time.',
+            table: {
+                defaultValue: { summary: '' },
+            },
+            control: {
+                type: 'inline-radio',
+                options: ['none', 'single', 'multiple'],
+            },
+        },
+    },
+};
+
+interface Properties {
+    compact?: boolean;
+    emphasized?: boolean;
+    justified?: boolean;
+    quiet?: boolean;
+    vertical?: boolean;
+    selects?: 'none' | 'single' | 'multiple';
+}
+
+const template = (args: Properties): TemplateResult => {
+    return html`
+        <sp-action-group
+            label="Favorite Color"
+            ...=${spreadProps(args)}
+            @change=${({ target }: Event & { target: ActionGroup }) => {
+                const next = target.nextElementSibling as HTMLDivElement;
+                next.textContent = `Selected: ${JSON.stringify(
+                    target.selected
+                )}`;
+            }}
+        >
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Red</sp-action-button>
+                <sp-tooltip slot="hover-content">
+                    This is a cool color.
+                </sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Green</sp-action-button>
+                <sp-tooltip slot="hover-content">
+                    You wouldn't be wrong.
+                </sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger" value="blue" selected>
+                    Blue
+                </sp-action-button>
+                <sp-tooltip slot="hover-content">The sky in spring.</sp-tooltip>
+            </overlay-trigger>
+            <overlay-trigger>
+                <sp-action-button slot="trigger">Yellow</sp-action-button>
+                <sp-tooltip slot="hover-content">The sun at noon.</sp-tooltip>
+            </overlay-trigger>
+        </sp-action-group>
+        ${args.selects == 'none'
+            ? html``
+            : html`
+                  <div>Selected:</div>
+              `}
+    `;
+};
+
+export const selectsSingle = (args: Properties): TemplateResult =>
+    template(args);
+selectsSingle.args = {
+    compact: true,
+    emphasized: true,
+    selects: 'single',
+};
+
+export const selectsMultiple = (args: Properties): TemplateResult =>
+    template(args);
+selectsMultiple.args = {
+    compact: true,
+    emphasized: true,
+    selects: 'multiple',
+};
+
+export const justified = (args: Properties): TemplateResult => template(args);
+justified.args = {
+    compact: true,
+    emphasized: true,
+    justified: true,
+};
+
+export const vertical = (args: Properties): TemplateResult => template(args);
+vertical.args = {
+    compact: true,
+    emphasized: true,
+    vertical: true,
+};

--- a/packages/action-group/stories/action-group.stories.ts
+++ b/packages/action-group/stories/action-group.stories.ts
@@ -159,43 +159,6 @@ export const selectsSingle = (args: Properties): TemplateResult => {
     `;
 };
 
-export const selectsSingleWithTooltips = (): TemplateResult => {
-    return html`
-        <sp-action-group
-            label="Favorite Color"
-            selects="single"
-            @change=${({ target }: Event & { target: ActionGroup }) => {
-                const next = target.nextElementSibling as HTMLDivElement;
-                next.textContent = `Selected: ${JSON.stringify(
-                    target.selected
-                )}`;
-            }}
-        >
-            <overlay-trigger>
-                <sp-action-button slot="trigger">Red</sp-action-button>
-                <sp-tooltip slot="hover-content">
-                    This is a cool color.
-                </sp-tooltip>
-            </overlay-trigger>
-            <overlay-trigger>
-                <sp-action-button slot="trigger">Green</sp-action-button>
-                <sp-tooltip slot="hover-content">
-                    You wouldn't be wrong.
-                </sp-tooltip>
-            </overlay-trigger>
-            <overlay-trigger>
-                <sp-action-button slot="trigger">Blue</sp-action-button>
-                <sp-tooltip slot="hover-content">The sky in spring.</sp-tooltip>
-            </overlay-trigger>
-            <overlay-trigger>
-                <sp-action-button slot="trigger">Yellow</sp-action-button>
-                <sp-tooltip slot="hover-content">The sun at noon.</sp-tooltip>
-            </overlay-trigger>
-        </sp-action-group>
-        <div>Selected:</div>
-    `;
-};
-
 export const selectsMultiple = (args: Properties): TemplateResult => {
     return html`
         <sp-action-group

--- a/test/visual/story-imports.ts
+++ b/test/visual/story-imports.ts
@@ -14,6 +14,7 @@ export * as AccordionStories from '../../packages/accordion/stories/accordion.st
 export * as ActionBarStories from '../../packages/action-bar/stories/action-bar.stories.js';
 export * as ActionButtonSizesStories from '../../packages/action-button/stories/action-button-sizes.stories.js';
 export * as ActionButtonStories from '../../packages/action-button/stories/action-button.stories.js';
+export * as ActionGroupTooltipStories from '../../packages/action-group/stories/action-group-tooltips.stories.js';
 export * as ActionGroupStories from '../../packages/action-group/stories/action-group.stories.js';
 export * as ActionMenuSizesStories from '../../packages/action-menu/stories/action-menu-sizes.stories.js';
 export * as ActionMenuStories from '../../packages/action-menu/stories/action-menu.stories.js';


### PR DESCRIPTION
## Description
Pass styles updating the application of border radius, justification, and width to button grand children of the Action Group pattern.

## Related Issue
fixes 1434

## Motivation and Context
Needed for delivery in various applications. To be correct.

## How Has This Been Tested?
- VRT screens added to prevent future regressions.

## Screenshots (if appropriate):
Preview site: https://westbrook-action-group--spectrum-web-components.netlify.app/storybook/index.html?path=/story/action-group-tooltips--selects-single
Accepted VRT updates: https://77523-158297197-gh.circle-artifacts.com/0/test/visual/review/index.html#ActionGroupTooltipStories/justified.png

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
