### PR TITLE
docs: expand accordion documentation to include its child item page

### DIFF
--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-The `<sp-accordion>` element is a list of items that can be expanded or collapsed to reveal additional content or information associated with each item. There can be zero expanded items, exactly one expanded item, or more than one item expanded at a time, depending on the configuration.
+The `<sp-accordion>` element contians a list of items that can be expanded or collapsed to reveal additional content or information associated with each item. There can be zero expanded items, exactly one expanded item, or more than one item expanded at a time, depending on the configuration. This list of items is defined by child [`<sp-accordion-item>`](./components/accordion-item) children that are targetted to the default slot of their `<sp-accordion>` parent.
 
 ### Usage
 

--- a/packages/accordion/accordion-item.md
+++ b/packages/accordion/accordion-item.md
@@ -1,0 +1,59 @@
+## Description
+
+The `<sp-accordion-item>` element represents a single item in an `<sp-accordion>` parent element. Its `label` attribute and default slot content make up the "headline" and "body" of the toggleable content item.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/accordion?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/accordion)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/accordion?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/accordion)
+[![Try it on webcomponents.dev](https://img.shields.io/badge/Try%20it%20on-webcomponents.dev-green?style=for-the-badge)](https://webcomponents.dev/edit/collection/fO75441E1Q5ZlI0e9pgq/Muvuvbd79YCP9tcdtnsW/src/index.ts)
+
+```
+yarn add @spectrum-web-components/accordion
+```
+
+Import the side effectful registration of `<sp-accordion-item>` via:
+
+```
+import '@spectrum-web-components/accordion/sp-accordion-item.js';
+```
+
+When looking to leverage the `AccordionItem` base class as a type and/or for extension purposes, do so via:
+
+```
+import { AccordionItem } from '@spectrum-web-components/accordion';
+```
+
+## Example
+
+```html
+<sp-accordion>
+    <sp-accordion-item label="Heading 1">
+        <div>The content can be toggled visible.</div>
+    </sp-accordion-item>
+</sp-accordion>
+```
+
+### Opened
+
+```html
+<sp-accordion allow-multiple>
+    <sp-accordion-item open label="Heading 2">
+        <div>This content is visible by default.</div>
+    </sp-accordion-item>
+</sp-accordion>
+```
+
+### Disabled
+
+```html
+<sp-accordion allow-multiple>
+    <sp-accordion-item disabled label="Heading 2">
+        <div>You can not toggle this content visible.</div>
+    </sp-accordion-item>
+</sp-accordion>
+```
+
+## Events
+
+An `<sp-accordion-item>` element will dispatch `sp-accordion-item-toggle` events when it is opened or closed. By default, these events are dispatched to allow the parent `<sp-accordion>` to manage which of its item children can shot their children at any one time, consumers can also listen for this event and leverage `event.target.open` to ascertain the current state of the item dispatching item.


### PR DESCRIPTION
## Description
Expand docs to include `sp-accordion-item` examples entry.

## Related Issue
fixes #1487

## Motivation and Context
The API page was "available" but only if you knew the URL.

## How Has This Been Tested?
https://westbrook-accordion-item--spectrum-web-components.netlify.app/components/accordion-item

## Types of changes
- [x] Docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
