### PR TITLE
fix: key interaction handling no longer prevents "tab" presses

### DIFF
--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -32,8 +32,6 @@ import { TinyColor } from '@ctrl/tinycolor';
 
 import styles from './color-area.css.js';
 
-const preventDefault = (event: KeyboardEvent): void => event.preventDefault();
-
 /**
  * @element sp-color-area
  */
@@ -171,6 +169,9 @@ export class ColorArea extends SpectrumElement {
         isString: false,
     };
 
+    @property({ attribute: false })
+    private activeAxis = 'x';
+
     @property({ type: Number })
     public x = 1;
 
@@ -211,15 +212,15 @@ export class ColorArea extends SpectrumElement {
 
     private handleKeydown(event: KeyboardEvent): void {
         const { key, code } = event;
-        event.preventDefault();
         if (['Shift', 'Meta', 'Control', 'Alt'].includes(key)) {
             this.altKeys.add(key);
             this.altered = this.altKeys.size;
         }
         if (code.search('Arrow') === 0) {
             this.activeKeys.add(code);
+            event.preventDefault();
+            this.handleKeypress();
         }
-        this.handleKeypress();
     }
 
     private handleKeypress(): void {
@@ -228,19 +229,15 @@ export class ColorArea extends SpectrumElement {
         this.activeKeys.forEach((code) => {
             switch (code) {
                 case 'ArrowUp':
-                case 'Up':
                     deltaY = this.step * -1;
                     break;
                 case 'ArrowDown':
-                case 'Down':
                     deltaY = this.step * 1;
                     break;
                 case 'ArrowLeft':
-                case 'Left':
                     deltaX = this.step * -1;
                     break;
                 case 'ArrowRight':
-                case 'Right':
                     deltaX = this.step * 1;
                     break;
                 /* c8 ignore next 2 */
@@ -249,8 +246,10 @@ export class ColorArea extends SpectrumElement {
             }
         });
         if (deltaX != 0) {
+            this.activeAxis = 'x';
             this.inputX.focus();
         } else if (deltaY != 0) {
+            this.activeAxis = 'y';
             this.inputY.focus();
         }
 
@@ -281,6 +280,7 @@ export class ColorArea extends SpectrumElement {
     }
 
     private handleKeyup(event: KeyboardEvent): void {
+        event.preventDefault();
         const { key, code } = event;
         if (['Shift', 'Meta', 'Control', 'Alt'].includes(key)) {
             this.altKeys.delete(key);
@@ -439,10 +439,10 @@ export class ColorArea extends SpectrumElement {
                 min="0"
                 max="1"
                 step=${this.step}
+                tabindex=${this.activeAxis === 'x' ? 0 : -1}
                 .value=${String(this.x)}
                 @input=${this.handleInput}
                 @change=${this.handleChange}
-                @keydown=${preventDefault}
             />
             <input
                 type="range"
@@ -452,10 +452,10 @@ export class ColorArea extends SpectrumElement {
                 min="0"
                 max="1"
                 step=${this.step}
+                tabindex=${this.activeAxis === 'y' ? 0 : -1}
                 .value=${String(this.y)}
                 @input=${this.handleInput}
                 @change=${this.handleChange}
-                @keydown=${preventDefault}
             />
         `;
     }

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -42,6 +42,64 @@ describe('ColorArea', () => {
 
         await expect(el).to.be.accessible();
     });
+    it('manages a single tab stop', async () => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <div>
+                    <input type="text" />
+                    <sp-color-area color="hsl(100, 50%, 50%)"></sp-color-area>
+                    <input type="text" />
+                </div>
+            `
+        );
+        const el = test.querySelector('sp-color-area') as ColorArea;
+        const input1 = test.querySelector(
+            'input:nth-of-type(1)'
+        ) as HTMLInputElement;
+        const input2 = test.querySelector(
+            'input:nth-of-type(2)'
+        ) as HTMLInputElement;
+
+        await elementUpdated(el);
+
+        input1.focus();
+
+        expect(document.activeElement).to.equal(input1);
+
+        await sendKeys({
+            press: 'Tab',
+        });
+
+        expect(document.activeElement).to.equal(el);
+
+        let value = el.value;
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        expect(el.value).to.not.equal(value);
+        await sendKeys({
+            press: 'Tab',
+        });
+
+        expect(document.activeElement).to.equal(input2);
+
+        await sendKeys({
+            press: 'Shift+Tab',
+        });
+
+        expect(document.activeElement).to.equal(el);
+
+        value = el.value;
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        expect(el.value).to.not.equal(value);
+        await sendKeys({
+            press: 'Shift+Tab',
+        });
+
+        expect(document.activeElement).to.equal(input1);
+    });
     it('accepts "color" values as hsl', async () => {
         const el = await fixture<ColorArea>(
             html`

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -204,7 +204,6 @@ export class ColorSlider extends Focusable {
     }
 
     private handleKeydown(event: KeyboardEvent): void {
-        event.preventDefault();
         const { key } = event;
         if (['Shift', 'Meta', 'Control', 'Alt'].includes(key)) {
             this.altKeys.add(key);
@@ -224,7 +223,10 @@ export class ColorSlider extends Focusable {
             case 'ArrowRight':
                 delta = this.step * (this.isLTR ? 1 : -1);
                 break;
+            default:
+                return;
         }
+        event.preventDefault();
 
         this.sliderHandlePosition = Math.min(
             100,

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -42,6 +42,65 @@ describe('ColorSlider', () => {
 
         await expect(el).to.be.accessible();
     });
+
+    it('manages a single tab stop', async () => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <div>
+                    <input type="text" id="test-input-1" />
+                    <sp-color-slider></sp-color-slider>
+                    <input type="text" id="test-input-2" />
+                </div>
+            `
+        );
+        const el = test.querySelector('sp-color-slider') as ColorSlider;
+        const input1 = test.querySelector(
+            'input:nth-of-type(1)'
+        ) as HTMLInputElement;
+        const input2 = test.querySelector(
+            'input:nth-of-type(2)'
+        ) as HTMLInputElement;
+
+        await elementUpdated(el);
+
+        input1.focus();
+
+        expect(document.activeElement).to.equal(input1);
+
+        await sendKeys({
+            press: 'Tab',
+        });
+
+        expect(document.activeElement).to.equal(el);
+
+        let value = el.value;
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        expect(el.value).to.not.equal(value);
+        await sendKeys({
+            press: 'Tab',
+        });
+
+        expect(document.activeElement).to.equal(input2);
+
+        await sendKeys({
+            press: 'Shift+Tab',
+        });
+
+        expect(document.activeElement).to.equal(el);
+
+        value = el.value;
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        expect(el.value).to.not.equal(value);
+        await sendKeys({
+            press: 'Shift+Tab',
+        });
+
+        expect(document.activeElement).to.equal(input1);
+    });
     it('manages [focused]', async () => {
         const el = await fixture<ColorSlider>(
             html`

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -213,9 +213,29 @@ export class ColorWheel extends Focusable {
             case 'ArrowRight':
                 delta = this.step * (this.isLTR ? 1 : -1);
                 break;
+            default:
+                return;
         }
+        event.preventDefault();
         this.value = (360 + this.value + delta) % 360;
+        this._previousColor = this._color.clone();
         this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
+        this.dispatchEvent(
+            new Event('input', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+        const applyDefault = this.dispatchEvent(
+            new Event('change', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
+            })
+        );
+        if (!applyDefault) {
+            this._color = this._previousColor;
+        }
     }
 
     private handleKeyup(event: KeyboardEvent): void {

--- a/packages/color-wheel/test/color-wheel.test.ts
+++ b/packages/color-wheel/test/color-wheel.test.ts
@@ -42,6 +42,65 @@ describe('ColorWheel', () => {
 
         await expect(el).to.be.accessible();
     });
+
+    it('manages a single tab stop', async () => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <div>
+                    <input type="text" id="test-input-1" />
+                    <sp-color-wheel></sp-color-wheel>
+                    <input type="text" id="test-input-2" />
+                </div>
+            `
+        );
+        const el = test.querySelector('sp-color-wheel') as ColorWheel;
+        const input1 = test.querySelector(
+            'input:nth-of-type(1)'
+        ) as HTMLInputElement;
+        const input2 = test.querySelector(
+            'input:nth-of-type(2)'
+        ) as HTMLInputElement;
+
+        await elementUpdated(el);
+
+        input1.focus();
+
+        expect(document.activeElement).to.equal(input1);
+
+        await sendKeys({
+            press: 'Tab',
+        });
+
+        expect(document.activeElement).to.equal(el);
+
+        let value = el.value;
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        expect(el.value).to.not.equal(value);
+        await sendKeys({
+            press: 'Tab',
+        });
+
+        expect(document.activeElement).to.equal(input2);
+
+        await sendKeys({
+            press: 'Shift+Tab',
+        });
+
+        expect(document.activeElement).to.equal(el);
+
+        value = el.value;
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        expect(el.value).to.not.equal(value);
+        await sendKeys({
+            press: 'Shift+Tab',
+        });
+
+        expect(document.activeElement).to.equal(input1);
+    });
     it('manages [focused]', async () => {
         const el = await fixture<ColorWheel>(
             html`


### PR DESCRIPTION
## Description
- ensure the `<sp-color-area>` and `<sp-color-sldier>` have a single tab stop and the the tab order does not get trapped within these elements

## Related Issue
fixes #1692 

## Motivation and Context
Color application interfaces should be keyboard accessible.

## How Has This Been Tested?
- unit tests
- manual test

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
