### PR TITLE
fix(menu): add support for submenu interactions, wip

### DIFF
--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -54,6 +54,7 @@
         "@spectrum-web-components/base": "^0.4.5",
         "@spectrum-web-components/icon": "^0.9.11",
         "@spectrum-web-components/icons-ui": "^0.6.11",
+        "@spectrum-web-components/overlay": "^0.11.16",
         "@spectrum-web-components/shared": "^0.12.9",
         "tslib": "^2.0.0"
     },

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -200,6 +200,49 @@ export const MenuGroupSelects = (): TemplateResult => {
     `;
 };
 
+export const submenu = (): TemplateResult => {
+    return html`
+        <sp-popover open style="width: 200px;">
+            <sp-menu>
+                <sp-menu-group>
+                    <span slot="header">New York</span>
+                    <sp-menu-item>Bronx</sp-menu-item>
+                    <sp-menu-item>
+                        Brooklyn
+                        <sp-menu slot="sub-menu">
+                            <sp-menu-item>
+                                Ft. Greene
+                                <sp-menu slot="sub-menu">
+                                    <sp-menu-item>S. Oxford St</sp-menu-item>
+                                    <sp-menu-item>S. Portland Ave</sp-menu-item>
+                                    <sp-menu-item>S. Elliot Pl</sp-menu-item>
+                                </sp-menu>
+                            </sp-menu-item>
+                            <sp-menu-item disabled>Park Slope</sp-menu-item>
+                            <sp-menu-item>Williamsburg</sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Manhattan
+                        <sp-menu slot="sub-menu">
+                            <sp-menu-item disabled>SoHo</sp-menu-item>
+                            <sp-menu-item>
+                                Union Square
+                                <sp-menu slot="sub-menu">
+                                    <sp-menu-item>14th St</sp-menu-item>
+                                    <sp-menu-item>Broadway</sp-menu-item>
+                                    <sp-menu-item>Park Ave</sp-menu-item>
+                                </sp-menu>
+                            </sp-menu-item>
+                            <sp-menu-item>Upper East Side</sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-menu-group>
+            </sp-menu>
+        </sp-popover>
+    `;
+};
+
 export const selectedOffPage = (): TemplateResult => {
     return html`
         <p style="height: 100vh; padding-bottom: 50px;">

--- a/packages/menu/tsconfig.json
+++ b/packages/menu/tsconfig.json
@@ -6,5 +6,9 @@
     },
     "include": ["*.ts", "src/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
-    "references": [{ "path": "../base" }, { "path": "../action-button" }]
+    "references": [
+        { "path": "../base" },
+        { "path": "../action-button" },
+        { "path": "../overlay" }
+    ]
 }


### PR DESCRIPTION
## Description
Add support for `<sp-menu-item>` element to host "sub menus".

### TODO:
- [ ] keyboard navigtion
- [ ] pointerenter/leave interactions
- [ ] slot/content management techniques
- [ ] `submenu` reference research

## Related Issue
fixes #146
refs #1559

## Motivation and Context
Spectrum compliance. App customizability.

## How Has This Been Tested?
- [ ] needs VRT
- [ ] needs unit tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
