### PR TITLE
Normalize size attribute usage pre-1.0

### DIFF
--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -192,13 +192,13 @@ Gallery cards can contain a heading, a subheading, an image preview, a descripti
 </div>
 ```
 
-### Small
+### Size
 
-The `small` attriibute can be applied to a standard card:
+`size="s"` will delivery the `<sp-card>` element at a "small" size. It can be leveraged with a standard card:
 
 ```html demo
 <div style="width: 208px; height: 264px">
-    <sp-card small heading="Card Heading" subheading="JPG Photo">
+    <sp-card size="s" heading="Card Heading" subheading="JPG Photo">
         <img
             slot="cover-photo"
             alt="Demo Image"
@@ -215,7 +215,7 @@ A `horizontal` card:
 <div
     style="color: var(--spectrum-body-text-color, var(--spectrum-alias-text-color));"
 >
-    <sp-card small horizontal heading="Card Heading" subheading="JPG Photo">
+    <sp-card size="s" horizontal heading="Card Heading" subheading="JPG Photo">
         <sp-icon slot="preview" style="width: 36px; height: 36px;">
             <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -241,7 +241,7 @@ Or a `quiet` card:
     style="color: var(--spectrum-body-text-color, var(--spectrum-alias-text-color)); width: 110px;"
 >
     <sp-card
-        small
+        size="s"
         heading="Card Heading"
         subheading="JPG Photo"
         variant="quiet"

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -65,8 +65,8 @@ export class Card extends ObserveSlotPresence(
     @property({ type: Boolean, reflect: true })
     public horizontal = false;
 
-    @property({ type: Boolean, reflect: true })
-    public small = false;
+    @property({ type: String, reflect: true })
+    public size?: 's';
 
     @property({ type: Boolean, reflect: true })
     public focused = false;
@@ -152,9 +152,7 @@ export class Card extends ObserveSlotPresence(
     protected get renderHeading(): TemplateResult {
         return html`
             <div class="title spectrum-Heading spectrum-Heading--sizeXS">
-                <slot name="heading">
-                    ${this.heading}
-                </slot>
+                <slot name="heading">${this.heading}</slot>
             </div>
         `;
     }
@@ -195,9 +193,7 @@ export class Card extends ObserveSlotPresence(
     private get renderSubtitleAndDescription(): TemplateResult {
         return html`
             <div class="subtitle spectrum-Detail spectrum-Detail--sizeS">
-                <slot name="subheading">
-                    ${this.subheading}
-                </slot>
+                <slot name="subheading">${this.subheading}</slot>
             </div>
             <slot name="description"></slot>
         `;
@@ -217,7 +213,7 @@ export class Card extends ObserveSlotPresence(
                       </sp-quick-actions>
                   `
                 : html``}
-            ${this.variant === 'quiet' && this.small
+            ${this.variant === 'quiet' && this.size === 's'
                 ? html`
                       <sp-quick-actions class="spectrum-QuickActions actions">
                           <slot name="actions"></slot>
@@ -231,7 +227,7 @@ export class Card extends ObserveSlotPresence(
                     ${this.variant === 'gallery'
                         ? this.renderSubtitleAndDescription
                         : html``}
-                    ${this.variant !== 'quiet' || !this.small
+                    ${this.variant !== 'quiet' || this.size !== 's'
                         ? html`
                               <div class="actionButton">
                                   <slot name="actions"></slot>

--- a/packages/card/src/spectrum-card.css
+++ b/packages/card/src/spectrum-card.css
@@ -451,35 +451,35 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Card--quiet .spectrum-Card-body */
     padding: 0;
 }
-:host([small]) {
+:host([size='s']) {
     /* .spectrum-Card--small */
     min-width: var(
         --spectrum-card-quiet-small-min-size,
         var(--spectrum-global-dimension-size-900)
     );
 }
-:host([dir='ltr'][small]) .quickActions {
+:host([dir='ltr'][size='s']) .quickActions {
     /* [dir=ltr] .spectrum-Card--small .spectrum-Card-quickActions */
     left: var(
         --spectrum-card-quiet-small-checkbox-margin,
         var(--spectrum-global-dimension-size-125)
     );
 }
-:host([dir='rtl'][small]) .quickActions {
+:host([dir='rtl'][size='s']) .quickActions {
     /* [dir=rtl] .spectrum-Card--small .spectrum-Card-quickActions */
     right: var(
         --spectrum-card-quiet-small-checkbox-margin,
         var(--spectrum-global-dimension-size-125)
     );
 }
-:host([small]) .quickActions {
+:host([size='s']) .quickActions {
     /* .spectrum-Card--small .spectrum-Card-quickActions */
     top: var(
         --spectrum-card-quiet-small-checkbox-margin,
         var(--spectrum-global-dimension-size-125)
     );
 }
-:host([small]) #preview {
+:host([size='s']) #preview {
     /* .spectrum-Card--small .spectrum-Card-preview */
     padding: var(
         --spectrum-card-quiet-small-preview-padding,
@@ -490,7 +490,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-900)
     );
 }
-:host([small]) .header {
+:host([size='s']) .header {
     /* .spectrum-Card--small .spectrum-Card-header */
     margin-top: var(
         --spectrum-card-quiet-small-body-margin-top,
@@ -501,7 +501,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-150)
     );
 }
-:host([small]) .title {
+:host([size='s']) .title {
     /* .spectrum-Card--small .spectrum-Card-title */
     font-size: var(
         --spectrum-card-quiet-small-title-text-size,

--- a/packages/card/src/spectrum-config.js
+++ b/packages/card/src/spectrum-config.js
@@ -79,9 +79,14 @@ const config = {
                     selector: '.is-drop-target',
                 },
                 {
-                    type: 'boolean',
-                    name: 'small',
-                    selector: '.spectrum-Card--small',
+                    type: 'enum',
+                    name: 'size',
+                    values: [
+                        {
+                            name: 's',
+                            selector: '.spectrum-Card--small',
+                        },
+                    ],
                 },
                 {
                     type: 'boolean',

--- a/packages/card/stories/card.stories.ts
+++ b/packages/card/stories/card.stories.ts
@@ -24,7 +24,7 @@ export default {
     component: 'sp-card',
     title: 'Card',
     args: {
-        small: false,
+        size: undefined,
         horizontal: false,
     },
     argTypes: {
@@ -39,21 +39,21 @@ export default {
                 type: 'boolean',
             },
         },
-        small: {
-            name: 'small',
-            type: { name: 'boolean', required: false },
+        size: {
+            name: 'size',
+            type: { name: 'string', required: false },
             table: {
-                type: { summary: 'boolean' },
-                defaultValue: { summary: false },
+                type: { summary: '"s"' },
+                defaultValue: { summary: undefined },
             },
-            control: { type: 'boolean' },
+            control: { type: 'text' },
         },
     },
 };
 
 interface StoryArgs {
     horizontal?: boolean;
-    small?: boolean;
+    size?: 's';
 }
 
 export const Default = (args: StoryArgs): TemplateResult => {
@@ -61,7 +61,7 @@ export const Default = (args: StoryArgs): TemplateResult => {
         <sp-card
             heading="Card Heading"
             subheading="JPG"
-            ?small=${args.small}
+            .size=${args.size}
             ?horizontal=${args.horizontal}
         >
             <img slot="cover-photo" src=${portrait} alt="Demo Graphic" />
@@ -76,7 +76,7 @@ export const actions = (args: StoryArgs): TemplateResult => {
         <sp-card
             heading="Card Heading"
             subheading="JPG"
-            ?small=${args.small}
+            .size=${args.size}
             ?horizontal=${args.horizontal}
         >
             <img slot="cover-photo" src=${portrait} alt="Demo Graphic" />
@@ -101,7 +101,7 @@ export const Gallery = (args: StoryArgs): TemplateResult => {
                 variant="gallery"
                 heading="Card Heading"
                 subheading="JPG"
-                ?small=${args.small}
+                .size=${args.size}
                 ?horizontal=${args.horizontal}
             >
                 <img
@@ -121,7 +121,7 @@ export const noPreviewImage = (args: StoryArgs): TemplateResult => {
         <sp-card
             heading="Card Heading"
             subheading="No preview image"
-            ?small=${args.small}
+            .size=${args.size}
             ?horizontal=${args.horizontal}
         >
             <div slot="footer">Footer</div>
@@ -136,7 +136,7 @@ export const Quiet = (args: StoryArgs): TemplateResult => {
                 variant="quiet"
                 heading="Card Heading"
                 subheading="JPG"
-                ?small=${args.small}
+                .size=${args.size}
                 ?horizontal=${args.horizontal}
             >
                 <img src=${portrait} alt="Demo Graphic" slot="preview" />
@@ -153,7 +153,7 @@ export const quietFile = (args: StoryArgs): TemplateResult => {
                 variant="quiet"
                 subheading="JPG"
                 asset="file"
-                ?small=${args.small}
+                .size=${args.size}
                 ?horizontal=${args.horizontal}
             >
                 <img src=${portrait} alt="Demo Graphic" slot="preview" />
@@ -171,7 +171,7 @@ export const quietFolder = (args: StoryArgs): TemplateResult => {
                 variant="quiet"
                 subheading="JPG"
                 asset="folder"
-                ?small=${args.small}
+                .size=${args.size}
                 ?horizontal=${args.horizontal}
             >
                 <img src=${portrait} alt="Demo Graphic" slot="preview" />
@@ -189,7 +189,7 @@ export const quietActions = (args: StoryArgs): TemplateResult => {
                 variant="quiet"
                 heading="Card Heading"
                 subheading="JPG"
-                ?small=${args.small}
+                .size=${args.size}
                 ?horizontal=${args.horizontal}
             >
                 <img src=${portrait} alt="Demo Graphic" slot="preview" />
@@ -218,7 +218,7 @@ export const small = (args: StoryArgs): TemplateResult => {
             style="--spectrum-card-title-padding-right: 0; --spectrum-card-title-padding-left: 0;"
         >
             <sp-card
-                ?small=${args.small}
+                .size=${args.size}
                 ?horizontal=${args.horizontal}
                 heading="Card Heading"
                 subheading="JPG"
@@ -235,13 +235,13 @@ export const small = (args: StoryArgs): TemplateResult => {
     `;
 };
 small.args = {
-    small: true,
+    size: 's',
 };
 
 export const smallHorizontal = (args: StoryArgs): TemplateResult => {
     return html`
         <sp-card
-            ?small=${args.small}
+            .size=${args.size}
             ?horizontal=${args.horizontal}
             heading="Card Heading"
             subheading="JPG"
@@ -255,14 +255,14 @@ export const smallHorizontal = (args: StoryArgs): TemplateResult => {
 };
 smallHorizontal.args = {
     horizontal: true,
-    small: true,
+    size: 's',
 };
 
 export const smallQuiet = (args: StoryArgs): TemplateResult => {
     return html`
         <div style="width: 115px">
             <sp-card
-                ?small=${args.small}
+                .size=${args.size}
                 ?horizontal=${args.horizontal}
                 heading="Card Heading"
                 subheading="JPG"
@@ -284,7 +284,7 @@ export const smallQuiet = (args: StoryArgs): TemplateResult => {
     `;
 };
 smallQuiet.args = {
-    small: true,
+    size: 's',
 };
 
 export const SlottedHeading = (args: StoryArgs): TemplateResult => {
@@ -304,7 +304,7 @@ export const SlottedHeading = (args: StoryArgs): TemplateResult => {
             --spectrum-alias-single-line-width: 100%;
         "
         >
-            <sp-card ?small=${args.small} ?horizontal=${args.horizontal}>
+            <sp-card .size=${args.size} ?horizontal=${args.horizontal}>
                 <img slot="cover-photo" src=${portrait} alt="Demo Graphic" />
                 <sp-textfield
                     class="slotted-textfield-heading"

--- a/packages/card/stories/card.stories.ts
+++ b/packages/card/stories/card.stories.ts
@@ -43,7 +43,7 @@ export default {
             name: 'size',
             type: { name: 'string', required: false },
             table: {
-                type: { summary: '"s"' },
+                type: { summary: '"s" | undefined' },
                 defaultValue: { summary: undefined },
             },
             control: { type: 'text' },
@@ -51,7 +51,7 @@ export default {
     },
 };
 
-interface StoryArgs {
+export interface StoryArgs {
     horizontal?: boolean;
     size?: 's';
 }

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -70,7 +70,7 @@ describe('card', () => {
         const el = await fixture<Card>(
             html`
                 <sp-card
-                    small
+                    size="s"
                     heading="Card Heading"
                     subheading="JPG"
                     variant="quiet"

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -18,7 +18,11 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
 
-import { Default, smallHorizontal } from '../stories/card.stories.js';
+import {
+    Default,
+    smallHorizontal,
+    StoryArgs,
+} from '../stories/card.stories.js';
 import { Checkbox } from '@spectrum-web-components/checkbox/src/Checkbox';
 import { spy } from 'sinon';
 import { spaceEvent } from '../../../test/testing-helpers.js';
@@ -125,7 +129,9 @@ describe('card', () => {
         await expect(el).to.be.accessible();
     });
     it('loads - [horizontal]', async () => {
-        const el = await fixture<Card>(smallHorizontal(smallHorizontal.args));
+        const el = await fixture<Card>(
+            smallHorizontal(smallHorizontal.args as StoryArgs)
+        );
 
         await elementUpdated(el);
 

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -24,61 +24,72 @@ When looking to leverage the `Dialog` base class as a type and/or for extension 
 import { Dialog } from '@spectrum-web-components/dialog';
 ```
 
+## Sizes
+
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
+
+```html demo
+<sp-dialog size="s">
+    <h2 slot="heading">Disclaimer</h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
+    augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam
+    in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra
+    nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo
+    duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus
+    nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem
+    ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu
+    mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
+    dignissim cras lobortis.
+</sp-dialog>
+```
+
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
+
+```html demo
+<sp-dialog size="m">
+    <h2 slot="heading">Disclaimer</h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
+    augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam
+    in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra
+    nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo
+    duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus
+    nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem
+    ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu
+    mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
+    dignissim cras lobortis.
+</sp-dialog>
+```
+
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
+
+```html demo
+<sp-dialog size="l">
+    <h2 slot="heading">Disclaimer</h2>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
+    augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam
+    in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra
+    nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo
+    duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus
+    nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem
+    ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu
+    mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
+    dignissim cras lobortis.
+</sp-dialog>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
 ## Variants
-
-### Small
-
-```html
-<sp-dialog size="small">
-    <h2 slot="heading">Disclaimer</h2>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
-    augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam
-    in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra
-    nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo
-    duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus
-    nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem
-    ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu
-    mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
-    dignissim cras lobortis.
-</sp-dialog>
-```
-
-### Medium
-
-```html
-<sp-dialog size="medium">
-    <h2 slot="heading">Disclaimer</h2>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
-    augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam
-    in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra
-    nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo
-    duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus
-    nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem
-    ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu
-    mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
-    dignissim cras lobortis.
-</sp-dialog>
-```
-
-### Large
-
-```html
-<sp-dialog size="large">
-    <h2 slot="heading">Disclaimer</h2>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
-    augue neque gravida. Libero volutpat sed ornare arcu. Quisque egestas diam
-    in arcu cursus euismod quis viverra. Posuere ac ut consequat semper viverra
-    nam libero justo laoreet. Enim ut tellus elementum sagittis vitae et leo
-    duis ut. Neque laoreet suspendisse interdum consectetur libero id faucibus
-    nisl. Diam volutpat commodo sed egestas egestas. Dolor magna eget est lorem
-    ipsum dolor. Vitae suscipit tellus mauris a diam maecenas sed. Turpis in eu
-    mi bibendum neque egestas congue. Rhoncus est pellentesque elit ullamcorper
-    dignissim cras lobortis.
-</sp-dialog>
-```
 
 ### Dismissable
 
@@ -87,7 +98,7 @@ When supplied with the `dissmissable` attribute an `<sp-dialog>` element will su
 Note: the `dissmissable` attribute will not be followed when `mode="fullscreen"` or `mode="fullscreenTakeover"` are applies in accordance with the Spectrum specification.
 
 ```html
-<sp-dialog size="medium" dismissable>
+<sp-dialog size="m" dismissable>
     <h2 slot="heading">Disclaimer</h2>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris
@@ -105,7 +116,7 @@ Note: the `dissmissable` attribute will not be followed when `mode="fullscreen"`
 ### No Divider
 
 ```html
-<sp-dialog size="medium" dismissable no-divider>
+<sp-dialog size="m" dismissable no-divider>
     <h2 slot="heading">Disclaimer</h2>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
     tempor incididunt ut labore et dolore magna aliqua. Auctor augue mauris

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -83,7 +83,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
     public mode?: 'fullscreen' | 'fullscreenTakeover';
 
     @property({ type: String, reflect: true })
-    public size?: 'small' | 'medium' | 'large' | 'alert';
+    public size?: 's' | 'm' | 'l';
 
     public focus(): void {
         if (this.shadowRoot) {

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -73,7 +73,7 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public mode?: 'fullscreen' | 'fullscreenTakeover';
 
     @property({ type: String, reflect: true })
-    public size?: 'small' | 'medium' | 'large' | 'alert';
+    public size?: 's' | 'm' | 'l';
 
     @property({ attribute: 'secondary-label' })
     public secondaryLabel = '';

--- a/packages/dialog/src/spectrum-config.js
+++ b/packages/dialog/src/spectrum-config.js
@@ -43,10 +43,18 @@ const config = {
                     type: 'enum',
                     name: 'size',
                     values: [
-                        '.spectrum-Dialog--small',
-                        '.spectrum-Dialog--medium',
-                        '.spectrum-Dialog--large',
-                        '.spectrum-Dialog--alert',
+                        {
+                            name: 's',
+                            selector: '.spectrum-Dialog--small',
+                        },
+                        {
+                            name: 'm',
+                            selector: '.spectrum-Dialog--medium',
+                        },
+                        {
+                            name: 'l',
+                            selector: '.spectrum-Dialog--large',
+                        },
                     ],
                 },
                 {

--- a/packages/dialog/src/spectrum-dialog.css
+++ b/packages/dialog/src/spectrum-dialog.css
@@ -60,15 +60,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     max-height: inherit;
     outline: none;
 }
-:host([size='small']) {
+:host([size='s']) {
     /* .spectrum-Dialog--small */
     width: var(--spectrum-dialog-confirm-small-width);
 }
-:host([size='medium']) {
+:host([size='m']) {
     /* .spectrum-Dialog--medium */
     width: var(--spectrum-dialog-confirm-medium-width);
 }
-:host([size='large']) {
+:host([size='l']) {
     /* .spectrum-Dialog--large */
     width: var(--spectrum-dialog-confirm-large-width);
 }

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -34,7 +34,7 @@ export const wrapperLabeledHero = (): TemplateResult => {
             dismissable
             headline="Wrapped Dialog w/ Hero Image"
             @close=${action('close')}
-            size="small"
+            size="s"
         >
             Content of the dialog
         </sp-dialog-wrapper>
@@ -62,7 +62,7 @@ export const wrapperDismissable = ({
             dismissable
             headline="Wrapped Dialog w/ Hero Image"
             @close=${announceAction('close')}
-            size="small"
+            size="s"
         >
             Content of the dialog
         </sp-dialog-wrapper>
@@ -90,7 +90,7 @@ export const wrapperDismissableUnderlay = (): TemplateResult => {
             headline="Wrapped Dialog w/ Hero Image"
             underlay
             @close=${action('close')}
-            size="small"
+            size="s"
         >
             Content of the dialog
         </sp-dialog-wrapper>
@@ -105,7 +105,7 @@ export const longContent = (): TemplateResult => {
                 headline="Dialog title"
                 dismissable
                 underlay
-                size="small"
+                size="s"
             >
                 <p>
                     Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
@@ -225,7 +225,7 @@ export const wrapperDismissableUnderlayError = (): TemplateResult => {
                 headline="Wrapped Dialog w/ Hero Image"
                 underlay
                 @close=${action('close')}
-                size="small"
+                size="s"
             >
                 Content of the dialog
             </sp-dialog-wrapper>
@@ -244,7 +244,7 @@ export const wrapperButtons = ({
     return html`
         <sp-dialog-wrapper
             open
-            size="large"
+            size="l"
             headline="Wrapped Dialog w/ Buttons"
             confirm-label="Keep Both"
             secondary-label="Replace"
@@ -264,7 +264,7 @@ export const wrapperButtonsUnderlay = (): TemplateResult => {
         <sp-dialog-wrapper
             open
             underlay
-            size="large"
+            size="l"
             headline="Wrapped Dialog w/ Buttons"
             confirm-label="Keep Both"
             secondary-label="Replace"

--- a/packages/dialog/stories/dialog.stories.ts
+++ b/packages/dialog/stories/dialog.stories.ts
@@ -23,7 +23,7 @@ export default {
 
 export const small = (): TemplateResult => {
     return html`
-        <sp-dialog size="small">
+        <sp-dialog size="s">
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
@@ -42,7 +42,7 @@ export const small = (): TemplateResult => {
 
 export const medium = (): TemplateResult => {
     return html`
-        <sp-dialog size="medium">
+        <sp-dialog size="m">
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
@@ -61,7 +61,7 @@ export const medium = (): TemplateResult => {
 
 export const large = (): TemplateResult => {
     return html`
-        <sp-dialog size="large">
+        <sp-dialog size="l">
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
@@ -80,7 +80,7 @@ export const large = (): TemplateResult => {
 
 export const dismissable = (): TemplateResult => {
     return html`
-        <sp-dialog size="medium" dismissable>
+        <sp-dialog size="m" dismissable>
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
@@ -99,7 +99,7 @@ export const dismissable = (): TemplateResult => {
 
 export const noDivider = (): TemplateResult => {
     return html`
-        <sp-dialog size="medium" dismissable no-divider>
+        <sp-dialog size="m" dismissable no-divider>
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
@@ -118,7 +118,7 @@ export const noDivider = (): TemplateResult => {
 
 export const hero = (): TemplateResult => {
     return html`
-        <sp-dialog size="medium" dismissable no-divider>
+        <sp-dialog size="m" dismissable no-divider>
             <div slot="hero" style="background-image: url(${landscape})"></div>
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/packages/tray/stories/tray.stories.ts
+++ b/packages/tray/stories/tray.stories.ts
@@ -47,7 +47,7 @@ type StoryArgs = {
 export const Default = (args: StoryArgs): TemplateResult => {
     return html`
         <sp-tray ?open=${args.open}>
-            <sp-dialog size="small">
+            <sp-dialog size="s">
                 <h2 slot="heading">New Messages</h2>
                 You have 5 new messages.
             </sp-dialog>


### PR DESCRIPTION
## Description
Normalize sizing attributes across packages not currently leveraging t-shirt sizing to make required breaking changes pre-1.0.
- `<sp-card small>` becomes `<sp-card size="s">`
- `<sp-dialog size="small|medium|large">` becomes `<sp-dialog size="s|m|l">`
- `<sp-dialog-wrapper size="small|medium|large">` becomes `<sp-dialog-wrapper size="s|m|l">`

https://normalize-size--spectrum-web-components.netlify.app/components/card
https://normalize-size--spectrum-web-components.netlify.app/components/dialog

## Related Issue
refs #865 

## Motivation and Context
Introduce expected breaking changes in our pre-1.0 environment.

## How Has This Been Tested?
VRTs

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
