### PR TITLE
fix: add "editable" option to "sp-slider"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 766233c60d183f9b6c8d59f20896637503831393
+        default: 06bbbd3e96552c01c402aa443f4cf4dc79ff1e4a
 commands:
     downstream:
         steps:

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -105,6 +105,8 @@ export class NumberField extends TextfieldBase {
     @property({ type: Number })
     public step?: number;
 
+    public stepperActive = false;
+
     @property({ type: Number, reflect: true, attribute: 'step-modifier' })
     public stepModifier = 10;
 
@@ -165,6 +167,7 @@ export class NumberField extends TextfieldBase {
             event.preventDefault();
             return;
         }
+        this.stepperActive = true;
         this.buttons.setPointerCapture(event.pointerId);
         const stepUpRect = this.buttons.children[0].getBoundingClientRect();
         const stepDownRect = this.buttons.children[1].getBoundingClientRect();
@@ -214,6 +217,7 @@ export class NumberField extends TextfieldBase {
         this.dispatchEvent(
             new Event('change', { bubbles: true, composed: true })
         );
+        this.stepperActive = false;
     }
 
     private doNextChange(event: PointerEvent): number {

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -18,6 +18,12 @@ Import the side effectful registration of `<sp-slider>` via:
 import '@spectrum-web-components/slider/sp-slider.js';
 ```
 
+When leveraging the `editable` attribute, the `@spectrum-web-components/number-field/sp-number-field.js` dependency will be asynchronously loaded via a dynamic import to reduce JS payload for applications not leveraging this feature. In the case that you would like to import those tranverse dependencies statically, import the side effectful registration of `<sp-slider>` as follows:
+
+```
+import '@spectrum-web-components/slider/sync/sp-slider.js';
+```
+
 When looking to leverage the `Slider` base class as a type and/or for extension purposes, do so via:
 
 ```
@@ -79,6 +85,38 @@ import { Slider } from '@spectrum-web-components/slider';
 ```html
 <sp-slider label="Slider Label" variant="ramp"></sp-slider>
 <sp-slider label="Slider Label - Disabled" variant="ramp" disabled></sp-slider>
+```
+
+### Editable
+
+An `<sp-slider>` element can be paired with an `<sp-number-field>` element via the `editable` attribute. The `<sp-number-field>` will be passed all of the standard options from the `<sp-slider>` element (e.g. `min`, `max`, `formatOptions`, etc.) and will also accept the `hide-stepper` attribute in order to prevent the display of its stepper UI.
+
+```html
+<sp-slider
+    label="Angle (editable)"
+    editable
+    hide-stepper
+    min="0"
+    max="360"
+    format-options='{
+        "style": "unit",
+        "unit": "degree",
+        "unitDisplay": "narrow"
+    }'
+></sp-slider>
+<sp-slider
+    label="Hours of the day (editable)"
+    editable
+    max="24"
+    min="0"
+    value="7.25"
+    step="0.25"
+    style="--spectrum-slider-editable-number-field-width: 100px;"
+    format-options='{
+        "style": "unit",
+        "unit": "hour"
+    }'
+></sp-slider>
 ```
 
 ## Advanced normalization

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -26,7 +26,9 @@
         "./sp-slider": "./sp-slider.js",
         "./sp-slider.js": "./sp-slider.js",
         "./sp-slider-handle": "./sp-slider-handle.js",
-        "./sp-slider-handle.js": "./sp-slider-handle.js"
+        "./sp-slider-handle.js": "./sp-slider-handle.js",
+        "./sync/sp-slider": "./sync/sp-slider.js",
+        "./sync/sp-slider.js": "./sync/sp-slider.js"
     },
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
@@ -48,6 +50,8 @@
     "dependencies": {
         "@internationalized/number": "^3.0.0",
         "@spectrum-web-components/base": "^0.4.5",
+        "@spectrum-web-components/field-label": "^0.5.3",
+        "@spectrum-web-components/number-field": "^0.1.4",
         "@spectrum-web-components/shared": "^0.12.7",
         "@spectrum-web-components/theme": "^0.8.12",
         "tslib": "^2.0.0"
@@ -58,6 +62,7 @@
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",
     "sideEffects": [
-        "./sp-*.js"
+        "./sp-*.js",
+        "./sync/sp-*.js"
     ]
 }

--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -77,6 +77,10 @@ export class HandleController implements Controller {
         return result;
     }
 
+    public get size(): number {
+        return this.handles.size;
+    }
+
     public inputForHandle(handle: SliderHandle): HTMLInputElement | undefined {
         if (this.handles.has(handle.handleName)) {
             const { input } = this.getHandleElements(handle);
@@ -104,7 +108,9 @@ export class HandleController implements Controller {
 
         const { input } = elements;
         if (input.valueAsNumber === handle.value) {
-            handle.dispatchInputEvent();
+            if (handle.dragging) {
+                handle.dispatchInputEvent();
+            }
         } else {
             input.valueAsNumber = handle.value;
             handle.value = input.valueAsNumber;
@@ -135,6 +141,12 @@ export class HandleController implements Controller {
 
     public get focusElement(): HTMLElement {
         const { input } = this.getActiveHandleElements();
+        if (
+            this.host.editable &&
+            !(input as InputWithModel).model.handle.dragging
+        ) {
+            return this.host.numberField;
+        }
         return input;
     }
 
@@ -233,7 +245,7 @@ export class HandleController implements Controller {
 
     private get boundingClientRect(): DOMRect {
         if (!this._boundingClientRect) {
-            this._boundingClientRect = this.host.getBoundingClientRect();
+            this._boundingClientRect = this.host.track.getBoundingClientRect();
         }
         return this._boundingClientRect;
     }
@@ -442,6 +454,7 @@ export class HandleController implements Controller {
                     aria-disabled=${ifDefined(
                         this.host.disabled ? 'true' : undefined
                     )}
+                    tabindex=${ifDefined(this.host.editable ? -1 : undefined)}
                     aria-label=${ifDefined(model.ariaLabel)}
                     aria-labelledby=${ariaLabelledBy}
                     aria-valuetext=${this.formattedValueForHandle(model)}

--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -141,9 +141,6 @@ export class SliderHandle extends Focusable {
     public normalization: SliderNormalization = defaultNormalization;
 
     public dispatchInputEvent(): void {
-        if (!this.dragging) {
-            return;
-        }
         const inputEvent = new Event('input', {
             bubbles: true,
             composed: true,

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -23,6 +23,11 @@ governing permissions and limitations under the License.
     );
 }
 
+sp-field-label {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
 /*
  * Removes blue outline from :host when it is being focused.
  * This situation is not addressed in spectrum-css because the slider element itself
@@ -32,6 +37,50 @@ governing permissions and limitations under the License.
 */
 :host(:focus) {
     outline: 0;
+}
+
+:host([editable]) {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+        'label .'
+        'slider number';
+}
+
+:host([editable]) #labelContainer {
+    grid-area: label;
+}
+
+:host([editable]) #labelContainer + div {
+    grid-area: slider;
+}
+
+:host([editable]) sp-number-field {
+    grid-area: number;
+
+    --spectrum-stepper-width: var(
+        --spectrum-slider-editable-number-field-width,
+        var(--spectrum-global-dimension-size-1000)
+    );
+}
+
+:host([hide-stepper]) sp-number-field {
+    --spectrum-stepper-width: var(
+        --spectrum-slider-editable-number-field-width,
+        var(--spectrum-global-dimension-size-900)
+    );
+}
+
+:host([editable][dir='ltr']) sp-number-field {
+    margin-left: var(--spectrum-global-dimension-size-200);
+}
+
+:host([editable][dir='rtl']) sp-number-field {
+    margin-right: var(--spectrum-global-dimension-size-200);
+}
+
+:host([editable]) output {
+    opacity: 0;
 }
 
 :host([disabled]) {

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -69,7 +69,7 @@ export default {
     },
 };
 
-interface StoryArgs {
+export interface StoryArgs {
     variant?: string;
     tickStep?: number;
     labelVisibility?: string;
@@ -183,6 +183,137 @@ export const noVisibleLabels = (args: StoryArgs): TemplateResult => {
 noVisibleLabels.args = {
     labelVisibility: 'none',
 };
+
+class NumberFieldDefined extends HTMLElement {
+    constructor() {
+        super();
+        this.numberFieldLoaderPromise = new Promise((res) => {
+            customElements.whenDefined('sp-number-field').then(() => {
+                res(true);
+            });
+        });
+    }
+
+    private numberFieldLoaderPromise: Promise<boolean> = Promise.resolve(false);
+
+    get updateComplete(): Promise<boolean> {
+        return this.numberFieldLoaderPromise;
+    }
+}
+
+customElements.define('number-field-defined', NumberFieldDefined);
+
+export const editable = (args: StoryArgs): TemplateResult => {
+    const handleEvent = (event: Event): void => {
+        const target = event.target as Slider;
+        if (target.value != null) {
+            action(event.type)(target.value.toString());
+        }
+    };
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                editable
+                max="360"
+                min="0"
+                value="90"
+                step="1"
+                @input=${handleEvent}
+                @change=${handleEvent}
+                .formatOptions=${{
+                    style: 'unit',
+                    unit: 'degree',
+                    unitDisplay: 'narrow',
+                }}
+                ...=${spreadProps(args)}
+            >
+                Angle
+            </sp-slider>
+        </div>
+    `;
+};
+
+editable.decorators = [
+    (story: () => TemplateResult): TemplateResult => {
+        return html`
+            ${story()}
+            <number-field-defined></number-field-defined>
+        `;
+    },
+];
+
+export const editableCustom = (args: StoryArgs): TemplateResult => {
+    const handleEvent = (event: Event): void => {
+        const target = event.target as Slider;
+        if (target.value != null) {
+            action(event.type)(target.value.toString());
+        }
+    };
+    return html`
+        <div
+            style="width: 500px; margin: 12px 20px; --spectrum-slider-editable-number-field-width: 150px;"
+        >
+            <sp-slider
+                editable
+                max="24"
+                min="0"
+                value="12.75"
+                step="0.25"
+                @input=${handleEvent}
+                @change=${handleEvent}
+                .formatOptions=${{ style: 'unit', unit: 'hour' }}
+                ...=${spreadProps(args)}
+            >
+                Hours
+            </sp-slider>
+        </div>
+    `;
+};
+
+editableCustom.decorators = [
+    (story: () => TemplateResult): TemplateResult => {
+        return html`
+            ${story()}
+            <number-field-defined></number-field-defined>
+        `;
+    },
+];
+
+export const hideStepper = (args: StoryArgs): TemplateResult => {
+    const handleEvent = (event: Event): void => {
+        const target = event.target as Slider;
+        if (target.value != null) {
+            action(event.type)(target.value.toString());
+        }
+    };
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                editable
+                hide-stepper
+                max="1"
+                min="0"
+                value=".5"
+                step="0.01"
+                @input=${handleEvent}
+                @change=${handleEvent}
+                .formatOptions=${{ style: 'percent' }}
+                ...=${spreadProps(args)}
+            >
+                Opacity
+            </sp-slider>
+        </div>
+    `;
+};
+
+hideStepper.decorators = [
+    (story: () => TemplateResult): TemplateResult => {
+        return html`
+            ${story()}
+            <number-field-defined></number-field-defined>
+        `;
+    },
+];
 
 export const Gradient = (args: StoryArgs): TemplateResult => {
     const handleEvent = (event: Event): void => {

--- a/packages/slider/sync/sp-slider.ts
+++ b/packages/slider/sync/sp-slider.ts
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/number-field/sp-number-field.js';
+import '../sp-slider.js';

--- a/packages/slider/test/slider-editable-sync.test.ts
+++ b/packages/slider/test/slider-editable-sync.test.ts
@@ -1,0 +1,173 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '../sync/sp-slider.js';
+import { Slider } from '../';
+import { editable, hideStepper, StoryArgs } from '../stories/slider.stories.js';
+import { fixture, elementUpdated, expect } from '@open-wc/testing';
+import { TemplateResult } from '@spectrum-web-components/base';
+import { sendKeys } from '@web/test-runner-commands';
+import { spy } from 'sinon';
+
+async function sliderFromFixture(
+    sliderFixture: (args: StoryArgs) => TemplateResult
+): Promise<Slider> {
+    const el = await fixture<Slider>(sliderFixture({}));
+    const slider = el.querySelector('sp-slider') as Slider;
+    return slider;
+}
+
+describe('Slider - editable, sync', () => {
+    it('loads', async () => {
+        const el = await sliderFromFixture(editable);
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+
+    it('loads - [hide-stepper]', async () => {
+        const el = await sliderFromFixture(hideStepper);
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+
+    it('focuses `<sp-number-field>` directly', async () => {
+        const el = await sliderFromFixture(editable);
+
+        await elementUpdated(el);
+
+        el.focus();
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+    });
+
+    it('edits via the `<sp-number-field>`', async () => {
+        const inputSpy = spy();
+        const changeSpy = spy();
+        const el = await sliderFromFixture(editable);
+        el.addEventListener('input', () => inputSpy());
+        el.addEventListener('change', () => changeSpy());
+
+        await elementUpdated(el);
+
+        el.focus();
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(90);
+
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ type: '45' });
+        await sendKeys({ press: 'Enter' });
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(45);
+        expect(inputSpy.callCount, 'one input').to.equal(1);
+        expect(changeSpy.callCount, 'one change').to.equal(1);
+
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Enter' });
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(45);
+        expect(inputSpy.callCount, 'still one input').to.equal(1);
+        expect(changeSpy.callCount, 'still one change').to.equal(1);
+    });
+
+    it('focuses `<input>` after pointer interactions', async () => {
+        let pointerId = -1;
+        const el = await sliderFromFixture(editable);
+
+        await elementUpdated(el);
+
+        expect(el.dragging).to.be.false;
+        expect(el.highlight).to.be.false;
+        expect(pointerId).to.equal(-1);
+
+        const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
+        handle.setPointerCapture = (id: number) => (pointerId = id);
+        handle.releasePointerCapture = (id: number) => (pointerId = id);
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 1,
+                pointerId: 1,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging).to.be.false;
+        expect(pointerId, '1').to.equal(-1);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 0,
+                pointerId: 1,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging, 'it is dragging 1').to.be.true;
+        expect(pointerId, '2').to.equal(1);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointerup', {
+                pointerId: 2,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging).to.be.false;
+        expect(el.highlight).to.be.false;
+        expect(pointerId, '3').to.equal(2);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 0,
+                pointerId: 1,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging, 'it is dragging 2').to.be.true;
+        expect(pointerId, '4').to.equal(1);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointercancel', {
+                pointerId: 3,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging).to.be.false;
+        expect(pointerId, '5').to.equal(3);
+        expect(el.shadowRoot.activeElement).to.equal(
+            el.handleController.inputForHandle(el)
+        );
+    });
+});

--- a/packages/slider/test/slider-editable.test.ts
+++ b/packages/slider/test/slider-editable.test.ts
@@ -1,0 +1,173 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '../sp-slider.js';
+import { Slider } from '../';
+import { editable, hideStepper, StoryArgs } from '../stories/slider.stories.js';
+import { fixture, elementUpdated, expect } from '@open-wc/testing';
+import { TemplateResult } from '@spectrum-web-components/base';
+import { sendKeys } from '@web/test-runner-commands';
+import { spy } from 'sinon';
+
+async function sliderFromFixture(
+    sliderFixture: (args: StoryArgs) => TemplateResult
+): Promise<Slider> {
+    const el = await fixture<Slider>(sliderFixture({}));
+    const slider = el.querySelector('sp-slider') as Slider;
+    return slider;
+}
+
+describe('Slider - editable', () => {
+    it('loads', async () => {
+        const el = await sliderFromFixture(editable);
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+
+    it('loads - [hide-stepper]', async () => {
+        const el = await sliderFromFixture(hideStepper);
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+
+    it('focuses `<sp-number-field>` directly', async () => {
+        const el = await sliderFromFixture(editable);
+
+        await elementUpdated(el);
+
+        el.focus();
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+    });
+
+    it('edits via the `<sp-number-field>`', async () => {
+        const inputSpy = spy();
+        const changeSpy = spy();
+        const el = await sliderFromFixture(editable);
+        el.addEventListener('input', () => inputSpy());
+        el.addEventListener('change', () => changeSpy());
+
+        await elementUpdated(el);
+
+        el.focus();
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(90);
+
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ type: '45' });
+        await sendKeys({ press: 'Enter' });
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(45);
+        expect(inputSpy.callCount, 'one input').to.equal(1);
+        expect(changeSpy.callCount, 'one change').to.equal(1);
+
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Enter' });
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(45);
+        expect(inputSpy.callCount, 'still one input').to.equal(1);
+        expect(changeSpy.callCount, 'still one change').to.equal(1);
+    });
+
+    it('focuses `<input>` after pointer interactions', async () => {
+        let pointerId = -1;
+        const el = await sliderFromFixture(editable);
+
+        await elementUpdated(el);
+
+        expect(el.dragging).to.be.false;
+        expect(el.highlight).to.be.false;
+        expect(pointerId).to.equal(-1);
+
+        const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
+        handle.setPointerCapture = (id: number) => (pointerId = id);
+        handle.releasePointerCapture = (id: number) => (pointerId = id);
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 1,
+                pointerId: 1,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging).to.be.false;
+        expect(pointerId, '1').to.equal(-1);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 0,
+                pointerId: 1,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging, 'it is dragging 1').to.be.true;
+        expect(pointerId, '2').to.equal(1);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointerup', {
+                pointerId: 2,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging).to.be.false;
+        expect(el.highlight).to.be.false;
+        expect(pointerId, '3').to.equal(2);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointerdown', {
+                button: 0,
+                pointerId: 1,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging, 'it is dragging 2').to.be.true;
+        expect(pointerId, '4').to.equal(1);
+
+        handle.dispatchEvent(
+            new PointerEvent('pointercancel', {
+                pointerId: 3,
+                cancelable: true,
+            })
+        );
+        await elementUpdated(el);
+
+        expect(el.dragging).to.be.false;
+        expect(pointerId, '5').to.equal(3);
+        expect(el.shadowRoot.activeElement).to.equal(
+            el.handleController.inputForHandle(el)
+        );
+    });
+});

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -460,7 +460,9 @@ describe('Slider', () => {
                     max="20"
                     @input=${() => inputSpy()}
                     style="width: 500px; float: left;"
-                ></sp-slider>
+                >
+                    Step = 0
+                </sp-slider>
             `
         );
 
@@ -479,11 +481,27 @@ describe('Slider', () => {
                 cancelable: true,
             })
         );
+        const handleBoundingRect = handle.getBoundingClientRect();
+        const position = [
+            handleBoundingRect.x + handleBoundingRect.width / 2,
+            handleBoundingRect.y + handleBoundingRect.height / 2,
+        ];
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position,
+                },
+                {
+                    type: 'down',
+                },
+            ],
+        });
 
         await elementUpdated(el);
 
-        expect(el.dragging).to.be.true;
-        expect(el.highlight).to.be.false;
+        expect(el.dragging, 'dragging').to.be.true;
+        expect(el.highlight, 'with no highlight').to.be.false;
         expect(pointerId, 'pointer id').to.equal(1);
 
         handle.dispatchEvent(
@@ -492,10 +510,18 @@ describe('Slider', () => {
                 cancelable: true,
             })
         );
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [200, position[1]],
+                },
+            ],
+        });
         await elementUpdated(el);
 
         expect(el.value).to.equal(8);
-        expect(inputSpy.callCount, 'call count').to.equal(1);
+        expect(inputSpy.callCount, 'call count').to.equal(2);
 
         handle.dispatchEvent(
             new PointerEvent('pointermove', {
@@ -503,10 +529,18 @@ describe('Slider', () => {
                 cancelable: true,
             })
         );
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [125, position[1]],
+                },
+            ],
+        });
         await elementUpdated(el);
 
         expect(el.value).to.equal(5);
-        expect(inputSpy.callCount).to.equal(2);
+        expect(inputSpy.callCount).to.equal(3);
     });
     it('will not pointermove unless `pointerdown`', async () => {
         const el = await fixture<Slider>(

--- a/packages/slider/tsconfig.json
+++ b/packages/slider/tsconfig.json
@@ -6,5 +6,5 @@
     },
     "include": ["*.ts", "src/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
-    "references": [{ "path": "../shared" }]
+    "references": [{ "path": "../shared" }, { "path": "../number-field" }]
 }


### PR DESCRIPTION
## Description
Add editable slider delivery binding an `<sp-number-field>` into the UI of the `<sp-slider editable>` element through dynamic importing the element registration.
- also adds a synchronous entry point into the functionality as desired.

## Related Issue
fixes #1572 

## Motivation and Context
Spectrum compliance and application flexibility.

## How Has This Been Tested?
- VRT
- unit tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
