### PR TITLE
[Color Area] Dispatch change event when using keyboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "test:visual:clean": "yarn test:visual:clean:baseline && yarn test:visual:clean:current",
         "test:visual:clean:baseline": "rimraf test/visual/screenshots-baseline",
         "test:visual:clean:current": "rimraf test/visual/screenshots-current",
-        "test:watch": "test:watch:focus unit",
+        "test:watch": "yarn test:watch:focus unit",
         "test:watch:focus": "yarn test:build && run-p watch:css \"test:build -w\" \"test:start --watch --group {1}\" --",
         "watch:css": "node ./tasks/watch-css.js"
     },

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -211,6 +211,7 @@ export class ColorArea extends SpectrumElement {
 
     private handleKeydown(event: KeyboardEvent): void {
         const { key, code } = event;
+        event.preventDefault();
         if (['Shift', 'Meta', 'Control', 'Alt'].includes(key)) {
             this.altKeys.add(key);
             this.altered = this.altKeys.size;
@@ -247,37 +248,35 @@ export class ColorArea extends SpectrumElement {
                     break;
             }
         });
-        if (deltaX != 0 || deltaY != 0) {
+        if (deltaX != 0) {
             this.inputX.focus();
-            this.inputX.dispatchEvent(
-                new Event('input', {
-                    bubbles: true,
-                    composed: true,
-                })
-            );
+        } else if (deltaY != 0) {
             this.inputY.focus();
-            this.inputY.dispatchEvent(
-                new Event('input', {
-                    bubbles: true,
-                    composed: true,
-                })
-            );
         }
+
         this.x = Math.min(1, Math.max(this.x + deltaX, 0));
         this.y = Math.min(1, Math.max(this.y + deltaY, 0));
 
         this._previousColor = this._color.clone();
         this._color = new TinyColor({ h: this.hue, s: this.x, v: 1 - this.y });
 
-        const applyDefault = this.dispatchEvent(
-            new Event('change', {
-                bubbles: true,
-                composed: true,
-                cancelable: true,
-            })
-        );
-        if (!applyDefault) {
-            this._color = this._previousColor;
+        if (deltaX != 0 || deltaY != 0) {
+            this.dispatchEvent(
+                new Event('input', {
+                    bubbles: true,
+                    composed: true,
+                })
+            );
+            const applyDefault = this.dispatchEvent(
+                new Event('change', {
+                    bubbles: true,
+                    composed: true,
+                    cancelable: true,
+                })
+            );
+            if (!applyDefault) {
+                this._color = this._previousColor;
+            }
         }
     }
 

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -247,7 +247,7 @@ export class ColorArea extends SpectrumElement {
                     break;
             }
         });
-        if (deltaX != 0) {
+        if (deltaX != 0 || deltaY != 0) {
             this.inputX.focus();
             this.inputX.dispatchEvent(
                 new Event('input', {
@@ -255,13 +255,6 @@ export class ColorArea extends SpectrumElement {
                     composed: true,
                 })
             );
-            // this.inputX.dispatchEvent(
-            //     new Event('change', {
-            //         bubbles: true,
-            //         composed: true,
-            //     })
-            // );
-        } else if (deltaY != 0) {
             this.inputY.focus();
             this.inputY.dispatchEvent(
                 new Event('input', {
@@ -269,12 +262,6 @@ export class ColorArea extends SpectrumElement {
                     composed: true,
                 })
             );
-            // this.inputY.dispatchEvent(
-            //     new Event('change', {
-            //         bubbles: true,
-            //         composed: true,
-            //     })
-            // );
         }
         this.x = Math.min(1, Math.max(this.x + deltaX, 0));
         this.y = Math.min(1, Math.max(this.y + deltaY, 0));

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -247,10 +247,34 @@ export class ColorArea extends SpectrumElement {
                     break;
             }
         });
-        if (deltaX) {
+        if (deltaX != 0) {
             this.inputX.focus();
-        } else if (deltaY) {
+            this.inputX.dispatchEvent(
+                new Event('input', {
+                    bubbles: true,
+                    composed: true,
+                })
+            );
+            // this.inputX.dispatchEvent(
+            //     new Event('change', {
+            //         bubbles: true,
+            //         composed: true,
+            //     })
+            // );
+        } else if (deltaY != 0) {
             this.inputY.focus();
+            this.inputY.dispatchEvent(
+                new Event('input', {
+                    bubbles: true,
+                    composed: true,
+                })
+            );
+            // this.inputY.dispatchEvent(
+            //     new Event('change', {
+            //         bubbles: true,
+            //         composed: true,
+            //     })
+            // );
         }
         this.x = Math.min(1, Math.max(this.x + deltaX, 0));
         this.y = Math.min(1, Math.max(this.y + deltaY, 0));
@@ -286,6 +310,16 @@ export class ColorArea extends SpectrumElement {
 
         this[name as 'x' | 'y'] = valueAsNumber;
         this._color = new TinyColor({ h: this.hue, s: this.x, v: 1 - this.y });
+    }
+
+    private handleChange(): void {
+        this.dispatchEvent(
+            new Event('change', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
     }
 
     private boundingClientRect!: DOMRect;
@@ -421,6 +455,7 @@ export class ColorArea extends SpectrumElement {
                 step=${this.step}
                 .value=${String(this.x)}
                 @input=${this.handleInput}
+                @change=${this.handleChange}
                 @keydown=${preventDefault}
             />
             <input
@@ -433,6 +468,7 @@ export class ColorArea extends SpectrumElement {
                 step=${this.step}
                 .value=${String(this.y)}
                 @input=${this.handleInput}
+                @change=${this.handleChange}
                 @keydown=${preventDefault}
             />
         `;

--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -41,6 +41,10 @@ export const Default = (): TemplateResult => {
                 const next = target.nextElementSibling as HTMLElement;
                 next.textContent = target.color as string;
                 next.style.color = target.color as string;
+                console.log('input');
+            }}
+            @change=${() => {
+                console.log('change');
             }}
         ></sp-color-area>
         <div style="color: #ff0000" aria-live="off">#ff0000</div>

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -28,6 +28,7 @@ import { HSL, HSLA, HSV, HSVA, RGB, RGBA, TinyColor } from '@ctrl/tinycolor';
 import '../sp-color-area.js';
 import { ColorArea } from '..';
 import { sendKeys } from '@web/test-runner-commands';
+import { spy } from 'sinon';
 
 describe('ColorArea', () => {
     it('loads default color-area accessibly', async () => {
@@ -324,6 +325,40 @@ describe('ColorArea', () => {
         expect(el.hue).to.equal(0);
         expect(el.x).to.equal(0.53125);
         expect(el.y).to.equal(0.53125);
+    });
+    it('dispatches input and change events in response to "Arrow*" keypresses', async () => {
+        const inputSpy = spy();
+        const changeSpy = spy();
+        const el = await fixture<ColorArea>(
+            html`
+                <sp-color-area
+                    color="hsla(100, 50%, 50%, 1)"
+                    @change=${() => changeSpy()}
+                    @input=${() => inputSpy()}
+                ></sp-color-area>
+            `
+        );
+
+        await elementUpdated(el);
+
+        el.focus();
+        const { handle } = (el as unknown) as { handle: HTMLElement };
+
+        handle.dispatchEvent(
+            new Event('input', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+        handle.dispatchEvent(
+            new Event('change', {
+                bubbles: true,
+                composed: false, // native change events do not compose themselves by default
+            })
+        );
+
+        expect(inputSpy.callCount).to.equal(1);
+        expect(changeSpy.callCount).to.equal(1);
     });
     it('retains `hue` value when s = 0 in HSL string format', async () => {
         const el = await fixture<ColorArea>(

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -119,13 +119,13 @@ describe('ColorArea', () => {
         await sendKeys({
             press: 'ArrowUp',
         });
+        await elementUpdated(el);
         await sendKeys({
             press: 'ArrowUp',
         });
-
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6666666666666666);
+        expect(el.x).to.equal(0.67);
         expect(el.y).to.equal(0.22999999999999998);
 
         await sendKeys({
@@ -138,7 +138,7 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.x).to.equal(0.6900000000000001);
-        expect(el.y).to.equal(0.22999999999999998);
+        expect(el.y).to.equal(0.23);
 
         await sendKeys({
             press: 'ArrowDown',
@@ -149,7 +149,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6900000000000001);
+        expect(el.x).to.equal(0.69);
         expect(el.y).to.equal(0.25);
 
         await sendKeys({
@@ -167,10 +167,7 @@ describe('ColorArea', () => {
     it('accepts "Arrow*" keypresses with alteration', async () => {
         const el = await fixture<ColorArea>(
             html`
-                <sp-color-area
-                    color="hsla(100, 50%, 50%, 1)"
-                    style="--spectrum-global-dimension-size-2400:192px"
-                ></sp-color-area>
+                <sp-color-area color="hsla(100, 50%, 50%, 1)"></sp-color-area>
             `
         );
 
@@ -190,7 +187,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6666666666666666);
+        expect(el.x).to.equal(0.65);
         expect(el.y).to.equal(0.15000000000000002);
 
         el.dispatchEvent(arrowRightEvent);
@@ -201,7 +198,7 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.x).to.equal(0.75);
-        expect(el.y).to.equal(0.15000000000000002);
+        expect(el.y).to.equal(0.15);
 
         el.dispatchEvent(arrowDownEvent);
         el.dispatchEvent(arrowDownKeyupEvent);
@@ -377,7 +374,7 @@ describe('ColorArea', () => {
         el.inputY.dispatchEvent(
             new Event('change', {
                 bubbles: true,
-                composed: false,
+                composed: false, // native change events do not compose themselves by default
             })
         );
 
@@ -406,8 +403,38 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(inputSpy.callCount).to.equal(2);
+        expect(inputSpy.callCount).to.equal(4);
         expect(changeSpy.callCount).to.equal(2);
+
+        el.inputY.focus();
+
+        await sendKeys({ press: 'ArrowUp' });
+        await sendKeys({ press: 'ArrowUp' });
+
+        await elementUpdated(el);
+
+        expect(inputSpy.callCount).to.equal(8);
+        expect(changeSpy.callCount).to.equal(4);
+
+        el.inputY.focus();
+
+        await sendKeys({ press: 'ArrowDown' });
+        await sendKeys({ press: 'ArrowDown' });
+
+        await elementUpdated(el);
+
+        expect(inputSpy.callCount).to.equal(12);
+        expect(changeSpy.callCount).to.equal(6);
+
+        el.inputX.focus();
+
+        await sendKeys({ press: 'ArrowLeft' });
+        await sendKeys({ press: 'ArrowLeft' });
+
+        await elementUpdated(el);
+
+        expect(inputSpy.callCount).to.equal(16);
+        expect(changeSpy.callCount).to.equal(8);
     });
     it('retains `hue` value when s = 0 in HSL string format', async () => {
         const el = await fixture<ColorArea>(

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -125,7 +125,7 @@ describe('ColorArea', () => {
         });
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.67);
+        expect(el.x).to.equal(0.6666666666666666);
         expect(el.y).to.equal(0.22999999999999998);
 
         await sendKeys({
@@ -137,8 +137,8 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6900000000000001);
-        expect(el.y).to.equal(0.23);
+        expect(el.x).to.equal(0.6866666666666666);
+        expect(el.y).to.equal(0.22999999999999998);
 
         await sendKeys({
             press: 'ArrowDown',
@@ -149,7 +149,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.69);
+        expect(el.x).to.equal(0.6866666666666666);
         expect(el.y).to.equal(0.25);
 
         await sendKeys({
@@ -161,7 +161,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.67);
+        expect(el.x).to.equal(0.6666666666666666);
         expect(el.y).to.equal(0.25);
     });
     it('accepts "Arrow*" keypresses with alteration', async () => {
@@ -187,7 +187,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.65);
+        expect(el.x).to.equal(0.6666666666666666);
         expect(el.y).to.equal(0.15000000000000002);
 
         el.dispatchEvent(arrowRightEvent);
@@ -197,8 +197,8 @@ describe('ColorArea', () => {
         el.dispatchEvent(arrowRightKeyupEvent);
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.75);
-        expect(el.y).to.equal(0.15);
+        expect(el.x).to.equal(0.7666666666666667);
+        expect(el.y).to.equal(0.15000000000000002);
 
         el.dispatchEvent(arrowDownEvent);
         el.dispatchEvent(arrowDownKeyupEvent);
@@ -208,7 +208,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.75);
+        expect(el.x).to.equal(0.7666666666666667);
         expect(el.y).to.equal(0.25);
 
         el.dispatchEvent(arrowLeftEvent);
@@ -220,7 +220,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6499999999999999);
+        expect(el.x).to.equal(0.6666666666666666);
         expect(el.y).to.equal(0.25);
     });
     it('accepts pointer events', async () => {
@@ -403,7 +403,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(inputSpy.callCount).to.equal(4);
+        expect(inputSpy.callCount).to.equal(2);
         expect(changeSpy.callCount).to.equal(2);
 
         el.inputY.focus();
@@ -413,7 +413,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(inputSpy.callCount).to.equal(8);
+        expect(inputSpy.callCount).to.equal(4);
         expect(changeSpy.callCount).to.equal(4);
 
         el.inputY.focus();
@@ -423,7 +423,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(inputSpy.callCount).to.equal(12);
+        expect(inputSpy.callCount).to.equal(6);
         expect(changeSpy.callCount).to.equal(6);
 
         el.inputX.focus();
@@ -433,7 +433,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(inputSpy.callCount).to.equal(16);
+        expect(inputSpy.callCount).to.equal(8);
         expect(changeSpy.callCount).to.equal(8);
     });
     it('retains `hue` value when s = 0 in HSL string format', async () => {

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -167,7 +167,10 @@ describe('ColorArea', () => {
     it('accepts "Arrow*" keypresses with alteration', async () => {
         const el = await fixture<ColorArea>(
             html`
-                <sp-color-area color="hsla(100, 50%, 50%, 1)"></sp-color-area>
+                <sp-color-area
+                    color="hsla(100, 50%, 50%, 1)"
+                    style="--spectrum-global-dimension-size-2400:192px"
+                ></sp-color-area>
             `
         );
 
@@ -180,36 +183,40 @@ describe('ColorArea', () => {
         el.dispatchEvent(shiftEvent);
         el.dispatchEvent(arrowUpEvent);
         el.dispatchEvent(arrowUpKeyupEvent);
+        // This ensures that all the keystrokes are processed seperately
+        await elementUpdated(el);
         el.dispatchEvent(arrowUpEvent);
         el.dispatchEvent(arrowUpKeyupEvent);
 
         await elementUpdated(el);
 
         expect(el.x).to.equal(0.6666666666666666);
-        expect(el.y).to.equal(0.2);
+        expect(el.y).to.equal(0.15000000000000002);
 
         el.dispatchEvent(arrowRightEvent);
         el.dispatchEvent(arrowRightKeyupEvent);
+        await elementUpdated(el);
         el.dispatchEvent(arrowRightEvent);
         el.dispatchEvent(arrowRightKeyupEvent);
-
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.7000000000000001);
-        expect(el.y).to.equal(0.2);
+        expect(el.x).to.equal(0.75);
+        expect(el.y).to.equal(0.15000000000000002);
 
         el.dispatchEvent(arrowDownEvent);
         el.dispatchEvent(arrowDownKeyupEvent);
+        await elementUpdated(el);
         el.dispatchEvent(arrowDownEvent);
         el.dispatchEvent(arrowDownKeyupEvent);
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.7000000000000001);
+        expect(el.x).to.equal(0.75);
         expect(el.y).to.equal(0.25);
 
         el.dispatchEvent(arrowLeftEvent);
         el.dispatchEvent(arrowLeftKeyupEvent);
+        await elementUpdated(el);
         el.dispatchEvent(arrowLeftEvent);
         el.dispatchEvent(arrowLeftKeyupEvent);
         el.dispatchEvent(shiftKeyupEvent);

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -137,7 +137,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6866666666666666);
+        expect(el.x).to.equal(0.6900000000000001);
         expect(el.y).to.equal(0.22999999999999998);
 
         await sendKeys({
@@ -149,7 +149,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6866666666666666);
+        expect(el.x).to.equal(0.6900000000000001);
         expect(el.y).to.equal(0.25);
 
         await sendKeys({
@@ -161,7 +161,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6666666666666666);
+        expect(el.x).to.equal(0.67);
         expect(el.y).to.equal(0.25);
     });
     it('accepts "Arrow*" keypresses with alteration', async () => {
@@ -186,7 +186,7 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.x).to.equal(0.6666666666666666);
-        expect(el.y).to.equal(0.15000000000000002);
+        expect(el.y).to.equal(0.2);
 
         el.dispatchEvent(arrowRightEvent);
         el.dispatchEvent(arrowRightKeyupEvent);
@@ -195,8 +195,8 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.7666666666666667);
-        expect(el.y).to.equal(0.15000000000000002);
+        expect(el.x).to.equal(0.7000000000000001);
+        expect(el.y).to.equal(0.2);
 
         el.dispatchEvent(arrowDownEvent);
         el.dispatchEvent(arrowDownKeyupEvent);
@@ -205,7 +205,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.7666666666666667);
+        expect(el.x).to.equal(0.7000000000000001);
         expect(el.y).to.equal(0.25);
 
         el.dispatchEvent(arrowLeftEvent);
@@ -216,7 +216,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6666666666666666);
+        expect(el.x).to.equal(0.6499999999999999);
         expect(el.y).to.equal(0.25);
     });
     it('accepts pointer events', async () => {
@@ -326,6 +326,57 @@ describe('ColorArea', () => {
         expect(el.x).to.equal(0.53125);
         expect(el.y).to.equal(0.53125);
     });
+    it('responds to events on the internal input element', async () => {
+        const inputSpy = spy();
+        const changeSpy = spy();
+        const el = await fixture<ColorArea>(
+            html`
+                <sp-color-area
+                    color="hsla(100, 50%, 50%, 1)"
+                    @change=${() => changeSpy()}
+                    @input=${() => inputSpy()}
+                ></sp-color-area>
+            `
+        );
+
+        await elementUpdated(el);
+
+        el.inputX.focus();
+
+        el.inputX.dispatchEvent(
+            new Event('input', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+        el.inputX.dispatchEvent(
+            new Event('change', {
+                bubbles: true,
+                composed: false, // native change events do not compose themselves by default
+            })
+        );
+
+        expect(inputSpy.callCount).to.equal(1);
+        expect(changeSpy.callCount).to.equal(1);
+
+        el.inputY.focus();
+
+        el.inputY.dispatchEvent(
+            new Event('input', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+        el.inputY.dispatchEvent(
+            new Event('change', {
+                bubbles: true,
+                composed: false,
+            })
+        );
+
+        expect(inputSpy.callCount).to.equal(2);
+        expect(changeSpy.callCount).to.equal(2);
+    });
     it('dispatches input and change events in response to "Arrow*" keypresses', async () => {
         const inputSpy = spy();
         const changeSpy = spy();
@@ -341,24 +392,15 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        el.focus();
-        const { handle } = (el as unknown) as { handle: HTMLElement };
+        el.inputX.focus();
 
-        handle.dispatchEvent(
-            new Event('input', {
-                bubbles: true,
-                composed: true,
-            })
-        );
-        handle.dispatchEvent(
-            new Event('change', {
-                bubbles: true,
-                composed: false, // native change events do not compose themselves by default
-            })
-        );
+        await sendKeys({ press: 'ArrowRight' });
+        await sendKeys({ press: 'ArrowRight' });
 
-        expect(inputSpy.callCount).to.equal(1);
-        expect(changeSpy.callCount).to.equal(1);
+        await elementUpdated(el);
+
+        expect(inputSpy.callCount).to.equal(2);
+        expect(changeSpy.callCount).to.equal(2);
     });
     it('retains `hue` value when s = 0 in HSL string format', async () => {
         const el = await fixture<ColorArea>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Similar to the other colour elements, ColorArea was not correctly dispatching change events when using the keyboard. That is now fixed. Hooray. Also, altering other tests that were previously incorrect/not optimal.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes https://github.com/adobe/spectrum-web-components/issues/1469 by extension

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Matching functionality with other colour elements and providing accessibility for users 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and with tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
