### PR TITLE
fix(overlay): allow external style access to "sp-theme" elemenets in overlays as a CSS part

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c57730acf03f1435648d43350e43a2f35361a9ac
+        default: 1601de1bace21b18541047e5c64d44fda75a9fb2
 commands:
     downstream:
         steps:

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -146,6 +146,10 @@ The work to both open and close an overlay is asynchronous. This asynchrony is s
 </sp-popover>
 ```
 
+## Styling
+
+When an overlay is opened from within a styled DOM scope as created by an `<sp-theme>` element, this scope will be resolved and recreated with in the `<active-overlay>` element that is created to host the overlaid content directly in the `<body>`. By default, the generated `<sp-theme>` element will be supplied with settings of the scope from which the overlay is triggered, including any "app" centric CSS Custom Properties that might be applied via `Theme.registerThemeFragment('app', 'app', themeFragment)` therein. In the case that you have set CSS Custom Properties for the scope created by an `<sp-theme>` element via other methods, you can specify that those values should also be applied to overlay content using the `theme` part on the `<active-overlay>` element via the `active-overlay::part(theme) { /* styles */ }` selector.
+
 ## Advanced Usage
 
 When working with the DOM-based APIs of custom elements, it is sometimes preferred to project content into an overlay from a different shadow root (eg projecting a single-slotted element into the overlay). To ensure that the content can be marshalled through any number of `<slot>` elements which are addressed into subsequent `<slot>` elements, be sure to use the `flatten: true` option when querying `slot.asignedNodes()`:

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -483,6 +483,7 @@ export class ActiveOverlay extends SpectrumElement {
                 color=${ifDefined(color)}
                 scale=${ifDefined(scale)}
                 lang=${ifDefined(lang)}
+                part="theme"
             >
                 ${content}
             </sp-theme>

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -67,7 +67,7 @@ const storyStyles = html`
         }
 
         #styled-div {
-            background-color: blue;
+            background-color: var(--styled-div-background-color, blue);
             color: white;
             padding: 4px 10px;
             margin-bottom: 10px;
@@ -141,7 +141,6 @@ const template = ({ placement, offset, open }: Properties): TemplateResult => {
                 slot="click-content"
                 placement="${placement}"
                 tip
-                open
             >
                 <div class="options-popover-content">
                     <sp-slider
@@ -198,6 +197,22 @@ export const openClickContent = (args: Properties): TemplateResult =>
         ...args,
         open: 'click',
     });
+
+export const customizedClickContent = (
+    args: Properties
+): TemplateResult => html`
+    <style>
+        active-overlay::part(theme) {
+            --styled-div-background-color: var(--spectrum-semantic-cta-color-background-default);
+            --spectrum-button-cta-m-background-color: rebeccapurple;
+        }
+    </style>
+    </style>
+    ${template({
+        ...args,
+        open: 'click',
+    })}
+`;
 
 const extraText = html`
     <p>This is some text.</p>

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -82,6 +82,7 @@ ActiveOverlay.prototype.renderTheme = function (
             color=${ifDefined(color)}
             scale=${ifDefined(scale)}
             lang=${ifDefined(lang)}
+            part="theme"
         >
             ${content}
         </sp-theme>


### PR DESCRIPTION
## Description
- surface `theme` part for external customization of the CSS Custom Properties hung off of the `sp-theme` element in an `active-overlay` 

cc: @ejez 

## Related Issue
fixes #1586

## Motivation and Context
Easier to customize your content.

## How Has This Been Tested?
VRT

## Screenshots (if appropriate):
https://westbrook-theme--spectrum-web-components.netlify.app/storybook/index.html?path=/story/overlay--customized-click-content

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
