### PR TITLE
fix: use ObserveSlotText mixin to prevent white space from overriding label attribute

### DIFF
--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -45,6 +45,7 @@
     "dependencies": {
         "@spectrum-web-components/base": "^0.4.3",
         "@spectrum-web-components/field-label": "^0.5.0",
+        "@spectrum-web-components/shared": "^0.12.4",
         "tslib": "^2.0.0"
     },
     "devDependencies": {

--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -20,13 +20,14 @@ import {
     SizedMixin,
 } from '@spectrum-web-components/base';
 
+import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import styles from './meter.css.js';
 
 /**
  * @element sp-meter
  */
-export class Meter extends SizedMixin(SpectrumElement) {
+export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
     public static get styles(): CSSResultArray {
         return [styles];
     }
@@ -56,6 +57,7 @@ export class Meter extends SizedMixin(SpectrumElement) {
     protected render(): TemplateResult {
         return html`
             <sp-field-label size=${this.size} class="label">
+                ${this.slotHasContent ? html`` : this.label}
                 <slot>${this.label}</slot>
             </sp-field-label>
             <sp-field-label size=${this.size} class="percentage">

--- a/packages/meter/test/benchmark/basic-test.ts
+++ b/packages/meter/test/benchmark/basic-test.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import '@spectrum-web-components/meter/sp-meter.js';
 import { html } from '@spectrum-web-components/base';
-import { measureFixtureCreation } from '../../../../test/benchmark/helpers';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
     <sp-meter open></sp-meter>

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -23,12 +23,13 @@ import {
 import { streamingListener } from '@spectrum-web-components/base/src/streaming-listener.js';
 
 import sliderStyles from './slider.css.js';
+import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
 import { StyleInfo } from 'lit-html/directives/style-map';
 
 export const variants = ['filled', 'ramp', 'range', 'tick'];
 
-export class Slider extends Focusable {
+export class Slider extends ObserveSlotText(Focusable, '') {
     public static get styles(): CSSResultArray {
         return [sliderStyles];
     }
@@ -137,7 +138,10 @@ export class Slider extends Focusable {
     private renderLabel(): TemplateResult {
         return html`
             <div id="labelContainer">
-                <label id="label" for="input"><slot>${this.label}</slot></label>
+                <label id="label" for="input">
+                    ${this.slotHasContent ? html`` : this.label}
+                    <slot>${this.label}</slot>
+                </label>
                 <output id="value" aria-live="off" for="input">
                     ${this.ariaValueText}
                 </output>

--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -70,14 +70,8 @@ export class Tab extends FocusVisiblePolyfillMixin(
                   `
                 : html``}
             <label id="itemLabel" ?hidden=${!this.hasLabel}>
-                ${!this.slotHasContent
-                    ? html`
-                          ${this.label}
-                          <slot></slot>
-                      `
-                    : html`
-                          <slot>${this.label}</slot>
-                      `}
+                ${this.slotHasContent ? html`` : this.label}
+                <slot>${this.label}</slot>
             </label>
         `;
     }


### PR DESCRIPTION
## Description
Using an attribute fallback value for a default `slot` element can produce unexpected results when there is a text node with whitespace in side of the host element. The `ObserveSlotText` mixin allows us to apply the attribute in a non-replacing location when there is no content in the slotted text node.

## Related Issue
fixes #1113

## Motivation and Context
Labels should be easy.

## How Has This Been Tested?
Passes VRTs and unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
