### PR TITLE
fix: correct a11y representation of a radio group

### DIFF
--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -17,6 +17,7 @@ import {
     queryAssignedNodes,
     PropertyValues,
 } from '@spectrum-web-components/base';
+import { FocusVisiblePolyfillMixin } from '@spectrum-web-components/shared/src/focus-visible.js';
 import { FieldGroup } from '@spectrum-web-components/field-group';
 
 import { Radio } from './Radio.js';
@@ -26,12 +27,15 @@ import { Radio } from './Radio.js';
  * @slot - The `sp-radio` elements to display/manage in the group.
  *
  */
-export class RadioGroup extends FieldGroup {
+export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
     @property({ type: String })
     public name = '';
 
     @queryAssignedNodes('')
     public defaultNodes!: Node[];
+
+    @property()
+    public label = '';
 
     public get buttons(): Radio[] {
         return this.defaultNodes.filter(
@@ -206,6 +210,7 @@ export class RadioGroup extends FieldGroup {
 
     protected firstUpdated(changes: PropertyValues<this>): void {
         super.firstUpdated(changes);
+        this.setAttribute('role', 'radiogroup');
         const checkedRadio = this.querySelector('sp-radio[checked]') as Radio;
         const checkedRadioValue = checkedRadio ? checkedRadio.value : '';
         // Prefer the checked item over the selected value
@@ -246,6 +251,13 @@ export class RadioGroup extends FieldGroup {
         super.updated(changes);
         if (changes.has('selected')) {
             this.validateRadios();
+        }
+        if (changes.has('label')) {
+            if (this.label) {
+                this.setAttribute('aria-label', this.label);
+            } else {
+                this.removeAttribute('aria-label');
+            }
         }
     }
 

--- a/packages/radio/src/radio.css
+++ b/packages/radio/src/radio.css
@@ -25,6 +25,10 @@ governing permissions and limitations under the License.
 
 /* End work around. */
 
+:host(:focus) {
+    outline: none;
+}
+
 :host([disabled]) {
     pointer-events: none;
 }

--- a/packages/radio/src/spectrum-config.js
+++ b/packages/radio/src/spectrum-config.js
@@ -58,6 +58,20 @@ const config = {
                     name: 'label',
                 },
             ],
+            complexSelectors: [
+                {
+                    replacement: ':host(:focus-visible) .spectrum-Radio-input',
+                    selector: /^.spectrum-Radio .spectrum-Radio-input.focus-ring/,
+                },
+                {
+                    replacement: ':focus-visible .spectrum-Radio-input',
+                    selector: /\s.spectrum-Radio-input.focus-ring/,
+                },
+                {
+                    replacement: ':host(:focus-visible) .spectrum-Radio-input',
+                    selector: /^.spectrum-Radio-input.focus-ring/,
+                },
+            ],
         },
     ],
 };

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -90,7 +90,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     /* .spectrum-Radio-input:checked+.spectrum-Radio-button:before */
     border-width: var(--spectrum-radio-border-width-checked);
 }
-#input:focus-visible + #button:after {
+:host(:focus-visible) #input + #button:after {
     /* .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:after */
     margin: calc(
         var(
@@ -362,10 +362,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([emphasized]) #input:focus-visible + #button:before,
-:host([emphasized]:hover) #input:focus-visible + #button:before,
-#input:focus-visible + #button:before,
-:host(:hover) #input:focus-visible + #button:before {
+:host([emphasized]:focus-visible) #input + #button:before,
+:host([emphasized]:hover:focus-visible) #input + #button:before,
+:host(:focus-visible) #input + #button:before,
+:host(:hover:focus-visible) #input + #button:before {
     /* .spectrum-Radio--emphasized .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:before,
    * .spectrum-Radio--emphasized:hover .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:before,
    * .spectrum-Radio .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:before,
@@ -375,10 +375,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-color-gray-700)
     );
 }
-:host([emphasized]) #input:focus-visible + #button:after,
-:host([emphasized]:hover) #input:focus-visible + #button:after,
-#input:focus-visible + #button:after,
-:host(:hover) #input:focus-visible + #button:after {
+:host([emphasized]:focus-visible) #input + #button:after,
+:host([emphasized]:hover:focus-visible) #input + #button:after,
+:host(:focus-visible) #input + #button:after,
+:host(:hover:focus-visible) #input + #button:after {
     /* .spectrum-Radio--emphasized .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:after,
    * .spectrum-Radio--emphasized:hover .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:after,
    * .spectrum-Radio .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:after,
@@ -394,10 +394,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-focus-ring-color)
         );
 }
-:host([emphasized][checked]) #input:focus-visible + #button:before,
-:host([emphasized][checked]:hover) #input:focus-visible + #button:before,
-:host([checked]) #input:focus-visible + #button:before,
-:host(:hover[checked]) #input:focus-visible + #button:before {
+:host([emphasized][checked]:focus-visible) #input + #button:before,
+:host([emphasized][checked]:hover:focus-visible) #input + #button:before,
+:host(:focus-visible[checked]) #input + #button:before,
+:host(:hover:focus-visible[checked]) #input + #button:before {
     /* .spectrum-Radio--emphasized .spectrum-Radio-input.focus-ring:checked+.spectrum-Radio-button:before,
    * .spectrum-Radio--emphasized:hover .spectrum-Radio-input.focus-ring:checked+.spectrum-Radio-button:before,
    * .spectrum-Radio .spectrum-Radio-input.focus-ring:checked+.spectrum-Radio-button:before,


### PR DESCRIPTION
## Description
While still tracking https://bugs.chromium.org/p/chromium/issues/detail?id=1158144#c_ts1615261031, this update allows both Firefox and Safari to show the posinset and setsize data automatically through appropriately preparing the "radiogroup" root and associating it correctly with child "radio" elements. Once the linked bug in Chrome is addressed, these updated should automatically be available in that context.

Note in the Chrome issue that the grouping issue also effects the naming in certain contexts. If this doesn't get addressed directly by the issue, we'll start a new issue to track further fixes in the browser.

## Related Issue
fixes #1278

## Motivation and Context
Accessibility!

## How Has This Been Tested?
Manually, unit tests, etc.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/123321531-15a8ce00-d501-11eb-8b3f-a72f2ff4a30e.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
