### PR TITLE
fix: update slotting in "sp-sidenav-item" to allow for labelling in HTML

### DIFF
--- a/packages/sidenav/README.md
+++ b/packages/sidenav/README.md
@@ -41,40 +41,33 @@ import {
 
 ```html
 <sp-sidenav defaultValue="Docs">
-    <sp-sidenav-item
-        value="Docs"
-        label="Docs"
-        href="/components/SideNav"
-    ></sp-sidenav-item>
-    <sp-sidenav-item
-        value="Guides"
-        label="Guides"
-        href="/guides/getting_started"
-    ></sp-sidenav-item>
-    <sp-sidenav-item
-        value="Community"
-        label="Community"
-        href="/community"
-    ></sp-sidenav-item>
-    <sp-sidenav-item
-        value="Storybook"
-        label="Storybook"
-        href="/storybook"
-        target="_blank"
-    ></sp-sidenav-item>
+    <sp-sidenav-item value="Docs" href="/components/SideNav">
+        Docs
+    </sp-sidenav-item>
+    <sp-sidenav-item value="Guides" href="/guides/getting_started">
+        Guides
+    </sp-sidenav-item>
+    <sp-sidenav-item value="Community" href="/community">
+        Community
+    </sp-sidenav-item>
+    <sp-sidenav-item value="Storybook" href="/storybook" target="_blank">
+        Storybook
+    </sp-sidenav-item>
     <sp-sidenav-item
         value="Releases"
-        label="Releases"
         href="http://git.corp.adobe.com/React/react-spectrum/releases"
         target="_blank"
         disabled
-    ></sp-sidenav-item>
+    >
+        Releases
+    </sp-sidenav-item>
     <sp-sidenav-item
         value="GitHub"
-        label="GitHub"
         href="http://git.corp.adobe.com/React/react-spectrum"
         target="_blank"
-    ></sp-sidenav-item>
+    >
+        GitHub
+    </sp-sidenav-item>
 </sp-sidenav>
 ```
 

--- a/packages/sidenav/src/Sidenav.ts
+++ b/packages/sidenav/src/Sidenav.ts
@@ -229,7 +229,10 @@ export class SideNav extends Focusable {
     protected render(): TemplateResult {
         return html`
             <nav @sidenav-select=${this.handleSelect}>
-                <slot @slotchange=${this.handleSlotchange}></slot>
+                <slot
+                    name="descendant"
+                    @slotchange=${this.handleSlotchange}
+                ></slot>
             </nav>
         `;
     }

--- a/packages/sidenav/src/SidenavHeading.ts
+++ b/packages/sidenav/src/SidenavHeading.ts
@@ -16,6 +16,7 @@ import {
     property,
     CSSResultArray,
     TemplateResult,
+    PropertyValues,
 } from '@spectrum-web-components/base';
 
 import sidenavItemStyles from './sidenav-item.css.js';
@@ -29,11 +30,18 @@ export class SideNavHeading extends SpectrumElement {
         return [sidenavItemStyles, sidenavHeadingStyles];
     }
 
+    protected update(changes: PropertyValues): void {
+        if (!this.hasAttribute('slot')) {
+            this.slot = 'descendant';
+        }
+        super.update(changes);
+    }
+
     protected render(): TemplateResult {
         return html`
             <h2 id="heading">${this.label}</h2>
             <div id="list" aria-labelledby="heading">
-                <slot></slot>
+                <slot name="descendant"></slot>
             </div>
         `;
     }

--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -19,7 +19,7 @@ import {
     ifDefined,
 } from '@spectrum-web-components/base';
 import { LikeAnchor } from '@spectrum-web-components/shared/src/like-anchor.js';
-import { Focusable } from '@spectrum-web-components/shared';
+import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
 
 import { SidenavSelectDetail, SideNav } from './Sidenav.js';
 
@@ -106,6 +106,13 @@ export class SideNavItem extends LikeAnchor(Focusable) {
         return this.shadowRoot.querySelector('#itemLink') as HTMLElement;
     }
 
+    protected update(changes: PropertyValues): void {
+        if (!this.hasAttribute('slot')) {
+            this.slot = 'descendant';
+        }
+        super.update(changes);
+    }
+
     protected render(): TemplateResult {
         return html`
             <a
@@ -122,21 +129,22 @@ export class SideNavItem extends LikeAnchor(Focusable) {
             >
                 <slot name="icon"></slot>
                 ${this.label}
+                <slot></slot>
             </a>
             ${this.expanded
                 ? html`
-                      <slot></slot>
+                      <slot name="descendant"></slot>
                   `
                 : html``}
         `;
     }
 
     protected updated(changes: PropertyValues): void {
-        super.updated(changes);
         if (changes.has('selected') || changes.has('manageTabIndex')) {
             const tabIndexForSelectedState = this.selected ? 0 : -1;
             this.tabIndex = this.manageTabIndex ? tabIndexForSelectedState : 0;
         }
+        super.updated(changes);
     }
 
     public connectedCallback(): void {

--- a/packages/sidenav/src/sidenav-item.css
+++ b/packages/sidenav/src/sidenav-item.css
@@ -90,3 +90,7 @@ governing permissions and limitations under the License.
             )
     );
 }
+
+a ::slotted(sp-sidenav-item) {
+    display: none;
+}

--- a/packages/sidenav/stories/sidenav.stories.ts
+++ b/packages/sidenav/stories/sidenav.stories.ts
@@ -86,20 +86,15 @@ export const levelsAndDisabled = (): TemplateResult => {
     return html`
         <sp-sidenav>
             <sp-sidenav-heading label="CATEGORY 1">
-                <sp-sidenav-item
-                    value="Section 1"
-                    label="Section 1"
-                ></sp-sidenav-item>
-                <sp-sidenav-item
-                    value="Section 2"
-                    label="Section 2"
-                    disabled
-                ></sp-sidenav-item>
-                <sp-sidenav-item value="Section 3" label="Section 3" expanded>
-                    <sp-sidenav-item
-                        value="Section 3a"
-                        label="Section 3a"
-                    ></sp-sidenav-item>
+                <sp-sidenav-item value="Section 1">Section 1</sp-sidenav-item>
+                <sp-sidenav-item value="Section 2" disabled>
+                    Section 2
+                </sp-sidenav-item>
+                <sp-sidenav-item value="Section 3" expanded>
+                    Section 3
+                    <sp-sidenav-item value="Section 3a">
+                        Section 3a
+                    </sp-sidenav-item>
                 </sp-sidenav-item>
             </sp-sidenav-heading>
         </sp-sidenav>

--- a/packages/sidenav/test/sidenav-item.test.ts
+++ b/packages/sidenav/test/sidenav-item.test.ts
@@ -73,7 +73,7 @@ describe('Sidenav Item', () => {
         if (!el.shadowRoot) return;
 
         let slot: HTMLSlotElement | null = el.shadowRoot.querySelector(
-            'slot:not([name])'
+            'slot[name="descendant"]'
         );
         expect(slot).not.to.exist;
 
@@ -86,7 +86,7 @@ describe('Sidenav Item', () => {
         expect(el.expanded).to.be.true;
 
         slot = el.shadowRoot.querySelector(
-            'slot:not([name])'
+            'slot[name="descendant"]'
         ) as HTMLSlotElement;
         expect(slot).to.exist;
         if (!slot) return;


### PR DESCRIPTION
## Description
Update `<sp-sidenav>` API to accept `label` content as HTML via the default `<slot>` element.

## Related Issue
fixes #1485

## Motivation and Context
Easier customization of content.

## How Has This Been Tested?
- needs VRTs
- needs unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
