### PR TITLE
fix(split-button): hide "selected" item from menu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c36232311ca79de3ba648fc08333d021d45a68b7
+        default: 6035abba9a5721c7647b3772a8ac1e7745d3e783
 commands:
     downstream:
         steps:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "packages/*/src/spectrum-vars.json": true,
         "**/*.js.map": true,
         "**/*.js": { "when": "$(basename).ts" },
-        "**/*.d.ts": { "when": "$(basename).ts" }
+        "**/*.d.ts": { "when": "$(basename).ts" },
+        "**/*.test-vrt.ts": true
     }
 }

--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -18,6 +18,12 @@ Import the side effectful registration of `<sp-action-menu>` via:
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
 ```
 
+The default of `<sp-action-menu>` will load dependencies in `@spectrum-web-components/overlay` asynchronously via a dynamic import. In the case that you would like to import those tranverse dependencies statically, import the side effectful registration of `<sp-action-menu>` as follows:
+
+```
+import '@spectrum-web-components/action-menu/sync/sp-action-menu.js';
+```
+
 When looking to leverage the `ActionMenu` base class as a type and/or for extension purposes, do so via:
 
 ```

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -24,7 +24,9 @@
         "./src/*": "./src/*",
         "./package.json": "./package.json",
         "./sp-action-menu": "./sp-action-menu.js",
-        "./sp-action-menu.js": "./sp-action-menu.js"
+        "./sp-action-menu.js": "./sp-action-menu.js",
+        "./sync/sp-action-menu": "./sync/sp-action-menu.js",
+        "./sync/sp-action-menu.js": "./sync/sp-action-menu.js"
     },
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
@@ -56,6 +58,7 @@
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",
     "sideEffects": [
-        "./sp-*.js"
+        "./sp-*.js",
+        "./sync/sp-*.js"
     ]
 }

--- a/packages/action-menu/sync/sp-action-menu.ts
+++ b/packages/action-menu/sync/sp-action-menu.ts
@@ -10,5 +10,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import './index.js';
-import '../sp-picker.js';
+import '@spectrum-web-components/picker/sync/index.js';
+import '../sp-action-menu.js';

--- a/packages/action-menu/test/action-menu-sync.test.ts
+++ b/packages/action-menu/test/action-menu-sync.test.ts
@@ -1,0 +1,145 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/action-menu/sync/sp-action-menu.js';
+import { ActionMenu } from '@spectrum-web-components/action-menu';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
+import '@spectrum-web-components/menu/sp-menu.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/menu/sp-menu-divider.js';
+import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+
+const deprecatedActionMenuFixture = async (): Promise<ActionMenu> =>
+    await fixture<ActionMenu>(
+        html`
+            <sp-action-menu label="More Actions">
+                <sp-menu>
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select Inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and Mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save Selection</sp-menu-item>
+                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                </sp-menu>
+            </sp-action-menu>
+        `
+    );
+
+const actionMenuFixture = async (): Promise<ActionMenu> =>
+    await fixture<ActionMenu>(
+        html`
+            <sp-action-menu label="More Actions">
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-action-menu>
+        `
+    );
+
+describe('Action menu', () => {
+    it('loads', async () => {
+        const el = await actionMenuFixture();
+        await elementUpdated(el);
+
+        expect(el).to.not.be.undefined;
+
+        await expect(el).to.be.accessible();
+    });
+    it('loads - [slot="label"]', async () => {
+        const el = await fixture<ActionMenu>(
+            html`
+                <sp-action-menu>
+                    <span slot="label">More Actions</span>
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select Inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and Mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save Selection</sp-menu-item>
+                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                </sp-action-menu>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('loads - [custom icon]', async () => {
+        const el = await fixture<ActionMenu>(
+            html`
+                <sp-action-menu label="More Actions">
+                    <sp-icon-settings slot="icon"></sp-icon-settings>
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select Inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and Mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save Selection</sp-menu-item>
+                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                </sp-action-menu>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('stays `quiet`', async () => {
+        const el = await actionMenuFixture();
+        await elementUpdated(el);
+
+        expect(el.quiet).to.be.true;
+
+        el.quiet = false;
+        await elementUpdated(el);
+
+        expect(el.quiet).to.be.true;
+    });
+    it('stay `valid`', async () => {
+        const el = await actionMenuFixture();
+
+        await elementUpdated(el);
+
+        expect(el.invalid).to.be.false;
+
+        el.invalid = true;
+        await elementUpdated(el);
+
+        expect(el.invalid).to.be.false;
+    });
+    it('opens unmeasured', async () => {
+        const el = await actionMenuFixture();
+
+        await elementUpdated(el);
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
+    });
+    it('opens unmeasured with deprecated syntax', async () => {
+        const el = await deprecatedActionMenuFixture();
+
+        await elementUpdated(el);
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
+    });
+});

--- a/packages/action-menu/tsconfig.json
+++ b/packages/action-menu/tsconfig.json
@@ -4,7 +4,7 @@
         "composite": true,
         "rootDir": "./"
     },
-    "include": ["*.ts", "src/*.ts"],
+    "include": ["*.ts", "src/*.ts", "sync/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
     "references": [
         { "path": "../action-button" },

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -12,6 +12,10 @@ governing permissions and limitations under the License.
 
 @import './spectrum-menu-item.css';
 
+:host([hidden]) {
+    display: none;
+}
+
 #button {
     position: absolute;
     inset: 0;

--- a/packages/overlay/overlay-trigger.md
+++ b/packages/overlay/overlay-trigger.md
@@ -26,6 +26,12 @@ Import the side-effectful registration of `<overlay-trigger>` via:
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 ```
 
+The default of `<overlay-trigger>` will load dependencies in `@spectrum-web-components/overlay` asynchronously via a dynamic import. In the case that you would like to import those tranverse dependencies statically, import the side effectful registration of `<overlay-trigger>` as follows:
+
+```
+import '@spectrum-web-components/overlay-trigger/sync/overlay-trigger.js';
+```
+
 When looking to leverage the `OverlayTrigger` base class as a type and/or for extension purposes, do so via:
 
 ```

--- a/packages/overlay/test/overlay-trigger-sync.test.ts
+++ b/packages/overlay/test/overlay-trigger-sync.test.ts
@@ -22,7 +22,7 @@ import {
     oneEvent,
 } from '@open-wc/testing';
 
-import '../overlay-trigger.js';
+import '../sync/overlay-trigger.js';
 import {
     OverlayTrigger,
     ActiveOverlay,

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -25,6 +25,8 @@
         "./package.json": "./package.json",
         "./sp-picker": "./sp-picker.js",
         "./sp-picker.js": "./sp-picker.js",
+        "./sync": "./sync/index.js",
+        "./sync/index.js": "./sync/index.js",
         "./sync/sp-picker": "./sync/sp-picker.js",
         "./sync/sp-picker.js": "./sync/sp-picker.js"
     },
@@ -64,6 +66,7 @@
     "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js",
+        "./sync/index.js",
         "./sync/sp-*.js"
     ]
 }

--- a/packages/picker/sync/index.ts
+++ b/packages/picker/sync/index.ts
@@ -10,5 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import './index.js';
-import '../sp-picker.js';
+import { Picker } from '../src/Picker.js';
+import {
+    Overlay,
+    OverlayOptions,
+    TriggerInteractions,
+} from '@spectrum-web-components/overlay';
+
+Picker.openOverlay = async (
+    target: HTMLElement,
+    interaction: TriggerInteractions,
+    content: HTMLElement,
+    options: OverlayOptions
+): Promise<() => void> => {
+    return await Overlay.open(target, interaction, content, options);
+};

--- a/packages/picker/test/picker-sync.test.ts
+++ b/packages/picker/test/picker-sync.test.ts
@@ -1,0 +1,1027 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '../sync/sp-picker.js';
+import { Picker } from '..';
+
+import '@spectrum-web-components/overlay/active-overlay.js';
+import { OverlayOpenCloseDetail } from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/menu/sp-menu.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/menu/sp-menu-divider.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
+import { Menu, MenuItem } from '@spectrum-web-components/menu';
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    waitUntil,
+    nextFrame,
+    oneEvent,
+} from '@open-wc/testing';
+import '@spectrum-web-components/shared/src/focus-visible.js';
+import { spy } from 'sinon';
+import {
+    arrowDownEvent,
+    arrowUpEvent,
+    arrowLeftEvent,
+    arrowRightEvent,
+    tabEvent,
+    tEvent,
+} from '../../../test/testing-helpers.js';
+import {
+    a11ySnapshot,
+    executeServerCommand,
+    findAccessibilityNode,
+    sendKeys,
+} from '@web/test-runner-commands';
+import { iconsOnly } from '../stories/picker.stories.js';
+
+const isMenuActiveElement = function (): boolean {
+    return document.activeElement instanceof Menu;
+};
+
+describe('Picker', () => {
+    const pickerFixture = async (): Promise<Picker> => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <div>
+                    <sp-field-label for="picker">
+                        Where do you live?
+                    </sp-field-label>
+                    <sp-picker
+                        id="picker"
+                        style="width: 200px; --spectrum-alias-ui-icon-chevron-size-100: 10px;"
+                    >
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item value="option-2">
+                            Select Inverse
+                        </sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and Mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save Selection</sp-menu-item>
+                        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                    </sp-picker>
+                </div>
+            `
+        );
+
+        await waitUntil(
+            () => !!window.applyFocusVisiblePolyfill,
+            'polyfill loaded'
+        );
+
+        return test.querySelector('sp-picker') as Picker;
+    };
+
+    const deprecatedPickerFixture = async (): Promise<Picker> => {
+        const test = await fixture<Picker>(
+            html`
+                <div>
+                    <sp-field-label for="picker-deprecated">
+                        Where do you live?
+                    </sp-field-label>
+                    <sp-picker
+                        id="picker-deprecated"
+                        label="Select a Country with a very long label, too long in fact"
+                    >
+                        <sp-menu>
+                            <sp-menu-item>Deselect</sp-menu-item>
+                            <sp-menu-item value="option-2">
+                                Select Inverse
+                            </sp-menu-item>
+                            <sp-menu-item>Feather...</sp-menu-item>
+                            <sp-menu-item>Select and Mask...</sp-menu-item>
+                            <sp-menu-divider></sp-menu-divider>
+                            <sp-menu-item>Save Selection</sp-menu-item>
+                            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                        </sp-menu>
+                    </sp-picker>
+                </div>
+            `
+        );
+
+        await waitUntil(
+            () => !!window.applyFocusVisiblePolyfill,
+            'polyfill loaded'
+        );
+
+        return test.querySelector('sp-picker') as Picker;
+    };
+
+    const slottedLabelFixture = async (): Promise<Picker> => {
+        const test = await fixture<Picker>(
+            html`
+                <div>
+                    <sp-field-label for="picker-slotted">
+                        Where do you live?
+                    </sp-field-label>
+                    <sp-picker id="picker-slotted">
+                        <span slot="label">
+                            Select a Country with a very long label, too long in
+                            fact
+                        </span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item value="option-2">
+                            Select Inverse
+                        </sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and Mask...</sp-menu-item>
+                        <sp-menu-divider></sp-menu-divider>
+                        <sp-menu-item>Save Selection</sp-menu-item>
+                        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                    </sp-picker>
+                </div>
+            `
+        );
+
+        await waitUntil(
+            () => !!window.applyFocusVisiblePolyfill,
+            'polyfill loaded'
+        );
+
+        return test.querySelector('sp-picker') as Picker;
+    };
+
+    afterEach(async () => {
+        const overlays = document.querySelectorAll('active-overlay');
+        overlays.forEach((overlay) => overlay.remove());
+    });
+
+    it('loads accessibly', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+
+    it('accepts a new item and value at the same time', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        el.value = 'option-2';
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('option-2');
+
+        const item = document.createElement('sp-menu-item');
+        item.value = 'option-new';
+        item.textContent = 'New Option';
+
+        el.append(item);
+        el.value = 'option-new';
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('option-new');
+    });
+    it('manages its "name" value in the accessibility tree', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+        type NamedNode = { name: string };
+        let snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+            children: NamedNode[];
+        };
+
+        expect(
+            findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Where do you live?'
+            ),
+            '`name` is the label text'
+        ).to.not.be.null;
+
+        el.value = 'option-2';
+        await elementUpdated(el);
+        snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+            children: NamedNode[];
+        };
+
+        expect(
+            findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Where do you live? Select Inverse'
+            ),
+            '`name` is the label text plus the selected item text'
+        ).to.not.be.null;
+    });
+
+    it('manages its "name" value in the accessibility tree when [icons-only]', async () => {
+        const test = await fixture<HTMLDivElement>(html`
+            <div>${iconsOnly({})}</div>
+        `);
+        const el = test.querySelector('sp-picker') as Picker;
+
+        await elementUpdated(el);
+        type NamedNode = { name: string };
+        let snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+            children: NamedNode[];
+        };
+
+        expect(
+            findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Choose an action type... Delete'
+            ),
+            '`name` is the label text'
+        ).to.not.be.null;
+
+        el.value = '2';
+        await elementUpdated(el);
+        snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+            children: NamedNode[];
+        };
+
+        expect(
+            findAccessibilityNode<NamedNode>(
+                snapshot,
+                (node) => node.name === 'Choose an action type... Copy'
+            ),
+            '`name` is the label text plus the selected item text'
+        ).to.not.be.null;
+    });
+
+    it('loads accessibly w/ slotted label', async () => {
+        const el = await slottedLabelFixture();
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('renders invalid accessibly', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        el.invalid = true;
+        await elementUpdated(el);
+
+        expect(el.invalid);
+        await expect(el).to.be.accessible();
+    });
+    it('renders selection accessibly', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        el.value = 'option-2';
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('opens with visible focus on a menu item on `DownArrow`', async () => {
+        const el = await pickerFixture();
+
+        const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+
+        await elementUpdated(el);
+
+        expect(firstItem.focused, 'not visually focused').to.be.false;
+
+        el.focus();
+        await elementUpdated(el);
+        const opened = oneEvent(el, 'sp-opened');
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        await opened;
+
+        expect(el.open).to.be.true;
+        expect(firstItem.focused, 'not visually focused').to.be.true;
+
+        const closed = oneEvent(el, 'sp-closed');
+        await sendKeys({
+            press: 'Escape',
+        });
+        await closed;
+
+        expect(el.open).to.be.false;
+        await waitUntil(() => !firstItem.focused, 'not visually focused');
+    });
+    it('opens without visible focus on a menu item on click', async () => {
+        const el = await pickerFixture();
+
+        /**
+         * Firefox will not accept a single "click" from Playwright as deactivating the
+         * :focus-visible heuristic. So, to trick it, we "click" three times! Once to
+         * open, once to close, and once to open again before taking the operative test
+         * that the first item in the menu is to given the `focused` attribute immediately.
+         */
+
+        const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+
+        await elementUpdated(el);
+        const boundingRect = el.getBoundingClientRect();
+
+        expect(firstItem.focused, 'not visually focused').to.be.false;
+        let opened = oneEvent(el, 'sp-opened');
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        boundingRect.x + boundingRect.width / 2,
+                        boundingRect.y + boundingRect.height / 2,
+                    ],
+                },
+                {
+                    type: 'down',
+                },
+                {
+                    type: 'up',
+                },
+            ],
+        });
+        await opened;
+        expect(el.open).to.be.true;
+        const closed = oneEvent(el, 'sp-closed');
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        boundingRect.x + boundingRect.width / 2,
+                        boundingRect.y + boundingRect.height / 2,
+                    ],
+                },
+                {
+                    type: 'down',
+                },
+                {
+                    type: 'up',
+                },
+            ],
+        });
+        await closed;
+
+        expect(el.open).to.be.false;
+        opened = oneEvent(el, 'sp-opened');
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        boundingRect.x + boundingRect.width / 2,
+                        boundingRect.y + boundingRect.height / 2,
+                    ],
+                },
+                {
+                    type: 'down',
+                },
+                {
+                    type: 'up',
+                },
+            ],
+        });
+        await opened;
+
+        expect(el.open).to.be.true;
+        expect(firstItem.focused, 'still not visually focused').to.be.false;
+    });
+    it('closes when becoming disabled', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+        expect(el.open).to.be.false;
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        el.disabled = true;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+    });
+    it('closes when clicking away', async () => {
+        const el = await pickerFixture();
+        el.id = 'closing';
+        const other = document.createElement('div');
+        document.body.append(other);
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        other.click();
+        await waitUntil(() => !el.open, 'closed');
+
+        other.remove();
+    });
+    it('toggles between pickers', async () => {
+        const el2 = await pickerFixture();
+        const el1 = await pickerFixture();
+
+        el1.id = 'away';
+        el2.id = 'other';
+
+        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
+
+        expect(el1.open, 'closed 1').to.be.false;
+        expect(el2.open, 'closed 1').to.be.false;
+        el1.click();
+        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
+        await waitUntil(() => el1.open && !el2.open, '1 open, 2 closed');
+
+        el2.click();
+        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
+        await waitUntil(() => !el1.open && el2.open, '1 closed, 2 open');
+
+        el1.click();
+        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
+        await waitUntil(() => el1.open && !el2.open, '1 open, 2 closed: again');
+    });
+    it('selects with deprecated syntax', async () => {
+        const el = await deprecatedPickerFixture();
+
+        await elementUpdated(el);
+
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        expect(el.selectedItem?.itemText).to.be.undefined;
+        expect(el.value).to.equal('');
+
+        secondItem.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
+        expect(el.value).to.equal('option-2');
+    });
+    it('selects', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        expect(el.selectedItem?.itemText).to.be.undefined;
+        expect(el.value).to.equal('');
+
+        secondItem.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
+        expect(el.value).to.equal('option-2');
+    });
+    it('re-selects', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        expect(el.selectedItem?.itemText).to.be.undefined;
+        expect(el.value).to.equal('');
+
+        secondItem.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
+        expect(el.value).to.equal('option-2');
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
+        expect(el.value).to.equal('option-2');
+
+        firstItem.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Deselect');
+        expect(el.value).to.equal('Deselect');
+    });
+    it('can have selection prevented', async () => {
+        const preventChangeSpy = spy();
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        expect(el.selectedItem?.itemText).to.be.undefined;
+        expect(el.value).to.equal('');
+        expect(secondItem.selected).to.be.false;
+
+        el.addEventListener('change', (event: Event): void => {
+            event.preventDefault();
+            preventChangeSpy();
+        });
+
+        secondItem.click();
+        await elementUpdated(el);
+        await waitUntil(() => el.open, 'reopens picker');
+        expect(secondItem.selected, 'selection prevented').to.be.false;
+        expect(preventChangeSpy.calledOnce);
+    });
+
+    it('can throw focus after `change`', async () => {
+        const el = await pickerFixture();
+        const input = document.createElement('input');
+        document.body.append(input);
+
+        await elementUpdated(el);
+
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        expect(el.selectedItem?.itemText).to.be.undefined;
+        expect(el.value).to.equal('');
+        expect(secondItem.selected).to.be.false;
+
+        el.addEventListener('change', (): void => {
+            input.focus();
+        });
+
+        secondItem.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.value, 'value changed').to.equal('option-2');
+        expect(secondItem.selected, 'selected changed').to.be.true;
+        await waitUntil(() => document.activeElement === input, 'focus throw');
+        input.remove();
+    });
+    it('opens on ArrowUp', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        const button = el.button as HTMLButtonElement;
+
+        el.focus();
+        await elementUpdated(el);
+
+        expect(el.open, 'inially closed').to.be.false;
+
+        button.dispatchEvent(tEvent);
+        await elementUpdated(el);
+
+        expect(el.open, 'still closed').to.be.false;
+
+        button.dispatchEvent(arrowUpEvent);
+        await elementUpdated(el);
+
+        expect(el.open, 'open by ArrowUp').to.be.true;
+
+        await waitUntil(
+            () => document.querySelector('active-overlay') !== null,
+            'an active-overlay has been inserted on the page'
+        );
+
+        button.dispatchEvent(
+            new KeyboardEvent('keyup', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+                key: 'Escape',
+                code: 'Escape',
+            })
+        );
+        await elementUpdated(el);
+        await waitUntil(() => el.open === false, 'closed by Escape');
+        await waitUntil(
+            () => document.querySelector('active-overlay') === null,
+            'an active-overlay has been inserted on the page'
+        );
+    });
+    it('opens on ArrowDown', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const button = el.button as HTMLButtonElement;
+
+        el.focus();
+        await elementUpdated(el);
+
+        expect(el.open, 'inially closed').to.be.false;
+
+        button.dispatchEvent(arrowDownEvent);
+        await elementUpdated(el);
+
+        expect(el.open, 'open by ArrowDown').to.be.true;
+        expect(el.selectedItem?.itemText).to.be.undefined;
+        expect(el.value).to.equal('');
+
+        firstItem.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Deselect');
+        expect(el.value).to.equal('Deselect');
+    });
+    it('quick selects on ArrowLeft/Right', async () => {
+        const selectionSpy = spy();
+        const el = await pickerFixture();
+        el.addEventListener('change', (event: Event) => {
+            const { value } = event.target as Picker;
+            selectionSpy(value);
+        });
+        const button = el.button as HTMLButtonElement;
+
+        await elementUpdated(el);
+        el.focus();
+        button.dispatchEvent(arrowLeftEvent);
+
+        await elementUpdated(el);
+
+        expect(selectionSpy.callCount).to.equal(1);
+        expect(selectionSpy.calledWith('Deselected'));
+        button.dispatchEvent(arrowLeftEvent);
+
+        await elementUpdated(el);
+        expect(selectionSpy.callCount).to.equal(1);
+        button.dispatchEvent(arrowRightEvent);
+
+        await elementUpdated(el);
+        expect(selectionSpy.calledWith('option-2'));
+
+        button.dispatchEvent(arrowRightEvent);
+        button.dispatchEvent(arrowRightEvent);
+        button.dispatchEvent(arrowRightEvent);
+        button.dispatchEvent(arrowRightEvent);
+
+        await elementUpdated(el);
+        expect(selectionSpy.callCount).to.equal(5);
+        expect(selectionSpy.calledWith('Save Selection'));
+        expect(selectionSpy.calledWith('Make Work Path')).to.be.false;
+    });
+    it('quick selects first item on ArrowRight when no value', async () => {
+        const selectionSpy = spy();
+        const el = await pickerFixture();
+        el.addEventListener('change', (event: Event) => {
+            const { value } = event.target as Picker;
+            selectionSpy(value);
+        });
+        const button = el.button as HTMLButtonElement;
+
+        await elementUpdated(el);
+        el.focus();
+        button.dispatchEvent(arrowRightEvent);
+
+        await elementUpdated(el);
+
+        expect(selectionSpy.callCount).to.equal(1);
+        expect(selectionSpy.calledWith('Deselected'));
+    });
+    it('loads', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+        expect(el).to.not.be.undefined;
+    });
+    it('refocuses on list when open', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+        const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+
+        el.open = true;
+        await elementUpdated(el);
+        await waitUntil(() => isMenuActiveElement(), 'first item focused');
+        expect(firstItem.focused).to.be.true;
+
+        el.blur();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        el.focus();
+        await elementUpdated(el);
+        await waitUntil(() => isMenuActiveElement(), 'first item refocused');
+        expect(el.open).to.be.true;
+        expect(isMenuActiveElement()).to.be.true;
+        expect(firstItem.focused).to.be.true;
+    });
+    it('allows tabing to close', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        el.open = true;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        el.focus();
+        await elementUpdated(el);
+        await waitUntil(() => isMenuActiveElement(), 'first item refocused');
+        expect(el.open).to.be.true;
+        expect(isMenuActiveElement()).to.be.true;
+
+        const menu = document.activeElement as Menu;
+        menu.dispatchEvent(tabEvent);
+
+        await elementUpdated(el);
+        await waitUntil(() => !el.open);
+
+        expect(el.open, 'closes').to.be.false;
+        expect(document.activeElement === menu, 'focuses something else').to.be
+            .false;
+    });
+    it('opens its menu inline of the tab order', async () => {
+        const el = await pickerFixture();
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.tabIndex = 0;
+
+        document.body.append(input);
+
+        await elementUpdated(el);
+
+        el.focus();
+        await elementUpdated(el);
+
+        await sendKeys({ press: 'Tab' });
+        expect(el.open, 'closes').to.be.false;
+        expect(document.activeElement, 'focuses input 1').to.equal(input);
+        await sendKeys({ press: 'Shift+Tab' });
+
+        const opened = oneEvent(el, 'sp-opened');
+        sendKeys({ press: 'ArrowDown' });
+        await opened;
+
+        await waitUntil(() => isMenuActiveElement(), 'first item focused');
+
+        const closed = oneEvent(el, 'sp-closed');
+        sendKeys({ press: 'Tab' });
+        await closed;
+
+        expect(el.open, 'closes').to.be.false;
+        expect(document.activeElement, 'focuses input 2').to.equal(input);
+        input.remove();
+    });
+    it('displays selected item text by default', async () => {
+        const focusSelectedSpy = spy();
+        const focusFirstSpy = spy();
+        const handleFirstFocus = (): void => focusFirstSpy();
+        const handleSelectedFocus = (): void => focusSelectedSpy();
+        const el = await fixture<Picker>(
+            html`
+                <sp-picker
+                    value="inverse"
+                    label="Select a Country with a very long label, too long in fact"
+                >
+                    <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
+                    <sp-menu-item value="inverse">Select Inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and Mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save Selection</sp-menu-item>
+                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                </sp-picker>
+            `
+        );
+
+        await elementUpdated(el);
+        await waitUntil(
+            () => el.selectedItem?.itemText === 'Select Inverse',
+            `Selected Item Text: ${el.selectedItem?.itemText}`
+        );
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:nth-of-type(1)'
+        ) as MenuItem;
+        const secondItem = el.querySelector(
+            'sp-menu-item:nth-of-type(2)'
+        ) as MenuItem;
+
+        firstItem.addEventListener('focus', handleFirstFocus);
+        secondItem.addEventListener('focus', handleSelectedFocus);
+
+        expect(el.value).to.equal('inverse');
+        expect(el.selectedItem?.itemText).to.equal('Select Inverse');
+
+        const button = el.button as HTMLButtonElement;
+        button.click();
+
+        await waitUntil(() => isMenuActiveElement(), 'menu focused');
+
+        expect(focusFirstSpy.called, 'do not focus first element').to.be.false;
+        expect(secondItem.focused, 'secondItem "focused"').to.be.true;
+    });
+    it('resets value when item not available', async () => {
+        const el = await fixture<Picker>(
+            html`
+                <sp-picker
+                    value="missing"
+                    label="Select a Country with a very long label, too long in fact"
+                >
+                    <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
+                    <sp-menu-item value="inverse">Select Inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and Mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save Selection</sp-menu-item>
+                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                </sp-picker>
+            `
+        );
+
+        await elementUpdated(el);
+        await waitUntil(() => el.value === '');
+
+        expect(el.value).to.equal('');
+        expect(el.selectedItem?.itemText).to.be.undefined;
+    });
+
+    it('allows event listeners on child items', async () => {
+        const mouseenterSpy = spy();
+        const handleMouseenter = (): void => mouseenterSpy();
+        const el = await fixture<Picker>(
+            html`
+                <sp-picker
+                    label="Select a Country with a very long label, too long in fact"
+                >
+                    <sp-menu-item
+                        value="deselect"
+                        @mouseenter=${handleMouseenter}
+                    >
+                        Deselect Text
+                    </sp-menu-item>
+                </sp-picker>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const hoverEl = el.querySelector('sp-menu-item') as MenuItem;
+
+        const opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        hoverEl.dispatchEvent(new MouseEvent('mouseenter'));
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+
+        const closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(mouseenterSpy.calledOnce).to.be.true;
+    });
+
+    it('dispatches events on open/close', async () => {
+        const openedSpy = spy();
+        const closedSpy = spy();
+        const handleOpenedSpy = (event: Event): void => openedSpy(event);
+        const handleClosedSpy = (event: Event): void => closedSpy(event);
+
+        const el = await fixture<Picker>(
+            html`
+                <sp-picker
+                    label="Select a Country with a very long label, too long in fact"
+                    @sp-opened=${handleOpenedSpy}
+                    @sp-closed=${handleClosedSpy}
+                >
+                    <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
+                </sp-picker>
+            `
+        );
+
+        await elementUpdated(el);
+        el.open = true;
+
+        await elementUpdated(el);
+        await oneEvent(el, 'sp-opened');
+
+        expect(openedSpy.calledOnce).to.be.true;
+        expect(closedSpy.calledOnce).to.be.false;
+
+        const openedEvent = openedSpy
+            .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
+        expect(openedEvent.detail.interaction).to.equal('inline');
+
+        el.open = false;
+        await elementUpdated(el);
+
+        await waitUntil(() => closedSpy.calledOnce, 'closed event received');
+
+        expect(closedSpy.calledOnce).to.be.true;
+
+        const closedEvent = closedSpy
+            .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
+        expect(closedEvent.detail.interaction).to.equal('inline');
+    });
+    it('does not open when [readonly]', async () => {
+        const el = await pickerFixture();
+
+        el.readonly = true;
+
+        await elementUpdated(el);
+
+        const button = el.button as HTMLButtonElement;
+
+        button.click();
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+    });
+    it('scrolls selected into view on open', async () => {
+        const el = await pickerFixture();
+
+        const popover = el.shadowRoot.querySelector(
+            'sp-popover'
+        ) as HTMLElement;
+        popover.style.height = '40px';
+
+        const firstItem = el.querySelector(
+            'sp-menu-item:first-child'
+        ) as MenuItem;
+        const lastItem = el.querySelector(
+            'sp-menu-item:last-child'
+        ) as MenuItem;
+        lastItem.disabled = false;
+        el.value = lastItem.value;
+
+        await elementUpdated(el);
+
+        el.open = true;
+
+        await elementUpdated(el);
+        await nextFrame();
+        const getParentOffset = (el: HTMLElement): number => {
+            const parentScroll = (el.parentElement as HTMLElement).scrollTop;
+            const parentOffset = el.offsetTop - parentScroll;
+            return parentOffset;
+        };
+        expect(lastItem.focused, 'last focused').to.be.true;
+        expect(firstItem.focused, 'first not focused').to.be.false;
+        expect(getParentOffset(lastItem)).to.be.lessThan(40);
+        expect(getParentOffset(firstItem)).to.be.lessThan(-1);
+
+        lastItem.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+        lastItem.dispatchEvent(arrowDownEvent);
+        await elementUpdated(el);
+        await nextFrame();
+        expect(lastItem.focused, 'last not focused').to.be.false;
+        expect(firstItem.focused, 'first focused').to.be.true;
+        expect(getParentOffset(lastItem)).to.be.greaterThan(40);
+        expect(getParentOffset(firstItem)).to.be.greaterThan(-1);
+    });
+});

--- a/packages/split-button/README.md
+++ b/packages/split-button/README.md
@@ -18,6 +18,12 @@ Import the side effectful registration of `<sp-split-button>` via:
 import '@spectrum-web-components/split-button/sp-split-button.js';
 ```
 
+The default of `<sp-split-button>` will load dependencies in `@spectrum-web-components/overlay` asynchronously via a dynamic import. In the case that you would like to import those tranverse dependencies statically, import the side effectful registration of `<sp-split-button>` as follows:
+
+```
+import '@spectrum-web-components/split-button/sync/sp-split-button.js';
+```
+
 When looking to leverage the `SplitButton` base class as a type and/or for extension purposes, do so via:
 
 ```

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -24,7 +24,9 @@
         "./src/*": "./src/*",
         "./package.json": "./package.json",
         "./sp-split-button": "./sp-split-button.js",
-        "./sp-split-button.js": "./sp-split-button.js"
+        "./sp-split-button.js": "./sp-split-button.js",
+        "./sync/sp-split-button": "./sync/sp-split-button.js",
+        "./sync/sp-split-button.js": "./sync/sp-split-button.js"
     },
     "scripts": {
         "test": "karma start --coverage"
@@ -59,6 +61,7 @@
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",
     "sideEffects": [
-        "./sp-*.js"
+        "./sp-*.js",
+        "./sync/sp-*.js"
     ]
 }

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -181,6 +181,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
                 this.selectedItem = this.selectedItem || this.menuItems[0];
                 this.selectedItem.selected = true;
             }
+            this.value = this.selectedItem.value;
             return;
         }
         await this.updateComplete;

--- a/packages/split-button/sync/sp-split-button.ts
+++ b/packages/split-button/sync/sp-split-button.ts
@@ -10,5 +10,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import './index.js';
-import '../sp-picker.js';
+import '@spectrum-web-components/picker/sync/index.js';
+import '../sp-split-button.js';

--- a/packages/split-button/test/benchmark/basic-test.ts
+++ b/packages/split-button/test/benchmark/basic-test.ts
@@ -11,9 +11,14 @@ governing permissions and limitations under the License.
 */
 
 import '@spectrum-web-components/split-button/sp-split-button.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
 import { html } from '@spectrum-web-components/base';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
-    <sp-splitbutton open></sp-splitbutton>
+    <sp-split-button open>
+        <sp-menu-item>Action 1</sp-menu-item>
+        <sp-menu-item>Action 2</sp-menu-item>
+        <sp-menu-item>Action 3</sp-menu-item>
+    </sp-split-button>
 `);

--- a/packages/split-button/test/split-button-sync.test.ts
+++ b/packages/split-button/test/split-button-sync.test.ts
@@ -1,0 +1,390 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    fixture,
+    elementUpdated,
+    expect,
+    html,
+    oneEvent,
+} from '@open-wc/testing';
+import { spy } from 'sinon';
+
+import '../sync/sp-split-button.js';
+import { SplitButton } from '..';
+import splitButtonDefault, {
+    field,
+    more,
+} from '../stories/split-button-cta.stories.js';
+import { MenuItem } from '@spectrum-web-components/menu';
+import { arrowDownEvent } from '../../../test/testing-helpers.js';
+import { TemplateResult } from '@spectrum-web-components/base';
+
+// wrap in div method
+
+function wrapInDiv(storyArgument: TemplateResult): TemplateResult {
+    return html`
+        <div>${storyArgument}</div>
+    `;
+}
+
+const deprecatedMenu = (): TemplateResult => html`
+    <sp-menu>
+        <sp-menu-item>Option 1</sp-menu-item>
+        <sp-menu-item>Option Extended</sp-menu-item>
+        <sp-menu-item>Short</sp-menu-item>
+    </sp-menu>
+`;
+
+describe('Splitbutton', () => {
+    it('loads [type="field"] splitbutton accessibly', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(field(splitButtonDefault.args))
+        );
+        const el1 = test.querySelector('sp-split-button') as SplitButton;
+        const el2 = test.querySelector('sp-split-button[left]') as SplitButton;
+
+        await elementUpdated(el1);
+        await elementUpdated(el2);
+
+        await expect(el1).to.be.accessible();
+        await expect(el2).to.be.accessible();
+    });
+    it('loads [type="field"] splitbutton accessibly with deprecated syntax', async () => {
+        const test = await fixture<HTMLDivElement>(html`
+            <div>
+                <sp-split-button>${deprecatedMenu()}</sp-split-button>
+                <sp-split-button left>${deprecatedMenu()}</sp-split-button>
+            </div>
+        `);
+        const el1 = test.querySelector('sp-split-button') as SplitButton;
+        const el2 = test.querySelector('sp-split-button[left]') as SplitButton;
+
+        await elementUpdated(el1);
+        await elementUpdated(el2);
+
+        await expect(el1).to.be.accessible();
+        await expect(el2).to.be.accessible();
+    });
+    it('loads [type="more"] splitbutton accessibly', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(more({ ...splitButtonDefault.args, ...more.args }))
+        );
+        const el1 = test.querySelector('sp-split-button') as SplitButton;
+        const el2 = test.querySelector('sp-split-button[left]') as SplitButton;
+
+        await elementUpdated(el1);
+        await elementUpdated(el2);
+
+        await expect(el1).to.be.accessible();
+        await expect(el2).to.be.accessible();
+    });
+    it('loads [type="more"] splitbutton accessibly with deprecated syntax', async () => {
+        const test = await fixture<HTMLDivElement>(html`
+            <div>
+                <sp-split-button type="more">
+                    ${deprecatedMenu()}
+                </sp-split-button>
+                <sp-split-button type="more" left>
+                    ${deprecatedMenu()}
+                </sp-split-button>
+            </div>
+        `);
+        const el1 = test.querySelector('sp-split-button') as SplitButton;
+        const el2 = test.querySelector('sp-split-button[left]') as SplitButton;
+
+        await elementUpdated(el1);
+        await elementUpdated(el2);
+
+        await expect(el1).to.be.accessible();
+        await expect(el2).to.be.accessible();
+    });
+
+    it('receives "focus()"', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(field(splitButtonDefault.args))
+        );
+        const el1 = test.querySelector('sp-split-button') as SplitButton;
+        const el2 = test.querySelector('sp-split-button[left]') as SplitButton;
+        const el1FocusElement = el1.focusElement;
+        const el2FocusElement = el2.shadowRoot.querySelector(
+            '.trigger'
+        ) as HTMLElement;
+
+        await elementUpdated(el1);
+        await elementUpdated(el2);
+
+        el1.focus();
+        await elementUpdated(el1);
+
+        expect(document.activeElement === el1);
+        expect(el1.shadowRoot.activeElement === el1FocusElement);
+
+        el2.focus();
+        await elementUpdated(el2);
+
+        expect(document.activeElement === el2);
+        expect(el1.shadowRoot.activeElement === el2FocusElement);
+    });
+    it('[type="field"] manages `selectedItem`', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(field(splitButtonDefault.args))
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+
+        await elementUpdated(el);
+
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
+        expect(el.open).to.be.false;
+
+        const item3 = el.querySelector('sp-menu-item:nth-child(3)') as MenuItem;
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const toggleButton = root.querySelector(
+            '.trigger'
+        ) as HTMLButtonElement;
+        const opened = oneEvent(el, 'sp-opened');
+        toggleButton.click();
+        await opened;
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+
+        const closed = oneEvent(el, 'sp-closed');
+        item3.click();
+        await closed;
+
+        await elementUpdated(el);
+
+        expect(el.selectedItem?.itemText).to.equal('Short');
+        expect(el.open).to.be.false;
+    });
+    it('[type="more"] manages `selectedItem.itemText`', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(more({ ...splitButtonDefault.args, ...more.args }))
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+
+        await elementUpdated(el);
+
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
+        expect(el.open).to.be.false;
+
+        const item3 = el.querySelector('sp-menu-item:nth-child(3)') as MenuItem;
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const toggleButton = root.querySelector(
+            '.trigger'
+        ) as HTMLButtonElement;
+        const opened = oneEvent(el, 'sp-opened');
+        toggleButton.click();
+        await opened;
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+
+        const closed = oneEvent(el, 'sp-closed');
+        item3.click();
+        await closed;
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
+    });
+    it('passes click events as [type="field"]', async () => {
+        const firstItemSpy = spy();
+        const secondItemSpy = spy();
+        const thirdItemSpy = spy();
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(
+                field(splitButtonDefault.args, {
+                    firstItemHandler: (): void => firstItemSpy(),
+                    secondItemHandler: (): void => secondItemSpy(),
+                    thirdItemHandler: (): void => thirdItemSpy(),
+                })
+            )
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+
+        await elementUpdated(el);
+
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
+        expect(el.open).to.be.false;
+
+        const item1 = el.querySelector('sp-menu-item:nth-child(1)') as MenuItem;
+        const item2 = el.querySelector('sp-menu-item:nth-child(2)') as MenuItem;
+        const item3 = el.querySelector('sp-menu-item:nth-child(3)') as MenuItem;
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const main = root.querySelector('#button') as HTMLButtonElement;
+
+        main.click();
+
+        await elementUpdated(el);
+
+        expect(firstItemSpy.called, 'first called').to.be.true;
+        expect(firstItemSpy.calledOnce, 'first calledOnce').to.be.true;
+
+        const trigger = root.querySelector('.trigger') as HTMLButtonElement;
+        let opened = oneEvent(el, 'sp-opened');
+        trigger.click();
+        await opened;
+
+        await elementUpdated(el);
+
+        expect(el.open, 'open').to.be.true;
+
+        let closed = oneEvent(el, 'sp-closed');
+        item3.click();
+        await closed;
+
+        await elementUpdated(el);
+
+        expect(el.open, 'not open').to.be.false;
+        expect(thirdItemSpy.called, 'third called').to.be.true;
+        expect(thirdItemSpy.calledOnce, 'third calledOnce').to.be.true;
+
+        main.click();
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Short');
+        expect(thirdItemSpy.called, 'third called, still').to.be.true;
+        expect(thirdItemSpy.callCount, 'third callCount').to.equal(2);
+        expect(thirdItemSpy.calledTwice, 'third calledTwice').to.be.true;
+
+        trigger.focus();
+        opened = oneEvent(el, 'sp-opened');
+        trigger.dispatchEvent(arrowDownEvent);
+        await opened;
+
+        await elementUpdated(el);
+
+        expect(el.open, 'reopened').to.be.true;
+
+        closed = oneEvent(el, 'sp-closed');
+        item2.click();
+        await closed;
+
+        await elementUpdated(el);
+
+        main.click();
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Option Extended');
+        expect(secondItemSpy.called, 'second called').to.be.true;
+        expect(secondItemSpy.calledTwice, 'second twice').to.be.true;
+
+        opened = oneEvent(el, 'sp-opened');
+        trigger.click();
+        await opened;
+
+        await elementUpdated(el);
+
+        expect(el.open, 'opened again').to.be.true;
+
+        closed = oneEvent(el, 'sp-closed');
+        item1.click();
+        await closed;
+        await elementUpdated(el);
+
+        main.click();
+
+        await elementUpdated(el);
+
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
+        expect(firstItemSpy.called, 'first called, sill').to.be.true;
+        expect(firstItemSpy.callCount, 'first callCount').to.equal(3);
+    });
+    it('passes click events as [type="more"]', async () => {
+        const firstItemSpy = spy();
+        const secondItemSpy = spy();
+        const thirdItemSpy = spy();
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(
+                more(
+                    { ...splitButtonDefault.args, ...more.args },
+                    {
+                        firstItemHandler: (): void => firstItemSpy(),
+                        secondItemHandler: (): void => secondItemSpy(),
+                        thirdItemHandler: (): void => thirdItemSpy(),
+                    }
+                )
+            )
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+
+        await elementUpdated(el);
+
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
+        expect(el.open).to.be.false;
+
+        const item2 = el.querySelector('sp-menu-item:nth-child(2)') as MenuItem;
+        const item3 = el.querySelector('sp-menu-item:nth-child(3)') as MenuItem;
+        const root = el.shadowRoot ? el.shadowRoot : el;
+        const main = root.querySelector('#button') as HTMLButtonElement;
+
+        main.click();
+
+        await elementUpdated(el);
+
+        expect(firstItemSpy.called, '1st called').to.be.true;
+        expect(firstItemSpy.calledOnce, '1st called once').to.be.true;
+
+        const trigger = root.querySelector('.trigger') as HTMLButtonElement;
+        let opened = oneEvent(el, 'sp-opened');
+        trigger.click();
+        await opened;
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+
+        let closed = oneEvent(el, 'sp-closed');
+        item3.click();
+        await closed;
+        await elementUpdated(el);
+
+        expect(el.open, 'not open').to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
+        expect(thirdItemSpy.called, '3rd called').to.be.true;
+        expect(thirdItemSpy.calledOnce, '3rd called once').to.be.true;
+        opened = oneEvent(el, 'sp-opened');
+        trigger.click();
+        await opened;
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+
+        closed = oneEvent(el, 'sp-closed');
+        item2.click();
+        await closed;
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+        expect(el.selectedItem?.itemText).to.equal('Option 1');
+        expect(secondItemSpy.called, '2nd called').to.be.true;
+        expect(secondItemSpy.calledOnce, '2nd called once').to.be.true;
+
+        main.click();
+
+        await elementUpdated(el);
+
+        expect(firstItemSpy.called).to.be.true;
+        expect(firstItemSpy.calledTwice, '1st called twice').to.be.true;
+    });
+});

--- a/packages/split-button/test/split-button.test.ts
+++ b/packages/split-button/test/split-button.test.ts
@@ -10,7 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    expect,
+    html,
+    oneEvent,
+} from '@open-wc/testing';
 import { spy } from 'sinon';
 
 import '../sp-split-button.js';
@@ -145,18 +151,22 @@ describe('Splitbutton', () => {
         const toggleButton = root.querySelector(
             '.trigger'
         ) as HTMLButtonElement;
+        const opened = oneEvent(el, 'sp-opened');
         toggleButton.click();
+        await opened;
 
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
 
+        const closed = oneEvent(el, 'sp-closed');
         item3.click();
+        await closed;
 
         await elementUpdated(el);
 
-        expect(el.open).to.be.false;
         expect(el.selectedItem?.itemText).to.equal('Short');
+        expect(el.open).to.be.false;
     });
     it('[type="more"] manages `selectedItem.itemText`', async () => {
         const test = await fixture<HTMLDivElement>(
@@ -174,13 +184,17 @@ describe('Splitbutton', () => {
         const toggleButton = root.querySelector(
             '.trigger'
         ) as HTMLButtonElement;
+        const opened = oneEvent(el, 'sp-opened');
         toggleButton.click();
+        await opened;
 
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
 
+        const closed = oneEvent(el, 'sp-closed');
         item3.click();
+        await closed;
 
         await elementUpdated(el);
 
@@ -221,17 +235,21 @@ describe('Splitbutton', () => {
         expect(firstItemSpy.calledOnce, 'first calledOnce').to.be.true;
 
         const trigger = root.querySelector('.trigger') as HTMLButtonElement;
+        let opened = oneEvent(el, 'sp-opened');
         trigger.click();
+        await opened;
 
         await elementUpdated(el);
 
         expect(el.open, 'open').to.be.true;
 
+        let closed = oneEvent(el, 'sp-closed');
         item3.click();
+        await closed;
 
         await elementUpdated(el);
 
-        expect(el.open).to.be.false;
+        expect(el.open, 'not open').to.be.false;
         expect(thirdItemSpy.called, 'third called').to.be.true;
         expect(thirdItemSpy.calledOnce, 'third calledOnce').to.be.true;
 
@@ -246,13 +264,17 @@ describe('Splitbutton', () => {
         expect(thirdItemSpy.calledTwice, 'third calledTwice').to.be.true;
 
         trigger.focus();
+        opened = oneEvent(el, 'sp-opened');
         trigger.dispatchEvent(arrowDownEvent);
+        await opened;
 
         await elementUpdated(el);
 
         expect(el.open, 'reopened').to.be.true;
 
+        closed = oneEvent(el, 'sp-closed');
         item2.click();
+        await closed;
 
         await elementUpdated(el);
 
@@ -265,13 +287,17 @@ describe('Splitbutton', () => {
         expect(secondItemSpy.called, 'second called').to.be.true;
         expect(secondItemSpy.calledTwice, 'second twice').to.be.true;
 
+        opened = oneEvent(el, 'sp-opened');
         trigger.click();
+        await opened;
 
         await elementUpdated(el);
 
         expect(el.open, 'opened again').to.be.true;
 
+        closed = oneEvent(el, 'sp-closed');
         item1.click();
+        await closed;
         await elementUpdated(el);
 
         main.click();
@@ -318,28 +344,34 @@ describe('Splitbutton', () => {
         expect(firstItemSpy.calledOnce, '1st called once').to.be.true;
 
         const trigger = root.querySelector('.trigger') as HTMLButtonElement;
+        let opened = oneEvent(el, 'sp-opened');
         trigger.click();
+        await opened;
 
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
 
+        let closed = oneEvent(el, 'sp-closed');
         item3.click();
-
+        await closed;
         await elementUpdated(el);
 
-        expect(el.open).to.be.false;
+        expect(el.open, 'not open').to.be.false;
         expect(el.selectedItem?.itemText).to.equal('Option 1');
         expect(thirdItemSpy.called, '3rd called').to.be.true;
         expect(thirdItemSpy.calledOnce, '3rd called once').to.be.true;
-
+        opened = oneEvent(el, 'sp-opened');
         trigger.click();
+        await opened;
 
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
 
+        closed = oneEvent(el, 'sp-closed');
         item2.click();
+        await closed;
 
         await elementUpdated(el);
 

--- a/packages/split-button/tsconfig.json
+++ b/packages/split-button/tsconfig.json
@@ -4,7 +4,7 @@
         "composite": true,
         "rootDir": "./"
     },
-    "include": ["*.ts", "src/*.ts"],
+    "include": ["*.ts", "src/*.ts", "sync/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
     "references": [
         { "path": "../button" },


### PR DESCRIPTION
## Description
- correct delivery of `sp-split-button` variants
- surface sync imports for Action Menu and Split Button patterns

## Related Issue
fixes #1642
fixes #1456

## Motivation and Context
Correctness, options.

## How Has This Been Tested?
VRT

## Screenshots (if appropriate):
https://westbrook-split-button--spectrum-web-components.netlify.app/storybook/index.html?path=/story/split-button--more-cta

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
