### PR TITLE
docs(action-button): expand sp-action-button documentation

### DIFF
--- a/packages/action-button/README.md
+++ b/packages/action-button/README.md
@@ -32,9 +32,17 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ```html demo
 <sp-action-group>
-    <sp-action-button size="s">Do action</sp-action-button>
-    <sp-action-button size="s" selected>Do action</sp-action-button>
-    <sp-action-button size="s" disabled>Do action</sp-action-button>
+    <sp-action-button size="s">Edit</sp-action-button>
+    <sp-action-button size="s">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+        Edit
+    </sp-action-button>
+    <sp-action-button size="s">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
+    <sp-action-button size="s" hold-affordance>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
 </sp-action-group>
 ```
 
@@ -44,9 +52,17 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ```html demo
 <sp-action-group>
-    <sp-action-button size="m">Do action</sp-action-button>
-    <sp-action-button size="m" selected>Do action</sp-action-button>
-    <sp-action-button size="m" disabled>Do action</sp-action-button>
+    <sp-action-button size="m">Edit</sp-action-button>
+    <sp-action-button size="m">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+        Edit
+    </sp-action-button>
+    <sp-action-button size="m">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
+    <sp-action-button size="m" hold-affordance>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
 </sp-action-group>
 ```
 
@@ -56,9 +72,17 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ```html demo
 <sp-action-group>
-    <sp-action-button size="l">Do action</sp-action-button>
-    <sp-action-button size="l" selected>Do action</sp-action-button>
-    <sp-action-button size="l" disabled>Do action</sp-action-button>
+    <sp-action-button size="l">Edit</sp-action-button>
+    <sp-action-button size="l">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+        Edit
+    </sp-action-button>
+    <sp-action-button size="l">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
+    <sp-action-button size="l" hold-affordance>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
 </sp-action-group>
 ```
 
@@ -68,9 +92,17 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ```html demo
 <sp-action-group>
-    <sp-action-button size="xl">Do action</sp-action-button>
-    <sp-action-button size="xl" selected>Do action</sp-action-button>
-    <sp-action-button size="xl" disabled>Do action</sp-action-button>
+    <sp-action-button size="xl">Edit</sp-action-button>
+    <sp-action-button size="xl">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+        Edit
+    </sp-action-button>
+    <sp-action-button size="xl">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
+    <sp-action-button size="xl" hold-affordance>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
 </sp-action-group>
 ```
 
@@ -79,43 +111,348 @@ import { ActionButton } from '@spectrum-web-components/action-button';
 
 ## Variants
 
-### Action button with icon
+The `<sp-action-button>` can be customized with either or both of the `emphasized` and `quiet` attributes. These will pair with either or both of the state attributes (`selected` and `disabled`) to decide the final visual delivery of the `<sp-action-button>`. Content addressed to the `icon` slot can also be provided and will be positioned just before the rest of the the supplied button content.
+
+### Standard
 
 ```html demo
-<sp-action-button>
-    <sp-icon-edit slot="icon"></sp-icon-edit>
-    This is an action button
-</sp-action-button>
+<div
+    style="display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); gap: 2em;"
+>
+    <div>
+        <sp-field-label for="standard">Default</sp-field-label>
+        <sp-action-group id="standard">
+            <sp-action-button>Edit</sp-action-button>
+            <sp-action-button>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-selected">Selected</sp-field-label>
+        <sp-action-group id="standard-selected">
+            <sp-action-button selected>Edit</sp-action-button>
+            <sp-action-button selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button selected hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-disabled">Disabled</sp-field-label>
+        <sp-action-group id="standard-disabled">
+            <sp-action-button disabled>Edit</sp-action-button>
+            <sp-action-button disabled>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button disabled>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button disabled hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-disabled-selected">
+            Disabled + Selected
+        </sp-field-label>
+        <sp-action-group id="standard-disabled-selected">
+            <sp-action-button disabled selected>Edit</sp-action-button>
+            <sp-action-button disabled selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button disabled selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button disabled selected hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+</div>
 ```
 
-### Icon only action button
+### Quiet
 
 ```html demo
-<sp-action-button label="Edit">
-    <sp-icon-edit slot="icon"></sp-icon-edit>
-</sp-action-button>
+<div
+    style="display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); gap: 2em;"
+>
+    <div>
+        <sp-field-label for="standard">Default</sp-field-label>
+        <sp-action-group quiet id="standard">
+            <sp-action-button quiet>Edit</sp-action-button>
+            <sp-action-button quiet>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button quiet>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button quiet hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-selected">Selected</sp-field-label>
+        <sp-action-group quiet id="standard-selected">
+            <sp-action-button quiet selected>Edit</sp-action-button>
+            <sp-action-button quiet selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button quiet selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button quiet selected hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-disabled">Disabled</sp-field-label>
+        <sp-action-group quiet id="standard-disabled">
+            <sp-action-button quiet disabled>Edit</sp-action-button>
+            <sp-action-button quiet disabled>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button quiet disabled>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button quiet disabled hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-disabled-selected">
+            Disabled + Selected
+        </sp-field-label>
+        <sp-action-group quiet id="standard-disabled-selected">
+            <sp-action-button quiet disabled selected>Edit</sp-action-button>
+            <sp-action-button quiet disabled selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button quiet disabled selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button quiet disabled selected hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+</div>
 ```
 
-### Emphasized action button
+### Emphasized
 
 ```html demo
-<sp-action-button label="Edit" emphasized selected>
-    <sp-icon-edit slot="icon"></sp-icon-edit>
-</sp-action-button>
+<div
+    style="display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); gap: 2em;"
+>
+    <div>
+        <sp-field-label for="standard">Default</sp-field-label>
+        <sp-action-group emphasized id="standard">
+            <sp-action-button emphasized>Edit</sp-action-button>
+            <sp-action-button emphasized>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button emphasized hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-selected">Selected</sp-field-label>
+        <sp-action-group emphasized id="standard-selected">
+            <sp-action-button emphasized selected>Edit</sp-action-button>
+            <sp-action-button emphasized selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button emphasized selected hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-disabled">Disabled</sp-field-label>
+        <sp-action-group emphasized id="standard-disabled">
+            <sp-action-button emphasized disabled>Edit</sp-action-button>
+            <sp-action-button emphasized disabled>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized disabled>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button emphasized disabled hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-disabled-selected">
+            Disabled + Selected
+        </sp-field-label>
+        <sp-action-group emphasized id="standard-disabled-selected">
+            <sp-action-button emphasized disabled selected>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized disabled selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized disabled selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button emphasized disabled selected hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+</div>
 ```
 
-### Action button with hold affordance
+### Emphasized + Quiet
+
+```html demo
+<div
+    style="display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); gap: 2em;"
+>
+    <div>
+        <sp-field-label for="standard">Default</sp-field-label>
+        <sp-action-group emphasized quiet id="standard">
+            <sp-action-button emphasized quiet>Edit</sp-action-button>
+            <sp-action-button emphasized quiet>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized quiet>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button emphasized quiet hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-selected">Selected</sp-field-label>
+        <sp-action-group emphasized quiet id="standard-selected">
+            <sp-action-button emphasized quiet selected>Edit</sp-action-button>
+            <sp-action-button emphasized quiet selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized quiet selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button emphasized quiet selected hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-disabled">Disabled</sp-field-label>
+        <sp-action-group emphasized quiet id="standard-disabled">
+            <sp-action-button emphasized quiet disabled>Edit</sp-action-button>
+            <sp-action-button emphasized quiet disabled>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized quiet disabled>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button emphasized quiet disabled hold-affordance>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+
+    <div>
+        <sp-field-label for="standard-disabled-selected">
+            Disabled + Selected
+        </sp-field-label>
+        <sp-action-group emphasized quiet id="standard-disabled-selected">
+            <sp-action-button emphasized quiet disabled selected>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized quiet disabled selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+                Edit
+            </sp-action-button>
+            <sp-action-button emphasized quiet disabled selected>
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+            <sp-action-button
+                emphasized
+                quiet
+                disabled
+                selected
+                hold-affordance
+            >
+                <sp-icon-edit slot="icon"></sp-icon-edit>
+            </sp-action-button>
+        </sp-action-group>
+    </div>
+</div>
+```
+
+## Action button with hold affordance
 
 The use of the `hold-affordance` attribute signifies that the `<sp-action-button>` in question will be delivered with a visual affordance outlining that special interaction with the button will dispatch a `longpress` event. Via a pointer input, this even will be dispatched when 300ms has passed after a `pointerdown` event without the presence of a `pointerup` or `pointercancel` event. Via the keyboard, an event with a code of `Space` or or `ArrowDown` while `altKey === true` will dispatch the event.
 
-```html-live demo
-<sp-action-group>
-    <overlay-trigger placement="bottom">
+```html demo
+<div
+    style="display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 2em;"
+>
+    <overlay-trigger placement="bottom-start">
         <sp-action-button label="Edit" hold-affordance slot="trigger">
             <sp-icon-edit slot="icon"></sp-icon-edit>
         </sp-action-button>
         <sp-popover slot="longpress-content" dialog tip>
-            <p class="spectrum-Body spectrum-Body--sizeM" style="color: var(--spectrum-body-m-text-color,var(--spectrum-alias-text-color));">This content is triggered by the "longpress" interaction.</p>
+            <p
+                style="color: var(--spectrum-body-m-text-color,var(--spectrum-alias-text-color));"
+            >
+                This content is triggered by the "longpress" interaction.
+            </p>
         </sp-popover>
     </overlay-trigger>
 
@@ -124,26 +461,68 @@ The use of the `hold-affordance` attribute signifies that the `<sp-action-button
             Show Longpress Content
         </sp-action-button>
         <sp-popover slot="longpress-content" dialog tip>
-            <p class="spectrum-Body spectrum-Body--sizeM" style="color: var(--spectrum-body-m-text-color,var(--spectrum-alias-text-color));">This content is triggered by the "longpress" interaction.</p>
+            <p
+                style="color: var(--spectrum-body-m-text-color,var(--spectrum-alias-text-color));"
+            >
+                This content is triggered by the "longpress" interaction.
+            </p>
         </sp-popover>
     </overlay-trigger>
 
-    <overlay-trigger placement="top">
+    <overlay-trigger placement="top-end">
         <sp-action-button hold-affordance selected slot="trigger">
             <sp-icon-edit slot="icon"></sp-icon-edit>
             Extended Content with Longpress
         </sp-action-button>
         <sp-popover slot="longpress-content" dialog tip>
-            <p class="spectrum-Body spectrum-Body--sizeM" style="color: var(--spectrum-body-m-text-color,var(--spectrum-alias-text-color));">This content is triggered by the "longpress" interaction.</p>
+            <p
+                style="color: var(--spectrum-body-m-text-color,var(--spectrum-alias-text-color));"
+            >
+                This content is triggered by the "longpress" interaction.
+            </p>
         </sp-popover>
     </overlay-trigger>
-</sp-action-group>
+</div>
 ```
 
 ## Toggles
 
-With the application of the `toggles` attribute, the button will self manage its `selected` property on `click`:
+With the application of the `toggles` attribute, the button will self manage its `selected` property on `click`. When this value is updated, a cancellable `change` event will be dispatched to inform the parent application.
 
 ```html demo
-<sp-action-button toggles>Toggle button</sp-action-button>
+<div
+    style="display: grid; grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 2em;"
+>
+    <div>
+        <sp-field-label for="toggles-default">Standard</sp-field-label>
+        <sp-action-button toggles id="toggles-default">
+            Toggle button
+        </sp-action-button>
+    </div>
+    <div>
+        <sp-field-label for="toggles-quiet">Quiet</sp-field-label>
+        <sp-action-button toggles quiet id="toggles-quiet">
+            Toggle button
+        </sp-action-button>
+    </div>
+    <div>
+        <sp-field-label for="toggles-emphasized">Emphasized</sp-field-label>
+        <sp-action-button toggles emphasized id="toggles-emphasized">
+            Toggle button
+        </sp-action-button>
+    </div>
+    <div>
+        <sp-field-label for="toggles-emphasized-quiet">
+            Emphasized + Quiet
+        </sp-field-label>
+        <sp-action-button
+            toggles
+            emphasized
+            quiet
+            id="toggles-emphasized-quiet"
+        >
+            Toggle button
+        </sp-action-button>
+    </div>
+</div>
 ```


### PR DESCRIPTION
## Description
Update and expand the `<sp-action-button>` documentation to align more closely with the Spectrum CSS documentation and more fully cover the surfaced element API.

## Related Issue
fixes #962
fixed #1052 

## Motivation and Context
Better documentation means less issues, and more diverse applications!

## Screenshots (if appropriate):
https://westbrook-action-button-docs--spectrum-web-components.netlify.app/components/action-button

## Types of changes
- [x] Docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
