### PR TITLE
fix: update role application logic to not overwrite menu* roles

### DIFF
--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -189,10 +189,17 @@ export class ButtonBase extends LikeAnchor(
 
     private manageAnchor(): void {
         if (this.href && this.href.length > 0) {
-            this.removeAttribute('role');
+            if (this.getAttribute('role') === 'button') {
+                this.setAttribute('role', 'link');
+            }
             this.removeEventListener('click', this.shouldProxyClick);
-        } else if (!this.hasAttribute('role')) {
-            this.setAttribute('role', 'button');
+        } else {
+            if (
+                !this.hasAttribute('role') ||
+                this.getAttribute('role') === 'link'
+            ) {
+                this.setAttribute('role', 'button');
+            }
             this.addEventListener('click', this.shouldProxyClick);
         }
     }

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -92,7 +92,12 @@ describe('Button', () => {
         el.href = '#';
 
         await elementUpdated(el);
-        expect(el.hasAttribute('role')).to.be.false;
+        expect(el.getAttribute('role')).to.equal('link');
+
+        el.removeAttribute('href');
+
+        await elementUpdated(el);
+        expect(el.getAttribute('role')).to.equal('button');
     });
     it('allows label to be toggled', async () => {
         const testNode = document.createTextNode('Button');
@@ -178,9 +183,7 @@ describe('Button', () => {
         const clickSpy = spy();
         const el = await fixture<Button>(
             html`
-                <sp-button @click=${() => clickSpy()}>
-                    Button
-                </sp-button>
+                <sp-button @click=${() => clickSpy()}>Button</sp-button>
             `
         );
 

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -148,6 +148,24 @@ describe('Menu', () => {
         await expect(el).to.be.accessible();
     });
 
+    it('renders w/ hrefs', async () => {
+        const el = await fixture<Menu>(
+            html`
+                <sp-menu>
+                    <sp-menu-item href="not-selected.html">
+                        Not Selected
+                    </sp-menu-item>
+                    <sp-menu-item href="selected.html">Selected</sp-menu-item>
+                    <sp-menu-item href="other.html">Other</sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+
     it('handle focus and keyboard input', async () => {
         const el = await fixture<Menu>(
             html`


### PR DESCRIPTION
## Description
Prevent `ButtonBase` from being cavalier with the role of elements that might be managed outside of its knowledge.
- allows `sp-menu-item[href="#"]` and tests it
- updates role related tests in button

## Related Issue
fixes #1508

## Motivation and Context
Removing the `role` is unexpected and endangers the accessibility of delivered content.

## How Has This Been Tested?
- unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
