### PR TITLE
fix(textfield): break very long within the Textarea's sizer element

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: b42bc845d071194c838dcad064ac2b18f6072b88
+        default: 29595bc1e4d51b31aff404bad7f177e78956c9e6
 commands:
     downstream:
         steps:

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -22,6 +22,7 @@ governing permissions and limitations under the License.
 
 :host([grows]) #sizer {
     box-sizing: border-box;
+    overflow-wrap: break-word;
     border: var(
             --spectrum-textfield-border-size,
             var(--spectrum-alias-border-size-thin)

--- a/packages/textfield/stories/textarea.stories.ts
+++ b/packages/textfield/stories/textarea.stories.ts
@@ -83,6 +83,19 @@ export const grows = (): TemplateResult => html`
     ></sp-textfield>
 `;
 
+export const growsWithLargeWords = (): TemplateResult => html`
+    <sp-field-label for="story">
+        Enter your life story with very long words...
+    </sp-field-label>
+    <sp-textfield
+        multiline
+        id="story"
+        value="Sed utperspiciatisundeomnisistenatuserrorsitvoluptatemaccusantiumdoloremquelaudantium,totamemaperiam, eaque ipsa quae ab illo inventore veritatis etquasiarchitectobeataevitaedictasuntexplicabo. Nemo enimipsamvoluptatemquiavoluptassitaspernaturautoditautfugitsedquiaconsequunturmagnidoloreseosquirationevoluptatemsequinesciunt."
+        grows
+        placeholder="Enter your life story"
+    ></sp-textfield>
+`;
+
 export const readonly = (): TemplateResult => html`
     <sp-textfield
         multiline


### PR DESCRIPTION
## Description

This PR introduces some small changes to the styling of the Textarea's sizer element, changes that will force very long words to break and wrap in order to properly resize the Textarea.

## Related Issue

fixes https://github.com/adobe/spectrum-web-components/issues/1664

## Motivation and Context

This change is necessary to fix the functionality of the `grows` variant of the Textarea component. Whithout these changes, the Textarea does not resize as expected when containing long words.

## How Has This Been Tested?

- manual testing
- added a new story to render the problematic use case for future observability

## Screenshots (if appropriate):

![Screenshot 2021-07-30 at 14 13 22](https://user-images.githubusercontent.com/8905546/127645046-00791c85-25ca-471e-afcc-c080f4aa460d.png)
![Screenshot 2021-07-30 at 14 13 33](https://user-images.githubusercontent.com/8905546/127645052-96023b89-060b-4190-93c9-4df65f8e939a.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
