### PR TITLE
perf: reorganize inheritance and composition in Menu Items

### DIFF
--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -218,9 +218,13 @@ describe('ActionGroup', () => {
         const el = await fixture<ActionGroup>(
             html`
                 <sp-action-group label="Selects Single Group" selects="single">
-                    <sp-action-button>First</sp-action-button>
-                    <sp-action-button selected>Second</sp-action-button>
-                    <sp-action-button class="third">Third</sp-action-button>
+                    <sp-action-button value="first">First</sp-action-button>
+                    <sp-action-button value="second" selected>
+                        Second
+                    </sp-action-button>
+                    <sp-action-button value="third" class="third">
+                        Third
+                    </sp-action-button>
                 </sp-action-group>
             `
         );
@@ -228,7 +232,7 @@ describe('ActionGroup', () => {
 
         await elementUpdated(el);
         expect(el.selected.length === 1);
-        expect(el.selected.includes('Second'));
+        expect(el.selected.includes('second'));
 
         thirdElement.click();
 
@@ -237,7 +241,7 @@ describe('ActionGroup', () => {
         expect(thirdElement.selected, 'third child selected');
 
         await waitUntil(
-            () => el.selected.length === 1 && el.selected.includes('Third'),
+            () => el.selected.length === 1 && el.selected.includes('third'),
             'Updates value of `selected`'
         );
     });

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -262,6 +262,9 @@ export class Menu extends SpectrumElement {
             }
             return el.getAttribute('role') === this.childRole;
         }) as MenuItem;
+        if (target?.href && target.href.length) {
+            return;
+        }
         if (target?.menuData.selectionRoot === this) {
             event.preventDefault();
             this.selectOrToggleItem(target);

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -40,3 +40,24 @@ governing permissions and limitations under the License.
 :host([dir='rtl']) [icon-only]::slotted(:last-of-type) {
     margin-left: auto;
 }
+
+:host([dir='ltr']) ::slotted([slot='icon']) {
+    /* [dir=ltr] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=ltr] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-right: var(--spectrum-listitem-icon-gap);
+}
+:host([dir='rtl']) ::slotted([slot='icon']) {
+    /* [dir=rtl] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=rtl] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-left: var(--spectrum-listitem-icon-gap);
+}
+:host([dir='rtl']) slot[name='icon'] + #label {
+    /* [dir=rtl] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=rtl] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-right: 0;
+}
+:host([dir='ltr']) slot[name='icon'] + #label {
+    /* [dir=ltr] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=ltr] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+    margin-left: 0;
+}

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -80,6 +80,11 @@ const config = {
                 },
                 {
                     type: 'boolean',
+                    selector: '.is-active',
+                    name: 'active',
+                },
+                {
+                    type: 'boolean',
                     selector: '.is-focused',
                     name: 'focused',
                 },

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -224,7 +224,7 @@ slot[name='icon'] + #label,
         var(--spectrum-alias-icon-color-selected)
     );
 }
-.is-active,
+:host([active]),
 :host(:active) {
     /* .spectrum-Menu-item .is-active,
    * .spectrum-Menu-item:active */

--- a/packages/menu/stories/menu-item.stories.ts
+++ b/packages/menu/stories/menu-item.stories.ts
@@ -78,7 +78,6 @@ export const href = (): TemplateResult => {
         <sp-menu style="width: 150px;">
             <sp-menu-item
                 href="https://opensource.adobe.com/spectrum-web-components"
-                target="_blank"
             >
                 <sp-icon-edit slot="icon"></sp-icon-edit>
                 Edit the Documentation Site

--- a/packages/picker/test/benchmark/basic-test.ts
+++ b/packages/picker/test/benchmark/basic-test.ts
@@ -277,5 +277,5 @@ measureFixtureCreation(
             )}
         </sp-picker>
     `,
-    { numRenders: 10 }
+    { numRenders: 20 }
 );


### PR DESCRIPTION
## Description
`<sp-menu-item>` is built with _many_ but not _all_ of the pieces of `<sp-action-button>`. The parts that it does't use are the least performant. Re-structure the `MenuItem` class with the used parts and increase its overall performance by removing the parts that are not used. 

## Related Issue
fixes #815 🙀 

## Motivation and Context
I feel the need, the need for speed. 

## How Has This Been Tested?
- new tests
- VRTs
- the below perf tests.

## Types of changes
- [x] Refactor

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.