### PR TITLE
Add change event to color slider

### DIFF
--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -51,7 +51,7 @@ export const joint = (): TemplateResult => {
     return html`
         <div>
             <sp-color-area
-                color="hsv(120, 0, 1)"
+                color="hsv(0, 0, 1)"
                 @input=${({ target }: Event & { target: ColorArea }) => {
                     const next = target.nextElementSibling as ColorSlider;
                     const display = next.nextElementSibling as HTMLElement;
@@ -61,8 +61,8 @@ export const joint = (): TemplateResult => {
                 }}
             ></sp-color-area>
             <sp-color-slider
-                color="hsv(120, 0, 1)"
-                @input=${({
+                color="hsv(0, 0, 1)"
+                @change=${({
                     target: { color, previousElementSibling },
                 }: Event & {
                     target: ColorSlider & {
@@ -72,7 +72,7 @@ export const joint = (): TemplateResult => {
                     previousElementSibling.color = color;
                 }}
             ></sp-color-slider>
-            <div style="color: hsv(120, 0, 1)">hsv(120, 0, 1)</div>
+            <div style="color: #ff0000">hsv(0, 0, 1)</div>
         </div>
     `;
 };

--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -62,7 +62,7 @@ export const joint = (): TemplateResult => {
             ></sp-color-area>
             <sp-color-slider
                 color="hsv(0, 0, 1)"
-                @change=${({
+                @input=${({
                     target: { color, previousElementSibling },
                 }: Event & {
                     target: ColorSlider & {

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -222,7 +222,7 @@ export class ColorSlider extends Focusable {
             Math.max(0, this.sliderHandlePosition + delta)
         );
         this.value = 360 * (this.sliderHandlePosition / 100);
-        this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
+        // this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
     }
 
     private handleKeyup(event: KeyboardEvent): void {
@@ -240,8 +240,8 @@ export class ColorSlider extends Focusable {
         const { valueAsNumber } = event.target;
 
         this.value = valueAsNumber;
-        this.sliderHandlePosition = 100 * (this.value / 360);
-        this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
+        //this.sliderHandlePosition = 100 * (this.value / 360);
+        //this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
 
         this.dispatchEvent(
             new Event('input', {
@@ -263,7 +263,6 @@ export class ColorSlider extends Focusable {
     private boundingClientRect!: DOMRect;
 
     private handlePointerdown(event: PointerEvent): void {
-        console.log('pointer down');
         if (event.button !== 0) {
             event.preventDefault();
             return;
@@ -277,8 +276,6 @@ export class ColorSlider extends Focusable {
     }
 
     private handlePointermove(event: PointerEvent): void {
-        console.log('pointer move');
-
         this.sliderHandlePosition = this.calculateHandlePosition(event);
         this.value = 360 * (this.sliderHandlePosition / 100);
 
@@ -294,8 +291,6 @@ export class ColorSlider extends Focusable {
     }
 
     private handlePointerup(event: PointerEvent): void {
-        console.log('pointer up');
-
         // Retain focus on input element after mouse up to enable keyboard interactions
         (event.target as HTMLElement).releasePointerCapture(event.pointerId);
 
@@ -385,7 +380,7 @@ export class ColorSlider extends Focusable {
                 step=${this.step}
                 aria-label=${this.label}
                 .value=${String(this.value)}
-                @change=${this.handleInputChange}
+                @input=${this.handleInputChange}
                 @keydown=${this.handleKeydown}
                 @keyup=${this.handleKeyup}
                 @focus=${this.handleFocus}
@@ -402,16 +397,12 @@ export class ColorSlider extends Focusable {
     protected updated(changed: PropertyValues): void {
         super.updated(changed);
         if (changed.has('value')) {
-            if (this.value === this.input.valueAsNumber) {
-                this.dispatchEvent(
-                    new Event('input', {
-                        bubbles: true,
-                        composed: true,
-                    })
-                );
-            } else {
-                this.value = this.input.valueAsNumber;
-            }
+            this.dispatchEvent(
+                new Event('input', {
+                    bubbles: true,
+                    composed: true,
+                })
+            );
         }
     }
 }

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -242,6 +242,14 @@ export class ColorSlider extends Focusable {
         this.value = valueAsNumber;
         this.sliderHandlePosition = 100 * (this.value / 360);
         this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
+
+        this.dispatchEvent(
+            new Event('input', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
     }
 
     private handleFocus(): void {
@@ -255,6 +263,7 @@ export class ColorSlider extends Focusable {
     private boundingClientRect!: DOMRect;
 
     private handlePointerdown(event: PointerEvent): void {
+        console.log('pointer down');
         if (event.button !== 0) {
             event.preventDefault();
             return;
@@ -268,6 +277,8 @@ export class ColorSlider extends Focusable {
     }
 
     private handlePointermove(event: PointerEvent): void {
+        console.log('pointer move');
+
         this.sliderHandlePosition = this.calculateHandlePosition(event);
         this.value = 360 * (this.sliderHandlePosition / 100);
 
@@ -283,6 +294,8 @@ export class ColorSlider extends Focusable {
     }
 
     private handlePointerup(event: PointerEvent): void {
+        console.log('pointer up');
+
         // Retain focus on input element after mouse up to enable keyboard interactions
         (event.target as HTMLElement).releasePointerCapture(event.pointerId);
 
@@ -384,5 +397,21 @@ export class ColorSlider extends Focusable {
     protected firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.boundingClientRect = this.getBoundingClientRect();
+    }
+
+    protected updated(changed: PropertyValues): void {
+        super.updated(changed);
+        if (changed.has('value')) {
+            if (this.value === this.input.valueAsNumber) {
+                this.dispatchEvent(
+                    new Event('input', {
+                        bubbles: true,
+                        composed: true,
+                    })
+                );
+            } else {
+                this.value = this.input.valueAsNumber;
+            }
+        }
     }
 }

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -365,7 +365,7 @@ export class ColorSlider extends Focusable {
                 step=${this.step}
                 aria-label=${this.label}
                 .value=${String(this.value)}
-                @input=${this.handleInputChange}
+                @change=${this.handleInputChange}
                 @keydown=${this.handleKeydown}
                 @keyup=${this.handleKeyup}
                 @focus=${this.handleFocus}

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -227,7 +227,9 @@ export class ColorSlider extends Focusable {
         }
     }
 
-    private handleInput(event: Event & { target: HTMLInputElement }): void {
+    private handleInputChange(
+        event: Event & { target: HTMLInputElement }
+    ): void {
         const { valueAsNumber } = event.target;
 
         this.value = valueAsNumber;
@@ -342,7 +344,7 @@ export class ColorSlider extends Focusable {
             </div>
             <sp-color-handle
                 class="handle"
-                color="hsl(${this._color.toHsl().h}, 100%, 50%)"
+                color="hsl(${this.value}, 100%, 50%)"
                 ?disabled=${this.disabled}
                 style="${this.vertical ? 'top' : 'left'}: ${this
                     .sliderHandlePosition}%"
@@ -363,7 +365,7 @@ export class ColorSlider extends Focusable {
                 step=${this.step}
                 aria-label=${this.label}
                 .value=${String(this.value)}
-                @input=${this.handleInput}
+                @input=${this.handleInputChange}
                 @keydown=${this.handleKeydown}
                 @keyup=${this.handleKeyup}
                 @focus=${this.handleFocus}

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -103,13 +103,23 @@ export class ColorSlider extends Focusable {
             case 'name':
                 return this._color.toName() || this._color.toRgbString();
             case 'hsl':
-                return this._format.isString
-                    ? this._color.toHslString()
-                    : this._color.toHsl();
+                if (this._format.isString) {
+                    const hueExp = /(^hs[v|va|l|la]\()\d{1,3}/;
+                    const hslString = this._color.toHslString();
+                    return hslString.replace(hueExp, `$1${this.value}`);
+                } else {
+                    const { s, l, a } = this._color.toHsl();
+                    return { h: this.value, s, l, a };
+                }
             case 'hsv':
-                return this._format.isString
-                    ? this._color.toHsvString()
-                    : this._color.toHsv();
+                if (this._format.isString) {
+                    const hueExp = /(^hs[v|va|l|la]\()\d{1,3}/;
+                    const hsvString = this._color.toHsvString();
+                    return hsvString.replace(hueExp, `$1${this.value}`);
+                } else {
+                    const { s, v, a } = this._color.toHsv();
+                    return { h: this.value, s, v, a };
+                }
             default:
                 return 'No color format applied.';
         }
@@ -145,9 +155,6 @@ export class ColorSlider extends Focusable {
             const colorInput = this._color.originalInput;
             const colorValues = Object.values(colorInput);
             this.value = colorValues[0];
-
-            // The below code line causes some tests to fail
-            //this.value = parseFloat((color as HSV).h.toString());
         } else {
             const { h } = this._color.toHsv();
             this.value = h;

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -80,6 +80,8 @@ describe('ColorSlider', () => {
         input.dispatchEvent(arrowUpKeyupEvent);
 
         await elementUpdated(el);
+        await elementUpdated(el);
+        await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(2);
 
@@ -448,7 +450,7 @@ describe('ColorSlider', () => {
 
         expect(el.sliderHandlePosition).to.equal(46.875);
     });
-    it('accepts change events', async () => {
+    it('accepts input events', async () => {
         const el = await fixture<ColorSlider>(
             html`
                 <sp-color-slider></sp-color-slider>
@@ -461,7 +463,7 @@ describe('ColorSlider', () => {
 
         const input = el.shadowRoot.querySelector('input') as HTMLInputElement;
         input.value = '300';
-        input.dispatchEvent(new Event('change'));
+        input.dispatchEvent(new Event('input'));
 
         await elementUpdated(el);
 

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -448,6 +448,26 @@ describe('ColorSlider', () => {
 
         expect(el.sliderHandlePosition).to.equal(46.875);
     });
+    it('accepts change events', async () => {
+        const el = await fixture<ColorSlider>(
+            html`
+                <sp-color-slider></sp-color-slider>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(0);
+
+        const input = el.shadowRoot.querySelector('input') as HTMLInputElement;
+        input.value = '300';
+        input.dispatchEvent(new Event('change'));
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(300);
+    });
+
     const colorFormats: {
         name: string;
         color:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->
The colour slider was not dispatching the input event to its external elements, and thus wasn't properly displaying the hue value when the user adjusts the slider. This can be seen in the current implementation, where adjusting the hue slider in the joint Colour Area story doesn't always match up with what's being shown in the colour area. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes https://github.com/adobe/spectrum-web-components/issues/1469

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Provides a better, less buggy UX

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually and with written tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
