### PR TITLE
docs: expand sidenav documentation to include child element pages

### DIFF
--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -7,7 +7,7 @@ prioritize content or features based on your users’ needs in a way that
 maintains clear, persistent visibility. Use side navigation within the context
 of larger elements and mechanisms within the app frame.
 
-`<sp-sidenav>` elements accept both `<sp-sidenav-item>` and `<sp-sidenv-heading>` elements as children in order to costruct a higherarchy of navigations elements. [`<sp-sidenav-item>`](./components/sidenav-item) elements will place themselves as a togglable child of their `<sp-sidenav>` element parent. `<sp-sidenav-heading>` elements will grat visible structure by grouping their child `<sp-sidenav-item>` children under a non-interactive heading.
+`<sp-sidenav>` elements accept both `<sp-sidenav-item>` and `<sp-sidenav-heading>` elements as children in order to construct a hierarchy of navigations elements. [`<sp-sidenav-item>`](./components/sidenav-item) elements will place themselves as a togglable child of their `<sp-sidenav>` element parent. `<sp-sidenav-heading>` elements will create visible structure by grouping their child `<sp-sidenav-item>` children under a non-interactive heading.
 
 ### Usage
 

--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -7,7 +7,7 @@ prioritize content or features based on your users’ needs in a way that
 maintains clear, persistent visibility. Use side navigation within the context
 of larger elements and mechanisms within the app frame.
 
-`<sp-sidenav>` elements accept both `<sp-sidenav-item>` and `<sp-sidenav-heading>` elements as children in order to construct a hierarchy of navigations elements. [`<sp-sidenav-item>`](./components/sidenav-item) elements will place themselves as a togglable child of their `<sp-sidenav>` element parent. `<sp-sidenav-heading>` elements will create visible structure by grouping their child `<sp-sidenav-item>` children under a non-interactive heading.
+`<sp-sidenav>` elements accept both `<sp-sidenav-item>` and `<sp-sidenav-heading>` elements as children in order to construct a hierarchy of navigation elements. [`<sp-sidenav-item>`](./components/sidenav-item) elements will place themselves as a togglable child of their `<sp-sidenav>` element parent. `<sp-sidenav-heading>` elements will create visible structure by grouping their child `<sp-sidenav-item>` children under a non-interactive heading.
 
 ### Usage
 

--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -7,6 +7,8 @@ prioritize content or features based on your users’ needs in a way that
 maintains clear, persistent visibility. Use side navigation within the context
 of larger elements and mechanisms within the app frame.
 
+`<sp-sidenav>` elements accept both `<sp-sidenav-item>` and `<sp-sidenv-heading>` elements as children in order to costruct a higherarchy of navigations elements. [`<sp-sidenav-item>`](./components/sidenav-item) elements will place themselves as a togglable child of their `<sp-sidenav>` element parent. `<sp-sidenav-heading>` elements will grat visible structure by grouping their child `<sp-sidenav-item>` children under a non-interactive heading.
+
 ### Usage
 
 [![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/sidenav?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/sidenav)
@@ -103,7 +105,6 @@ will send the user to the location of the item.
 ## Icon
 
 ```html
-<sp-icons-medium></sp-icons-medium>
 <sp-sidenav>
     <sp-sidenav-item value="Section Title 1" label="Section Title 1">
         <sp-icon-star slot="icon"></sp-icon-star>

--- a/packages/sidenav/sidenav-item.md
+++ b/packages/sidenav/sidenav-item.md
@@ -1,6 +1,6 @@
 ## Description
 
-An `<sp-sidenav-item>` stands as both a child item of an `<sp-sidenav>` element, as well as a parent for further subdivisions of that navigation. An `<sp-sidenav-item>` with further `<sp-sidenav-item>` children will count as a toggle for the visibility of this never level of navigation items, while also updating the parent `<sp-sidenav>` element to its value when selected.
+An `<sp-sidenav-item>` stands as both a child item of an `<sp-sidenav>` element, as well as a parent for further subdivisions of that navigation. An `<sp-sidenav-item>` with further `<sp-sidenav-item>` children will count as a toggle for the visibility of this next level of navigation items, while also updating the parent `<sp-sidenav>` element to its value when selected.
 
 ### Usage
 

--- a/packages/sidenav/sidenav-item.md
+++ b/packages/sidenav/sidenav-item.md
@@ -1,6 +1,6 @@
 ## Description
 
-An `<sp-sidenav-item>` stands as both a child item of an `<sp-sidenav>` element as well as a parent for further subdivisions of that navigation. An `<sp-sidenav-item>` with further `<sp-sidenav-item>` children will count as a toggle for the visibility of this never level of navigation items, while also updating the parent `<sp-sidenav>` element to its value when selected.
+An `<sp-sidenav-item>` stands as both a child item of an `<sp-sidenav>` element, as well as a parent for further subdivisions of that navigation. An `<sp-sidenav-item>` with further `<sp-sidenav-item>` children will count as a toggle for the visibility of this never level of navigation items, while also updating the parent `<sp-sidenav>` element to its value when selected.
 
 ### Usage
 

--- a/packages/sidenav/sidenav-item.md
+++ b/packages/sidenav/sidenav-item.md
@@ -1,0 +1,62 @@
+## Description
+
+An `<sp-sidenav-item>` stands as both a child item of an `<sp-sidenav>` element as well as a parent for further subdivisions of that navigation. An `<sp-sidenav-item>` with further `<sp-sidenav-item>` children will count as a toggle for the visibility of this never level of navigation items, while also updating the parent `<sp-sidenav>` element to its value when selected.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/sidenav?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/sidenav)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/sidenav?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/sidenav)
+[![Try it on webcomponents.dev](https://img.shields.io/badge/Try%20it%20on-webcomponents.dev-green?style=for-the-badge)](https://webcomponents.dev/edit/collection/fO75441E1Q5ZlI0e9pgq/WQ6UEUP8wfm9bKUKpWgi/src/index.ts)
+
+```
+yarn add @spectrum-web-components/sidenav
+```
+
+Import the side effectful registration of `<sp-sidenav-item>` via:
+
+```
+import '@spectrum-web-components/sidenav/sp-sidenav-item.js';
+```
+
+When looking to leverage the `SidenavItem` base classes as a type and/or for extension purposes, do so via:
+
+```
+import { SidenavItem } from '@spectrum-web-components/sidenav';
+```
+
+## Example
+
+```html
+<sp-sidenav>
+    <sp-sidenav-item
+        value="Docs"
+        label="Docs"
+        href="/components/SideNav"
+    ></sp-sidenav-item>
+</sp-sidenav>
+```
+
+## Multi-level
+
+```html
+<sp-sidenav>
+    <sp-sidenav-item value="Styles" label="Styles" expanded>
+        <sp-sidenav-item value="Color" label="Color"></sp-sidenav-item>
+        <sp-sidenav-item value="Grid" label="Grid" expanded>
+            <sp-sidenav-item value="Layout" label="Layout"></sp-sidenav-item>
+            <sp-sidenav-item value="Responsive" label="Responsive"></sp-sidenav-item>
+        </sp-sidenav-item>
+        <sp-sidenav-item value="Typography" label="Typography"></sp-sidenav-item>
+    </sp-sidenav-item>
+</sp-sidenav-itm>
+```
+
+## Icon
+
+```html
+<sp-sidenav>
+    <sp-sidenav-item value="Section Title 1" label="Section Title 1">
+        <sp-icon-star slot="icon"></sp-icon-star>
+    </sp-sidenav-item>
+</sp-sidenav>
+```


### PR DESCRIPTION
## Description
Expand docs to include `sp-sidenav-item` examples entry.

## Related Issue
fixes #1486

## Motivation and Context
The API page was "available" but only if you knew the URL.

## How Has This Been Tested?
https://westbrook-sidenav-item--spectrum-web-components.netlify.app/components/accordion-item

## Types of changes
- [x] Docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
