### PR TITLE
fix: manage "lang" via context provided by "sp-theme"

### DIFF
--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -32,7 +32,9 @@ import { NumberField } from '@spectrum-web-components/number-field';
 
 ## Number formatting
 
-An `<sp-number-field>` element will process its numeric value with `new Intl.NumberFormat(navigator.language, this.formatOptions).format(this.value)` in order to prepare it for visual delivery in the input. In order to customize this processing supply your own `Intl.NumberFormatOptions` via the `formatOptions` property, or `format-options` attribute as follows.
+An `<sp-number-field>` element will process its numeric value with `new Intl.NumberFormat(this.resolvedLanguage, this.formatOptions).format(this.value)` in order to prepare it for visual delivery in the input. In order to customize this processing supply your own `Intl.NumberFormatOptions` via the `formatOptions` property, or `format-options` attribute as seen below.
+
+`this.resolvedLanguage` represents the language in which the `<sp-number-field>` element is currently being delivered. By default, this value will represent the language established by the `lang` attribute on the root `<html>` element while falling back to `navigator.language` when that is not present. This value can be customized via a language context provided by a parent element that listens for the `sp-language-context` event and supplies update language settings to the `callback` function contained therein. Applications leveraging the [`<sp-theme>`](./components/theme) element to manage the visual delivery or text direction of their content will be also be provided a reactive context for supplying language information to its descendants.
 
 ### Decimals
 

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -53,7 +53,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@formatjs/intl-numberformat": "^7.1.0",
+        "@formatjs/intl-numberformat": "^7.1.4",
         "@spectrum-css/stepper": "^3.0.3"
     },
     "types": "./src/index.d.ts",

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -35,6 +35,7 @@ import {
     setUserAgent,
 } from '@web/test-runner-commands';
 import { spy } from 'sinon';
+import { ProvideLang } from '@spectrum-web-components/theme';
 
 async function getElFrom(test: TemplateResult): Promise<NumberField> {
     const wrapped = await fixture<HTMLDivElement>(html`
@@ -92,6 +93,7 @@ describe('NumberField', () => {
                 .polyfilled
         ) {
             await import('@formatjs/intl-numberformat/locale-data/en.js');
+            await import('@formatjs/intl-numberformat/locale-data/fr.js');
         }
     });
     it('loads default number-field accessibly', async () => {
@@ -100,19 +102,50 @@ describe('NumberField', () => {
 
         await expect(el).to.be.accessible();
     });
-    it('receives input', async () => {
-        const el = await getElFrom(Default({ value: 1337 }));
-        expect(el.formattedValue).to.equal('1,337');
-        expect(el.valueAsString).to.equal('1337');
-        expect(el.value).to.equal(1337);
-        el.focus();
-        await sendKeys({ type: '7331' });
-        await elementUpdated(el);
-        await sendKeys({ press: 'Enter' });
-        await elementUpdated(el);
-        expect(el.formattedValue).to.equal('13,377,331');
-        expect(el.valueAsString).to.equal('13377331');
-        expect(el.value).to.equal(13377331);
+    describe('receives input', () => {
+        it('without language context', async () => {
+            const el = await getElFrom(Default({ value: 1337 }));
+            expect(el.formattedValue).to.equal('1,337');
+            expect(el.valueAsString).to.equal('1337');
+            expect(el.value).to.equal(1337);
+            el.focus();
+            await sendKeys({ type: '7331' });
+            await elementUpdated(el);
+            await sendKeys({ press: 'Enter' });
+            await elementUpdated(el);
+            expect(el.formattedValue).to.equal('13,377,331');
+            expect(el.valueAsString).to.equal('13377331');
+            expect(el.value).to.equal(13377331);
+        });
+        it('with language context', async () => {
+            const lang = 'fr';
+            const langResolvers: ProvideLang['callback'][] = [];
+            const createLangResolver = (
+                event: CustomEvent<ProvideLang>
+            ): void => {
+                langResolvers.push(event.detail.callback);
+                resolveLanguage();
+            };
+            const resolveLanguage = (): void => {
+                langResolvers.forEach((resolver) => resolver(lang));
+            };
+            const el = await getElFrom(html`
+                <div @sp-language-context=${createLangResolver}>
+                    ${Default({ value: 1337 })}
+                </div>
+            `);
+            expect(el.formattedValue).to.equal('1 337');
+            expect(el.valueAsString).to.equal('1337');
+            expect(el.value).to.equal(1337);
+            el.focus();
+            await sendKeys({ type: '7331' });
+            await elementUpdated(el);
+            await sendKeys({ press: 'Enter' });
+            await elementUpdated(el);
+            expect(el.formattedValue).to.equal('13 377 331');
+            expect(el.valueAsString).to.equal('13377331');
+            expect(el.value).to.equal(13377331);
+        });
     });
     describe('Increments', () => {
         let el: NumberField;
@@ -272,6 +305,7 @@ describe('NumberField', () => {
                 currencyDisplay: 'code',
                 currencySign: 'accounting',
             };
+            await elementUpdated(el);
             el.value = 45;
             expect(el.value).to.equal(45);
             el.focus();
@@ -826,6 +860,11 @@ describe('NumberField', () => {
             expect(el.valueAsString).to.equal('2');
             expect(el.value).to.equal(2);
             el.value = 11;
+            await elementUpdated(el);
+            expect(el.formattedValue).to.equal('7');
+            expect(el.valueAsString).to.equal('7');
+            expect(el.value).to.equal(7);
+            el.value = 27;
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('7');
             expect(el.valueAsString).to.equal('7');

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -149,11 +149,13 @@ export class ActiveOverlay extends SpectrumElement {
     @property({ reflect: true })
     public placement?: Placement;
     @property({ attribute: false })
-    public color?: Color;
+    public theme: {
+        color?: Color;
+        scale?: Scale;
+        lang?: string;
+    } = {};
     @property({ attribute: false })
     public receivesFocus?: 'auto';
-    @property({ attribute: false })
-    public scale?: Scale;
 
     public tabbingAway = false;
     private originalPlacement?: Placement;
@@ -181,7 +183,7 @@ export class ActiveOverlay extends SpectrumElement {
     }
 
     private get hasTheme(): boolean {
-        return !!this.color || !!this.scale;
+        return !!this.theme.color || !!this.theme.scale || !!this.theme.lang;
     }
 
     public offset = 6;
@@ -345,8 +347,7 @@ export class ActiveOverlay extends SpectrumElement {
         this.placement = detail.placement;
         this.offset = detail.offset;
         this.interaction = detail.interaction;
-        this.color = detail.theme.color;
-        this.scale = detail.theme.scale;
+        this.theme = detail.theme;
         this.receivesFocus = detail.receivesFocus;
     }
 
@@ -476,9 +477,13 @@ export class ActiveOverlay extends SpectrumElement {
     }
 
     public renderTheme(content: TemplateResult): TemplateResult {
-        const { color, scale } = this;
+        const { color, scale, lang } = this.theme;
         return html`
-            <sp-theme color=${ifDefined(color)} scale=${ifDefined(scale)}>
+            <sp-theme
+                color=${ifDefined(color)}
+                scale=${ifDefined(scale)}
+                lang=${ifDefined(lang)}
+            >
                 ${content}
             </sp-theme>
         `;

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -108,6 +108,7 @@ export class Overlay {
         const queryThemeDetail: ThemeData = {
             color: undefined,
             scale: undefined,
+            lang: undefined,
         };
         const queryThemeEvent = new CustomEvent<ThemeData>('sp-query-theme', {
             bubbles: true,

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -786,8 +786,8 @@ describe('Overlay Trigger', () => {
             ) as ActiveOverlay;
 
             expect(overlay).to.exist;
-            expect(overlay.color).to.not.equal('dark');
-            expect(overlay.color).to.equal('light');
+            expect(overlay.theme.color).to.not.equal('dark');
+            expect(overlay.theme.color).to.equal('light');
         });
         it('manages multiple layers of `type="modal"', async () => {
             const el = await fixture(html`

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -210,7 +210,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    protected update(changedProperties: Map<string, boolean>): void {
+    protected update(changedProperties: PropertyValues): void {
         if (changedProperties.has('disabled')) {
             this.handleDisabledChanged(
                 this.disabled,

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -92,7 +92,9 @@ Normalization is the process of converting a slider to a value between 0 and 1 w
 
 ## Labels and Formatting
 
-An `<sp-slider>` or `<sp-slider-handle>` element will process its numeric value with `new Intl.NumberFormat(navigator.language, this.formatOptions).format(this.value)` in order to prepare it for visual delivery in the input. In order to customize this processing supply your own `Intl.NumberFormatOptions` via the `formatOptions` property, or `format-options` attribute as follows.
+An `<sp-slider>` or `<sp-slider-handle>` element will process its numeric value with `new Intl.NumberFormat(this.resolvedLanguage, this.formatOptions).format(this.value)` in order to prepare it for visual delivery in the input. In order to customize this processing supply your own `Intl.NumberFormatOptions` via the `formatOptions` property, or `format-options` attribute as seen below.
+
+`this.resolvedLanguage` represents the language in which the `<sp-slider>` or `<sp-slider-handle>` element is currently being delivered. By default, this value will represent the language established by the `lang` attribute on the root `<html>` element while falling back to `navigator.language` when that is not present. This value can be customized via a language context provided by a parent element that listens for the `sp-language-context` event and supplies update language settings to the `callback` function contained therein. Applications leveraging the [`<sp-theme>`](./components/theme) element to manage the visual delivery or text direcdirectiontion of their content will be also be provided a reactive context for supplying language information to its descendants.
 
 ```html
 <sp-slider

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -49,6 +49,7 @@
         "@internationalized/number": "^3.0.0",
         "@spectrum-web-components/base": "^0.4.4",
         "@spectrum-web-components/shared": "^0.12.5",
+        "@spectrum-web-components/theme": "^0.8.9",
         "tslib": "^2.0.0"
     },
     "devDependencies": {

--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -90,10 +90,6 @@ export class HandleController implements Controller {
         this.host.requestUpdate();
     }
 
-    public get language(): string {
-        return this.host.language;
-    }
-
     /**
      * It is possible for value attributes to be set programmatically. The <input>
      * for a particular slider needs to have an opportunity to validate any such
@@ -581,5 +577,12 @@ export class HandleController implements Controller {
         });
 
         this.model = modelValues;
+    }
+
+    public async handleUpdatesComplete(): Promise<void> {
+        const updates = [...this.handles.values()]
+            .filter((handle) => handle !== this.host)
+            .map((handle) => handle.updateComplete);
+        await Promise.all(updates);
     }
 }

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -71,9 +71,6 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
     /* Ensure that a '' value for `variant` removes the attribute instead of a blank value */
     private _variant = '';
 
-    @property({ type: String })
-    public language: string = navigator.language;
-
     @property({ attribute: false })
     public getAriaValueText: (values: Map<string, string>) => string = (
         values
@@ -284,5 +281,10 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
             '--spectrum-slider-track-segment-position': `${start * 100}%`,
         };
         return styles;
+    }
+
+    protected async _getUpdateComplete(): Promise<void> {
+        await super._getUpdateComplete();
+        await this.handleController.handleUpdatesComplete();
     }
 }

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -83,6 +83,10 @@ updateTheme('light', 'medium');
 
 When bundling your application, be sure to consult the documentation of your bundler for the correct way to ensure proper packaging of the sort of programattic dependancy graph that this will create.
 
+### Language Context
+
+The `<sp-theme>` element provides a language context for its descendents in the DOM. Descendents can resolve this context by dispatching a `sp-language-context` DOM event and supplying a `callback(lang: string) => void` method in the `detail` entry of the Custom Event. These callbacks will be reactively envoked when the `lang` attribute on the `<sp-theme>` element is updated. In this way you can control the resolved language in [`<sp-number-field>`](./components/number-field), [`<sp-slider>`](./components/slider), and more elements in one centralized place.
+
 ## Light theme
 
 ```html demo

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -67,7 +67,7 @@ const reduceMotionProperties = css`
 ActiveOverlay.prototype.renderTheme = function (
     content: TemplateResult
 ): TemplateResult {
-    const { color, scale } = this;
+    const { color, scale, lang } = this.theme;
     return html`
         ${window.__swc_hack_knobs__.defaultReduceMotion
             ? html`
@@ -78,7 +78,11 @@ ActiveOverlay.prototype.renderTheme = function (
                   </style>
               `
             : html``}
-        <sp-theme color=${ifDefined(color)} scale=${ifDefined(scale)}>
+        <sp-theme
+            color=${ifDefined(color)}
+            scale=${ifDefined(scale)}
+            lang=${ifDefined(lang)}
+        >
             ${content}
         </sp-theme>
     `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,7 +1385,7 @@
   dependencies:
     tslib "^2.1.0"
 
-"@formatjs/intl-numberformat@^7.1.0":
+"@formatjs/intl-numberformat@^7.1.4":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-numberformat/-/intl-numberformat-7.1.4.tgz#67f35b2c1f22d126879c7c7fb048cc627b2f38a3"
   integrity sha512-rOFMlx1oLaQ7tLUwWWaqMvjQ8n4Z/C7jUlBG0qfM4oSOksluKO4MEyJZZeYjRVuNEMipIj34h12t8KicXj6gKg==


### PR DESCRIPTION
## Description
- provide `language` as a context container on `sp-theme`
- leverage this context in `sp-number-field` and `sp-slider`
- add NumberFormatter and NumberParser caching to `sp-number-field`
- expand `updateComplete` processing for `sp-slider` to include `handles`
- tests!

One last to-do, but I wanted to allow others to get eyes on the implementation as desired:
- [x] Add documentation to all three elements!
  - https://westbrook-lang-context--spectrum-web-components.netlify.app/components/theme
  - https://westbrook-lang-context--spectrum-web-components.netlify.app/components/number-field
  - https://westbrook-lang-context--spectrum-web-components.netlify.app/components/slider 

### Perf benchmarks
```
┌─────────────┬───────────────────┐
│   Benchmark │ slider:test-basic │
├─────────────┼───────────────────┤
│     Browser │ chrome-headless   │
│             │ 91.0.4472.106     │
├─────────────┼───────────────────┤
│ Sample size │ 50                │
└─────────────┴───────────────────┘

┌─────────┬────────────┬─────────────────────┬───────────────────┬───────────────────┐
│ Version │ Bytes      │            Avg time │         vs remote │               vs  │
├─────────┼────────────┼─────────────────────┼───────────────────┼───────────────────┤
│ remote  │ 390.85 KiB │ 142.13ms - 149.20ms │                   │            unsure │
│         │            │                     │          -        │         -4% - +3% │
│         │            │                     │                   │ -5.66ms - +4.47ms │
├─────────┼────────────┼─────────────────────┼───────────────────┼───────────────────┤
│ <none>  │ 390.52 KiB │ 142.63ms - 149.88ms │            unsure │                   │
│         │            │                     │         -3% - +4% │          -        │
│         │            │                     │ -4.47ms - +5.66ms │                   │
└─────────┴────────────┴─────────────────────┴───────────────────┴───────────────────┘


┌─────────────┬─────────────────────────┐
│   Benchmark │ number-field:basic-test │
├─────────────┼─────────────────────────┤
│     Browser │ chrome-headless         │
│             │ 91.0.4472.106           │
├─────────────┼─────────────────────────┤
│ Sample size │ 50                      │
└─────────────┴─────────────────────────┘

┌─────────┬────────────┬─────────────────────┬───────────────────┬───────────────────┐
│ Version │ Bytes      │            Avg time │         vs remote │               vs  │
├─────────┼────────────┼─────────────────────┼───────────────────┼───────────────────┤
│ remote  │ 556.96 KiB │ 160.08ms - 168.60ms │                   │            unsure │
│         │            │                     │          -        │         -4% - +3% │
│         │            │                     │                   │ -5.91ms - +5.55ms │
├─────────┼────────────┼─────────────────────┼───────────────────┼───────────────────┤
│ <none>  │ 556.93 KiB │ 160.68ms - 168.35ms │            unsure │                   │
│         │            │                     │         -3% - +4% │          -        │
│         │            │                     │ -5.55ms - +5.91ms │                   │
└─────────┴────────────┴─────────────────────┴───────────────────┴───────────────────┘

slider:test-basic: 142.13ms - 149.20ms
slider:test-basic: 142.63ms - 149.88ms
number-field:basic-test: 160.08ms - 168.60ms
number-field:basic-test: 160.68ms - 168.35ms
```

## Related Issue
fixes #1495 

## Motivation and Context
Easier customization when outside of the default browser context for language.

## How Has This Been Tested?
Unit tests, manually.

## Screenshots (if appropriate):
https://westbrook-lang-context--spectrum-web-components.netlify.app/components/number-field
You can use document.querySelector('docs-page').shadowRoot.querySelector('sp-theme').lang = 'fr' replacing 'fr' with your favorite language to test them out.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
