### PR TITLE
feat: use @custom-elements-manifest/analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "build:ts:clean": "node ./tasks/build-packages-clean.js",
         "build:watch": "node ./tasks/watch-packages.js",
         "custom-element-json": "yarn custom-element-json:elements && yarn custom-element-json:icons",
-        "custom-element-json:elements": "lerna exec --ignore \"{@spectrum-web-components/{base,bundle,icons-ui,icons-workflow,modal,iconset,shared,styles},example-project-rollup,example-project-webpack,swc-templates}\" -- wca analyze \"*.d.ts\" --format json --outFile custom-elements.json",
-        "custom-element-json:icons": "lerna exec --scope \"@spectrum-web-components/{icons-ui,icons-workflow}\" -- wca analyze \"icons/*.d.ts\" --format json --outFile custom-elements.json",
-        "docs:analyze": "wca analyze \"packages/*/*.d.ts\" --format json --outFile documentation/custom-elements.json",
+        "custom-element-json:elements": "lerna exec --ignore \"{@spectrum-web-components/{base,bundle,icons-ui,icons-workflow,modal,iconset,shared,styles},example-project-rollup,example-project-webpack,swc-templates}\" -- cem analyze --globs \"**/*.ts\" --exclude \"**/*.d.ts\" --exclude \"**/stories/**\" --exclude \"**/elements/**\" --outdir . --litelement",
+        "custom-element-json:icons": "lerna exec --scope \"@spectrum-web-components/{icons-ui,icons-workflow}\" -- cem analyze --globs \"**/*.ts\" --exclude \"**/*.d.ts\" --exclude \"**/stories/**\" --outdir . --litelement",
+        "docs:analyze": "cem analyze --globs \"packages/**/*.ts\" --exclude \"**/*.d.ts\" --exclude \"**/stories/**\" --exclude \"**/icons/**\" --exclude \"**/elements/**\" --outdir documentation --litelement",
         "docs:build": "run-p build docs:analyze && yarn docs:ts && run-p docs:build:staging storybook:build",
         "docs:build:production": "node ./tasks/build-documentation-production.js",
         "docs:build:staging": "node ./tasks/build-documentation-staging.js",
@@ -45,7 +45,7 @@
         "lint:css": "stylelint \"packages/**/*.css\"",
         "lint:docs": "eslint -f pretty \"documentation/**/*.ts\"",
         "lint:js": "pretty-quick --pattern \"tasks/**/*.js\" && pretty-quick --pattern \"scripts/**/*.js\"",
-        "lint:packagejson": "pretty-quick --pattern package.json packages/*/package.json projects/*/package.json",
+        "lint:packagejson": "pretty-quick --pattern package.json && pretty-quick --pattern \"packages/*/package.json\" && pretty-quick --pattern \"projects/*/package.json\"",
         "lint:ts": "pretty-quick --pattern \"packages/**/*.ts\" && eslint -f pretty \"packages/**/*.ts\"",
         "lint:versions": "node ./scripts/lint-versions.js",
         "new-package": "cd projects/templates && plop",
@@ -96,6 +96,7 @@
         "@commitlint/cli": "^12.0.1",
         "@commitlint/config-conventional": "^12.0.0",
         "@commitlint/config-lerna-scopes": "^12.0.1",
+        "@custom-elements-manifest/analyzer": "^0.4.12",
         "@open-wc/building-webpack": "^2.13.46",
         "@open-wc/dev-server-hmr": "^0.1.1",
         "@open-wc/lit-helpers": "^0.3.12",
@@ -137,6 +138,7 @@
         "common-tags": "^1.8.0",
         "css-loader": "^5.2.0",
         "cssnano": "^4.1.10",
+        "custom-elements-manifest": "^1.0.0",
         "deepmerge": "^4.0.0",
         "element-closest": "^3.0.1",
         "eslint": "^7.21.0",
@@ -204,7 +206,6 @@
         "ts-loader": "^8.0.0",
         "typescript": "^4.3.2",
         "walker": "^1.0.7",
-        "web-component-analyzer": "^1.1.6",
         "webpack": "^4.41.6",
         "webpack-bundle-analyzer": "^4.3.0",
         "webpack-cli": "^4.3.1",
@@ -216,6 +217,7 @@
     "resolutions": {
         "cssnano/**/postcss-calc": "7.0.0"
     },
+    "customElements": "documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -56,7 +56,7 @@
         "@spectrum-css/accordion": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/accordion/src/AccordionItem.ts
+++ b/packages/accordion/src/AccordionItem.ts
@@ -24,7 +24,7 @@ import chevronIconStyles from '@spectrum-web-components/icon/src/spectrum-icon-c
 import styles from './accordion-item.css.js';
 
 /**
- * @element sp-accordion
+ * @element sp-accordion-item
  * @slot - The content of the item that is hidden when the item is not open
  */
 export class AccordionItem extends Focusable {

--- a/packages/action-bar/package.json
+++ b/packages/action-bar/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/actionbar": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -54,7 +54,7 @@
         "@spectrum-css/actionbutton": "^1.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/actiongroup": "^1.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/asset": "^3.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/avatar": "^3.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/banner": "^3.0.0-beta.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -49,5 +49,6 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
+    "customElements": "custom-elements.json",
     "sideEffects": false
 }

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -105,6 +105,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./elements.js"
     ]

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/buttongroup": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -56,7 +56,7 @@
         "@spectrum-css/button": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -57,7 +57,7 @@
         "@spectrum-css/card": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -54,7 +54,7 @@
         "@spectrum-css/checkbox": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/coachmark": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/color-area/package.json
+++ b/packages/color-area/package.json
@@ -53,7 +53,7 @@
         "@spectrum-css/colorarea": "^1.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/color-handle/package.json
+++ b/packages/color-handle/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/colorhandle": "^1.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/color-loupe/package.json
+++ b/packages/color-loupe/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/colorloupe": "^1.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/color-slider/package.json
+++ b/packages/color-slider/package.json
@@ -54,7 +54,7 @@
         "@spectrum-css/colorslider": "^1.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/color-wheel/package.json
+++ b/packages/color-wheel/package.json
@@ -54,7 +54,7 @@
         "@spectrum-css/colorwheel": "^1.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -63,7 +63,7 @@
         "@spectrum-css/dialog": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/divider": "^1.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js",
         "./stories/typography-decorator.js"

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/dropzone": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/fieldgroup": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -54,7 +54,7 @@
         "@spectrum-css/fieldlabel": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/icon": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -59,7 +59,7 @@
         "prettier": "^2.2.1"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./src/index.js",
         "./icons/*"

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -58,7 +58,7 @@
         "prettier": "^2.2.1"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./src/index.js",
         "./icons/*"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -45,6 +45,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./src/index.js",
         "./stories/icons-demo.js"

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/illustratedmessage": "^3.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/link": "^3.1.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -61,7 +61,7 @@
         "@spectrum-css/menu": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -53,7 +53,7 @@
         "@spectrum-css/progressbar": "^1.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -49,7 +49,7 @@
         "@spectrum-css/modal": "^3.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -57,7 +57,7 @@
         "@spectrum-css/stepper": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -57,7 +57,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./active-overlay.js",
         "./overlay-trigger.js",

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -61,7 +61,7 @@
         "@spectrum-css/picker": "^1.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js",
         "./sync/sp-*.js"

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/popover": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/progressbar": "^1.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/progresscircle": "^1.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/quickaction": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -55,7 +55,7 @@
         "@spectrum-css/radio": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -55,7 +55,7 @@
         "@spectrum-css/search": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -47,5 +47,6 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
+    "customElements": "custom-elements.json",
     "sideEffects": false
 }

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -56,7 +56,7 @@
         "@spectrum-css/sidenav": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -56,7 +56,7 @@
         "@spectrum-css/slider": "^3.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -57,7 +57,7 @@
         "@spectrum-css/splitbutton": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/splitview": "^3.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/statuslight": "^3.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -76,6 +76,7 @@
         "@spectrum-css/typography": "^3.0.2",
         "@spectrum-css/vars": "^3.0.2"
     },
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./*.css"
     ],

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/switch": "^1.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -56,7 +56,7 @@
         "@spectrum-css/tabs": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -55,7 +55,7 @@
         "@spectrum-css/tags": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -55,7 +55,7 @@
         "@spectrum-css/textfield": "^3.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -61,7 +61,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js",
         "./theme-*.js",

--- a/packages/thumbnail/package.json
+++ b/packages/thumbnail/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/thumbnail": "^1.0.2"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -54,7 +54,7 @@
         "@spectrum-css/toast": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -52,7 +52,7 @@
         "@spectrum-css/tooltip": "^3.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/top-nav/package.json
+++ b/packages/top-nav/package.json
@@ -52,7 +52,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -53,7 +53,7 @@
         "@spectrum-css/tray": "^1.0.3"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -51,7 +51,7 @@
         "@spectrum-css/underlay": "^2.0.10"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js"
     ]

--- a/projects/example-project-rollup/package.json
+++ b/projects/example-project-rollup/package.json
@@ -45,6 +45,7 @@
     "tslib": "^1.11.0",
     "typescript": "^4.0.2"
   },
+  "customElements": "custom-elements.json",
   "prettier": {
     "singleQuote": true,
     "arrowParens": "avoid"

--- a/projects/example-project-webpack/package.json
+++ b/projects/example-project-webpack/package.json
@@ -34,5 +34,6 @@
         "webpack": "^4.27.0",
         "webpack-bundle-analyzer": "^4.3.0",
         "webpack-cli": "^4.3.1"
-    }
+    },
+    "customElements": "custom-elements.json"
 }

--- a/projects/story-decorator/package.json
+++ b/projects/story-decorator/package.json
@@ -55,7 +55,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js",
         "./sp-*.ts"

--- a/projects/templates/package.json
+++ b/projects/templates/package.json
@@ -11,5 +11,6 @@
     },
     "devDependencies": {
         "plop": "^2.6.0"
-    }
+    },
+    "customElements": "custom-elements.json"
 }

--- a/projects/vrt-compare/package.json
+++ b/projects/vrt-compare/package.json
@@ -55,7 +55,7 @@
         "tslib": "^2.0.0"
     },
     "types": "./src/index.d.ts",
-    "customElementsManifest": "custom-elements.json",
+    "customElements": "custom-elements.json",
     "sideEffects": [
         "./onion-skinner.js",
         "./onion-skinner.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,6 +1349,20 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz#c3c5ae543c897caa9c2a68630bed355be5f9990f"
   integrity sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==
 
+"@custom-elements-manifest/analyzer@^0.4.12":
+  version "0.4.12"
+  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/analyzer/-/analyzer-0.4.12.tgz#55dd21bf00faa6cc33a1ba248de6b9fcb804ef6f"
+  integrity sha512-AvHMmiC5TpYBYmjdZ/5OKhsTQbJvb1A7jkTb3/DUuVZrRpvNuVz6/fhyQ0giF5VFwmPWgBdMdaA2qNDQlK0lIg==
+  dependencies:
+    "@web/config-loader" "^0.1.3"
+    chokidar "^3.5.2"
+    command-line-args "^5.1.1"
+    comment-parser "^1.1.5"
+    custom-elements-manifest "^1.0.0"
+    debounce "^1.2.1"
+    globby "^11.0.4"
+    typescript "^4.3.2"
+
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
@@ -5303,6 +5317,14 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anymatch@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -7194,6 +7216,21 @@ chokidar@^3.0.0, chokidar@^3.0.2, chokidar@^3.4.1, chokidar@^3.4.3:
   optionalDependencies:
     fsevents "~2.3.1"
 
+chokidar@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -7661,6 +7698,11 @@ commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+comment-parser@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.5.tgz#453627ef8f67dbcec44e79a9bd5baa37f0bce9b2"
+  integrity sha512-RePCE4leIhBlmrqiYTvaqEeGYg7qpSl4etaIabKtdOQVi+mSTIBBklGUwIr79GXYnl3LpMwmDw4KeR2stNc6FA==
 
 common-path-prefix@^2.0.0:
   version "2.0.0"
@@ -8467,6 +8509,11 @@ cuss@^1.15.0:
   resolved "https://registry.yarnpkg.com/cuss/-/cuss-1.21.0.tgz#1aba3bb911fadda8566855ed036295af8116be40"
   integrity sha512-X3VvImImJ5q6w0wOgJtxAX+RC06d26egp/A/vdSxqOrsRtAA9biXAkc4PZGj/3gx0+z+gDFri6BpcpwuG1/UEw==
 
+custom-elements-manifest@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz#b35c2129076a1dc9f95d720c6f7b5b71a857274b"
+  integrity sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -8506,7 +8553,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debounce@^1.2.0:
+debounce@^1.2.0, debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
@@ -10767,7 +10814,7 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@~2.3.1:
+fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -11041,7 +11088,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -11186,6 +11233,18 @@ globby@^11.0.1, globby@^11.0.2, globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -18601,7 +18660,7 @@ readdirp@^2.0.0, readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readdirp@^3.4.0:
+readdirp@^3.4.0, readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
@@ -22333,7 +22392,7 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-web-component-analyzer@^1.1.6, web-component-analyzer@~1.1.1:
+web-component-analyzer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/web-component-analyzer/-/web-component-analyzer-1.1.6.tgz#d9bd904d904a711c19ba6046a45b60a7ee3ed2e9"
   integrity sha512-1PyBkb/jijDEVE+Pnk3DTmVHD8takipdvAwvZv1V8jIidsSIJ5nhN87Gs+4dpEb1vw48yp8dnbZKkvMYJ+C0VQ==


### PR DESCRIPTION
## Description
- switch from `web-component-analyzer` to `@custom-elements-manifest/analyzer` so that we can start leveraging the latest version of https://github.com/webcomponents/custom-elements-manifest
- update the docs site to leverage the new data format

## Motivation and Context
A much broader ecosystem is coming up around the new schema and we should be ready to leverage it.

## How Has This Been Tested?
https://westbrook-analyzer--spectrum-web-components.netlify.app/components/search/api

## Types of changes
- [x] Docs

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
