### PR TITLE
docs: stop keydown propagation when on an input element

### DIFF
--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -193,6 +193,14 @@ export class StoryDecorator extends SpectrumElement {
         }
     }
 
+    protected handleKeydown(event: KeyboardEvent): void {
+        const path = event.composedPath();
+        const hasInput = path.some((node) => node instanceof HTMLInputElement);
+        if (hasInput) {
+            event.stopPropagation();
+        }
+    }
+
     protected render(): TemplateResult {
         return html`
             <sp-theme
@@ -200,6 +208,7 @@ export class StoryDecorator extends SpectrumElement {
                 scale=${this.scale}
                 dir=${this.direction}
                 part="container"
+                @keydown=${this.handleKeydown}
             >
                 <slot @slotchange=${this.checkReady}></slot>
                 ${this.screenshot ? nothing : this.manageTheme}


### PR DESCRIPTION
## Description
`event.stopPropagation()` on `keydown` events in the story decorator that pass through an `<input>` element so that it's easier to experience the full glory of documented elements.

## Related Issue
fixes #1513

## Motivation and Context
Storybook can be greedy about its use of keyboard interactions.

## Types of changes
- [x] docs tooling

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
