### PR TITLE
[Color Area] Prevent TinyColor from overriding hue value on HSV/HSL colour formats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 11e0459cd14cde1294eb1564d92c15cea8335d9c
+        default: 7e1112cb6b23c5806fce1dafc0a001c2baaf0c96
 commands:
     downstream:
         steps:

--- a/packages/color-area/README.md
+++ b/packages/color-area/README.md
@@ -36,9 +36,6 @@ The current color formats supported are as follows:
 -   RGB, RGBA
 -   Strings (eg "red", "blue")
 
-**Please note for the following formats: HSV, HSVA, HSL, HSLA**
-When using the HSL or HSV formats, and a color's value (in HSV) is set to 0, or its luminosity (in HSL) is set to 0 or 1, the hue and saturation values may not be preserved by the element's `color` property. This is detailed in the [TinyColor documentation](https://www.npmjs.com/package/@ctrl/tinycolor).
-
 ## Standard
 
 ```html

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -96,12 +96,18 @@ export class ColorArea extends SpectrumElement {
                     const hslString = this._color.toHslString();
                     return hslString.replace(hueExp, `$1${this.hue}`);
                 } else {
-                    return this._color.toHsl();
+                    const { s, l, a } = this._color.toHsl();
+                    return { h: this.hue, s, l, a };
                 }
             case 'hsv':
-                return this._format.isString
-                    ? this._color.toHsvString()
-                    : this._color.toHsv();
+                if (this._format.isString) {
+                    const hueExp = /(^hs[v|va|l|la]\()\d{1,3}/;
+                    const hsvString = this._color.toHsvString();
+                    return hsvString.replace(hueExp, `$1${this.hue}`);
+                } else {
+                    const { s, v, a } = this._color.toHsv();
+                    return { h: this.hue, s, v, a };
+                }
             case 'hex':
             case 'hex3':
             case 'hex4':

--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -14,12 +14,26 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/color-slider/sp-color-slider.js';
 import { ColorSlider } from '@spectrum-web-components/color-slider/src/ColorSlider';
+import { text } from 'express';
+import { string } from 'yargs';
 import '../sp-color-area.js';
 import { ColorArea } from '../src/ColorArea.js';
 
 export default {
     title: 'Color/Area',
     component: 'sp-color-area',
+    argTypes: {
+        color: {
+            name: 'color',
+            type: { name: 'ColorValue', required: 'true' },
+            description: 'The color displayed by the ColorArea.',
+            table: {
+                type: { summary: 'ColorValue' },
+                defaultValue: { summary: '' },
+            },
+            control: 'text',
+        },
+    },
 };
 
 export const Default = (): TemplateResult => {
@@ -39,7 +53,7 @@ export const joint = (): TemplateResult => {
     return html`
         <div>
             <sp-color-area
-                color="#7f3e3e"
+                color="hsv(120, 0, 1)"
                 @input=${({ target }: Event & { target: ColorArea }) => {
                     const next = target.nextElementSibling as ColorSlider;
                     const display = next.nextElementSibling as HTMLElement;
@@ -49,7 +63,7 @@ export const joint = (): TemplateResult => {
                 }}
             ></sp-color-area>
             <sp-color-slider
-                color="#7f3e3e"
+                color="hsv(120, 0, 1)"
                 @input=${({
                     target: { color, previousElementSibling },
                 }: Event & {
@@ -60,7 +74,7 @@ export const joint = (): TemplateResult => {
                     previousElementSibling.color = color;
                 }}
             ></sp-color-slider>
-            <div style="color: #7f3e3e">#7f3e3e</div>
+            <div style="color: hsv(120, 0, 1)">hsv(120, 0, 1)</div>
         </div>
     `;
 };

--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -14,8 +14,6 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/color-slider/sp-color-slider.js';
 import { ColorSlider } from '@spectrum-web-components/color-slider/src/ColorSlider';
-import { text } from 'express';
-import { string } from 'yargs';
 import '../sp-color-area.js';
 import { ColorArea } from '../src/ColorArea.js';
 

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -318,7 +318,7 @@ describe('ColorArea', () => {
         expect(el.x).to.equal(0.53125);
         expect(el.y).to.equal(0.53125);
     });
-    it('retains `hue` value when s = 0 in HSL format', async () => {
+    it('retains `hue` value when s = 0 in HSL string format', async () => {
         const el = await fixture<ColorArea>(
             html`
                 <sp-color-area color="hsl(100, 50%, 50%)"></sp-color-area>
@@ -339,22 +339,100 @@ describe('ColorArea', () => {
         expect(el.x, 'new x').to.equal(0);
         expect(el.y, 'new y').to.equal(0.5);
         expect(el.color).to.equal('hsl(100, 0%, 50%)');
+    });
+    it('retains `hue` value when s = 0 in HSL object format', async () => {
+        let inputColor = { h: 100, s: 0.5, l: 0.5 };
 
-        el.color = { h: 100, s: 0.5, l: 0.5 };
+        const el = await fixture<ColorArea>(
+            html`
+                <sp-color-area .color=${inputColor}></sp-color-area>
+            `
+        );
+
         await elementUpdated(el);
+
+        let outputColor = el.color as { h: number; s: number; l: number };
+        const variance = 0.00005;
 
         expect(el.hue).to.equal(100);
         expect(el.x, 'x').to.equal(0.6666666666666666);
         expect(el.y, 'y').to.equal(0.25);
-        expect(el.color).to.deep.equal({ h: 100, s: 0.5, l: 0.5, a: 1 });
 
-        el.color = { h: 100, s: 0, l: 0.5 };
+        expect(Math.abs(outputColor.h - inputColor.h)).to.be.lessThan(variance);
+        expect(Math.abs(outputColor.s - inputColor.s)).to.be.lessThan(variance);
+        expect(Math.abs(outputColor.l - inputColor.l)).to.be.lessThan(variance);
+
+        inputColor = { h: 100, s: 0, l: 0.5 };
+        el.color = inputColor;
+
         await elementUpdated(el);
+        outputColor = el.color as { h: number; s: number; l: number };
 
         expect(el.hue).to.equal(100);
         expect(el.x, 'x').to.equal(0);
         expect(el.y, 'y').to.equal(0.5);
-        expect(el.color).to.deep.equal({ h: 100, s: 0, l: 0.5, a: 1 });
+
+        expect(Math.abs(outputColor.h - inputColor.h)).to.be.lessThan(variance);
+        expect(Math.abs(outputColor.s - inputColor.s)).to.be.lessThan(variance);
+        expect(Math.abs(outputColor.l - inputColor.l)).to.be.lessThan(variance);
+    });
+    it('retains `hue` value when s = 0 in HSV string format', async () => {
+        const el = await fixture<ColorArea>(
+            html`
+                <sp-color-area color="hsv(100, 50%, 50%)"></sp-color-area>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.hue, 'hue').to.equal(100);
+        expect(el.x, 'x').to.equal(0.5);
+        expect(el.y, 'y').to.equal(0.5);
+        expect(el.color).to.equal('hsv(100, 50%, 50%)');
+
+        el.color = 'hsv(100, 0%, 50%)';
+        await elementUpdated(el);
+
+        expect(el.hue, 'new hue').to.equal(100);
+        expect(el.x, 'new x').to.equal(0);
+        expect(el.y, 'new y').to.equal(0.5);
+        expect(el.color).to.equal('hsv(100, 0%, 50%)');
+    });
+    it('retains `hue` value when s = 0 in HSV object format', async () => {
+        let inputColor = { h: 100, s: 0.5, v: 0.5 };
+
+        const el = await fixture<ColorArea>(
+            html`
+                <sp-color-area .color=${inputColor}></sp-color-area>
+            `
+        );
+
+        await elementUpdated(el);
+
+        let outputColor = el.color as { h: number; s: number; v: number };
+        const variance = 0.00005;
+
+        expect(el.hue).to.equal(100);
+        expect(el.x, 'x').to.equal(0.5);
+        expect(el.y, 'y').to.equal(0.5);
+
+        expect(Math.abs(outputColor.h - inputColor.h)).to.be.lessThan(variance);
+        expect(Math.abs(outputColor.s - inputColor.s)).to.be.lessThan(variance);
+        expect(Math.abs(outputColor.v - inputColor.v)).to.be.lessThan(variance);
+
+        inputColor = { h: 100, s: 0, v: 0.5 };
+        el.color = inputColor;
+
+        await elementUpdated(el);
+        outputColor = el.color as { h: number; s: number; v: number };
+
+        expect(el.hue).to.equal(100);
+        expect(el.x, 'x').to.equal(0);
+        expect(el.y, 'y').to.equal(0.5);
+
+        expect(Math.abs(outputColor.h - inputColor.h)).to.be.lessThan(variance);
+        expect(Math.abs(outputColor.s - inputColor.s)).to.be.lessThan(variance);
+        expect(Math.abs(outputColor.v - inputColor.v)).to.be.lessThan(variance);
     });
     const colorFormats: {
         name: string;

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -50,11 +50,11 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.hue, 'hue').to.equal(100.00000000000003);
+        expect(el.hue, 'hue').to.equal(100);
         expect(el.x, 'x').to.equal(0.6666666666666666);
         expect(el.y, 'y').to.equal(0.25);
     });
-    it('accepts "color" values as hsls', async () => {
+    it('accepts "color" values as hsla', async () => {
         const el = await fixture<ColorArea>(
             html`
                 <sp-color-area color="hsla(100, 50%, 50%, 1)"></sp-color-area>
@@ -317,6 +317,44 @@ describe('ColorArea', () => {
         expect(el.hue).to.equal(0);
         expect(el.x).to.equal(0.53125);
         expect(el.y).to.equal(0.53125);
+    });
+    it('retains `hue` value when s = 0 in HSL format', async () => {
+        const el = await fixture<ColorArea>(
+            html`
+                <sp-color-area color="hsl(100, 50%, 50%)"></sp-color-area>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.hue, 'hue').to.equal(100);
+        expect(el.x, 'x').to.equal(0.6666666666666666);
+        expect(el.y, 'y').to.equal(0.25);
+        expect(el.color).to.equal('hsl(100, 50%, 50%)');
+
+        el.color = 'hsl(100, 0%, 50%)';
+        await elementUpdated(el);
+
+        expect(el.hue, 'new hue').to.equal(100);
+        expect(el.x, 'new x').to.equal(0);
+        expect(el.y, 'new y').to.equal(0.5);
+        expect(el.color).to.equal('hsl(100, 0%, 50%)');
+
+        el.color = { h: 100, s: 0.5, l: 0.5 };
+        await elementUpdated(el);
+
+        expect(el.hue).to.equal(100);
+        expect(el.x, 'x').to.equal(0.6666666666666666);
+        expect(el.y, 'y').to.equal(0.25);
+        expect(el.color).to.deep.equal({ h: 100, s: 0.5, l: 0.5, a: 1 });
+
+        el.color = { h: 100, s: 0, l: 0.5 };
+        await elementUpdated(el);
+
+        expect(el.hue).to.equal(100);
+        expect(el.x, 'x').to.equal(0);
+        expect(el.y, 'y').to.equal(0.5);
+        expect(el.color).to.deep.equal({ h: 100, s: 0, l: 0.5, a: 1 });
     });
     const colorFormats: {
         name: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
TinyColor has a problem where it, upon using HSL/HSV colour models, does not preserve the value of `hue` if the saturation is set to 0. By extracting the `hue` in the `set color()` method, as is done in `sp-color-slider` and `sp-color-wheel`, we can preserve the hue when it's given by the user. In the `get color()` method, we use a RegEx to remove the incorrect `hue` value and replace it with the `hue` property when the colour format is a string. When it is an object, we simply inject the `hue` property into an object and return that. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes https://github.com/adobe/spectrum-web-components/issues/1470

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Getting rid of a long-standing bug. Thanks, TinyColor.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
