### PR TITLE
refactor: use latest axe-core and update sp-radio as instructed

### DIFF
--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -105,13 +105,6 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
         );
     }
 
-    protected handleClick(event: Event): void {
-        const target = event.composedPath()[0];
-        if (target === this && !this.checked) {
-            this.activate();
-        }
-    }
-
     protected activate(): void {
         this.checked = true;
         this.dispatchEvent(
@@ -122,18 +115,15 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
         );
     }
 
+    protected handleKeyup(event: KeyboardEvent): void {
+        if (event.code === 'Space') {
+            this.activate();
+        }
+    }
+
     protected render(): TemplateResult {
         return html`
-            <input
-                id="input"
-                type="radio"
-                value=${this.value}
-                .checked=${this.checked}
-                @change=${this.handleChange}
-                aria-hidden="true"
-                tabindex="-1"
-                ?disabled=${this.disabled}
-            />
+            <div id="input"></div>
             <span id="button"></span>
             <span id="label" role="presentation"><slot></slot></span>
         `;
@@ -146,7 +136,8 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
             this.tabIndex = 0;
         }
         this.manageAutoFocus();
-        this.addEventListener('click', this.handleClick);
+        this.addEventListener('click', this.activate);
+        this.addEventListener('keyup', this.handleKeyup);
     }
 
     protected updated(changes: PropertyValues): void {
@@ -163,6 +154,13 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
                 this.setAttribute('aria-checked', 'true');
             } else {
                 this.setAttribute('aria-checked', 'false');
+            }
+        }
+        if (changes.has('disabled')) {
+            if (this.disabled) {
+                this.setAttribute('aria-disabled', 'true');
+            } else {
+                this.removeAttribute('aria-disabeld');
             }
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,10 +5922,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^4.0.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966"
-  integrity sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==
+axe-core@4.3.1, axe-core@^4.0.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.1.tgz#0c6a076e4a1c3e0544ba6a9479158f9be7a7928e"
+  integrity sha512-3WVgVPs/7OnKU3s+lqMtkv3wQlg3WxK1YifmpJSDO0E1aPBrZWlrrTO6cxRqCXLuX2aYgCljqXIQd0VnRidV0g==
 
 axobject-query@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Description
Updating `axe-core` to support ongoing changes to `sp-menu` surfaces a new test failure in `sp-radio`, this updates Radio out of band so that it doesn't collide with the menu work.

## Motivation and Context
#accessibility

## How Has This Been Tested?
It failed tests, suddenly, so we fixed it.

## Screenshots (if appropriate):
https://westbrook-axe--spectrum-web-components.netlify.app/storybook/index.html?path=/story/radio--group-example

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
