### PR TITLE
fix(tabs): ensure tabs has layout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 960c6243c41e1fca19e6e209a41db12ce8ef5156
+        default: c57730acf03f1435648d43350e43a2f35361a9ac
 commands:
     downstream:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: d2c1c488bca68f75b4a391fe3c8060fe789f32c1
+        default: 960c6243c41e1fca19e6e209a41db12ce8ef5156
 commands:
     downstream:
         steps:

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -45,6 +45,23 @@ import {
 </sp-tabs>
 ```
 
+### Disabled
+
+When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+
+```html
+<sp-tabs selected="2" disabled>
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
+</sp-tabs>
+```
+
 ### Vertical
 
 ```html

--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -50,6 +50,9 @@ export class Tab extends FocusVisiblePolyfillMixin(
         return !!this.label || this.slotHasContent;
     }
 
+    @property({ type: Boolean, reflect: true })
+    public disabled = false;
+
     @property({ reflect: true })
     public label = '';
 
@@ -92,6 +95,13 @@ export class Tab extends FocusVisiblePolyfillMixin(
                 this.selected ? 'true' : 'false'
             );
             this.setAttribute('tabindex', this.selected ? '0' : '-1');
+        }
+        if (changes.has('disabled')) {
+            if (this.disabled) {
+                this.setAttribute('aria-disabled', 'true');
+            } else {
+                this.removeAttribute('aria-disabled');
+            }
         }
     }
 }

--- a/packages/tabs/src/tab.css
+++ b/packages/tabs/src/tab.css
@@ -12,6 +12,10 @@ governing permissions and limitations under the License.
 
 @import './spectrum-tab.css';
 
+:host([disabled]) {
+    pointer-events: none;
+}
+
 :host([vertical]) {
     display: flex;
     flex-direction: column;

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -20,8 +20,26 @@ governing permissions and limitations under the License.
     grid-template-columns: auto 1fr;
 }
 
+:host([disabled]) #selectionIndicator {
+    background-color: var(
+        --spectrum-tabs-m-text-color-disabled,
+        var(--spectrum-alias-text-color-disabled)
+    );
+}
+
+:host([disabled]) ::slotted(sp-tab) {
+    color: var(
+        --spectrum-tabs-m-text-color-disabled,
+        var(--spectrum-alias-text-color-disabled)
+    );
+}
+
 #list {
     justify-content: var(--swc-tabs-list-justify-content);
+}
+
+:host([disabled]) #list {
+    pointer-events: none;
 }
 
 /*

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -12,6 +12,18 @@ governing permissions and limitations under the License.
 
 @import './spectrum-tabs.css';
 
+:host {
+    display: grid;
+}
+
+:host([direction^='vertical']) {
+    grid-template-columns: auto 1fr;
+}
+
+#list {
+    justify-content: var(--swc-tabs-list-justify-content);
+}
+
 /*
  * While https://github.com/adobe/spectrum-css/issues/641 goes unaddressed,
  * then we'll need to place this at `top: 0;` ourselves.

--- a/packages/tabs/stories/tabs.stories.ts
+++ b/packages/tabs/stories/tabs.stories.ts
@@ -125,8 +125,7 @@ export const VerticalSized = (args: Properties): TemplateResult => {
         <style>
             sp-tabs {
                 height: 75vh;
-                flex-direction: column;
-                justify-content: center;
+                --swc-tabs-list-justify-content: center;
             }
         </style>
         <sp-tabs
@@ -149,8 +148,7 @@ export const VerticalRight = (args: Properties): TemplateResult => {
         <style>
             sp-tabs {
                 height: 75vh;
-                flex-direction: column;
-                justify-content: center;
+                --swc-tabs-list-justify-content: center;
             }
         </style>
         <sp-tabs

--- a/packages/tabs/stories/tabs.stories.ts
+++ b/packages/tabs/stories/tabs.stories.ts
@@ -103,6 +103,30 @@ export const Autofocus = (args: Properties): TemplateResult => {
     `;
 };
 
+export const disabledTabs = (args: Properties): TemplateResult => {
+    return html`
+        <sp-tabs selected="1" disabled ?auto=${args.auto} label="Disabled Tabs">
+            <sp-tab label="Tab 1" value="1"></sp-tab>
+            <sp-tab label="Tab 2" value="2"></sp-tab>
+            <sp-tab label="Tab 3" value="3"></sp-tab>
+            <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
+        </sp-tabs>
+    `;
+};
+
+export const disabledTab = (args: Properties): TemplateResult => {
+    return html`
+        <sp-tabs selected="1" ?auto=${args.auto} label="Disabled Tab">
+            <sp-tab label="Tab 1" value="1"></sp-tab>
+            <sp-tab label="Tab 2" value="2" disabled></sp-tab>
+            <sp-tab label="Tab 3" value="3" disabled></sp-tab>
+            <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
+        </sp-tabs>
+    `;
+};
+
 export const Vertical = (args: Properties): TemplateResult => {
     return html`
         <sp-tabs

--- a/packages/tabs/tab.md
+++ b/packages/tabs/tab.md
@@ -91,3 +91,20 @@ import {
     </sp-tab-panel>
 </sp-tabs>
 ```
+
+### Disabled
+
+When an `<sp-tab>` element is given the `disabled` attribute it will prevent visitor from selecting that tab and its contents. The ability to select other tabs and their content will go unimpeaded.
+
+```html
+<sp-tabs selected="2">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3" disabled></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1 is selectable</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4 is selectable</sp-tab-panel>
+</sp-tabs>
+```

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -81,6 +81,32 @@ describe('Tabs', () => {
         await expect(tabs).to.be.accessible();
     });
 
+    it('can be disabled', async () => {
+        const tabs = await createTabs();
+        const tab = tabs.querySelector('[label="Tab 3"]') as Tab;
+        tabs.disabled = true;
+        await elementUpdated(tabs);
+        expect(tabs.selected).to.equal('first');
+        tab.click();
+        await elementUpdated(tabs);
+        expect(tabs.selected).to.equal('first');
+    });
+
+    it('can have disabled sp-tab children', async () => {
+        const tabs = await createTabs();
+        const tab2 = tabs.querySelector('[label="Tab 2"]') as Tab;
+        const tab3 = tabs.querySelector('[label="Tab 3"]') as Tab;
+        tab3.disabled = true;
+        await elementUpdated(tab3);
+        expect(tabs.selected).to.equal('first');
+        tab3.click();
+        await elementUpdated(tabs);
+        expect(tabs.selected).to.equal('first');
+        tab2.click();
+        await elementUpdated(tabs);
+        expect(tabs.selected).to.equal('second');
+    });
+
     it('reflects selected tab with selected property', async () => {
         const tabs = await createTabs();
 


### PR DESCRIPTION
## Description
- give tabs layout by default
- correct VRT for sized vertical tabs
- visually and functionally support `[disabled]` on `sp-tabs` and `sp-tab` elements

## Related Issue
fixes #1612
fixes #1471 

## Motivation and Context
Correctness. Ease of use.

## How Has This Been Tested?
VRT, manually.

## Screenshots (if appropriate):
https://westbrook-tabs--spectrum-web-components.netlify.app/storybook/index.html?path=/story/tabs--vertical-sized

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
