### PR TITLE
fix: allow detached elements to be used as content for an overlay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 4cf3dfcdfea47220e84049f73a8e1a7694a3b161
+        default: b1e4f25ac1f15bd3bdd818025090e30007364e6b
 commands:
     downstream:
         steps:

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 import { html, TemplateResult, ifDefined } from '@spectrum-web-components/base';
 import {
     openOverlay,
+    Overlay,
     OverlayContentTypes,
     OverlayTrigger,
     Placement,
@@ -23,6 +24,7 @@ import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
 import { DialogWrapper } from '@spectrum-web-components/dialog';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-open-in.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/picker/sp-picker.js';
@@ -691,4 +693,53 @@ export const virtualElement = (args: Properties): TemplateResult => {
 
 virtualElement.args = {
     placement: 'right-end',
+};
+
+export const detachedElement = (): TemplateResult => {
+    let closeOverlay: (() => void) | undefined;
+    const openDetachedOverlayContent = async ({
+        target,
+    }: {
+        target: HTMLElement;
+    }): Promise<void> => {
+        if (closeOverlay) {
+            closeOverlay();
+            closeOverlay = undefined;
+            return;
+        }
+        const div = document.createElement('div');
+        div.textContent = 'This div is overlaid';
+        div.setAttribute(
+            'style',
+            `
+            background-color: var(--spectrum-global-color-gray-50);
+            color: var(--spectrum-global-color-gray-800);
+            border: 1px solid;
+            padding: 2em;
+        `
+        );
+        closeOverlay = await Overlay.open(target, 'click', div, {
+            offset: 0,
+            placement: 'bottom',
+        });
+    };
+    requestAnimationFrame(() => {
+        openDetachedOverlayContent({
+            target: document.querySelector(
+                '#detached-content-trigger'
+            ) as HTMLElement,
+        });
+    });
+    return html`
+        <sp-action-button
+            id="detached-content-trigger"
+            @click=${openDetachedOverlayContent}
+            @sp-closed=${() => (closeOverlay = undefined)}
+        >
+            <sp-icon-open-in
+                slot="icon"
+                label="Open in overlay"
+            ></sp-icon-open-in>
+        </sp-action-button>
+    `;
 };

--- a/packages/overlay/test/overlay.test.ts
+++ b/packages/overlay/test/overlay.test.ts
@@ -23,6 +23,7 @@ import {
     expect,
     elementUpdated,
     waitUntil,
+    oneEvent,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 
@@ -479,5 +480,41 @@ describe('Overlays', () => {
         await waitUntil(
             () => document.querySelector('active-element') === null
         );
+    });
+
+    it('opens detached content', async () => {
+        const textContent = 'This is a detached element that has been overlaid';
+        const el = await fixture<HTMLButtonElement>(
+            html`
+                <button>Trigger</button>
+            `
+        );
+
+        const content = document.createElement('div');
+        content.textContent = textContent;
+
+        const opened = oneEvent(el, 'sp-opened');
+        const closeOverlay = await Overlay.open(el, 'click', content, {
+            placement: 'bottom',
+        });
+        await opened;
+
+        let activeOverlay = document.querySelector('active-overlay');
+
+        if (activeOverlay) {
+            expect(activeOverlay.textContent).to.equal(textContent);
+        } else {
+            expect(activeOverlay).to.not.be.null;
+        }
+
+        const closed = oneEvent(el, 'sp-closed');
+        closeOverlay();
+        await closed;
+
+        activeOverlay = document.querySelector('active-overlay');
+
+        expect(activeOverlay).to.be.null;
+
+        content.remove();
     });
 });

--- a/packages/shared/src/reparent-children.ts
+++ b/packages/shared/src/reparent-children.ts
@@ -22,7 +22,9 @@ function restoreChildren<T extends Element>(
         if (cleanupCallbacks[index]) {
             cleanupCallbacks[index](srcElement);
         }
-        parentElement.replaceChild(srcElement, placeholderItem);
+        if (parentElement && parentElement !== placeholderItem) {
+            parentElement.replaceChild(srcElement, placeholderItem);
+        }
         delete placeholderItems[index];
     }
     return srcElements;
@@ -37,11 +39,6 @@ export const reparentChildren = <T extends Element>(
     const cleanupCallbacks: ((el: T) => void)[] = [];
 
     for (let index = 0; index < srcElements.length; ++index) {
-        const placeholderItem: Comment = document.createComment(
-            'placeholder for reparented element'
-        );
-        placeholderItems.push(placeholderItem);
-
         const srcElement = srcElements[index];
         if (prepareCallback) {
             cleanupCallbacks.push(
@@ -51,9 +48,15 @@ export const reparentChildren = <T extends Element>(
                     })
             );
         }
+        const placeholderItem: Comment = document.createComment(
+            'placeholder for reparented element'
+        );
+        placeholderItems.push(placeholderItem);
         const parentElement =
             srcElement.parentElement || srcElement.getRootNode();
-        parentElement.replaceChild(placeholderItem, srcElement);
+        if (parentElement && parentElement !== srcElement) {
+            parentElement.replaceChild(placeholderItem, srcElement);
+        }
         newParent.append(srcElement);
     }
 


### PR DESCRIPTION
## Description
- allow detached elements (e.g. `document.createElement('div')`) to be used as "content" in an overlay

## Related Issue
fixes #1540

## Motivation and Context
Alternatives to rendering into a document fragment when you don't want the overlay content to exist in the DOM when closed should be available.

## How Has This Been Tested?
- unit test
- story


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
