### PR TITLE
fix: add icon present and icon-only support to Picker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 1da21edc588af1d3b8563fc13201fe49ffbf8089
+        default: 4cf3dfcdfea47220e84049f73a8e1a7694a3b161
 commands:
     downstream:
         steps:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "scripts": {
         "analyze": "lit-analyzer \"packages/*/src/**/!(*.css).ts\"",
         "analyze:quick": "lit-analyzer \"packages/*/src/!(*.css).ts\"",
-        "build": "yarn build:css && yarn build:ts:clean && yarn build:decorator && yarn build:compare",
+        "build": "yarn build:css && yarn build:ts && yarn build:decorator && yarn build:compare",
+        "build:clean": "yarn build:css && yarn build:ts:clean && yarn build:decorator && yarn build:compare",
         "build:clear-cache": "rimraf packages/*/lib && rimraf packages/*/tsconfig.tsbuildinfo",
         "build:compare": "tsc --build projects/vrt-compare/tsconfig.json",
         "build:css": "node ./tasks/build-css.js",
@@ -35,7 +36,7 @@
         "docs:start": "yarn docs:analyze && run-p watch:css build:watch \"docs:ts -w\" docs:start:watch",
         "docs:start:watch": "node ./tasks/watch-documentation.js",
         "docs:ts": "tsc --build documentation/tsconfig.json",
-        "get-ready": "yarn build:clear-cache && run-p process-icons process-spectrum && yarn build",
+        "get-ready": "yarn build:clear-cache && run-p process-icons process-spectrum && yarn build:clean",
         "icons": "node ./scripts/process-icons.js && pretty-quick --pattern \"packages/**/*.svg.ts\"",
         "icons:ui": "lerna run --scope @spectrum-web-components/icons-ui build",
         "icons:workflow": "lerna run --scope @spectrum-web-components/icons-workflow build",

--- a/packages/menu/menu-item.md
+++ b/packages/menu/menu-item.md
@@ -36,6 +36,27 @@ Menus are a collection of `<sp-menu-item>`s that can be modified via a `disabled
 </sp-menu>
 ```
 
+### Icon slot
+
+Content assigned to the `icon` slot will be placed at the beginning of the `<sp-menu-item>`.
+
+```html
+<sp-menu style="width: 200px;">
+    <sp-menu-item>
+        <sp-icon-save-floppy slot="icon"></sp-icon-save-floppy>
+        Save
+    </sp-menu-item>
+    <sp-menu-item>
+        <sp-icon-stopwatch slot="icon"></sp-icon-stopwatch>
+        Finish
+    </sp-menu-item>
+    <sp-menu-item>
+        <sp-icon-user-activity slot="icon"></sp-icon-user-activity>
+        Review
+    </sp-menu-item>
+</sp-menu>
+```
+
 ### Value slot
 
 Content assigned to the `value` slot will be placed at the end of the `<sp-menu-item>`, like values, keyboard shortcuts, etc., based on the current text direction.

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -53,15 +53,25 @@ export class MenuItem extends ActionButton {
     })
     public noWrap = false;
 
-    /**
-     * Hide this getter from web-component-analyzer until
-     * https://github.com/runem/web-component-analyzer/issues/131
-     * has been addressed.
-     *
-     * @private
-     */
-    public get itemText(): string {
-        return (this.textContent || /* c8 ignore next */ '').trim();
+    public get itemChildren(): { icon: Element[]; content: Node[] } {
+        const iconSlot = this.shadowRoot.querySelector(
+            'slot[name="icon"]'
+        ) as HTMLSlotElement;
+        const icon = !iconSlot
+            ? []
+            : iconSlot.assignedElements().map((element) => {
+                  const newElement = element.cloneNode(true) as HTMLElement;
+                  newElement.removeAttribute('slot');
+                  newElement.classList.toggle('icon');
+                  return newElement;
+              });
+        const contentSlot = this.shadowRoot.querySelector(
+            'slot:not([name])'
+        ) as HTMLSlotElement;
+        const content = !contentSlot
+            ? []
+            : contentSlot.assignedNodes().map((node) => node.cloneNode(true));
+        return { icon, content };
     }
 
     protected get buttonContent(): TemplateResult[] {

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -24,3 +24,11 @@ governing permissions and limitations under the License.
 :host([dir='rtl']) ::slotted([slot='value']) {
     margin-right: var(--spectrum-listitem-icon-gap);
 }
+
+:host([dir='ltr']) [icon-only]::slotted(:last-of-type) {
+    margin-right: auto;
+}
+
+:host([dir='rtl']) [icon-only]::slotted(:last-of-type) {
+    margin-left: auto;
+}

--- a/packages/picker/README.md
+++ b/packages/picker/README.md
@@ -177,6 +177,80 @@ import { Picker } from '@spectrum-web-components/picker';
 </sp-tab-panel>
 </sp-tabs>
 
+## Icons
+
+`<sp-menu-item>`s in an `<sp-picker>` that are provided content addressed to their `icon` slot will be passed to the `<sp-picker>` element when that item is chosen.
+
+```html
+<sp-field-label for="picker-icons">Choose an action...</sp-field-label>
+<sp-picker label="What would you like to do?" value="item-2" id="picker-icons">
+    <sp-menu-item>
+        <sp-icon-save-floppy slot="icon"></sp-icon-save-floppy>
+        Save
+    </sp-menu-item>
+    <sp-menu-item>
+        <sp-icon-stopwatch slot="icon"></sp-icon-stopwatch>
+        Finish
+    </sp-menu-item>
+    <sp-menu-item>
+        <sp-icon-user-activity slot="icon"></sp-icon-user-activity>
+        Review
+    </sp-menu-item>
+</sp-picker>
+```
+
+## Icons only
+
+You can choose to only display the icon in the `<sp-picker>` element when an item is selected by applying the `icons-only` attribute. In the case that your `<sp-menu-item>` elements still have text content, that content will be applied to `<sp-picker>` element in a non-visible way.
+
+```html
+<sp-field-label for="picker-icons-value">Choose an action...</sp-field-label>
+<sp-picker
+    label="What would you like to do?"
+    value="item-2"
+    id="picker-icons-value"
+    icons-only
+>
+    <sp-menu-item>
+        <sp-icon-save-floppy slot="icon"></sp-icon-save-floppy>
+        Save
+    </sp-menu-item>
+    <sp-menu-item>
+        <sp-icon-stopwatch slot="icon"></sp-icon-stopwatch>
+        Finish
+    </sp-menu-item>
+    <sp-menu-item>
+        <sp-icon-user-activity slot="icon"></sp-icon-user-activity>
+        Review
+    </sp-menu-item>
+</sp-picker>
+```
+
+When you choose to leverage `<sp-menu-item>` elements without text content, you will need to be sure to apply accessible labeling to the `[slot="icon"]` content as follows:
+
+```html
+<sp-field-label for="picker-icons-only">Choose an action...</sp-field-label>
+<sp-picker
+    label="What would you like to do?"
+    value="item-2"
+    id="picker-icons-only"
+    icons-only
+>
+    <sp-menu-item>
+        <sp-icon-save-floppy slot="icon" label="Save"></sp-icon-save-floppy>
+    </sp-menu-item>
+    <sp-menu-item>
+        <sp-icon-stopwatch slot="icon" label="Finish"></sp-icon-stopwatch>
+    </sp-menu-item>
+    <sp-menu-item>
+        <sp-icon-user-activity
+            slot="icon"
+            label="Review"
+        ></sp-icon-user-activity>
+    </sp-menu-item>
+</sp-picker>
+```
+
 ## Value
 
 When the `value` of an `<sp-picker>` matches the `value` attribute or the trimmed `textContent` (or `itemText`) of a descendent `<sp-menu-item>` element, it will make that element as `selected`.

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -75,3 +75,21 @@ sp-popover {
         var(--spectrum-alias-icon-color-focus)
     );
 }
+
+.visually-hidden {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+:host([dir='ltr']) #label.visually-hidden + .picker {
+    margin-left: auto;
+}
+
+:host([dir='rtl']) #label.visually-hidden + .picker {
+    margin-right: auto;
+}

--- a/packages/picker/src/spectrum-config.js
+++ b/packages/picker/src/spectrum-config.js
@@ -70,10 +70,6 @@ const config = {
             ],
             classes: [
                 {
-                    selector: '.spectrum-Icon',
-                    name: 'icon',
-                },
-                {
                     selector: '.spectrum-Picker-menuIcon',
                     name: 'picker',
                 },
@@ -88,6 +84,10 @@ const config = {
                 {
                     selector: '.spectrum-Picker-validationIcon',
                     name: 'validationIcon',
+                },
+                {
+                    selector: '.spectrum-Picker-icon',
+                    name: 'icon',
                 },
             ],
             ids: [

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -94,23 +94,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border-width: var(--spectrum-picker-disabled-border-size);
     cursor: default;
 }
-:host([dir='ltr']) #button .spectrum-Picker-icon {
+:host([dir='ltr']) #button .icon {
     /* [dir=ltr] .spectrum-Picker .spectrum-Picker-icon */
     margin-right: var(--spectrum-picker-icon-gap);
 }
-:host([dir='rtl']) #button .spectrum-Picker-icon {
+:host([dir='rtl']) #button .icon {
     /* [dir=rtl] .spectrum-Picker .spectrum-Picker-icon */
     margin-left: var(--spectrum-picker-icon-gap);
 }
-.spectrum-Picker-icon {
+.icon {
     /* .spectrum-Picker .spectrum-Picker-icon */
     flex-shrink: 0;
 }
-:host([dir='ltr']) #button #label + .spectrum-Picker-icon {
+:host([dir='ltr']) #button #label + .icon {
     /* [dir=ltr] .spectrum-Picker .spectrum-Picker-label+.spectrum-Picker-icon */
     margin-left: var(--spectrum-picker-icon-gap);
 }
-:host([dir='rtl']) #button #label + .spectrum-Picker-icon {
+:host([dir='rtl']) #button #label + .icon {
     /* [dir=rtl] .spectrum-Picker .spectrum-Picker-label+.spectrum-Picker-icon */
     margin-right: var(--spectrum-picker-icon-gap);
 }
@@ -606,10 +606,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-text-color-disabled)
     );
 }
-:host([disabled]) #button .spectrum-Picker-icon,
+:host([disabled]) #button .icon,
 :host([disabled]) #button .picker,
 :host([disabled]) #button .validationIcon,
-#button:disabled .spectrum-Picker-icon,
+#button:disabled .icon,
 #button:disabled .picker,
 #button:disabled .validationIcon {
     /* .spectrum-Picker.is-disabled .spectrum-Picker-icon,

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -16,6 +16,9 @@ import '../sp-picker.js';
 import { Picker } from '../';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-copy.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-delete.js';
 import { states } from './states.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import { spreadProps } from '@open-wc/lit-helpers';
@@ -83,6 +86,7 @@ interface StoryArgs {
     invalid?: boolean;
     open?: boolean;
     quiet?: boolean;
+    showText?: boolean;
 }
 
 export const Default = (args: StoryArgs): TemplateResult => {
@@ -143,6 +147,103 @@ export const quiet = (args: StoryArgs): TemplateResult => {
 };
 quiet.args = {
     quiet: true,
+};
+
+export const icons = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-field-label for="picker-quiet">
+            Choose an action type...
+        </sp-field-label>
+        <sp-picker
+            ...=${spreadProps(args)}
+            id="picker-quiet"
+            @change="${(event: Event): void => {
+                const picker = event.target as Picker;
+                console.log(`Change: ${picker.value}`);
+            }}"
+            label="Pick an action"
+            value="1"
+        >
+            <sp-menu-item value="1">
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-menu-item>
+            <sp-menu-item value="2">
+                <sp-icon-copy slot="icon"></sp-icon-copy>
+                Copy
+            </sp-menu-item>
+            <sp-menu-item value="3">
+                <sp-icon-delete slot="icon"></sp-icon-delete>
+                Delete
+            </sp-menu-item>
+        </sp-picker>
+    `;
+};
+
+export const iconValue = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-field-label for="picker-quiet">
+            Choose an action type...
+        </sp-field-label>
+        <sp-picker
+            ...=${spreadProps(args)}
+            id="picker-quiet"
+            @change="${(event: Event): void => {
+                const picker = event.target as Picker;
+                console.log(`Change: ${picker.value}`);
+            }}"
+            label="Pick an action"
+            icons-only
+            style="--spectrum-picker-width: 100px"
+            value="2"
+        >
+            <sp-menu-item value="1">
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-menu-item>
+            <sp-menu-item value="2">
+                <sp-icon-copy slot="icon"></sp-icon-copy>
+                Copy
+            </sp-menu-item>
+            <sp-menu-item value="3">
+                <sp-icon-delete slot="icon"></sp-icon-delete>
+                Delete
+            </sp-menu-item>
+        </sp-picker>
+    `;
+};
+
+export const iconsOnly = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-field-label for="picker-quiet">
+            Choose an action type...
+        </sp-field-label>
+        <sp-picker
+            ...=${spreadProps(args)}
+            id="picker-quiet"
+            @change="${(event: Event): void => {
+                const picker = event.target as Picker;
+                console.log(`Change: ${picker.value}`);
+            }}"
+            label="Pick an action"
+            icons-only
+            style="--spectrum-picker-width: 100px"
+            value="3"
+        >
+            <sp-menu-item value="1">
+                <sp-icon-edit slot="icon" label="Edit"></sp-icon-edit>
+            </sp-menu-item>
+            <sp-menu-item value="2">
+                <sp-icon-copy slot="icon" label="Copy"></sp-icon-copy>
+            </sp-menu-item>
+            <sp-menu-item value="3">
+                <sp-icon-delete slot="icon" label="Delete"></sp-icon-delete>
+            </sp-menu-item>
+        </sp-picker>
+    `;
+};
+iconsOnly.args = {
+    open: true,
 };
 
 export const Open = (args: StoryArgs): TemplateResult => {

--- a/packages/picker/test/benchmark/basic-test.ts
+++ b/packages/picker/test/benchmark/basic-test.ts
@@ -269,7 +269,7 @@ const countryList = [
 
 measureFixtureCreation(
     html`
-        <sp-picker>
+        <sp-picker value="Zimbabwe">
             ${countryList.map(
                 (country) => html`
                     <sp-menu-item>${country}</sp-menu-item>
@@ -277,5 +277,5 @@ measureFixtureCreation(
             )}
         </sp-picker>
     `,
-    { numRenders: 1 }
+    { numRenders: 10 }
 );

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -45,6 +45,7 @@ import {
     findAccessibilityNode,
     sendKeys,
 } from '@web/test-runner-commands';
+import { iconsOnly } from '../stories/picker.stories.js';
 
 const isMenuActiveElement = function (): boolean {
     return document.activeElement instanceof Menu;
@@ -198,12 +199,10 @@ describe('Picker', () => {
         expect(
             findAccessibilityNode<NamedNode>(
                 snapshot,
-                (node) =>
-                    node.name ===
-                    'Where do you live? Select a Country with a very long label, too long in fact'
+                (node) => node.name === 'Where do you live?'
             ),
             '`name` is the label text'
-        );
+        ).to.not.be.null;
 
         el.value = 'option-2';
         await elementUpdated(el);
@@ -217,7 +216,42 @@ describe('Picker', () => {
                 (node) => node.name === 'Where do you live? Select Inverse'
             ),
             '`name` is the label text plus the selected item text'
-        );
+        ).to.not.be.null;
+    });
+
+    it('manages its "name" value in the accessibility tree when [icons-only]', async () => {
+        const test = await fixture<HTMLDivElement>(html`
+            <div>${iconsOnly({})}</div>
+        `);
+        const el = test.querySelector('sp-picker') as Picker;
+
+        await elementUpdated(el);
+        type NamedNode = { name: string };
+        let snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+            children: NamedNode[];
+        };
+
+        expect(
+            findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Choose an action type... Delete'
+            ),
+            '`name` is the label text'
+        ).to.not.be.null;
+
+        el.value = '2';
+        await elementUpdated(el);
+        snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+            children: NamedNode[];
+        };
+
+        expect(
+            findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Choose an action type... Copy'
+            ),
+            '`name` is the label text plus the selected item text'
+        ).to.not.be.null;
     });
 
     it('loads accessibly w/ slotted label', async () => {


### PR DESCRIPTION
## Description
- add icon passing from `<sp-menu-item>` to `<sp-picker>`
- add `icons-only` attribute to the `<sp-picker>` element which allows it to display only the icon from the selected element while consuming the content into the accessibility tree

## Related Issue
fixes #1569

## Motivation and Context
Spectrum coverage. Product team support. Feature completeness.

## How Has This Been Tested?
- unit test
- screenshots

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1156657/123716100-c982c400-d847-11eb-8655-e3cd526e827b.png)
![image](https://user-images.githubusercontent.com/1156657/123716124-d3a4c280-d847-11eb-9e6a-1fcf03ae3125.png)
![image](https://user-images.githubusercontent.com/1156657/123717135-3bf4a380-d84a-11eb-92ec-2e19e2eabee3.png)
https://westbrook-icon-picker--spectrum-web-components.netlify.app/storybook/index.html?path=/story/picker--icons

## Types of changes=
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
