### PR TITLE
fix: correct sp-textfield[multiline][grows] styling and add story for regression testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 242b511dd488518b5c3d901c5671478b02d12204
+        default: 19e24c2de3f15171ae7f083f3ddddd7c4902f1a4
 commands:
     downstream:
         steps:

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 @import './spectrum-textfield.css';
 
-:host([grows]) #input {
+:host([grows]) .input {
     position: absolute;
     top: 0;
     left: 0;
@@ -31,18 +31,10 @@ governing permissions and limitations under the License.
         --spectrum-textfield-border-radius,
         var(--spectrum-alias-border-radius-regular)
     );
-    padding: 3px
-        var(
-            --spectrum-textfield-padding-x,
-            var(--spectrum-global-dimension-size-150)
-        )
-        5px
-        calc(
-            var(
-                    --spectrum-textfield-padding-x,
-                    var(--spectrum-global-dimension-size-150)
-                ) - 1px
-        );
+    padding: var(--spectrum-textarea-padding-top)
+        var(--spectrum-textarea-padding-right)
+        var(--spectrum-textarea-padding-bottom)
+        calc(var(--spectrum-textarea-padding-left) - 1px);
     text-indent: 0;
     width: 100%;
     vertical-align: top;

--- a/packages/textfield/stories/textarea.stories.ts
+++ b/packages/textfield/stories/textarea.stories.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 import { html } from 'lit-html';
 
 import '../sp-textfield.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
 import { TemplateResult } from '@spectrum-web-components/base';
 
 export default {
@@ -70,6 +71,17 @@ export const Default = (): TemplateResult => {
         ></sp-textfield>
     `;
 };
+
+export const grows = (): TemplateResult => html`
+    <sp-field-label for="story">Enter your life story...</sp-field-label>
+    <sp-textfield
+        multiline
+        id="story"
+        value="Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt."
+        grows
+        placeholder="Enter your life story"
+    ></sp-textfield>
+`;
 
 export const readonly = (): TemplateResult => html`
     <sp-textfield


### PR DESCRIPTION
## Description
- correct visual delivery of `sp-textfield[multiline][grows]`
- add story to VRT to prevent future regressions

## Related Issue
fixes #1568

## Motivation and Context
Should work as expected!

## How Has This Been Tested?
VRTs

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/123098437-25d88480-d3ff-11eb-89b1-52f77631d5a5.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
