### PR TITLE
fix: match footer default color to content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 4b9b1721e3409abb33c33a68d5d4c29756edaae9
+        default: 67f6ed0c6bac29df7a78021742ba947034b2d189
 commands:
     downstream:
         steps:

--- a/packages/dialog/src/dialog.css
+++ b/packages/dialog/src/dialog.css
@@ -16,6 +16,13 @@ governing permissions and limitations under the License.
     overflow: hidden;
 }
 
+.footer {
+    color: var(
+        --spectrum-dialog-confirm-description-text-color,
+        var(--spectrum-global-color-gray-800)
+    );
+}
+
 .content[tabindex] {
     overflow: auto;
 }


### PR DESCRIPTION
## Description
Ensure text color styling is actively applied to footer content in a dialog.

## Related Issue
Fixes #1149

## Motivation and Context
![image](https://user-images.githubusercontent.com/1156657/123262110-87fbbd00-d4c5-11eb-913a-5ba6826f12c9.png)

## How Has This Been Tested?
VRTs on https://westbrook-dialog-footer--spectrum-web-components.netlify.app/components/dialog-wrapper

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/123262190-9c3fba00-d4c5-11eb-8f9b-6c22c282f98f.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
