### PR TITLE
ci: comment tachometer results for changed files to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,64 @@
+name: Performance check
+
+on: pull_request
+
+jobs:
+    compare:
+        name: Compare performance to latest release
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  ref: main
+
+            - uses: actions/checkout@v2
+
+            - name: Setup Node 14.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 14.x
+
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+
+            - uses: actions/cache@v2
+              id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+            - name: Install dependencies
+              run: yarn --frozen-lockfile
+
+            - name: Tachometer the changed packages
+              run: yarn test:changed
+
+            - uses: actions/github-script@v4
+              with:
+                  script: |
+                      const buildTachometerComment = require('./tasks/build-tachometer-comment.cjs').buildTachometerComment;
+                      const body = buildTachometerComment();
+                      github.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                      }).then(({data}) => {
+                        const priorComment = data.find(comment => comment.body.startsWith('# Tachometer results for changed packages'));
+                        if (priorComment) {
+                          github.issues.updateComment({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            comment_id: priorComment.id,
+                            body
+                          });
+                        } else {
+                          github.issues.createComment({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: context.issue.number,
+                            body
+                          });
+                        }
+                      });

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ yarn-error.log
 .tsbuildinfo
 .rush
 .devcontainer
+tach-results.*
 
 documentation/components/searchIndex.json
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "test": "yarn test:focus unit",
         "test:bench": "node test/benchmark/cli.cjs",
         "test:build": "node test/visual/create.js && tsc --build test/tsconfig-plugins.json && tsc --build test/tsconfig-test.json",
+        "test:changed": "node ./tasks/test-changes.js",
         "test:ci": "yarn test:build && yarn test:start",
         "test:focus": "yarn build && yarn test:ci --coverage --group",
         "test:start": "web-test-runner",
@@ -81,7 +82,7 @@
         "test:visual:clean:baseline": "rimraf test/visual/screenshots-baseline",
         "test:visual:clean:current": "rimraf test/visual/screenshots-current",
         "test:watch": "test:watch:focus unit",
-        "test:watch:focus": "yarn test:build && yarn test:build:plugins && run-p watch:css \"test:build -w\" \"test:start --watch --group {1}\" --",
+        "test:watch:focus": "yarn test:build && run-p watch:css \"test:build -w\" \"test:start --watch --group {1}\" --",
         "watch:css": "node ./tasks/watch-css.js"
     },
     "peerDependencies": {
@@ -191,6 +192,7 @@
         "posthtml-match-helper": "^1.0.1",
         "prettier": "^2.2.1",
         "prettier-plugin-package": "^1.3.0",
+        "pretty-bytes": "^5.6.0",
         "pretty-quick": "^3.1.0",
         "prismjs": "^1.15.0",
         "raw-loader": "^4.0.0",

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -203,28 +203,19 @@ describe('Overlay Trigger', () => {
             expect(outerTrigger.disabled).to.be.false;
 
             expect(outerButton).to.exist;
-            outerButton.click();
 
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'Wait for the DOM node to be stolen and reparented into the overlay'
-            );
+            const opened = oneEvent(outerButton, 'sp-opened');
+            outerButton.click();
+            await opened;
 
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
             expect(isVisible(outerClickContent)).to.be.true;
 
+            const closed = oneEvent(outerButton, 'sp-closed');
             outerTrigger.disabled = true;
-
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'Wait for the DOM node to be returned to the overlay trigger'
-            );
+            await closed;
 
             expect(isVisible(outerClickContent)).to.be.false;
             expect(outerTrigger.disabled).to.be.true;

--- a/tasks/build-tachometer-comment.cjs
+++ b/tasks/build-tachometer-comment.cjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const globby = require('globby');
+const fs = require('fs');
+const prettyBytes = require('pretty-bytes');
+
+const getTachometerResults = () => {
+    const results = [];
+    for (const result of globby.sync(`./tach-results.*.json`)) {
+        const file = fs.readFileSync(result, 'utf8');
+        const json = JSON.parse(file);
+        results.push(json.benchmarks);
+    }
+    return results;
+};
+
+function formatConfidenceInterval(ci, format) {
+    return `${format(ci.low)} - ${format(ci.high)}`;
+}
+
+function percent(n) {
+    // return (n * 100).toFixed(0);
+    return n.toFixed(0) + '%';
+}
+
+function milli(n) {
+    return n.toFixed(2) + 'ms';
+}
+
+const colorizeSign = (n, format) => {
+    // Argh, it appears we can't color text using inline styes :(
+    if (n > 0) {
+        // return ansi.format(`[red bold]{+}${format(n)}`);
+        return `+${format(n)}`;
+    } else if (n < 0) {
+        // Negate the value so that we don't get a double negative sign.
+        // return ansi.format(`[green bold]{-}${format(-n)}`);
+        return `-${format(-n)}`;
+    } else {
+        return format(n);
+    }
+};
+
+function negate(ci) {
+    return {
+        low: -ci.high,
+        high: -ci.low,
+    };
+}
+
+function formatDifference({ absolute, percentChange: relative }) {
+    let word, rel, abs;
+    if (Math.round(relative.low) == 0 && Math.round(relative.high) == 0) {
+        // Our formatting for percents uses `.toFixed(0)`. In cases where we would
+        // show 0% - 0% but the actual result is actually not zero (i.e. -0.5 - 0.4)
+        // let's still show the result as unsure to avoid a situation where we would
+        // display something like "slower ❌ 0% - 0% (0.00ms - 0.00ms)"
+        word = `<strong>unsure 🔍</strong>`; // bold blue
+        rel = formatConfidenceInterval(relative, (n) =>
+            colorizeSign(n, percent)
+        );
+        abs = formatConfidenceInterval(absolute, (n) => colorizeSign(n, milli));
+    } else if (absolute.low > 0 && relative.low > 0) {
+        word = `<strong>slower ❌</strong>`; // bold red
+        rel = formatConfidenceInterval(relative, percent);
+        abs = formatConfidenceInterval(absolute, milli);
+    } else if (absolute.high < 0 && relative.high < 0) {
+        word = `<strong>faster ✔</strong>`; // bold green
+        rel = formatConfidenceInterval(negate(relative), percent);
+        abs = formatConfidenceInterval(negate(absolute), milli);
+    } else {
+        word = `<strong>unsure 🔍</strong>`; // bold blue
+        rel = formatConfidenceInterval(relative, (n) =>
+            colorizeSign(n, percent)
+        );
+        abs = formatConfidenceInterval(absolute, (n) => colorizeSign(n, milli));
+    }
+
+    return {
+        label: word,
+        relative: rel,
+        absolute: abs,
+    };
+}
+
+const buildTable = (result) => {
+    const remote = result[0];
+    const remoteDifferences = formatDifference(remote.differences[1]);
+    const remoteDifferencesString = `${remoteDifferences.label} <br> ${remoteDifferences.relative} <br> ${remoteDifferences.absolute}`;
+    const branch = result[1];
+    const branchDifferences = formatDifference(branch.differences[0]);
+    const branchDifferencesString = `${branchDifferences.label} <br> ${branchDifferences.relative} <br> ${branchDifferences.absolute}`;
+    const packageName = `${result[0].name.split(':')[0]}`;
+    const table = `<a id="${packageName}"></a>
+
+## ${packageName} [_permalink_](#user-content-${packageName})
+| Version | Bytes | Avg Time | vs remote | vs branch |
+|---|---|---|---|---|
+| remote | ${prettyBytes(remote.bytesSent)} | ${formatConfidenceInterval(
+        remote.mean,
+        milli
+    )} | - | ${remoteDifferencesString} |
+| branch | ${prettyBytes(branch.bytesSent)} | ${formatConfidenceInterval(
+        branch.mean,
+        milli
+    )} | ${branchDifferencesString} | - |
+`;
+    return table;
+};
+
+const buildTachometerComment = () => {
+    const results = getTachometerResults();
+    const tables = results.map(buildTable);
+    const comment = `# Tachometer results for changed packages
+${tables.join(`
+    
+`)}`;
+    return comment;
+};
+
+console.log(buildTachometerComment());
+
+module.exports = {
+    buildTachometerComment,
+};

--- a/tasks/test-changes.js
+++ b/tasks/test-changes.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { execSync } from 'child_process';
+
+const getChangedPackages = () => {
+    let command;
+    try {
+        command = execSync(
+            'yarn lerna ls --since origin/main --json --loglevel silent'
+        );
+    } catch (error) {
+        console.log(error.message);
+        console.log(error.stdout.toString());
+        return [];
+    }
+    const json = command
+        .toString()
+        .split('✨')[0]
+        .trim()
+        .split('silent')[1]
+        .trim();
+    const packageList = JSON.parse(json).reduce((acc, item) => {
+        const name = item.name.replace('@spectrum-web-components/', '');
+        if (
+            // There are no benchmarks available in this directory.
+            item.location.search('projects') === -1 &&
+            // The icons-* tests are particular and long, exclude in CI.
+            !name.startsWith('icons-')
+        ) {
+            acc.push(name);
+        }
+        return acc;
+    }, []);
+    return packageList;
+};
+
+const testChangedPackages = () => {
+    const packages = getChangedPackages();
+    console.log(
+        `Running tachometer on the following packages: ${packages.join(', ')}`
+    );
+    if (packages.length) {
+        execSync('yarn build:tests');
+        execSync(`yarn test:bench -j -p ${packages.join(' ')}`, {
+            stdio: 'inherit',
+        });
+    }
+};
+
+testChangedPackages();

--- a/test/benchmark/cli.ts
+++ b/test/benchmark/cli.ts
@@ -85,6 +85,13 @@ const optionDefinitions: commandLineUsage.OptionDefinition[] = [
         type: String,
         defaultValue: 'element',
     },
+    {
+        name: 'json',
+        description: 'Save output to json.',
+        alias: 'j',
+        type: Boolean,
+        defaultValue: false,
+    },
 ];
 
 interface Options {
@@ -96,6 +103,7 @@ interface Options {
     browser: string;
     compare: string;
     start: string;
+    json: boolean;
 }
 
 (async () => {
@@ -238,11 +246,13 @@ $ node test/benchmark/cli -n 20
             }
         );
 
-        const statResults = await main([
-            ...runCommands,
-            `--config=./test/benchmark/config.json`,
-            `--force-clean-npm-install`,
-        ]);
+        if (opts.json) {
+            runCommands.push(`--json-file=tach-results.${packageName}.json`);
+        }
+        runCommands.push(`--config=./test/benchmark/config.json`);
+        runCommands.push(`--force-clean-npm-install`);
+
+        const statResults = await main(runCommands);
 
         if (!statResults) {
             return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -18317,7 +18317,7 @@ prettier@^2.0.4, prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
-pretty-bytes@^5.1.0, pretty-bytes@^5.3.0:
+pretty-bytes@^5.1.0, pretty-bytes@^5.3.0, pretty-bytes@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==


### PR DESCRIPTION
## Description
Use Github Actions to report Tachometer results for the packages that Lerna outlines as having changes from `origin/main` in to pull requests as a self updating comment.

The time this takes scales up with the number of packages changed, which also influences the benefit of making smaller changes.

## Related Issue
fixes #137 (our oldest open issue!!)

## Motivation and Context
Easier to tell that our changes are for the greater good of the library.

## How Has This Been Tested?
You'll see below. I'll also create a couple of other demo PRs with active branches and list them here for review as well.

Draft PR of the changes for `lit-next` including this code: https://github.com/adobe/spectrum-web-components/pull/1636
Draft PR of the changes for `westbrook/menu-selects` including this code: https://github.com/adobe/spectrum-web-components/pull/1637

## Types of changes
- [x] CI tooling

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
