### PR TITLE
fix: add "value" slot to sp-menu-item

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 19e24c2de3f15171ae7f083f3ddddd7c4902f1a4
+        default: d712e57300d17a3ef9f2ff6e2822e5b5a5855542
 commands:
     downstream:
         steps:

--- a/packages/menu/menu-item.md
+++ b/packages/menu/menu-item.md
@@ -29,14 +29,26 @@ import { MenuItem } from '@spectrum-web-components/menu';
 Menus are a collection of `<sp-menu-item>`s that can be modified via a `disabled` or `selected` attribute to represent an item in that state.
 
 ```html
-<sp-menu>
+<sp-menu selectable>
     <sp-menu-item>Active Menu Item</sp-menu-item>
     <sp-menu-item disabled>Disabled Menu Item</sp-menu-item>
     <sp-menu-item selected>Selected Menu Item</sp-menu-item>
 </sp-menu>
 ```
 
-### Value
+### Value slot
+
+Content assigned to the `value` slot will be placed at the end of the `<sp-menu-item>`, like values, keyboard shortcuts, etc., based on the current text direction.
+
+```html
+<sp-menu style="width: 200px;">
+    <sp-menu-item>Save<kbd slot="value">⌘S</kbd></sp-menu-item>
+    <sp-menu-item>Completed<span slot="value">47%</apn></sp-menu-item>
+    <sp-menu-item>Activity<sp-link slot="value" href="#">More&nbsp;info</sp-link></sp-menu-item>
+</sp-menu>
+```
+
+### Value attribute
 
 When displayed as a descendent of an element that manages selection (e.g. `<sp-action-menu>`, `<sp-picker>`, `<sp-split-button>`, etc.), an `<sp-menu-item>` will represent the "selected" value of that ancestor when its `value` attribute or the trimmed `textContent` (represeted by `el.itemText`) matches the `value` of the ancestor element.
 

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -31,6 +31,7 @@ export interface MenuItemQueryRoleEventDetail {
 /**
  * Spectrum Menu Item Component
  * @element sp-menu-item
+ * @slot value - content placed at the end of the Menu Item like values, keyboard shortcuts, etc.
  */
 export class MenuItem extends ActionButton {
     public static get styles(): CSSResultArray {
@@ -65,6 +66,11 @@ export class MenuItem extends ActionButton {
 
     protected get buttonContent(): TemplateResult[] {
         const content = super.buttonContent;
+        content.push(
+            html`
+                <slot name="value"></slot>
+            `
+        );
         if (this.selected) {
             content.push(html`
                 <sp-icon-checkmark100

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -16,3 +16,11 @@ governing permissions and limitations under the License.
     position: absolute;
     inset: 0;
 }
+
+:host([dir='ltr']) ::slotted([slot='value']) {
+    margin-left: var(--spectrum-listitem-icon-gap);
+}
+
+:host([dir='rtl']) ::slotted([slot='value']) {
+    margin-right: var(--spectrum-listitem-icon-gap);
+}

--- a/packages/menu/stories/menu-item.stories.ts
+++ b/packages/menu/stories/menu-item.stories.ts
@@ -38,6 +38,25 @@ export const noWrap = (): TemplateResult => {
     `;
 };
 
+export const valueSlot = (): TemplateResult => {
+    return html`
+        <sp-menu style="width: 150px;" selectable>
+            <sp-menu-item>
+                Save
+                <kbd slot="value">⌘S</kbd>
+            </sp-menu-item>
+            <sp-menu-item selected>
+                Save As...
+                <kbd slot="value">⇧⌘S</kbd>
+            </sp-menu-item>
+            <sp-menu-item disabled>
+                Save All
+                <kbd slot="value">⌥⌘S</kbd>
+            </sp-menu-item>
+        </sp-menu>
+    `;
+};
+
 export const href = (): TemplateResult => {
     return html`
         <sp-menu style="width: 150px;">


### PR DESCRIPTION
## Description
Add the `slot="value"` interface for including content at the end of the Menu Item, e.g. keyboard shortcuts, etc.

Preview available at:
- https://westbrook-menu-item--spectrum-web-components.netlify.app/storybook/index.html?path=/story/menu-item--value-slot
- https://westbrook-menu-item--spectrum-web-components.netlify.app/components/menu-item

## Related Issue
fixes #1515

## Motivation and Context
Menu Items should be more customizable

## How Has This Been Tested?
VRTs

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/123100775-6802c580-d401-11eb-8eae-f128b34a8da1.png)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
