### PR TITLE
Propogate open to child sp-popover 

### DIFF
--- a/packages/action-bar/src/ActionBar.ts
+++ b/packages/action-bar/src/ActionBar.ts
@@ -68,7 +68,7 @@ export class ActionBar extends SpectrumElement {
 
     public render(): TemplateResult {
         return html`
-            <sp-popover open id="popover">
+            <sp-popover ?open=${this.open} id="popover">
                 <slot></slot>
             </sp-popover>
         `;


### PR DESCRIPTION
fixes #1417 

## Description

propogates open attribute from sp-action-bar to the child sp-popover

## Related Issue

#1417

## Motivation and Context

the sp-popover was always rendered as open which made it visible to the accessibility tree as it was being rendered with visibility:visible which will expose content in the tree even if a child of visibility:hidden

## How Has This Been Tested?

Running in the docs and ensuring that the content is only rendered in the a11y tree when the action-bar is open

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
