### PR TITLE
fix: normalize wheel input directionally for more predictable input

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -269,7 +269,10 @@ export class NumberField extends TextfieldBase {
 
     protected onScroll(event: WheelEvent): void {
         event.preventDefault();
-        this.stepBy(event.deltaY);
+        const { deltaY } = event;
+        if (deltaY !== 0) {
+            this.stepBy(deltaY / Math.abs(deltaY));
+        }
     }
 
     protected onFocus(): void {

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -194,7 +194,7 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
-            el.dispatchEvent(new WheelEvent('wheel', { deltaY: 1 }));
+            el.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('1');
             expect(el.valueAsString).to.equal('1');
@@ -248,7 +248,7 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
-            el.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+            el.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('-1');
             expect(el.valueAsString).to.equal('-1');


### PR DESCRIPTION
## Description
Use wheel directionally rather than based on "distance" for more predictable input.

## Related Issue
fixes #1531

## Motivation and Context
Users should not be surprised.

## How Has This Been Tested?
Unit tests.

## Screenshots (if appropriate):
https://westbrook-numberfield-wheel-step--spectrum-web-components.netlify.app/components/number-field

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
