### PR TITLE
fix: expand support for maintaining hue and saturation across customization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 165201f1035928ae100cc6578e8c93d9e410b61a
+        default: 1da21edc588af1d3b8563fc13201fe49ffbf8089
 commands:
     downstream:
         steps:

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -21,7 +21,12 @@ import {
 } from '@spectrum-web-components/base';
 import { streamingListener } from '@spectrum-web-components/base/src/streaming-listener.js';
 import { WithSWCResizeObserver, SWCResizeObserverEntry } from './types';
-import { ColorHandle, ColorValue } from '@spectrum-web-components/color-handle';
+import {
+    ColorHandle,
+    ColorValue,
+    extractHueAndSaturationRegExp,
+    replaceHueRegExp,
+} from '@spectrum-web-components/color-handle';
 import '@spectrum-web-components/color-handle/sp-color-handle.js';
 import { TinyColor } from '@ctrl/tinycolor';
 
@@ -92,18 +97,16 @@ export class ColorArea extends SpectrumElement {
                 return this._color.toName() || this._color.toRgbString();
             case 'hsl':
                 if (this._format.isString) {
-                    const hueExp = /(^hs[v|va|l|la]\()\d{1,3}/;
                     const hslString = this._color.toHslString();
-                    return hslString.replace(hueExp, `$1${this.hue}`);
+                    return hslString.replace(replaceHueRegExp, `$1${this.hue}`);
                 } else {
                     const { s, l, a } = this._color.toHsl();
                     return { h: this.hue, s, l, a };
                 }
             case 'hsv':
                 if (this._format.isString) {
-                    const hueExp = /(^hs[v|va|l|la]\()\d{1,3}/;
                     const hsvString = this._color.toHsvString();
-                    return hsvString.replace(hueExp, `$1${this.hue}`);
+                    return hsvString.replace(replaceHueRegExp, `$1${this.hue}`);
                 } else {
                     const { s, v, a } = this._color.toHsv();
                     return { h: this.hue, s, v, a };
@@ -141,8 +144,7 @@ export class ColorArea extends SpectrumElement {
         let originalHue: number | undefined = undefined;
 
         if (isString && format.startsWith('hs')) {
-            const hueExp = /^hs[v|va|l|la]\((\d{1,3})/;
-            const values = hueExp.exec(color as string);
+            const values = extractHueAndSaturationRegExp.exec(color as string);
 
             if (values !== null) {
                 const [, h] = values;

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -322,9 +322,6 @@ export class ColorArea extends SpectrumElement {
     private handlePointerup(event: PointerEvent): void {
         event.preventDefault();
         (event.target as HTMLElement).releasePointerCapture(event.pointerId);
-        if (event.pointerType === 'mouse') {
-            this.handleFocusout();
-        }
         const applyDefault = this.dispatchEvent(
             new Event('change', {
                 bubbles: true,
@@ -332,6 +329,10 @@ export class ColorArea extends SpectrumElement {
                 cancelable: true,
             })
         );
+        this.inputX.focus();
+        if (event.pointerType === 'mouse') {
+            this.handleFocusout();
+        }
         if (!applyDefault) {
             this._color = this._previousColor;
         }
@@ -394,6 +395,7 @@ export class ColorArea extends SpectrumElement {
             </div>
 
             <sp-color-handle
+                tabindex="-1"
                 class="handle"
                 color=${this._color.toHslString()}
                 ?disabled=${this.disabled}

--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -63,13 +63,20 @@ export const joint = (): TemplateResult => {
             <sp-color-slider
                 color="hsv(120 0% 1)"
                 @input=${({
-                    target: { color, previousElementSibling },
+                    target: {
+                        color,
+                        previousElementSibling,
+                        nextElementSibling,
+                    },
                 }: Event & {
                     target: ColorSlider & {
                         previousElementSibling: ColorArea;
+                        nextElementSibling: HTMLDivElement;
                     };
                 }): void => {
                     previousElementSibling.color = color;
+                    nextElementSibling.textContent = color as string;
+                    nextElementSibling.style.color = color as string;
                 }}
             ></sp-color-slider>
             <div style="color: hsv(120, 0, 1)">hsv(120, 0, 1)</div>

--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -51,7 +51,7 @@ export const joint = (): TemplateResult => {
     return html`
         <div>
             <sp-color-area
-                color="hsv(120, 0, 1)"
+                color="hsv (120 0% 100%)"
                 @input=${({ target }: Event & { target: ColorArea }) => {
                     const next = target.nextElementSibling as ColorSlider;
                     const display = next.nextElementSibling as HTMLElement;
@@ -61,7 +61,7 @@ export const joint = (): TemplateResult => {
                 }}
             ></sp-color-area>
             <sp-color-slider
-                color="hsv(120, 0, 1)"
+                color="hsv(120 0% 1)"
                 @input=${({
                     target: { color, previousElementSibling },
                 }: Event & {

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -63,9 +63,16 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.hue, 'hugh').to.equal(100.00000000000003);
+        expect(el.hue, 'hugh').to.equal(100);
         expect(el.x, 'ex').to.equal(0.6666666666666666);
         expect(el.y, 'why').to.equal(0.25);
+
+        el.color = 'hsla(120, 100%, 0, 1)';
+        await elementUpdated(el);
+
+        expect(el.hue, 'hue 2').to.equal(120);
+        expect(el.x, 'x 2').to.equal(0);
+        expect(el.y, 'y 2').to.equal(1);
     });
     it('accepts "color" values as rgb', async () => {
         const el = await fixture<ColorArea>(
@@ -102,7 +109,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.hue, 'hue').to.equal(100.00000000000003);
+        expect(el.hue, 'hue').to.equal(100);
         expect(el.x, 'x').to.equal(0.6666666666666666);
         expect(el.y, 'y').to.equal(0.25);
 
@@ -165,7 +172,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.hue, 'hue').to.equal(100.00000000000003);
+        expect(el.hue, 'hue').to.equal(100);
         expect(el.x, 'x').to.equal(0.6666666666666666);
         expect(el.y, 'y').to.equal(0.25);
 

--- a/packages/color-handle/src/ColorHandle.ts
+++ b/packages/color-handle/src/ColorHandle.ts
@@ -34,6 +34,10 @@ export type ColorValue =
     | HSL
     | HSLA;
 
+export const extractHueAndSaturationRegExp = /^hs[v|l]a?\s?\((\d{1,3}\.?\d*?),?\s?(\d{1,3})/;
+export const replaceHueAndSaturationRegExp = /(^hs[v|l]a?\s?\()\d{1,3}\.?\d*?(,?\s?)\d{1,3}/;
+export const replaceHueRegExp = /(^hs[v|l]a?\()\d{1,3}/;
+
 /**
  * @element sp-color-handle
  */

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -250,11 +250,11 @@ export class ColorSlider extends Focusable {
         this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
     }
 
-    private handleFocus(): void {
+    private handleFocusin(): void {
         this.focused = true;
     }
 
-    private handleBlur(): void {
+    private handleFocusout(): void {
         this.focused = false;
     }
 
@@ -269,7 +269,7 @@ export class ColorSlider extends Focusable {
         this.boundingClientRect = this.getBoundingClientRect();
         (event.target as HTMLElement).setPointerCapture(event.pointerId);
         if (event.pointerType === 'mouse') {
-            this.handleFocus();
+            this.handleFocusin();
         }
     }
 
@@ -302,8 +302,9 @@ export class ColorSlider extends Focusable {
         if (!applyDefault) {
             this._color = this._previousColor;
         }
+        this.focus();
         if (event.pointerType === 'mouse') {
-            this.handleBlur();
+            this.handleFocusout();
         }
     }
 
@@ -356,6 +357,7 @@ export class ColorSlider extends Focusable {
                 </div>
             </div>
             <sp-color-handle
+                tabindex="-1"
                 class="handle"
                 color="hsl(${this.value}, 100%, 50%)"
                 ?disabled=${this.disabled}
@@ -381,8 +383,6 @@ export class ColorSlider extends Focusable {
                 @input=${this.handleInput}
                 @keydown=${this.handleKeydown}
                 @keyup=${this.handleKeyup}
-                @focus=${this.handleFocus}
-                @blur=${this.handleBlur}
             />
         `;
     }
@@ -390,5 +390,7 @@ export class ColorSlider extends Focusable {
     protected firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.boundingClientRect = this.getBoundingClientRect();
+        this.addEventListener('focusin', this.handleFocusin);
+        this.addEventListener('focusout', this.handleFocusout);
     }
 }

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -25,7 +25,9 @@ import styles from './color-slider.css.js';
 import {
     ColorHandle,
     ColorValue,
-} from '@spectrum-web-components/color-handle/src/ColorHandle';
+    extractHueAndSaturationRegExp,
+    replaceHueAndSaturationRegExp,
+} from '@spectrum-web-components/color-handle';
 import { TinyColor } from '@ctrl/tinycolor';
 
 /**
@@ -103,13 +105,27 @@ export class ColorSlider extends Focusable {
             case 'name':
                 return this._color.toName() || this._color.toRgbString();
             case 'hsl':
-                return this._format.isString
-                    ? this._color.toHslString()
-                    : this._color.toHsl();
+                if (this._format.isString) {
+                    const hslString = this._color.toHslString();
+                    return hslString.replace(
+                        replaceHueAndSaturationRegExp,
+                        `$1${this.value}$2${this._saturation}`
+                    );
+                } else {
+                    const { s, l, a } = this._color.toHsl();
+                    return { h: this.value, s, l, a };
+                }
             case 'hsv':
-                return this._format.isString
-                    ? this._color.toHsvString()
-                    : this._color.toHsv();
+                if (this._format.isString) {
+                    const hsvString = this._color.toHsvString();
+                    return hsvString.replace(
+                        replaceHueAndSaturationRegExp,
+                        `$1${this.value}$2${this._saturation}`
+                    );
+                } else {
+                    const { s, v, a } = this._color.toHsv();
+                    return { h: this.value, s, v, a };
+                }
             default:
                 return 'No color format applied.';
         }
@@ -134,20 +150,17 @@ export class ColorSlider extends Focusable {
         };
 
         if (isString && format.startsWith('hs')) {
-            const hueExp = /^hs[v|va|l|la]\((\d{1,3})/;
-            const values = hueExp.exec(color as string);
-
+            const values = extractHueAndSaturationRegExp.exec(color as string);
             if (values !== null) {
-                const [, h] = values;
+                const [, h, s] = values;
                 this.value = Number(h);
+                this._saturation = Number(s);
             }
         } else if (!isString && format.startsWith('hs')) {
             const colorInput = this._color.originalInput;
             const colorValues = Object.values(colorInput);
             this.value = colorValues[0];
-
-            // The below code line causes some tests to fail
-            //this.value = parseFloat((color as HSV).h.toString());
+            this._saturation = colorValues[1];
         } else {
             const { h } = this._color.toHsv();
             this.value = h;
@@ -159,6 +172,8 @@ export class ColorSlider extends Focusable {
     private _color = new TinyColor({ h: 0, s: 1, v: 1 });
 
     private _previousColor = new TinyColor({ h: 0, s: 1, v: 1 });
+
+    private _saturation!: number;
 
     private _format: { format: string; isString: boolean } = {
         format: '',
@@ -342,7 +357,7 @@ export class ColorSlider extends Focusable {
             </div>
             <sp-color-handle
                 class="handle"
-                color="hsl(${this._color.toHsl().h}, 100%, 50%)"
+                color="hsl(${this.value}, 100%, 50%)"
                 ?disabled=${this.disabled}
                 style="${this.vertical ? 'top' : 'left'}: ${this
                     .sliderHandlePosition}%"

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -536,28 +536,45 @@ describe('ColorSlider', () => {
                 <sp-color-slider></sp-color-slider>
             `
         );
-        el.color = 'hsl(300, 60%, 100%)';
-        expect(el.value).to.equal(300);
+        const hue = 300;
+        const hsl = `hsl(${hue}, 60%, 100%)`;
+        el.color = hsl;
+        expect(el.value).to.equal(hue);
+        expect(el.color).to.equal(hsl);
 
-        el.color = 'hsla(300, 60%, 100%, 1)';
-        expect(el.value).to.equal(300);
+        const hsla = `hsla(${hue}, 60%, 100%, 0.9)`;
+        el.color = hsla;
+        expect(el.value).to.equal(hue);
+        expect(el.color).to.equal(hsla);
 
-        el.color = 'hsv(300, 60%, 100%)';
-        expect(el.value).to.equal(300);
+        const hsv = `hsv(${hue}, 60%, 100%)`;
+        el.color = hsv;
+        expect(el.value).to.equal(hue);
+        expect(el.color).to.equal(hsv);
 
-        el.color = 'hsva(300, 60%, 100%, 1)';
-        expect(el.value).to.equal(300);
+        const hsva = `hsva(${hue}, 60%, 100%, 0.9)`;
+        el.color = hsva;
+        expect(el.value).to.equal(hue);
+        expect(el.color).to.equal(hsva);
 
-        el.color = new TinyColor({ h: 300, s: 60, v: 100 });
-        expect(el.value).to.equal(300);
+        const tinyHSV = new TinyColor({ h: hue, s: 60, v: 100 });
+        el.color = tinyHSV;
+        expect(el.value).to.equal(hue);
+        expect(tinyHSV.equals(el.color)).to.be.true;
 
-        el.color = new TinyColor({ h: 300, s: 60, v: 100, a: 1 });
-        expect(el.value).to.equal(300);
+        const tinyHSVA = new TinyColor({ h: hue, s: 60, v: 100, a: 1 });
+        el.color = tinyHSVA;
+        expect(el.value).to.equal(hue);
+        expect(tinyHSVA.equals(el.color)).to.be.true;
 
-        el.color = new TinyColor({ h: 300, s: 60, l: 100 });
-        expect(el.value).to.equal(300);
+        const tinyHSL = new TinyColor({ h: hue, s: 60, l: 100 });
+        el.color = tinyHSL;
+        expect(el.value).to.equal(hue);
+        expect(tinyHSL.equals(el.color)).to.be.true;
 
-        el.color = new TinyColor({ h: 300, s: 60, l: 100, a: 1 });
-        expect(el.value).to.equal(300);
+        const tinyHSLA = new TinyColor({ h: hue, s: 60, l: 100, a: 1 });
+        el.color = tinyHSLA;
+        expect(el.value).to.equal(hue);
+        expect(tinyHSLA.equals(el.color)).to.be.true;
     });
 });

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -233,11 +233,11 @@ export class ColorWheel extends Focusable {
         this.value = valueAsNumber;
         this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
     }
-    private handleFocus(): void {
+    private handleFocusin(): void {
         this.focused = true;
     }
 
-    private handleBlur(): void {
+    private handleFocusout(): void {
         this.focused = false;
     }
 
@@ -252,7 +252,7 @@ export class ColorWheel extends Focusable {
         this.boundingClientRect = this.getBoundingClientRect();
         (event.target as HTMLElement).setPointerCapture(event.pointerId);
         if (event.pointerType === 'mouse') {
-            this.handleFocus();
+            this.handleFocusin();
         }
     }
 
@@ -283,8 +283,9 @@ export class ColorWheel extends Focusable {
         if (!applyDefault) {
             this._color = this._previousColor;
         }
+        this.focus();
         if (event.pointerType === 'mouse') {
-            this.handleBlur();
+            this.handleFocusout();
         }
     }
 
@@ -338,6 +339,7 @@ export class ColorWheel extends Focusable {
             </slot>
 
             <sp-color-handle
+                tabindex="-1"
                 class="handle"
                 color="hsl(${this.value}, 100%, 50%)"
                 ?disabled=${this.disabled}
@@ -363,8 +365,6 @@ export class ColorWheel extends Focusable {
                 @input=${this.handleInput}
                 @keydown=${this.handleKeydown}
                 @keyup=${this.handleKeyup}
-                @focus=${this.handleFocus}
-                @blur=${this.handleBlur}
             />
         `;
     }
@@ -372,6 +372,8 @@ export class ColorWheel extends Focusable {
     protected firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.boundingClientRect = this.getBoundingClientRect();
+        this.addEventListener('focusin', this.handleFocusin);
+        this.addEventListener('focusout', this.handleFocusout);
     }
 
     private observer?: WithSWCResizeObserver['ResizeObserver'];

--- a/packages/color-wheel/test/color-wheel.test.ts
+++ b/packages/color-wheel/test/color-wheel.test.ts
@@ -374,4 +374,51 @@ describe('ColorWheel', () => {
         el.color = color;
         expect(color.equals(el.color));
     });
+    it(`maintains hue value`, async () => {
+        const el = await fixture<ColorWheel>(
+            html`
+                <sp-color-wheel></sp-color-wheel>
+            `
+        );
+        const hue = 300;
+        const hsl = `hsl(${hue}, 60%, 100%)`;
+        el.color = hsl;
+        expect(el.value).to.equal(hue);
+        expect(el.color).to.equal(hsl);
+
+        const hsla = `hsla(${hue}, 60%, 100%, 0.9)`;
+        el.color = hsla;
+        expect(el.value).to.equal(hue);
+        expect(el.color).to.equal(hsla);
+
+        const hsv = `hsv(${hue}, 60%, 100%)`;
+        el.color = hsv;
+        expect(el.value).to.equal(hue);
+        expect(el.color).to.equal(hsv);
+
+        const hsva = `hsva(${hue}, 60%, 100%, 0.9)`;
+        el.color = hsva;
+        expect(el.value).to.equal(hue);
+        expect(el.color).to.equal(hsva);
+
+        const tinyHSV = new TinyColor({ h: hue, s: 60, v: 100 });
+        el.color = tinyHSV;
+        expect(el.value).to.equal(hue);
+        expect(tinyHSV.equals(el.color)).to.be.true;
+
+        const tinyHSVA = new TinyColor({ h: hue, s: 60, v: 100, a: 1 });
+        el.color = tinyHSVA;
+        expect(el.value).to.equal(hue);
+        expect(tinyHSVA.equals(el.color)).to.be.true;
+
+        const tinyHSL = new TinyColor({ h: hue, s: 60, l: 100 });
+        el.color = tinyHSL;
+        expect(el.value).to.equal(hue);
+        expect(tinyHSL.equals(el.color)).to.be.true;
+
+        const tinyHSLA = new TinyColor({ h: hue, s: 60, l: 100, a: 1 });
+        el.color = tinyHSLA;
+        expect(el.value).to.equal(hue);
+        expect(tinyHSLA.equals(el.color)).to.be.true;
+    });
 });


### PR DESCRIPTION
## Description
- update the regex for extracting and setting hue/saturation values on hsl/hsla/hsv/hsva colors
- update focus management so that arrow keys can be accepted immediately after drag interactions on the same color control

## Motivation and Context
RegExp adoption of hue and saturation values should be robust.

## How Has This Been Tested?
- expanded unit tests
- updated VRTs

## Screenshots (if appropriate):
https://westbrook-hue-and-saturation--spectrum-web-components.netlify.app/storybook/index.html?path=/story/color-area--joint

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
