### PR TITLE
fix: lint away debugger statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
         "sourceType": "module"
     },
     "rules": {
+        "no-debugger": 2,
         "import/extensions": ["error", "ignorePackages", { "ts": "never" }],
         "import/prefer-default-export": "off",
         "spectrum-web-components/prevent-argument-names": [

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,8 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+STAGED_FILES_TO_LINT=$(git diff --name-only --cached -- "*.ts" "*.js")
+yarn eslint -f pretty $STAGED_FILES_TO_LINT
 yarn analyze:quick
 yarn lint:css
 yarn pretty-quick --staged

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "lint:docs": "eslint -f pretty \"documentation/**/*.ts\"",
         "lint:js": "pretty-quick --pattern \"tasks/**/*.js\" && pretty-quick --pattern \"scripts/**/*.js\"",
         "lint:packagejson": "pretty-quick --pattern package.json packages/*/package.json projects/*/package.json",
-        "lint:ts": "pretty-quick --pattern \"packages/**/*.ts\"",
+        "lint:ts": "pretty-quick --pattern \"packages/**/*.ts\" && eslint -f pretty \"packages/**/*.ts\"",
         "lint:versions": "node ./scripts/lint-versions.js",
         "new-package": "cd projects/templates && plop",
         "postcustom-element-json": "lerna exec --ignore \"{@spectrum-web-components/{base,bundle,icons-ui,icons-workflow,iconset,modal,shared,styles},example-project-rollup,example-project-webpack,swc-templates}\" -- test -f custom-elements.json",

--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -13,6 +13,7 @@
         "plugin:lit-a11y/recommended"
     ],
     "rules": {
+        "no-debugger": 2,
         "spectrum-web-components/prevent-argument-names": [
             "error",
             ["e", "ev", "evt", "err"]

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -27,7 +27,7 @@ import { TinyColor } from '@ctrl/tinycolor';
 
 import styles from './color-area.css.js';
 
-const preventDefault = (event: KeyboardEvent) => event.preventDefault();
+const preventDefault = (event: KeyboardEvent): void => event.preventDefault();
 
 /**
  * @element sp-color-area

--- a/packages/iconset/stories/icons-demo.ts
+++ b/packages/iconset/stories/icons-demo.ts
@@ -30,7 +30,7 @@ export class DelayedReady extends SpectrumElement {
     _delayedReady!: Promise<void>;
     _resolveDelayedReady!: () => void;
 
-    protected render() {
+    protected render(): TemplateResult {
         return html`
             <slot @slotchange=${this.handleSlotchange}></slot>
         `;

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -45,7 +45,6 @@ export class RadioGroup extends FieldGroup {
     }
 
     public focus(): void {
-        debugger;
         if (!this.buttons.length) {
             return;
         }

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -1,3 +1,4 @@
+/* eslint-disable lit-a11y/click-events-have-key-events */
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description
Update linting to catch more thing at commit and CI time, including `debugger` statements.

Remove errant `debugger` statement and a couple of other lint fixes.

## Related Issue
fixes #1510 

## Motivation and Context
It shouldn't `debugger` in production.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
