### PR TITLE
test: normalize overlay-trigger testing and use oneEvent() to manage timing

### DIFF
--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -50,201 +50,137 @@ const pressEscape = (): void => pressKey('Escape');
 const pressSpace = (): void => pressKey('Space');
 
 describe('Overlay Trigger', () => {
-    let testDiv!: HTMLDivElement;
+    describe('open/close', () => {
+        let testDiv!: HTMLDivElement;
+        let innerTrigger!: OverlayTrigger;
+        let outerTrigger!: OverlayTrigger;
+        let innerButton!: Button;
+        let outerButton!: Button;
+        let innerClickContent!: Popover;
+        let outerClickContent!: Popover;
+        let hoverContent!: HTMLDivElement;
 
-    beforeEach(async () => {
-        testDiv = await fixture<HTMLDivElement>(
-            html`
-                <div>
-                    <style>
-                        body {
-                            display: flex;
-                            align-items: center;
-                            justify-content: center;
-                        }
-                    </style>
-                    <overlay-trigger id="trigger" placement="top">
-                        <sp-button
-                            id="outer-button"
-                            variant="primary"
-                            slot="trigger"
-                        >
-                            Show Popover
-                        </sp-button>
-                        <sp-popover
-                            id="outer-popover"
-                            dialog
-                            slot="click-content"
-                            direction="bottom"
-                            tip
-                            open
-                            tabindex="0"
-                        >
-                            <div class="options-popover-content">
-                                <overlay-trigger
-                                    id="inner-trigger"
-                                    placement="bottom"
-                                >
-                                    <sp-button id="inner-button" slot="trigger">
-                                        Press Me
-                                    </sp-button>
-                                    <sp-popover
-                                        id="inner-popover"
-                                        dialog
-                                        slot="click-content"
-                                        direction="bottom"
-                                        tip
-                                        open
-                                        tabindex="0"
+        beforeEach(async () => {
+            testDiv = await fixture<HTMLDivElement>(
+                html`
+                    <div>
+                        <style>
+                            body {
+                                display: flex;
+                                align-items: center;
+                                justify-content: center;
+                            }
+                        </style>
+                        <overlay-trigger id="trigger" placement="top">
+                            <sp-button
+                                id="outer-button"
+                                variant="primary"
+                                slot="trigger"
+                            >
+                                Show Popover
+                            </sp-button>
+                            <sp-popover
+                                id="outer-popover"
+                                dialog
+                                slot="click-content"
+                                direction="bottom"
+                                tip
+                                open
+                                tabindex="0"
+                            >
+                                <div class="options-popover-content">
+                                    <overlay-trigger
+                                        id="inner-trigger"
+                                        placement="bottom"
                                     >
-                                        <div class="options-popover-content">
-                                            Another Popover
-                                        </div>
-                                    </sp-popover>
-                                </overlay-trigger>
+                                        <sp-button
+                                            id="inner-button"
+                                            slot="trigger"
+                                        >
+                                            Press Me
+                                        </sp-button>
+                                        <sp-popover
+                                            id="inner-popover"
+                                            dialog
+                                            slot="click-content"
+                                            direction="bottom"
+                                            tip
+                                            open
+                                            tabindex="0"
+                                        >
+                                            <div
+                                                class="options-popover-content"
+                                            >
+                                                Another Popover
+                                            </div>
+                                        </sp-popover>
+                                    </overlay-trigger>
+                                </div>
+                            </sp-popover>
+                            <div
+                                id="hover-content"
+                                slot="hover-content"
+                                class="tooltip"
+                                delay="100"
+                            >
+                                Tooltip
                             </div>
-                        </sp-popover>
-                        <div
-                            id="hover-content"
-                            slot="hover-content"
-                            class="tooltip"
-                            delay="100"
-                        >
-                            Tooltip
-                        </div>
-                    </overlay-trigger>
-                </div>
-            `
-        );
-        await elementUpdated(testDiv);
-    });
+                        </overlay-trigger>
+                    </div>
+                `
+            );
+            await elementUpdated(testDiv);
 
-    afterEach(async () => {
-        let activeOverlay = document.querySelector('active-overlay');
-        while (activeOverlay) {
-            activeOverlay.remove();
-            activeOverlay = document.querySelector('active-overlay');
-        }
-        const outerTrigger = testDiv.querySelector(
-            '#trigger'
-        ) as OverlayTrigger;
-        if (outerTrigger) {
+            innerTrigger = testDiv.querySelector(
+                '#inner-trigger'
+            ) as OverlayTrigger;
+            outerTrigger = testDiv.querySelector('#trigger') as OverlayTrigger;
+            innerButton = testDiv.querySelector('#inner-button') as Button;
+            outerButton = testDiv.querySelector('#outer-button') as Button;
+            innerClickContent = testDiv.querySelector(
+                '#inner-popover'
+            ) as Popover;
+            outerClickContent = testDiv.querySelector(
+                '#outer-popover'
+            ) as Popover;
+            hoverContent = testDiv.querySelector(
+                '#hover-content'
+            ) as HTMLDivElement;
+        });
+
+        afterEach(async () => {
             outerTrigger.removeAttribute('type');
-        }
-        const innerTrigger = testDiv.querySelector(
-            '#inner-trigger'
-        ) as OverlayTrigger;
-        if (innerTrigger) {
+            if (outerTrigger.open) {
+                const closed = oneEvent(outerTrigger, 'sp-closed');
+                outerTrigger.open = undefined;
+                await closed;
+            }
             innerTrigger.removeAttribute('type');
-        }
-    });
+            if (innerTrigger.open) {
+                const closed = oneEvent(innerTrigger, 'sp-closed');
+                innerTrigger.open = undefined;
+                await closed;
+            }
+        });
 
-    it('loads', async () => {
-        const popover = testDiv.querySelector('sp-popover');
-        if (!(popover instanceof Popover))
-            throw new Error('popover is not an instance of Popover');
+        it('loads', async () => {
+            if (!(outerClickContent instanceof Popover))
+                throw new Error('popover is not an instance of Popover');
 
-        expect(popover).to.exist;
-        expect(popover.shadowRoot).to.exist;
-        expect(popover.parentElement).to.be.an.instanceOf(OverlayTrigger);
-    });
+            expect(outerClickContent).to.exist;
+            expect(outerClickContent.shadowRoot).to.exist;
+            expect(outerClickContent.parentElement).to.be.an.instanceOf(
+                OverlayTrigger
+            );
+        });
 
-    it('opens a popover', async () => {
-        const button = testDiv.querySelector('#outer-button') as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-
-        expect(isVisible(outerPopover)).to.be.false;
-
-        expect(button).to.exist;
-        button.click();
-
-        // Wait for the DOM node to be stolen and reparented into the overlay
-        await waitForPredicate(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger)
-        );
-
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        expect(isVisible(outerPopover)).to.be.true;
-    });
-
-    it('[disabled] closes a popover', async () => {
-        const el = testDiv.querySelector('#trigger') as OverlayTrigger;
-        const button = testDiv.querySelector('#outer-button') as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-
-        expect(isVisible(outerPopover)).to.be.false;
-        expect(el.disabled).to.be.false;
-
-        expect(button).to.exist;
-        button.click();
-
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger),
-            'Wait for the DOM node to be stolen and reparented into the overlay'
-        );
-
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        expect(isVisible(outerPopover)).to.be.true;
-
-        el.disabled = true;
-
-        await waitUntil(
-            () => outerPopover.parentElement instanceof OverlayTrigger,
-            'Wait for the DOM node to be returned to the overlay trigger'
-        );
-
-        expect(isVisible(outerPopover)).to.be.false;
-        expect(el.disabled).to.be.true;
-    });
-
-    it('resizes a popover', async () => {
-        const button = testDiv.querySelector('#outer-button') as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-
-        expect(isVisible(outerPopover)).to.be.false;
-
-        expect(button).to.exist;
-        button.click();
-
-        // Wait for the DOM node to be stolen and reparented into the overlay
-        await waitForPredicate(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger)
-        );
-
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        expect(isVisible(outerPopover)).to.be.true;
-
-        window.dispatchEvent(new Event('resize'));
-        window.dispatchEvent(new Event('resize'));
-
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        expect(isVisible(outerPopover)).to.be.true;
-    });
-
-    ['inline', 'modal', 'replace'].map((type: string) => {
-        it(`opens a popover - [type="${type}"]`, async () => {
+        it('opens a popover', async () => {
             const button = testDiv.querySelector(
                 '#outer-button'
             ) as HTMLElement;
             const outerPopover = testDiv.querySelector(
                 '#outer-popover'
             ) as Popover;
-            const outerTrigger = testDiv.querySelector(
-                '#trigger'
-            ) as OverlayTrigger;
-            outerTrigger.type = type as Extract<
-                TriggerInteractions,
-                'inline' | 'modal' | 'replace'
-            >;
-            await elementUpdated(outerTrigger);
 
             expect(isVisible(outerPopover)).to.be.false;
 
@@ -261,605 +197,721 @@ describe('Overlay Trigger', () => {
             );
             expect(isVisible(outerPopover)).to.be.true;
         });
+
+        it('[disabled] closes a popover', async () => {
+            expect(isVisible(outerClickContent)).to.be.false;
+            expect(outerTrigger.disabled).to.be.false;
+
+            expect(outerButton).to.exist;
+            outerButton.click();
+
+            await waitUntil(
+                () =>
+                    !(
+                        outerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'Wait for the DOM node to be stolen and reparented into the overlay'
+            );
+
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                OverlayTrigger
+            );
+            expect(isVisible(outerClickContent)).to.be.true;
+
+            outerTrigger.disabled = true;
+
+            await waitUntil(
+                () => outerClickContent.parentElement instanceof OverlayTrigger,
+                'Wait for the DOM node to be returned to the overlay trigger'
+            );
+
+            expect(isVisible(outerClickContent)).to.be.false;
+            expect(outerTrigger.disabled).to.be.true;
+        });
+
+        it('resizes a popover', async () => {
+            expect(isVisible(outerClickContent)).to.be.false;
+
+            expect(outerButton).to.exist;
+            outerButton.click();
+
+            // Wait for the DOM node to be stolen and reparented into the overlay
+            await waitForPredicate(
+                () =>
+                    !(outerClickContent.parentElement instanceof OverlayTrigger)
+            );
+
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                OverlayTrigger
+            );
+            expect(isVisible(outerClickContent)).to.be.true;
+
+            window.dispatchEvent(new Event('resize'));
+            window.dispatchEvent(new Event('resize'));
+
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                OverlayTrigger
+            );
+            expect(isVisible(outerClickContent)).to.be.true;
+        });
+
+        ['inline', 'modal', 'replace'].map((type: string) => {
+            it(`opens a popover - [type="${type}"]`, async () => {
+                outerTrigger.type = type as Extract<
+                    TriggerInteractions,
+                    'inline' | 'modal' | 'replace'
+                >;
+                await elementUpdated(outerTrigger);
+
+                expect(isVisible(outerClickContent)).to.be.false;
+
+                expect(outerButton).to.exist;
+                outerButton.click();
+
+                // Wait for the DOM node to be stolen and reparented into the overlay
+                await waitForPredicate(
+                    () =>
+                        !(
+                            outerClickContent.parentElement instanceof
+                            OverlayTrigger
+                        )
+                );
+
+                expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                    OverlayTrigger
+                );
+                expect(isVisible(outerClickContent)).to.be.true;
+            });
+        });
+
+        it('does not open a hover popover when a click popover is open', async () => {
+            expect(isVisible(outerClickContent), 'outer popover not visible').to
+                .be.false;
+            expect(isVisible(hoverContent), 'hover popover not visible').to.be
+                .false;
+
+            expect(outerButton).to.exist;
+            outerButton.click();
+
+            // Wait for the DOM node to be stolen and reparented into the overlay
+            await waitUntil(
+                () =>
+                    !(outerClickContent.parentElement instanceof OverlayTrigger)
+            );
+
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                OverlayTrigger
+            );
+            expect(isVisible(outerClickContent), 'outer popover visible').to.be
+                .true;
+            expect(isVisible(hoverContent), 'hover popover still not visible')
+                .to.be.false;
+
+            outerButton.dispatchEvent(
+                new Event('mouseenter', {
+                    bubbles: true,
+                    composed: true,
+                })
+            );
+
+            await nextFrame();
+            await waitUntil(
+                () => hoverContent.parentElement instanceof OverlayTrigger,
+                'hover should not open'
+            );
+
+            expect(isVisible(outerClickContent), 'outer popover visible again')
+                .to.be.true;
+            expect(isVisible(hoverContent), 'hover popover not visible again')
+                .to.be.false;
+        });
+
+        it('does not open a popover when [disabled]', async () => {
+            const root = outerTrigger.shadowRoot
+                ? outerTrigger.shadowRoot
+                : outerTrigger;
+            const triggerZone = root.querySelector(
+                '#trigger'
+            ) as HTMLDivElement;
+
+            expect(outerTrigger.disabled).to.be.false;
+            outerButton.click();
+            await waitUntil(
+                () =>
+                    !(
+                        outerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'outer hoverConent stolen and reparented into the overlay'
+            );
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                OverlayTrigger
+            );
+            document.body.click();
+            await waitUntil(
+                () => outerClickContent.parentElement instanceof OverlayTrigger,
+                'outter hoverConent returned to OverlayTrigger'
+            );
+            expect(outerClickContent.parentElement).to.be.an.instanceOf(
+                OverlayTrigger
+            );
+
+            outerTrigger.disabled = true;
+            await elementUpdated(outerTrigger);
+
+            expect(outerTrigger.disabled).to.be.true;
+            expect(outerTrigger.hasAttribute('disabled')).to.be.true;
+            outerButton.click();
+            await waitUntil(
+                () => outerClickContent.parentElement instanceof OverlayTrigger,
+                'outter hoverConent never left'
+            );
+            expect(outerClickContent.parentElement).to.be.an.instanceOf(
+                OverlayTrigger
+            );
+            triggerZone.dispatchEvent(new Event('mouseenter'));
+            await waitUntil(
+                () => outerClickContent.parentElement instanceof OverlayTrigger,
+                'outter hoverConent never left'
+            );
+            expect(outerClickContent.parentElement).to.be.an.instanceOf(
+                OverlayTrigger
+            );
+
+            outerTrigger.disabled = false;
+            await elementUpdated(outerTrigger);
+
+            expect(outerTrigger.disabled).to.be.false;
+            expect(outerTrigger.hasAttribute('disabled')).to.be.false;
+            outerButton.click();
+            await waitUntil(
+                () =>
+                    !(
+                        outerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'outer hoverConent stolen and reparented into the overlay'
+            );
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                OverlayTrigger
+            );
+            outerButton.click();
+            await waitUntil(
+                () => outerClickContent.parentElement instanceof OverlayTrigger,
+                'outter hoverConent returned to OverlayTrigger'
+            );
+            expect(outerClickContent.parentElement).to.be.an.instanceOf(
+                OverlayTrigger
+            );
+        });
+
+        it('opens a nested popover', async () => {
+            expect(isVisible(outerClickContent)).to.be.false;
+            expect(isVisible(innerClickContent)).to.be.false;
+
+            expect(outerButton).to.exist;
+            outerButton.click();
+
+            await waitUntil(
+                () =>
+                    !(
+                        outerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'outer hoverConent stolen and reparented into the overlay'
+            );
+
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                OverlayTrigger
+            );
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(isVisible(innerClickContent)).to.be.false;
+
+            innerButton.click();
+
+            await waitUntil(
+                () =>
+                    !(
+                        innerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'inner hoverConent stolen and reparented into the overlay'
+            );
+
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(isVisible(innerClickContent)).to.be.true;
+        });
+
+        it('focus previous "modal" when closing nested "modal"', async () => {
+            outerTrigger.type = 'modal';
+            innerTrigger.type = 'modal';
+
+            expect(isVisible(outerClickContent), 'outer popover starts closed')
+                .to.be.false;
+            expect(isVisible(innerClickContent), 'inner popover starts closed')
+                .to.be.false;
+
+            expect(outerButton).to.exist;
+            const outerOpen = oneEvent(outerButton, 'sp-opened');
+            outerButton.click();
+            await outerOpen;
+
+            await waitUntil(
+                () =>
+                    !(
+                        outerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'outer hoverConent stolen and reparented into the overlay'
+            );
+
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
+                OverlayTrigger
+            );
+            expect(isVisible(outerClickContent), 'outer popover opens').to.be
+                .true;
+            expect(isVisible(innerClickContent), 'inner popover stays closed')
+                .to.be.false;
+
+            const innerOpen = oneEvent(innerButton, 'sp-opened');
+            innerButton.click();
+            await innerOpen;
+
+            await waitUntil(
+                () =>
+                    !(
+                        innerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'inner hoverConent stolen and reparented into the overlay'
+            );
+
+            expect(isVisible(outerClickContent), 'outer popover stays open').to
+                .be.true;
+            expect(isVisible(innerClickContent), 'inner popover opens').to.be
+                .true;
+
+            const innerClose = oneEvent(innerButton, 'sp-closed');
+            pressEscape();
+            await innerClose;
+
+            await waitUntil(
+                () => innerClickContent.parentElement instanceof OverlayTrigger,
+                'inner hoverConent returned to OverlayTrigger'
+            );
+
+            expect(
+                document.activeElement === outerClickContent,
+                'outer popover recieved focus'
+            ).to.be.true;
+        });
+
+        it('escape closes an open popover', async () => {
+            outerButton.click();
+
+            await waitUntil(
+                () =>
+                    !(
+                        outerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'outer content stolen and reparented'
+            );
+
+            innerButton.click();
+
+            await waitUntil(
+                () =>
+                    !(
+                        innerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'inner content stolen and reparented'
+            );
+
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(isVisible(innerClickContent)).to.be.true;
+
+            pressSpace();
+
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(isVisible(innerClickContent)).to.be.true;
+
+            pressEscape();
+
+            await waitUntil(
+                () => innerClickContent.parentElement instanceof OverlayTrigger,
+                'inner content returned'
+            );
+
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(isVisible(innerClickContent)).to.be.false;
+
+            pressEscape();
+
+            await waitUntil(
+                () => outerClickContent.parentElement instanceof OverlayTrigger,
+                'outer content returned'
+            );
+
+            expect(isVisible(outerClickContent)).to.be.false;
+            expect(isVisible(innerClickContent)).to.be.false;
+        });
+
+        it('click closes an open popover', async () => {
+            outerButton.click();
+
+            await waitUntil(
+                () =>
+                    !(
+                        outerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'outer content stolen and reparented'
+            );
+
+            innerButton.click();
+
+            await waitUntil(
+                () =>
+                    !(
+                        innerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'inner content stolen and reparented'
+            );
+
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(isVisible(innerClickContent)).to.be.true;
+
+            // Test that clicking in the overlay content does not close the overlay
+            // 200ms is slightly more than the overlay animation fade out time (130ms)
+            innerClickContent.click();
+            await aTimeout(200);
+
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(isVisible(innerClickContent)).to.be.true;
+
+            document.body.click();
+
+            // Wait for the DOM node to be put back in its original place
+            await waitUntil(
+                () => innerClickContent.parentElement instanceof OverlayTrigger,
+                'outer content returned'
+            );
+
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(isVisible(innerClickContent)).to.be.false;
+
+            document.body.click();
+
+            // Wait for the DOM node to be put back in its original place
+            await waitUntil(
+                () => outerClickContent.parentElement instanceof OverlayTrigger,
+                'inner content returned'
+            );
+
+            expect(isVisible(outerClickContent)).to.be.false;
+            expect(isVisible(innerClickContent)).to.be.false;
+        });
+
+        it('opens a hover popover', async () => {
+            const root = outerTrigger.shadowRoot
+                ? outerTrigger.shadowRoot
+                : outerTrigger;
+            const triggerZone = root.querySelector(
+                '#trigger'
+            ) as HTMLDivElement;
+
+            expect(triggerZone).to.exist;
+            if (!triggerZone) return;
+
+            expect(outerButton).to.exist;
+            expect(hoverContent).to.exist;
+
+            expect(isVisible(hoverContent)).to.be.false;
+
+            const mouseEnter = new MouseEvent('mouseenter');
+            triggerZone.dispatchEvent(mouseEnter);
+
+            // Wait for the DOM node to be stolen from its original place
+            await waitUntil(
+                () => !(hoverContent.parentElement instanceof OverlayTrigger),
+                'hoverContent stolen'
+            );
+
+            expect(isVisible(hoverContent)).to.be.true;
+
+            const mouseLeave = new MouseEvent('mouseleave');
+            triggerZone.dispatchEvent(mouseLeave);
+
+            // Wait for the DOM node to be put back in its original place
+            await waitUntil(
+                () => hoverContent.parentElement instanceof OverlayTrigger,
+                'hoverContent returned'
+            );
+
+            expect(isVisible(hoverContent)).to.be.false;
+        });
+
+        it('closes a hover popover', async () => {
+            const root = outerTrigger.shadowRoot
+                ? outerTrigger.shadowRoot
+                : outerTrigger;
+            const triggerZone = root.querySelector(
+                '#trigger'
+            ) as HTMLDivElement;
+
+            expect(triggerZone).to.exist;
+            if (!triggerZone) return;
+
+            expect(outerButton).to.exist;
+            expect(hoverContent).to.exist;
+
+            expect(
+                isVisible(hoverContent),
+                'hoverContent should not be visible'
+            ).to.be.false;
+
+            const mouseEnter = new MouseEvent('mouseenter');
+            const mouseLeave = new MouseEvent('mouseleave');
+            triggerZone.dispatchEvent(mouseEnter);
+            await nextFrame();
+            triggerZone.dispatchEvent(mouseLeave);
+
+            await waitUntil(
+                () => isVisible(hoverContent) === false,
+                'hoverContent should still not be visible'
+            );
+        });
+
+        it('dispatches events on open/close', async () => {
+            const openedSpy = spy();
+            const closedSpy = spy();
+
+            outerTrigger.addEventListener('sp-opened', openedSpy);
+            outerTrigger.addEventListener('sp-closed', closedSpy);
+
+            outerButton.click();
+
+            await waitUntil(
+                () =>
+                    !(
+                        outerClickContent.parentElement instanceof
+                        OverlayTrigger
+                    ),
+                'outer content stolen and reparented'
+            );
+
+            await waitUntil(() => openedSpy.calledOnce, 'opened event sent');
+
+            expect(isVisible(outerClickContent)).to.be.true;
+            expect(closed).to.be.false;
+
+            const openedEvent = openedSpy
+                .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
+            expect(openedEvent.detail.interaction).to.equal('click');
+
+            document.body.click();
+
+            // Wait for the DOM node to be put back in its original place
+            await waitUntil(
+                () => outerClickContent.parentElement instanceof OverlayTrigger,
+                'inner content returned'
+            );
+
+            await waitUntil(() => closedSpy.calledOnce, 'closed event sent');
+
+            const closedEvent = closedSpy
+                .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
+            expect(closedEvent.detail.interaction).to.equal('click');
+
+            expect(isVisible(outerClickContent)).to.be.false;
+        });
     });
-
-    it('does not open a hover popover when a click popover is open', async () => {
-        const button = testDiv.querySelector('#outer-button') as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-        const hoverContent = testDiv.querySelector(
-            '#hover-content'
-        ) as HTMLDivElement;
-
-        expect(isVisible(outerPopover), 'outer popover not visible').to.be
-            .false;
-        expect(isVisible(hoverContent), 'hover popover not visible').to.be
-            .false;
-
-        expect(button).to.exist;
-        button.click();
-
-        // Wait for the DOM node to be stolen and reparented into the overlay
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger)
-        );
-
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        expect(isVisible(outerPopover), 'outer popover visible').to.be.true;
-        expect(isVisible(hoverContent), 'hover popover still not visible').to.be
-            .false;
-
-        button.dispatchEvent(
-            new Event('mouseenter', {
-                bubbles: true,
-                composed: true,
-            })
-        );
-
-        await nextFrame();
-        await waitUntil(
-            () => hoverContent.parentElement instanceof OverlayTrigger,
-            'hover should not open'
-        );
-
-        expect(isVisible(outerPopover), 'outer popover visible again').to.be
-            .true;
-        expect(isVisible(hoverContent), 'hover popover not visible again').to.be
-            .false;
-    });
-
-    it('does not open a popover when [disabled]', async () => {
-        const trigger = testDiv.querySelector('#trigger') as OverlayTrigger;
-        const root = trigger.shadowRoot ? trigger.shadowRoot : trigger;
-        const triggerZone = root.querySelector('#trigger') as HTMLDivElement;
-        const button = testDiv.querySelector('#outer-button') as Button;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-
-        expect(trigger.disabled).to.be.false;
-        button.click();
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger),
-            'outer hoverConent stolen and reparented into the overlay'
-        );
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        document.body.click();
-        await waitUntil(
-            () => outerPopover.parentElement instanceof OverlayTrigger,
-            'outter hoverConent returned to OverlayTrigger'
-        );
-        expect(outerPopover.parentElement).to.be.an.instanceOf(OverlayTrigger);
-
-        trigger.disabled = true;
-        await elementUpdated(trigger);
-
-        expect(trigger.disabled).to.be.true;
-        expect(trigger.hasAttribute('disabled')).to.be.true;
-        button.click();
-        await waitUntil(
-            () => outerPopover.parentElement instanceof OverlayTrigger,
-            'outter hoverConent never left'
-        );
-        expect(outerPopover.parentElement).to.be.an.instanceOf(OverlayTrigger);
-        triggerZone.dispatchEvent(new Event('mouseenter'));
-        await waitUntil(
-            () => outerPopover.parentElement instanceof OverlayTrigger,
-            'outter hoverConent never left'
-        );
-        expect(outerPopover.parentElement).to.be.an.instanceOf(OverlayTrigger);
-
-        trigger.disabled = false;
-        await elementUpdated(trigger);
-
-        expect(trigger.disabled).to.be.false;
-        expect(trigger.hasAttribute('disabled')).to.be.false;
-        button.click();
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger),
-            'outer hoverConent stolen and reparented into the overlay'
-        );
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        button.click();
-        await waitUntil(
-            () => outerPopover.parentElement instanceof OverlayTrigger,
-            'outter hoverConent returned to OverlayTrigger'
-        );
-        expect(outerPopover.parentElement).to.be.an.instanceOf(OverlayTrigger);
-    });
-
-    it('opens a nested popover', async () => {
-        const button = testDiv.querySelector('#outer-button') as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-        const innerPopover = testDiv.querySelector('#inner-popover') as Popover;
-
-        expect(isVisible(outerPopover)).to.be.false;
-        expect(isVisible(innerPopover)).to.be.false;
-
-        expect(button).to.exist;
-        button.click();
-
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger),
-            'outer hoverConent stolen and reparented into the overlay'
-        );
-
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(isVisible(innerPopover)).to.be.false;
-
-        const innerButton = document.querySelector(
-            '#inner-button'
-        ) as HTMLElement;
-
-        innerButton.click();
-
-        await waitUntil(
-            () => !(innerPopover.parentElement instanceof OverlayTrigger),
-            'inner hoverConent stolen and reparented into the overlay'
-        );
-
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(isVisible(innerPopover)).to.be.true;
-    });
-
-    it('focus previous "modal" when closing nested "modal"', async () => {
-        const button = testDiv.querySelector('#outer-button') as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-        const innerPopover = testDiv.querySelector('#inner-popover') as Popover;
-        const outerTrigger = testDiv.querySelector(
-            '#trigger'
-        ) as OverlayTrigger;
-        const innerTrigger = testDiv.querySelector(
-            '#inner-trigger'
-        ) as OverlayTrigger;
-
-        outerTrigger.type = 'modal';
-        innerTrigger.type = 'modal';
-
-        expect(isVisible(outerPopover), 'outer popover starts closed').to.be
-            .false;
-        expect(isVisible(innerPopover), 'inner popover starts closed').to.be
-            .false;
-
-        expect(button).to.exist;
-        const outerOpen = oneEvent(button, 'sp-opened');
-        button.click();
-        await outerOpen;
-
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger),
-            'outer hoverConent stolen and reparented into the overlay'
-        );
-
-        expect(outerPopover.parentElement).to.not.be.an.instanceOf(
-            OverlayTrigger
-        );
-        expect(isVisible(outerPopover), 'outer popover opens').to.be.true;
-        expect(isVisible(innerPopover), 'inner popover stays closed').to.be
-            .false;
-
-        const innerButton = document.querySelector(
-            '#inner-button'
-        ) as HTMLElement;
-
-        const innerOpen = oneEvent(innerButton, 'sp-opened');
-        innerButton.click();
-        await innerOpen;
-
-        await waitUntil(
-            () => !(innerPopover.parentElement instanceof OverlayTrigger),
-            'inner hoverConent stolen and reparented into the overlay'
-        );
-
-        expect(isVisible(outerPopover), 'outer popover stays open').to.be.true;
-        expect(isVisible(innerPopover), 'inner popover opens').to.be.true;
-
-        const innerClose = oneEvent(innerButton, 'sp-closed');
-        pressEscape();
-        await innerClose;
-
-        await waitUntil(
-            () => innerPopover.parentElement instanceof OverlayTrigger,
-            'inner hoverConent returned to OverlayTrigger'
-        );
-
-        expect(
-            document.activeElement === outerPopover,
-            'outer popover recieved focus'
-        ).to.be.true;
-    });
-
-    it('escape closes an open popover', async () => {
-        const innerButton = testDiv.querySelector(
-            '#inner-button'
-        ) as HTMLElement;
-        const outerButton = testDiv.querySelector(
-            '#outer-button'
-        ) as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-        const innerPopover = testDiv.querySelector('#inner-popover') as Popover;
-
-        outerButton.click();
-
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger),
-            'outer content stolen and reparented'
-        );
-
-        innerButton.click();
-
-        await waitUntil(
-            () => !(innerPopover.parentElement instanceof OverlayTrigger),
-            'inner content stolen and reparented'
-        );
-
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(isVisible(innerPopover)).to.be.true;
-
-        pressSpace();
-
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(isVisible(innerPopover)).to.be.true;
-
-        pressEscape();
-
-        await waitUntil(
-            () => innerPopover.parentElement instanceof OverlayTrigger,
-            'inner content returned'
-        );
-
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(isVisible(innerPopover)).to.be.false;
-
-        pressEscape();
-
-        await waitUntil(
-            () => outerPopover.parentElement instanceof OverlayTrigger,
-            'outer content returned'
-        );
-
-        expect(isVisible(outerPopover)).to.be.false;
-        expect(isVisible(innerPopover)).to.be.false;
-    });
-
-    it('click closes an open popover', async () => {
-        const innerButton = testDiv.querySelector(
-            '#inner-button'
-        ) as HTMLElement;
-        const outerButton = testDiv.querySelector(
-            '#outer-button'
-        ) as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
-        const innerPopover = testDiv.querySelector('#inner-popover') as Popover;
-
-        outerButton.click();
-
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger),
-            'outer content stolen and reparented'
-        );
-
-        innerButton.click();
-
-        await waitUntil(
-            () => !(innerPopover.parentElement instanceof OverlayTrigger),
-            'inner content stolen and reparented'
-        );
-
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(isVisible(innerPopover)).to.be.true;
-
-        // Test that clicking in the overlay content does not close the overlay
-        // 200ms is slightly more than the overlay animation fade out time (130ms)
-        innerPopover.click();
-        await aTimeout(200);
-
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(isVisible(innerPopover)).to.be.true;
-
-        document.body.click();
-
-        // Wait for the DOM node to be put back in its original place
-        await waitUntil(
-            () => innerPopover.parentElement instanceof OverlayTrigger,
-            'outer content returned'
-        );
-
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(isVisible(innerPopover)).to.be.false;
-
-        document.body.click();
-
-        // Wait for the DOM node to be put back in its original place
-        await waitUntil(
-            () => outerPopover.parentElement instanceof OverlayTrigger,
-            'inner content returned'
-        );
-
-        expect(isVisible(outerPopover)).to.be.false;
-        expect(isVisible(innerPopover)).to.be.false;
-    });
-
-    it('opens a hover popover', async () => {
-        const outerButton = testDiv.querySelector(
-            '#outer-button'
-        ) as HTMLElement;
-        const hoverContent = testDiv.querySelector(
-            '#hover-content'
-        ) as HTMLElement;
-        const outerTrigger = testDiv.querySelector('#trigger') as HTMLElement;
-
-        let triggerShadowDiv: HTMLElement | null = null;
-        if (outerTrigger.shadowRoot) {
-            triggerShadowDiv = outerTrigger.shadowRoot.querySelector('div');
-        }
-
-        expect(triggerShadowDiv).to.exist;
-        if (!triggerShadowDiv) return;
-
-        expect(outerButton).to.exist;
-        expect(hoverContent).to.exist;
-
-        expect(isVisible(hoverContent)).to.be.false;
-
-        const mouseEnter = new MouseEvent('mouseenter');
-        triggerShadowDiv.dispatchEvent(mouseEnter);
-
-        // Wait for the DOM node to be stolen from its original place
-        await waitUntil(
-            () => !(hoverContent.parentElement instanceof OverlayTrigger),
-            'hoverContent stolen'
-        );
-
-        expect(isVisible(hoverContent)).to.be.true;
-
-        const mouseLeave = new MouseEvent('mouseleave');
-        triggerShadowDiv.dispatchEvent(mouseLeave);
-
-        // Wait for the DOM node to be put back in its original place
-        await waitUntil(
-            () => hoverContent.parentElement instanceof OverlayTrigger,
-            'hoverContent returned'
-        );
-
-        expect(isVisible(hoverContent)).to.be.false;
-    });
-
-    it('closes a hover popover', async () => {
-        const outerButton = testDiv.querySelector(
-            '#outer-button'
-        ) as HTMLElement;
-        const hoverContent = testDiv.querySelector(
-            '#hover-content'
-        ) as HTMLElement;
-        const outerTrigger = testDiv.querySelector('#trigger') as HTMLElement;
-
-        let triggerShadowDiv: HTMLElement | null = null;
-        if (outerTrigger.shadowRoot) {
-            triggerShadowDiv = outerTrigger.shadowRoot.querySelector('div');
-        }
-
-        expect(triggerShadowDiv).to.exist;
-        if (!triggerShadowDiv) return;
-
-        expect(outerButton).to.exist;
-        expect(hoverContent).to.exist;
-
-        expect(isVisible(hoverContent), 'hoverContent should not be visible').to
-            .be.false;
-
-        const mouseEnter = new MouseEvent('mouseenter');
-        const mouseLeave = new MouseEvent('mouseleave');
-        triggerShadowDiv.dispatchEvent(mouseEnter);
-        await nextFrame();
-        triggerShadowDiv.dispatchEvent(mouseLeave);
-
-        await waitUntil(
-            () => isVisible(hoverContent) === false,
-            'hoverContent should still not be visible'
-        );
-    });
-
-    it('acquires a `color` and `size` from `sp-theme`', async () => {
-        const el = await fixture<Theme>(html`
-            <sp-theme color="dark">
-                <sp-theme color="light">
-                    <overlay-trigger id="trigger" placement="top">
-                        <sp-button
-                            id="outer-button"
-                            variant="primary"
-                            slot="trigger"
-                        >
-                            Show Popover
-                        </sp-button>
-                        <sp-popover
-                            id="outer-popover"
-                            dialog
-                            slot="click-content"
-                            direction="bottom"
-                            tip
-                            open
-                        >
-                            Popover content!
-                        </sp-popover>
-                    </overlay-trigger>
+    describe('System interactions', () => {
+        afterEach(async () => {
+            const triggers = document.querySelectorAll('overlay-trigger');
+            const closes: Promise<CustomEvent<unknown>>[] = [];
+            triggers.forEach((trigger) => {
+                if (trigger.open) {
+                    const close = oneEvent(trigger, 'sp-closed');
+                    trigger.open = undefined;
+                    closes.push(close);
+                }
+            });
+            await Promise.all(closes);
+        });
+        it('acquires a `color` and `size` from `sp-theme`', async () => {
+            const el = await fixture<Theme>(html`
+                <sp-theme color="dark">
+                    <sp-theme color="light">
+                        <overlay-trigger id="trigger" placement="top">
+                            <sp-button
+                                id="outer-button"
+                                variant="primary"
+                                slot="trigger"
+                            >
+                                Show Popover
+                            </sp-button>
+                            <sp-popover
+                                id="outer-popover"
+                                dialog
+                                slot="click-content"
+                                direction="bottom"
+                                tip
+                                open
+                            >
+                                Popover content!
+                            </sp-popover>
+                        </overlay-trigger>
+                    </sp-theme>
                 </sp-theme>
-            </sp-theme>
-        `);
+            `);
 
-        await elementUpdated(el);
+            await elementUpdated(el);
 
-        expect(document.querySelector('active-overlay')).to.be.null;
+            expect(document.querySelector('active-overlay')).to.be.null;
 
-        const button = el.querySelector('sp-button') as Button;
-        button.click();
+            const button = el.querySelector('sp-button') as Button;
+            const opened = oneEvent(button, 'sp-opened');
+            button.click();
+            await opened;
 
-        await elementUpdated(el);
+            await elementUpdated(el);
 
-        const overlay = document.querySelector(
-            'active-overlay'
-        ) as ActiveOverlay;
+            const overlay = document.querySelector(
+                'active-overlay'
+            ) as ActiveOverlay;
 
-        expect(overlay).to.exist;
-        expect(overlay.color).to.not.equal('dark');
-        expect(overlay.color).to.equal('light');
-    });
+            expect(overlay).to.exist;
+            expect(overlay.color).to.not.equal('dark');
+            expect(overlay.color).to.equal('light');
+        });
+        it('manages multiple layers of `type="modal"', async () => {
+            const el = await fixture(html`
+                <overlay-trigger type="modal" placement="none">
+                    <sp-button slot="trigger" variant="cta">
+                        Toggle Dialog
+                    </sp-button>
+                    <sp-popover dialog slot="click-content">
+                        <overlay-trigger>
+                            <sp-button slot="trigger" variant="primary">
+                                Toggle Dialog
+                            </sp-button>
+                            <sp-popover dialog slot="click-content">
+                                <overlay-trigger type="modal">
+                                    <sp-button
+                                        slot="trigger"
+                                        variant="secondary"
+                                    >
+                                        Toggle Dialog
+                                    </sp-button>
+                                    <sp-popover dialog slot="click-content">
+                                        <p>
+                                            When you get this deep, this
+                                            ActiveOverlay should be the only one
+                                            in [slot="open"].
+                                        </p>
+                                        <p>
+                                            All of the rest of the ActiveOverlay
+                                            elements should have had their
+                                            [slot] attribute removed.
+                                        </p>
+                                        <p>
+                                            Closing this ActiveOverlay should
+                                            replace them...
+                                        </p>
+                                    </sp-popover>
+                                </overlay-trigger>
+                            </sp-popover>
+                        </overlay-trigger>
+                    </sp-popover>
+                </overlay-trigger>
+            `);
+            const overlayTriggers = [...el.querySelectorAll('overlay-trigger')];
+            let activeOverlays = [
+                ...document.querySelectorAll('active-overlay'),
+            ];
+            const triggers = [
+                ...el.querySelectorAll('sp-button[slot="trigger"]'),
+            ] as Button[];
 
-    it('dispatches events on open/close', async () => {
-        const openedSpy = spy();
-        const closedSpy = spy();
+            expect(activeOverlays.length, 'no previous overlays').to.equal(0);
 
-        const el = testDiv.querySelector('#trigger') as OverlayTrigger;
-        const outerButton = testDiv.querySelector(
-            '#outer-button'
-        ) as HTMLElement;
-        const outerPopover = testDiv.querySelector('#outer-popover') as Popover;
+            triggers[0]?.click();
+            await elementUpdated(overlayTriggers[0]);
+            await waitUntil(() => {
+                activeOverlays = [
+                    ...document.querySelectorAll('active-overlay'),
+                ];
+                return activeOverlays.length === 1;
+            }, 'The first `active-overlay` element has been added.');
 
-        el.addEventListener('sp-opened', openedSpy);
-        el.addEventListener('sp-closed', closedSpy);
+            expect(activeOverlays.length).to.equal(1);
+            expect(
+                activeOverlays[0].slot,
+                'first overlay, first time'
+            ).to.equal('open');
 
-        outerButton.click();
+            triggers[1]?.click();
+            await elementUpdated(overlayTriggers[1]);
+            await waitUntil(() => {
+                activeOverlays = [
+                    ...document.querySelectorAll('active-overlay'),
+                ];
+                return activeOverlays.length === 2;
+            }, 'The second `active-overlay` element has been added.');
 
-        await waitUntil(
-            () => !(outerPopover.parentElement instanceof OverlayTrigger),
-            'outer content stolen and reparented'
-        );
+            expect(
+                activeOverlays[0].slot,
+                'first overlay, second time'
+            ).to.equal('open');
+            expect(
+                activeOverlays[1].slot,
+                'second overlay, second time'
+            ).to.equal('open');
 
-        await waitUntil(() => openedSpy.calledOnce, 'opened event sent');
+            triggers[2]?.click();
+            await elementUpdated(overlayTriggers[2]);
+            await waitUntil(() => {
+                activeOverlays = [
+                    ...document.querySelectorAll('active-overlay'),
+                ];
+                return activeOverlays.length === 3;
+            }, 'The third `active-overlay` element has been added.');
 
-        expect(isVisible(outerPopover)).to.be.true;
-        expect(closed).to.be.false;
+            expect(
+                activeOverlays[0].hasAttribute('slot'),
+                'first overlay, third time'
+            ).to.be.false;
+            expect(
+                activeOverlays[1].hasAttribute('slot'),
+                'second overlay, third time'
+            ).to.be.false;
+            expect(
+                activeOverlays[2].slot,
+                'third overlay, third time'
+            ).to.equal('open');
 
-        const openedEvent = openedSpy
-            .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
-        expect(openedEvent.detail.interaction).to.equal('click');
+            await nextFrame();
+            document.body.click();
+            await elementUpdated(overlayTriggers[1]);
+            await waitUntil(() => {
+                activeOverlays = [
+                    ...document.querySelectorAll('active-overlay'),
+                ];
+                return activeOverlays.length === 2;
+            }, 'The third `active-overlay` element has been removed.');
 
-        document.body.click();
-
-        // Wait for the DOM node to be put back in its original place
-        await waitUntil(
-            () => outerPopover.parentElement instanceof OverlayTrigger,
-            'inner content returned'
-        );
-
-        await waitUntil(() => closedSpy.calledOnce, 'closed event sent');
-
-        const closedEvent = closedSpy
-            .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
-        expect(closedEvent.detail.interaction).to.equal('click');
-
-        expect(isVisible(outerPopover)).to.be.false;
-    });
-    it('manages multiple layers of `type="modal"', async () => {
-        const el = await fixture(html`
-            <overlay-trigger type="modal" placement="none">
-                <sp-button slot="trigger" variant="cta">
-                    Toggle Dialog
-                </sp-button>
-                <sp-popover dialog slot="click-content">
-                    <overlay-trigger>
-                        <sp-button slot="trigger" variant="primary">
-                            Toggle Dialog
-                        </sp-button>
-                        <sp-popover dialog slot="click-content">
-                            <overlay-trigger type="modal">
-                                <sp-button slot="trigger" variant="secondary">
-                                    Toggle Dialog
-                                </sp-button>
-                                <sp-popover dialog slot="click-content">
-                                    <p>
-                                        When you get this deep, this
-                                        ActiveOverlay should be the only one in
-                                        [slot="open"].
-                                    </p>
-                                    <p>
-                                        All of the rest of the ActiveOverlay
-                                        elements should have had their [slot]
-                                        attribute removed.
-                                    </p>
-                                    <p>
-                                        Closing this ActiveOverlay should
-                                        replace them...
-                                    </p>
-                                </sp-popover>
-                            </overlay-trigger>
-                        </sp-popover>
-                    </overlay-trigger>
-                </sp-popover>
-            </overlay-trigger>
-        `);
-        const overlayTriggers = [...el.querySelectorAll('overlay-trigger')];
-        let activeOverlays = [...document.querySelectorAll('active-overlay')];
-        const triggers = [
-            ...el.querySelectorAll('sp-button[slot="trigger"]'),
-        ] as Button[];
-
-        expect(activeOverlays.length).to.equal(0);
-
-        triggers[0]?.click();
-        await elementUpdated(overlayTriggers[0]);
-        await waitUntil(() => {
-            activeOverlays = [...document.querySelectorAll('active-overlay')];
-            return activeOverlays.length === 1;
-        }, 'The first `active-overlay` element has been added.');
-
-        expect(activeOverlays.length).to.equal(1);
-        expect(activeOverlays[0].slot, 'first overlay, first time').to.equal(
-            'open'
-        );
-
-        triggers[1]?.click();
-        await elementUpdated(overlayTriggers[1]);
-        await waitUntil(() => {
-            activeOverlays = [...document.querySelectorAll('active-overlay')];
-            return activeOverlays.length === 2;
-        }, 'The second `active-overlay` element has been added.');
-
-        expect(activeOverlays[0].slot, 'first overlay, second time').to.equal(
-            'open'
-        );
-        expect(activeOverlays[1].slot, 'second overlay, second time').to.equal(
-            'open'
-        );
-
-        triggers[2]?.click();
-        await elementUpdated(overlayTriggers[2]);
-        await waitUntil(() => {
-            activeOverlays = [...document.querySelectorAll('active-overlay')];
-            return activeOverlays.length === 3;
-        }, 'The third `active-overlay` element has been added.');
-
-        expect(
-            activeOverlays[0].hasAttribute('slot'),
-            'first overlay, third time'
-        ).to.be.false;
-        expect(
-            activeOverlays[1].hasAttribute('slot'),
-            'second overlay, third time'
-        ).to.be.false;
-        expect(activeOverlays[2].slot, 'third overlay, third time').to.equal(
-            'open'
-        );
-
-        await nextFrame();
-        document.body.click();
-        await elementUpdated(overlayTriggers[1]);
-        await waitUntil(() => {
-            activeOverlays = [...document.querySelectorAll('active-overlay')];
-            return activeOverlays.length === 2;
-        }, 'The third `active-overlay` element has been removed.');
-
-        await waitUntil(() => {
-            return activeOverlays[0].slot === 'open';
-        }, 'first overlay, last time');
-        expect(activeOverlays[1].slot, 'second overlay, last time').to.equal(
-            'open'
-        );
+            await waitUntil(() => {
+                return activeOverlays[0].slot === 'open';
+            }, 'first overlay, last time');
+            expect(
+                activeOverlays[1].slot,
+                'second overlay, last time'
+            ).to.equal('open');
+        });
     });
 });


### PR DESCRIPTION
## Description
- normalize test language across the file
- better leverage `oneEvent` when timing has proven flaky
- update cleanup code for stability/timing

## Motivation and Context
Tests should be reliable

## How Has This Been Tested?
It is tests.

## Types of changes
- [ ] Refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
