### PR TITLE
[RFC] feat(table): add table pattern

### DIFF
--- a/packages/table/.npmignore
+++ b/packages/table/.npmignore
@@ -1,0 +1,2 @@
+stories
+test

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -1,0 +1,28 @@
+## Description
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/table?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/table)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/table?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/table)
+
+```
+yarn add @spectrum-web-components/table
+```
+
+Import the side effectful registration of `<sp-table>` via:
+
+```
+import '@spectrum-web-components/table/sp-table.js';
+```
+
+When looking to leverage the `Table` base class as a type and/or for extension purposes, do so via:
+
+```
+import { Table } from '@spectrum-web-components/table';
+```
+
+## Example
+
+```html
+<sp-table></sp-table>
+```

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,0 +1,58 @@
+{
+    "name": "@spectrum-web-components/table",
+    "version": "0.0.1",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "Web component implementation of a Spectrum design Table",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adobe/spectrum-web-components.git",
+        "directory": "packages/table"
+    },
+    "author": "",
+    "homepage": "https://adobe.github.io/spectrum-web-components/components/table",
+    "bugs": {
+        "url": "https://github.com/adobe/spectrum-web-components/issues"
+    },
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        ".": "./src/index.js",
+        "./src/*": "./src/*.js",
+        "./package.json": "./package.json",
+        "./sp-table": "./sp-table.js",
+        "./sp-table.js": "./sp-table.js"
+    },
+    "scripts": {
+        "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
+    },
+    "files": [
+        "**/*.d.ts",
+        "**/*.js",
+        "**/*.js.map",
+        "custom-elements.json",
+        "!stories/",
+        "!test/"
+    ],
+    "keywords": [
+        "spectrum css",
+        "web components",
+        "lit-element",
+        "lit-html"
+    ],
+    "dependencies": {
+        "@spectrum-web-components/base": "^0.4.4",
+        "tslib": "^2.0.0"
+    },
+    "devDependencies": {
+        "@spectrum-css/table": "^3.0.3"
+    },
+    "types": "./src/index.d.ts",
+    "customElementsManifest": "custom-elements.json",
+    "sideEffects": [
+        "./sp-*.js"
+    ]
+}

--- a/packages/table/sp-cell.ts
+++ b/packages/table/sp-cell.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Cell } from './src/Cell.js';
+
+customElements.define('sp-cell', Cell);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-cell': Cell;
+    }
+}

--- a/packages/table/sp-head-cell.ts
+++ b/packages/table/sp-head-cell.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { HeadCell } from './src/HeadCell.js';
+
+customElements.define('sp-head-cell', HeadCell);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-head-cell': HeadCell;
+    }
+}

--- a/packages/table/sp-row.ts
+++ b/packages/table/sp-row.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Row } from './src/Row.js';
+
+customElements.define('sp-row', Row);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-row': Row;
+    }
+}

--- a/packages/table/sp-table.ts
+++ b/packages/table/sp-table.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Table } from './src/Table.js';
+
+customElements.define('sp-table', Table);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-table': Table;
+    }
+}

--- a/packages/table/src/Cell.ts
+++ b/packages/table/src/Cell.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    query,
+    SpectrumElement,
+    TemplateResult,
+} from '@spectrum-web-components/base';
+
+/**
+ * @element sp-cell
+ */
+export class Cell extends SpectrumElement {
+    @query('slot')
+    public contentSlot!: HTMLSlotElement;
+
+    protected render(): TemplateResult {
+        return html`
+            <slot></slot>
+        `;
+    }
+}

--- a/packages/table/src/HeadCell.ts
+++ b/packages/table/src/HeadCell.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    property,
+    query,
+    SpectrumElement,
+    TemplateResult,
+} from '@spectrum-web-components/base';
+
+export type HeadCellOrder = 'ascending' | 'descending';
+
+/**
+ * @element sp-head-cell
+ */
+export class HeadCell extends SpectrumElement {
+    @property({ type: Boolean })
+    public sortable = false;
+
+    @property({ type: String })
+    public order: HeadCellOrder = 'ascending';
+
+    @query('slot')
+    public contentSlot!: HTMLSlotElement;
+
+    protected render(): TemplateResult {
+        return html`
+            <slot></slot>
+        `;
+    }
+}

--- a/packages/table/src/Row.ts
+++ b/packages/table/src/Row.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    queryAssignedNodes,
+    SpectrumElement,
+    TemplateResult,
+} from '@spectrum-web-components/base';
+import { Cell } from './Cell';
+
+/**
+ * @element sp-row
+ */
+export class Row extends SpectrumElement {
+    @queryAssignedNodes('', true, 'sp-cell')
+    private cellNodes!: ReadonlyArray<Cell> | null;
+
+    public ready: Promise<ReadonlyArray<Cell>>;
+
+    private readyResolve!: (value: ReadonlyArray<Cell>) => void;
+
+    constructor() {
+        super();
+
+        this.ready = new Promise((resolve) => {
+            this.readyResolve = resolve;
+        });
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            <slot
+                style="display: none;"
+                @slotchange="${this.onSlotChanges}"
+            ></slot>
+        `;
+    }
+
+    private onSlotChanges(): void {
+        if (this.cellNodes !== null) {
+            this.readyResolve(this.cellNodes);
+        }
+    }
+}

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -1,0 +1,145 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    html,
+    SpectrumElement,
+    CSSResultArray,
+    TemplateResult,
+    queryAssignedNodes,
+    classMap,
+    property,
+    ifDefined,
+} from '@spectrum-web-components/base';
+
+import styles from './table.css.js';
+import { HeadCell, HeadCellOrder } from './HeadCell';
+import { Row } from './Row';
+
+export type CellContent = string | TemplateResult | ReadonlyArray<Node>;
+
+export declare interface HeadCellData {
+    content: CellContent;
+    sortable?: boolean;
+    order?: HeadCellOrder;
+}
+
+export type HeaderData = ReadonlyArray<HeadCellData>;
+
+export declare interface CellData {
+    content: CellContent;
+}
+
+export type RowData = ReadonlyArray<CellData>;
+
+export type TableData = ReadonlyArray<RowData>;
+
+/**
+ * @element sp-table
+ */
+export class Table extends SpectrumElement {
+    public static get styles(): CSSResultArray {
+        return [styles];
+    }
+
+    @property({ type: Array })
+    public header: HeaderData = [];
+
+    @property({ type: Array })
+    public data: TableData = [];
+
+    @queryAssignedNodes('', true, 'sp-head-cell')
+    private headCellNodes!: ReadonlyArray<HeadCell> | null;
+
+    @queryAssignedNodes('', true, 'sp-row')
+    private rowNodes!: ReadonlyArray<Row> | null;
+
+    protected render(): TemplateResult {
+        return html`
+            <slot
+                style="display: none;"
+                @slotchange="${this.onSlotChanges}"
+            ></slot>
+
+            <div class="spectrum-Table" role="grid">
+                <div
+                    class="spectrum-Table-head"
+                    style="display: flex"
+                    role="row"
+                >
+                    ${this.header.map(
+                        (c) => html`
+                            <div
+                                class="spectrum-Table-headCell ${classMap({
+                                    'is-sortable': c.sortable === true,
+                                    'is-sorted-desc':
+                                        c.sortable === true &&
+                                        c.order === 'descending',
+                                })}"
+                                style="flex: 1"
+                                role="columnheader"
+                                aria-sort="${ifDefined(c.order)}"
+                                tabindex="0"
+                            >
+                                ${c.content}
+                            </div>
+                        `
+                    )}
+                </div>
+                <div class="spectrum-Table-body" role="rowgroup">
+                    ${this.data.map(
+                        (r) => html`
+                            <div
+                                class="spectrum-Table-row"
+                                style="display: flex"
+                                role="row"
+                            >
+                                ${r.map(
+                                    (c) => html`
+                                        <div
+                                            class="spectrum-Table-cell"
+                                            style="flex: 1"
+                                            role="gridcell"
+                                            tabindex="0"
+                                        >
+                                            ${c.content}
+                                        </div>
+                                    `
+                                )}
+                            </div>
+                        `
+                    )}
+                </div>
+            </div>
+        `;
+    }
+
+    private onSlotChanges(): void {
+        if (this.headCellNodes !== null && this.headCellNodes.length > 0) {
+            this.header = this.headCellNodes.map((c) => ({
+                content: c.contentSlot.assignedNodes(),
+                sortable: c.sortable,
+                order: c.order,
+            }));
+        }
+
+        if (this.rowNodes !== null && this.rowNodes.length > 0) {
+            Promise.all(this.rowNodes.map((r) => r.ready)).then((rows) => {
+                this.data = rows.map((r) => {
+                    return r.map((c) => ({
+                        content: c.contentSlot.assignedNodes(),
+                    }));
+                });
+            });
+        }
+    }
+}

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export * from './Table.js';

--- a/packages/table/src/spectrum-config.js
+++ b/packages/table/src/spectrum-config.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const config = {
+    spectrum: 'table',
+    components: [
+        {
+            name: 'table',
+            host: {
+                selector: '.spectrum-Table',
+            },
+        },
+    ],
+};
+
+export default config;

--- a/packages/table/src/spectrum-table.css
+++ b/packages/table/src/spectrum-table.css
@@ -1,0 +1,858 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host {
+    /* .spectrum-Table */
+    border-collapse: separate;
+    border-spacing: 0;
+}
+:host([dir='ltr']) .spectrum-Table-sortedIcon {
+    /* [dir=ltr] .spectrum-Table-sortedIcon */
+    margin-left: var(
+        --spectrum-table-header-sort-icon-gap,
+        var(--spectrum-global-dimension-size-125)
+    );
+}
+:host([dir='rtl']) .spectrum-Table-sortedIcon {
+    /* [dir=rtl] .spectrum-Table-sortedIcon */
+    margin-right: var(
+        --spectrum-table-header-sort-icon-gap,
+        var(--spectrum-global-dimension-size-125)
+    );
+}
+.spectrum-Table-sortedIcon {
+    /* .spectrum-Table-sortedIcon */
+    display: none;
+    vertical-align: middle;
+    transition: transform var(--spectrum-global-animation-duration-100, 0.13s)
+        ease-in-out;
+}
+:host([dir='ltr']) .spectrum-Table-headCell {
+    /* [dir=ltr] .spectrum-Table-headCell */
+    text-align: left;
+}
+:host([dir='rtl']) .spectrum-Table-headCell {
+    /* [dir=rtl] .spectrum-Table-headCell */
+    text-align: right;
+}
+.spectrum-Table-headCell {
+    /* .spectrum-Table-headCell */
+    box-sizing: border-box;
+    font-size: var(
+        --spectrum-table-header-text-size,
+        var(--spectrum-global-dimension-font-size-50)
+    );
+    font-weight: var(
+        --spectrum-table-header-text-font-weight,
+        var(--spectrum-global-font-weight-bold)
+    );
+    line-height: var(
+        --spectrum-table-header-text-line-height,
+        var(--spectrum-alias-heading-text-line-height)
+    );
+    min-height: var(
+        --spectrum-table-header-min-height,
+        var(--spectrum-global-dimension-size-150)
+    );
+    letter-spacing: var(
+        --spectrum-table-header-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-medium)
+    );
+    text-transform: uppercase;
+    padding: var(
+            --spectrum-table-header-padding-y,
+            var(--spectrum-global-dimension-static-size-125)
+        )
+        var(
+            --spectrum-table-header-padding-x,
+            var(--spectrum-global-dimension-size-200)
+        );
+    transition: color var(--spectrum-global-animation-duration-100, 0.13s)
+        ease-in-out;
+    cursor: default;
+    outline: 0;
+    border-radius: var(--spectrum-table-header-border-radius, 0);
+}
+.spectrum-Table-headCell.is-sortable {
+    /* .spectrum-Table-headCell.is-sortable */
+    cursor: pointer;
+}
+.spectrum-Table-headCell.is-sorted-asc .spectrum-Table-sortedIcon,
+.spectrum-Table-headCell.is-sorted-desc .spectrum-Table-sortedIcon {
+    /* .spectrum-Table-headCell.is-sorted-asc .spectrum-Table-sortedIcon,
+   * .spectrum-Table-headCell.is-sorted-desc .spectrum-Table-sortedIcon */
+    display: inline-block;
+    margin-top: calc(var(--spectrum-global-dimension-size-25) * -1);
+}
+.spectrum-Table-headCell.is-sorted-asc .spectrum-Table-sortedIcon {
+    /* .spectrum-Table-headCell.is-sorted-asc .spectrum-Table-sortedIcon */
+    transform: rotate(-90deg);
+}
+.spectrum-Table-cell--alignCenter {
+    /* .spectrum-Table-cell--alignCenter */
+    text-align: center;
+}
+:host([dir='ltr']) .spectrum-Table-cell--alignRight {
+    /* [dir=ltr] .spectrum-Table-cell--alignRight */
+    text-align: right;
+}
+:host([dir='rtl']) .spectrum-Table-cell--alignRight {
+    /* [dir=rtl] .spectrum-Table-cell--alignRight */
+    text-align: left;
+}
+:host([dir='ltr']) .spectrum-Table-body.is-drop-target:before,
+:host([dir='ltr']) .spectrum-Table-row.is-drop-target:before {
+    /* [dir=ltr] .spectrum-Table-body.is-drop-target:before,
+   * [dir=ltr] .spectrum-Table-row.is-drop-target:before */
+    left: 0;
+}
+:host([dir='rtl']) .spectrum-Table-body.is-drop-target:before,
+:host([dir='rtl']) .spectrum-Table-row.is-drop-target:before {
+    /* [dir=rtl] .spectrum-Table-body.is-drop-target:before,
+   * [dir=rtl] .spectrum-Table-row.is-drop-target:before */
+    right: 0;
+}
+:host([dir='ltr']) .spectrum-Table-body.is-drop-target:before,
+:host([dir='ltr']) .spectrum-Table-row.is-drop-target:before {
+    /* [dir=ltr] .spectrum-Table-body.is-drop-target:before,
+   * [dir=ltr] .spectrum-Table-row.is-drop-target:before */
+    right: 0;
+}
+:host([dir='rtl']) .spectrum-Table-body.is-drop-target:before,
+:host([dir='rtl']) .spectrum-Table-row.is-drop-target:before {
+    /* [dir=rtl] .spectrum-Table-body.is-drop-target:before,
+   * [dir=rtl] .spectrum-Table-row.is-drop-target:before */
+    left: 0;
+}
+.spectrum-Table-body.is-drop-target:before,
+.spectrum-Table-row.is-drop-target:before {
+    /* .spectrum-Table-body.is-drop-target:before,
+   * .spectrum-Table-row.is-drop-target:before */
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
+}
+.spectrum-Table-body {
+    /* .spectrum-Table-body */
+    position: relative;
+    border-width: var(
+        --spectrum-table-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+    border-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+    overflow: auto;
+    vertical-align: var(--spectrum-table-cell-vertical-alignment, top);
+}
+:host(:not(.spectrum-Table--quiet)) tbody.spectrum-Table-body {
+    /* .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body */
+    border-width: var(
+        --spectrum-table-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+    border-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+:host([dir='ltr']:not(.spectrum-Table--quiet))
+    tbody.spectrum-Table-body
+    .spectrum-Table-row:first-child
+    .spectrum-Table-cell:first-child {
+    /* [dir=ltr] .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body .spectrum-Table-row:first-child .spectrum-Table-cell:first-child */
+    border-top-left-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+:host([dir='rtl']:not(.spectrum-Table--quiet))
+    tbody.spectrum-Table-body
+    .spectrum-Table-row:first-child
+    .spectrum-Table-cell:first-child {
+    /* [dir=rtl] .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body .spectrum-Table-row:first-child .spectrum-Table-cell:first-child */
+    border-top-right-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+:host([dir='ltr']:not(.spectrum-Table--quiet))
+    tbody.spectrum-Table-body
+    .spectrum-Table-row:first-child
+    .spectrum-Table-cell:last-child {
+    /* [dir=ltr] .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body .spectrum-Table-row:first-child .spectrum-Table-cell:last-child */
+    border-top-right-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+:host([dir='rtl']:not(.spectrum-Table--quiet))
+    tbody.spectrum-Table-body
+    .spectrum-Table-row:first-child
+    .spectrum-Table-cell:last-child {
+    /* [dir=rtl] .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body .spectrum-Table-row:first-child .spectrum-Table-cell:last-child */
+    border-top-left-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+:host([dir='ltr']:not(.spectrum-Table--quiet))
+    tbody.spectrum-Table-body
+    .spectrum-Table-row:last-child
+    .spectrum-Table-cell:first-child {
+    /* [dir=ltr] .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body .spectrum-Table-row:last-child .spectrum-Table-cell:first-child */
+    border-bottom-left-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+:host([dir='rtl']:not(.spectrum-Table--quiet))
+    tbody.spectrum-Table-body
+    .spectrum-Table-row:last-child
+    .spectrum-Table-cell:first-child {
+    /* [dir=rtl] .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body .spectrum-Table-row:last-child .spectrum-Table-cell:first-child */
+    border-bottom-right-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+:host([dir='ltr']:not(.spectrum-Table--quiet))
+    tbody.spectrum-Table-body
+    .spectrum-Table-row:last-child
+    .spectrum-Table-cell:last-child {
+    /* [dir=ltr] .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body .spectrum-Table-row:last-child .spectrum-Table-cell:last-child */
+    border-bottom-right-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+:host([dir='rtl']:not(.spectrum-Table--quiet))
+    tbody.spectrum-Table-body
+    .spectrum-Table-row:last-child
+    .spectrum-Table-cell:last-child {
+    /* [dir=rtl] .spectrum-Table:not(.spectrum-Table--quiet) tbody.spectrum-Table-body .spectrum-Table-row:last-child .spectrum-Table-cell:last-child */
+    border-bottom-left-radius: var(
+        --spectrum-table-border-radius,
+        var(--spectrum-alias-border-radius-regular)
+    );
+}
+.spectrum-Table-cell {
+    /* .spectrum-Table-cell */
+    box-sizing: border-box;
+    font-size: var(
+        --spectrum-table-cell-text-size,
+        var(--spectrum-alias-font-size-default)
+    );
+    font-weight: var(
+        --spectrum-table-cell-text-font-weight,
+        var(--spectrum-global-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-table-cell-text-line-height,
+        var(--spectrum-alias-component-text-line-height)
+    );
+    padding: var(
+            --spectrum-table-cell-padding-y,
+            var(--spectrum-global-dimension-size-175)
+        )
+        var(
+            --spectrum-table-cell-padding-x,
+            var(--spectrum-global-dimension-size-200)
+        );
+    min-height: calc(
+        var(
+                --spectrum-table-cell-min-height,
+                var(--spectrum-global-dimension-size-600)
+            ) -
+            var(
+                --spectrum-table-cell-padding-y,
+                var(--spectrum-global-dimension-size-175)
+            ) * 2
+    );
+}
+.spectrum-Table-cell,
+.spectrum-Table-headCell {
+    /* .spectrum-Table-cell,
+   * .spectrum-Table-headCell */
+    position: relative;
+}
+.spectrum-Table-cell:focus-visible,
+.spectrum-Table-cell.is-focused,
+.spectrum-Table-headCell:focus-visible,
+.spectrum-Table-headCell.is-focused {
+    /* .spectrum-Table-cell.focus-ring,
+   * .spectrum-Table-cell.is-focused,
+   * .spectrum-Table-headCell.focus-ring,
+   * .spectrum-Table-headCell.is-focused */
+    outline: none;
+}
+:host([dir='ltr']) .spectrum-Table-cell:focus-visible:before,
+:host([dir='ltr']) .spectrum-Table-cell.is-focused:before,
+:host([dir='ltr']) .spectrum-Table-headCell:focus-visible:before,
+:host([dir='ltr']) .spectrum-Table-headCell.is-focused:before {
+    /* [dir=ltr] .spectrum-Table-cell.focus-ring:before,
+   * [dir=ltr] .spectrum-Table-cell.is-focused:before,
+   * [dir=ltr] .spectrum-Table-headCell.focus-ring:before,
+   * [dir=ltr] .spectrum-Table-headCell.is-focused:before */
+    right: 0;
+}
+:host([dir='rtl']) .spectrum-Table-cell:focus-visible:before,
+:host([dir='rtl']) .spectrum-Table-cell.is-focused:before,
+:host([dir='rtl']) .spectrum-Table-headCell:focus-visible:before,
+:host([dir='rtl']) .spectrum-Table-headCell.is-focused:before {
+    /* [dir=rtl] .spectrum-Table-cell.focus-ring:before,
+   * [dir=rtl] .spectrum-Table-cell.is-focused:before,
+   * [dir=rtl] .spectrum-Table-headCell.focus-ring:before,
+   * [dir=rtl] .spectrum-Table-headCell.is-focused:before */
+    left: 0;
+}
+:host([dir='ltr']) .spectrum-Table-cell:focus-visible:before,
+:host([dir='ltr']) .spectrum-Table-cell.is-focused:before,
+:host([dir='ltr']) .spectrum-Table-headCell:focus-visible:before,
+:host([dir='ltr']) .spectrum-Table-headCell.is-focused:before {
+    /* [dir=ltr] .spectrum-Table-cell.focus-ring:before,
+   * [dir=ltr] .spectrum-Table-cell.is-focused:before,
+   * [dir=ltr] .spectrum-Table-headCell.focus-ring:before,
+   * [dir=ltr] .spectrum-Table-headCell.is-focused:before */
+    left: 0;
+}
+:host([dir='rtl']) .spectrum-Table-cell:focus-visible:before,
+:host([dir='rtl']) .spectrum-Table-cell.is-focused:before,
+:host([dir='rtl']) .spectrum-Table-headCell:focus-visible:before,
+:host([dir='rtl']) .spectrum-Table-headCell.is-focused:before {
+    /* [dir=rtl] .spectrum-Table-cell.focus-ring:before,
+   * [dir=rtl] .spectrum-Table-cell.is-focused:before,
+   * [dir=rtl] .spectrum-Table-headCell.focus-ring:before,
+   * [dir=rtl] .spectrum-Table-headCell.is-focused:before */
+    right: 0;
+}
+.spectrum-Table-cell:focus-visible:before,
+.spectrum-Table-cell.is-focused:before,
+.spectrum-Table-headCell:focus-visible:before,
+.spectrum-Table-headCell.is-focused:before {
+    /* .spectrum-Table-cell.focus-ring:before,
+   * .spectrum-Table-cell.is-focused:before,
+   * .spectrum-Table-headCell.focus-ring:before,
+   * .spectrum-Table-headCell.is-focused:before */
+    content: '';
+    z-index: 1;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    border-radius: calc(
+        var(
+                --spectrum-table-cell-border-radius-key-focus,
+                var(--spectrum-alias-border-radius-regular)
+            ) - 1px
+    );
+}
+:host([dir='ltr']) .spectrum-Table-headCell:focus-visible:before,
+:host([dir='ltr']) .spectrum-Table-headCell.is-focused:before {
+    /* [dir=ltr] .spectrum-Table-headCell.focus-ring:before,
+   * [dir=ltr] .spectrum-Table-headCell.is-focused:before */
+    right: var(
+        --spectrum-table-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+}
+:host([dir='rtl']) .spectrum-Table-headCell:focus-visible:before,
+:host([dir='rtl']) .spectrum-Table-headCell.is-focused:before {
+    /* [dir=rtl] .spectrum-Table-headCell.focus-ring:before,
+   * [dir=rtl] .spectrum-Table-headCell.is-focused:before */
+    left: var(
+        --spectrum-table-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+}
+:host([dir='ltr']) .spectrum-Table-headCell:focus-visible:before,
+:host([dir='ltr']) .spectrum-Table-headCell.is-focused:before {
+    /* [dir=ltr] .spectrum-Table-headCell.focus-ring:before,
+   * [dir=ltr] .spectrum-Table-headCell.is-focused:before */
+    left: var(
+        --spectrum-table-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+}
+:host([dir='rtl']) .spectrum-Table-headCell:focus-visible:before,
+:host([dir='rtl']) .spectrum-Table-headCell.is-focused:before {
+    /* [dir=rtl] .spectrum-Table-headCell.focus-ring:before,
+   * [dir=rtl] .spectrum-Table-headCell.is-focused:before */
+    right: var(
+        --spectrum-table-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+}
+.spectrum-Table-headCell:focus-visible:before,
+.spectrum-Table-headCell.is-focused:before {
+    /* .spectrum-Table-headCell.focus-ring:before,
+   * .spectrum-Table-headCell.is-focused:before */
+    top: var(
+        --spectrum-table-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+    bottom: var(
+        --spectrum-table-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+}
+:host([dir='ltr']) .spectrum-Table-cell--divider {
+    /* [dir=ltr] .spectrum-Table-cell--divider */
+    border-right-width: var(
+        --spectrum-table-divider-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+}
+:host([dir='rtl']) .spectrum-Table-cell--divider {
+    /* [dir=rtl] .spectrum-Table-cell--divider */
+    border-left-width: var(
+        --spectrum-table-divider-border-size,
+        var(--spectrum-alias-border-size-thin)
+    );
+}
+.spectrum-Table-row {
+    /* .spectrum-Table-row */
+    position: relative;
+    cursor: pointer;
+    transition: background-color
+        var(--spectrum-global-animation-duration-100, 0.13s) ease-in-out;
+}
+.spectrum-Table-row:focus {
+    /* .spectrum-Table-row:focus */
+    outline: 0;
+}
+:host > .spectrum-Table-body > .spectrum-Table-row:last-of-type {
+    /* .spectrum-Table>.spectrum-Table-body>.spectrum-Table-row:last-of-type */
+    border-bottom-style: none;
+}
+.spectrum-Table--quiet .spectrum-Table-body {
+    /* .spectrum-Table--quiet .spectrum-Table-body */
+    border-radius: var(--spectrum-table-quiet-border-radius, 0);
+}
+.spectrum-Table--quiet .spectrum-Table-body.is-drop-target:before,
+.spectrum-Table--quiet .spectrum-Table-row.is-drop-target:before {
+    /* .spectrum-Table--quiet .spectrum-Table-body.is-drop-target:before,
+   * .spectrum-Table--quiet .spectrum-Table-row.is-drop-target:before */
+    border-radius: var(
+        --spectrum-alias-border-radius-regular,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+:host([dir='ltr']) .spectrum-Table-checkboxCell {
+    /* [dir=ltr] .spectrum-Table-checkboxCell */
+    padding-right: var(
+        --spectrum-table-cell-checkbox-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+:host([dir='rtl']) .spectrum-Table-checkboxCell {
+    /* [dir=rtl] .spectrum-Table-checkboxCell */
+    padding-left: var(
+        --spectrum-table-cell-checkbox-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    );
+}
+.spectrum-Table-checkboxCell {
+    /* .spectrum-Table-checkboxCell */
+    padding-top: 0;
+    padding-bottom: 0;
+    vertical-align: var(
+        --spectrum-table-cell-checkbox-vertical-alignment,
+        middle
+    );
+}
+.spectrum-Table-checkbox {
+    /* .spectrum-Table-checkbox */
+    vertical-align: super;
+}
+.spectrum-Table-headCell {
+    /* .spectrum-Table-headCell */
+    color: var(
+        --spectrum-table-header-text-color,
+        var(--spectrum-alias-label-text-color)
+    );
+    background-color: var(
+        --spectrum-table-header-background-color,
+        var(--spectrum-alias-background-color-transparent)
+    );
+}
+.spectrum-Table-headCell.is-sortable .spectrum-Table-sortedIcon {
+    /* .spectrum-Table-headCell.is-sortable .spectrum-Table-sortedIcon */
+    color: var(
+        --spectrum-table-header-sort-icon-color,
+        var(--spectrum-global-color-gray-600)
+    );
+}
+.spectrum-Table-headCell.is-sortable:hover {
+    /* .spectrum-Table-headCell.is-sortable:hover */
+    color: var(
+        --spectrum-table-header-text-color-hover,
+        var(--spectrum-alias-text-color-hover)
+    );
+}
+.spectrum-Table-headCell.is-sortable:hover .spectrum-Table-sortedIcon {
+    /* .spectrum-Table-headCell.is-sortable:hover .spectrum-Table-sortedIcon */
+    color: var(
+        --spectrum-table-header-sort-icon-color-hover,
+        var(--spectrum-alias-icon-color-hover)
+    );
+}
+.spectrum-Table-headCell.is-sortable:focus-visible,
+.spectrum-Table-headCell.is-sortable.is-focused {
+    /* .spectrum-Table-headCell.is-sortable.focus-ring,
+   * .spectrum-Table-headCell.is-sortable.is-focused */
+    color: var(
+        --spectrum-table-header-text-color-key-focus,
+        var(--spectrum-alias-text-color-hover)
+    );
+}
+.spectrum-Table-headCell.is-sortable:focus-visible .spectrum-Table-sortedIcon,
+.spectrum-Table-headCell.is-sortable.is-focused .spectrum-Table-sortedIcon {
+    /* .spectrum-Table-headCell.is-sortable.focus-ring .spectrum-Table-sortedIcon,
+   * .spectrum-Table-headCell.is-sortable.is-focused .spectrum-Table-sortedIcon */
+    color: var(
+        --spectrum-table-header-sort-icon-color-key-focus,
+        var(--spectrum-alias-icon-color-focus)
+    );
+}
+.spectrum-Table-headCell.is-sortable:active {
+    /* .spectrum-Table-headCell.is-sortable:active */
+    color: var(
+        --spectrum-table-header-text-color-down,
+        var(--spectrum-alias-text-color-down)
+    );
+}
+.spectrum-Table-headCell.is-sortable:active .spectrum-Table-sortedIcon {
+    /* .spectrum-Table-headCell.is-sortable:active .spectrum-Table-sortedIcon */
+    color: var(
+        --spectrum-table-header-sort-icon-color-down,
+        var(--spectrum-alias-icon-color-down)
+    );
+}
+.spectrum-Table-cell:focus-visible:before,
+.spectrum-Table-cell.is-focused:before,
+.spectrum-Table-headCell:focus-visible:before,
+.spectrum-Table-headCell.is-focused:before {
+    /* .spectrum-Table-cell.focus-ring:before,
+   * .spectrum-Table-cell.is-focused:before,
+   * .spectrum-Table-headCell.focus-ring:before,
+   * .spectrum-Table-headCell.is-focused:before */
+    box-shadow: inset 0 0 0 2px
+        var(
+            --spectrum-table-cell-border-color-key-focus,
+            var(--spectrum-alias-border-color-focus)
+        );
+}
+.spectrum-Table-body {
+    /* .spectrum-Table-body */
+    border-style: solid;
+    border-color: var(
+        --spectrum-table-border-color,
+        var(--spectrum-alias-border-color-mid)
+    );
+    background-color: var(
+        --spectrum-table-background-color,
+        var(--spectrum-global-color-gray-50)
+    );
+}
+.spectrum-Table-body.is-drop-target {
+    /* .spectrum-Table-body.is-drop-target */
+    border-color: var(
+        --spectrum-alias-border-color-focus,
+        var(--spectrum-global-color-blue-400)
+    );
+    box-shadow: 0 0 0 1px
+        var(
+            --spectrum-alias-border-color-focus,
+            var(--spectrum-global-color-blue-400)
+        );
+}
+.spectrum-Table-body.is-drop-target:before {
+    /* .spectrum-Table-body.is-drop-target:before */
+    background-color: var(--spectrum-alias-highlight-selected);
+}
+:host([dir='ltr'])
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:first-child {
+    /* [dir=ltr] tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:first-child */
+    border-left: 1px solid
+        var(
+            --spectrum-table-border-color,
+            var(--spectrum-alias-border-color-mid)
+        );
+}
+:host([dir='rtl'])
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:first-child {
+    /* [dir=rtl] tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:first-child */
+    border-right: 1px solid
+        var(
+            --spectrum-table-border-color,
+            var(--spectrum-alias-border-color-mid)
+        );
+}
+:host([dir='ltr'])
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:last-child {
+    /* [dir=ltr] tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:last-child */
+    border-right: 1px solid
+        var(
+            --spectrum-table-border-color,
+            var(--spectrum-alias-border-color-mid)
+        );
+}
+:host([dir='rtl'])
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:last-child {
+    /* [dir=rtl] tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:last-child */
+    border-left: 1px solid
+        var(
+            --spectrum-table-border-color,
+            var(--spectrum-alias-border-color-mid)
+        );
+}
+.spectrum-Table-row {
+    /* .spectrum-Table-row */
+    border-bottom: 1px solid
+        var(
+            --spectrum-table-border-color,
+            var(--spectrum-alias-border-color-mid)
+        );
+    background-color: var(
+        --spectrum-table-row-background-color,
+        var(--spectrum-alias-background-color-transparent)
+    );
+}
+.spectrum-Table-row:hover {
+    /* .spectrum-Table-row:hover */
+    background-color: var(
+        --spectrum-table-row-background-color-hover,
+        var(--spectrum-alias-highlight-hover)
+    );
+}
+.spectrum-Table-row:focus-visible,
+.spectrum-Table-row.is-focused {
+    /* .spectrum-Table-row.focus-ring,
+   * .spectrum-Table-row.is-focused */
+    background-color: var(
+        --spectrum-table-row-background-color-hover,
+        var(--spectrum-alias-highlight-hover)
+    );
+}
+.spectrum-Table-row:active {
+    /* .spectrum-Table-row:active */
+    background-color: var(
+        --spectrum-table-row-background-color-down,
+        var(--spectrum-alias-highlight-active)
+    );
+}
+.spectrum-Table-row.is-selected {
+    /* .spectrum-Table-row.is-selected */
+    background-color: var(
+        --spectrum-table-row-background-color-selected,
+        var(--spectrum-alias-highlight-selected)
+    );
+}
+.spectrum-Table-row.is-selected:hover {
+    /* .spectrum-Table-row.is-selected:hover */
+    background-color: var(
+        --spectrum-table-row-background-color-selected-hover,
+        var(--spectrum-alias-highlight-selected-hover)
+    );
+}
+.spectrum-Table-row.is-selected:focus-visible,
+.spectrum-Table-row.is-selected.is-focused {
+    /* .spectrum-Table-row.is-selected.focus-ring,
+   * .spectrum-Table-row.is-selected.is-focused */
+    background-color: var(
+        --spectrum-table-row-background-color-selected-key-focus,
+        var(--spectrum-alias-highlight-selected-hover)
+    );
+}
+.spectrum-Table-row.is-drop-target:before {
+    /* .spectrum-Table-row.is-drop-target:before */
+    box-shadow: inset 0 0 0 2px
+        var(
+            --spectrum-alias-border-color-focus,
+            var(--spectrum-global-color-blue-400)
+        );
+    background-color: var(--spectrum-alias-highlight-selected);
+}
+.spectrum-Table-cell {
+    /* .spectrum-Table-cell */
+    color: var(
+        --spectrum-table-cell-text-color,
+        var(--spectrum-alias-text-color)
+    );
+    background-color: var(
+        --spectrum-table-cell-background-color,
+        var(--spectrum-alias-background-color-transparent)
+    );
+}
+:host([dir='ltr']) .spectrum-Table-cell--divider {
+    /* [dir=ltr] .spectrum-Table-cell--divider */
+    border-right-style: solid;
+}
+:host([dir='rtl']) .spectrum-Table-cell--divider {
+    /* [dir=rtl] .spectrum-Table-cell--divider */
+    border-left-style: solid;
+}
+:host([dir='ltr']) .spectrum-Table-cell--divider {
+    /* [dir=ltr] .spectrum-Table-cell--divider */
+    border-right-color: var(
+        --spectrum-table-divider-border-color,
+        var(--spectrum-alias-border-color-mid)
+    );
+}
+:host([dir='rtl']) .spectrum-Table-cell--divider {
+    /* [dir=rtl] .spectrum-Table-cell--divider */
+    border-left-color: var(
+        --spectrum-table-divider-border-color,
+        var(--spectrum-alias-border-color-mid)
+    );
+}
+.spectrum-Table--quiet .spectrum-Table-body {
+    /* .spectrum-Table--quiet .spectrum-Table-body */
+    border-width: 1px 0;
+    background-color: var(
+        --spectrum-table-quiet-cell-background-color,
+        var(--spectrum-alias-background-color-transparent)
+    );
+}
+.spectrum-Table--quiet .spectrum-Table-body.is-drop-target {
+    /* .spectrum-Table--quiet .spectrum-Table-body.is-drop-target */
+    box-shadow: none;
+    border-color: transparent;
+}
+.spectrum-Table--quiet .spectrum-Table-body.is-drop-target:before {
+    /* .spectrum-Table--quiet .spectrum-Table-body.is-drop-target:before */
+    box-shadow: inset 0 0 0 2px
+        var(
+            --spectrum-alias-border-color-focus,
+            var(--spectrum-global-color-blue-400)
+        );
+}
+.spectrum-Table--quiet .spectrum-Table-row {
+    /* .spectrum-Table--quiet .spectrum-Table-row */
+    background-color: var(
+        --spectrum-table-quiet-row-background-color,
+        var(--spectrum-alias-background-color-transparent)
+    );
+}
+.spectrum-Table--quiet .spectrum-Table-row:hover {
+    /* .spectrum-Table--quiet .spectrum-Table-row:hover */
+    background-color: var(
+        --spectrum-table-quiet-row-background-color-hover,
+        var(--spectrum-alias-highlight-hover)
+    );
+}
+.spectrum-Table--quiet .spectrum-Table-row:focus-visible,
+.spectrum-Table--quiet .spectrum-Table-row.is-focused {
+    /* .spectrum-Table--quiet .spectrum-Table-row.focus-ring,
+   * .spectrum-Table--quiet .spectrum-Table-row.is-focused */
+    background-color: var(
+        --spectrum-table-quiet-row-background-color-hover,
+        var(--spectrum-alias-highlight-hover)
+    );
+}
+.spectrum-Table--quiet .spectrum-Table-row:active {
+    /* .spectrum-Table--quiet .spectrum-Table-row:active */
+    background-color: var(
+        --spectrum-table-quiet-row-background-color-down,
+        var(--spectrum-alias-highlight-active)
+    );
+}
+.spectrum-Table--quiet .spectrum-Table-row.is-selected {
+    /* .spectrum-Table--quiet .spectrum-Table-row.is-selected */
+    background-color: var(
+        --spectrum-table-quiet-row-background-color-selected,
+        var(--spectrum-alias-highlight-selected)
+    );
+}
+.spectrum-Table--quiet .spectrum-Table-row.is-selected:hover {
+    /* .spectrum-Table--quiet .spectrum-Table-row.is-selected:hover */
+    background-color: var(
+        --spectrum-table-quiet-row-background-color-selected-hover,
+        var(--spectrum-alias-highlight-selected-hover)
+    );
+}
+.spectrum-Table--quiet .spectrum-Table-row.is-selected:focus-visible,
+.spectrum-Table--quiet .spectrum-Table-row.is-selected.is-focused {
+    /* .spectrum-Table--quiet .spectrum-Table-row.is-selected.focus-ring,
+   * .spectrum-Table--quiet .spectrum-Table-row.is-selected.is-focused */
+    background-color: var(
+        --spectrum-table-quiet-row-background-color-selected-key-focus,
+        var(--spectrum-alias-highlight-selected-hover)
+    );
+}
+:host([dir='ltr'])
+    .spectrum-Table--quiet
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:first-child,
+:host([dir='ltr'])
+    .spectrum-Table--quiet
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:last-child {
+    /* [dir=ltr] .spectrum-Table--quiet tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:first-child,
+   * [dir=ltr] .spectrum-Table--quiet tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:last-child */
+    border-left: none;
+}
+:host([dir='rtl'])
+    .spectrum-Table--quiet
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:first-child,
+:host([dir='rtl'])
+    .spectrum-Table--quiet
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:last-child {
+    /* [dir=rtl] .spectrum-Table--quiet tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:first-child,
+   * [dir=rtl] .spectrum-Table--quiet tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:last-child */
+    border-right: none;
+}
+:host([dir='ltr'])
+    .spectrum-Table--quiet
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:first-child,
+:host([dir='ltr'])
+    .spectrum-Table--quiet
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:last-child {
+    /* [dir=ltr] .spectrum-Table--quiet tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:first-child,
+   * [dir=ltr] .spectrum-Table--quiet tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:last-child */
+    border-right: none;
+}
+:host([dir='rtl'])
+    .spectrum-Table--quiet
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:first-child,
+:host([dir='rtl'])
+    .spectrum-Table--quiet
+    tbody.spectrum-Table-body
+    .spectrum-Table-row
+    .spectrum-Table-cell:last-child {
+    /* [dir=rtl] .spectrum-Table--quiet tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:first-child,
+   * [dir=rtl] .spectrum-Table--quiet tbody.spectrum-Table-body .spectrum-Table-row .spectrum-Table-cell:last-child */
+    border-left: none;
+}

--- a/packages/table/src/table.css
+++ b/packages/table/src/table.css
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import './spectrum-table.css';

--- a/packages/table/stories/table.stories.ts
+++ b/packages/table/stories/table.stories.ts
@@ -1,0 +1,96 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, TemplateResult } from '@spectrum-web-components/base';
+
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-chevron-down.js';
+import '../sp-table.js';
+import '../sp-head-cell';
+import '../sp-row';
+import '../sp-cell';
+import { HeaderData, TableData } from '../src';
+
+export default {
+    title: 'Table',
+    component: 'sp-table',
+};
+
+export const Elements = (): TemplateResult => {
+    return html`
+        <sp-table>
+            <sp-head-cell sortable order="descending">
+                Head Cell 1
+                <sp-icon-chevron-down></sp-icon-chevron-down>
+            </sp-head-cell>
+            <sp-head-cell sortable>Head Cell 2</sp-head-cell>
+            <sp-head-cell>Head Cell 3</sp-head-cell>
+
+            <sp-row>
+                <sp-cell>Row Cell 1/1</sp-cell>
+                <sp-cell>Row Cell 1/2</sp-cell>
+                <sp-cell>Row Cell 1/3</sp-cell>
+            </sp-row>
+
+            <sp-row>
+                <sp-cell>Row Cell 2/1</sp-cell>
+                <sp-cell>Row Cell 2/2</sp-cell>
+                <sp-cell>Row Cell 2/3</sp-cell>
+            </sp-row>
+
+            <sp-row>
+                <sp-cell>Row Cell 3/1</sp-cell>
+                <sp-cell>Row Cell 3/2</sp-cell>
+                <sp-cell>Row Cell 3/3</sp-cell>
+            </sp-row>
+        </sp-table>
+    `;
+};
+
+export const Property = (): TemplateResult => {
+    const header: HeaderData = [
+        {
+            content: html`
+                Head Cell 1
+                <sp-icon-chevron-down></sp-icon-chevron-down>
+            `,
+            sortable: true,
+            order: 'descending',
+        },
+        {
+            content: 'Head Cell 2',
+            sortable: true,
+        },
+        { content: 'Head Cell 3' },
+    ];
+
+    const data: TableData = [
+        [
+            { content: 'Row Cell 1/1' },
+            { content: 'Row Cell 1/2' },
+            { content: 'Row Cell 1/3' },
+        ],
+        [
+            { content: 'Row Cell 2/1' },
+            { content: 'Row Cell 2/2' },
+            { content: 'Row Cell 2/3' },
+        ],
+        [
+            { content: 'Row Cell 3/1' },
+            { content: 'Row Cell 3/2' },
+            { content: 'Row Cell 3/3' },
+        ],
+    ];
+
+    return html`
+        <sp-table .header="${header}" .data="${data}"></sp-table>
+    `;
+};

--- a/packages/table/test/benchmark/basic-test.ts
+++ b/packages/table/test/benchmark/basic-test.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/table/sp-table.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-table></sp-table>
+`);

--- a/packages/table/test/table.test.ts
+++ b/packages/table/test/table.test.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
+
+import '../sp-table.js';
+import { Table } from '..';
+
+describe('Table', () => {
+    it('loads default table accessibly', async () => {
+        const el = await fixture<Table>(
+            html`
+                <sp-table></sp-table>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/table/tsconfig.json
+++ b/packages/table/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "./"
+    },
+    "include": ["*.ts", "src/*.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../base" }]
+}


### PR DESCRIPTION
## Description

This is a basic and really naive implementation of the [table](https://opensource.adobe.com/spectrum-css/table.html) pattern.

I think that it could be better if someone with more experience actually implemented the table pattern given how table components are complicated. But even if someone else was to implement it, this PR could still be used as an inspiration (maybe).

Here is a list of things that are missing (and probably many more I missed):
* Only div style tables, no `<table>` tables
* No multi-select, column dividers, and other variants
* No tests
* Position of icons in header cells is off
* I'm not sure if I used the slots correctly (I don't think I did)
* I didn't check anything related to accessibility
* I'm not sure about the names of the elements
* No documentation
* Storybook should contain more examples
* Storybook examples have wrong ordering icons
* No updates to `spectrum-config.js`
* Wouldn't using light DOM be easier and preferable?

Currently there are 2 ways for defining tables (both in storybook):

1. using properties
```html
<sp-table .header=${header} .data=${data}></sp-table>
```
2. using slots
```html
<sp-table>
  <sp-head-cell>Head cell 1</sp-head-cell>
  <sp-head-cell>Head cell 1</sp-head-cell>
  <sp-row>
    <sp-cell>Cell 1</sp-cell>
    <sp-cell>Cell 2</sp-cell>
  </sp-row>
</sp-table>
```

The second way is just an extension of the first one and I believe that both are equally useful. 1st option is suitable for constructing tables from JS (maybe with data from some API). The 2nd option is convenient when creating tables that contain eg. unrelated data or when using some backend framework (dotnet in our case):

```cshtml
<sp-table>
  <sp-head-cell>Name</sp-head-cell>
  <sp-head-cell>Email</sp-head-cell>

  @foreach (var user in Model.Users)
  {
    <sp-row>
      <sp-cell>@user.Name</sp-cell>
      <sp-cell>@user.Email</sp-cell>
    </sp-row>
  }
</sp-table>
```

But the 2nd option is slower to render. Also, it is possible to use a combination of both methods.

## Related Issue

* https://github.com/adobe/spectrum-web-components/issues/290

## Motivation and Context

Spectrum CSS contains tables but there is no implementation of tables in spectrum web components.

## How Has This Been Tested?

* Visually in storybook
* By using this implementation in our dashboard (but just briefly)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
