### PR TITLE
feat(split-view): redraw when primary-size change

### DIFF
--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -401,6 +401,10 @@ export class SplitView extends SpectrumElement {
 
     protected updated(changed: PropertyValues): void {
         super.updated(changed);
+        if (changed.has('primarySize')) {
+            this.splitterPos = undefined;
+            this.checkResize();
+        }
         if (
             changed.has('splitterPos') &&
             this.splitterPos !== undefined &&

--- a/packages/split-view/stories/split-view.stories.ts
+++ b/packages/split-view/stories/split-view.stories.ts
@@ -19,13 +19,20 @@ export default {
     component: 'sp-split-view',
 };
 
-export const Horizontal = (): TemplateResult => {
+interface Properties {
+    primarySize?: string;
+}
+
+export const Horizontal = (args: Properties): TemplateResult => {
     return html`
-        <sp-split-view style="height: 200px" primary-size="100">
+        <sp-split-view style="height: 200px" primary-size="${args.primarySize}">
             <div>First panel</div>
             <div>Second panel</div>
         </sp-split-view>
     `;
+};
+Horizontal.args = {
+    primarySize: '100',
 };
 
 export const HorizontalResizable = (): TemplateResult => {

--- a/packages/split-view/test/split-view.test.ts
+++ b/packages/split-view/test/split-view.test.ts
@@ -1031,4 +1031,24 @@ describe('SplitView', () => {
         expect(el.splitterPos || 0).to.equal(pos - 10);
         expect(changeSpy.callCount).to.equal(1);
     });
+
+    it('resizes when primarySize changes', async () => {
+        const el = await fixture<SplitView>(
+            html`
+                <sp-split-view
+                    resizable
+                    primary-size="100"
+                    style=${`height: 200px; width: 500px;`}
+                >
+                    <div>First panel</div>
+                    <div>Second panel</div>
+                </sp-split-view>
+            `
+        );
+        await elementUpdated(el);
+        expect(el.splitterPos || 0).to.equal(100);
+        el.primarySize = '300';
+        await elementUpdated(el);
+        expect(el.splitterPos || 0).to.equal(300);
+    });
 });


### PR DESCRIPTION
## Description

This change automatically updates the splitter position when `primarySize` property changes.

## Related Issue

https://github.com/adobe/spectrum-web-components/issues/1610

## Motivation and Context

According to docs `primarySize` can be set with the `primary-size` attribute. Right now that applies only to the initial state. This change allows (us) to use the split view component as some kind of sidebar which is opened/closed automatically based on some user action.

## How Has This Been Tested?

* Added test
* Added `primarySize` control to storybook (just to the first example)
* By using this change with patch-package in the thing I'm working on

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
