### PR TITLE
[RFC] feat: allow native :dir(...) selector usage where availables

### DIFF
--- a/packages/accordion/src/spectrum-accordion-item.css
+++ b/packages/accordion/src/spectrum-accordion-item.css
@@ -10,16 +10,38 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host(:dir(ltr)) #indicator {
+    left: var(
+        --spectrum-accordion-item-padding-x,
+        var(--spectrum-global-dimension-size-225)
+    ); /* [dir=ltr] .spectrum-Accordion-itemIndicator */
+}
 :host([dir='ltr']) #indicator {
     left: var(
         --spectrum-accordion-item-padding-x,
         var(--spectrum-global-dimension-size-225)
     ); /* [dir=ltr] .spectrum-Accordion-itemIndicator */
 }
+:host(:dir(rtl)) #indicator {
+    right: var(
+        --spectrum-accordion-item-padding-x,
+        var(--spectrum-global-dimension-size-225)
+    ); /* [dir=rtl] .spectrum-Accordion-itemIndicator */
+}
 :host([dir='rtl']) #indicator {
     right: var(
         --spectrum-accordion-item-padding-x,
         var(--spectrum-global-dimension-size-225)
+    ); /* [dir=rtl] .spectrum-Accordion-itemIndicator */
+}
+:host(:dir(rtl)) #indicator {
+    transform: matrix(
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0
     ); /* [dir=rtl] .spectrum-Accordion-itemIndicator */
 }
 :host([dir='rtl']) #indicator {
@@ -67,6 +89,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin: 0; /* .spectrum-Accordion-itemHeading */
     position: relative;
 }
+:host(:dir(ltr)) #header {
+    padding-left: calc(
+        var(
+                --spectrum-accordion-item-padding-x,
+                var(--spectrum-global-dimension-size-225)
+            ) +
+            var(
+                --spectrum-accordion-icon-height,
+                var(--spectrum-global-dimension-size-125)
+            ) +
+            var(
+                --spectrum-accordion-icon-gap,
+                var(--spectrum-global-dimension-size-100)
+            ) +
+            var(
+                --spectrum-accordion-item-border-left-size,
+                var(--spectrum-alias-border-size-thick)
+            )
+    ); /* [dir=ltr] .spectrum-Accordion-itemHeader */
+}
 :host([dir='ltr']) #header {
     padding-left: calc(
         var(
@@ -86,6 +128,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-alias-border-size-thick)
             )
     ); /* [dir=ltr] .spectrum-Accordion-itemHeader */
+}
+:host(:dir(rtl)) #header {
+    padding-right: calc(
+        var(
+                --spectrum-accordion-item-padding-x,
+                var(--spectrum-global-dimension-size-225)
+            ) +
+            var(
+                --spectrum-accordion-icon-height,
+                var(--spectrum-global-dimension-size-125)
+            ) +
+            var(
+                --spectrum-accordion-icon-gap,
+                var(--spectrum-global-dimension-size-100)
+            ) +
+            var(
+                --spectrum-accordion-item-border-left-size,
+                var(--spectrum-alias-border-size-thick)
+            )
+    ); /* [dir=rtl] .spectrum-Accordion-itemHeader */
 }
 :host([dir='rtl']) #header {
     padding-right: calc(
@@ -107,11 +169,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=rtl] .spectrum-Accordion-itemHeader */
 }
+:host(:dir(ltr)) #header {
+    padding-right: var(
+        --spectrum-accordion-item-padding-x,
+        var(--spectrum-global-dimension-size-225)
+    ); /* [dir=ltr] .spectrum-Accordion-itemHeader */
+}
 :host([dir='ltr']) #header {
     padding-right: var(
         --spectrum-accordion-item-padding-x,
         var(--spectrum-global-dimension-size-225)
     ); /* [dir=ltr] .spectrum-Accordion-itemHeader */
+}
+:host(:dir(rtl)) #header {
+    padding-left: var(
+        --spectrum-accordion-item-padding-x,
+        var(--spectrum-global-dimension-size-225)
+    ); /* [dir=rtl] .spectrum-Accordion-itemHeader */
 }
 :host([dir='rtl']) #header {
     padding-left: var(
@@ -119,8 +193,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-225)
     ); /* [dir=rtl] .spectrum-Accordion-itemHeader */
 }
+:host(:dir(ltr)) #header {
+    text-align: left; /* [dir=ltr] .spectrum-Accordion-itemHeader */
+}
 :host([dir='ltr']) #header {
     text-align: left; /* [dir=ltr] .spectrum-Accordion-itemHeader */
+}
+:host(:dir(rtl)) #header {
+    text-align: right; /* [dir=rtl] .spectrum-Accordion-itemHeader */
 }
 :host([dir='rtl']) #header {
     text-align: right; /* [dir=rtl] .spectrum-Accordion-itemHeader */
@@ -169,8 +249,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #header:focus {
     outline: none; /* .spectrum-Accordion-itemHeader:focus */
 }
+:host(:dir(ltr)) #header:focus:after {
+    left: 0; /* [dir=ltr] .spectrum-Accordion-itemHeader:focus:after */
+}
 :host([dir='ltr']) #header:focus:after {
     left: 0; /* [dir=ltr] .spectrum-Accordion-itemHeader:focus:after */
+}
+:host(:dir(rtl)) #header:focus:after {
+    right: 0; /* [dir=rtl] .spectrum-Accordion-itemHeader:focus:after */
 }
 :host([dir='rtl']) #header:focus:after {
     right: 0; /* [dir=rtl] .spectrum-Accordion-itemHeader:focus:after */
@@ -211,18 +297,34 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     padding-top: 0; /* .spectrum-Accordion-itemContent */
 }
+:host(:dir(ltr)[open]) > #heading > #indicator {
+    transform: rotate(
+        90deg
+    ); /* [dir=ltr] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemHeading>.spectrum-Accordion-itemIndicator */
+}
 :host([dir='ltr'][open]) > #heading > #indicator {
     transform: rotate(
         90deg
     ); /* [dir=ltr] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemHeading>.spectrum-Accordion-itemIndicator */
 }
+:host(:dir(rtl)[open]) > #heading > #indicator {
+    transform: matrix(-1, 0, 0, 1, 0, 0) rotate(90deg); /* [dir=rtl] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemHeading>.spectrum-Accordion-itemIndicator */
+}
 :host([dir='rtl'][open]) > #heading > #indicator {
     transform: matrix(-1, 0, 0, 1, 0, 0) rotate(90deg); /* [dir=rtl] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemHeading>.spectrum-Accordion-itemIndicator */
+}
+:host(:dir(ltr)[open]) > #indicator {
+    transform: rotate(
+        90deg
+    ); /* [dir=ltr] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemIndicator */
 }
 :host([dir='ltr'][open]) > #indicator {
     transform: rotate(
         90deg
     ); /* [dir=ltr] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemIndicator */
+}
+:host(:dir(rtl)[open]) > #indicator {
+    transform: matrix(-1, 0, 0, 1, 0, 0) rotate(90deg); /* [dir=rtl] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemIndicator */
 }
 :host([dir='rtl'][open]) > #indicator {
     transform: matrix(-1, 0, 0, 1, 0, 0) rotate(90deg); /* [dir=rtl] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemIndicator */

--- a/packages/action-bar/src/spectrum-action-bar.css
+++ b/packages/action-bar/src/spectrum-action-bar.css
@@ -48,14 +48,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-ActionBar.is-open */
     opacity: 1;
 }
+:host(:dir(ltr)[variant='sticky']) {
+    left: 0; /* [dir=ltr] .spectrum-ActionBar--sticky */
+}
 :host([dir='ltr'][variant='sticky']) {
     left: 0; /* [dir=ltr] .spectrum-ActionBar--sticky */
+}
+:host(:dir(rtl)[variant='sticky']) {
+    right: 0; /* [dir=rtl] .spectrum-ActionBar--sticky */
 }
 :host([dir='rtl'][variant='sticky']) {
     right: 0; /* [dir=rtl] .spectrum-ActionBar--sticky */
 }
+:host(:dir(ltr)[variant='sticky']) {
+    right: 0; /* [dir=ltr] .spectrum-ActionBar--sticky */
+}
 :host([dir='ltr'][variant='sticky']) {
     right: 0; /* [dir=ltr] .spectrum-ActionBar--sticky */
+}
+:host(:dir(rtl)[variant='sticky']) {
+    left: 0; /* [dir=rtl] .spectrum-ActionBar--sticky */
 }
 :host([dir='rtl'][variant='sticky']) {
     left: 0; /* [dir=rtl] .spectrum-ActionBar--sticky */
@@ -69,20 +81,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([variant='fixed']) {
     position: fixed; /* .spectrum-ActionBar--fixed */
 }
+:host(:dir(ltr)) #popover {
+    padding-left: var(
+        --spectrum-actionbar-padding-left
+    ); /* [dir=ltr] .spectrum-ActionBar-popover */
+}
 :host([dir='ltr']) #popover {
     padding-left: var(
         --spectrum-actionbar-padding-left
     ); /* [dir=ltr] .spectrum-ActionBar-popover */
+}
+:host(:dir(rtl)) #popover {
+    padding-right: var(
+        --spectrum-actionbar-padding-left
+    ); /* [dir=rtl] .spectrum-ActionBar-popover */
 }
 :host([dir='rtl']) #popover {
     padding-right: var(
         --spectrum-actionbar-padding-left
     ); /* [dir=rtl] .spectrum-ActionBar-popover */
 }
+:host(:dir(ltr)) #popover {
+    padding-right: var(
+        --spectrum-actionbar-padding-right
+    ); /* [dir=ltr] .spectrum-ActionBar-popover */
+}
 :host([dir='ltr']) #popover {
     padding-right: var(
         --spectrum-actionbar-padding-right
     ); /* [dir=ltr] .spectrum-ActionBar-popover */
+}
+:host(:dir(rtl)) #popover {
+    padding-left: var(
+        --spectrum-actionbar-padding-right
+    ); /* [dir=rtl] .spectrum-ActionBar-popover */
 }
 :host([dir='rtl']) #popover {
     padding-left: var(

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -1149,11 +1149,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-actionbutton-focus-ring-gap)
     );
 }
+:host(:dir(ltr)) {
+    padding-left: var(
+        --spectrum-actionbutton-textonly-padding-left-adjusted
+    ); /* [dir=ltr] .spectrum-ActionButton */
+    padding-right: var(--spectrum-actionbutton-textonly-padding-right-adjusted);
+}
 :host([dir='ltr']) {
     padding-left: var(
         --spectrum-actionbutton-textonly-padding-left-adjusted
     ); /* [dir=ltr] .spectrum-ActionButton */
     padding-right: var(--spectrum-actionbutton-textonly-padding-right-adjusted);
+}
+:host(:dir(rtl)) {
+    padding-left: var(--spectrum-actionbutton-textonly-padding-right-adjusted);
+    padding-right: var(
+        --spectrum-actionbutton-textonly-padding-left-adjusted
+    ); /* [dir=rtl] .spectrum-ActionButton */
 }
 :host([dir='rtl']) {
     padding-left: var(--spectrum-actionbutton-textonly-padding-right-adjusted);
@@ -1172,6 +1184,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     min-width: var(--spectrum-actionbutton-textonly-min-width);
     position: relative; /* .spectrum-ActionButton */
 }
+:host(:dir(ltr)) ::slotted([slot='icon']) {
+    margin-left: calc(
+        (
+                var(--spectrum-actionbutton-textonly-padding-left-adjusted) -
+                    var(--spectrum-actionbutton-padding-left-adjusted)
+            ) * -1
+    ); /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon */
+}
 :host([dir='ltr']) ::slotted([slot='icon']) {
     margin-left: calc(
         (
@@ -1179,6 +1199,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                     var(--spectrum-actionbutton-padding-left-adjusted)
             ) * -1
     ); /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon */
+}
+:host(:dir(rtl)) ::slotted([slot='icon']) {
+    margin-right: calc(
+        (
+                var(--spectrum-actionbutton-textonly-padding-left-adjusted) -
+                    var(--spectrum-actionbutton-padding-left-adjusted)
+            ) * -1
+    ); /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon */
 }
 :host([dir='rtl']) ::slotted([slot='icon']) {
     margin-right: calc(
@@ -1188,25 +1216,41 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1
     ); /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon */
 }
+:host(:dir(ltr)) slot[name='icon'] + #label {
+    padding-left: var(
+        --spectrum-actionbutton-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
+}
 :host([dir='ltr']) slot[name='icon'] + #label {
     padding-left: var(
         --spectrum-actionbutton-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
+}
+:host(:dir(rtl)) slot[name='icon'] + #label {
+    padding-right: var(
+        --spectrum-actionbutton-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
 }
 :host([dir='rtl']) slot[name='icon'] + #label {
     padding-right: var(
         --spectrum-actionbutton-texticon-icon-gap
     ); /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
 }
+:host(:dir(ltr)) slot[name='icon'] + #label {
+    padding-right: 0; /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
+}
 :host([dir='ltr']) slot[name='icon'] + #label {
     padding-right: 0; /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
+}
+:host(:dir(rtl)) slot[name='icon'] + #label {
+    padding-left: 0; /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
 }
 :host([dir='rtl']) slot[name='icon'] + #label {
     padding-left: 0; /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon+.spectrum-ActionButton-label */
 }
 .hold-affordance + ::slotted([slot='icon']),
-:host([dir]) slot[icon-only] sp-icon,
-:host([dir]) slot[icon-only]::slotted([slot='icon']) {
+:host slot[icon-only] sp-icon,
+:host slot[icon-only]::slotted([slot='icon']) {
     margin-left: calc(
         (
                 var(--spectrum-actionbutton-textonly-padding-left-adjusted) -
@@ -1226,14 +1270,34 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     text-overflow: ellipsis;
     white-space: nowrap; /* .spectrum-ActionButton-label */
 }
+:host(:dir(ltr)) .hold-affordance {
+    right: var(
+        --spectrum-actionbutton-textonly-hold-icon-padding-right
+    ); /* [dir=ltr] .spectrum-ActionButton-hold */
+}
 :host([dir='ltr']) .hold-affordance {
     right: var(
         --spectrum-actionbutton-textonly-hold-icon-padding-right
     ); /* [dir=ltr] .spectrum-ActionButton-hold */
 }
+:host(:dir(rtl)) .hold-affordance {
+    left: var(
+        --spectrum-actionbutton-textonly-hold-icon-padding-right
+    ); /* [dir=rtl] .spectrum-ActionButton-hold */
+}
 :host([dir='rtl']) .hold-affordance {
     left: var(
         --spectrum-actionbutton-textonly-hold-icon-padding-right
+    ); /* [dir=rtl] .spectrum-ActionButton-hold */
+}
+:host(:dir(rtl)) .hold-affordance {
+    transform: matrix(
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0
     ); /* [dir=rtl] .spectrum-ActionButton-hold */
 }
 :host([dir='rtl']) .hold-affordance {

--- a/packages/action-button/src/spectrum-config.js
+++ b/packages/action-button/src/spectrum-config.js
@@ -110,7 +110,7 @@ const config = {
             complexSelectors: [
                 {
                     replacement:
-                        ":host([dir]) slot[icon-only]::slotted([slot='icon']), :host([dir]) slot[icon-only] sp-icon",
+                        ":host slot[icon-only]::slotted([slot='icon']), :host slot[icon-only] sp-icon",
                     selector:
                         '.spectrum-ActionButton .spectrum-Icon:only-child',
                 },

--- a/packages/action-group/src/action-group.css
+++ b/packages/action-group/src/action-group.css
@@ -78,6 +78,23 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-component-border-radius);
 }
 
+:host(:dir(ltr)[compact]:not([quiet]):not([vertical]))
+    ::slotted(:not([role]):first-child) {
+    /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+    --spectrum-actionbutton-m-border-radius: var(
+            --spectrum-alias-border-radius-regular
+        )
+        0 0 var(--spectrum-alias-border-radius-regular);
+}
+
+:host(:dir(rtl)[compact]:not([quiet]):not([vertical]))
+    ::slotted(:not([role]):first-child) {
+    /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+    --spectrum-actionbutton-m-border-radius: 0
+        var(--spectrum-alias-border-radius-regular)
+        var(--spectrum-alias-border-radius-regular) 0;
+}
+
 :host([dir='ltr'][compact]:not([quiet]):not([vertical]))
     ::slotted(:not([role]):first-child) {
     /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
@@ -90,6 +107,23 @@ governing permissions and limitations under the License.
     /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
     --overriden-border-radius: 0 var(--spectrum-alias-component-border-radius)
         var(--spectrum-alias-component-border-radius) 0;
+}
+
+:host(:dir(ltr)[compact]:not([quiet]):not([vertical]))
+    ::slotted(:not([role]):last-child) {
+    /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+    --spectrum-actionbutton-m-border-radius: 0
+        var(--spectrum-alias-border-radius-regular)
+        var(--spectrum-alias-border-radius-regular) 0;
+}
+
+:host(:dir(rtl)[compact]:not([quiet]):not([vertical]))
+    ::slotted(:not([role]):last-child) {
+    /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+    --spectrum-actionbutton-m-border-radius: var(
+            --spectrum-alias-border-radius-regular
+        )
+        0 0 var(--spectrum-alias-border-radius-regular);
 }
 
 :host([dir='ltr'][compact]:not([quiet]):not([vertical]))

--- a/packages/action-group/src/spectrum-action-group.css
+++ b/packages/action-group/src/spectrum-action-group.css
@@ -35,11 +35,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-actiongroup-button-gap)
     );
 }
+:host(:dir(ltr):not([vertical]):not([compact])) ::slotted(:not(:last-child)) {
+    margin-right: var(
+        --spectrum-actiongroup-button-gap-x,
+        var(--spectrum-alias-actiongroup-button-gap)
+    ); /* [dir=ltr] .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) .spectrum-ActionGroup-item:not(:last-child) */
+}
 :host([dir='ltr']:not([vertical]):not([compact])) ::slotted(:not(:last-child)) {
     margin-right: var(
         --spectrum-actiongroup-button-gap-x,
         var(--spectrum-alias-actiongroup-button-gap)
     ); /* [dir=ltr] .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) .spectrum-ActionGroup-item:not(:last-child) */
+}
+:host(:dir(rtl):not([vertical]):not([compact])) ::slotted(:not(:last-child)) {
+    margin-left: var(
+        --spectrum-actiongroup-button-gap-x,
+        var(--spectrum-alias-actiongroup-button-gap)
+    ); /* [dir=rtl] .spectrum-ActionGroup:not(.spectrum-ActionGroup--vertical).spectrum-ActionGroup:not(.spectrum-ActionGroup--compact) .spectrum-ActionGroup-item:not(:last-child) */
 }
 :host([dir='rtl']:not([vertical]):not([compact])) ::slotted(:not(:last-child)) {
     margin-left: var(
@@ -51,10 +63,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: inline-flex; /* .spectrum-ActionGroup--vertical */
     flex-direction: column;
 }
+:host(:dir(ltr)[vertical]) ::slotted(:not(:first-child)) {
+    margin-left: var(
+        --spectrum-actiongroup-button-gap-reset
+    ); /* [dir=ltr] .spectrum-ActionGroup--vertical .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
 :host([dir='ltr'][vertical]) ::slotted(:not(:first-child)) {
     margin-left: var(
         --spectrum-actiongroup-button-gap-reset
     ); /* [dir=ltr] .spectrum-ActionGroup--vertical .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
+:host(:dir(rtl)[vertical]) ::slotted(:not(:first-child)) {
+    margin-right: var(
+        --spectrum-actiongroup-button-gap-reset
+    ); /* [dir=rtl] .spectrum-ActionGroup--vertical .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
 :host([dir='rtl'][vertical]) ::slotted(:not(:first-child)) {
     margin-right: var(
@@ -67,10 +89,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-actiongroup-button-gap)
     ); /* .spectrum-ActionGroup--vertical .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
+:host(:dir(ltr)[vertical][vertical]) {
+    margin-left: var(
+        --spectrum-actiongroup-button-gap-reset
+    ); /* [dir=ltr] .spectrum-ActionGroup--vertical.spectrum-ActionGroup--vertical */
+}
 :host([dir='ltr'][vertical][vertical]) {
     margin-left: var(
         --spectrum-actiongroup-button-gap-reset
     ); /* [dir=ltr] .spectrum-ActionGroup--vertical.spectrum-ActionGroup--vertical */
+}
+:host(:dir(rtl)[vertical][vertical]) {
+    margin-right: var(
+        --spectrum-actiongroup-button-gap-reset
+    ); /* [dir=rtl] .spectrum-ActionGroup--vertical.spectrum-ActionGroup--vertical */
 }
 :host([dir='rtl'][vertical][vertical]) {
     margin-right: var(
@@ -89,11 +121,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-actiongroup-button-gap-compact)
     ); /* .spectrum-ActionGroup--compact */
 }
+:host(:dir(ltr)[compact][quiet]) ::slotted(:not(:first-child)) {
+    margin-left: var(
+        --spectrum-actiongroup-quiet-compact-button-gap,
+        var(--spectrum-alias-actiongroup-button-gap-quiet-compact)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact.spectrum-ActionGroup--quiet .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
 :host([dir='ltr'][compact][quiet]) ::slotted(:not(:first-child)) {
     margin-left: var(
         --spectrum-actiongroup-quiet-compact-button-gap,
         var(--spectrum-alias-actiongroup-button-gap-quiet-compact)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact.spectrum-ActionGroup--quiet .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
+:host(:dir(rtl)[compact][quiet]) ::slotted(:not(:first-child)) {
+    margin-right: var(
+        --spectrum-actiongroup-quiet-compact-button-gap,
+        var(--spectrum-alias-actiongroup-button-gap-quiet-compact)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact.spectrum-ActionGroup--quiet .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
 :host([dir='rtl'][compact][quiet]) ::slotted(:not(:first-child)) {
     margin-right: var(
@@ -106,10 +150,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-actiongroup-button-gap-reset
     ); /* .spectrum-ActionGroup--compact.spectrum-ActionGroup--quiet .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
+:host(:dir(ltr)[compact][quiet][vertical]) ::slotted(:not(:first-child)) {
+    margin-left: var(
+        --spectrum-actiongroup-button-gap-reset
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact.spectrum-ActionGroup--quiet.spectrum-ActionGroup--vertical .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
 :host([dir='ltr'][compact][quiet][vertical]) ::slotted(:not(:first-child)) {
     margin-left: var(
         --spectrum-actiongroup-button-gap-reset
     ); /* [dir=ltr] .spectrum-ActionGroup--compact.spectrum-ActionGroup--quiet.spectrum-ActionGroup--vertical .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
+:host(:dir(rtl)[compact][quiet][vertical]) ::slotted(:not(:first-child)) {
+    margin-right: var(
+        --spectrum-actiongroup-button-gap-reset
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact.spectrum-ActionGroup--quiet.spectrum-ActionGroup--vertical .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
 :host([dir='rtl'][compact][quiet][vertical]) ::slotted(:not(:first-child)) {
     margin-right: var(
@@ -134,11 +188,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     position: relative; /* .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item */
     z-index: 0;
 }
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:first-child) {
+    border-top-left-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+}
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:first-child) {
     border-top-left-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+}
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:first-child) {
+    border-top-right-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
 }
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:first-child) {
     border-top-right-radius: var(
@@ -146,17 +212,37 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
 }
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:first-child) {
+    border-bottom-left-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+}
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:first-child) {
     border-bottom-left-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
 }
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:first-child) {
+    border-bottom-right-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+}
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:first-child) {
     border-bottom-right-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+}
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:first-child) {
+    margin-right: calc(
+        var(
+                --spectrum-actionbutton-m-texticon-border-size,
+                var(--spectrum-alias-border-size-thin)
+            ) * -1 / 2
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
 }
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:first-child) {
     margin-right: calc(
@@ -165,6 +251,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-alias-border-size-thin)
             ) * -1 / 2
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
+}
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:first-child) {
+    margin-left: calc(
+        var(
+                --spectrum-actionbutton-m-texticon-border-size,
+                var(--spectrum-alias-border-size-thin)
+            ) * -1 / 2
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
 }
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:first-child) {
     margin-left: calc(
@@ -204,11 +298,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 )
         ); /* .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:first-child */
 }
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:last-child) {
+    border-top-right-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+}
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:last-child) {
     border-top-right-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+}
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:last-child) {
+    border-top-left-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
 }
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:last-child) {
     border-top-left-radius: var(
@@ -216,17 +322,37 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
 }
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:last-child) {
+    border-bottom-right-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+}
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:last-child) {
     border-bottom-right-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
 }
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:last-child) {
+    border-bottom-left-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+}
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:last-child) {
     border-bottom-left-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+}
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:last-child) {
+    margin-left: calc(
+        var(
+                --spectrum-actionbutton-m-texticon-border-size,
+                var(--spectrum-alias-border-size-thin)
+            ) * -1 / 2
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
 }
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:last-child) {
     margin-left: calc(
@@ -236,6 +362,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1 / 2
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
 }
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:last-child) {
+    margin-right: calc(
+        var(
+                --spectrum-actionbutton-m-texticon-border-size,
+                var(--spectrum-alias-border-size-thin)
+            ) * -1 / 2
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+}
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:last-child) {
     margin-right: calc(
         var(
@@ -244,8 +378,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1 / 2
     ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
 }
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:last-child) {
+    margin-right: 0; /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+}
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:last-child) {
     margin-right: 0; /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
+}
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:last-child) {
+    margin-left: 0; /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
 }
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:last-child) {
     margin-left: 0; /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item:last-child */
@@ -292,6 +432,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([compact]:not([quiet])) ::slotted(:focus-visible) {
     z-index: 3; /* .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item.focus-ring */
 }
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:not(:first-child)) {
+    margin-left: calc(
+        var(
+                --spectrum-actionbutton-m-texticon-border-size,
+                var(--spectrum-alias-border-size-thin)
+            ) * -1 / 2
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:not(:first-child)) {
     margin-left: calc(
         var(
@@ -299,6 +447,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-alias-border-size-thin)
             ) * -1 / 2
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:not(:first-child)) {
+    margin-right: calc(
+        var(
+                --spectrum-actionbutton-m-texticon-border-size,
+                var(--spectrum-alias-border-size-thin)
+            ) * -1 / 2
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:not(:first-child)) {
     margin-right: calc(
@@ -308,6 +464,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1 / 2
     ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
+:host(:dir(ltr)[compact]:not([quiet])) ::slotted(:not(:first-child)) {
+    margin-right: calc(
+        var(
+                --spectrum-actionbutton-m-texticon-border-size,
+                var(--spectrum-alias-border-size-thin)
+            ) * -1 / 2
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
 :host([dir='ltr'][compact]:not([quiet])) ::slotted(:not(:first-child)) {
     margin-right: calc(
         var(
@@ -315,6 +479,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-alias-border-size-thin)
             ) * -1 / 2
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
+}
+:host(:dir(rtl)[compact]:not([quiet])) ::slotted(:not(:first-child)) {
+    margin-left: calc(
+        var(
+                --spectrum-actionbutton-m-texticon-border-size,
+                var(--spectrum-alias-border-size-thin)
+            ) * -1 / 2
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet) .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
 :host([dir='rtl'][compact]:not([quiet])) ::slotted(:not(:first-child)) {
     margin-left: calc(
@@ -344,11 +516,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1 / 2
     ); /* .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item+.spectrum-ActionGroup-item */
 }
+:host(:dir(ltr)[compact][vertical]:not([quiet])) ::slotted(:first-child) {
+    border-top-left-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:first-child */
+}
 :host([dir='ltr'][compact][vertical]:not([quiet])) ::slotted(:first-child) {
     border-top-left-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:first-child */
+}
+:host(:dir(rtl)[compact][vertical]:not([quiet])) ::slotted(:first-child) {
+    border-top-right-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:first-child */
 }
 :host([dir='rtl'][compact][vertical]:not([quiet])) ::slotted(:first-child) {
     border-top-right-radius: var(
@@ -356,11 +540,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:first-child */
 }
+:host(:dir(ltr)[compact][vertical]:not([quiet])) ::slotted(:first-child) {
+    border-top-right-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:first-child */
+}
 :host([dir='ltr'][compact][vertical]:not([quiet])) ::slotted(:first-child) {
     border-top-right-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:first-child */
+}
+:host(:dir(rtl)[compact][vertical]:not([quiet])) ::slotted(:first-child) {
+    border-top-left-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:first-child */
 }
 :host([dir='rtl'][compact][vertical]:not([quiet])) ::slotted(:first-child) {
     border-top-left-radius: var(
@@ -377,11 +573,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1 / 2
     );
 }
+:host(:dir(ltr)[compact][vertical]:not([quiet])) ::slotted(:last-child) {
+    border-bottom-left-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:last-child */
+}
 :host([dir='ltr'][compact][vertical]:not([quiet])) ::slotted(:last-child) {
     border-bottom-left-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:last-child */
+}
+:host(:dir(rtl)[compact][vertical]:not([quiet])) ::slotted(:last-child) {
+    border-bottom-right-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:last-child */
 }
 :host([dir='rtl'][compact][vertical]:not([quiet])) ::slotted(:last-child) {
     border-bottom-right-radius: var(
@@ -389,11 +597,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:last-child */
 }
+:host(:dir(ltr)[compact][vertical]:not([quiet])) ::slotted(:last-child) {
+    border-bottom-right-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:last-child */
+}
 :host([dir='ltr'][compact][vertical]:not([quiet])) ::slotted(:last-child) {
     border-bottom-right-radius: var(
         --spectrum-actionbutton-m-texticon-border-radius,
         var(--spectrum-alias-component-border-radius)
     ); /* [dir=ltr] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:last-child */
+}
+:host(:dir(rtl)[compact][vertical]:not([quiet])) ::slotted(:last-child) {
+    border-bottom-left-radius: var(
+        --spectrum-actionbutton-m-texticon-border-radius,
+        var(--spectrum-alias-component-border-radius)
+    ); /* [dir=rtl] .spectrum-ActionGroup--compact:not(.spectrum-ActionGroup--quiet).spectrum-ActionGroup--vertical .spectrum-ActionGroup-item:last-child */
 }
 :host([dir='rtl'][compact][vertical]:not([quiet])) ::slotted(:last-child) {
     border-bottom-left-radius: var(

--- a/packages/action-menu/src/action-menu.css
+++ b/packages/action-menu/src/action-menu.css
@@ -36,6 +36,24 @@ governing permissions and limitations under the License.
     display: none;
 }
 
+:host(:dir(ltr)) ::slotted([slot='icon']),
+:host(:dir(ltr)) .icon {
+    /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon */
+    margin-left: calc(
+        -1 * (var(--spectrum-actionbutton-textonly-padding-left-adjusted) -
+                    var(--spectrum-actionbutton-padding-left-adjusted))
+    );
+}
+
+:host(:dir(rtl)) ::slotted([slot='icon']),
+:host(:dir(rtl)) .icon {
+    /* [dir=rtl] .spectrum-ActionButton .spectrum-Icon */
+    margin-right: calc(
+        -1 * (var(--spectrum-actionbutton-textonly-padding-left-adjusted) -
+                    var(--spectrum-actionbutton-padding-left-adjusted))
+    );
+}
+
 :host([dir='ltr']) ::slotted([slot='icon']),
 :host([dir='ltr']) .icon {
     /* [dir=ltr] .spectrum-ActionButton .spectrum-Icon */
@@ -54,8 +72,8 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([dir]) slot[icon-only]::slotted([slot='icon']),
-:host([dir]) slot[icon-only] .icon {
+:host slot[icon-only]::slotted([slot='icon']),
+:host slot[icon-only] .icon {
     /* .spectrum-ActionButton .spectrum-ActionButton-hold+.spectrum-Icon,
    * .spectrum-ActionButton .spectrum-Icon:only-child */
     margin-left: calc(

--- a/packages/avatar/src/spectrum-avatar.css
+++ b/packages/avatar/src/spectrum-avatar.css
@@ -184,14 +184,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     user-select: none;
     width: var(--spectrum-avatar-width);
 }
+:host(:dir(ltr)):after {
+    left: 0; /* [dir=ltr] .spectrum-Avatar:after */
+}
 :host([dir='ltr']):after {
     left: 0; /* [dir=ltr] .spectrum-Avatar:after */
+}
+:host(:dir(rtl)):after {
+    right: 0; /* [dir=rtl] .spectrum-Avatar:after */
 }
 :host([dir='rtl']):after {
     right: 0; /* [dir=rtl] .spectrum-Avatar:after */
 }
+:host(:dir(ltr)):after {
+    right: 0; /* [dir=ltr] .spectrum-Avatar:after */
+}
 :host([dir='ltr']):after {
     right: 0; /* [dir=ltr] .spectrum-Avatar:after */
+}
+:host(:dir(rtl)):after {
+    left: 0; /* [dir=rtl] .spectrum-Avatar:after */
 }
 :host([dir='rtl']):after {
     left: 0; /* [dir=rtl] .spectrum-Avatar:after */

--- a/packages/banner/src/spectrum-banner.css
+++ b/packages/banner/src/spectrum-banner.css
@@ -36,8 +36,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #header {
     font-weight: 700; /* .spectrum-Banner-header */
 }
+:host(:dir(ltr)[corner]) {
+    right: -10px; /* [dir=ltr] .spectrum-Banner--corner */
+}
 :host([dir='ltr'][corner]) {
     right: -10px; /* [dir=ltr] .spectrum-Banner--corner */
+}
+:host(:dir(rtl)[corner]) {
+    left: -10px; /* [dir=rtl] .spectrum-Banner--corner */
 }
 :host([dir='rtl'][corner]) {
     left: -10px; /* [dir=rtl] .spectrum-Banner--corner */

--- a/packages/button-group/src/button-group.css
+++ b/packages/button-group/src/button-group.css
@@ -16,6 +16,14 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-label-flex-grow: 1;
 }
 
+:host(:dir(ltr)[vertical]) ::slotted(sp-action-button) {
+    --spectrum-actionbutton-label-text-align: left;
+}
+
+:host(:dir(rtl)[vertical]) ::slotted(sp-action-button) {
+    --spectrum-actionbutton-label-text-align: right;
+}
+
 :host([dir='ltr'][vertical]) ::slotted(sp-action-button) {
     --spectrum-actionbutton-label-text-align: left;
 }

--- a/packages/button-group/src/spectrum-button-group.css
+++ b/packages/button-group/src/spectrum-button-group.css
@@ -19,11 +19,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 ::slotted(*) {
     flex-shrink: 0; /* .spectrum-ButtonGroup .spectrum-ButtonGroup-item */
 }
+:host(:dir(ltr)) ::slotted(:not(:first-of-type)) {
+    margin-left: var(
+        --spectrum-buttongroup-button-gap-x,
+        var(--spectrum-global-dimension-static-size-200)
+    ); /* [dir=ltr] .spectrum-ButtonGroup .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
+}
 :host([dir='ltr']) ::slotted(:not(:first-of-type)) {
     margin-left: var(
         --spectrum-buttongroup-button-gap-x,
         var(--spectrum-global-dimension-static-size-200)
     ); /* [dir=ltr] .spectrum-ButtonGroup .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
+}
+:host(:dir(rtl)) ::slotted(:not(:first-of-type)) {
+    margin-right: var(
+        --spectrum-buttongroup-button-gap-x,
+        var(--spectrum-global-dimension-static-size-200)
+    ); /* [dir=rtl] .spectrum-ButtonGroup .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
 }
 :host([dir='rtl']) ::slotted(:not(:first-of-type)) {
     margin-right: var(
@@ -35,10 +47,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: inline-flex; /* .spectrum-ButtonGroup--vertical */
     flex-direction: column;
 }
+:host(:dir(ltr)[vertical]) ::slotted(:not(:first-of-type)) {
+    margin-left: var(
+        --spectrum-buttongroup-button-gap-reset
+    ); /* [dir=ltr] .spectrum-ButtonGroup--vertical .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
+}
 :host([dir='ltr'][vertical]) ::slotted(:not(:first-of-type)) {
     margin-left: var(
         --spectrum-buttongroup-button-gap-reset
     ); /* [dir=ltr] .spectrum-ButtonGroup--vertical .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
+}
+:host(:dir(rtl)[vertical]) ::slotted(:not(:first-of-type)) {
+    margin-right: var(
+        --spectrum-buttongroup-button-gap-reset
+    ); /* [dir=rtl] .spectrum-ButtonGroup--vertical .spectrum-ButtonGroup-item+.spectrum-ButtonGroup-item */
 }
 :host([dir='rtl'][vertical]) ::slotted(:not(:first-of-type)) {
     margin-right: var(

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -17,7 +17,7 @@ governing permissions and limitations under the License.
     vertical-align: top;
 }
 
-:host([dir]) {
+:host([size]) {
     /* spectrum-css uses "-webkit-appearance: button" to workaround an
      * iOS and Safari issue. However, it results in incorrect styling
      * when applied in :host

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -375,6 +375,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-button-primary-fill-texticon-border-size)
     );
 }
+:host(:dir(ltr)) {
+    padding-left: var(
+        --spectrum-button-primary-fill-textonly-padding-left-adjusted
+    ); /* [dir=ltr] .spectrum-Button */
+    padding-right: var(
+        --spectrum-button-primary-fill-textonly-padding-right-adjusted
+    );
+}
 :host([dir='ltr']) {
     padding-left: var(
         --spectrum-button-primary-fill-textonly-padding-left-adjusted
@@ -382,6 +390,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-right: var(
         --spectrum-button-primary-fill-textonly-padding-right-adjusted
     );
+}
+:host(:dir(rtl)) {
+    padding-left: var(
+        --spectrum-button-primary-fill-textonly-padding-right-adjusted
+    );
+    padding-right: var(
+        --spectrum-button-primary-fill-textonly-padding-left-adjusted
+    ); /* [dir=rtl] .spectrum-Button */
 }
 :host([dir='rtl']) {
     padding-left: var(
@@ -415,6 +431,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     box-shadow: none; /* .spectrum-Button:hover,
    * .spectrum-Button:active */
 }
+:host(:dir(ltr)) ::slotted([slot='icon']) {
+    margin-left: calc(
+        (
+                var(
+                        --spectrum-button-primary-fill-textonly-padding-left-adjusted
+                    ) -
+                    var(--spectrum-button-primary-fill-padding-left-adjusted)
+            ) * -1
+    ); /* [dir=ltr] .spectrum-Button .spectrum-Icon */
+}
 :host([dir='ltr']) ::slotted([slot='icon']) {
     margin-left: calc(
         (
@@ -424,6 +450,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                     var(--spectrum-button-primary-fill-padding-left-adjusted)
             ) * -1
     ); /* [dir=ltr] .spectrum-Button .spectrum-Icon */
+}
+:host(:dir(rtl)) ::slotted([slot='icon']) {
+    margin-right: calc(
+        (
+                var(
+                        --spectrum-button-primary-fill-textonly-padding-left-adjusted
+                    ) -
+                    var(--spectrum-button-primary-fill-padding-left-adjusted)
+            ) * -1
+    ); /* [dir=rtl] .spectrum-Button .spectrum-Icon */
 }
 :host([dir='rtl']) ::slotted([slot='icon']) {
     margin-right: calc(
@@ -435,18 +471,34 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1
     ); /* [dir=rtl] .spectrum-Button .spectrum-Icon */
 }
+:host(:dir(ltr)) slot[name='icon'] + #label {
+    padding-left: var(
+        --spectrum-button-primary-fill-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
+}
 :host([dir='ltr']) slot[name='icon'] + #label {
     padding-left: var(
         --spectrum-button-primary-fill-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
+}
+:host(:dir(rtl)) slot[name='icon'] + #label {
+    padding-right: var(
+        --spectrum-button-primary-fill-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
 }
 :host([dir='rtl']) slot[name='icon'] + #label {
     padding-right: var(
         --spectrum-button-primary-fill-texticon-icon-gap
     ); /* [dir=rtl] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
 }
+:host(:dir(ltr)) slot[name='icon'] + #label {
+    padding-right: 0; /* [dir=ltr] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
+}
 :host([dir='ltr']) slot[name='icon'] + #label {
     padding-right: 0; /* [dir=ltr] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
+}
+:host(:dir(rtl)) slot[name='icon'] + #label {
+    padding-left: 0; /* [dir=rtl] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */
 }
 :host([dir='rtl']) slot[name='icon'] + #label {
     padding-left: 0; /* [dir=rtl] .spectrum-Button .spectrum-Icon+.spectrum-Button-label */

--- a/packages/card/src/spectrum-card.css
+++ b/packages/card/src/spectrum-card.css
@@ -254,10 +254,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Card:hover .spectrum-Card-quickActions,
    * .spectrum-Card:hover .spectrum-Card-actions */
 }
+:host(:dir(ltr)) .actions {
+    right: var(
+        --spectrum-card-actions-margin
+    ); /* [dir=ltr] .spectrum-Card-actions */
+}
 :host([dir='ltr']) .actions {
     right: var(
         --spectrum-card-actions-margin
     ); /* [dir=ltr] .spectrum-Card-actions */
+}
+:host(:dir(rtl)) .actions {
+    left: var(
+        --spectrum-card-actions-margin
+    ); /* [dir=rtl] .spectrum-Card-actions */
 }
 :host([dir='rtl']) .actions {
     left: var(
@@ -273,10 +283,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     top: var(--spectrum-card-actions-margin);
     visibility: hidden;
 }
+:host(:dir(ltr)) .quick-actions {
+    left: var(
+        --spectrum-card-checkbox-margin
+    ); /* [dir=ltr] .spectrum-Card-quickActions */
+}
 :host([dir='ltr']) .quick-actions {
     left: var(
         --spectrum-card-checkbox-margin
     ); /* [dir=ltr] .spectrum-Card-quickActions */
+}
+:host(:dir(rtl)) .quick-actions {
+    right: var(
+        --spectrum-card-checkbox-margin
+    ); /* [dir=rtl] .spectrum-Card-quickActions */
 }
 :host([dir='rtl']) .quick-actions {
     right: var(
@@ -295,6 +315,12 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-quickactions-height,
         var(--spectrum-global-dimension-size-500)
     );
+}
+:host(:dir(ltr)) .quick-actions .checkbox,
+:host(:dir(rtl)) .quick-actions .checkbox {
+    margin: 0; /* [dir=ltr] .spectrum-Card-quickActions .spectrum-Checkbox,
+   * [dir=rtl] 
+  .spectrum-Card-quickActions .spectrum-Checkbox */
 }
 :host([dir='ltr']) .quick-actions .checkbox,
 :host([dir='rtl']) .quick-actions .checkbox {
@@ -319,20 +345,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Card-coverPhoto */
     justify-content: center;
 }
+:host(:dir(ltr)) .body {
+    padding-right: var(
+        --spectrum-card-body-padding-right
+    ); /* [dir=ltr] .spectrum-Card-body */
+}
 :host([dir='ltr']) .body {
     padding-right: var(
         --spectrum-card-body-padding-right
     ); /* [dir=ltr] .spectrum-Card-body */
+}
+:host(:dir(rtl)) .body {
+    padding-left: var(
+        --spectrum-card-body-padding-right
+    ); /* [dir=rtl] .spectrum-Card-body */
 }
 :host([dir='rtl']) .body {
     padding-left: var(
         --spectrum-card-body-padding-right
     ); /* [dir=rtl] .spectrum-Card-body */
 }
+:host(:dir(ltr)) .body {
+    padding-left: var(
+        --spectrum-card-body-padding-left
+    ); /* [dir=ltr] .spectrum-Card-body */
+}
 :host([dir='ltr']) .body {
     padding-left: var(
         --spectrum-card-body-padding-left
     ); /* [dir=ltr] .spectrum-Card-body */
+}
+:host(:dir(rtl)) .body {
+    padding-right: var(
+        --spectrum-card-body-padding-left
+    ); /* [dir=rtl] .spectrum-Card-body */
 }
 :host([dir='rtl']) .body {
     padding-right: var(
@@ -366,10 +412,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     height: var(--spectrum-card-body-content-min-height);
     margin-top: var(--spectrum-card-body-content-margin-top);
 }
+:host(:dir(ltr)) .title {
+    padding-right: var(
+        --spectrum-card-title-padding-right
+    ); /* [dir=ltr] .spectrum-Card-title */
+}
 :host([dir='ltr']) .title {
     padding-right: var(
         --spectrum-card-title-padding-right
     ); /* [dir=ltr] .spectrum-Card-title */
+}
+:host(:dir(rtl)) .title {
+    padding-left: var(
+        --spectrum-card-title-padding-right
+    ); /* [dir=rtl] .spectrum-Card-title */
 }
 :host([dir='rtl']) .title {
     padding-left: var(
@@ -381,10 +437,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     text-overflow: ellipsis;
     white-space: nowrap; /* .spectrum-Card-title */
 }
+:host(:dir(ltr)) .subtitle {
+    padding-right: var(
+        --spectrum-card-subtitle-padding-right
+    ); /* [dir=ltr] .spectrum-Card-subtitle */
+}
 :host([dir='ltr']) .subtitle {
     padding-right: var(
         --spectrum-card-subtitle-padding-right
     ); /* [dir=ltr] .spectrum-Card-subtitle */
+}
+:host(:dir(rtl)) .subtitle {
+    padding-left: var(
+        --spectrum-card-subtitle-padding-right
+    ); /* [dir=rtl] .spectrum-Card-subtitle */
 }
 :host([dir='rtl']) .subtitle {
     padding-left: var(
@@ -396,10 +462,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-card-subtitle-text-size
     ); /* .spectrum-Card-description */
 }
+:host(:dir(ltr)) .subtitle + ::slotted([slot='description']):before {
+    padding-right: var(
+        --spectrum-card-subtitle-padding-right
+    ); /* [dir=ltr] .spectrum-Card-subtitle+.spectrum-Card-description:before */
+}
 :host([dir='ltr']) .subtitle + ::slotted([slot='description']):before {
     padding-right: var(
         --spectrum-card-subtitle-padding-right
     ); /* [dir=ltr] .spectrum-Card-subtitle+.spectrum-Card-description:before */
+}
+:host(:dir(rtl)) .subtitle + ::slotted([slot='description']):before {
+    padding-left: var(
+        --spectrum-card-subtitle-padding-right
+    ); /* [dir=rtl] .spectrum-Card-subtitle+.spectrum-Card-description:before */
 }
 :host([dir='rtl']) .subtitle + ::slotted([slot='description']):before {
     padding-left: var(
@@ -409,20 +485,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .subtitle + ::slotted([slot='description']):before {
     content: '•'; /* .spectrum-Card-subtitle+.spectrum-Card-description:before */
 }
+:host(:dir(ltr)) ::slotted([slot='footer']) {
+    margin-right: var(
+        --spectrum-card-body-padding-right
+    ); /* [dir=ltr] .spectrum-Card-footer */
+}
 :host([dir='ltr']) ::slotted([slot='footer']) {
     margin-right: var(
         --spectrum-card-body-padding-right
     ); /* [dir=ltr] .spectrum-Card-footer */
+}
+:host(:dir(rtl)) ::slotted([slot='footer']) {
+    margin-left: var(
+        --spectrum-card-body-padding-right
+    ); /* [dir=rtl] .spectrum-Card-footer */
 }
 :host([dir='rtl']) ::slotted([slot='footer']) {
     margin-left: var(
         --spectrum-card-body-padding-right
     ); /* [dir=rtl] .spectrum-Card-footer */
 }
+:host(:dir(ltr)) ::slotted([slot='footer']) {
+    margin-left: var(
+        --spectrum-card-body-padding-left
+    ); /* [dir=ltr] .spectrum-Card-footer */
+}
 :host([dir='ltr']) ::slotted([slot='footer']) {
     margin-left: var(
         --spectrum-card-body-padding-left
     ); /* [dir=ltr] .spectrum-Card-footer */
+}
+:host(:dir(rtl)) ::slotted([slot='footer']) {
+    margin-right: var(
+        --spectrum-card-body-padding-left
+    ); /* [dir=rtl] .spectrum-Card-footer */
 }
 :host([dir='rtl']) ::slotted([slot='footer']) {
     margin-right: var(
@@ -474,10 +570,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     width: 100%; /* .spectrum-Card--quiet .spectrum-Card-preview,
    * .spectrum-Card--gallery .spectrum-Card-preview */
 }
+:host(:dir(ltr)[variant='gallery']) #preview:before,
+:host(:dir(ltr)[variant='quiet']) #preview:before {
+    left: 0; /* [dir=ltr] .spectrum-Card--quiet .spectrum-Card-preview:before,
+   * [dir=ltr]  .spectrum-Card--gallery .spectrum-Card-preview:before */
+}
 :host([dir='ltr'][variant='gallery']) #preview:before,
 :host([dir='ltr'][variant='quiet']) #preview:before {
     left: 0; /* [dir=ltr] .spectrum-Card--quiet .spectrum-Card-preview:before,
    * [dir=ltr]  .spectrum-Card--gallery .spectrum-Card-preview:before */
+}
+:host(:dir(rtl)[variant='gallery']) #preview:before,
+:host(:dir(rtl)[variant='quiet']) #preview:before {
+    right: 0; /* [dir=rtl] .spectrum-Card--quiet .spectrum-Card-preview:before,
+   * [dir=rtl]  .spectrum-Card--gallery .spectrum-Card-preview:before */
 }
 :host([dir='rtl'][variant='gallery']) #preview:before,
 :host([dir='rtl'][variant='quiet']) #preview:before {
@@ -517,40 +623,78 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([horizontal]) {
     flex-direction: row; /* .spectrum-Card--horizontal */
 }
+:host(:dir(ltr)[horizontal]) #preview {
+    border-top-left-radius: var(
+        --spectrum-card-quiet-border-radius
+    ); /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
 :host([dir='ltr'][horizontal]) #preview {
     border-top-left-radius: var(
         --spectrum-card-quiet-border-radius
     ); /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
+:host(:dir(rtl)[horizontal]) #preview {
+    border-top-right-radius: var(
+        --spectrum-card-quiet-border-radius
+    ); /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
 :host([dir='rtl'][horizontal]) #preview {
     border-top-right-radius: var(
         --spectrum-card-quiet-border-radius
     ); /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
+:host(:dir(ltr)[horizontal]) #preview {
+    border-top-right-radius: 0; /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
 :host([dir='ltr'][horizontal]) #preview {
     border-top-right-radius: 0; /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
+:host(:dir(rtl)[horizontal]) #preview {
+    border-top-left-radius: 0; /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
 :host([dir='rtl'][horizontal]) #preview {
     border-top-left-radius: 0; /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
+:host(:dir(ltr)[horizontal]) #preview {
+    border-bottom-left-radius: var(
+        --spectrum-card-quiet-border-radius
+    ); /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
 :host([dir='ltr'][horizontal]) #preview {
     border-bottom-left-radius: var(
         --spectrum-card-quiet-border-radius
     ); /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
+:host(:dir(rtl)[horizontal]) #preview {
+    border-bottom-right-radius: var(
+        --spectrum-card-quiet-border-radius
+    ); /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
 :host([dir='rtl'][horizontal]) #preview {
     border-bottom-right-radius: var(
         --spectrum-card-quiet-border-radius
     ); /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
+:host(:dir(ltr)[horizontal]) #preview {
+    border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
 :host([dir='ltr'][horizontal]) #preview {
     border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
+:host(:dir(rtl)[horizontal]) #preview {
+    border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
 :host([dir='rtl'][horizontal]) #preview {
     border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
+:host(:dir(ltr)[horizontal]) #preview {
+    border-right: var(--spectrum-card-border-size) solid transparent; /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
 :host([dir='ltr'][horizontal]) #preview {
     border-right: var(--spectrum-card-border-size) solid transparent; /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-preview */
+}
+:host(:dir(rtl)[horizontal]) #preview {
+    border-left: var(--spectrum-card-border-size) solid transparent; /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
 }
 :host([dir='rtl'][horizontal]) #preview {
     border-left: var(--spectrum-card-border-size) solid transparent; /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-preview */
@@ -569,8 +713,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin-top: 0; /* .spectrum-Card--horizontal .spectrum-Card-header,
    * .spectrum-Card--horizontal .spectrum-Card-content */
 }
+:host(:dir(ltr)[horizontal]) .title {
+    padding-right: 0; /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-title */
+}
 :host([dir='ltr'][horizontal]) .title {
     padding-right: 0; /* [dir=ltr] .spectrum-Card--horizontal .spectrum-Card-title */
+}
+:host(:dir(rtl)[horizontal]) .title {
+    padding-left: 0; /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-title */
 }
 :host([dir='rtl'][horizontal]) .title {
     padding-left: 0; /* [dir=rtl] .spectrum-Card--horizontal .spectrum-Card-title */

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -265,16 +265,32 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     opacity: 1;
     transform: scale(1);
 }
+:host(:dir(ltr)) #label {
+    text-align: left; /* [dir=ltr] .spectrum-Checkbox-label */
+}
 :host([dir='ltr']) #label {
     text-align: left; /* [dir=ltr] .spectrum-Checkbox-label */
 }
+:host(:dir(rtl)) #label {
+    text-align: right; /* [dir=rtl] .spectrum-Checkbox-label */
+}
 :host([dir='rtl']) #label {
     text-align: right; /* [dir=rtl] .spectrum-Checkbox-label */
+}
+:host(:dir(ltr)) #label {
+    margin-left: var(
+        --spectrum-checkbox-text-gap
+    ); /* [dir=ltr] .spectrum-Checkbox-label */
 }
 :host([dir='ltr']) #label {
     margin-left: var(
         --spectrum-checkbox-text-gap
     ); /* [dir=ltr] .spectrum-Checkbox-label */
+}
+:host(:dir(rtl)) #label {
+    margin-right: var(
+        --spectrum-checkbox-text-gap
+    ); /* [dir=rtl] .spectrum-Checkbox-label */
 }
 :host([dir='rtl']) #label {
     margin-right: var(
@@ -347,10 +363,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ease-out,
         margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
 }
+:host(:dir(ltr)) #checkmark,
+:host(:dir(ltr)) #partialCheckmark {
+    left: 50%; /* [dir=ltr] .spectrum-Checkbox-checkmark,
+   * [dir=ltr] 
+.spectrum-Checkbox-partialCheckmark */
+}
 :host([dir='ltr']) #checkmark,
 :host([dir='ltr']) #partialCheckmark {
     left: 50%; /* [dir=ltr] .spectrum-Checkbox-checkmark,
    * [dir=ltr] 
+.spectrum-Checkbox-partialCheckmark */
+}
+:host(:dir(rtl)) #checkmark,
+:host(:dir(rtl)) #partialCheckmark {
+    right: 50%; /* [dir=rtl] .spectrum-Checkbox-checkmark,
+   * [dir=rtl] 
 .spectrum-Checkbox-partialCheckmark */
 }
 :host([dir='rtl']) #checkmark,
@@ -371,10 +399,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         transform var(--spectrum-global-animation-duration-100, 0.13s)
             ease-in-out;
 }
+:host(:dir(ltr)) #checkmark {
+    margin-left: calc(
+        var(--spectrum-checkbox-checkmark-size) / -2
+    ); /* [dir=ltr] .spectrum-Checkbox-checkmark */
+}
 :host([dir='ltr']) #checkmark {
     margin-left: calc(
         var(--spectrum-checkbox-checkmark-size) / -2
     ); /* [dir=ltr] .spectrum-Checkbox-checkmark */
+}
+:host(:dir(rtl)) #checkmark {
+    margin-right: calc(
+        var(--spectrum-checkbox-checkmark-size) / -2
+    ); /* [dir=rtl] .spectrum-Checkbox-checkmark */
 }
 :host([dir='rtl']) #checkmark {
     margin-right: calc(
@@ -386,10 +424,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-checkbox-checkmark-size) / -2
     ); /* .spectrum-Checkbox-checkmark */
 }
+:host(:dir(ltr)) #partialCheckmark {
+    margin-left: calc(
+        var(--spectrum-checkbox-checkmark-size) / -2
+    ); /* [dir=ltr] .spectrum-Checkbox-partialCheckmark */
+}
 :host([dir='ltr']) #partialCheckmark {
     margin-left: calc(
         var(--spectrum-checkbox-checkmark-size) / -2
     ); /* [dir=ltr] .spectrum-Checkbox-partialCheckmark */
+}
+:host(:dir(rtl)) #partialCheckmark {
+    margin-right: calc(
+        var(--spectrum-checkbox-checkmark-size) / -2
+    ); /* [dir=rtl] .spectrum-Checkbox-partialCheckmark */
 }
 :host([dir='rtl']) #partialCheckmark {
     margin-right: calc(
@@ -487,8 +535,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-component-text-color-down)
     ); /* .spectrum-Checkbox:active .spectrum-Checkbox-label */
 }
-#input:disabled + #box:before,
-:host([dir]) #input:checked:disabled + #box:before {
+:host #input:checked:disabled + #box:before,
+:host #input:disabled + #box:before {
     background-color: var(
         --spectrum-checkbox-m-box-background-color-disabled,
         var(--spectrum-global-color-gray-75)
@@ -620,8 +668,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Checkbox--emphasized:active.is-indeterminate .spectrum-Checkbox-box:before,
    * .spectrum-Checkbox--emphasized:active .spectrum-Checkbox-input:checked+.spectrum-Checkbox-box:before */
 }
-:host([invalid][dir]) #box:before,
-:host([invalid][dir]) #input:checked + #box:before {
+:host([invalid]) #box:before,
+:host([invalid][size]) #input + #box:before,
+:host([invalid][size]) #input:checked + #box:before {
     border-color: var(
         --spectrum-checkbox-m-box-border-color-error,
         var(--spectrum-global-color-red-500)
@@ -667,7 +716,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Checkbox.is-invalid .spectrum-Checkbox-input.focus-ring~.spectrum-Checkbox-label */
 }
 :host([invalid]:hover) #box:before,
-:host([invalid][dir]:hover) #input:checked + #box:before {
+:host([invalid][size]:hover) #input:checked + #box:before {
     border-color: var(
         --spectrum-checkbox-m-box-border-color-error-hover,
         var(--spectrum-global-color-red-600)
@@ -764,7 +813,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-checkbox-m-text-color-key-focus: FieldText;
         --spectrum-checkbox-m-text-color: FieldText;
     }
-    :host([invalid][dir]) #box:before {
+    :host([invalid]) #box:before {
         border-color: var(
             --spectrum-checkbox-m-box-border-color,
             var(--spectrum-alias-toggle-border-color-default)
@@ -776,7 +825,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-global-color-red-500)
         );
     }
-    :host([invalid][dir]) #input:checked + #box:before {
+    :host([invalid][size]) #input + #box:before,
+    :host([invalid][size]) #input:checked + #box:before {
         border-color: var(
             --spectrum-checkbox-m-box-border-color-error,
             var(--spectrum-global-color-red-500)

--- a/packages/checkbox/src/spectrum-config.js
+++ b/packages/checkbox/src/spectrum-config.js
@@ -83,47 +83,34 @@ const config = {
             ],
             complexSelectors: [
                 {
-                    replacement:
-                        ':host([dir]) #input:checked:disabled + #box:before',
+                    replacement: ':host #input:checked:disabled + #box:before',
                     selector:
                         /\.spectrum-Checkbox \.spectrum-Checkbox-input:checked:disabled\s?\+\s?\.spectrum-Checkbox-box::?before/,
                 },
                 {
-                    replacement: '#input:disabled + #box:before',
+                    replacement: ':host #input:disabled + #box:before',
                     selector:
                         /\.spectrum-Checkbox \.spectrum-Checkbox-input:disabled\s?\+\s?\.spectrum-Checkbox-box::?before/,
                 },
                 {
-                    replacement: ':host([invalid][dir]) #box:before',
-                    selector:
-                        /\.spectrum-Checkbox\.is-invalid \.spectrum-Checkbox-box::?before/,
-                },
-                {
-                    replacement:
-                        ':host([invalid][dir]) #input:checked + #box:before',
-                    selector:
-                        /\.spectrum-Checkbox\.is-invalid \.spectrum-Checkbox-input:checked\s?\+\s?\.spectrum-Checkbox-box::?before/,
-                    //.spectrum-Checkbox.is-invalid .spectrum-Checkbox-input:checked + .spectrum-Checkbox-box::?before
-                },
-                {
-                    replacement: ':host([invalid][dir]) #box:before',
+                    replacement: ':host([invalid][size]) #box:before',
                     selector:
                         '.spectrum-Checkbox.is-invalid .spectrum-Checkbox-box::?before',
                 },
                 {
                     replacement:
-                        ':host([invalid][dir]) #input:checked + #box:before',
+                        ':host([invalid][size]) #input:checked + #box:before, :host([invalid][size]) #input + #box:before',
                     selector:
                         /\.spectrum-Checkbox\.is-invalid \.spectrum-Checkbox-input:checked\s?\+\s?\.spectrum-Checkbox-box::?before/,
                 },
                 {
-                    replacement: ':host([invalid][dir]:hover) #box:before',
+                    replacement: ':host([invalid][size]:hover) #box:before',
                     selector:
                         '.spectrum-Checkbox.is-invalid:hover .spectrum-Checkbox-box::?before',
                 },
                 {
                     replacement:
-                        ':host([invalid][dir]:hover) #input:checked + #box:before',
+                        ':host([invalid][size]:hover) #input:checked + #box:before',
                     selector:
                         /\.spectrum-Checkbox\.is-invalid:hover \.spectrum-Checkbox-input:checked\s?\+\s?\.spectrum-Checkbox-box::?before/,
                 },

--- a/packages/coachmark/src/spectrum-coachmark.css
+++ b/packages/coachmark/src/spectrum-coachmark.css
@@ -71,8 +71,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         );
     }
 }
+:host(:dir(ltr)) .spectrum-CoachMarkPopover-footer {
+    text-align: right; /* [dir=ltr] .spectrum-CoachMarkPopover-footer */
+}
 :host([dir='ltr']) .spectrum-CoachMarkPopover-footer {
     text-align: right; /* [dir=ltr] .spectrum-CoachMarkPopover-footer */
+}
+:host(:dir(rtl)) .spectrum-CoachMarkPopover-footer {
+    text-align: left; /* [dir=rtl] .spectrum-CoachMarkPopover-footer */
 }
 :host([dir='rtl']) .spectrum-CoachMarkPopover-footer {
     text-align: left; /* [dir=rtl] .spectrum-CoachMarkPopover-footer */
@@ -126,6 +132,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * 3
     ); /* .spectrum-CoachMarkIndicator */
 }
+:host(:dir(ltr)) .ring {
+    left: calc(
+        var(
+                --spectrum-coachmark-indicator-ring-diameter,
+                var(--spectrum-global-dimension-size-200)
+            ) * 0.75
+    ); /* [dir=ltr] .spectrum-CoachMarkIndicator-ring */
+}
 :host([dir='ltr']) .ring {
     left: calc(
         var(
@@ -133,6 +147,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-200)
             ) * 0.75
     ); /* [dir=ltr] .spectrum-CoachMarkIndicator-ring */
+}
+:host(:dir(rtl)) .ring {
+    right: calc(
+        var(
+                --spectrum-coachmark-indicator-ring-diameter,
+                var(--spectrum-global-dimension-size-200)
+            ) * 0.75
+    ); /* [dir=rtl] .spectrum-CoachMarkIndicator-ring */
 }
 :host([dir='rtl']) .ring {
     right: calc(
@@ -184,6 +206,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * 2.75
     ); /* .spectrum-CoachMarkIndicator--quiet */
 }
+:host(:dir(ltr)[quiet]) .ring {
+    left: calc(
+        var(
+                --spectrum-coachmark-quiet-indicator-ring-diameter,
+                var(--spectrum-global-dimension-size-100)
+            ) * 0.75
+    ); /* [dir=ltr] .spectrum-CoachMarkIndicator--quiet .spectrum-CoachMarkIndicator-ring */
+}
 :host([dir='ltr'][quiet]) .ring {
     left: calc(
         var(
@@ -191,6 +221,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-100)
             ) * 0.75
     ); /* [dir=ltr] .spectrum-CoachMarkIndicator--quiet .spectrum-CoachMarkIndicator-ring */
+}
+:host(:dir(rtl)[quiet]) .ring {
+    right: calc(
+        var(
+                --spectrum-coachmark-quiet-indicator-ring-diameter,
+                var(--spectrum-global-dimension-size-100)
+            ) * 0.75
+    ); /* [dir=rtl] .spectrum-CoachMarkIndicator--quiet .spectrum-CoachMarkIndicator-ring */
 }
 :host([dir='rtl'][quiet]) .ring {
     right: calc(

--- a/packages/dialog/src/spectrum-dialog.css
+++ b/packages/dialog/src/spectrum-dialog.css
@@ -101,10 +101,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         );
     width: 100%;
 }
+:host(:dir(ltr)) ::slotted([slot='heading']) {
+    padding-right: var(
+        --spectrum-dialog-confirm-gap-size
+    ); /* [dir=ltr] .spectrum-Dialog-heading */
+}
 :host([dir='ltr']) ::slotted([slot='heading']) {
     padding-right: var(
         --spectrum-dialog-confirm-gap-size
     ); /* [dir=ltr] .spectrum-Dialog-heading */
+}
+:host(:dir(rtl)) ::slotted([slot='heading']) {
+    padding-left: var(
+        --spectrum-dialog-confirm-gap-size
+    ); /* [dir=rtl] .spectrum-Dialog-heading */
 }
 :host([dir='rtl']) ::slotted([slot='heading']) {
     padding-left: var(
@@ -125,8 +135,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin: 0;
     outline: none;
 }
+:host(:dir(ltr)) .no-header::slotted([slot='heading']) {
+    padding-right: 0; /* [dir=ltr] .spectrum-Dialog-heading.spectrum-Dialog-heading--noHeader */
+}
 :host([dir='ltr']) .no-header::slotted([slot='heading']) {
     padding-right: 0; /* [dir=ltr] .spectrum-Dialog-heading.spectrum-Dialog-heading--noHeader */
+}
+:host(:dir(rtl)) .no-header::slotted([slot='heading']) {
+    padding-left: 0; /* [dir=rtl] .spectrum-Dialog-heading.spectrum-Dialog-heading--noHeader */
 }
 :host([dir='rtl']) .no-header::slotted([slot='heading']) {
     padding-left: 0; /* [dir=rtl] .spectrum-Dialog-heading.spectrum-Dialog-heading--noHeader */
@@ -208,10 +224,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin-bottom: 0; /* .spectrum-Dialog-footer>*,
    * .spectrum-Dialog-footer>.spectrum-Button+.spectrum-Button */
 }
+:host(:dir(ltr)) .button-group {
+    padding-left: var(
+        --spectrum-dialog-confirm-gap-size
+    ); /* [dir=ltr] .spectrum-Dialog-buttonGroup */
+}
 :host([dir='ltr']) .button-group {
     padding-left: var(
         --spectrum-dialog-confirm-gap-size
     ); /* [dir=ltr] .spectrum-Dialog-buttonGroup */
+}
+:host(:dir(rtl)) .button-group {
+    padding-right: var(
+        --spectrum-dialog-confirm-gap-size
+    ); /* [dir=rtl] .spectrum-Dialog-buttonGroup */
 }
 :host([dir='rtl']) .button-group {
     padding-right: var(
@@ -242,10 +268,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([dismissable]) .grid .footer {
     grid-area: footer/footer/buttonGroup/buttonGroup; /* .spectrum-Dialog.spectrum-Dialog--dismissable .spectrum-Dialog-grid .spectrum-Dialog-footer */
 }
+:host(:dir(ltr)) .close-button {
+    margin-right: var(
+        --spectrum-dialog-confirm-close-button-padding
+    ); /* [dir=ltr] .spectrum-Dialog-closeButton */
+}
 :host([dir='ltr']) .close-button {
     margin-right: var(
         --spectrum-dialog-confirm-close-button-padding
     ); /* [dir=ltr] .spectrum-Dialog-closeButton */
+}
+:host(:dir(rtl)) .close-button {
+    margin-left: var(
+        --spectrum-dialog-confirm-close-button-padding
+    ); /* [dir=rtl] .spectrum-Dialog-closeButton */
 }
 :host([dir='rtl']) .close-button {
     margin-left: var(

--- a/packages/field-group/src/field-group.css
+++ b/packages/field-group/src/field-group.css
@@ -12,9 +12,20 @@ governing permissions and limitations under the License.
 
 @import './spectrum-field-group.css';
 
-:host([horizontal][dir='rtl']) slot:not([name])::slotted(*:not(:last-child)),
-:host([dir='rtl']:not([vertical]))
-    slot:not([name])::slotted(*:not(:last-child)) {
+:host([horizontal]:dir(rtl)) ::slotted(*:not(:last-child)),
+:host(:dir(rtl):not([vertical])) ::slotted(*:not(:last-child)) {
+    /* .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item+.spectrum-FieldGroup-item */
+    margin: 0 0 0 var(--spectrum-global-dimension-size-200);
+}
+
+:host([horizontal]:dir(ltr)) ::slotted(*:not(:last-child)),
+:host(:dir(ltr):not([vertical])) ::slotted(*:not(:last-child)) {
+    /* .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item+.spectrum-FieldGroup-item */
+    margin: 0 var(--spectrum-global-dimension-size-200) 0 0;
+}
+
+:host([horizontal][dir='rtl']) ::slotted(*:not(:last-child)),
+:host([dir='rtl']:not([vertical])) ::slotted(*:not(:last-child)) {
     /* .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item+.spectrum-FieldGroup-item */
     margin: 0 0 0 var(--spectrum-fieldgroup-margin);
 }

--- a/packages/field-group/src/spectrum-field-group.css
+++ b/packages/field-group/src/spectrum-field-group.css
@@ -20,10 +20,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     flex-wrap: wrap;
     vertical-align: top;
 }
+:host(:dir(ltr)[horizontal]) slot:not([name])::slotted(:not(:last-child)) {
+    margin-right: var(
+        --spectrum-fieldgroup-margin
+    ); /* [dir=ltr] .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item:not(:last-child) */
+}
 :host([dir='ltr'][horizontal]) slot:not([name])::slotted(:not(:last-child)) {
     margin-right: var(
         --spectrum-fieldgroup-margin
     ); /* [dir=ltr] .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item:not(:last-child) */
+}
+:host(:dir(rtl)[horizontal]) slot:not([name])::slotted(:not(:last-child)) {
+    margin-left: var(
+        --spectrum-fieldgroup-margin
+    ); /* [dir=rtl] .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item:not(:last-child) */
 }
 :host([dir='rtl'][horizontal]) slot:not([name])::slotted(:not(:last-child)) {
     margin-left: var(

--- a/packages/field-label/src/spectrum-field-label.css
+++ b/packages/field-label/src/spectrum-field-label.css
@@ -130,11 +130,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-top: var(--spectrum-fieldlabel-padding-top);
     vertical-align: top;
 }
+:host(:dir(ltr)) .required-icon {
+    margin-left: var(
+        --spectrum-fieldlabel-asterisk-gap
+    ); /* [dir=ltr] .spectrum-FieldLabel-requiredIcon */
+    margin-right: 0;
+}
 :host([dir='ltr']) .required-icon {
     margin-left: var(
         --spectrum-fieldlabel-asterisk-gap
     ); /* [dir=ltr] .spectrum-FieldLabel-requiredIcon */
     margin-right: 0;
+}
+:host(:dir(rtl)) .required-icon {
+    margin-left: 0;
+    margin-right: var(
+        --spectrum-fieldlabel-asterisk-gap
+    ); /* [dir=rtl] .spectrum-FieldLabel-requiredIcon */
 }
 :host([dir='rtl']) .required-icon {
     margin-left: 0;
@@ -146,12 +158,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin-bottom: 0;
     margin-top: 0; /* .spectrum-FieldLabel-requiredIcon */
 }
+:host(:dir(ltr)[side-aligned='start']) {
+    padding-left: 0; /* [dir=ltr] .spectrum-FieldLabel--left */
+    padding-right: var(
+        --spectrum-fieldlabel-m-side-padding-right,
+        var(--spectrum-global-dimension-size-150)
+    );
+}
 :host([dir='ltr'][side-aligned='start']) {
     padding-left: 0; /* [dir=ltr] .spectrum-FieldLabel--left */
     padding-right: var(
         --spectrum-fieldlabel-m-side-padding-right,
         var(--spectrum-global-dimension-size-150)
     );
+}
+:host(:dir(rtl)[side-aligned='start']) {
+    padding-left: var(
+        --spectrum-fieldlabel-m-side-padding-right,
+        var(--spectrum-global-dimension-size-150)
+    );
+    padding-right: 0; /* [dir=rtl] .spectrum-FieldLabel--left */
 }
 :host([dir='rtl'][side-aligned='start']) {
     padding-left: var(
@@ -168,11 +194,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-100)
     );
 }
+:host(:dir(ltr)[side-aligned='start']) .required-icon {
+    margin-left: var(
+        --spectrum-fieldlabel-asterisk-gap
+    ); /* [dir=ltr] .spectrum-FieldLabel--left .spectrum-FieldLabel-requiredIcon */
+    margin-right: 0;
+}
 :host([dir='ltr'][side-aligned='start']) .required-icon {
     margin-left: var(
         --spectrum-fieldlabel-asterisk-gap
     ); /* [dir=ltr] .spectrum-FieldLabel--left .spectrum-FieldLabel-requiredIcon */
     margin-right: 0;
+}
+:host(:dir(rtl)[side-aligned='start']) .required-icon {
+    margin-left: 0;
+    margin-right: var(
+        --spectrum-fieldlabel-asterisk-gap
+    ); /* [dir=rtl] .spectrum-FieldLabel--left .spectrum-FieldLabel-requiredIcon */
 }
 :host([dir='rtl'][side-aligned='start']) .required-icon {
     margin-left: 0;
@@ -187,11 +225,24 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-100)
     ); /* .spectrum-FieldLabel--left .spectrum-FieldLabel-requiredIcon */
 }
+:host(:dir(ltr)[side-aligned='end']) {
+    text-align: right; /* [dir=ltr] .spectrum-FieldLabel--right */
+}
 :host([dir='ltr'][side-aligned='end']) {
     text-align: right; /* [dir=ltr] .spectrum-FieldLabel--right */
 }
+:host(:dir(rtl)[side-aligned='end']) {
+    text-align: left; /* [dir=rtl] .spectrum-FieldLabel--right */
+}
 :host([dir='rtl'][side-aligned='end']) {
     text-align: left; /* [dir=rtl] .spectrum-FieldLabel--right */
+}
+:host(:dir(ltr)[side-aligned='end']) {
+    padding-left: 0; /* [dir=ltr] .spectrum-FieldLabel--right */
+    padding-right: var(
+        --spectrum-fieldlabel-m-side-padding-right,
+        var(--spectrum-global-dimension-size-150)
+    );
 }
 :host([dir='ltr'][side-aligned='end']) {
     padding-left: 0; /* [dir=ltr] .spectrum-FieldLabel--right */
@@ -199,6 +250,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-fieldlabel-m-side-padding-right,
         var(--spectrum-global-dimension-size-150)
     );
+}
+:host(:dir(rtl)[side-aligned='end']) {
+    padding-left: var(
+        --spectrum-fieldlabel-m-side-padding-right,
+        var(--spectrum-global-dimension-size-150)
+    );
+    padding-right: 0; /* [dir=rtl] .spectrum-FieldLabel--right */
 }
 :host([dir='rtl'][side-aligned='end']) {
     padding-left: var(

--- a/packages/help-text/src/spectrum-help-text.css
+++ b/packages/help-text/src/spectrum-help-text.css
@@ -163,10 +163,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: flex; /* .spectrum-HelpText */
     font-size: var(--spectrum-helptext-neutral-texticon-text-size);
 }
+:host(:dir(ltr)) .icon {
+    margin-right: var(
+        --spectrum-helptext-neutral-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-HelpText .spectrum-HelpText-validationIcon */
+}
 :host([dir='ltr']) .icon {
     margin-right: var(
         --spectrum-helptext-neutral-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-HelpText .spectrum-HelpText-validationIcon */
+}
+:host(:dir(rtl)) .icon {
+    margin-left: var(
+        --spectrum-helptext-neutral-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-HelpText .spectrum-HelpText-validationIcon */
 }
 :host([dir='rtl']) .icon {
     margin-left: var(
@@ -182,10 +192,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-helptext-negative-texticon-icon-padding-top
     ); /* .spectrum-HelpText .spectrum-HelpText-validationIcon */
 }
+:host(:dir(ltr)) .text {
+    margin-right: var(
+        --spectrum-helptext-neutral-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-HelpText .spectrum-HelpText-text */
+}
 :host([dir='ltr']) .text {
     margin-right: var(
         --spectrum-helptext-neutral-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-HelpText .spectrum-HelpText-text */
+}
+:host(:dir(rtl)) .text {
+    margin-left: var(
+        --spectrum-helptext-neutral-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-HelpText .spectrum-HelpText-text */
 }
 :host([dir='rtl']) .text {
     margin-left: var(

--- a/packages/menu/src/menu-group.css
+++ b/packages/menu/src/menu-group.css
@@ -24,6 +24,19 @@ governing permissions and limitations under the License.
  * direction of the content while https://github.com/adobe/spectrum-css/issues/794
  * persists at the Spectrum CSS level.
  */
+
+:host(:dir(ltr)) .header {
+    /* .spectrum-Menu-sectionHeading */
+    padding: 0 var(--spectrum-global-dimension-size-450) 0
+        var(--spectrum-global-dimension-size-150);
+}
+
+:host(:dir(rtl)) .header {
+    /* .spectrum-Menu-sectionHeading */
+    padding: 0 var(--spectrum-global-dimension-size-150) 0
+        var(--spectrum-global-dimension-size-450);
+}
+
 :host([dir='ltr']) .header {
     /* .spectrum-Menu-sectionHeading */
     padding: 0 var(--spectrum-global-dimension-size-450) 0

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -28,12 +28,28 @@ governing permissions and limitations under the License.
     align-self: start;
 }
 
+:host(:dir(ltr)) ::slotted([slot='value']) {
+    margin-left: var(--spectrum-listitem-icon-gap);
+}
+
+:host(:dir(rtl)) ::slotted([slot='value']) {
+    margin-right: var(--spectrum-listitem-icon-gap);
+}
+
 :host([dir='ltr']) ::slotted([slot='value']) {
     margin-left: var(--spectrum-listitem-texticon-icon-gap);
 }
 
 :host([dir='rtl']) ::slotted([slot='value']) {
     margin-right: var(--spectrum-listitem-texticon-icon-gap);
+}
+
+:host(:dir(ltr)) [icon-only]::slotted(:last-of-type) {
+    margin-right: auto;
+}
+
+:host(:dir(rtl)) [icon-only]::slotted(:last-of-type) {
+    margin-left: auto;
 }
 
 :host([dir='ltr']) [icon-only]::slotted(:last-of-type) {

--- a/packages/menu/src/spectrum-checkmark.css
+++ b/packages/menu/src/spectrum-checkmark.css
@@ -16,11 +16,25 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     opacity: 1; /* .spectrum-Menu-checkmark */
     transform: scale(1); /* .spectrum-Menu-checkmark */
 }
+:host(:dir(ltr)) .checkmark {
+    padding-left: var(
+        --spectrum-listitem-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-Menu-checkmark,
+   * [dir=ltr] 
+.spectrum-Menu-chevron */
+}
 :host([dir='ltr']) .checkmark {
     padding-left: var(
         --spectrum-listitem-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-Menu-checkmark,
    * [dir=ltr] 
+.spectrum-Menu-chevron */
+}
+:host(:dir(rtl)) .checkmark {
+    padding-right: var(
+        --spectrum-listitem-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-Menu-checkmark,
+   * [dir=rtl] 
 .spectrum-Menu-chevron */
 }
 :host([dir='rtl']) .checkmark {

--- a/packages/menu/src/spectrum-chevron.css
+++ b/packages/menu/src/spectrum-chevron.css
@@ -10,11 +10,25 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host(:dir(ltr)) .chevron {
+    padding-left: var(
+        --spectrum-listitem-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-Menu-checkmark,
+   * [dir=ltr] 
+.spectrum-Menu-chevron */
+}
 :host([dir='ltr']) .chevron {
     padding-left: var(
         --spectrum-listitem-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-Menu-checkmark,
    * [dir=ltr] 
+.spectrum-Menu-chevron */
+}
+:host(:dir(rtl)) .chevron {
+    padding-right: var(
+        --spectrum-listitem-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-Menu-checkmark,
+   * [dir=rtl] 
 .spectrum-Menu-chevron */
 }
 :host([dir='rtl']) .chevron {
@@ -31,6 +45,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-listitem-texticon-ui-icon-margin-top) -
             var(--spectrum-listitem-texticon-padding-y) + 1px
     );
+}
+:host(:dir(rtl)) .chevron {
+    transform: matrix(-1, 0, 0, 1, 0, 0); /* [dir=rtl] .spectrum-Menu-chevron */
 }
 :host([dir='rtl']) .chevron {
     transform: matrix(-1, 0, 0, 1, 0, 0); /* [dir=rtl] .spectrum-Menu-chevron */

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -55,15 +55,23 @@ const config = {
                 },
                 {
                     replacement:
-                        ':host([dir="ltr"][selects]) ::slotted(sp-menu-item[selected])',
-                    selector:
-                        '.spectrum-Menu[dir=ltr].is-selectable .spectrum-Menu-item.is-selected',
+                        '.is-selectable ::slotted(sp-menu-item[selected])',
+                    selector: /\.is-selectable \.spectrum-Menu-item\.is-selected(?!\S)/,
                 },
                 {
                     replacement:
-                        ':host([dir="rtl"][selects]) ::slotted(sp-menu-item[selected])',
-                    selector:
-                        '.spectrum-Menu[dir=rtl].is-selectable .spectrum-Menu-item.is-selected',
+                        '.is-selectable ::slotted(sp-menu-item[selected])',
+                    selector: /\.is-selectable \.spectrum-Menu-item\.is-selected(?!\S)/,
+                },
+                {
+                    replacement:
+                        '.is-selectable ::slotted(sp-menu-item:not([selected]))',
+                    selector: /\.is-selectable \.spectrum-Menu-item(?!\S)/,
+                },
+                {
+                    replacement:
+                        '.is-selectable ::slotted(sp-menu-item:not([selected]))',
+                    selector: /\.is-selectable \.spectrum-Menu-item(?!\S)/,
                 },
             ],
         },

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -10,9 +10,17 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host(:dir(ltr)) {
+    border-left: var(--spectrum-listitem-texticon-focus-indicator-size) solid
+        transparent; /* [dir=ltr] .spectrum-Menu-item */
+}
 :host([dir='ltr']) {
     border-left: var(--spectrum-listitem-texticon-focus-indicator-size) solid
         transparent; /* [dir=ltr] .spectrum-Menu-item */
+}
+:host(:dir(rtl)) {
+    border-right: var(--spectrum-listitem-texticon-focus-indicator-size) solid
+        transparent; /* [dir=rtl] .spectrum-Menu-item */
 }
 :host([dir='rtl']) {
     border-right: var(--spectrum-listitem-texticon-focus-indicator-size) solid
@@ -38,6 +46,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host(:focus) {
     outline: none; /* .spectrum-Menu-item:focus */
 }
+:host(:dir(ltr)[selected]) {
+    padding-right: calc(
+        var(--spectrum-listitem-texticon-padding-right) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    ); /* [dir=ltr] .spectrum-Menu-item.is-selected */
+}
 :host([dir='ltr'][selected]) {
     padding-right: calc(
         var(--spectrum-listitem-texticon-padding-right) -
@@ -46,6 +63,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-alias-border-size-thin)
             )
     ); /* [dir=ltr] .spectrum-Menu-item.is-selected */
+}
+:host(:dir(rtl)[selected]) {
+    padding-left: calc(
+        var(--spectrum-listitem-texticon-padding-right) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    ); /* [dir=rtl] .spectrum-Menu-item.is-selected */
 }
 :host([dir='rtl'][selected]) {
     padding-left: calc(
@@ -65,12 +91,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     flex-shrink: 0; /* .spectrum-Menu-item .spectrum-Icon,
    * .spectrum-Menu-item .spectrum-Menu-itemIcon */
 }
+:host(:dir(ltr)) slot[name='icon'] + #label,
+:host([dir='ltr']) .icon + #label {
+    margin-left: var(
+        --spectrum-listitem-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=ltr] 
+  .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+}
 :host([dir='ltr']) .icon + #label,
 :host([dir='ltr']) slot[name='icon'] + #label {
     margin-left: var(
         --spectrum-listitem-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
    * [dir=ltr] 
+  .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
+}
+:host(:dir(rtl)) slot[name='icon'] + #label,
+:host([dir='rtl']) .icon + #label {
+    margin-right: var(
+        --spectrum-listitem-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-Menu-item .spectrum-Icon+.spectrum-Menu-itemLabel,
+   * [dir=rtl] 
   .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
 }
 :host([dir='rtl']) .icon + #label,
@@ -110,12 +152,28 @@ slot[name='icon'] + #label {
     text-overflow: ellipsis; /* .spectrum-Menu-itemLabel--wrapping */
     white-space: nowrap;
 }
+:host(:dir(ltr)) .checkmark,
+:host(:dir(ltr)) .chevron {
+    padding-left: var(
+        --spectrum-listitem-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-Menu-checkmark,
+   * [dir=ltr] 
+.spectrum-Menu-chevron */
+}
 :host([dir='ltr']) .checkmark,
 :host([dir='ltr']) .chevron {
     padding-left: var(
         --spectrum-listitem-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-Menu-checkmark,
    * [dir=ltr] 
+.spectrum-Menu-chevron */
+}
+:host(:dir(rtl)) .checkmark,
+:host(:dir(rtl)) .chevron {
+    padding-right: var(
+        --spectrum-listitem-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-Menu-checkmark,
+   * [dir=rtl] 
 .spectrum-Menu-chevron */
 }
 :host([dir='rtl']) .checkmark,
@@ -125,6 +183,9 @@ slot[name='icon'] + #label {
     ); /* [dir=rtl] .spectrum-Menu-checkmark,
    * [dir=rtl] 
 .spectrum-Menu-chevron */
+}
+:host(:dir(rtl)) .chevron {
+    transform: matrix(-1, 0, 0, 1, 0, 0); /* [dir=rtl] .spectrum-Menu-chevron */
 }
 :host([dir='rtl']) .chevron {
     transform: matrix(-1, 0, 0, 1, 0, 0); /* [dir=rtl] .spectrum-Menu-chevron */
@@ -138,6 +199,24 @@ slot[name='icon'] + #label {
         --spectrum-listitem-m-texticon-text-color,
         var(--spectrum-alias-component-text-color-default)
     );
+}
+:host(:dir(ltr).focus-visible),
+:host([dir='ltr'][focused]) {
+    border-left-color: var(
+        --spectrum-listitem-m-texticon-focus-indicator-color,
+        var(--spectrum-alias-border-color-key-focus)
+    ); /* [dir=ltr] .spectrum-Menu-item.focus-ring,
+   * [dir=ltr] 
+  .spectrum-Menu-item.is-focused */
+}
+:host(:dir(ltr):focus-visible),
+:host([dir='ltr'][focused]) {
+    border-left-color: var(
+        --spectrum-listitem-m-texticon-focus-indicator-color,
+        var(--spectrum-alias-border-color-key-focus)
+    ); /* [dir=ltr] .spectrum-Menu-item.focus-ring,
+   * [dir=ltr] 
+  .spectrum-Menu-item.is-focused */
 }
 :host([dir='ltr'].focus-visible),
 :host([dir='ltr'][focused]) {
@@ -155,6 +234,24 @@ slot[name='icon'] + #label {
         var(--spectrum-alias-border-color-key-focus)
     ); /* [dir=ltr] .spectrum-Menu-item.focus-ring,
    * [dir=ltr] 
+  .spectrum-Menu-item.is-focused */
+}
+:host(:dir(rtl).focus-visible),
+:host([dir='rtl'][focused]) {
+    border-right-color: var(
+        --spectrum-listitem-m-texticon-focus-indicator-color,
+        var(--spectrum-alias-border-color-key-focus)
+    ); /* [dir=rtl] .spectrum-Menu-item.focus-ring,
+   * [dir=rtl] 
+  .spectrum-Menu-item.is-focused */
+}
+:host(:dir(rtl):focus-visible),
+:host([dir='rtl'][focused]) {
+    border-right-color: var(
+        --spectrum-listitem-m-texticon-focus-indicator-color,
+        var(--spectrum-alias-border-color-key-focus)
+    ); /* [dir=rtl] .spectrum-Menu-item.focus-ring,
+   * [dir=rtl] 
   .spectrum-Menu-item.is-focused */
 }
 :host([dir='rtl'].focus-visible),

--- a/packages/menu/src/spectrum-menu.css
+++ b/packages/menu/src/spectrum-menu.css
@@ -114,15 +114,34 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     overflow: auto;
     padding: 0;
 }
-:host([dir='ltr'][selects]) ::slotted(sp-menu-item) {
+:host(:dir(ltr)[selects]) ::slotted(sp-menu-item:not([selected])) {
     padding-right: var(
         --spectrum-listitem-texticon-selectable-padding-right
     ); /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item */
 }
-:host([dir='rtl'][selects]) ::slotted(sp-menu-item) {
+:host([dir='ltr'][selects]) ::slotted(sp-menu-item:not([selected])) {
+    padding-right: var(
+        --spectrum-listitem-texticon-selectable-padding-right
+    ); /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+}
+:host(:dir(rtl)[selects]) ::slotted(sp-menu-item:not([selected])) {
     padding-left: var(
         --spectrum-listitem-texticon-selectable-padding-right
     ); /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+}
+:host([dir='rtl'][selects]) ::slotted(sp-menu-item:not([selected])) {
+    padding-left: var(
+        --spectrum-listitem-texticon-selectable-padding-right
+    ); /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item */
+}
+:host(:dir(ltr)[selects]) ::slotted(sp-menu-item[selected]) {
+    padding-right: calc(
+        var(--spectrum-listitem-texticon-padding-right) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    ); /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
 }
 :host([dir='ltr'][selects]) ::slotted(sp-menu-item[selected]) {
     padding-right: calc(
@@ -132,6 +151,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-alias-border-size-thin)
             )
     ); /* [dir=ltr] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
+}
+:host(:dir(rtl)[selects]) ::slotted(sp-menu-item[selected]) {
+    padding-left: calc(
+        var(--spectrum-listitem-texticon-padding-right) -
+            var(
+                --spectrum-popover-border-size,
+                var(--spectrum-alias-border-size-thin)
+            )
+    ); /* [dir=rtl] .spectrum-Menu.is-selectable .spectrum-Menu-item.is-selected */
 }
 :host([dir='rtl'][selects]) ::slotted(sp-menu-item[selected]) {
     padding-left: calc(

--- a/packages/meter/src/meter.css
+++ b/packages/meter/src/meter.css
@@ -16,6 +16,10 @@ governing permissions and limitations under the License.
     transform-origin: left;
 }
 
+:host(:dir(rtl)) .fill {
+    transform-origin: right;
+}
+
 :host([dir='rtl']) .fill {
     transform-origin: right;
 }

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -138,10 +138,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border: none; /* .spectrum-ProgressBar-fill */
     transition: width 1s;
 }
+:host(:dir(ltr)) .label,
+:host(:dir(ltr)) .percentage {
+    text-align: left; /* [dir=ltr] .spectrum-ProgressBar-label,
+   * [dir=ltr] 
+.spectrum-ProgressBar-percentage */
+}
 :host([dir='ltr']) .label,
 :host([dir='ltr']) .percentage {
     text-align: left; /* [dir=ltr] .spectrum-ProgressBar-label,
    * [dir=ltr] 
+.spectrum-ProgressBar-percentage */
+}
+:host(:dir(rtl)) .label,
+:host(:dir(rtl)) .percentage {
+    text-align: right; /* [dir=rtl] .spectrum-ProgressBar-label,
+   * [dir=rtl] 
 .spectrum-ProgressBar-percentage */
 }
 :host([dir='rtl']) .label,
@@ -160,10 +172,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .label {
     flex: 1 1 0%; /* .spectrum-ProgressBar-label */
 }
+:host(:dir(ltr)) .percentage {
+    margin-left: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=ltr] .spectrum-ProgressBar-percentage */
+}
 :host([dir='ltr']) .percentage {
     margin-left: var(
         --spectrum-fieldlabel-side-padding-right
     ); /* [dir=ltr] .spectrum-ProgressBar-percentage */
+}
+:host(:dir(rtl)) .percentage {
+    margin-right: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=rtl] .spectrum-ProgressBar-percentage */
 }
 :host([dir='rtl']) .percentage {
     margin-right: var(
@@ -185,10 +207,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-progressbar-width
     ); /* .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-track */
 }
+:host(:dir(ltr)[side-label]) .label {
+    margin-right: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-label */
+}
 :host([dir='ltr'][side-label]) .label {
     margin-right: var(
         --spectrum-fieldlabel-side-padding-right
     ); /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-label */
+}
+:host(:dir(rtl)[side-label]) .label {
+    margin-left: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=rtl] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-label */
 }
 :host([dir='rtl'][side-label]) .label {
     margin-left: var(
@@ -199,16 +231,32 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     flex-grow: 0; /* .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-label */
     margin-bottom: 0;
 }
+:host(:dir(ltr)[side-label]) .percentage {
+    text-align: right; /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
+}
 :host([dir='ltr'][side-label]) .percentage {
     text-align: right; /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
 }
+:host(:dir(rtl)[side-label]) .percentage {
+    text-align: left; /* [dir=rtl] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
+}
 :host([dir='rtl'][side-label]) .percentage {
     text-align: left; /* [dir=rtl] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
+}
+:host(:dir(ltr)[side-label]) .percentage {
+    margin-left: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
 }
 :host([dir='ltr'][side-label]) .percentage {
     margin-left: var(
         --spectrum-fieldlabel-side-padding-right
     ); /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
+}
+:host(:dir(rtl)[side-label]) .percentage {
+    margin-right: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=rtl] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
 }
 :host([dir='rtl'][side-label]) .percentage {
     margin-right: var(
@@ -229,9 +277,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-ProgressBar--indeterminate .spectrum-ProgressBar-fill */
     will-change: transform;
 }
+:host(:dir(ltr)[indeterminate]) .fill {
+    animation: indeterminate-loop-ltr
+        var(--spectrum-progressbar-indeterminate-duration) infinite; /* [dir=ltr] .spectrum-ProgressBar--indeterminate .spectrum-ProgressBar-fill */
+}
 :host([dir='ltr'][indeterminate]) .fill {
     animation: indeterminate-loop-ltr
         var(--spectrum-progressbar-indeterminate-duration) infinite; /* [dir=ltr] .spectrum-ProgressBar--indeterminate .spectrum-ProgressBar-fill */
+}
+:host(:dir(rtl)[indeterminate]) .fill {
+    animation: indeterminate-loop-rtl
+        var(--spectrum-progressbar-indeterminate-duration) infinite; /* [dir=rtl] .spectrum-ProgressBar--indeterminate .spectrum-ProgressBar-fill */
 }
 :host([dir='rtl'][indeterminate]) .fill {
     animation: indeterminate-loop-rtl

--- a/packages/number-field/src/number-field.css
+++ b/packages/number-field/src/number-field.css
@@ -40,6 +40,38 @@ sp-field-button {
     );
 }
 
+:host(:dir(ltr)[invalid]:not([hide-stepper])) .icon {
+    /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    right: calc(
+        var(--spectrum-stepper-button-width) +
+            var(--spectrum-textfield-error-icon-margin-left)
+    );
+}
+
+:host(:dir(rtl)[invalid]:not([hide-stepper])) .icon {
+    /* [dir=rtl] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    left: calc(
+        var(--spectrum-stepper-button-width) +
+            var(--spectrum-textfield-error-icon-margin-left)
+    );
+}
+
+:host(:dir(ltr)[valid]:not([hide-stepper])) .icon {
+    /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    right: calc(
+        var(--spectrum-stepper-button-width) +
+            var(--spectrum-textfield-error-icon-margin-left)
+    );
+}
+
+:host(:dir(rtl)[valid]:not([hide-stepper])) .icon {
+    /* [dir=rtl] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    left: calc(
+        var(--spectrum-stepper-button-width) +
+            var(--spectrum-textfield-error-icon-margin-left)
+    );
+}
+
 :host([dir='ltr'][invalid]:not([hide-stepper])) .icon {
     /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
     right: calc(
@@ -72,6 +104,26 @@ sp-field-button {
     );
 }
 
+:host(:dir(ltr)[quiet][invalid]:not([hide-stepper])) .icon {
+    /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    right: var(--spectrum-stepper-button-width);
+}
+
+:host(:dir(rtl)[quiet][invalid]:not([hide-stepper])) .icon {
+    /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+    left: var(--spectrum-stepper-button-width);
+}
+
+:host(:dir(ltr)[quiet][valid]:not([hide-stepper])) .icon {
+    /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    right: var(--spectrum-stepper-button-width);
+}
+
+:host(:dir(rtl)[quiet][valid]:not([hide-stepper])) .icon {
+    /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+    left: var(--spectrum-stepper-button-width);
+}
+
 :host([dir='ltr'][quiet][invalid]:not([hide-stepper])) .icon {
     /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
     right: var(--spectrum-stepper-button-width);
@@ -92,6 +144,22 @@ sp-field-button {
     left: var(--spectrum-stepper-button-width);
 }
 
+:host(:dir(ltr):not([hide-stepper])) .icon-workflow {
+    /* [dir=ltr] .spectrum-Textfield-icon */
+    left: calc(
+        var(--spectrum-stepper-button-width) +
+            var(--spectrum-textfield-error-icon-margin-left)
+    );
+}
+
+:host(:dir(rtl):not([hide-stepper])) .icon-workflow {
+    /* [dir=rtl] .spectrum-Textfield-icon */
+    right: calc(
+        var(--spectrum-stepper-button-width) +
+            var(--spectrum-textfield-error-icon-margin-left)
+    );
+}
+
 :host([dir='ltr']:not([hide-stepper])) .icon-workflow {
     /* [dir=ltr] .spectrum-Textfield-icon */
     left: calc(
@@ -106,6 +174,16 @@ sp-field-button {
         var(--spectrum-stepper-button-width) +
             var(--spectrum-textfield-error-icon-margin-left)
     );
+}
+
+:host(:dir(ltr)[quiet]:not([hide-stepper])) .icon-workflow {
+    /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-icon */
+    left: var(--spectrum-stepper-button-width);
+}
+
+:host(:dir(rtl)[quiet]:not([hide-stepper])) .icon-workflow {
+    /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-icon */
+    right: var(--spectrum-stepper-button-width);
 }
 
 :host([dir='ltr'][quiet]:not([hide-stepper])) .icon-workflow {

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -63,11 +63,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #textfield:before {
     content: ''; /* .spectrum-Stepper:before */
 }
+:host(:dir(ltr)) .buttons {
+    border-top-left-radius: 0; /* [dir=ltr] .spectrum-Stepper-buttons */
+}
 :host([dir='ltr']) .buttons {
     border-top-left-radius: 0; /* [dir=ltr] .spectrum-Stepper-buttons */
 }
+:host(:dir(rtl)) .buttons {
+    border-top-right-radius: 0; /* [dir=rtl] .spectrum-Stepper-buttons */
+}
 :host([dir='rtl']) .buttons {
     border-top-right-radius: 0; /* [dir=rtl] .spectrum-Stepper-buttons */
+}
+:host(:dir(ltr)) .buttons {
+    border-top-right-radius: var(
+        --spectrum-alias-border-radius-regular,
+        var(--spectrum-global-dimension-size-50)
+    ); /* [dir=ltr] .spectrum-Stepper-buttons */
 }
 :host([dir='ltr']) .buttons {
     border-top-right-radius: var(
@@ -75,11 +87,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-50)
     ); /* [dir=ltr] .spectrum-Stepper-buttons */
 }
+:host(:dir(rtl)) .buttons {
+    border-top-left-radius: var(
+        --spectrum-alias-border-radius-regular,
+        var(--spectrum-global-dimension-size-50)
+    ); /* [dir=rtl] .spectrum-Stepper-buttons */
+}
 :host([dir='rtl']) .buttons {
     border-top-left-radius: var(
         --spectrum-alias-border-radius-regular,
         var(--spectrum-global-dimension-size-50)
     ); /* [dir=rtl] .spectrum-Stepper-buttons */
+}
+:host(:dir(ltr)) .buttons {
+    border-bottom-right-radius: var(
+        --spectrum-alias-border-radius-regular,
+        var(--spectrum-global-dimension-size-50)
+    ); /* [dir=ltr] .spectrum-Stepper-buttons */
 }
 :host([dir='ltr']) .buttons {
     border-bottom-right-radius: var(
@@ -87,14 +111,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-50)
     ); /* [dir=ltr] .spectrum-Stepper-buttons */
 }
+:host(:dir(rtl)) .buttons {
+    border-bottom-left-radius: var(
+        --spectrum-alias-border-radius-regular,
+        var(--spectrum-global-dimension-size-50)
+    ); /* [dir=rtl] .spectrum-Stepper-buttons */
+}
 :host([dir='rtl']) .buttons {
     border-bottom-left-radius: var(
         --spectrum-alias-border-radius-regular,
         var(--spectrum-global-dimension-size-50)
     ); /* [dir=rtl] .spectrum-Stepper-buttons */
 }
+:host(:dir(ltr)) .buttons {
+    border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Stepper-buttons */
+}
 :host([dir='ltr']) .buttons {
     border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Stepper-buttons */
+}
+:host(:dir(rtl)) .buttons {
+    border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Stepper-buttons */
 }
 :host([dir='rtl']) .buttons {
     border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Stepper-buttons */
@@ -104,12 +140,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     transition: box-shadow var(--spectrum-global-animation-duration-100, 0.13s)
         ease-in-out;
 }
+:host(:dir(ltr)) .stepDown,
+:host(:dir(ltr)) .stepUp {
+    padding-left: var(
+        --spectrum-stepper-button-padding
+    ); /* [dir=ltr] .spectrum-Stepper-stepUp,
+   * [dir=ltr] 
+.spectrum-Stepper-stepDown */
+}
 :host([dir='ltr']) .stepDown,
 :host([dir='ltr']) .stepUp {
     padding-left: var(
         --spectrum-stepper-button-padding
     ); /* [dir=ltr] .spectrum-Stepper-stepUp,
    * [dir=ltr] 
+.spectrum-Stepper-stepDown */
+}
+:host(:dir(rtl)) .stepDown,
+:host(:dir(rtl)) .stepUp {
+    padding-right: var(
+        --spectrum-stepper-button-padding
+    ); /* [dir=rtl] .spectrum-Stepper-stepUp,
+   * [dir=rtl] 
 .spectrum-Stepper-stepDown */
 }
 :host([dir='rtl']) .stepDown,
@@ -120,6 +172,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=rtl] 
 .spectrum-Stepper-stepDown */
 }
+:host(:dir(ltr)) .stepDown,
+:host(:dir(ltr)) .stepUp {
+    padding-right: var(
+        --spectrum-stepper-button-padding
+    ); /* [dir=ltr] .spectrum-Stepper-stepUp,
+   * [dir=ltr] 
+.spectrum-Stepper-stepDown */
+}
 :host([dir='ltr']) .stepDown,
 :host([dir='ltr']) .stepUp {
     padding-right: var(
@@ -128,12 +188,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=ltr] 
 .spectrum-Stepper-stepDown */
 }
+:host(:dir(rtl)) .stepDown,
+:host(:dir(rtl)) .stepUp {
+    padding-left: var(
+        --spectrum-stepper-button-padding
+    ); /* [dir=rtl] .spectrum-Stepper-stepUp,
+   * [dir=rtl] 
+.spectrum-Stepper-stepDown */
+}
 :host([dir='rtl']) .stepDown,
 :host([dir='rtl']) .stepUp {
     padding-left: var(
         --spectrum-stepper-button-padding
     ); /* [dir=rtl] .spectrum-Stepper-stepUp,
    * [dir=rtl] 
+.spectrum-Stepper-stepDown */
+}
+:host(:dir(ltr)) .stepDown,
+:host(:dir(ltr)) .stepUp {
+    border-left-width: var(
+        --spectrum-stepper-border-size-reset
+    ); /* [dir=ltr] .spectrum-Stepper-stepUp,
+   * [dir=ltr] 
 .spectrum-Stepper-stepDown */
 }
 :host([dir='ltr']) .stepDown,
@@ -144,12 +220,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=ltr] 
 .spectrum-Stepper-stepDown */
 }
+:host(:dir(rtl)) .stepDown,
+:host(:dir(rtl)) .stepUp {
+    border-right-width: var(
+        --spectrum-stepper-border-size-reset
+    ); /* [dir=rtl] .spectrum-Stepper-stepUp,
+   * [dir=rtl] 
+.spectrum-Stepper-stepDown */
+}
 :host([dir='rtl']) .stepDown,
 :host([dir='rtl']) .stepUp {
     border-right-width: var(
         --spectrum-stepper-border-size-reset
     ); /* [dir=rtl] .spectrum-Stepper-stepUp,
    * [dir=rtl] 
+.spectrum-Stepper-stepDown */
+}
+:host(:dir(ltr)) .stepDown,
+:host(:dir(ltr)) .stepUp {
+    border-top-left-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=ltr] .spectrum-Stepper-stepUp,
+   * [dir=ltr] 
 .spectrum-Stepper-stepDown */
 }
 :host([dir='ltr']) .stepDown,
@@ -160,6 +252,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=ltr] 
 .spectrum-Stepper-stepDown */
 }
+:host(:dir(rtl)) .stepDown,
+:host(:dir(rtl)) .stepUp {
+    border-top-right-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=rtl] .spectrum-Stepper-stepUp,
+   * [dir=rtl] 
+.spectrum-Stepper-stepDown */
+}
 :host([dir='rtl']) .stepDown,
 :host([dir='rtl']) .stepUp {
     border-top-right-radius: var(
@@ -168,12 +268,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=rtl] 
 .spectrum-Stepper-stepDown */
 }
+:host(:dir(ltr)) .stepDown,
+:host(:dir(ltr)) .stepUp {
+    border-bottom-left-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=ltr] .spectrum-Stepper-stepUp,
+   * [dir=ltr] 
+.spectrum-Stepper-stepDown */
+}
 :host([dir='ltr']) .stepDown,
 :host([dir='ltr']) .stepUp {
     border-bottom-left-radius: var(
         --spectrum-stepper-border-radius-reset
     ); /* [dir=ltr] .spectrum-Stepper-stepUp,
    * [dir=ltr] 
+.spectrum-Stepper-stepDown */
+}
+:host(:dir(rtl)) .stepDown,
+:host(:dir(rtl)) .stepUp {
+    border-bottom-right-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=rtl] .spectrum-Stepper-stepUp,
+   * [dir=rtl] 
 .spectrum-Stepper-stepDown */
 }
 :host([dir='rtl']) .stepDown,
@@ -202,10 +318,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Stepper-stepDown .spectrum-Icon */
     opacity: 1;
 }
+:host(:dir(ltr)) .stepUp {
+    border-bottom-right-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=ltr] .spectrum-Stepper-stepUp */
+}
 :host([dir='ltr']) .stepUp {
     border-bottom-right-radius: var(
         --spectrum-stepper-border-radius-reset
     ); /* [dir=ltr] .spectrum-Stepper-stepUp */
+}
+:host(:dir(rtl)) .stepUp {
+    border-bottom-left-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=rtl] .spectrum-Stepper-stepUp */
 }
 :host([dir='rtl']) .stepUp {
     border-bottom-left-radius: var(
@@ -216,10 +342,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border-bottom: none; /* .spectrum-Stepper-stepUp */
     padding-top: var(--spectrum-stepper-icon-nudge-top);
 }
+:host(:dir(ltr)) .stepDown {
+    border-top-right-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=ltr] .spectrum-Stepper-stepDown */
+}
 :host([dir='ltr']) .stepDown {
     border-top-right-radius: var(
         --spectrum-stepper-border-radius-reset
     ); /* [dir=ltr] .spectrum-Stepper-stepDown */
+}
+:host(:dir(rtl)) .stepDown {
+    border-top-left-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=rtl] .spectrum-Stepper-stepDown */
 }
 :host([dir='rtl']) .stepDown {
     border-top-left-radius: var(
@@ -235,20 +371,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     flex: 1; /* .spectrum-Stepper-textfield */
     width: auto;
 }
+:host(:dir(ltr)) .input {
+    border-top-right-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=ltr] .spectrum-Stepper-input */
+}
 :host([dir='ltr']) .input {
     border-top-right-radius: var(
         --spectrum-stepper-border-radius-reset
     ); /* [dir=ltr] .spectrum-Stepper-input */
+}
+:host(:dir(rtl)) .input {
+    border-top-left-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=rtl] .spectrum-Stepper-input */
 }
 :host([dir='rtl']) .input {
     border-top-left-radius: var(
         --spectrum-stepper-border-radius-reset
     ); /* [dir=rtl] .spectrum-Stepper-input */
 }
+:host(:dir(ltr)) .input {
+    border-bottom-right-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=ltr] .spectrum-Stepper-input */
+}
 :host([dir='ltr']) .input {
     border-bottom-right-radius: var(
         --spectrum-stepper-border-radius-reset
     ); /* [dir=ltr] .spectrum-Stepper-input */
+}
+:host(:dir(rtl)) .input {
+    border-bottom-left-radius: var(
+        --spectrum-stepper-border-radius-reset
+    ); /* [dir=rtl] .spectrum-Stepper-input */
 }
 :host([dir='rtl']) .input {
     border-bottom-left-radius: var(
@@ -270,12 +426,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-stepper-border-radius-reset
     ); /* .spectrum-Stepper--quiet .spectrum-Stepper-buttons */
 }
+:host(:dir(ltr)[quiet]) .stepDown,
+:host(:dir(ltr)[quiet]) .stepUp {
+    border-right-width: var(
+        --spectrum-stepper-border-size-reset
+    ); /* [dir=ltr] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
+   * [dir=ltr] 
+  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
+}
 :host([dir='ltr'][quiet]) .stepDown,
 :host([dir='ltr'][quiet]) .stepUp {
     border-right-width: var(
         --spectrum-stepper-border-size-reset
     ); /* [dir=ltr] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
    * [dir=ltr] 
+  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
+}
+:host(:dir(rtl)[quiet]) .stepDown,
+:host(:dir(rtl)[quiet]) .stepUp {
+    border-left-width: var(
+        --spectrum-stepper-border-size-reset
+    ); /* [dir=rtl] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
+   * [dir=rtl] 
   .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
 }
 :host([dir='rtl'][quiet]) .stepDown,
@@ -286,10 +458,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=rtl] 
   .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
 }
+:host(:dir(ltr)[quiet]) .stepDown,
+:host(:dir(ltr)[quiet]) .stepUp {
+    border-left: none; /* [dir=ltr] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
+   * [dir=ltr] 
+  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
+}
 :host([dir='ltr'][quiet]) .stepDown,
 :host([dir='ltr'][quiet]) .stepUp {
     border-left: none; /* [dir=ltr] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
    * [dir=ltr] 
+  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
+}
+:host(:dir(rtl)[quiet]) .stepDown,
+:host(:dir(rtl)[quiet]) .stepUp {
+    border-right: none; /* [dir=rtl] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
+   * [dir=rtl] 
   .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
 }
 :host([dir='rtl'][quiet]) .stepDown,
@@ -298,10 +482,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=rtl] 
   .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
 }
+:host(:dir(ltr)[quiet]) .stepDown,
+:host(:dir(ltr)[quiet]) .stepUp {
+    padding-right: 0; /* [dir=ltr] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
+   * [dir=ltr] 
+  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
+}
 :host([dir='ltr'][quiet]) .stepDown,
 :host([dir='ltr'][quiet]) .stepUp {
     padding-right: 0; /* [dir=ltr] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
    * [dir=ltr] 
+  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
+}
+:host(:dir(rtl)[quiet]) .stepDown,
+:host(:dir(rtl)[quiet]) .stepUp {
+    padding-left: 0; /* [dir=rtl] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
+   * [dir=rtl] 
   .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
 }
 :host([dir='rtl'][quiet]) .stepDown,
@@ -321,12 +517,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Stepper--quiet .spectrum-Stepper-stepUp,
    * .spectrum-Stepper--quiet .spectrum-Stepper-stepDown */
 }
+:host(:dir(ltr)[quiet]) .stepDown:after,
+:host(:dir(ltr)[quiet]) .stepUp:after {
+    right: calc(
+        var(--spectrum-stepper-button-offset) * -1
+    ); /* [dir=ltr] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp:after,
+   * [dir=ltr]  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown:after */
+}
 :host([dir='ltr'][quiet]) .stepDown:after,
 :host([dir='ltr'][quiet]) .stepUp:after {
     right: calc(
         var(--spectrum-stepper-button-offset) * -1
     ); /* [dir=ltr] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp:after,
    * [dir=ltr]  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown:after */
+}
+:host(:dir(rtl)[quiet]) .stepDown:after,
+:host(:dir(rtl)[quiet]) .stepUp:after {
+    left: calc(
+        var(--spectrum-stepper-button-offset) * -1
+    ); /* [dir=rtl] .spectrum-Stepper--quiet .spectrum-Stepper-stepUp:after,
+   * [dir=rtl]  .spectrum-Stepper--quiet .spectrum-Stepper-stepDown:after */
 }
 :host([dir='rtl'][quiet]) .stepDown:after,
 :host([dir='rtl'][quiet]) .stepUp:after {

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -18,14 +18,10 @@ import {
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
-import { property } from '@spectrum-web-components/base/src/decorators.js';
+import { property, queryAsync } from '@spectrum-web-components/base/src/decorators.js';
 import { reparentChildren } from '@spectrum-web-components/shared/src/reparent-children.js';
 import { firstFocusableIn } from '@spectrum-web-components/shared/src/first-focusable-in.js';
-import type {
-    Color,
-    Scale,
-    ThemeVariant,
-} from '@spectrum-web-components/theme/src/Theme.js';
+import type { Theme, ThemeData } from '@spectrum-web-components/theme/src/Theme.js';
 import styles from './active-overlay.css.js';
 import {
     OverlayOpenCloseDetail,
@@ -152,15 +148,25 @@ export class ActiveOverlay extends SpectrumElement {
 
     @property({ reflect: true })
     public placement?: Placement;
+    
     @property({ attribute: false })
-    public theme: {
-        color?: Color;
-        scale?: Scale;
-        lang?: string;
-        theme?: ThemeVariant;
-    } = {};
+    public theme: ThemeData = {};
+
     @property({ attribute: false })
     public receivesFocus?: 'auto';
+
+    @queryAsync('sp-theme')
+    private themeEl!: Theme;
+
+    public ready = false;
+
+    public async startManagingContentDirection(el: HTMLElement): Promise<void> {
+        (await this.themeEl).startManagingContentDirection(el);
+    }
+
+    public async stopManagingContentDirection(el: HTMLElement): Promise<void> {
+        (await this.themeEl).stopManagingContentDirection(el);
+    }
 
     public tabbingAway = false;
     private originalPlacement?: Placement;
@@ -535,13 +541,14 @@ export class ActiveOverlay extends SpectrumElement {
     }
 
     public renderTheme(content: TemplateResult): TemplateResult {
-        const { color, scale, lang, theme } = this.theme;
+        const { color, scale, lang, dir, theme } = this.theme;
         return html`
             <sp-theme
                 theme=${ifDefined(theme)}
                 color=${ifDefined(color)}
                 scale=${ifDefined(scale)}
                 lang=${ifDefined(lang)}
+                dir=${ifDefined(dir)}
                 part="theme"
             >
                 ${content}

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -110,6 +110,7 @@ export class Overlay {
             scale: undefined,
             lang: undefined,
             theme: undefined,
+            dir: undefined,
         };
         const queryThemeEvent = new CustomEvent<ThemeData>('sp-query-theme', {
             bubbles: true,

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -54,6 +54,14 @@ sp-popover {
     flex-shrink: 0;
 }
 
+:host(:dir(ltr)) #label.visually-hidden + .picker {
+    margin-left: auto;
+}
+
+:host(:dir(rtl)) #label.visually-hidden + .picker {
+    margin-right: auto;
+}
+
 /**
  * The accessibility team would prefer that it be possible to override the :focus-visible
  * heuristics in _some_ cases, like when clicking an `sp-field-label`...

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -52,11 +52,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #button:disabled {
     cursor: default; /* .spectrum-Picker:disabled */
 }
+:host(:dir(ltr)) #button {
+    padding-left: var(
+        --spectrum-picker-textonly-padding-left-adjusted
+    ); /* [dir=ltr] .spectrum-Picker */
+    padding-right: var(--spectrum-picker-textonly-padding-right-adjusted);
+}
 :host([dir='ltr']) #button {
     padding-left: var(
         --spectrum-picker-textonly-padding-left-adjusted
     ); /* [dir=ltr] .spectrum-Picker */
     padding-right: var(--spectrum-picker-textonly-padding-right-adjusted);
+}
+:host(:dir(rtl)) #button {
+    padding-left: var(--spectrum-picker-textonly-padding-right-adjusted);
+    padding-right: var(
+        --spectrum-picker-textonly-padding-left-adjusted
+    ); /* [dir=rtl] .spectrum-Picker */
 }
 :host([dir='rtl']) #button {
     padding-left: var(--spectrum-picker-textonly-padding-right-adjusted);
@@ -91,10 +103,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Picker.is-disabled */
     cursor: default;
 }
+:host(:dir(ltr)) #button .icon {
+    margin-right: var(
+        --spectrum-picker-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-Picker .spectrum-Picker-icon */
+}
 :host([dir='ltr']) #button .icon {
     margin-right: var(
         --spectrum-picker-texticon-icon-gap
     ); /* [dir=ltr] .spectrum-Picker .spectrum-Picker-icon */
+}
+:host(:dir(rtl)) #button .icon {
+    margin-left: var(
+        --spectrum-picker-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-Picker .spectrum-Picker-icon */
 }
 :host([dir='rtl']) #button .icon {
     margin-left: var(
@@ -104,6 +126,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .icon {
     flex-shrink: 0; /* .spectrum-Picker .spectrum-Picker-icon */
 }
+:host(:dir(ltr)) #button #label + .icon {
+    margin-left: calc(
+        (
+                var(--spectrum-picker-textonly-padding-left-adjusted) -
+                    var(--spectrum-picker-padding-left-adjusted)
+            ) * -1
+    ); /* [dir=ltr] .spectrum-Picker .spectrum-Picker-label+.spectrum-Picker-icon */
+}
 :host([dir='ltr']) #button #label + .icon {
     margin-left: calc(
         (
@@ -111,6 +141,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                     var(--spectrum-picker-padding-left-adjusted)
             ) * -1
     ); /* [dir=ltr] .spectrum-Picker .spectrum-Picker-label+.spectrum-Picker-icon */
+}
+:host(:dir(rtl)) #button #label + .icon {
+    margin-right: calc(
+        (
+                var(--spectrum-picker-textonly-padding-left-adjusted) -
+                    var(--spectrum-picker-padding-left-adjusted)
+            ) * -1
+    ); /* [dir=rtl] .spectrum-Picker .spectrum-Picker-label+.spectrum-Picker-icon */
 }
 :host([dir='rtl']) #button #label + .icon {
     margin-right: calc(
@@ -498,8 +536,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     box-shadow: none; /* .spectrum-Picker--quiet:disabled.focus-ring,
    * .spectrum-Picker--quiet.is-disabled.focus-ring */
 }
+:host(:dir(ltr)) #label {
+    text-align: left; /* [dir=ltr] .spectrum-Picker-label */
+}
 :host([dir='ltr']) #label {
     text-align: left; /* [dir=ltr] .spectrum-Picker-label */
+}
+:host(:dir(rtl)) #label {
+    text-align: right; /* [dir=rtl] .spectrum-Picker-label */
 }
 :host([dir='rtl']) #label {
     text-align: right; /* [dir=rtl] .spectrum-Picker-label */
@@ -535,20 +579,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         ease-out;
     vertical-align: top;
 }
+:host(:dir(ltr)) .validation-icon {
+    margin-left: var(
+        --spectrum-picker-texticon-error-icon-margin-left
+    ); /* [dir=ltr] .spectrum-Picker-validationIcon */
+}
 :host([dir='ltr']) .validation-icon {
     margin-left: var(
         --spectrum-picker-texticon-error-icon-margin-left
     ); /* [dir=ltr] .spectrum-Picker-validationIcon */
+}
+:host(:dir(rtl)) .validation-icon {
+    margin-right: var(
+        --spectrum-picker-texticon-error-icon-margin-left
+    ); /* [dir=rtl] .spectrum-Picker-validationIcon */
 }
 :host([dir='rtl']) .validation-icon {
     margin-right: var(
         --spectrum-picker-texticon-error-icon-margin-left
     ); /* [dir=rtl] .spectrum-Picker-validationIcon */
 }
+:host(:dir(ltr)) #label ~ .picker {
+    margin-left: var(
+        --spectrum-picker-texticon-ui-icon-gap
+    ); /* [dir=ltr] .spectrum-Picker-label~.spectrum-Picker-menuIcon */
+}
 :host([dir='ltr']) #label ~ .picker {
     margin-left: var(
         --spectrum-picker-texticon-ui-icon-gap
     ); /* [dir=ltr] .spectrum-Picker-label~.spectrum-Picker-menuIcon */
+}
+:host(:dir(rtl)) #label ~ .picker {
+    margin-right: var(
+        --spectrum-picker-texticon-ui-icon-gap
+    ); /* [dir=rtl] .spectrum-Picker-label~.spectrum-Picker-menuIcon */
 }
 :host([dir='rtl']) #label ~ .picker {
     margin-right: var(
@@ -559,6 +623,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     max-width: var(
         --spectrum-picker-texticon-popover-max-width
     ); /* .spectrum-Picker-popover */
+}
+:host(:dir(ltr)) .spectrum-Picker-popover--quiet {
+    margin-left: calc(
+        (
+                var(
+                        --spectrum-picker-m-quiet-texticon-popover-offset-x,
+                        var(--spectrum-global-dimension-size-150)
+                    ) +
+                    var(
+                        --spectrum-popover-border-size,
+                        var(--spectrum-alias-border-size-thin)
+                    )
+            ) * -1
+    ); /* [dir=ltr] .spectrum-Picker-popover--quiet */
 }
 :host([dir='ltr']) .spectrum-Picker-popover--quiet {
     margin-left: calc(
@@ -573,6 +651,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                     )
             ) * -1
     ); /* [dir=ltr] .spectrum-Picker-popover--quiet */
+}
+:host(:dir(rtl)) .spectrum-Picker-popover--quiet {
+    margin-right: calc(
+        (
+                var(
+                        --spectrum-picker-m-quiet-texticon-popover-offset-x,
+                        var(--spectrum-global-dimension-size-150)
+                    ) +
+                    var(
+                        --spectrum-popover-border-size,
+                        var(--spectrum-alias-border-size-thin)
+                    )
+            ) * -1
+    ); /* [dir=rtl] .spectrum-Picker-popover--quiet */
 }
 :host([dir='rtl']) .spectrum-Picker-popover--quiet {
     margin-right: calc(

--- a/packages/progress-bar/src/progress-bar.css
+++ b/packages/progress-bar/src/progress-bar.css
@@ -17,6 +17,10 @@ governing permissions and limitations under the License.
     transform-origin: left;
 }
 
+:host(:dir(rtl)) .fill {
+    transform-origin: right;
+}
+
 :host([dir='rtl']) .fill {
     transform-origin: right;
 }

--- a/packages/progress-bar/src/spectrum-progress-bar.css
+++ b/packages/progress-bar/src/spectrum-progress-bar.css
@@ -138,10 +138,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     border: none; /* .spectrum-ProgressBar-fill */
     transition: width 1s;
 }
+:host(:dir(ltr)) .label,
+:host(:dir(ltr)) .percentage {
+    text-align: left; /* [dir=ltr] .spectrum-ProgressBar-label,
+   * [dir=ltr] 
+.spectrum-ProgressBar-percentage */
+}
 :host([dir='ltr']) .label,
 :host([dir='ltr']) .percentage {
     text-align: left; /* [dir=ltr] .spectrum-ProgressBar-label,
    * [dir=ltr] 
+.spectrum-ProgressBar-percentage */
+}
+:host(:dir(rtl)) .label,
+:host(:dir(rtl)) .percentage {
+    text-align: right; /* [dir=rtl] .spectrum-ProgressBar-label,
+   * [dir=rtl] 
 .spectrum-ProgressBar-percentage */
 }
 :host([dir='rtl']) .label,
@@ -160,10 +172,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .label {
     flex: 1 1 0%; /* .spectrum-ProgressBar-label */
 }
+:host(:dir(ltr)) .percentage {
+    margin-left: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=ltr] .spectrum-ProgressBar-percentage */
+}
 :host([dir='ltr']) .percentage {
     margin-left: var(
         --spectrum-fieldlabel-side-padding-right
     ); /* [dir=ltr] .spectrum-ProgressBar-percentage */
+}
+:host(:dir(rtl)) .percentage {
+    margin-right: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=rtl] .spectrum-ProgressBar-percentage */
 }
 :host([dir='rtl']) .percentage {
     margin-right: var(
@@ -185,10 +207,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-progressbar-width
     ); /* .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-track */
 }
+:host(:dir(ltr)[side-label]) .label {
+    margin-right: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-label */
+}
 :host([dir='ltr'][side-label]) .label {
     margin-right: var(
         --spectrum-fieldlabel-side-padding-right
     ); /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-label */
+}
+:host(:dir(rtl)[side-label]) .label {
+    margin-left: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=rtl] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-label */
 }
 :host([dir='rtl'][side-label]) .label {
     margin-left: var(
@@ -199,16 +231,32 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     flex-grow: 0; /* .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-label */
     margin-bottom: 0;
 }
+:host(:dir(ltr)[side-label]) .percentage {
+    text-align: right; /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
+}
 :host([dir='ltr'][side-label]) .percentage {
     text-align: right; /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
 }
+:host(:dir(rtl)[side-label]) .percentage {
+    text-align: left; /* [dir=rtl] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
+}
 :host([dir='rtl'][side-label]) .percentage {
     text-align: left; /* [dir=rtl] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
+}
+:host(:dir(ltr)[side-label]) .percentage {
+    margin-left: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
 }
 :host([dir='ltr'][side-label]) .percentage {
     margin-left: var(
         --spectrum-fieldlabel-side-padding-right
     ); /* [dir=ltr] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
+}
+:host(:dir(rtl)[side-label]) .percentage {
+    margin-right: var(
+        --spectrum-fieldlabel-side-padding-right
+    ); /* [dir=rtl] .spectrum-ProgressBar--sideLabel .spectrum-ProgressBar-percentage */
 }
 :host([dir='rtl'][side-label]) .percentage {
     margin-right: var(
@@ -229,9 +277,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-ProgressBar--indeterminate .spectrum-ProgressBar-fill */
     will-change: transform;
 }
+:host(:dir(ltr)[indeterminate]) .fill {
+    animation: indeterminate-loop-ltr
+        var(--spectrum-progressbar-indeterminate-duration) infinite; /* [dir=ltr] .spectrum-ProgressBar--indeterminate .spectrum-ProgressBar-fill */
+}
 :host([dir='ltr'][indeterminate]) .fill {
     animation: indeterminate-loop-ltr
         var(--spectrum-progressbar-indeterminate-duration) infinite; /* [dir=ltr] .spectrum-ProgressBar--indeterminate .spectrum-ProgressBar-fill */
+}
+:host(:dir(rtl)[indeterminate]) .fill {
+    animation: indeterminate-loop-rtl
+        var(--spectrum-progressbar-indeterminate-duration) infinite; /* [dir=rtl] .spectrum-ProgressBar--indeterminate .spectrum-ProgressBar-fill */
 }
 :host([dir='rtl'][indeterminate]) .fill {
     animation: indeterminate-loop-rtl

--- a/packages/progress-circle/src/spectrum-progress-circle.css
+++ b/packages/progress-circle/src/spectrum-progress-circle.css
@@ -416,8 +416,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-400)
     );
 }
+:host(:dir(ltr)) .fills {
+    left: 0; /* [dir=ltr] .spectrum-ProgressCircle-fills */
+}
 :host([dir='ltr']) .fills {
     left: 0; /* [dir=ltr] .spectrum-ProgressCircle-fills */
+}
+:host(:dir(rtl)) .fills {
+    right: 0; /* [dir=rtl] .spectrum-ProgressCircle-fills */
 }
 :host([dir='rtl']) .fills {
     right: 0; /* [dir=rtl] .spectrum-ProgressCircle-fills */

--- a/packages/quick-actions/src/spectrum-quick-actions.css
+++ b/packages/quick-actions/src/spectrum-quick-actions.css
@@ -62,11 +62,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-global-dimension-size-50)
         );
 }
+:host(:dir(ltr)) slot[name='action'] + ::slotted([slot='action']) {
+    margin-left: var(
+        --spectrum-quickactions-button-gap-x,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=ltr] .spectrum-QuickActions .spectrum-ActionButton+.spectrum-ActionButton */
+}
 :host([dir='ltr']) slot[name='action'] + ::slotted([slot='action']) {
     margin-left: var(
         --spectrum-quickactions-button-gap-x,
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=ltr] .spectrum-QuickActions .spectrum-ActionButton+.spectrum-ActionButton */
+}
+:host(:dir(rtl)) slot[name='action'] + ::slotted([slot='action']) {
+    margin-right: var(
+        --spectrum-quickactions-button-gap-x,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=rtl] .spectrum-QuickActions .spectrum-ActionButton+.spectrum-ActionButton */
 }
 :host([dir='rtl']) slot[name='action'] + ::slotted([slot='action']) {
     margin-right: var(
@@ -74,11 +86,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=rtl] .spectrum-QuickActions .spectrum-ActionButton+.spectrum-ActionButton */
 }
+:host(:dir(ltr)[text-only]) slot[name='action'] + ::slotted([slot='action']) {
+    margin-left: var(
+        --spectrum-quickactions-text-button-gap-x,
+        var(--spectrum-global-dimension-size-50)
+    ); /* [dir=ltr] .spectrum-QuickActions--textOnly .spectrum-ActionButton+.spectrum-ActionButton */
+}
 :host([dir='ltr'][text-only]) slot[name='action'] + ::slotted([slot='action']) {
     margin-left: var(
         --spectrum-quickactions-text-button-gap-x,
         var(--spectrum-global-dimension-size-50)
     ); /* [dir=ltr] .spectrum-QuickActions--textOnly .spectrum-ActionButton+.spectrum-ActionButton */
+}
+:host(:dir(rtl)[text-only]) slot[name='action'] + ::slotted([slot='action']) {
+    margin-right: var(
+        --spectrum-quickactions-text-button-gap-x,
+        var(--spectrum-global-dimension-size-50)
+    ); /* [dir=rtl] .spectrum-QuickActions--textOnly .spectrum-ActionButton+.spectrum-ActionButton */
 }
 :host([dir='rtl'][text-only]) slot[name='action'] + ::slotted([slot='action']) {
     margin-right: var(

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -106,16 +106,32 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * -1
     ); /* .spectrum-Radio-input.focus-ring+.spectrum-Radio-button:after */
 }
+:host(:dir(ltr)) #label {
+    text-align: left; /* [dir=ltr] .spectrum-Radio-label */
+}
 :host([dir='ltr']) #label {
     text-align: left; /* [dir=ltr] .spectrum-Radio-label */
 }
+:host(:dir(rtl)) #label {
+    text-align: right; /* [dir=rtl] .spectrum-Radio-label */
+}
 :host([dir='rtl']) #label {
     text-align: right; /* [dir=rtl] .spectrum-Radio-label */
+}
+:host(:dir(ltr)) #label {
+    margin-left: var(
+        --spectrum-radio-text-gap
+    ); /* [dir=ltr] .spectrum-Radio-label */
 }
 :host([dir='ltr']) #label {
     margin-left: var(
         --spectrum-radio-text-gap
     ); /* [dir=ltr] .spectrum-Radio-label */
+}
+:host(:dir(rtl)) #label {
+    margin-right: var(
+        --spectrum-radio-text-gap
+    ); /* [dir=rtl] .spectrum-Radio-label */
 }
 :host([dir='rtl']) #label {
     margin-right: var(

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -22,8 +22,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: inline-block; /* .spectrum-Search */
     position: relative;
 }
+:host(:dir(ltr)) #button {
+    right: 0; /* [dir=ltr] .spectrum-Search-clearButton */
+}
 :host([dir='ltr']) #button {
     right: 0; /* [dir=ltr] .spectrum-Search-clearButton */
+}
+:host(:dir(rtl)) #button {
+    left: 0; /* [dir=rtl] .spectrum-Search-clearButton */
 }
 :host([dir='rtl']) #button {
     left: 0; /* [dir=rtl] .spectrum-Search-clearButton */
@@ -51,15 +57,42 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-50)
     ); /* .spectrum-Search-textfield:after */
 }
+:host(:dir(ltr):not([quiet])) #textfield .icon {
+    left: var(
+        --spectrum-alias-search-padding-left-m
+    ); /* [dir=ltr] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-icon */
+}
 :host([dir='ltr']:not([quiet])) #textfield .icon {
     left: var(
         --spectrum-alias-search-padding-left-m
     ); /* [dir=ltr] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-icon */
 }
+:host(:dir(rtl):not([quiet])) #textfield .icon {
+    right: var(
+        --spectrum-alias-search-padding-left-m
+    ); /* [dir=rtl] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-icon */
+}
 :host([dir='rtl']:not([quiet])) #textfield .icon {
     right: var(
         --spectrum-alias-search-padding-left-m
     ); /* [dir=rtl] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-icon */
+}
+:host(:dir(ltr):not([quiet])) #textfield #input {
+    padding-left: calc(
+        var(--spectrum-alias-search-padding-left-m) +
+            var(
+                --spectrum-alias-workflow-icon-size-m,
+                var(--spectrum-global-dimension-size-225)
+            ) +
+            var(
+                --spectrum-textfield-m-texticon-icon-gap,
+                var(--spectrum-global-dimension-size-100)
+            ) -
+            var(
+                --spectrum-textfield-m-texticon-border-size,
+                var(--spectrum-alias-input-border-size)
+            )
+    ); /* [dir=ltr] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-input */
 }
 :host([dir='ltr']:not([quiet])) #textfield #input {
     padding-left: calc(
@@ -77,6 +110,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-alias-input-border-size)
             )
     ); /* [dir=ltr] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-input */
+}
+:host(:dir(rtl):not([quiet])) #textfield #input {
+    padding-right: calc(
+        var(--spectrum-alias-search-padding-left-m) +
+            var(
+                --spectrum-alias-workflow-icon-size-m,
+                var(--spectrum-global-dimension-size-225)
+            ) +
+            var(
+                --spectrum-textfield-m-texticon-icon-gap,
+                var(--spectrum-global-dimension-size-100)
+            ) -
+            var(
+                --spectrum-textfield-m-texticon-border-size,
+                var(--spectrum-alias-input-border-size)
+            )
+    ); /* [dir=rtl] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-input */
 }
 :host([dir='rtl']:not([quiet])) #textfield #input {
     padding-right: calc(

--- a/packages/sidenav/src/sidenav-item.css
+++ b/packages/sidenav/src/sidenav-item.css
@@ -39,6 +39,58 @@ governing permissions and limitations under the License.
     justify-content: start;
 }
 
+:host(:dir(ltr)) #item-link[data-level='1'] {
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level1,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+
+:host(:dir(ltr)) #item-link[data-level='2'] {
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level2,
+                var(--spectrum-global-dimension-size-300)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+
+:host(:dir(rtl)) #item-link[data-level='1'] {
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level1,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+
+:host(:dir(rtl)) #item-link[data-level='2'] {
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level2,
+                var(--spectrum-global-dimension-size-300)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+
 :host([dir='ltr']) #item-link[data-level='1'] {
     padding-left: calc(
         var(

--- a/packages/sidenav/src/spectrum-sidenav-heading.css
+++ b/packages/sidenav/src/spectrum-sidenav-heading.css
@@ -18,11 +18,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin: 0;
     padding: 0;
 }
+:host(:dir(ltr)) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
+    margin-right: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=ltr] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+}
 :host([dir='ltr']) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
     margin-right: var(
         --spectrum-sidenav-icon-gap,
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=ltr] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+}
+:host(:dir(rtl)) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
+    margin-left: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=rtl] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
 }
 :host([dir='rtl']) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
     margin-left: var(
@@ -30,14 +42,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=rtl] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
 }
+:host(:dir(ltr)) #heading {
+    margin-right: 0; /* [dir=ltr] .spectrum-SideNav-heading */
+}
 :host([dir='ltr']) #heading {
     margin-right: 0; /* [dir=ltr] .spectrum-SideNav-heading */
+}
+:host(:dir(rtl)) #heading {
+    margin-left: 0; /* [dir=rtl] .spectrum-SideNav-heading */
 }
 :host([dir='rtl']) #heading {
     margin-left: 0; /* [dir=rtl] .spectrum-SideNav-heading */
 }
+:host(:dir(ltr)) #heading {
+    margin-left: 0; /* [dir=ltr] .spectrum-SideNav-heading */
+}
 :host([dir='ltr']) #heading {
     margin-left: 0; /* [dir=ltr] .spectrum-SideNav-heading */
+}
+:host(:dir(rtl)) #heading {
+    margin-right: 0; /* [dir=rtl] .spectrum-SideNav-heading */
 }
 :host([dir='rtl']) #heading {
     margin-right: 0; /* [dir=rtl] .spectrum-SideNav-heading */
@@ -88,6 +112,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-top: 0;
     text-transform: uppercase;
 }
+:host(:dir(ltr))
+    .spectrum-SideNav--multiLevel
+    #list
+    .spectrum-SideNav-itemLink {
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
+}
 :host([dir='ltr'])
     .spectrum-SideNav--multiLevel
     #list
@@ -102,6 +141,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-150)
             )
     ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
+}
+:host(:dir(rtl))
+    .spectrum-SideNav--multiLevel
+    #list
+    .spectrum-SideNav-itemLink {
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    ); /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
 }
 :host([dir='rtl'])
     .spectrum-SideNav--multiLevel
@@ -118,6 +172,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
 }
+:host(:dir(ltr))
+    .spectrum-SideNav--multiLevel
+    #list
+    #list
+    .spectrum-SideNav-itemLink {
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
+}
 :host([dir='ltr'])
     .spectrum-SideNav--multiLevel
     #list
@@ -133,6 +203,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-150)
             )
     ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
+}
+:host(:dir(rtl))
+    .spectrum-SideNav--multiLevel
+    #list
+    #list
+    .spectrum-SideNav-itemLink {
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    ); /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
 }
 :host([dir='rtl'])
     .spectrum-SideNav--multiLevel

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -92,11 +92,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     transition: border var(--spectrum-global-animation-duration-100, 0.13s)
         ease-out;
 }
+:host(:dir(ltr)) #item-link ::slotted([slot='icon']) {
+    margin-right: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=ltr] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+}
 :host([dir='ltr']) #item-link ::slotted([slot='icon']) {
     margin-right: var(
         --spectrum-sidenav-icon-gap,
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=ltr] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
+}
+:host(:dir(rtl)) #item-link ::slotted([slot='icon']) {
+    margin-left: var(
+        --spectrum-sidenav-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=rtl] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
 }
 :host([dir='rtl']) #item-link ::slotted([slot='icon']) {
     margin-left: var(
@@ -107,17 +119,41 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #item-link ::slotted([slot='icon']) {
     flex-shrink: 0; /* .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
 }
+:host(:dir(ltr)) .spectrum-SideNav-heading {
+    margin-right: 0; /* [dir=ltr] .spectrum-SideNav-heading */
+}
 :host([dir='ltr']) .spectrum-SideNav-heading {
     margin-right: 0; /* [dir=ltr] .spectrum-SideNav-heading */
+}
+:host(:dir(rtl)) .spectrum-SideNav-heading {
+    margin-left: 0; /* [dir=rtl] .spectrum-SideNav-heading */
 }
 :host([dir='rtl']) .spectrum-SideNav-heading {
     margin-left: 0; /* [dir=rtl] .spectrum-SideNav-heading */
 }
+:host(:dir(ltr)) .spectrum-SideNav-heading {
+    margin-left: 0; /* [dir=ltr] .spectrum-SideNav-heading */
+}
 :host([dir='ltr']) .spectrum-SideNav-heading {
     margin-left: 0; /* [dir=ltr] .spectrum-SideNav-heading */
 }
+:host(:dir(rtl)) .spectrum-SideNav-heading {
+    margin-right: 0; /* [dir=rtl] .spectrum-SideNav-heading */
+}
 :host([dir='rtl']) .spectrum-SideNav-heading {
     margin-right: 0; /* [dir=rtl] .spectrum-SideNav-heading */
+}
+:host(:dir(ltr)) .spectrum-SideNav--multiLevel #list #item-link {
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
 }
 :host([dir='ltr']) .spectrum-SideNav--multiLevel #list #item-link {
     padding-left: calc(
@@ -131,6 +167,18 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
 }
+:host(:dir(rtl)) .spectrum-SideNav--multiLevel #list #item-link {
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    ); /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
+}
 :host([dir='rtl']) .spectrum-SideNav--multiLevel #list #item-link {
     padding-right: calc(
         var(
@@ -143,6 +191,18 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
 }
+:host(:dir(ltr)) .spectrum-SideNav--multiLevel #list #list #item-link {
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
+}
 :host([dir='ltr']) .spectrum-SideNav--multiLevel #list #list #item-link {
     padding-left: calc(
         var(
@@ -154,6 +214,18 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-150)
             )
     ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
+}
+:host(:dir(rtl)) .spectrum-SideNav--multiLevel #list #list #item-link {
+    padding-right: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    ); /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
 }
 :host([dir='rtl']) .spectrum-SideNav--multiLevel #list #list #item-link {
     padding-right: calc(

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -97,12 +97,30 @@ sp-field-label {
     justify-content: start;
 }
 
+:host(:dir(ltr)) .not-exact .tick {
+    padding-right: var(--sp-slider-tick-offset);
+}
+
+:host(:dir(rtl)) .not-exact .tick {
+    padding-left: var(--sp-slider-tick-offset);
+}
+
 :host([dir='ltr']) .not-exact .tick {
     padding-right: var(--sp-slider-tick-offset);
 }
 
 :host([dir='rtl']) .not-exact .tick {
     padding-left: var(--sp-slider-tick-offset);
+}
+
+:host(:dir(ltr)) .not-exact .tick:after {
+    left: auto;
+    transform: translate(-50%, 0);
+}
+
+:host(:dir(rtl)) .not-exact .tick:after {
+    right: auto;
+    transform: translate(50%, 0);
 }
 
 :host([dir='ltr']) .not-exact .tick:after {
@@ -124,6 +142,24 @@ sp-field-label {
     background-size: var(--spectrum-slider-track-background-size) !important;
 }
 
+:host(:dir(ltr)) .track:before {
+    background: var(
+        --spectrum-slider-track-color,
+        var(--spectrum-global-color-gray-300)
+    );
+}
+
+:host(:dir(rtl)) .track:before {
+    /* .spectrum-Slider-track:before */
+    background: var(
+        --spectrum-slider-track-color-rtl,
+        var(
+            --spectrum-slider-track-color,
+            var(--spectrum-global-color-gray-300)
+        )
+    );
+}
+
 :host([dir='ltr']) .track:before {
     background: var(
         --spectrum-slider-track-color,
@@ -140,6 +176,14 @@ sp-field-label {
             var(--spectrum-global-color-gray-300)
         )
     );
+}
+
+:host(:dir(ltr)) .track:last-of-type:before {
+    background-position: 100%;
+}
+
+:host(:dir(rtl)) .track:first-of-type:before {
+    background-position: 100%;
 }
 
 :host([dir='ltr']) .track:last-of-type:before {
@@ -165,6 +209,14 @@ sp-field-label {
  * Begin workaround for https://github.com/adobe/spectrum-css/issues/1205
  */
 
+:host(:dir(ltr)[variant='range']) .track,
+:host(:dir(rtl)[variant='range']) .track {
+    /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track */
+    margin: var(--spectrum-slider-range-track-reset);
+    margin-top: calc(var(--spectrum-slider-track-height) / -2);
+}
+
 :host([dir='ltr'][variant='range']) .track,
 :host([dir='rtl'][variant='range']) .track {
     /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
@@ -176,6 +228,14 @@ sp-field-label {
 /**
  * End workaround for https://github.com/adobe/spectrum-css/issues/1205
  */
+
+:host(:dir(ltr)) .track:not(:first-of-type):not(:last-of-type) {
+    left: var(--spectrum-slider-track-segment-position);
+}
+
+:host(:dir(rtl)) .track:not(:first-of-type):not(:last-of-type) {
+    right: var(--spectrum-slider-track-segment-position);
+}
 
 :host([dir='ltr']) .track:not(:first-of-type):not(:last-of-type) {
     left: var(--spectrum-slider-track-segment-position);
@@ -193,6 +253,14 @@ sp-field-label {
     position: absolute;
     white-space: nowrap;
     width: 1px;
+}
+
+:host([label-visibility='value']:dir(ltr)) #value {
+    margin-left: auto;
+}
+
+:host([label-visibility='value']:dir(rtl)) #value {
+    margin-right: auto;
 }
 
 :host([label-visibility='value'][dir='ltr']) #value {

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -116,10 +116,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     user-select: none;
     z-index: 1;
 }
+:host(:dir(ltr)) #controls {
+    margin-left: var(
+        --spectrum-slider-controls-margin
+    ); /* [dir=ltr] .spectrum-Slider-controls */
+}
 :host([dir='ltr']) #controls {
     margin-left: var(
         --spectrum-slider-controls-margin
     ); /* [dir=ltr] .spectrum-Slider-controls */
+}
+:host(:dir(rtl)) #controls {
+    margin-right: var(
+        --spectrum-slider-controls-margin
+    ); /* [dir=rtl] .spectrum-Slider-controls */
 }
 :host([dir='rtl']) #controls {
     margin-right: var(
@@ -135,10 +145,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     width: calc(100% - var(--spectrum-slider-controls-margin) * 2);
     z-index: auto;
 }
+:host(:dir(ltr)) #fill,
+:host(:dir(ltr)) .track {
+    left: 0; /* [dir=ltr] .spectrum-Slider-track,
+   * [dir=ltr] 
+.spectrum-Slider-fill */
+}
 :host([dir='ltr']) #fill,
 :host([dir='ltr']) .track {
     left: 0; /* [dir=ltr] .spectrum-Slider-track,
    * [dir=ltr] 
+.spectrum-Slider-fill */
+}
+:host(:dir(rtl)) #fill,
+:host(:dir(rtl)) .track {
+    right: 0; /* [dir=rtl] .spectrum-Slider-track,
+   * [dir=rtl] 
 .spectrum-Slider-fill */
 }
 :host([dir='rtl']) #fill,
@@ -147,10 +169,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=rtl] 
 .spectrum-Slider-fill */
 }
+:host(:dir(ltr)) #fill,
+:host(:dir(ltr)) .track {
+    right: auto; /* [dir=ltr] .spectrum-Slider-track,
+   * [dir=ltr] 
+.spectrum-Slider-fill */
+}
 :host([dir='ltr']) #fill,
 :host([dir='ltr']) .track {
     right: auto; /* [dir=ltr] .spectrum-Slider-track,
    * [dir=ltr] 
+.spectrum-Slider-fill */
+}
+:host(:dir(rtl)) #fill,
+:host(:dir(rtl)) .track {
+    left: auto; /* [dir=rtl] .spectrum-Slider-track,
+   * [dir=rtl] 
 .spectrum-Slider-fill */
 }
 :host([dir='rtl']) #fill,
@@ -172,12 +206,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     top: calc(var(--spectrum-slider-height) / 2);
     z-index: 1;
 }
+:host(:dir(ltr)) #fill,
+:host(:dir(ltr)) .track {
+    padding-left: 0; /* [dir=ltr] .spectrum-Slider-track,
+   * [dir=ltr] 
+.spectrum-Slider-fill */
+    padding-right: var(--spectrum-slider-track-handleoffset);
+}
 :host([dir='ltr']) #fill,
 :host([dir='ltr']) .track {
     padding-left: 0; /* [dir=ltr] .spectrum-Slider-track,
    * [dir=ltr] 
 .spectrum-Slider-fill */
     padding-right: var(--spectrum-slider-track-handleoffset);
+}
+:host(:dir(rtl)) #fill,
+:host(:dir(rtl)) .track {
+    padding-left: var(--spectrum-slider-track-handleoffset);
+    padding-right: 0; /* [dir=rtl] .spectrum-Slider-track,
+   * [dir=rtl] 
+.spectrum-Slider-fill */
 }
 :host([dir='rtl']) #fill,
 :host([dir='rtl']) .track {
@@ -186,12 +234,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=rtl] 
 .spectrum-Slider-fill */
 }
+:host(:dir(ltr)) #fill,
+:host(:dir(ltr)) .track {
+    margin-left: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=ltr] .spectrum-Slider-track,
+   * [dir=ltr] 
+.spectrum-Slider-fill */
+}
 :host([dir='ltr']) #fill,
 :host([dir='ltr']) .track {
     margin-left: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=ltr] .spectrum-Slider-track,
    * [dir=ltr] 
+.spectrum-Slider-fill */
+}
+:host(:dir(rtl)) #fill,
+:host(:dir(rtl)) .track {
+    margin-right: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=rtl] .spectrum-Slider-track,
+   * [dir=rtl] 
 .spectrum-Slider-fill */
 }
 :host([dir='rtl']) #fill,
@@ -208,40 +272,80 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-top: 0; /* .spectrum-Slider-track,
    * .spectrum-Slider-fill */
 }
+:host(:dir(ltr)) #fill:before,
+:host(:dir(ltr)) .track:before {
+    border-top-left-radius: 0; /* [dir=ltr] .spectrum-Slider-track:before,
+   * [dir=ltr]  .spectrum-Slider-fill:before */
+}
 :host([dir='ltr']) #fill:before,
 :host([dir='ltr']) .track:before {
     border-top-left-radius: 0; /* [dir=ltr] .spectrum-Slider-track:before,
    * [dir=ltr]  .spectrum-Slider-fill:before */
+}
+:host(:dir(rtl)) #fill:before,
+:host(:dir(rtl)) .track:before {
+    border-top-right-radius: 0; /* [dir=rtl] .spectrum-Slider-track:before,
+   * [dir=rtl]  .spectrum-Slider-fill:before */
 }
 :host([dir='rtl']) #fill:before,
 :host([dir='rtl']) .track:before {
     border-top-right-radius: 0; /* [dir=rtl] .spectrum-Slider-track:before,
    * [dir=rtl]  .spectrum-Slider-fill:before */
 }
+:host(:dir(ltr)) #fill:before,
+:host(:dir(ltr)) .track:before {
+    border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Slider-track:before,
+   * [dir=ltr]  .spectrum-Slider-fill:before */
+}
 :host([dir='ltr']) #fill:before,
 :host([dir='ltr']) .track:before {
     border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Slider-track:before,
    * [dir=ltr]  .spectrum-Slider-fill:before */
+}
+:host(:dir(rtl)) #fill:before,
+:host(:dir(rtl)) .track:before {
+    border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Slider-track:before,
+   * [dir=rtl]  .spectrum-Slider-fill:before */
 }
 :host([dir='rtl']) #fill:before,
 :host([dir='rtl']) .track:before {
     border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Slider-track:before,
    * [dir=rtl]  .spectrum-Slider-fill:before */
 }
+:host(:dir(ltr)) #fill:before,
+:host(:dir(ltr)) .track:before {
+    border-top-right-radius: 0; /* [dir=ltr] .spectrum-Slider-track:before,
+   * [dir=ltr]  .spectrum-Slider-fill:before */
+}
 :host([dir='ltr']) #fill:before,
 :host([dir='ltr']) .track:before {
     border-top-right-radius: 0; /* [dir=ltr] .spectrum-Slider-track:before,
    * [dir=ltr]  .spectrum-Slider-fill:before */
+}
+:host(:dir(rtl)) #fill:before,
+:host(:dir(rtl)) .track:before {
+    border-top-left-radius: 0; /* [dir=rtl] .spectrum-Slider-track:before,
+   * [dir=rtl]  .spectrum-Slider-fill:before */
 }
 :host([dir='rtl']) #fill:before,
 :host([dir='rtl']) .track:before {
     border-top-left-radius: 0; /* [dir=rtl] .spectrum-Slider-track:before,
    * [dir=rtl]  .spectrum-Slider-fill:before */
 }
+:host(:dir(ltr)) #fill:before,
+:host(:dir(ltr)) .track:before {
+    border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Slider-track:before,
+   * [dir=ltr]  .spectrum-Slider-fill:before */
+}
 :host([dir='ltr']) #fill:before,
 :host([dir='ltr']) .track:before {
     border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Slider-track:before,
    * [dir=ltr]  .spectrum-Slider-fill:before */
+}
+:host(:dir(rtl)) #fill:before,
+:host(:dir(rtl)) .track:before {
+    border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Slider-track:before,
+   * [dir=rtl]  .spectrum-Slider-fill:before */
 }
 :host([dir='rtl']) #fill:before,
 :host([dir='rtl']) .track:before {
@@ -255,85 +359,171 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: block;
     height: 100%;
 }
+:host(:dir(ltr)) .track:first-of-type:before {
+    border-top-left-radius: var(
+        --spectrum-slider-track-border-radius
+    ); /* [dir=ltr] .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='ltr']) .track:first-of-type:before {
     border-top-left-radius: var(
         --spectrum-slider-track-border-radius
     ); /* [dir=ltr] .spectrum-Slider-track:first-of-type:before */
+}
+:host(:dir(rtl)) .track:first-of-type:before {
+    border-top-right-radius: var(
+        --spectrum-slider-track-border-radius
+    ); /* [dir=rtl] .spectrum-Slider-track:first-of-type:before */
 }
 :host([dir='rtl']) .track:first-of-type:before {
     border-top-right-radius: var(
         --spectrum-slider-track-border-radius
     ); /* [dir=rtl] .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(ltr)) .track:first-of-type:before {
+    border-bottom-left-radius: var(
+        --spectrum-slider-track-border-radius
+    ); /* [dir=ltr] .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='ltr']) .track:first-of-type:before {
     border-bottom-left-radius: var(
         --spectrum-slider-track-border-radius
     ); /* [dir=ltr] .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(rtl)) .track:first-of-type:before {
+    border-bottom-right-radius: var(
+        --spectrum-slider-track-border-radius
+    ); /* [dir=rtl] .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='rtl']) .track:first-of-type:before {
     border-bottom-right-radius: var(
         --spectrum-slider-track-border-radius
     ); /* [dir=rtl] .spectrum-Slider-track:first-of-type:before */
+}
+:host(:dir(ltr)) .track:first-of-type:before {
+    border-top-right-radius: 0; /* [dir=ltr] .spectrum-Slider-track:first-of-type:before */
 }
 :host([dir='ltr']) .track:first-of-type:before {
     border-top-right-radius: 0; /* [dir=ltr] .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(rtl)) .track:first-of-type:before {
+    border-top-left-radius: 0; /* [dir=rtl] .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='rtl']) .track:first-of-type:before {
     border-top-left-radius: 0; /* [dir=rtl] .spectrum-Slider-track:first-of-type:before */
+}
+:host(:dir(ltr)) .track:first-of-type:before {
+    border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Slider-track:first-of-type:before */
 }
 :host([dir='ltr']) .track:first-of-type:before {
     border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(rtl)) .track:first-of-type:before {
+    border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='rtl']) .track:first-of-type:before {
     border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Slider-track:first-of-type:before */
+}
+:host(:dir(ltr)) .track:last-of-type:before {
+    border-top-left-radius: 0; /* [dir=ltr] .spectrum-Slider-track:last-of-type:before */
 }
 :host([dir='ltr']) .track:last-of-type:before {
     border-top-left-radius: 0; /* [dir=ltr] .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(rtl)) .track:last-of-type:before {
+    border-top-right-radius: 0; /* [dir=rtl] .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='rtl']) .track:last-of-type:before {
     border-top-right-radius: 0; /* [dir=rtl] .spectrum-Slider-track:last-of-type:before */
+}
+:host(:dir(ltr)) .track:last-of-type:before {
+    border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Slider-track:last-of-type:before */
 }
 :host([dir='ltr']) .track:last-of-type:before {
     border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(rtl)) .track:last-of-type:before {
+    border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='rtl']) .track:last-of-type:before {
     border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Slider-track:last-of-type:before */
+}
+:host(:dir(ltr)) .track:last-of-type:before {
+    border-top-right-radius: var(
+        --spectrum-slider-track-border-radius
+    ); /* [dir=ltr] .spectrum-Slider-track:last-of-type:before */
 }
 :host([dir='ltr']) .track:last-of-type:before {
     border-top-right-radius: var(
         --spectrum-slider-track-border-radius
     ); /* [dir=ltr] .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(rtl)) .track:last-of-type:before {
+    border-top-left-radius: var(
+        --spectrum-slider-track-border-radius
+    ); /* [dir=rtl] .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='rtl']) .track:last-of-type:before {
     border-top-left-radius: var(
         --spectrum-slider-track-border-radius
     ); /* [dir=rtl] .spectrum-Slider-track:last-of-type:before */
+}
+:host(:dir(ltr)) .track:last-of-type:before {
+    border-bottom-right-radius: var(
+        --spectrum-slider-track-border-radius
+    ); /* [dir=ltr] .spectrum-Slider-track:last-of-type:before */
 }
 :host([dir='ltr']) .track:last-of-type:before {
     border-bottom-right-radius: var(
         --spectrum-slider-track-border-radius
     ); /* [dir=ltr] .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(rtl)) .track:last-of-type:before {
+    border-bottom-left-radius: var(
+        --spectrum-slider-track-border-radius
+    ); /* [dir=rtl] .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='rtl']) .track:last-of-type:before {
     border-bottom-left-radius: var(
         --spectrum-slider-track-border-radius
     ); /* [dir=rtl] .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(ltr)) .track ~ .track {
+    left: auto; /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
+}
 :host([dir='ltr']) .track ~ .track {
     left: auto; /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
 }
+:host(:dir(rtl)) .track ~ .track {
+    right: auto; /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+}
 :host([dir='rtl']) .track ~ .track {
     right: auto; /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+}
+:host(:dir(ltr)) .track ~ .track {
+    right: var(
+        --spectrum-slider-range-track-reset
+    ); /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
 }
 :host([dir='ltr']) .track ~ .track {
     right: var(
         --spectrum-slider-range-track-reset
     ); /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
 }
+:host(:dir(rtl)) .track ~ .track {
+    left: var(
+        --spectrum-slider-range-track-reset
+    ); /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+}
 :host([dir='rtl']) .track ~ .track {
     left: var(
         --spectrum-slider-range-track-reset
     ); /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+}
+:host(:dir(ltr)) .track ~ .track {
+    padding-left: var(
+        --spectrum-slider-track-handleoffset
+    ); /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
+    padding-right: 0;
 }
 :host([dir='ltr']) .track ~ .track {
     padding-left: var(
@@ -341,26 +531,52 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
     padding-right: 0;
 }
+:host(:dir(rtl)) .track ~ .track {
+    padding-left: 0;
+    padding-right: var(
+        --spectrum-slider-track-handleoffset
+    ); /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
+}
 :host([dir='rtl']) .track ~ .track {
     padding-left: 0;
     padding-right: var(
         --spectrum-slider-track-handleoffset
     ); /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
 }
+:host(:dir(ltr)) .track ~ .track {
+    margin-left: var(
+        --spectrum-slider-range-track-reset
+    ); /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
+}
 :host([dir='ltr']) .track ~ .track {
     margin-left: var(
         --spectrum-slider-range-track-reset
     ); /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
+}
+:host(:dir(rtl)) .track ~ .track {
+    margin-right: var(
+        --spectrum-slider-range-track-reset
+    ); /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
 }
 :host([dir='rtl']) .track ~ .track {
     margin-right: var(
         --spectrum-slider-range-track-reset
     ); /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
 }
+:host(:dir(ltr)) .track ~ .track {
+    margin-right: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
+}
 :host([dir='ltr']) .track ~ .track {
     margin-right: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=ltr] .spectrum-Slider-track~.spectrum-Slider-track */
+}
+:host(:dir(rtl)) .track ~ .track {
+    margin-left: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=rtl] .spectrum-Slider-track~.spectrum-Slider-track */
 }
 :host([dir='rtl']) .track ~ .track {
     margin-left: var(
@@ -371,11 +587,24 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-bottom: 0;
     padding-top: 0; /* .spectrum-Slider-track~.spectrum-Slider-track */
 }
+:host(:dir(ltr)) #fill {
+    margin-left: 0; /* [dir=ltr] .spectrum-Slider-fill */
+}
 :host([dir='ltr']) #fill {
     margin-left: 0; /* [dir=ltr] .spectrum-Slider-fill */
 }
+:host(:dir(rtl)) #fill {
+    margin-right: 0; /* [dir=rtl] .spectrum-Slider-fill */
+}
 :host([dir='rtl']) #fill {
     margin-right: 0; /* [dir=rtl] .spectrum-Slider-fill */
+}
+:host(:dir(ltr)) #fill {
+    padding-left: calc(
+        var(--spectrum-slider-controls-margin) +
+            var(--spectrum-slider-track-handleoffset)
+    ); /* [dir=ltr] .spectrum-Slider-fill */
+    padding-right: 0;
 }
 :host([dir='ltr']) #fill {
     padding-left: calc(
@@ -383,6 +612,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-slider-track-handleoffset)
     ); /* [dir=ltr] .spectrum-Slider-fill */
     padding-right: 0;
+}
+:host(:dir(rtl)) #fill {
+    padding-left: 0;
+    padding-right: calc(
+        var(--spectrum-slider-controls-margin) +
+            var(--spectrum-slider-track-handleoffset)
+    ); /* [dir=rtl] .spectrum-Slider-fill */
 }
 :host([dir='rtl']) #fill {
     padding-left: 0;
@@ -395,12 +631,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-bottom: 0;
     padding-top: 0; /* .spectrum-Slider-fill */
 }
+:host(:dir(ltr)) .spectrum-Slider-fill--right {
+    padding-left: 0; /* [dir=ltr] .spectrum-Slider-fill--right */
+    padding-right: calc(
+        var(--spectrum-slider-controls-margin) +
+            var(--spectrum-slider-track-handleoffset)
+    );
+}
 :host([dir='ltr']) .spectrum-Slider-fill--right {
     padding-left: 0; /* [dir=ltr] .spectrum-Slider-fill--right */
     padding-right: calc(
         var(--spectrum-slider-controls-margin) +
             var(--spectrum-slider-track-handleoffset)
     );
+}
+:host(:dir(rtl)) .spectrum-Slider-fill--right {
+    padding-left: calc(
+        var(--spectrum-slider-controls-margin) +
+            var(--spectrum-slider-track-handleoffset)
+    );
+    padding-right: 0; /* [dir=rtl] .spectrum-Slider-fill--right */
 }
 :host([dir='rtl']) .spectrum-Slider-fill--right {
     padding-left: calc(
@@ -417,63 +667,127 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     -webkit-user-select: text; /* .spectrum-Slider--range .spectrum-Slider-value */
     user-select: text;
 }
+:host(:dir(ltr)[variant='range']) .track:before {
+    border-top-left-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
 :host([dir='ltr'][variant='range']) .track:before {
     border-top-left-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
+:host(:dir(rtl)[variant='range']) .track:before {
+    border-top-right-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:before */
 }
 :host([dir='rtl'][variant='range']) .track:before {
     border-top-right-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:before */
 }
+:host(:dir(ltr)[variant='range']) .track:before {
+    border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
 :host([dir='ltr'][variant='range']) .track:before {
     border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
+:host(:dir(rtl)[variant='range']) .track:before {
+    border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:before */
 }
 :host([dir='rtl'][variant='range']) .track:before {
     border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:before */
 }
+:host(:dir(ltr)[variant='range']) .track:before {
+    border-top-right-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
 :host([dir='ltr'][variant='range']) .track:before {
     border-top-right-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
+:host(:dir(rtl)[variant='range']) .track:before {
+    border-top-left-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:before */
 }
 :host([dir='rtl'][variant='range']) .track:before {
     border-top-left-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:before */
 }
+:host(:dir(ltr)[variant='range']) .track:before {
+    border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
 :host([dir='ltr'][variant='range']) .track:before {
     border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:before */
 }
+:host(:dir(rtl)[variant='range']) .track:before {
+    border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
 :host([dir='rtl'][variant='range']) .track:before {
     border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:before */
+}
+:host(:dir(ltr)[variant='range']) .track:first-of-type {
+    padding-left: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+    padding-right: var(--spectrum-slider-track-handleoffset);
 }
 :host([dir='ltr'][variant='range']) .track:first-of-type {
     padding-left: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
     padding-right: var(--spectrum-slider-track-handleoffset);
 }
+:host(:dir(rtl)[variant='range']) .track:first-of-type {
+    padding-left: var(--spectrum-slider-track-handleoffset);
+    padding-right: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+}
 :host([dir='rtl'][variant='range']) .track:first-of-type {
     padding-left: var(--spectrum-slider-track-handleoffset);
     padding-right: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+}
+:host(:dir(ltr)[variant='range']) .track:first-of-type {
+    left: var(
+        --spectrum-slider-range-track-reset
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
 }
 :host([dir='ltr'][variant='range']) .track:first-of-type {
     left: var(
         --spectrum-slider-range-track-reset
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
 }
+:host(:dir(rtl)[variant='range']) .track:first-of-type {
+    right: var(
+        --spectrum-slider-range-track-reset
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+}
 :host([dir='rtl'][variant='range']) .track:first-of-type {
     right: var(
         --spectrum-slider-range-track-reset
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
 }
+:host(:dir(ltr)[variant='range']) .track:first-of-type {
+    right: auto; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+}
 :host([dir='ltr'][variant='range']) .track:first-of-type {
     right: auto; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
 }
+:host(:dir(rtl)[variant='range']) .track:first-of-type {
+    left: auto; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+}
 :host([dir='rtl'][variant='range']) .track:first-of-type {
     left: auto; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+}
+:host(:dir(ltr)[variant='range']) .track:first-of-type {
+    margin-left: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
 }
 :host([dir='ltr'][variant='range']) .track:first-of-type {
     margin-left: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
 }
+:host(:dir(rtl)[variant='range']) .track:first-of-type {
+    margin-right: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+}
 :host([dir='rtl'][variant='range']) .track:first-of-type {
     margin-right: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type */
+}
+:host(:dir(ltr)[variant='range']) .track:first-of-type:before {
+    border-top-left-radius: var(
+        --spectrum-slider-m-track-border-radius,
+        var(--spectrum-global-dimension-static-size-10)
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
 }
 :host([dir='ltr'][variant='range']) .track:first-of-type:before {
     border-top-left-radius: var(
@@ -481,11 +795,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-static-size-10)
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(rtl)[variant='range']) .track:first-of-type:before {
+    border-top-right-radius: var(
+        --spectrum-slider-m-track-border-radius,
+        var(--spectrum-global-dimension-static-size-10)
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='rtl'][variant='range']) .track:first-of-type:before {
     border-top-right-radius: var(
         --spectrum-slider-m-track-border-radius,
         var(--spectrum-global-dimension-static-size-10)
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
+}
+:host(:dir(ltr)[variant='range']) .track:first-of-type:before {
+    border-bottom-left-radius: var(
+        --spectrum-slider-m-track-border-radius,
+        var(--spectrum-global-dimension-static-size-10)
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
 }
 :host([dir='ltr'][variant='range']) .track:first-of-type:before {
     border-bottom-left-radius: var(
@@ -493,28 +819,58 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-static-size-10)
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(rtl)[variant='range']) .track:first-of-type:before {
+    border-bottom-right-radius: var(
+        --spectrum-slider-m-track-border-radius,
+        var(--spectrum-global-dimension-static-size-10)
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='rtl'][variant='range']) .track:first-of-type:before {
     border-bottom-right-radius: var(
         --spectrum-slider-m-track-border-radius,
         var(--spectrum-global-dimension-static-size-10)
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(ltr)[variant='range']) .track:first-of-type:before {
+    border-top-right-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='ltr'][variant='range']) .track:first-of-type:before {
     border-top-right-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
+}
+:host(:dir(rtl)[variant='range']) .track:first-of-type:before {
+    border-top-left-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
 }
 :host([dir='rtl'][variant='range']) .track:first-of-type:before {
     border-top-left-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(ltr)[variant='range']) .track:first-of-type:before {
+    border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='ltr'][variant='range']) .track:first-of-type:before {
     border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
 }
+:host(:dir(rtl)[variant='range']) .track:first-of-type:before {
+    border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
+}
 :host([dir='rtl'][variant='range']) .track:first-of-type:before {
     border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:first-of-type:before */
+}
+:host(:dir(ltr)[variant='range']) [dir='ltr'] .track,
+:host(:dir(ltr)[variant='range']) [dir='rtl'] .track {
+    left: auto; /* [dir=ltr"] [dir="ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=ltr"] [dir="rtl] 
+    .spectrum-Slider--range .spectrum-Slider-track */
 }
 :host([dir='ltr'][variant='range']) [dir='ltr'] .track,
 :host([dir='ltr'][variant='range']) [dir='rtl'] .track {
     left: auto; /* [dir=ltr"] [dir="ltr] .spectrum-Slider--range .spectrum-Slider-track,
    * [dir=ltr"] [dir="rtl] 
+    .spectrum-Slider--range .spectrum-Slider-track */
+}
+:host(:dir(ltr)[variant='range']) [dir='rtl'] .track,
+:host(:dir(rtl)[variant='range']) [dir='rtl'] .track {
+    right: auto; /* [dir=rtl"] [dir="ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl"] [dir="rtl] 
     .spectrum-Slider--range .spectrum-Slider-track */
 }
 :host([dir='ltr'][variant='range']) [dir='rtl'] .track,
@@ -523,10 +879,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=rtl"] [dir="rtl] 
     .spectrum-Slider--range .spectrum-Slider-track */
 }
+:host(:dir(ltr)[variant='range']) [dir='ltr'] .track,
+:host(:dir(ltr)[variant='range']) [dir='rtl'] .track {
+    right: auto; /* [dir=ltr"] [dir="ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=ltr"] [dir="rtl] 
+    .spectrum-Slider--range .spectrum-Slider-track */
+}
 :host([dir='ltr'][variant='range']) [dir='ltr'] .track,
 :host([dir='ltr'][variant='range']) [dir='rtl'] .track {
     right: auto; /* [dir=ltr"] [dir="ltr] .spectrum-Slider--range .spectrum-Slider-track,
    * [dir=ltr"] [dir="rtl] 
+    .spectrum-Slider--range .spectrum-Slider-track */
+}
+:host(:dir(ltr)[variant='range']) [dir='rtl'] .track,
+:host(:dir(rtl)[variant='range']) [dir='rtl'] .track {
+    left: auto; /* [dir=rtl"] [dir="ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl"] [dir="rtl] 
     .spectrum-Slider--range .spectrum-Slider-track */
 }
 :host([dir='ltr'][variant='range']) [dir='rtl'] .track,
@@ -534,6 +902,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     left: auto; /* [dir=rtl"] [dir="ltr] .spectrum-Slider--range .spectrum-Slider-track,
    * [dir=rtl"] [dir="rtl] 
     .spectrum-Slider--range .spectrum-Slider-track */
+}
+:host(:dir(ltr)[variant='range']) .track,
+:host(:dir(rtl)[variant='range']) .track {
+    margin-left: var(--spectrum-slider-range-track-reset);
+    margin-right: var(--spectrum-slider-range-track-reset);
+    padding-left: var(
+        --spectrum-slider-track-middle-handleoffset
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
+   * [dir=rtl] 
+    .spectrum-Slider--range .spectrum-Slider-track */
+    padding-right: var(--spectrum-slider-track-middle-handleoffset);
 }
 :host([dir='ltr'][variant='range']) .track,
 :host([dir='rtl'][variant='range']) .track {
@@ -546,11 +925,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     .spectrum-Slider--range .spectrum-Slider-track */
     padding-right: var(--spectrum-slider-track-middle-handleoffset);
 }
+:host(:dir(ltr)[variant='range']) .track:last-of-type {
+    padding-left: var(
+        --spectrum-slider-track-handleoffset
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+    padding-right: 0;
+}
 :host([dir='ltr'][variant='range']) .track:last-of-type {
     padding-left: var(
         --spectrum-slider-track-handleoffset
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
     padding-right: 0;
+}
+:host(:dir(rtl)[variant='range']) .track:last-of-type {
+    padding-left: 0;
+    padding-right: var(
+        --spectrum-slider-track-handleoffset
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
 }
 :host([dir='rtl'][variant='range']) .track:last-of-type {
     padding-left: 0;
@@ -558,31 +949,63 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-slider-track-handleoffset
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
 }
+:host(:dir(ltr)[variant='range']) .track:last-of-type {
+    left: auto; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+}
 :host([dir='ltr'][variant='range']) .track:last-of-type {
     left: auto; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
 }
+:host(:dir(rtl)[variant='range']) .track:last-of-type {
+    right: auto; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+}
 :host([dir='rtl'][variant='range']) .track:last-of-type {
     right: auto; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+}
+:host(:dir(ltr)[variant='range']) .track:last-of-type {
+    right: var(
+        --spectrum-slider-range-track-reset
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
 }
 :host([dir='ltr'][variant='range']) .track:last-of-type {
     right: var(
         --spectrum-slider-range-track-reset
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
 }
+:host(:dir(rtl)[variant='range']) .track:last-of-type {
+    left: var(
+        --spectrum-slider-range-track-reset
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+}
 :host([dir='rtl'][variant='range']) .track:last-of-type {
     left: var(
         --spectrum-slider-range-track-reset
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+}
+:host(:dir(ltr)[variant='range']) .track:last-of-type {
+    margin-right: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
 }
 :host([dir='ltr'][variant='range']) .track:last-of-type {
     margin-right: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
 }
+:host(:dir(rtl)[variant='range']) .track:last-of-type {
+    margin-left: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+}
 :host([dir='rtl'][variant='range']) .track:last-of-type {
     margin-left: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type */
+}
+:host(:dir(ltr)[variant='range']) .track:last-of-type:before {
+    border-top-right-radius: var(
+        --spectrum-slider-m-track-border-radius,
+        var(--spectrum-global-dimension-static-size-10)
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
 }
 :host([dir='ltr'][variant='range']) .track:last-of-type:before {
     border-top-right-radius: var(
@@ -590,11 +1013,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-static-size-10)
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(rtl)[variant='range']) .track:last-of-type:before {
+    border-top-left-radius: var(
+        --spectrum-slider-m-track-border-radius,
+        var(--spectrum-global-dimension-static-size-10)
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='rtl'][variant='range']) .track:last-of-type:before {
     border-top-left-radius: var(
         --spectrum-slider-m-track-border-radius,
         var(--spectrum-global-dimension-static-size-10)
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
+}
+:host(:dir(ltr)[variant='range']) .track:last-of-type:before {
+    border-bottom-right-radius: var(
+        --spectrum-slider-m-track-border-radius,
+        var(--spectrum-global-dimension-static-size-10)
+    ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
 }
 :host([dir='ltr'][variant='range']) .track:last-of-type:before {
     border-bottom-right-radius: var(
@@ -602,38 +1037,76 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-static-size-10)
     ); /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(rtl)[variant='range']) .track:last-of-type:before {
+    border-bottom-left-radius: var(
+        --spectrum-slider-m-track-border-radius,
+        var(--spectrum-global-dimension-static-size-10)
+    ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='rtl'][variant='range']) .track:last-of-type:before {
     border-bottom-left-radius: var(
         --spectrum-slider-m-track-border-radius,
         var(--spectrum-global-dimension-static-size-10)
     ); /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(ltr)[variant='range']) .track:last-of-type:before {
+    border-top-left-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='ltr'][variant='range']) .track:last-of-type:before {
     border-top-left-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
+}
+:host(:dir(rtl)[variant='range']) .track:last-of-type:before {
+    border-top-right-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
 }
 :host([dir='rtl'][variant='range']) .track:last-of-type:before {
     border-top-right-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(ltr)[variant='range']) .track:last-of-type:before {
+    border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='ltr'][variant='range']) .track:last-of-type:before {
     border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
 }
+:host(:dir(rtl)[variant='range']) .track:last-of-type:before {
+    border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
+}
 :host([dir='rtl'][variant='range']) .track:last-of-type:before {
     border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track:last-of-type:before */
+}
+:host(:dir(ltr)) #ramp {
+    left: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=ltr] .spectrum-Slider-ramp */
 }
 :host([dir='ltr']) #ramp {
     left: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=ltr] .spectrum-Slider-ramp */
 }
+:host(:dir(rtl)) #ramp {
+    right: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=rtl] .spectrum-Slider-ramp */
+}
 :host([dir='rtl']) #ramp {
     right: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=rtl] .spectrum-Slider-ramp */
 }
+:host(:dir(ltr)) #ramp {
+    right: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=ltr] .spectrum-Slider-ramp */
+}
 :host([dir='ltr']) #ramp {
     right: var(
         --spectrum-slider-track-margin-offset
     ); /* [dir=ltr] .spectrum-Slider-ramp */
+}
+:host(:dir(rtl)) #ramp {
+    left: var(
+        --spectrum-slider-track-margin-offset
+    ); /* [dir=rtl] .spectrum-Slider-ramp */
 }
 :host([dir='rtl']) #ramp {
     left: var(
@@ -647,6 +1120,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Slider-ramp */
     position: absolute;
     top: calc(var(--spectrum-slider-ramp-track-height) / 2);
+}
+:host(:dir(rtl)) #ramp svg {
+    transform: matrix(
+        -1,
+        0,
+        0,
+        1,
+        0,
+        0
+    ); /* [dir=rtl] .spectrum-Slider-ramp svg */
 }
 :host([dir='rtl']) #ramp svg {
     transform: matrix(
@@ -662,17 +1145,35 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     height: 100%;
     width: 100%; /* .spectrum-Slider-ramp svg */
 }
+:host(:dir(ltr)) .handle {
+    left: 0; /* [dir=ltr] .spectrum-Slider-handle */
+}
 :host([dir='ltr']) .handle {
     left: 0; /* [dir=ltr] .spectrum-Slider-handle */
 }
+:host(:dir(rtl)) .handle {
+    right: 0; /* [dir=rtl] .spectrum-Slider-handle */
+}
 :host([dir='rtl']) .handle {
     right: 0; /* [dir=rtl] .spectrum-Slider-handle */
+}
+:host(:dir(ltr)) .handle {
+    margin-left: calc(
+        var(--spectrum-slider-handle-width) / -2
+    ); /* [dir=ltr] .spectrum-Slider-handle */
+    margin-right: 0;
 }
 :host([dir='ltr']) .handle {
     margin-left: calc(
         var(--spectrum-slider-handle-width) / -2
     ); /* [dir=ltr] .spectrum-Slider-handle */
     margin-right: 0;
+}
+:host(:dir(rtl)) .handle {
+    margin-left: 0;
+    margin-right: calc(
+        var(--spectrum-slider-handle-width) / -2
+    ); /* [dir=rtl] .spectrum-Slider-handle */
 }
 :host([dir='rtl']) .handle {
     margin-left: 0;
@@ -746,10 +1247,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) * 2
     ); /* .spectrum-Slider-handle.is-focused:before */
 }
+:host(:dir(ltr)) .input {
+    left: var(
+        --spectrum-slider-input-left
+    ); /* [dir=ltr] .spectrum-Slider-input */
+}
 :host([dir='ltr']) .input {
     left: var(
         --spectrum-slider-input-left
     ); /* [dir=ltr] .spectrum-Slider-input */
+}
+:host(:dir(rtl)) .input {
+    right: var(
+        --spectrum-slider-input-left
+    ); /* [dir=rtl] .spectrum-Slider-input */
 }
 :host([dir='rtl']) .input {
     right: var(
@@ -788,8 +1299,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     position: relative;
     width: auto;
 }
+:host(:dir(ltr)) #label {
+    padding-left: 0; /* [dir=ltr] .spectrum-Slider-label */
+}
 :host([dir='ltr']) #label {
     padding-left: 0; /* [dir=ltr] .spectrum-Slider-label */
+}
+:host(:dir(rtl)) #label {
+    padding-right: 0; /* [dir=rtl] .spectrum-Slider-label */
 }
 :host([dir='rtl']) #label {
     padding-right: 0; /* [dir=rtl] .spectrum-Slider-label */
@@ -797,14 +1314,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 #label {
     flex-grow: 1; /* .spectrum-Slider-label */
 }
+:host(:dir(ltr)) #value {
+    padding-right: 0; /* [dir=ltr] .spectrum-Slider-value */
+}
 :host([dir='ltr']) #value {
     padding-right: 0; /* [dir=ltr] .spectrum-Slider-value */
+}
+:host(:dir(rtl)) #value {
+    padding-left: 0; /* [dir=rtl] .spectrum-Slider-value */
 }
 :host([dir='rtl']) #value {
     padding-left: 0; /* [dir=rtl] .spectrum-Slider-value */
 }
+:host(:dir(ltr)) #value {
+    text-align: right; /* [dir=ltr] .spectrum-Slider-value */
+}
 :host([dir='ltr']) #value {
     text-align: right; /* [dir=ltr] .spectrum-Slider-value */
+}
+:host(:dir(rtl)) #value {
+    text-align: left; /* [dir=rtl] .spectrum-Slider-value */
 }
 :host([dir='rtl']) #value {
     text-align: left; /* [dir=rtl] .spectrum-Slider-value */
@@ -814,10 +1343,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     cursor: default;
     flex-grow: 0; /* .spectrum-Slider-value */
 }
+:host(:dir(ltr)) #value {
+    margin-left: var(
+        --spectrum-slider-label-gap-x
+    ); /* [dir=ltr] .spectrum-Slider-value */
+}
 :host([dir='ltr']) #value {
     margin-left: var(
         --spectrum-slider-label-gap-x
     ); /* [dir=ltr] .spectrum-Slider-value */
+}
+:host(:dir(rtl)) #value {
+    margin-right: var(
+        --spectrum-slider-label-gap-x
+    ); /* [dir=rtl] .spectrum-Slider-value */
 }
 :host([dir='rtl']) #value {
     margin-right: var(
@@ -835,10 +1374,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     position: relative; /* .spectrum-Slider-tick */
     width: var(--spectrum-slider-tick-mark-width);
 }
+:host(:dir(ltr)) .tick:after {
+    left: calc(
+        50% - var(--spectrum-slider-tick-mark-width) / 2
+    ); /* [dir=ltr] .spectrum-Slider-tick:after */
+}
 :host([dir='ltr']) .tick:after {
     left: calc(
         50% - var(--spectrum-slider-tick-mark-width) / 2
     ); /* [dir=ltr] .spectrum-Slider-tick:after */
+}
+:host(:dir(rtl)) .tick:after {
+    right: calc(
+        50% - var(--spectrum-slider-tick-mark-width) / 2
+    ); /* [dir=rtl] .spectrum-Slider-tick:after */
 }
 :host([dir='rtl']) .tick:after {
     right: calc(
@@ -879,34 +1428,66 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin-right: 0;
     position: absolute;
 }
+:host(:dir(ltr)) .tick:first-of-type {
+    left: calc(
+        var(--spectrum-slider-tick-mark-width) / -2
+    ); /* [dir=ltr] .spectrum-Slider-tick:first-of-type */
+}
 :host([dir='ltr']) .tick:first-of-type {
     left: calc(
         var(--spectrum-slider-tick-mark-width) / -2
     ); /* [dir=ltr] .spectrum-Slider-tick:first-of-type */
+}
+:host(:dir(rtl)) .tick:first-of-type {
+    right: calc(
+        var(--spectrum-slider-tick-mark-width) / -2
+    ); /* [dir=rtl] .spectrum-Slider-tick:first-of-type */
 }
 :host([dir='rtl']) .tick:first-of-type {
     right: calc(
         var(--spectrum-slider-tick-mark-width) / -2
     ); /* [dir=rtl] .spectrum-Slider-tick:first-of-type */
 }
+:host(:dir(ltr)) .tick:first-of-type .tickLabel {
+    left: 0; /* [dir=ltr] .spectrum-Slider-tick:first-of-type .spectrum-Slider-tickLabel */
+}
 :host([dir='ltr']) .tick:first-of-type .tickLabel {
     left: 0; /* [dir=ltr] .spectrum-Slider-tick:first-of-type .spectrum-Slider-tickLabel */
 }
+:host(:dir(rtl)) .tick:first-of-type .tickLabel {
+    right: 0; /* [dir=rtl] .spectrum-Slider-tick:first-of-type .spectrum-Slider-tickLabel */
+}
 :host([dir='rtl']) .tick:first-of-type .tickLabel {
     right: 0; /* [dir=rtl] .spectrum-Slider-tick:first-of-type .spectrum-Slider-tickLabel */
+}
+:host(:dir(ltr)) .tick:last-of-type {
+    right: calc(
+        var(--spectrum-slider-tick-mark-width) / -2
+    ); /* [dir=ltr] .spectrum-Slider-tick:last-of-type */
 }
 :host([dir='ltr']) .tick:last-of-type {
     right: calc(
         var(--spectrum-slider-tick-mark-width) / -2
     ); /* [dir=ltr] .spectrum-Slider-tick:last-of-type */
 }
+:host(:dir(rtl)) .tick:last-of-type {
+    left: calc(
+        var(--spectrum-slider-tick-mark-width) / -2
+    ); /* [dir=rtl] .spectrum-Slider-tick:last-of-type */
+}
 :host([dir='rtl']) .tick:last-of-type {
     left: calc(
         var(--spectrum-slider-tick-mark-width) / -2
     ); /* [dir=rtl] .spectrum-Slider-tick:last-of-type */
 }
+:host(:dir(ltr)) .tick:last-of-type .tickLabel {
+    right: 0; /* [dir=ltr] .spectrum-Slider-tick:last-of-type .spectrum-Slider-tickLabel */
+}
 :host([dir='ltr']) .tick:last-of-type .tickLabel {
     right: 0; /* [dir=ltr] .spectrum-Slider-tick:last-of-type .spectrum-Slider-tickLabel */
+}
+:host(:dir(rtl)) .tick:last-of-type .tickLabel {
+    left: 0; /* [dir=rtl] .spectrum-Slider-tick:last-of-type .spectrum-Slider-tickLabel */
 }
 :host([dir='rtl']) .tick:last-of-type .tickLabel {
     left: 0; /* [dir=rtl] .spectrum-Slider-tick:last-of-type .spectrum-Slider-tickLabel */

--- a/packages/split-button/src/spectrum-split-button.css
+++ b/packages/split-button/src/spectrum-split-button.css
@@ -61,11 +61,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     position: relative; /* .spectrum-SplitButton */
     vertical-align: top;
 }
+:host(:dir(ltr)) #button {
+    margin-left: 0; /* [dir=ltr] .spectrum-SplitButton-action */
+}
 :host([dir='ltr']) #button {
     margin-left: 0; /* [dir=ltr] .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)) #button {
+    margin-right: 0; /* [dir=rtl] .spectrum-SplitButton-action */
+}
 :host([dir='rtl']) #button {
     margin-right: 0; /* [dir=rtl] .spectrum-SplitButton-action */
+}
+:host(:dir(ltr)) #button {
+    border-top-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton-action */
 }
 :host([dir='ltr']) #button {
     border-top-left-radius: var(
@@ -73,23 +85,47 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)) #button {
+    border-top-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton-action */
+}
 :host([dir='rtl']) #button {
     border-top-right-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)) #button {
+    border-top-right-radius: 0; /* [dir=ltr] .spectrum-SplitButton-action */
+}
 :host([dir='ltr']) #button {
     border-top-right-radius: 0; /* [dir=ltr] .spectrum-SplitButton-action */
+}
+:host(:dir(rtl)) #button {
+    border-top-left-radius: 0; /* [dir=rtl] .spectrum-SplitButton-action */
 }
 :host([dir='rtl']) #button {
     border-top-left-radius: 0; /* [dir=rtl] .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)) #button {
+    border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-SplitButton-action */
+}
 :host([dir='ltr']) #button {
     border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)) #button {
+    border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-SplitButton-action */
+}
 :host([dir='rtl']) #button {
     border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-SplitButton-action */
+}
+:host(:dir(ltr)) #button {
+    border-bottom-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton-action */
 }
 :host([dir='ltr']) #button {
     border-bottom-left-radius: var(
@@ -97,41 +133,83 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)) #button {
+    border-bottom-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton-action */
+}
 :host([dir='rtl']) #button {
     border-bottom-right-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)) #button {
+    padding-right: var(
+        --spectrum-splitbutton-flat-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton-action */
+}
 :host([dir='ltr']) #button {
     padding-right: var(
         --spectrum-splitbutton-flat-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton-action */
+}
+:host(:dir(rtl)) #button {
+    padding-left: var(
+        --spectrum-splitbutton-flat-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton-action */
 }
 :host([dir='rtl']) #button {
     padding-left: var(
         --spectrum-splitbutton-flat-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)) #button {
+    padding-left: var(
+        --spectrum-splitbutton-round-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton-action */
+}
 :host([dir='ltr']) #button {
     padding-left: var(
         --spectrum-splitbutton-round-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)) #button {
+    padding-right: var(
+        --spectrum-splitbutton-round-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton-action */
+}
 :host([dir='rtl']) #button {
     padding-right: var(
         --spectrum-splitbutton-round-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton-action */
+}
+:host(:dir(ltr)) #button[variant='accent'] {
+    padding-right: var(
+        --spectrum-splitbutton-cta-flat-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton-action.spectrum-Button--accent */
 }
 :host([dir='ltr']) #button[variant='accent'] {
     padding-right: var(
         --spectrum-splitbutton-cta-flat-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton-action.spectrum-Button--accent */
 }
+:host(:dir(rtl)) #button[variant='accent'] {
+    padding-left: var(
+        --spectrum-splitbutton-cta-flat-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton-action.spectrum-Button--accent */
+}
 :host([dir='rtl']) #button[variant='accent'] {
     padding-left: var(
         --spectrum-splitbutton-cta-flat-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton-action.spectrum-Button--accent */
+}
+:host(:dir(ltr)) #button[variant='accent'] {
+    margin-right: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=ltr] .spectrum-SplitButton-action.spectrum-Button--accent */
 }
 :host([dir='ltr']) #button[variant='accent'] {
     margin-right: var(
@@ -139,43 +217,87 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=ltr] .spectrum-SplitButton-action.spectrum-Button--accent */
 }
+:host(:dir(rtl)) #button[variant='accent'] {
+    margin-left: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=rtl] .spectrum-SplitButton-action.spectrum-Button--accent */
+}
 :host([dir='rtl']) #button[variant='accent'] {
     margin-left: var(
         --spectrum-button-m-primary-outline-texticon-border-size,
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=rtl] .spectrum-SplitButton-action.spectrum-Button--accent */
 }
+:host(:dir(ltr)) #button:after {
+    border-top-right-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=ltr] .spectrum-SplitButton-action:after */
+}
 :host([dir='ltr']) #button:after {
     border-top-right-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=ltr] .spectrum-SplitButton-action:after */
+}
+:host(:dir(rtl)) #button:after {
+    border-top-left-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=rtl] .spectrum-SplitButton-action:after */
 }
 :host([dir='rtl']) #button:after {
     border-top-left-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=rtl] .spectrum-SplitButton-action:after */
 }
+:host(:dir(ltr)) #button:after {
+    border-bottom-right-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=ltr] .spectrum-SplitButton-action:after */
+}
 :host([dir='ltr']) #button:after {
     border-bottom-right-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=ltr] .spectrum-SplitButton-action:after */
 }
+:host(:dir(rtl)) #button:after {
+    border-bottom-left-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=rtl] .spectrum-SplitButton-action:after */
+}
 :host([dir='rtl']) #button:after {
     border-bottom-left-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=rtl] .spectrum-SplitButton-action:after */
+}
+:host(:dir(ltr)) .trigger {
+    margin-left: 0; /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr']) .trigger {
     margin-left: 0; /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)) .trigger {
+    margin-right: 0; /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl']) .trigger {
     margin-right: 0; /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)) .trigger {
+    border-top-left-radius: 0; /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr']) .trigger {
     border-top-left-radius: 0; /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)) .trigger {
+    border-top-right-radius: 0; /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl']) .trigger {
     border-top-right-radius: 0; /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)) .trigger {
+    border-top-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr']) .trigger {
     border-top-right-radius: var(
@@ -183,11 +305,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)) .trigger {
+    border-top-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl']) .trigger {
     border-top-left-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)) .trigger {
+    border-bottom-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr']) .trigger {
     border-bottom-right-radius: var(
@@ -195,42 +329,84 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)) .trigger {
+    border-bottom-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl']) .trigger {
     border-bottom-left-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton-trigger */
 }
+:host(:dir(ltr)) .trigger {
+    border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-SplitButton-trigger */
+}
 :host([dir='ltr']) .trigger {
     border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)) .trigger {
+    border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl']) .trigger {
     border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)) .trigger {
+    border-left-width: var(
+        --spectrum-splitbutton-trigger-border-left
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr']) .trigger {
     border-left-width: var(
         --spectrum-splitbutton-trigger-border-left
     ); /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)) .trigger {
+    border-right-width: var(
+        --spectrum-splitbutton-trigger-border-left
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl']) .trigger {
     border-right-width: var(
         --spectrum-splitbutton-trigger-border-left
     ); /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)) .trigger {
+    padding-left: var(
+        --spectrum-splitbutton-trigger-flat-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr']) .trigger {
     padding-left: var(
         --spectrum-splitbutton-trigger-flat-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)) .trigger {
+    padding-right: var(
+        --spectrum-splitbutton-trigger-flat-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl']) .trigger {
     padding-right: var(
         --spectrum-splitbutton-trigger-flat-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton-trigger */
 }
+:host(:dir(ltr)) .trigger {
+    padding-right: var(
+        --spectrum-splitbutton-trigger-round-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger */
+}
 :host([dir='ltr']) .trigger {
     padding-right: var(
         --spectrum-splitbutton-trigger-round-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton-trigger */
+}
+:host(:dir(rtl)) .trigger {
+    padding-left: var(
+        --spectrum-splitbutton-trigger-round-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger */
 }
 :host([dir='rtl']) .trigger {
     padding-left: var(
@@ -242,21 +418,43 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-splitbutton-trigger-min-width
     ); /* .spectrum-SplitButton-trigger */
 }
+:host(:dir(ltr)) .trigger[variant='accent'] {
+    padding-left: var(
+        --spectrum-splitbutton-cta-trigger-flat-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger.spectrum-Button--accent */
+}
 :host([dir='ltr']) .trigger[variant='accent'] {
     padding-left: var(
         --spectrum-splitbutton-cta-trigger-flat-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton-trigger.spectrum-Button--accent */
+}
+:host(:dir(rtl)) .trigger[variant='accent'] {
+    padding-right: var(
+        --spectrum-splitbutton-cta-trigger-flat-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger.spectrum-Button--accent */
 }
 :host([dir='rtl']) .trigger[variant='accent'] {
     padding-right: var(
         --spectrum-splitbutton-cta-trigger-flat-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton-trigger.spectrum-Button--accent */
 }
+:host(:dir(ltr)) .trigger[variant='accent'] {
+    border-left-width: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger.spectrum-Button--accent */
+}
 :host([dir='ltr']) .trigger[variant='accent'] {
     border-left-width: var(
         --spectrum-button-m-primary-outline-texticon-border-size,
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=ltr] .spectrum-SplitButton-trigger.spectrum-Button--accent */
+}
+:host(:dir(rtl)) .trigger[variant='accent'] {
+    border-right-width: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger.spectrum-Button--accent */
 }
 :host([dir='rtl']) .trigger[variant='accent'] {
     border-right-width: var(
@@ -270,20 +468,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .trigger:focus-visible {
     box-shadow: none; /* .spectrum-SplitButton-trigger.focus-ring */
 }
+:host(:dir(ltr)) .trigger:after {
+    border-top-left-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger:after */
+}
 :host([dir='ltr']) .trigger:after {
     border-top-left-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=ltr] .spectrum-SplitButton-trigger:after */
+}
+:host(:dir(rtl)) .trigger:after {
+    border-top-right-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger:after */
 }
 :host([dir='rtl']) .trigger:after {
     border-top-right-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=rtl] .spectrum-SplitButton-trigger:after */
 }
+:host(:dir(ltr)) .trigger:after {
+    border-bottom-left-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=ltr] .spectrum-SplitButton-trigger:after */
+}
 :host([dir='ltr']) .trigger:after {
     border-bottom-left-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=ltr] .spectrum-SplitButton-trigger:after */
+}
+:host(:dir(rtl)) .trigger:after {
+    border-bottom-right-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=rtl] .spectrum-SplitButton-trigger:after */
 }
 :host([dir='rtl']) .trigger:after {
     border-bottom-right-radius: var(
@@ -304,27 +522,55 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     z-index: 1; /* .spectrum-SplitButton-action:focus,
    * .spectrum-SplitButton-trigger:focus */
 }
+:host(:dir(ltr)) #button .label + .spectrum-Icon {
+    margin-left: var(
+        --spectrum-splitbutton-icon-gap
+    ); /* [dir=ltr] .spectrum-SplitButton-action .spectrum-Button-label+.spectrum-Icon */
+}
 :host([dir='ltr']) #button .label + .spectrum-Icon {
     margin-left: var(
         --spectrum-splitbutton-icon-gap
     ); /* [dir=ltr] .spectrum-SplitButton-action .spectrum-Button-label+.spectrum-Icon */
+}
+:host(:dir(rtl)) #button .label + .spectrum-Icon {
+    margin-right: var(
+        --spectrum-splitbutton-icon-gap
+    ); /* [dir=rtl] .spectrum-SplitButton-action .spectrum-Button-label+.spectrum-Icon */
 }
 :host([dir='rtl']) #button .label + .spectrum-Icon {
     margin-right: var(
         --spectrum-splitbutton-icon-gap
     ); /* [dir=rtl] .spectrum-SplitButton-action .spectrum-Button-label+.spectrum-Icon */
 }
+:host(:dir(ltr)[left]) #button {
+    border-top-left-radius: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='ltr'][left]) #button {
     border-top-left-radius: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
+:host(:dir(rtl)[left]) #button {
+    border-top-right-radius: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
 :host([dir='rtl'][left]) #button {
     border-top-right-radius: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)[left]) #button {
+    border-top-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='ltr'][left]) #button {
     border-top-right-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
+:host(:dir(rtl)[left]) #button {
+    border-top-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
 :host([dir='rtl'][left]) #button {
     border-top-left-radius: var(
@@ -332,69 +578,139 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)[left]) #button {
+    border-bottom-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='ltr'][left]) #button {
     border-bottom-right-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)[left]) #button {
+    border-bottom-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='rtl'][left]) #button {
     border-bottom-left-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
+:host(:dir(ltr)[left]) #button {
+    border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
 :host([dir='ltr'][left]) #button {
     border-bottom-left-radius: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)[left]) #button {
+    border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='rtl'][left]) #button {
     border-bottom-right-radius: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
+:host(:dir(ltr)[left]) #button {
+    margin-right: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
 :host([dir='ltr'][left]) #button {
     margin-right: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)[left]) #button {
+    margin-left: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='rtl'][left]) #button {
     margin-left: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)[left]) #button {
+    margin-left: var(
+        --spectrum-spltibutton-margin-left
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='ltr'][left]) #button {
     margin-left: var(
         --spectrum-spltibutton-margin-left
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
+:host(:dir(rtl)[left]) #button {
+    margin-right: var(
+        --spectrum-spltibutton-margin-left
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
 :host([dir='rtl'][left]) #button {
     margin-right: var(
         --spectrum-spltibutton-margin-left
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)[left]) #button {
+    padding-left: var(
+        --spectrum-splitbutton-flat-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='ltr'][left]) #button {
     padding-left: var(
         --spectrum-splitbutton-flat-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
+:host(:dir(rtl)[left]) #button {
+    padding-right: var(
+        --spectrum-splitbutton-flat-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
 :host([dir='rtl'][left]) #button {
     padding-right: var(
         --spectrum-splitbutton-flat-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(ltr)[left]) #button {
+    padding-right: var(
+        --spectrum-splitbutton-round-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='ltr'][left]) #button {
     padding-right: var(
         --spectrum-splitbutton-round-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action */
 }
+:host(:dir(rtl)[left]) #button {
+    padding-left: var(
+        --spectrum-splitbutton-round-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
 :host([dir='rtl'][left]) #button {
     padding-left: var(
         --spectrum-splitbutton-round-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action */
+}
+:host(:dir(ltr)[left]) #button[variant='accent'] {
+    padding-left: var(
+        --spectrum-splitbutton-cta-flat-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--accent */
 }
 :host([dir='ltr'][left]) #button[variant='accent'] {
     padding-left: var(
         --spectrum-splitbutton-cta-flat-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--accent */
 }
+:host(:dir(rtl)[left]) #button[variant='accent'] {
+    padding-right: var(
+        --spectrum-splitbutton-cta-flat-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--accent */
+}
 :host([dir='rtl'][left]) #button[variant='accent'] {
     padding-right: var(
         --spectrum-splitbutton-cta-flat-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--accent */
+}
+:host(:dir(ltr)[left]) #button[variant='accent'] {
+    margin-left: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--accent */
 }
 :host([dir='ltr'][left]) #button[variant='accent'] {
     margin-left: var(
@@ -402,21 +718,43 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--accent */
 }
+:host(:dir(rtl)[left]) #button[variant='accent'] {
+    margin-right: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--accent */
+}
 :host([dir='rtl'][left]) #button[variant='accent'] {
     margin-right: var(
         --spectrum-button-m-primary-outline-texticon-border-size,
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action.spectrum-Button--accent */
 }
+:host(:dir(ltr)[left]) #button:after {
+    border-top-left-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
 :host([dir='ltr'][left]) #button:after {
     border-top-left-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
 }
+:host(:dir(rtl)[left]) #button:after {
+    border-top-right-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
 :host([dir='rtl'][left]) #button:after {
     border-top-right-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
+:host(:dir(ltr)[left]) #button:after {
+    border-top-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
 }
 :host([dir='ltr'][left]) #button:after {
     border-top-right-radius: var(
@@ -424,11 +762,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
 }
+:host(:dir(rtl)[left]) #button:after {
+    border-top-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
 :host([dir='rtl'][left]) #button:after {
     border-top-left-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
+:host(:dir(ltr)[left]) #button:after {
+    border-bottom-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
 }
 :host([dir='ltr'][left]) #button:after {
     border-bottom-right-radius: var(
@@ -436,27 +786,55 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
 }
+:host(:dir(rtl)[left]) #button:after {
+    border-bottom-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
 :host([dir='rtl'][left]) #button:after {
     border-bottom-left-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
 }
+:host(:dir(ltr)[left]) #button:after {
+    border-bottom-left-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
 :host([dir='ltr'][left]) #button:after {
     border-bottom-left-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
 }
+:host(:dir(rtl)[left]) #button:after {
+    border-bottom-right-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
 :host([dir='rtl'][left]) #button:after {
     border-bottom-right-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-action:after */
+}
+:host(:dir(ltr)[left]) .trigger {
+    margin-right: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr'][left]) .trigger {
     margin-right: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)[left]) .trigger {
+    margin-left: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl'][left]) .trigger {
     margin-left: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)[left]) .trigger {
+    border-top-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr'][left]) .trigger {
     border-top-left-radius: var(
@@ -464,29 +842,59 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)[left]) .trigger {
+    border-top-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl'][left]) .trigger {
     border-top-right-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)[left]) .trigger {
+    border-top-right-radius: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr'][left]) .trigger {
     border-top-right-radius: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)[left]) .trigger {
+    border-top-left-radius: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl'][left]) .trigger {
     border-top-left-radius: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)[left]) .trigger {
+    border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr'][left]) .trigger {
     border-bottom-right-radius: 0; /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)[left]) .trigger {
+    border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl'][left]) .trigger {
     border-bottom-left-radius: 0; /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(ltr)[left]) .trigger {
+    border-bottom-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='ltr'][left]) .trigger {
     border-bottom-left-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
+:host(:dir(rtl)[left]) .trigger {
+    border-bottom-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
 :host([dir='rtl'][left]) .trigger {
     border-bottom-right-radius: var(
@@ -494,57 +902,115 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(ltr)[left]) .trigger {
+    border-left-width: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='ltr'][left]) .trigger {
     border-left-width: var(
         --spectrum-button-m-primary-outline-texticon-border-size,
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)[left]) .trigger {
+    border-right-width: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl'][left]) .trigger {
     border-right-width: var(
         --spectrum-button-m-primary-outline-texticon-border-size,
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)[left]) .trigger {
+    border-right-width: var(
+        --spectrum-splitbutton-trigger-border-left
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
 :host([dir='ltr'][left]) .trigger {
     border-right-width: var(
         --spectrum-splitbutton-trigger-border-left
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)[left]) .trigger {
+    border-left-width: var(
+        --spectrum-splitbutton-trigger-border-left
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl'][left]) .trigger {
     border-left-width: var(
         --spectrum-splitbutton-trigger-border-left
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(ltr)[left]) .trigger {
+    padding-right: var(
+        --spectrum-splitbutton-trigger-flat-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='ltr'][left]) .trigger {
     padding-right: var(
         --spectrum-splitbutton-trigger-flat-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
+:host(:dir(rtl)[left]) .trigger {
+    padding-left: var(
+        --spectrum-splitbutton-trigger-flat-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
 :host([dir='rtl'][left]) .trigger {
     padding-left: var(
         --spectrum-splitbutton-trigger-flat-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(ltr)[left]) .trigger {
+    padding-left: var(
+        --spectrum-splitbutton-trigger-round-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='ltr'][left]) .trigger {
     padding-left: var(
         --spectrum-splitbutton-trigger-round-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
 }
+:host(:dir(rtl)[left]) .trigger {
+    padding-right: var(
+        --spectrum-splitbutton-trigger-round-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
 :host([dir='rtl'][left]) .trigger {
     padding-right: var(
         --spectrum-splitbutton-trigger-round-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger */
+}
+:host(:dir(ltr)[left]) .trigger[variant='accent'] {
+    padding-right: var(
+        --spectrum-splitbutton-cta-trigger-flat-edge-padding
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--accent */
 }
 :host([dir='ltr'][left]) .trigger[variant='accent'] {
     padding-right: var(
         --spectrum-splitbutton-cta-trigger-flat-edge-padding
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--accent */
 }
+:host(:dir(rtl)[left]) .trigger[variant='accent'] {
+    padding-left: var(
+        --spectrum-splitbutton-cta-trigger-flat-edge-padding
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--accent */
+}
 :host([dir='rtl'][left]) .trigger[variant='accent'] {
     padding-left: var(
         --spectrum-splitbutton-cta-trigger-flat-edge-padding
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--accent */
+}
+:host(:dir(ltr)[left]) .trigger[variant='accent'] {
+    border-right-width: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--accent */
 }
 :host([dir='ltr'][left]) .trigger[variant='accent'] {
     border-right-width: var(
@@ -552,11 +1018,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--accent */
 }
+:host(:dir(rtl)[left]) .trigger[variant='accent'] {
+    border-left-width: var(
+        --spectrum-button-m-primary-outline-texticon-border-size,
+        var(--spectrum-alias-border-size-thick)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--accent */
+}
 :host([dir='rtl'][left]) .trigger[variant='accent'] {
     border-left-width: var(
         --spectrum-button-m-primary-outline-texticon-border-size,
         var(--spectrum-alias-border-size-thick)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger.spectrum-Button--accent */
+}
+:host(:dir(ltr)[left]) .trigger:after {
+    border-top-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
 }
 :host([dir='ltr'][left]) .trigger:after {
     border-top-left-radius: var(
@@ -564,37 +1042,75 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
 }
+:host(:dir(rtl)[left]) .trigger:after {
+    border-top-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
+}
 :host([dir='rtl'][left]) .trigger:after {
     border-top-right-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
 }
+:host(:dir(ltr)[left]) .trigger:after {
+    border-top-right-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
+}
 :host([dir='ltr'][left]) .trigger:after {
     border-top-right-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
 }
+:host(:dir(rtl)[left]) .trigger:after {
+    border-top-left-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
+}
 :host([dir='rtl'][left]) .trigger:after {
     border-top-left-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
+}
+:host(:dir(ltr)[left]) .trigger:after {
+    border-bottom-right-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
 }
 :host([dir='ltr'][left]) .trigger:after {
     border-bottom-right-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
 }
+:host(:dir(rtl)[left]) .trigger:after {
+    border-bottom-left-radius: var(
+        --spectrum-splitbutton-border-radius-edge
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
+}
 :host([dir='rtl'][left]) .trigger:after {
     border-bottom-left-radius: var(
         --spectrum-splitbutton-border-radius-edge
     ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
+}
+:host(:dir(ltr)[left]) .trigger:after {
+    border-bottom-left-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
 }
 :host([dir='ltr'][left]) .trigger:after {
     border-bottom-left-radius: var(
         --spectrum-button-m-primary-outline-texticon-border-radius,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
+}
+:host(:dir(rtl)[left]) .trigger:after {
+    border-bottom-right-radius: var(
+        --spectrum-button-m-primary-outline-texticon-border-radius,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-SplitButton--left .spectrum-SplitButton-trigger:after */
 }
 :host([dir='rtl'][left]) .trigger:after {
     border-bottom-right-radius: var(

--- a/packages/split-view/src/spectrum-split-view.css
+++ b/packages/split-view/src/spectrum-split-view.css
@@ -23,6 +23,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 ::slotted(*) {
     height: 100%; /* .spectrum-SplitView-pane */
 }
+:host(:dir(ltr)) #gripper {
+    left: calc(
+        (
+                var(
+                        --spectrum-dragbar-gripper-width,
+                        var(--spectrum-global-dimension-static-size-50)
+                    ) + 2 *
+                    var(--spectrum-dragbar-gripper-border-width-horizontal, 3px) -
+                    var(
+                        --spectrum-dragbar-handle-width,
+                        var(--spectrum-global-dimension-static-size-25)
+                    )
+            ) / 2 * -1
+    ); /* [dir=ltr] .spectrum-SplitView-gripper */
+}
 :host([dir='ltr']) #gripper {
     left: calc(
         (
@@ -37,6 +52,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                     )
             ) / 2 * -1
     ); /* [dir=ltr] .spectrum-SplitView-gripper */
+}
+:host(:dir(rtl)) #gripper {
+    right: calc(
+        (
+                var(
+                        --spectrum-dragbar-gripper-width,
+                        var(--spectrum-global-dimension-static-size-50)
+                    ) + 2 *
+                    var(--spectrum-dragbar-gripper-border-width-horizontal, 3px) -
+                    var(
+                        --spectrum-dragbar-handle-width,
+                        var(--spectrum-global-dimension-static-size-25)
+                    )
+            ) / 2 * -1
+    ); /* [dir=rtl] .spectrum-SplitView-gripper */
 }
 :host([dir='rtl']) #gripper {
     right: calc(
@@ -86,6 +116,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     z-index: 1;
 }
+:host(:dir(ltr)) #splitter.is-collapsed-end #gripper:before,
+:host(:dir(ltr)) #splitter.is-collapsed-start #gripper:before {
+    left: calc(
+        50% -
+            var(
+                --spectrum-dragbar-handle-width,
+                var(--spectrum-global-dimension-static-size-25)
+            ) / 2
+    ); /* [dir=ltr] .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper:before,
+   * [dir=ltr]  .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper:before */
+}
 :host([dir='ltr']) #splitter.is-collapsed-end #gripper:before,
 :host([dir='ltr']) #splitter.is-collapsed-start #gripper:before {
     left: calc(
@@ -96,6 +137,17 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) / 2
     ); /* [dir=ltr] .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper:before,
    * [dir=ltr]  .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper:before */
+}
+:host(:dir(rtl)) #splitter.is-collapsed-end #gripper:before,
+:host(:dir(rtl)) #splitter.is-collapsed-start #gripper:before {
+    right: calc(
+        50% -
+            var(
+                --spectrum-dragbar-handle-width,
+                var(--spectrum-global-dimension-static-size-25)
+            ) / 2
+    ); /* [dir=rtl] .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper:before,
+   * [dir=rtl]  .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper:before */
 }
 :host([dir='rtl']) #splitter.is-collapsed-end #gripper:before,
 :host([dir='rtl']) #splitter.is-collapsed-start #gripper:before {
@@ -120,20 +172,38 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-static-size-25)
     );
 }
+:host(:dir(ltr)) #splitter.is-collapsed-start #gripper {
+    left: 0; /* [dir=ltr] .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper */
+}
 :host([dir='ltr']) #splitter.is-collapsed-start #gripper {
     left: 0; /* [dir=ltr] .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper */
+}
+:host(:dir(rtl)) #splitter.is-collapsed-start #gripper {
+    right: 0; /* [dir=rtl] .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper */
 }
 :host([dir='rtl']) #splitter.is-collapsed-start #gripper {
     right: 0; /* [dir=rtl] .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper */
 }
+:host(:dir(ltr)) #splitter.is-collapsed-end #gripper {
+    right: 0; /* [dir=ltr] .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
+}
 :host([dir='ltr']) #splitter.is-collapsed-end #gripper {
     right: 0; /* [dir=ltr] .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
+}
+:host(:dir(rtl)) #splitter.is-collapsed-end #gripper {
+    left: 0; /* [dir=rtl] .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
 }
 :host([dir='rtl']) #splitter.is-collapsed-end #gripper {
     left: 0; /* [dir=rtl] .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
 }
+:host(:dir(ltr)) #splitter.is-collapsed-end #gripper {
+    left: auto; /* [dir=ltr] .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
+}
 :host([dir='ltr']) #splitter.is-collapsed-end #gripper {
     left: auto; /* [dir=ltr] .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
+}
+:host(:dir(rtl)) #splitter.is-collapsed-end #gripper {
+    right: auto; /* [dir=rtl] .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
 }
 :host([dir='rtl']) #splitter.is-collapsed-end #gripper {
     right: auto; /* [dir=rtl] .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
@@ -145,10 +215,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     height: auto; /* .spectrum-SplitView--vertical .spectrum-SplitView-pane */
     width: var(--spectrum-splitview-vertical-width);
 }
+:host(:dir(ltr)[vertical]) #gripper {
+    left: var(
+        --spectrum-splitview-vertical-gripper-width
+    ); /* [dir=ltr] .spectrum-SplitView--vertical .spectrum-SplitView-gripper */
+}
 :host([dir='ltr'][vertical]) #gripper {
     left: var(
         --spectrum-splitview-vertical-gripper-width
     ); /* [dir=ltr] .spectrum-SplitView--vertical .spectrum-SplitView-gripper */
+}
+:host(:dir(rtl)[vertical]) #gripper {
+    right: var(
+        --spectrum-splitview-vertical-gripper-width
+    ); /* [dir=rtl] .spectrum-SplitView--vertical .spectrum-SplitView-gripper */
 }
 :host([dir='rtl'][vertical]) #gripper {
     right: var(
@@ -192,12 +272,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-splitview-vertical-width
     ); /* .spectrum-SplitView--vertical .spectrum-SplitView-splitter */
 }
+:host(:dir(ltr)[vertical]) #splitter.is-collapsed-end #gripper,
+:host(:dir(ltr)[vertical]) #splitter.is-collapsed-start #gripper {
+    left: var(
+        --spectrum-splitview-vertical-gripper-width
+    ); /* [dir=ltr] .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper,
+   * [dir=ltr]  .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
+}
 :host([dir='ltr'][vertical]) #splitter.is-collapsed-end #gripper,
 :host([dir='ltr'][vertical]) #splitter.is-collapsed-start #gripper {
     left: var(
         --spectrum-splitview-vertical-gripper-width
     ); /* [dir=ltr] .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper,
    * [dir=ltr]  .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
+}
+:host(:dir(rtl)[vertical]) #splitter.is-collapsed-end #gripper,
+:host(:dir(rtl)[vertical]) #splitter.is-collapsed-start #gripper {
+    right: var(
+        --spectrum-splitview-vertical-gripper-width
+    ); /* [dir=rtl] .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper,
+   * [dir=rtl]  .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
 }
 :host([dir='rtl'][vertical]) #splitter.is-collapsed-end #gripper,
 :host([dir='rtl'][vertical]) #splitter.is-collapsed-start #gripper {
@@ -206,12 +300,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* [dir=rtl] .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper,
    * [dir=rtl]  .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper */
 }
+:host(:dir(ltr)[vertical]) #splitter.is-collapsed-end #gripper:before,
+:host(:dir(ltr)[vertical]) #splitter.is-collapsed-start #gripper:before {
+    left: var(
+        --spectrum-splitview-vertical-gripper-reset
+    ); /* [dir=ltr] .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper:before,
+   * [dir=ltr]  .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper:before */
+}
 :host([dir='ltr'][vertical]) #splitter.is-collapsed-end #gripper:before,
 :host([dir='ltr'][vertical]) #splitter.is-collapsed-start #gripper:before {
     left: var(
         --spectrum-splitview-vertical-gripper-reset
     ); /* [dir=ltr] .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper:before,
    * [dir=ltr]  .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper:before */
+}
+:host(:dir(rtl)[vertical]) #splitter.is-collapsed-end #gripper:before,
+:host(:dir(rtl)[vertical]) #splitter.is-collapsed-start #gripper:before {
+    right: var(
+        --spectrum-splitview-vertical-gripper-reset
+    ); /* [dir=rtl] .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-start .spectrum-SplitView-gripper:before,
+   * [dir=rtl]  .spectrum-SplitView--vertical .spectrum-SplitView-splitter.is-collapsed-end .spectrum-SplitView-gripper:before */
 }
 :host([dir='rtl'][vertical]) #splitter.is-collapsed-end #gripper:before,
 :host([dir='rtl'][vertical]) #splitter.is-collapsed-start #gripper:before {

--- a/packages/split-view/src/split-view.css
+++ b/packages/split-view/src/split-view.css
@@ -60,6 +60,16 @@ governing permissions and limitations under the License.
     cursor: ns-resize;
 }
 
+:host([resizable]:dir(ltr)) #splitter.is-resized-start,
+:host([resizable]:dir(rtl)) #splitter.is-resized-end {
+    cursor: e-resize;
+}
+
+:host([resizable]:dir(ltr)) #splitter.is-resized-end,
+:host([resizable]:dir(rtl)) #splitter.is-resized-start {
+    cursor: w-resize;
+}
+
 :host([resizable][dir='ltr']) #splitter.is-resized-start,
 :host([resizable][dir='rtl']) #splitter.is-resized-end {
     cursor: e-resize;
@@ -83,6 +93,16 @@ governing permissions and limitations under the License.
     cursor: ew-resize;
 }
 
+:host([resizable]:dir(ltr)[collapsible]) #splitter.is-collapsed-start,
+:host([resizable]:dir(rtl)[collapsible]) #splitter.is-collapsed-end {
+    cursor: e-resize;
+}
+
+:host([resizable]:dir(ltr)[collapsible]) #splitter.is-collapsed-end,
+:host([resizable]:dir(rtl)[collapsible]) #splitter.is-collapsed-start {
+    cursor: w-resize;
+}
+
 :host([resizable][dir='ltr'][collapsible]) #splitter.is-collapsed-start,
 :host([resizable][dir='rtl'][collapsible]) #splitter.is-collapsed-end {
     cursor: e-resize;
@@ -104,6 +124,46 @@ governing permissions and limitations under the License.
 :host([vertical][resizable][collapsible]) #splitter.is-resized-start,
 :host([vertical][resizable][collapsible]) #splitter.is-resized-end {
     cursor: ns-resize;
+}
+
+/**
+ * Apply X offset to compensate adapted hover area (margin/padding) of splitter
+ */
+:host(:dir(ltr)[resizable]) #gripper {
+    left: calc(
+        var(--spectrum-global-dimension-static-size-125) +
+            (
+                var(
+                        --spectrum-dragbar-gripper-width,
+                        var(--spectrum-global-dimension-static-size-50)
+                    ) + 2 *
+                    var(--spectrum-dragbar-gripper-border-width-horizontal, 3px) -
+                    var(
+                        --spectrum-dragbar-handle-width,
+                        var(--spectrum-global-dimension-static-size-25)
+                    )
+            ) / 2 * -1
+    );
+}
+
+/**
+ * Apply X offset to compensate adapted hover area (margin/padding) of splitter
+ */
+:host(:dir(rtl)[resizable]) #gripper {
+    right: calc(
+        var(--spectrum-global-dimension-static-size-125) +
+            (
+                var(
+                        --spectrum-dragbar-gripper-width,
+                        var(--spectrum-global-dimension-static-size-50)
+                    ) + 2 *
+                    var(--spectrum-dragbar-gripper-border-width-horizontal, 3px) -
+                    var(
+                        --spectrum-dragbar-handle-width,
+                        var(--spectrum-global-dimension-static-size-25)
+                    )
+            ) / 2 * -1
+    );
 }
 
 /**
@@ -153,6 +213,22 @@ governing permissions and limitations under the License.
     margin-top: var(--spectrum-global-dimension-static-size-125);
     left: 50%;
     right: 50%;
+}
+
+:host(:dir(ltr)[resizable]) #splitter.is-collapsed-start #gripper {
+    left: var(--spectrum-global-dimension-static-size-125);
+}
+
+:host(:dir(rtl)[resizable]) #splitter.is-collapsed-start #gripper {
+    right: var(--spectrum-global-dimension-static-size-125);
+}
+
+:host(:dir(ltr)[resizable]) #splitter.is-collapsed-end #gripper {
+    left: var(--spectrum-global-dimension-static-size-25);
+}
+
+:host(:dir(rtl)[resizable]) #splitter.is-collapsed-end #gripper {
+    right: var(--spectrum-global-dimension-static-size-25);
 }
 
 :host([dir='ltr'][resizable]) #splitter.is-collapsed-start #gripper {

--- a/packages/status-light/src/spectrum-config.js
+++ b/packages/status-light/src/spectrum-config.js
@@ -70,7 +70,7 @@ const config = {
             ],
             complexSelectors: [
                 {
-                    replacement: ':host([dir])',
+                    replacement: ':host([size])',
                     selector: /^.spectrum-StatusLight$/,
                 },
             ],

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -174,7 +174,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-600)
     );
 }
-:host([dir]) {
+:host([size]) {
     --spectrum-statuslight-info-dot-resolved-margin-top: calc(
         var(--spectrum-statuslight-info-dot-margin-top) -
             var(--spectrum-statuslight-info-text-padding-top)
@@ -192,11 +192,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     padding-right: 0;
     padding-top: var(--spectrum-statuslight-info-text-padding-top);
 }
+:host(:dir(ltr)):before {
+    margin-left: var(
+        --spectrum-global-dimension-size-0
+    ); /* [dir=ltr] .spectrum-StatusLight:before */
+    margin-right: var(--spectrum-statuslight-info-text-gap);
+}
 :host([dir='ltr']):before {
     margin-left: var(
         --spectrum-global-dimension-size-0
     ); /* [dir=ltr] .spectrum-StatusLight:before */
     margin-right: var(--spectrum-statuslight-info-text-gap);
+}
+:host(:dir(rtl)):before {
+    margin-left: var(--spectrum-statuslight-info-text-gap);
+    margin-right: var(
+        --spectrum-global-dimension-size-0
+    ); /* [dir=rtl] .spectrum-StatusLight:before */
 }
 :host([dir='rtl']):before {
     margin-left: var(--spectrum-statuslight-info-text-gap);
@@ -220,7 +232,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([variant='neutral']) {
     font-style: italic; /* .spectrum-StatusLight--neutral */
 }
-:host([dir]) {
+:host([size]) {
     color: var(
         --spectrum-statuslight-m-info-text-color,
         var(--spectrum-alias-text-color)

--- a/packages/switch/src/spectrum-config.js
+++ b/packages/switch/src/spectrum-config.js
@@ -49,20 +49,18 @@ const config = {
             ],
             complexSelectors: [
                 {
-                    replacement:
-                        ':host([disabled][checked][dir]) #input + #switch',
+                    replacement: ':host([disabled][checked]) #input + #switch',
                     selector:
                         '.spectrum-Switch .spectrum-Switch-input:disabled:checked + .spectrum-Switch-switch',
                 },
                 {
                     replacement:
-                        ':host([disabled][checked][dir]) #input + #switch:before',
+                        ':host([disabled][checked]) #input + #switch:before',
                     selector:
                         '.spectrum-Switch .spectrum-Switch-input:disabled:checked + .spectrum-Switch-switch::before',
                 },
                 {
-                    replacement:
-                        ':host([disabled][checked][dir]) #input ~ #label',
+                    replacement: ':host([disabled][checked]) #input ~ #label',
                     selector:
                         '.spectrum-Switch .spectrum-Switch-input:disabled:checked ~ .spectrum-Switch-label',
                 },

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -52,10 +52,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     --spectrum-switch-label-line-height: 1.49;
 }
+:host(:dir(ltr)) {
+    margin-right: calc(
+        var(--spectrum-switch-cursor-hit-x) * 2
+    ); /* [dir=ltr] .spectrum-Switch */
+}
 :host([dir='ltr']) {
     margin-right: calc(
         var(--spectrum-switch-cursor-hit-x) * 2
     ); /* [dir=ltr] .spectrum-Switch */
+}
+:host(:dir(rtl)) {
+    margin-left: calc(
+        var(--spectrum-switch-cursor-hit-x) * 2
+    ); /* [dir=rtl] .spectrum-Switch */
 }
 :host([dir='rtl']) {
     margin-left: calc(
@@ -70,8 +80,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     position: relative;
     vertical-align: top;
 }
+:host(:dir(ltr)) #input {
+    left: 0; /* [dir=ltr] .spectrum-Switch-input */
+}
 :host([dir='ltr']) #input {
     left: 0; /* [dir=ltr] .spectrum-Switch-input */
+}
+:host(:dir(rtl)) #input {
+    right: 0; /* [dir=rtl] .spectrum-Switch-input */
 }
 :host([dir='rtl']) #input {
     right: 0; /* [dir=rtl] .spectrum-Switch-input */
@@ -88,10 +104,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     width: 100%;
     z-index: 1;
 }
+:host(:dir(ltr)[checked]) #input + #switch:before {
+    transform: translateX(
+        calc(var(--spectrum-switch-track-width) - 100%)
+    ); /* [dir=ltr] .spectrum-Switch-input:checked+.spectrum-Switch-switch:before */
+}
 :host([dir='ltr'][checked]) #input + #switch:before {
     transform: translateX(
         calc(var(--spectrum-switch-track-width) - 100%)
     ); /* [dir=ltr] .spectrum-Switch-input:checked+.spectrum-Switch-switch:before */
+}
+:host(:dir(rtl)[checked]) #input + #switch:before {
+    transform: translateX(
+        calc((var(--spectrum-switch-track-width) - 100%) * -1)
+    ); /* [dir=rtl] .spectrum-Switch-input:checked+.spectrum-Switch-switch:before */
 }
 :host([dir='rtl'][checked]) #input + #switch:before {
     transform: translateX(
@@ -129,14 +155,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     transition: color var(--spectrum-global-animation-duration-200, 0.16s)
         ease-in-out;
 }
+:host(:dir(ltr)) #switch {
+    left: 0; /* [dir=ltr] .spectrum-Switch-switch */
+}
 :host([dir='ltr']) #switch {
     left: 0; /* [dir=ltr] .spectrum-Switch-switch */
+}
+:host(:dir(rtl)) #switch {
+    right: 0; /* [dir=rtl] .spectrum-Switch-switch */
 }
 :host([dir='rtl']) #switch {
     right: 0; /* [dir=rtl] .spectrum-Switch-switch */
 }
+:host(:dir(ltr)) #switch {
+    right: 0; /* [dir=ltr] .spectrum-Switch-switch */
+}
 :host([dir='ltr']) #switch {
     right: 0; /* [dir=ltr] .spectrum-Switch-switch */
+}
+:host(:dir(rtl)) #switch {
+    left: 0; /* [dir=rtl] .spectrum-Switch-switch */
 }
 :host([dir='rtl']) #switch {
     left: 0; /* [dir=rtl] .spectrum-Switch-switch */
@@ -171,8 +209,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: block; /* .spectrum-Switch-switch:before */
     position: absolute;
 }
+:host(:dir(ltr)) #switch:before {
+    left: 0; /* [dir=ltr] .spectrum-Switch-switch:before */
+}
 :host([dir='ltr']) #switch:before {
     left: 0; /* [dir=ltr] .spectrum-Switch-switch:before */
+}
+:host(:dir(rtl)) #switch:before {
+    right: 0; /* [dir=rtl] .spectrum-Switch-switch:before */
 }
 :host([dir='rtl']) #switch:before {
     right: 0; /* [dir=rtl] .spectrum-Switch-switch:before */
@@ -192,14 +236,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ease-in-out; /* .spectrum-Switch-switch:before */
     width: var(--spectrum-switch-handle-size);
 }
+:host(:dir(ltr)) #switch:after {
+    left: 0; /* [dir=ltr] .spectrum-Switch-switch:after */
+}
 :host([dir='ltr']) #switch:after {
     left: 0; /* [dir=ltr] .spectrum-Switch-switch:after */
+}
+:host(:dir(rtl)) #switch:after {
+    right: 0; /* [dir=rtl] .spectrum-Switch-switch:after */
 }
 :host([dir='rtl']) #switch:after {
     right: 0; /* [dir=rtl] .spectrum-Switch-switch:after */
 }
+:host(:dir(ltr)) #switch:after {
+    right: 0; /* [dir=ltr] .spectrum-Switch-switch:after */
+}
 :host([dir='ltr']) #switch:after {
     right: 0; /* [dir=ltr] .spectrum-Switch-switch:after */
+}
+:host(:dir(rtl)) #switch:after {
+    left: 0; /* [dir=rtl] .spectrum-Switch-switch:after */
 }
 :host([dir='rtl']) #switch:after {
     left: 0; /* [dir=rtl] .spectrum-Switch-switch:after */
@@ -323,19 +379,19 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-component-text-color-disabled)
     ); /* .spectrum-Switch .spectrum-Switch-input:disabled~.spectrum-Switch-label */
 }
-:host([disabled][checked][dir]) #input + #switch {
+:host([disabled][checked]) #input + #switch {
     background-color: var(
         --spectrum-switch-m-track-color-selected-disabled,
         var(--spectrum-global-color-gray-400)
     ); /* .spectrum-Switch .spectrum-Switch-input:disabled:checked+.spectrum-Switch-switch */
 }
-:host([disabled][checked][dir]) #input + #switch:before {
+:host([disabled][checked]) #input + #switch:before {
     border-color: var(
         --spectrum-switch-m-handle-border-color-selected-disabled,
         var(--spectrum-global-color-gray-400)
     ); /* .spectrum-Switch .spectrum-Switch-input:disabled:checked+.spectrum-Switch-switch:before */
 }
-:host([disabled][checked][dir]) #input ~ #label {
+:host([disabled][checked]) #input ~ #label {
     color: var(
         --spectrum-switch-m-text-color-selected-disabled,
         var(--spectrum-alias-component-text-color-disabled)

--- a/packages/switch/src/switch.css
+++ b/packages/switch/src/switch.css
@@ -33,6 +33,26 @@ governing permissions and limitations under the License.
 
 /* Continue work around... */
 
+:host(:dir(ltr)[checked]) #input + #switch:before {
+    /* [dir=ltr] .spectrum-Switch-input:checked+.spectrum-Switch-switch:before */
+    transform: translateX(
+        calc(
+            var(--spectrum-switch-track-width) -
+                var(--spectrum-switch-handle-size)
+        )
+    );
+}
+
+:host(:dir(rtl)[checked]) #input + #switch:before {
+    /* [dir=rtl] .spectrum-Switch-input:checked+.spectrum-Switch-switch:before */
+    transform: translateX(
+        calc(
+            var(--spectrum-switch-handle-size) -
+                var(--spectrum-switch-track-width)
+        )
+    );
+}
+
 :host([dir='ltr'][checked]) #input + #switch:before {
     /* [dir=ltr] .spectrum-Switch-input:checked+.spectrum-Switch-switch:before */
     transform: translateX(

--- a/packages/tabs/src/spectrum-tab.css
+++ b/packages/tabs/src/spectrum-tab.css
@@ -37,11 +37,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-tabs-quiet-textonly-tabitem-height
     ); /* .spectrum-Tabs-item .spectrum-Icon */
 }
+:host(:dir(ltr)) slot[name='icon'] + #item-label {
+    margin-left: calc(
+        var(--spectrum-tabs-quiet-textonly-tabitem-icon-gap) -
+            var(--spectrum-global-dimension-size-40)
+    ); /* [dir=ltr] .spectrum-Tabs-item .spectrum-Icon+.spectrum-Tabs-itemLabel */
+}
 :host([dir='ltr']) slot[name='icon'] + #item-label {
     margin-left: calc(
         var(--spectrum-tabs-quiet-textonly-tabitem-icon-gap) -
             var(--spectrum-global-dimension-size-40)
     ); /* [dir=ltr] .spectrum-Tabs-item .spectrum-Icon+.spectrum-Tabs-itemLabel */
+}
+:host(:dir(rtl)) slot[name='icon'] + #item-label {
+    margin-right: calc(
+        var(--spectrum-tabs-quiet-textonly-tabitem-icon-gap) -
+            var(--spectrum-global-dimension-size-40)
+    ); /* [dir=rtl] .spectrum-Tabs-item .spectrum-Icon+.spectrum-Tabs-itemLabel */
 }
 :host([dir='rtl']) slot[name='icon'] + #item-label {
     margin-right: calc(
@@ -49,20 +61,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-global-dimension-size-40)
     ); /* [dir=rtl] .spectrum-Tabs-item .spectrum-Icon+.spectrum-Tabs-itemLabel */
 }
+:host(:dir(ltr)):before {
+    left: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
+    ); /* [dir=ltr] .spectrum-Tabs-item:before */
+}
 :host([dir='ltr']):before {
     left: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
     ); /* [dir=ltr] .spectrum-Tabs-item:before */
+}
+:host(:dir(rtl)):before {
+    right: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
+    ); /* [dir=rtl] .spectrum-Tabs-item:before */
 }
 :host([dir='rtl']):before {
     right: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
     ); /* [dir=rtl] .spectrum-Tabs-item:before */
 }
+:host(:dir(ltr)):before {
+    right: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
+    ); /* [dir=ltr] .spectrum-Tabs-item:before */
+}
 :host([dir='ltr']):before {
     right: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
     ); /* [dir=ltr] .spectrum-Tabs-item:before */
+}
+:host(:dir(rtl)):before {
+    left: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
+    ); /* [dir=rtl] .spectrum-Tabs-item:before */
 }
 :host([dir='rtl']):before {
     left: calc(

--- a/packages/tabs/src/spectrum-tabs.css
+++ b/packages/tabs/src/spectrum-tabs.css
@@ -705,28 +705,54 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     vertical-align: top;
     z-index: 0;
 }
+:host(:dir(ltr)) ::slotted(:not([slot])):before {
+    left: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
+    ); /* [dir=ltr] .spectrum-Tabs-item:before */
+}
 :host([dir='ltr']) ::slotted(:not([slot])):before {
     left: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
     ); /* [dir=ltr] .spectrum-Tabs-item:before */
+}
+:host(:dir(rtl)) ::slotted(:not([slot])):before {
+    right: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
+    ); /* [dir=rtl] .spectrum-Tabs-item:before */
 }
 :host([dir='rtl']) ::slotted(:not([slot])):before {
     right: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
     ); /* [dir=rtl] .spectrum-Tabs-item:before */
 }
+:host(:dir(ltr)) ::slotted(:not([slot])):before {
+    right: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
+    ); /* [dir=ltr] .spectrum-Tabs-item:before */
+}
 :host([dir='ltr']) ::slotted(:not([slot])):before {
     right: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
     ); /* [dir=ltr] .spectrum-Tabs-item:before */
 }
+:host(:dir(rtl)) ::slotted(:not([slot])):before {
+    left: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
+    ); /* [dir=rtl] .spectrum-Tabs-item:before */
+}
 :host([dir='rtl']) ::slotted(:not([slot])):before {
     left: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-padding-x) * -1
     ); /* [dir=rtl] .spectrum-Tabs-item:before */
+}
+:host(:dir(ltr)) #selection-indicator {
+    left: 0; /* [dir=ltr] .spectrum-Tabs-selectionIndicator */
 }
 :host([dir='ltr']) #selection-indicator {
     left: 0; /* [dir=ltr] .spectrum-Tabs-selectionIndicator */
+}
+:host(:dir(rtl)) #selection-indicator {
+    right: 0; /* [dir=rtl] .spectrum-Tabs-selectionIndicator */
 }
 :host([dir='rtl']) #selection-indicator {
     right: 0; /* [dir=rtl] .spectrum-Tabs-selectionIndicator */
@@ -755,11 +781,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([direction^='horizontal']) ::slotted(:not([slot])) {
     vertical-align: top; /* .spectrum-Tabs--horizontal .spectrum-Tabs-item */
 }
+:host(:dir(ltr)[direction^='horizontal'])
+    ::slotted(:not([slot]):not(:first-child)) {
+    margin-left: var(
+        --spectrum-tabs-textonly-tabitem-margin-right
+    ); /* [dir=ltr] .spectrum-Tabs--horizontal .spectrum-Tabs-item+*:not(.spectrum-Tabs-selectionIndicator) */
+}
 :host([dir='ltr'][direction^='horizontal'])
     ::slotted(:not([slot]):not(:first-child)) {
     margin-left: var(
         --spectrum-tabs-textonly-tabitem-margin-right
     ); /* [dir=ltr] .spectrum-Tabs--horizontal .spectrum-Tabs-item+*:not(.spectrum-Tabs-selectionIndicator) */
+}
+:host(:dir(rtl)[direction^='horizontal'])
+    ::slotted(:not([slot]):not(:first-child)) {
+    margin-right: var(
+        --spectrum-tabs-textonly-tabitem-margin-right
+    ); /* [dir=rtl] .spectrum-Tabs--horizontal .spectrum-Tabs-item+*:not(.spectrum-Tabs-selectionIndicator) */
 }
 :host([dir='rtl'][direction^='horizontal'])
     ::slotted(:not([slot]):not(:first-child)) {
@@ -781,8 +819,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([quiet]) #list {
     display: inline-flex; /* .spectrum-Tabs--quiet */
 }
+:host(:dir(ltr)[direction^='vertical']) #list {
+    border-left: var(--spectrum-tabs-quiet-textonly-divider-size) solid; /* [dir=ltr] .spectrum-Tabs--vertical */
+}
 :host([dir='ltr'][direction^='vertical']) #list {
     border-left: var(--spectrum-tabs-quiet-textonly-divider-size) solid; /* [dir=ltr] .spectrum-Tabs--vertical */
+}
+:host(:dir(rtl)[direction^='vertical']) #list {
+    border-right: var(--spectrum-tabs-quiet-textonly-divider-size) solid; /* [dir=rtl] .spectrum-Tabs--vertical */
 }
 :host([dir='rtl'][direction^='vertical']) #list {
     border-right: var(--spectrum-tabs-quiet-textonly-divider-size) solid; /* [dir=rtl] .spectrum-Tabs--vertical */
@@ -792,10 +836,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     flex-direction: column;
     padding: 0;
 }
+:host(:dir(ltr)[direction^='vertical']) ::slotted(:not([slot])) {
+    margin-left: calc(
+        var(--spectrum-tabs-vertical-textonly-tabitem-gap) / 2
+    ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item */
+}
 :host([dir='ltr'][direction^='vertical']) ::slotted(:not([slot])) {
     margin-left: calc(
         var(--spectrum-tabs-vertical-textonly-tabitem-gap) / 2
     ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item */
+}
+:host(:dir(rtl)[direction^='vertical']) ::slotted(:not([slot])) {
+    margin-right: calc(
+        var(--spectrum-tabs-vertical-textonly-tabitem-gap) / 2
+    ); /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-item */
 }
 :host([dir='rtl'][direction^='vertical']) ::slotted(:not([slot])) {
     margin-right: calc(
@@ -817,20 +871,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
     padding-top: 0;
 }
+:host(:dir(ltr)[direction^='vertical']) ::slotted(:not([slot])):before {
+    left: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-size) * -1
+    ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
+}
 :host([dir='ltr'][direction^='vertical']) ::slotted(:not([slot])):before {
     left: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-size) * -1
     ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
+}
+:host(:dir(rtl)[direction^='vertical']) ::slotted(:not([slot])):before {
+    right: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-size) * -1
+    ); /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
 }
 :host([dir='rtl'][direction^='vertical']) ::slotted(:not([slot])):before {
     right: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-size) * -1
     ); /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
 }
+:host(:dir(ltr)[direction^='vertical']) ::slotted(:not([slot])):before {
+    right: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-size) * -1
+    ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
+}
 :host([dir='ltr'][direction^='vertical']) ::slotted(:not([slot])):before {
     right: calc(
         var(--spectrum-tabs-textonly-tabitem-focus-ring-size) * -1
     ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
+}
+:host(:dir(rtl)[direction^='vertical']) ::slotted(:not([slot])):before {
+    left: calc(
+        var(--spectrum-tabs-textonly-tabitem-focus-ring-size) * -1
+    ); /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-item:before */
 }
 :host([dir='rtl'][direction^='vertical']) ::slotted(:not([slot])):before {
     left: calc(
@@ -850,16 +924,32 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     line-height: var(--spectrum-tabs-compact-vertical-textonly-tabitem-height);
     margin-bottom: var(--spectrum-tabs-compact-vertical-textonly-tabitem-gap);
 }
+:host(:dir(ltr)[direction^='vertical']) #selection-indicator {
+    left: 0; /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+}
 :host([dir='ltr'][direction^='vertical']) #selection-indicator {
     left: 0; /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
 }
+:host(:dir(rtl)[direction^='vertical']) #selection-indicator {
+    right: 0; /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+}
 :host([dir='rtl'][direction^='vertical']) #selection-indicator {
     right: 0; /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+}
+:host(:dir(ltr)[direction^='vertical']) #selection-indicator {
+    left: calc(
+        var(--spectrum-tabs-quiet-textonly-divider-size) * -1
+    ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
 }
 :host([dir='ltr'][direction^='vertical']) #selection-indicator {
     left: calc(
         var(--spectrum-tabs-quiet-textonly-divider-size) * -1
     ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+}
+:host(:dir(rtl)[direction^='vertical']) #selection-indicator {
+    right: calc(
+        var(--spectrum-tabs-quiet-textonly-divider-size) * -1
+    ); /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
 }
 :host([dir='rtl'][direction^='vertical']) #selection-indicator {
     right: calc(
@@ -875,10 +965,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-tabs-textonly-divider-background-color
     ); /* .spectrum-Tabs */
 }
+:host(:dir(ltr)[direction^='vertical']) #list {
+    border-left-color: var(
+        --spectrum-tabs-vertical-textonly-divider-background-color
+    ); /* [dir=ltr] .spectrum-Tabs--vertical */
+}
 :host([dir='ltr'][direction^='vertical']) #list {
     border-left-color: var(
         --spectrum-tabs-vertical-textonly-divider-background-color
     ); /* [dir=ltr] .spectrum-Tabs--vertical */
+}
+:host(:dir(rtl)[direction^='vertical']) #list {
+    border-right-color: var(
+        --spectrum-tabs-vertical-textonly-divider-background-color
+    ); /* [dir=rtl] .spectrum-Tabs--vertical */
 }
 :host([dir='rtl'][direction^='vertical']) #list {
     border-right-color: var(
@@ -910,12 +1010,28 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-tabs-emphasized-texticon-tabitem-selection-indicator-background-color-selected
     ); /* .spectrum-Tabs--quiet.spectrum-Tabs--emphasized .spectrum-Tabs-selectionIndicator */
 }
+:host(:dir(ltr)[direction^='vertical'][compact]) #list,
+:host(:dir(ltr)[direction^='vertical'][quiet]) #list {
+    border-left-color: var(
+        --spectrum-tabs-vertical-quiet-textonly-divider-background-color
+    ); /* [dir=ltr] .spectrum-Tabs--vertical.spectrum-Tabs--quiet,
+   * [dir=ltr] 
+  .spectrum-Tabs--vertical.spectrum-Tabs--compact */
+}
 :host([dir='ltr'][direction^='vertical'][compact]) #list,
 :host([dir='ltr'][direction^='vertical'][quiet]) #list {
     border-left-color: var(
         --spectrum-tabs-vertical-quiet-textonly-divider-background-color
     ); /* [dir=ltr] .spectrum-Tabs--vertical.spectrum-Tabs--quiet,
    * [dir=ltr] 
+  .spectrum-Tabs--vertical.spectrum-Tabs--compact */
+}
+:host(:dir(rtl)[direction^='vertical'][compact]) #list,
+:host(:dir(rtl)[direction^='vertical'][quiet]) #list {
+    border-right-color: var(
+        --spectrum-tabs-vertical-quiet-textonly-divider-background-color
+    ); /* [dir=rtl] .spectrum-Tabs--vertical.spectrum-Tabs--quiet,
+   * [dir=rtl] 
   .spectrum-Tabs--vertical.spectrum-Tabs--compact */
 }
 :host([dir='rtl'][direction^='vertical'][compact]) #list,
@@ -933,10 +1049,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Tabs--vertical.spectrum-Tabs--quiet .spectrum-Tabs-selectionIndicator,
    * .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-selectionIndicator */
 }
+:host(:dir(ltr)[direction^='vertical']) .spectrum-Tabs--emphasized {
+    border-left-color: var(
+        --spectrum-tabs-emphasized-textonly-divider-background-color
+    ); /* [dir=ltr] .spectrum-Tabs--vertical.spectrum-Tabs--emphasized */
+}
 :host([dir='ltr'][direction^='vertical']) .spectrum-Tabs--emphasized {
     border-left-color: var(
         --spectrum-tabs-emphasized-textonly-divider-background-color
     ); /* [dir=ltr] .spectrum-Tabs--vertical.spectrum-Tabs--emphasized */
+}
+:host(:dir(rtl)[direction^='vertical']) .spectrum-Tabs--emphasized {
+    border-right-color: var(
+        --spectrum-tabs-emphasized-textonly-divider-background-color
+    ); /* [dir=rtl] .spectrum-Tabs--vertical.spectrum-Tabs--emphasized */
 }
 :host([dir='rtl'][direction^='vertical']) .spectrum-Tabs--emphasized {
     border-right-color: var(

--- a/packages/tabs/src/tab.css
+++ b/packages/tabs/src/tab.css
@@ -62,7 +62,7 @@ governing permissions and limitations under the License.
     height: 100%;
 }
 
-:host([dir][vertical]) slot[name='icon'] + #item-label {
+:host([vertical]) slot[name='icon'] + #item-label {
     font-size: var(
         --spectrum-tabs-text-size,
         var(--spectrum-alias-font-size-default)

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -67,6 +67,47 @@ governing permissions and limitations under the License.
     --spectrum-tabs-height: var(--spectrum-tabs-quiet-compact-height);
 }
 
+/*
+ * The following manually add the `vertical-right` direction to sp-tab-list
+ * It can be removed after https://github.com/adobe/spectrum-css/issues/637 is resolved
+ * In the interim, if there are ever Visual Regression failures to the 'Vertical' tabs story
+ * then it is likely that this CSS will need to be updated with changes in @spectrum-css/tabs
+ */
+
+:host(:dir(ltr)[direction='vertical-right']) #list {
+    /* .spectrum-Tabs--vertical */
+    display: inline-flex;
+    flex-direction: column;
+    padding: 0;
+    border-right: var(
+            --spectrum-tabs-vertical-rule-width,
+            var(--spectrum-alias-border-size-thick)
+        )
+        solid; /* .spectrum-Tabs--vertical */
+
+    border-right-color: var(
+        --spectrum-tabs-vertical-rule-color,
+        var(--spectrum-global-color-gray-200)
+    );
+}
+
+:host(:dir(rtl)[direction='vertical-right']) #list {
+    /* .spectrum-Tabs--vertical */
+    display: inline-flex;
+    flex-direction: column;
+    padding: 0;
+    border-left: var(
+            --spectrum-tabs-vertical-rule-width,
+            var(--spectrum-alias-border-size-thick)
+        )
+        solid; /* .spectrum-Tabs--vertical */
+
+    border-left-color: var(
+        --spectrum-tabs-vertical-rule-color,
+        var(--spectrum-global-color-gray-200)
+    );
+}
+
 /* 
  * The shorthand border declaration in :host([direction='horizontal']) was overiding
  * the border-bottom-color declared in :host 
@@ -81,7 +122,7 @@ governing permissions and limitations under the License.
 /*
  * Power scale based indicator transitions
  */
-:host([dir][direction='horizontal']) #selection-indicator {
+:host([direction='horizontal']) #selection-indicator {
     width: 1px;
 }
 
@@ -91,6 +132,7 @@ governing permissions and limitations under the License.
  * In the interim, if there are ever Visual Regression failures to the 'Vertical' tabs story
  * then it is likely that this CSS will need to be updated with changes in @spectrum-css/tabs
  */
+
 :host([dir='ltr'][direction='vertical-right']) #list {
     /* .spectrum-Tabs--vertical */
     border-left: 0;
@@ -121,6 +163,158 @@ governing permissions and limitations under the License.
     );
 }
 
+:host(:dir(ltr)[direction='vertical-right']) ::slotted(*) {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
+    height: var(
+        --spectrum-tabs-vertical-item-height,
+        var(--spectrum-global-dimension-size-550)
+    );
+    padding: 0
+        var(
+            --spectrum-tabs-focus-ring-padding-x,
+            var(--spectrum-global-dimension-size-100)
+        );
+    margin-right: calc(
+        var(
+                --spectrum-tabs-vertical-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) -
+            var(
+                --spectrum-tabs-focus-ring-padding-x,
+                var(--spectrum-global-dimension-size-100)
+            )
+    );
+    margin-bottom: var(
+        --spectrum-tabs-vertical-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+
+:host(:dir(rtl)[direction='vertical-right']) ::slotted(*) {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
+    height: var(
+        --spectrum-tabs-vertical-item-height,
+        var(--spectrum-global-dimension-size-550)
+    );
+    padding: 0
+        var(
+            --spectrum-tabs-focus-ring-padding-x,
+            var(--spectrum-global-dimension-size-100)
+        );
+    margin-left: calc(
+        var(
+                --spectrum-tabs-vertical-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) -
+            var(
+                --spectrum-tabs-focus-ring-padding-x,
+                var(--spectrum-global-dimension-size-100)
+            )
+    );
+    margin-bottom: var(
+        --spectrum-tabs-vertical-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+
+:host([dir='ltr'][direction='vertical-right']) ::slotted(*) {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
+    height: var(
+        --spectrum-tabs-vertical-item-height,
+        var(--spectrum-global-dimension-size-550)
+    );
+    padding: 0
+        var(
+            --spectrum-tabs-focus-ring-padding-x,
+            var(--spectrum-global-dimension-size-100)
+        );
+    margin-right: calc(
+        var(
+                --spectrum-tabs-vertical-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) -
+            var(
+                --spectrum-tabs-focus-ring-padding-x,
+                var(--spectrum-global-dimension-size-100)
+            )
+    );
+    margin-bottom: var(
+        --spectrum-tabs-vertical-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+
+:host([dir='rtl'][direction='vertical-right']) ::slotted(*) {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-item */
+    height: var(
+        --spectrum-tabs-vertical-item-height,
+        var(--spectrum-global-dimension-size-550)
+    );
+    padding: 0
+        var(
+            --spectrum-tabs-focus-ring-padding-x,
+            var(--spectrum-global-dimension-size-100)
+        );
+    margin-left: calc(
+        var(
+                --spectrum-tabs-vertical-item-margin-left,
+                var(--spectrum-global-dimension-size-150)
+            ) -
+            var(
+                --spectrum-tabs-focus-ring-padding-x,
+                var(--spectrum-global-dimension-size-100)
+            )
+    );
+    margin-bottom: var(
+        --spectrum-tabs-vertical-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    );
+}
+
+:host([direction='vertical-right'][compact]) ::slotted(*) {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-item */
+    line-height: var(
+        --spectrum-tabs-compact-vertical-item-height,
+        var(--spectrum-global-dimension-size-400)
+    );
+    margin-bottom: var(
+        --spectrum-tabs-compact-vertical-item-gap,
+        var(--spectrum-global-dimension-size-50)
+    ); /* .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-item,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-item .spectrum-Icon */
+
+    height: var(
+        --spectrum-tabs-compact-vertical-item-height,
+        var(--spectrum-global-dimension-size-400)
+    );
+}
+
+:host(:dir(ltr)[direction='vertical-right']) #selection-indicator {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+    position: absolute;
+    left: auto;
+    width: var(
+        --spectrum-tabs-vertical-rule-width,
+        var(--spectrum-alias-border-size-thick)
+    );
+    right: calc(
+        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
+    );
+}
+
+:host(:dir(rtl)[direction='vertical-right']) #selection-indicator {
+    /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
+    position: absolute;
+    right: auto;
+    width: var(
+        --spectrum-tabs-vertical-rule-width,
+        var(--spectrum-alias-border-size-thick)
+    );
+    left: calc(
+        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
+    );
+}
+
 :host([dir='ltr'][direction='vertical-right']) #selection-indicator {
     /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
     left: auto;
@@ -134,6 +328,56 @@ governing permissions and limitations under the License.
     right: auto;
     left: calc(
         -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
+    );
+}
+
+:host(:dir(ltr)[direction='vertical-right'][compact]) #list,
+:host(:dir(ltr)[direction='vertical-right'][quiet]) #list {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
+    border-right-color: var(
+        --spectrum-tabs-quiet-vertical-rule-color,
+        var(--spectrum-alias-border-color-transparent)
+    );
+}
+
+:host(:dir(rtl)[direction='vertical-right'][compact]) #list,
+:host(:dir(rtl)[direction='vertical-right'][quiet]) #list {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
+    border-left-color: var(
+        --spectrum-tabs-quiet-vertical-rule-color,
+        var(--spectrum-alias-border-color-transparent)
+    );
+}
+
+:host([dir='ltr'][direction='vertical-right'][compact]) #list,
+:host([dir='ltr'][direction='vertical-right'][quiet]) #list {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
+    border-right-color: var(
+        --spectrum-tabs-quiet-vertical-rule-color,
+        var(--spectrum-alias-border-color-transparent)
+    );
+}
+
+:host([dir='rtl'][direction='vertical-right'][compact]) #list,
+:host([dir='rtl'][direction='vertical-right'][quiet]) #list {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet */
+    border-left-color: var(
+        --spectrum-tabs-quiet-vertical-rule-color,
+        var(--spectrum-alias-border-color-transparent)
+    );
+}
+
+:host([direction='vertical-right'][compact]) #selection-indicator,
+:host([direction='vertical-right'][quiet]) #selection-indicator {
+    /* .spectrum-Tabs--vertical.spectrum-Tabs--compact .spectrum-Tabs-selectionIndicator,
+   * .spectrum-Tabs--vertical.spectrum-Tabs--quiet .spectrum-Tabs-selectionIndicator */
+    background-color: var(
+        --spectrum-tabs-quiet-selection-indicator-color,
+        var(--spectrum-global-color-gray-900)
     );
 }
 

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -156,20 +156,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-global-dimension-font-size-200
     );
 }
+:host(:dir(ltr)) {
+    padding-left: var(
+        --spectrum-tag-textonly-padding-right
+    ); /* [dir=ltr] .spectrum-Tag */
+}
 :host([dir='ltr']) {
     padding-left: var(
         --spectrum-tag-textonly-padding-right
     ); /* [dir=ltr] .spectrum-Tag */
+}
+:host(:dir(rtl)) {
+    padding-right: var(
+        --spectrum-tag-textonly-padding-right
+    ); /* [dir=rtl] .spectrum-Tag */
 }
 :host([dir='rtl']) {
     padding-right: var(
         --spectrum-tag-textonly-padding-right
     ); /* [dir=rtl] .spectrum-Tag */
 }
+:host(:dir(ltr)) {
+    padding-right: var(
+        --spectrum-tag-textonly-padding-right
+    ); /* [dir=ltr] .spectrum-Tag */
+}
 :host([dir='ltr']) {
     padding-right: var(
         --spectrum-tag-textonly-padding-right
     ); /* [dir=ltr] .spectrum-Tag */
+}
+:host(:dir(rtl)) {
+    padding-left: var(
+        --spectrum-tag-textonly-padding-right
+    ); /* [dir=rtl] .spectrum-Tag */
 }
 :host([dir='rtl']) {
     padding-left: var(
@@ -204,6 +224,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([disabled]) {
     pointer-events: none; /* .spectrum-Tag.is-disabled */
 }
+:host(:dir(ltr)) > ::slotted([slot='avatar']),
+:host(:dir(ltr)) > ::slotted([slot='icon']) {
+    padding-right: var(
+        --spectrum-tag-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-Tag>.spectrum-Icon,
+   * [dir=ltr] 
+  .spectrum-Tag>.spectrum-Avatar */
+}
 :host([dir='ltr']) > ::slotted([slot='avatar']),
 :host([dir='ltr']) > ::slotted([slot='icon']) {
     padding-right: var(
@@ -212,12 +240,29 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=ltr] 
   .spectrum-Tag>.spectrum-Avatar */
 }
+:host(:dir(rtl)) > ::slotted([slot='avatar']),
+:host(:dir(rtl)) > ::slotted([slot='icon']) {
+    padding-left: var(
+        --spectrum-tag-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-Tag>.spectrum-Icon,
+   * [dir=rtl] 
+  .spectrum-Tag>.spectrum-Avatar */
+}
 :host([dir='rtl']) > ::slotted([slot='avatar']),
 :host([dir='rtl']) > ::slotted([slot='icon']) {
     padding-left: var(
         --spectrum-tag-texticon-icon-gap
     ); /* [dir=rtl] .spectrum-Tag>.spectrum-Icon,
    * [dir=rtl] 
+  .spectrum-Tag>.spectrum-Avatar */
+}
+:host(:dir(ltr)) > ::slotted([slot='avatar']),
+:host(:dir(ltr)) > ::slotted([slot='icon']) {
+    margin-left: calc(
+        var(--spectrum-tag-texticon-padding-left) -
+            var(--spectrum-tag-textonly-padding-left)
+    ); /* [dir=ltr] .spectrum-Tag>.spectrum-Icon,
+   * [dir=ltr] 
   .spectrum-Tag>.spectrum-Avatar */
 }
 :host([dir='ltr']) > ::slotted([slot='avatar']),
@@ -229,6 +274,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=ltr] 
   .spectrum-Tag>.spectrum-Avatar */
 }
+:host(:dir(rtl)) > ::slotted([slot='avatar']),
+:host(:dir(rtl)) > ::slotted([slot='icon']) {
+    margin-right: calc(
+        var(--spectrum-tag-texticon-padding-left) -
+            var(--spectrum-tag-textonly-padding-left)
+    ); /* [dir=rtl] .spectrum-Tag>.spectrum-Icon,
+   * [dir=rtl] 
+  .spectrum-Tag>.spectrum-Avatar */
+}
 :host([dir='rtl']) > ::slotted([slot='avatar']),
 :host([dir='rtl']) > ::slotted([slot='icon']) {
     margin-right: calc(
@@ -238,10 +292,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=rtl] 
   .spectrum-Tag>.spectrum-Avatar */
 }
+:host(:dir(ltr)) .clear-button {
+    margin-right: calc(
+        var(--spectrum-tag-texticon-padding-right) * -1
+    ); /* [dir=ltr] .spectrum-Tag .spectrum-ClearButton */
+}
 :host([dir='ltr']) .clear-button {
     margin-right: calc(
         var(--spectrum-tag-texticon-padding-right) * -1
     ); /* [dir=ltr] .spectrum-Tag .spectrum-ClearButton */
+}
+:host(:dir(rtl)) .clear-button {
+    margin-left: calc(
+        var(--spectrum-tag-texticon-padding-right) * -1
+    ); /* [dir=rtl] .spectrum-Tag .spectrum-ClearButton */
 }
 :host([dir='rtl']) .clear-button {
     margin-left: calc(

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -250,6 +250,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .input:-moz-ui-invalid {
     box-shadow: none; /* .spectrum-Textfield-input:-moz-ui-invalid */
 }
+:host(:dir(ltr)[valid]) #textfield .input {
+    padding-right: calc(
+        var(--spectrum-textfield-texticon-padding-right) +
+            var(--spectrum-textfield-texticon-success-icon-width) +
+            var(
+                --spectrum-textfield-icon-inline-end-override,
+                var(--spectrum-textfield-texticon-success-icon-margin-left)
+            )
+    ); /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-input */
+}
 :host([dir='ltr'][valid]) #textfield .input {
     padding-right: calc(
         var(--spectrum-textfield-texticon-padding-right) +
@@ -259,6 +269,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-textfield-texticon-success-icon-margin-left)
             )
     ); /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-input */
+}
+:host(:dir(rtl)[valid]) #textfield .input {
+    padding-left: calc(
+        var(--spectrum-textfield-texticon-padding-right) +
+            var(--spectrum-textfield-texticon-success-icon-width) +
+            var(
+                --spectrum-textfield-icon-inline-end-override,
+                var(--spectrum-textfield-texticon-success-icon-margin-left)
+            )
+    ); /* [dir=rtl] .spectrum-Textfield.is-valid .spectrum-Textfield-input */
 }
 :host([dir='rtl'][valid]) #textfield .input {
     padding-left: calc(
@@ -270,6 +290,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=rtl] .spectrum-Textfield.is-valid .spectrum-Textfield-input */
 }
+:host(:dir(ltr)[invalid]) #textfield .input {
+    padding-right: calc(
+        var(--spectrum-textfield-texticon-padding-right) +
+            var(--spectrum-textfield-texticon-invalid-icon-width) +
+            var(
+                --spectrum-textfield-icon-inline-end-override,
+                var(--spectrum-textfield-texticon-invalid-icon-margin-left)
+            )
+    ); /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-input */
+}
 :host([dir='ltr'][invalid]) #textfield .input {
     padding-right: calc(
         var(--spectrum-textfield-texticon-padding-right) +
@@ -279,6 +309,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-textfield-texticon-invalid-icon-margin-left)
             )
     ); /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-input */
+}
+:host(:dir(rtl)[invalid]) #textfield .input {
+    padding-left: calc(
+        var(--spectrum-textfield-texticon-padding-right) +
+            var(--spectrum-textfield-texticon-invalid-icon-width) +
+            var(
+                --spectrum-textfield-icon-inline-end-override,
+                var(--spectrum-textfield-texticon-invalid-icon-margin-left)
+            )
+    ); /* [dir=rtl] .spectrum-Textfield.is-invalid .spectrum-Textfield-input */
 }
 :host([dir='rtl'][invalid]) #textfield .input {
     padding-left: calc(
@@ -301,20 +341,40 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-textarea-padding-bottom)
         calc(var(--spectrum-textarea-padding-left) - 1px);
 }
+:host(:dir(ltr)[quiet]) .input {
+    padding-left: var(
+        --spectrum-textfield-quiet-texticon-padding-left
+    ); /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-input */
+}
 :host([dir='ltr'][quiet]) .input {
     padding-left: var(
         --spectrum-textfield-quiet-texticon-padding-left
     ); /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-input */
+}
+:host(:dir(rtl)[quiet]) .input {
+    padding-right: var(
+        --spectrum-textfield-quiet-texticon-padding-left
+    ); /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-input */
 }
 :host([dir='rtl'][quiet]) .input {
     padding-right: var(
         --spectrum-textfield-quiet-texticon-padding-left
     ); /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-input */
 }
+:host(:dir(ltr)[quiet]) .input {
+    padding-right: var(
+        --spectrum-textfield-quiet-texticon-padding-right
+    ); /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-input */
+}
 :host([dir='ltr'][quiet]) .input {
     padding-right: var(
         --spectrum-textfield-quiet-texticon-padding-right
     ); /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-input */
+}
+:host(:dir(rtl)[quiet]) .input {
+    padding-left: var(
+        --spectrum-textfield-quiet-texticon-padding-right
+    ); /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-input */
 }
 :host([dir='rtl'][quiet]) .input {
     padding-left: var(
@@ -334,11 +394,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     overflow-y: hidden;
     resize: none;
 }
+:host(:dir(ltr)[invalid][quiet]) .input {
+    padding-right: calc(
+        var(--spectrum-textfield-texticon-invalid-icon-width) +
+            var(--spectrum-textfield-quiet-texticon-invalid-icon-margin-left)
+    ); /* [dir=ltr] .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+}
 :host([dir='ltr'][invalid][quiet]) .input {
     padding-right: calc(
         var(--spectrum-textfield-texticon-invalid-icon-width) +
             var(--spectrum-textfield-quiet-texticon-invalid-icon-margin-left)
     ); /* [dir=ltr] .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+}
+:host(:dir(rtl)[invalid][quiet]) .input {
+    padding-left: calc(
+        var(--spectrum-textfield-texticon-invalid-icon-width) +
+            var(--spectrum-textfield-quiet-texticon-invalid-icon-margin-left)
+    ); /* [dir=rtl] .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
 }
 :host([dir='rtl'][invalid][quiet]) .input {
     padding-left: calc(
@@ -346,11 +418,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-textfield-quiet-texticon-invalid-icon-margin-left)
     ); /* [dir=rtl] .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
 }
+:host(:dir(ltr)[valid][quiet]) .input {
+    padding-right: calc(
+        var(--spectrum-textfield-texticon-success-icon-width) +
+            var(--spectrum-textfield-quiet-texticon-success-icon-margin-left)
+    ); /* [dir=ltr] .is-valid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+}
 :host([dir='ltr'][valid][quiet]) .input {
     padding-right: calc(
         var(--spectrum-textfield-texticon-success-icon-width) +
             var(--spectrum-textfield-quiet-texticon-success-icon-margin-left)
     ); /* [dir=ltr] .is-valid.spectrum-Textfield--quiet .spectrum-Textfield-input */
+}
+:host(:dir(rtl)[valid][quiet]) .input {
+    padding-left: calc(
+        var(--spectrum-textfield-texticon-success-icon-width) +
+            var(--spectrum-textfield-quiet-texticon-success-icon-margin-left)
+    ); /* [dir=rtl] .is-valid.spectrum-Textfield--quiet .spectrum-Textfield-input */
 }
 :host([dir='rtl'][valid][quiet]) .input {
     padding-left: calc(
@@ -362,17 +446,35 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     pointer-events: all;
     position: absolute; /* .spectrum-Textfield-validationIcon */
 }
+:host(:dir(ltr)[quiet]) .icon {
+    padding-right: 0; /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-validationIcon */
+}
 :host([dir='ltr'][quiet]) .icon {
     padding-right: 0; /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-validationIcon */
 }
+:host(:dir(rtl)[quiet]) .icon {
+    padding-left: 0; /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-validationIcon */
+}
 :host([dir='rtl'][quiet]) .icon {
     padding-left: 0; /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-validationIcon */
+}
+:host(:dir(ltr)[invalid]) #textfield .icon {
+    right: var(
+        --spectrum-textfield-icon-inline-end-override,
+        var(--spectrum-textfield-texticon-invalid-icon-margin-left)
+    ); /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
 :host([dir='ltr'][invalid]) #textfield .icon {
     right: var(
         --spectrum-textfield-icon-inline-end-override,
         var(--spectrum-textfield-texticon-invalid-icon-margin-left)
     ); /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+}
+:host(:dir(rtl)[invalid]) #textfield .icon {
+    left: var(
+        --spectrum-textfield-icon-inline-end-override,
+        var(--spectrum-textfield-texticon-invalid-icon-margin-left)
+    ); /* [dir=rtl] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
 :host([dir='rtl'][invalid]) #textfield .icon {
     left: var(
@@ -390,11 +492,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-textfield-texticon-invalid-icon-width
     ); /* .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
+:host(:dir(ltr)[quiet][invalid]) #textfield .icon {
+    right: var(
+        --spectrum-textfield-icon-inline-end-override,
+        0
+    ); /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+}
 :host([dir='ltr'][quiet][invalid]) #textfield .icon {
     right: var(
         --spectrum-textfield-icon-inline-end-override,
         0
     ); /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
+}
+:host(:dir(rtl)[quiet][invalid]) #textfield .icon {
+    left: var(
+        --spectrum-textfield-icon-inline-end-override,
+        0
+    ); /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
 :host([dir='rtl'][quiet][invalid]) #textfield .icon {
     left: var(
@@ -402,11 +516,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         0
     ); /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
+:host(:dir(ltr)[valid]) #textfield .icon {
+    right: var(
+        --spectrum-textfield-icon-inline-end-override,
+        var(--spectrum-textfield-texticon-success-icon-margin-left)
+    ); /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+}
 :host([dir='ltr'][valid]) #textfield .icon {
     right: var(
         --spectrum-textfield-icon-inline-end-override,
         var(--spectrum-textfield-texticon-success-icon-margin-left)
     ); /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+}
+:host(:dir(rtl)[valid]) #textfield .icon {
+    left: var(
+        --spectrum-textfield-icon-inline-end-override,
+        var(--spectrum-textfield-texticon-success-icon-margin-left)
+    ); /* [dir=rtl] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
 :host([dir='rtl'][valid]) #textfield .icon {
     left: var(
@@ -424,11 +550,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-textfield-texticon-success-icon-width
     ); /* .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
+:host(:dir(ltr)[quiet][valid]) #textfield .icon {
+    right: var(
+        --spectrum-textfield-icon-inline-end-override,
+        0
+    ); /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+}
 :host([dir='ltr'][quiet][valid]) #textfield .icon {
     right: var(
         --spectrum-textfield-icon-inline-end-override,
         0
     ); /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
+}
+:host(:dir(rtl)[quiet][valid]) #textfield .icon {
+    left: var(
+        --spectrum-textfield-icon-inline-end-override,
+        0
+    ); /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
 :host([dir='rtl'][quiet][valid]) #textfield .icon {
     left: var(
@@ -436,10 +574,20 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         0
     ); /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
+:host(:dir(ltr)) .icon-workflow {
+    left: var(
+        --spectrum-textfield-texticon-padding-left
+    ); /* [dir=ltr] .spectrum-Textfield-icon */
+}
 :host([dir='ltr']) .icon-workflow {
     left: var(
         --spectrum-textfield-texticon-padding-left
     ); /* [dir=ltr] .spectrum-Textfield-icon */
+}
+:host(:dir(rtl)) .icon-workflow {
+    right: var(
+        --spectrum-textfield-texticon-padding-left
+    ); /* [dir=rtl] .spectrum-Textfield-icon */
 }
 :host([dir='rtl']) .icon-workflow {
     right: var(
@@ -465,11 +613,25 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-225)
     );
 }
+:host(:dir(ltr)[quiet]) .icon-workflow {
+    left: 0; /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-icon */
+}
 :host([dir='ltr'][quiet]) .icon-workflow {
     left: 0; /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-icon */
 }
+:host(:dir(rtl)[quiet]) .icon-workflow {
+    right: 0; /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-icon */
+}
 :host([dir='rtl'][quiet]) .icon-workflow {
     right: 0; /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-icon */
+}
+:host(:dir(ltr)[quiet]) .icon-workflow ~ .input {
+    padding-left: calc(
+        var(
+                --spectrum-alias-workflow-icon-size-m,
+                var(--spectrum-global-dimension-size-225)
+            ) + var(--spectrum-textfield-quiet-texticon-icon-gap)
+    ); /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-icon~.spectrum-Textfield-input */
 }
 :host([dir='ltr'][quiet]) .icon-workflow ~ .input {
     padding-left: calc(
@@ -479,6 +641,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) + var(--spectrum-textfield-quiet-texticon-icon-gap)
     ); /* [dir=ltr] .spectrum-Textfield--quiet .spectrum-Textfield-icon~.spectrum-Textfield-input */
 }
+:host(:dir(rtl)[quiet]) .icon-workflow ~ .input {
+    padding-right: calc(
+        var(
+                --spectrum-alias-workflow-icon-size-m,
+                var(--spectrum-global-dimension-size-225)
+            ) + var(--spectrum-textfield-quiet-texticon-icon-gap)
+    ); /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-icon~.spectrum-Textfield-input */
+}
 :host([dir='rtl'][quiet]) .icon-workflow ~ .input {
     padding-right: calc(
         var(
@@ -486,6 +656,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-225)
             ) + var(--spectrum-textfield-quiet-texticon-icon-gap)
     ); /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-icon~.spectrum-Textfield-input */
+}
+:host(:dir(ltr)) .icon-workflow + .input {
+    padding-left: calc(
+        var(--spectrum-textfield-texticon-padding-left) +
+            var(
+                --spectrum-alias-workflow-icon-size-m,
+                var(--spectrum-global-dimension-size-225)
+            ) + var(--spectrum-textfield-texticon-icon-gap)
+    ); /* [dir=ltr] .spectrum-Textfield-icon+.spectrum-Textfield-input */
 }
 :host([dir='ltr']) .icon-workflow + .input {
     padding-left: calc(
@@ -495,6 +674,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
                 var(--spectrum-global-dimension-size-225)
             ) + var(--spectrum-textfield-texticon-icon-gap)
     ); /* [dir=ltr] .spectrum-Textfield-icon+.spectrum-Textfield-input */
+}
+:host(:dir(rtl)) .icon-workflow + .input {
+    padding-right: calc(
+        var(--spectrum-textfield-texticon-padding-left) +
+            var(
+                --spectrum-alias-workflow-icon-size-m,
+                var(--spectrum-global-dimension-size-225)
+            ) + var(--spectrum-textfield-texticon-icon-gap)
+    ); /* [dir=rtl] .spectrum-Textfield-icon+.spectrum-Textfield-input */
 }
 :host([dir='rtl']) .icon-workflow + .input {
     padding-right: calc(

--- a/packages/theme/src/Theme.ts
+++ b/packages/theme/src/Theme.ts
@@ -74,6 +74,7 @@ export interface ThemeData {
     scale?: Scale;
     lang?: string;
     theme?: ThemeVariant;
+    dir?: 'ltr' | 'rtl';
 }
 
 type ThemeKindProvider = {
@@ -289,6 +290,7 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
         const { detail: theme } = event;
         theme.color = this.color || undefined;
         theme.scale = this.scale || undefined;
+        theme.dir = (this.dir as 'ltr' | 'rtl') || undefined;
         theme.lang =
             this.lang || document.documentElement.lang || navigator.language;
         theme.theme = this.theme || undefined;
@@ -346,6 +348,10 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
 
     public startManagingContentDirection(el: HTMLElement): void {
         this.trackedChildren.add(el);
+        el.setAttribute(
+            'dir',
+            this.dir === 'rtl' ? this.dir : this.dir || 'ltr'
+        );
     }
 
     public stopManagingContentDirection(el: HTMLElement): void {

--- a/packages/toast/src/spectrum-toast.css
+++ b/packages/toast/src/spectrum-toast.css
@@ -24,11 +24,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-global-dimension-size-130
     );
 }
+:host(:dir(ltr)) {
+    padding-right: var(
+        --spectrum-toast-neutral-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=ltr] .spectrum-Toast */
+}
 :host([dir='ltr']) {
     padding-right: var(
         --spectrum-toast-neutral-padding-right,
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=ltr] .spectrum-Toast */
+}
+:host(:dir(rtl)) {
+    padding-left: var(
+        --spectrum-toast-neutral-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=rtl] .spectrum-Toast */
 }
 :host([dir='rtl']) {
     padding-left: var(
@@ -36,11 +48,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=rtl] .spectrum-Toast */
 }
+:host(:dir(ltr)) {
+    padding-left: var(
+        --spectrum-toast-neutral-padding-left,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-Toast */
+}
 :host([dir='ltr']) {
     padding-left: var(
         --spectrum-toast-neutral-padding-left,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-Toast */
+}
+:host(:dir(rtl)) {
+    padding-right: var(
+        --spectrum-toast-neutral-padding-left,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-Toast */
 }
 :host([dir='rtl']) {
     padding-right: var(
@@ -75,11 +99,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-100)
     );
 }
+:host(:dir(ltr)) .type {
+    margin-right: var(
+        --spectrum-toast-neutral-icon-padding-right,
+        var(--spectrum-global-dimension-size-150)
+    ); /* [dir=ltr] .spectrum-Toast-typeIcon */
+}
 :host([dir='ltr']) .type {
     margin-right: var(
         --spectrum-toast-neutral-icon-padding-right,
         var(--spectrum-global-dimension-size-150)
     ); /* [dir=ltr] .spectrum-Toast-typeIcon */
+}
+:host(:dir(rtl)) .type {
+    margin-left: var(
+        --spectrum-toast-neutral-icon-padding-right,
+        var(--spectrum-global-dimension-size-150)
+    ); /* [dir=rtl] .spectrum-Toast-typeIcon */
 }
 :host([dir='rtl']) .type {
     margin-left: var(
@@ -87,8 +123,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-150)
     ); /* [dir=rtl] .spectrum-Toast-typeIcon */
 }
+:host(:dir(ltr)) .type {
+    margin-left: 0; /* [dir=ltr] .spectrum-Toast-typeIcon */
+}
 :host([dir='ltr']) .type {
     margin-left: 0; /* [dir=ltr] .spectrum-Toast-typeIcon */
+}
+:host(:dir(rtl)) .type {
+    margin-right: 0; /* [dir=rtl] .spectrum-Toast-typeIcon */
 }
 :host([dir='rtl']) .type {
     margin-right: 0; /* [dir=rtl] .spectrum-Toast-typeIcon */
@@ -99,11 +141,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     margin-bottom: var(--spectrum-toast-icon-padding-y);
     margin-top: var(--spectrum-toast-icon-padding-y);
 }
+:host(:dir(ltr)) .content {
+    padding-right: var(
+        --spectrum-toast-neutral-content-padding-right,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=ltr] .spectrum-Toast-content */
+}
 :host([dir='ltr']) .content {
     padding-right: var(
         --spectrum-toast-neutral-content-padding-right,
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=ltr] .spectrum-Toast-content */
+}
+:host(:dir(rtl)) .content {
+    padding-left: var(
+        --spectrum-toast-neutral-content-padding-right,
+        var(--spectrum-global-dimension-size-200)
+    ); /* [dir=rtl] .spectrum-Toast-content */
 }
 :host([dir='rtl']) .content {
     padding-left: var(
@@ -111,14 +165,26 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-200)
     ); /* [dir=rtl] .spectrum-Toast-content */
 }
+:host(:dir(ltr)) .content {
+    padding-left: 0; /* [dir=ltr] .spectrum-Toast-content */
+}
 :host([dir='ltr']) .content {
     padding-left: 0; /* [dir=ltr] .spectrum-Toast-content */
+}
+:host(:dir(rtl)) .content {
+    padding-right: 0; /* [dir=rtl] .spectrum-Toast-content */
 }
 :host([dir='rtl']) .content {
     padding-right: 0; /* [dir=rtl] .spectrum-Toast-content */
 }
+:host(:dir(ltr)) .content {
+    text-align: left; /* [dir=ltr] .spectrum-Toast-content */
+}
 :host([dir='ltr']) .content {
     text-align: left; /* [dir=ltr] .spectrum-Toast-content */
+}
+:host(:dir(rtl)) .content {
+    text-align: right; /* [dir=rtl] .spectrum-Toast-content */
 }
 :host([dir='rtl']) .content {
     text-align: right; /* [dir=rtl] .spectrum-Toast-content */
@@ -150,6 +216,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     display: flex; /* .spectrum-Toast-buttons */
     flex: 0 0 auto;
 }
+:host(:dir(ltr)) .buttons .spectrum-ClearButton + .spectrum-ClearButton,
+:host(:dir(ltr)) .buttons .spectrum-ClearButton + ::slotted([slot='action']),
+:host(:dir(ltr)) .buttons slot[name='action'] + .spectrum-ClearButton,
+:host(:dir(ltr)) .buttons slot[name='action'] + ::slotted([slot='action']) {
+    margin-left: var(
+        --spectrum-toast-neutral-button-gap-x,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=ltr] .spectrum-Toast-buttons .spectrum-Button+.spectrum-Button,
+   * [dir=ltr] 
+    .spectrum-Toast-buttons .spectrum-Button+.spectrum-ClearButton,
+   * [dir=ltr] 
+    .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-Button,
+   * [dir=ltr] 
+    .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-ClearButton */
+}
 :host([dir='ltr']) .buttons .spectrum-ClearButton + .spectrum-ClearButton,
 :host([dir='ltr']) .buttons .spectrum-ClearButton + ::slotted([slot='action']),
 :host([dir='ltr']) .buttons slot[name='action'] + .spectrum-ClearButton,
@@ -163,6 +244,21 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * [dir=ltr] 
     .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-Button,
    * [dir=ltr] 
+    .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-ClearButton */
+}
+:host(:dir(rtl)) .buttons .spectrum-ClearButton + .spectrum-ClearButton,
+:host(:dir(rtl)) .buttons .spectrum-ClearButton + ::slotted([slot='action']),
+:host(:dir(rtl)) .buttons slot[name='action'] + .spectrum-ClearButton,
+:host(:dir(rtl)) .buttons slot[name='action'] + ::slotted([slot='action']) {
+    margin-right: var(
+        --spectrum-toast-neutral-button-gap-x,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=rtl] .spectrum-Toast-buttons .spectrum-Button+.spectrum-Button,
+   * [dir=rtl] 
+    .spectrum-Toast-buttons .spectrum-Button+.spectrum-ClearButton,
+   * [dir=rtl] 
+    .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-Button,
+   * [dir=rtl] 
     .spectrum-Toast-buttons .spectrum-ClearButton+.spectrum-ClearButton */
 }
 :host([dir='rtl']) .buttons .spectrum-ClearButton + .spectrum-ClearButton,
@@ -184,21 +280,43 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     align-self: center;
     flex: 1 1 auto; /* .spectrum-Toast-body */
 }
+:host(:dir(ltr)) .body ::slotted([slot='action']) {
+    float: right; /* [dir=ltr] .spectrum-Toast-body .spectrum-Button */
+}
 :host([dir='ltr']) .body ::slotted([slot='action']) {
     float: right; /* [dir=ltr] .spectrum-Toast-body .spectrum-Button */
 }
+:host(:dir(rtl)) .body ::slotted([slot='action']) {
+    float: left; /* [dir=rtl] .spectrum-Toast-body .spectrum-Button */
+}
 :host([dir='rtl']) .body ::slotted([slot='action']) {
     float: left; /* [dir=rtl] .spectrum-Toast-body .spectrum-Button */
+}
+:host(:dir(ltr)) .body ::slotted([slot='action']) {
+    margin-right: var(
+        --spectrum-toast-button-margin-right
+    ); /* [dir=ltr] .spectrum-Toast-body .spectrum-Button */
 }
 :host([dir='ltr']) .body ::slotted([slot='action']) {
     margin-right: var(
         --spectrum-toast-button-margin-right
     ); /* [dir=ltr] .spectrum-Toast-body .spectrum-Button */
 }
+:host(:dir(rtl)) .body ::slotted([slot='action']) {
+    margin-left: var(
+        --spectrum-toast-button-margin-right
+    ); /* [dir=rtl] .spectrum-Toast-body .spectrum-Button */
+}
 :host([dir='rtl']) .body ::slotted([slot='action']) {
     margin-left: var(
         --spectrum-toast-button-margin-right
     ); /* [dir=rtl] .spectrum-Toast-body .spectrum-Button */
+}
+:host(:dir(ltr)) .body + .buttons {
+    padding-left: var(
+        --spectrum-toast-neutral-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
 }
 :host([dir='ltr']) .body + .buttons {
     padding-left: var(
@@ -206,20 +324,38 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
 }
+:host(:dir(rtl)) .body + .buttons {
+    padding-right: var(
+        --spectrum-toast-neutral-padding-right,
+        var(--spectrum-global-dimension-size-100)
+    ); /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
+}
 :host([dir='rtl']) .body + .buttons {
     padding-right: var(
         --spectrum-toast-neutral-padding-right,
         var(--spectrum-global-dimension-size-100)
     ); /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
 }
+:host(:dir(ltr)) .body + .buttons {
+    border-left-width: 1px; /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
+}
 :host([dir='ltr']) .body + .buttons {
     border-left-width: 1px; /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
+}
+:host(:dir(rtl)) .body + .buttons {
+    border-right-width: 1px; /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
 }
 :host([dir='rtl']) .body + .buttons {
     border-right-width: 1px; /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
 }
+:host(:dir(ltr)) .body + .buttons {
+    border-left-style: solid; /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
+}
 :host([dir='ltr']) .body + .buttons {
     border-left-style: solid; /* [dir=ltr] .spectrum-Toast-body+.spectrum-Toast-buttons */
+}
+:host(:dir(rtl)) .body + .buttons {
+    border-right-style: solid; /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
 }
 :host([dir='rtl']) .body + .buttons {
     border-right-style: solid; /* [dir=rtl] .spectrum-Toast-body+.spectrum-Toast-buttons */
@@ -243,6 +379,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .type {
     color: #fff; /* .spectrum-Toast-typeIcon */
 }
+:host(:dir(ltr)) .buttons {
+    border-left-color: hsla(
+        0,
+        0%,
+        100%,
+        0.2
+    ); /* [dir=ltr] .spectrum-Toast-buttons */
+}
 :host([dir='ltr']) .buttons {
     border-left-color: hsla(
         0,
@@ -250,6 +394,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         100%,
         0.2
     ); /* [dir=ltr] .spectrum-Toast-buttons */
+}
+:host(:dir(rtl)) .buttons {
+    border-right-color: hsla(
+        0,
+        0%,
+        100%,
+        0.2
+    ); /* [dir=rtl] .spectrum-Toast-buttons */
 }
 :host([dir='rtl']) .buttons {
     border-right-color: hsla(

--- a/packages/tooltip/src/spectrum-tooltip.css
+++ b/packages/tooltip/src/spectrum-tooltip.css
@@ -189,6 +189,18 @@ p {
             ) * -1
     );
 }
+:host(:dir(ltr)) ::slotted([slot='icon']) {
+    margin-left: calc(
+        var(
+                --spectrum-tooltip-neutral-icon-margin-x,
+                var(--spectrum-global-dimension-size-85)
+            ) -
+            var(
+                --spectrum-tooltip-neutral-padding-x,
+                var(--spectrum-global-dimension-size-85)
+            )
+    ); /* [dir=ltr] .spectrum-Tooltip-typeIcon */
+}
 :host([dir='ltr']) ::slotted([slot='icon']) {
     margin-left: calc(
         var(
@@ -200,6 +212,18 @@ p {
                 var(--spectrum-global-dimension-size-85)
             )
     ); /* [dir=ltr] .spectrum-Tooltip-typeIcon */
+}
+:host(:dir(rtl)) ::slotted([slot='icon']) {
+    margin-right: calc(
+        var(
+                --spectrum-tooltip-neutral-icon-margin-x,
+                var(--spectrum-global-dimension-size-85)
+            ) -
+            var(
+                --spectrum-tooltip-neutral-padding-x,
+                var(--spectrum-global-dimension-size-85)
+            )
+    ); /* [dir=rtl] .spectrum-Tooltip-typeIcon */
 }
 :host([dir='rtl']) ::slotted([slot='icon']) {
     margin-right: calc(
@@ -213,11 +237,23 @@ p {
             )
     ); /* [dir=rtl] .spectrum-Tooltip-typeIcon */
 }
+:host(:dir(ltr)) ::slotted([slot='icon']) {
+    margin-right: var(
+        --spectrum-tooltip-neutral-icon-margin-x,
+        var(--spectrum-global-dimension-size-85)
+    ); /* [dir=ltr] .spectrum-Tooltip-typeIcon */
+}
 :host([dir='ltr']) ::slotted([slot='icon']) {
     margin-right: var(
         --spectrum-tooltip-neutral-icon-margin-x,
         var(--spectrum-global-dimension-size-85)
     ); /* [dir=ltr] .spectrum-Tooltip-typeIcon */
+}
+:host(:dir(rtl)) ::slotted([slot='icon']) {
+    margin-left: var(
+        --spectrum-tooltip-neutral-icon-margin-x,
+        var(--spectrum-global-dimension-size-85)
+    ); /* [dir=rtl] .spectrum-Tooltip-typeIcon */
 }
 :host([dir='rtl']) ::slotted([slot='icon']) {
     margin-left: var(

--- a/packages/tray/src/spectrum-tray-wrapper.css
+++ b/packages/tray/src/spectrum-tray-wrapper.css
@@ -10,8 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 
 THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host(:dir(ltr)) {
+    left: 0; /* [dir=ltr] .spectrum-Tray-wrapper */
+}
 :host([dir='ltr']) {
     left: 0; /* [dir=ltr] .spectrum-Tray-wrapper */
+}
+:host(:dir(rtl)) {
+    right: 0; /* [dir=rtl] .spectrum-Tray-wrapper */
 }
 :host([dir='rtl']) {
     right: 0; /* [dir=rtl] .spectrum-Tray-wrapper */

--- a/packages/tray/src/spectrum-tray.css
+++ b/packages/tray/src/spectrum-tray.css
@@ -30,8 +30,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     --spectrum-dialog-confirm-exit-animation-delay: 0ms; /* .spectrum-Tray */
     --spectrum-tray-margin-top: 64px;
 }
+:host(:dir(ltr)) .spectrum-Tray-wrapper {
+    left: 0; /* [dir=ltr] .spectrum-Tray-wrapper */
+}
 :host([dir='ltr']) .spectrum-Tray-wrapper {
     left: 0; /* [dir=ltr] .spectrum-Tray-wrapper */
+}
+:host(:dir(rtl)) .spectrum-Tray-wrapper {
+    right: 0; /* [dir=rtl] .spectrum-Tray-wrapper */
 }
 :host([dir='rtl']) .spectrum-Tray-wrapper {
     right: 0; /* [dir=rtl] .spectrum-Tray-wrapper */

--- a/projects/documentation/src/components/layout.css
+++ b/projects/documentation/src/components/layout.css
@@ -138,8 +138,16 @@ header svg {
     justify-content: flex-end;
 }
 
+:host(:dir(ltr)) .theme-control {
+    margin-left: var(--spectrum-global-dimension-size-400);
+}
+
 :host([dir='ltr']) .theme-control {
     margin-left: var(--spectrum-global-dimension-size-400);
+}
+
+:host(:dir(rtl)) .theme-control {
+    margin-right: var(--spectrum-global-dimension-size-400);
 }
 
 :host([dir='rtl']) .theme-control {

--- a/projects/documentation/src/components/side-nav.css
+++ b/projects/documentation/src/components/side-nav.css
@@ -30,16 +30,34 @@ aside {
     aside {
         position: fixed;
         top: 0;
-        left: 0;
         transition: transform
             var(
                 --spectrum-dialog-confirm-background-entry-animation-duration,
                 var(--spectrum-global-animation-duration-600)
             )
             cubic-bezier(0, 0, 0.4, 1);
-        transform: translateX(-100%);
         z-index: 10;
         min-height: 100vh;
+    }
+
+    :host([dir='ltr']) aside {
+        left: 0;
+        transform: translateX(-100%);
+    }
+
+    :host(:dir(ltr)) aside {
+        left: 0;
+        transform: translateX(-100%);
+    }
+
+    :host([dir='rtl']) aside {
+        right: 0;
+        transform: translateX(100%);
+    }
+
+    :host(:dir(rtl)) aside {
+        right: 0;
+        transform: translateX(100%);
     }
 
     :host([open]) aside {
@@ -75,8 +93,16 @@ docs-spectrum-logo {
     padding-top: 7px;
 }
 
+:host(:dir(ltr)) docs-spectrum-logo {
+    margin-right: 16px;
+}
+
 :host([dir='ltr']) docs-spectrum-logo {
     margin-right: 16px;
+}
+
+:host(:dir(rtl)) docs-spectrum-logo {
+    margin-left: 16px;
 }
 
 :host([dir='rtl']) docs-spectrum-logo {

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -80,7 +80,7 @@ const reduceMotionProperties = css`
 ActiveOverlay.prototype.renderTheme = function (
     content: TemplateResult
 ): TemplateResult {
-    const { color, scale, theme, lang } = this.theme;
+    const { color, scale, theme, dir, lang } = this.theme;
     return html`
         ${window.__swc_hack_knobs__.defaultReduceMotion
             ? html`
@@ -96,6 +96,7 @@ ActiveOverlay.prototype.renderTheme = function (
             color=${ifDefined(color)}
             scale=${ifDefined(scale)}
             lang=${ifDefined(lang)}
+            dir=${ifDefined(dir)}
             part="theme"
         >
             ${content}

--- a/scripts/css-processing.cjs
+++ b/scripts/css-processing.cjs
@@ -28,6 +28,7 @@ const postCSSPlugins = (resourcePath, toTS) => {
             stage: 2,
             features: {
                 'nesting-rules': true,
+                'dir-pseudo-class': false,
             },
         }),
         // minify the css with cssnano presets


### PR DESCRIPTION
Testing perf updates in CI for Firefox where the native`:dir()` selector is currently correctly enough implemented to leverage.

EDITOR'S NOTE: While perf testing is generally done against Chrome, this branch specifically looks at performance in Firefox as it is the only browser that has an implementation in this area that we can rely on.