### PR TITLE
Westbrook/slider track

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 26ae0c0f5ea0cd3952923e8c2a0d06cb387ba439
+        default: 242b511dd488518b5c3d901c5671478b02d12204
 commands:
     downstream:
         steps:

--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -348,6 +348,12 @@ export class HandleController implements Controller {
         this.requestUpdate();
     };
 
+    private onInputKeydown = (event: Event): void => {
+        const input = event.target as InputWithModel;
+        input.model.handle.highlight = true;
+        this.requestUpdate();
+    };
+
     private dispatchChangeEvent(
         input: HTMLInputElement,
         handle: SliderHandle
@@ -446,6 +452,7 @@ export class HandleController implements Controller {
                     @change=${this.onInputChange}
                     @focus=${this.onInputFocus}
                     @blur=${this.onInputBlur}
+                    @keydown=${this.onInputKeydown}
                     .model=${model}
                 />
             </div>

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -110,6 +110,22 @@ governing permissions and limitations under the License.
     ) !important;
 }
 
+/**
+ * Begin workaround for https://github.com/adobe/spectrum-css/issues/1205
+ */
+
+:host([dir='ltr'][variant='range']) .track,
+:host([dir='rtl'][variant='range']) .track {
+    /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track */
+    margin: var(--spectrum-slider-range-track-reset);
+    margin-top: calc(var(--spectrum-slider-track-height) / -2);
+}
+
+/**
+ * End workaround for https://github.com/adobe/spectrum-css/issues/1205
+ */
+
 :host([dir='ltr']) .track:not(:first-of-type):not(:last-of-type) {
     left: var(--spectrum-slider-track-segment-position);
 }


### PR DESCRIPTION
## Description
- ensure that keyboard interaction triggers the `handle-highlight` class on slider handles, the same as `focus` events do
- work around #1527 with a local CSS implementation while we wait for https://github.com/adobe/spectrum-css/issues/1205 to be corrected at the source.

## Related Issue
fixes #1529
refs #1527

## Motivation and Context
Get `<sp-slider-handle>` ready for an immediate release.

## How Has This Been Tested?
- update VRTs
- technically would could add a unit test for #1529 but I'm not a huge fan of the element introspection that would be necessary 

## Screenshots (if appropriate):
https://83465-158297197-gh.circle-artifacts.com/0/test/visual/review/index.html
![image](https://user-images.githubusercontent.com/1156657/121621998-2c4c2100-ca3b-11eb-9cc6-277d73fc5514.png)

## Types of changes
- [x] Polish

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
