### PR TITLE
docs: use correct component name

### DIFF
--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -41,7 +41,7 @@ export type LongpressEvent = {
 type ActionButtonSize = Exclude<ElementSize, 'xxl'>;
 
 /**
- * @element sp-card
+ * @element sp-action-button
  *
  * @fires change - Announces a change in the `selected` property of an action button
  * @fires longpress - Synthesizes a "longpress" interaction that signifies a


### PR DESCRIPTION
Correct the associated element name in ActionButton.ts.