### PR TITLE
fix: update when events are added to manage overlays

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -39,10 +39,6 @@ export class OverlayStack {
     private handlingResize = false;
     private overlayTimer = new OverlayTimer();
 
-    public constructor() {
-        this.addEventListeners();
-    }
-
     private canTabTrap = true;
     private trappingInited = false;
     private tabTrapper!: HTMLElement;
@@ -158,6 +154,17 @@ export class OverlayStack {
         window.addEventListener('resize', this.handleResize);
     }
 
+    private removeEventListeners(): void {
+        this.document.removeEventListener(
+            'click',
+            this.handleMouseCapture,
+            true
+        );
+        this.document.removeEventListener('click', this.handleMouse);
+        this.document.removeEventListener('keyup', this.handleKeyUp);
+        window.removeEventListener('resize', this.handleResize);
+    }
+
     private isClickOverlayActiveForTrigger(trigger: HTMLElement): boolean {
         return this.overlays.some(
             (item) => trigger === item.trigger && item.interaction === 'click'
@@ -165,6 +172,9 @@ export class OverlayStack {
     }
 
     public async openOverlay(details: OverlayOpenDetail): Promise<boolean> {
+        if (!this.overlays.length) {
+            this.addEventListeners();
+        }
         if (this.findOverlayForContent(details.content)) {
             return false;
         }
@@ -423,6 +433,10 @@ export class OverlayStack {
                     },
                 })
             );
+
+            if (!this.overlays.length) {
+                this.removeEventListeners();
+            }
         }
     }
 

--- a/packages/overlay/test/benchmark/basic-test.ts
+++ b/packages/overlay/test/benchmark/basic-test.ts
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(
+    html`
+        <overlay-trigger>
+            <sp-button slot="trigger">Trigger</sp-button>
+            <sp-popover slot="content">
+                <p>This is the content.</p>
+            </sp-popover>
+        </overlay-trigger>
+    `
+);


### PR DESCRIPTION
## Description
Only listen for overlay events when an overlay is actually open.

## Related Issue
fixes #1512

## Motivation and Context
Allow for inclusion of the code before the `<body>` tag. Make the code more performant to boot up.

## How Has This Been Tested?
- tests all pass

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
