### PR TITLE
feat(slider): support customizing visible label delivery 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 0b1f6fa9eaf6a48c4b15f54f7ea85181e465b310
+        default: aa8a18f56f8af4fe5526f060006ad0c810699c73
 commands:
     downstream:
         steps:

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -115,12 +115,29 @@ for a multi-handle slider, you can format the combined value label for all
 handles by passing a formatting function to the `getAriaValueText` property
 on the parent `sp-slider`.
 
-You can suppress the value label altogether using the `hide-value-label`
-attribute.
+### Label Visibility
+
+Be default an `<sp-slider>` element has both a "text" label and a "value" label. Either or both of these can be surpressed visually as needed by your application UI. This delivery is controlled by the `label-visibility` attribute (or `labelVisibility` property) which accepts `text`, `value`, or `none` as values.
+
+Use `label-visibility="text"` to supress the "value" label:
 
 ```html
-<sp-slider label="No value label" hide-value-label></sp-slider>
+<sp-slider label="No visible value label" label-visibility="text"></sp-slider>
 ```
+
+Use `label-visibility="value"` to supress the "text" label:
+
+```html
+<sp-slider label="No visible text label" label-visibility="value"></sp-slider>
+```
+
+Use `label-visibility="none"` to supress the "text" label:
+
+```html
+<sp-slider label="No visible labels" label-visibility="none"></sp-slider>
+```
+
+In each case outlined above the content for both labels will be made available to screen readers, so be sure to manage the content delivered to visitors in that context.
 
 ## Events
 

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -88,8 +88,8 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
         return this.getAriaValueText(this.handleController.formattedValues);
     }
 
-    @property({ type: Boolean, reflect: true, attribute: 'hide-value-label' })
-    public hideValueLabel = false;
+    @property({ type: String, reflect: true, attribute: 'label-visibility' })
+    public labelVisibility?: 'text' | 'value' | 'none';
 
     @property({ type: Number, reflect: true })
     public min = 0;
@@ -142,9 +142,16 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
     }
 
     private renderLabel(): TemplateResult {
+        const textLabelVisible =
+            this.labelVisibility === 'none' || this.labelVisibility === 'value';
+        const valueLabelVisible =
+            this.labelVisibility === 'none' || this.labelVisibility === 'text';
         return html`
             <div id="labelContainer">
                 <label
+                    class=${classMap({
+                        'visually-hidden': textLabelVisible,
+                    })}
                     id="label"
                     for=${this.handleController.activeHandleInputId}
                 >
@@ -153,7 +160,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                 </label>
                 <output
                     class=${classMap({
-                        'visually-hidden': this.hideValueLabel,
+                        'visually-hidden': valueLabelVisible,
                     })}
                     id="value"
                     aria-live="off"

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -143,3 +143,11 @@ governing permissions and limitations under the License.
     white-space: nowrap;
     width: 1px;
 }
+
+:host([label-visibility='value'][dir='ltr']) #value {
+    margin-left: auto;
+}
+
+:host([label-visibility='value'][dir='rtl']) #value {
+    margin-right: auto;
+}

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -50,16 +50,29 @@ export default {
                 type: 'number',
             },
         },
+        labelVisibility: {
+            name: 'Label Visibility',
+            description: 'The labels visibily available in the UI',
+            table: {
+                type: { summary: '"text" | "value" | "none" | undefined' },
+                defaultValue: { summary: undefined },
+            },
+            control: {
+                type: 'text',
+            },
+        },
     },
     args: {
         variant: undefined,
         tickStep: 0.1,
+        labelVisibility: undefined,
     },
 };
 
 interface StoryArgs {
     variant?: string;
     tickStep?: number;
+    labelVisibility?: string;
 }
 
 export const Default = (args: StoryArgs): TemplateResult => {
@@ -85,6 +98,90 @@ export const Default = (args: StoryArgs): TemplateResult => {
             </sp-slider>
         </div>
     `;
+};
+
+export const noVisibleTextLabel = (args: StoryArgs): TemplateResult => {
+    const handleEvent = (event: Event): void => {
+        const target = event.target as Slider;
+        if (target.value != null) {
+            action(event.type)(target.value.toString());
+        }
+    };
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                max="1"
+                min="0"
+                value=".5"
+                step="0.01"
+                @input=${handleEvent}
+                @change=${handleEvent}
+                .formatOptions=${{ style: 'percent' }}
+                ...=${spreadProps(args)}
+            >
+                Opacity
+            </sp-slider>
+        </div>
+    `;
+};
+noVisibleTextLabel.args = {
+    labelVisibility: 'value',
+};
+
+export const noVisibleValueLabel = (args: StoryArgs): TemplateResult => {
+    const handleEvent = (event: Event): void => {
+        const target = event.target as Slider;
+        if (target.value != null) {
+            action(event.type)(target.value.toString());
+        }
+    };
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                max="1"
+                min="0"
+                value=".5"
+                step="0.01"
+                @input=${handleEvent}
+                @change=${handleEvent}
+                .formatOptions=${{ style: 'percent' }}
+                ...=${spreadProps(args)}
+            >
+                Opacity
+            </sp-slider>
+        </div>
+    `;
+};
+noVisibleValueLabel.args = {
+    labelVisibility: 'text',
+};
+
+export const noVisibleLabels = (args: StoryArgs): TemplateResult => {
+    const handleEvent = (event: Event): void => {
+        const target = event.target as Slider;
+        if (target.value != null) {
+            action(event.type)(target.value.toString());
+        }
+    };
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                max="1"
+                min="0"
+                value=".5"
+                step="0.01"
+                @input=${handleEvent}
+                @change=${handleEvent}
+                .formatOptions=${{ style: 'percent' }}
+                ...=${spreadProps(args)}
+            >
+                Opacity
+            </sp-slider>
+        </div>
+    `;
+};
+noVisibleLabels.args = {
+    labelVisibility: 'none',
 };
 
 export const Gradient = (args: StoryArgs): TemplateResult => {


### PR DESCRIPTION
## Description
Allow control over the labelling that is surfaced by the `<sp-slider>` element while not requiring developers to leverage accessibility focused features to do so.

## Related Issue
fixes #1159

## Motivation and Context
Be accessible _and_ flexible.

## How Has This Been Tested?
VRTs

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
