### PR TITLE
test: clean up before retesting VRTs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: bc2a983098271b82cc39f652a4885a035bdb4989
+        default: c36232311ca79de3ba648fc08333d021d45a68b7
 commands:
     downstream:
         steps:

--- a/test/visual/test.ts
+++ b/test/visual/test.ts
@@ -78,21 +78,22 @@ export const test = (
                         `${color} - ${scale} - ${dir} - ${name} - ${story}`
                     );
                 } catch (error) {
+                    test.remove();
                     /**
                      * _Sometimes_ the browser will fail on weird renderings of rounded edges.
                      * This retry allows it another change to render the test from scratch before
                      * actually failing on this story.
                      **/
-                    const test = await fixture<StoryDecorator>(wrap());
-                    await elementUpdated(test);
-                    render(storyResult, test);
+                    const retest = await fixture<StoryDecorator>(wrap());
+                    await elementUpdated(retest);
+                    render(storyResult, retest);
                     await waitUntil(
-                        () => test.ready,
+                        () => retest.ready,
                         'Wait for decorator to become ready...',
                         { timeout: 15000 }
                     );
                     await visualDiff(
-                        test,
+                        retest,
                         `${color} - ${scale} - ${dir} - ${name} - ${story}`
                     );
                 }

--- a/test/visual/test.ts
+++ b/test/visual/test.ts
@@ -42,6 +42,8 @@ export const test = (
     Object.keys(tests).map((story) => {
         if (story !== 'default') {
             it(story, async () => {
+                const test = await fixture<StoryDecorator>(wrap());
+                await elementUpdated(test);
                 const testsDefault = (tests as any).default;
                 const args = {
                     ...(testsDefault.args || {}),
@@ -64,8 +66,6 @@ export const test = (
                     }
                     storyResult = decoratedStory as TemplateResult;
                 }
-                const test = await fixture<StoryDecorator>(wrap());
-                await elementUpdated(test);
                 render(storyResult, test);
                 await waitUntil(
                     () => test.ready,


### PR DESCRIPTION
## Description
- prevent VRT retry from placing a _second_ instance of the test
- update code order to prevent runtime side effects in the tests from happening too early

## Motivation and Context
Test stability

## How Has This Been Tested?
It is tests.

## Screenshots (if appropriate):
https://60fc81e1bf892e67cbfba04d--spectrum-web-components.netlify.app/review/

## Types of changes
- [x] Test processing update

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
