### PR TITLE
fix: prevent native inputs in Arch Linux Firefox

### DIFF
--- a/packages/checkbox/src/checkbox.css
+++ b/packages/checkbox/src/checkbox.css
@@ -28,3 +28,12 @@ governing permissions and limitations under the License.
 :host(:empty) label {
     display: none;
 }
+
+/**
+ * Work around https://github.com/adobe/spectrum-css/issues/1195
+ */
+#input {
+    opacity: 0;
+}
+
+/* End work around for https://github.com/adobe/spectrum-css/issues/1195 */

--- a/packages/radio/src/radio.css
+++ b/packages/radio/src/radio.css
@@ -32,3 +32,12 @@ governing permissions and limitations under the License.
 :host([disabled]) {
     pointer-events: none;
 }
+
+/**
+ * Work around https://github.com/adobe/spectrum-css/issues/1195
+ */
+#input {
+    opacity: 0;
+}
+
+/* End work around for https://github.com/adobe/spectrum-css/issues/1195 */

--- a/packages/switch/src/switch.css
+++ b/packages/switch/src/switch.css
@@ -31,7 +31,16 @@ governing permissions and limitations under the License.
     pointer-events: none;
 }
 
-/* Continue work around... */
+/**
+ * Work around https://github.com/adobe/spectrum-css/issues/1195
+ */
+#input {
+    opacity: 0;
+}
+
+/* End work around for https://github.com/adobe/spectrum-css/issues/1195 */
+
+/* Continue work around for https://github.com/adobe/spectrum-css/issues/1089 */
 
 :host([dir='ltr'][checked]) #input + #switch:before {
     /* [dir=ltr] .spectrum-Switch-input:checked+.spectrum-Switch-switch:before */
@@ -53,4 +62,4 @@ governing permissions and limitations under the License.
     );
 }
 
-/* End work around. */
+/* End work around for https://github.com/adobe/spectrum-css/issues/1089 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Don't wait for Spectrum CSS to fix https://github.com/adobe/spectrum-css/issues/1195 with https://github.com/adobe/spectrum-css/pull/1208 or similar, start shipping correctly in Arch Linux Firefox, now.

## Related Issue
fixes #1460

## Motivation and Context
Things should display correctly.

## How Has This Been Tested?
Manual testing?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
