### PR TITLE
chore: adding a rebase action for PR comments

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -20,7 +20,7 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
             - name: Get PR number
-              run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
+              run: echo "$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $PR_NUMBER
             - name: Automatic rebase
               uses: cirrus-actions/rebase@1.4
               env:

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -19,10 +19,13 @@ jobs:
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+            - name: Get PR number
+              run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
             - name: Automatic rebase
               uses: cirrus-actions/rebase@1.4
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ PR_NUMBER }}
 
             # TODO: This tool is better but doesn't yet support rebasing; coming soon
             # https://github.com/chinthakagodawita/autoupdate

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -19,7 +19,6 @@ jobs:
               uses: cirrus-actions/rebase@1.4
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_NUMBER: ${{ env.PR_NUMBER }}
 
             # TODO: This tool is better but doesn't yet support rebasing; coming soon
             # https://github.com/chinthakagodawita/autoupdate

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -4,7 +4,8 @@ name: Auto-rebase open PRs
 on:
     # This will trigger on all pushes to all branches
     # push: {}
-    # Triggers if commits are pushed to certain branches, e.g.:
+
+    # Triggers if commits are pushed to certain branches, great for testing
     push:
         branches:
             - chore-add-autoupdate-action

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -12,7 +12,6 @@ on:
 jobs:
     autoupdate:
         name: Auto-rebase open PRs
-        if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
         runs-on: ubuntu-latest
         steps:
             - name: Checkout the latest code

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,34 +1,25 @@
 # This workflow updates all open PRs if their base branch is pushed to
 # https://github.com/cirrus-actions/rebase
-name: Auto-rebase open PRs
+name: Rebase PRs when commented
 on:
-    # This will trigger on all pushes to all branches
-    # push: {}
-
-    # Triggers if commits are pushed to certain branches, great for testing
-    pull_request:
-        types: [synchronize]
-        branches:
-            - chore-add-autoupdate-action
+    issue_comment:
+        types: [created]
 jobs:
-    autoupdate:
-        name: Auto-rebase open PRs
+    rebase:
+        name: Rebase PRs when commented
+        if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
         runs-on: ubuntu-latest
         steps:
-            # - name: Checkout the latest code
-            #   uses: actions/checkout@v2
-            #   with:
-            #       token: ${{ secrets.GITHUB_TOKEN }}
-            #       fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
-            - name: Get PR number
-              run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
-            - name: Test PR value
-              run: echo ${{ GITHUB_EVENT_PATH }}
-            # - name: Automatic rebase
-            #   uses: cirrus-actions/rebase@1.4
-            #   env:
-            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            #       PR_NUMBER: ${{ env.PR_NUMBER }}
+            - name: Checkout the latest code
+              uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+            - name: Automatic rebase
+              uses: cirrus-actions/rebase@1.4
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ env.PR_NUMBER }}
 
             # TODO: This tool is better but doesn't yet support rebasing; coming soon
             # https://github.com/chinthakagodawita/autoupdate

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -20,12 +20,12 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
             - name: Get PR number
-              run: echo "$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $PR_NUMBER
+              run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
             - name: Automatic rebase
               uses: cirrus-actions/rebase@1.4
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_NUMBER: ${{ PR_NUMBER }}
+                  PR_NUMBER: ${{ env.PR_NUMBER }}
 
             # TODO: This tool is better but doesn't yet support rebasing; coming soon
             # https://github.com/chinthakagodawita/autoupdate

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,0 +1,37 @@
+# This workflow updates all open PRs if their base branch is pushed to
+# https://github.com/cirrus-actions/rebase
+name: Auto-rebase open PRs
+on:
+    # This will trigger on all pushes to all branches
+    # push: {}
+    # Triggers if commits are pushed to certain branches, e.g.:
+    push:
+        branches:
+            - chore-add-autoupdate-action
+jobs:
+    autoupdate:
+        name: Auto-rebase open PRs
+        if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout the latest code
+              uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+            - name: Automatic rebase
+              uses: cirrus-actions/rebase@1.4
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            # TODO: This tool is better but doesn't yet support rebasing; coming soon
+            # https://github.com/chinthakagodawita/autoupdate
+            # - uses: chinthakagodawita/autoupdate-action@v0.1.4
+            #   env:
+            #     GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+            #     MERGE_MSG: "chore: branch was auto-updated with the latest"
+            #     MERGE_CONFLICT_ACTION: ignore
+            #     # enable for testing
+            #     DRY_RUN: true
+            #     # Only monitor PRs that are not currently in the draft state
+            #     PR_READY_STATE: ready_for_review

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -6,7 +6,8 @@ on:
     # push: {}
 
     # Triggers if commits are pushed to certain branches, great for testing
-    push:
+    pull_request:
+        types: [synchronize]
         branches:
             - chore-add-autoupdate-action
 jobs:
@@ -22,7 +23,7 @@ jobs:
             - name: Get PR number
               run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
             - name: Test PR value
-              run: echo ${{ env.PR_NUMBER }}
+              run: echo ${{ GITHUB_EVENT_PATH }}
             # - name: Automatic rebase
             #   uses: cirrus-actions/rebase@1.4
             #   env:

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -14,18 +14,20 @@ jobs:
         name: Auto-rebase open PRs
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout the latest code
-              uses: actions/checkout@v2
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+            # - name: Checkout the latest code
+            #   uses: actions/checkout@v2
+            #   with:
+            #       token: ${{ secrets.GITHUB_TOKEN }}
+            #       fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
             - name: Get PR number
               run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
-            - name: Automatic rebase
-              uses: cirrus-actions/rebase@1.4
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR_NUMBER: ${{ env.PR_NUMBER }}
+            - name: Test PR value
+              run: echo ${{ env.PR_NUMBER }}
+            # - name: Automatic rebase
+            #   uses: cirrus-actions/rebase@1.4
+            #   env:
+            #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            #       PR_NUMBER: ${{ env.PR_NUMBER }}
 
             # TODO: This tool is better but doesn't yet support rebasing; coming soon
             # https://github.com/chinthakagodawita/autoupdate


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding an action that will rebase when you comment `/rebase` to an open PR. Why not just have folks do this on the command line? Often I'm glancing at PRs that are almost ready to merge on my phone or tablet and can't pull down the repo easily; being able to add a comment to handle the rebase in the UI is delightful!

## Motivation and Context

Prevent the need to press the GitHub UI auto-update button which performs a merge instead of a rebase.

## How Has This Been Tested?

Coming soon!  You can only test issue comments when the script exists in the main branch 🤦 

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/989066/51547853-14a57b00-1e35-11e9-841d-33114f0f0bd5.gif

## Types of changes

- [x] Chore

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
