### PR TITLE
Color controls focus management updates.

### DIFF
--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -18,6 +18,7 @@ import {
     property,
     PropertyValues,
     query,
+    ifDefined,
 } from '@spectrum-web-components/base';
 import { streamingListener } from '@spectrum-web-components/base/src/streaming-listener.js';
 import { WithSWCResizeObserver, SWCResizeObserverEntry } from './types';
@@ -174,10 +175,48 @@ export class ColorArea extends SpectrumElement {
     private activeAxis = 'x';
 
     @property({ type: Number })
-    public x = 1;
+    public get x(): number {
+        return this._x;
+    }
+
+    public set x(x: number) {
+        if (x === this.x) {
+            return;
+        }
+        const oldValue = this.x;
+        if (this.inputX) {
+            // Use the native `input[type='range']` control to validate this value after `firstUpdate`
+            this.inputX.value = x.toString();
+            this._x = this.inputX.valueAsNumber;
+        } else {
+            this._x = x;
+        }
+        this.requestUpdate('x', oldValue);
+    }
+
+    private _x = 1;
 
     @property({ type: Number })
-    public y = 0;
+    public get y(): number {
+        return this._y;
+    }
+
+    public set y(y: number) {
+        if (y === this.y) {
+            return;
+        }
+        const oldValue = this.y;
+        if (this.inputY) {
+            // Use the native `input[type='range']` control to validate this value after `firstUpdate`
+            this.inputY.value = y.toString();
+            this._y = this.inputY.valueAsNumber;
+        } else {
+            this._y = y;
+        }
+        this.requestUpdate('y', oldValue);
+    }
+
+    private _y = 0;
 
     @property({ type: Number })
     public step = 0.01;
@@ -188,38 +227,61 @@ export class ColorArea extends SpectrumElement {
     @query('[name="y"]')
     public inputY!: HTMLInputElement;
 
-    private get altered(): number {
-        return this._altered;
-    }
-
-    private set altered(altered: number) {
-        this._altered = altered;
-        this.step = Math.max(0.01, this.altered * 5 * 0.01);
-    }
-
-    private _altered = 0;
-
-    private altKeys = new Set();
+    private altered = 0;
 
     private activeKeys = new Set();
+
+    public focus(focusOptions: FocusOptions = {}): void {
+        super.focus(focusOptions);
+        this.forwardFocus();
+    }
+
+    private forwardFocus(): void {
+        const activeElement = (this.getRootNode() as Document)
+            .activeElement as HTMLElement;
+        if (activeElement) {
+            let shouldFocus = false;
+            try {
+                // Browsers without support for the `:focus-visible`
+                // selector will throw on the following test (Safari, older things).
+                // Some won't throw, but will be focusing item rather than the menu and
+                // will rely on the polyfill to know whether focus is "visible" or not.
+                shouldFocus =
+                    activeElement.matches(':focus-visible') ||
+                    activeElement.matches('.focus-visible');
+            } catch (error) {
+                shouldFocus = activeElement.matches('.focus-visible');
+            }
+            this.focused = shouldFocus;
+        }
+        if (this.activeAxis === 'x') {
+            this.inputX.focus();
+        } else {
+            this.inputY.focus();
+        }
+    }
 
     private handleFocusin(): void {
         this.focused = true;
     }
 
     private handleFocusout(): void {
+        if (this._pointerDown) {
+            return;
+        }
         this.focused = false;
     }
 
     private handleKeydown(event: KeyboardEvent): void {
-        const { key, code } = event;
-        if (['Shift', 'Meta', 'Control', 'Alt'].includes(key)) {
-            this.altKeys.add(key);
-            this.altered = this.altKeys.size;
-        }
-        if (code.search('Arrow') === 0) {
-            this.activeKeys.add(code);
+        const { code } = event;
+        this.focused = true;
+        this.altered = [event.shiftKey, event.ctrlKey, event.altKey].filter(
+            (key) => !!key
+        ).length;
+        const isArrowKey = code.search('Arrow') === 0;
+        if (isArrowKey) {
             event.preventDefault();
+            this.activeKeys.add(code);
             this.handleKeypress();
         }
     }
@@ -227,19 +289,20 @@ export class ColorArea extends SpectrumElement {
     private handleKeypress(): void {
         let deltaX = 0;
         let deltaY = 0;
+        const step = Math.max(this.step, this.altered * 5 * this.step);
         this.activeKeys.forEach((code) => {
             switch (code) {
                 case 'ArrowUp':
-                    deltaY = this.step * -1;
+                    deltaY = step * -1;
                     break;
                 case 'ArrowDown':
-                    deltaY = this.step * 1;
+                    deltaY = step * 1;
                     break;
                 case 'ArrowLeft':
-                    deltaX = this.step * -1;
+                    deltaX = step * -1;
                     break;
                 case 'ArrowRight':
-                    deltaX = this.step * 1;
+                    deltaX = step * 1;
                     break;
                 /* c8 ignore next 2 */
                 default:
@@ -253,7 +316,6 @@ export class ColorArea extends SpectrumElement {
             this.activeAxis = 'y';
             this.inputY.focus();
         }
-
         this.x = Math.min(1, Math.max(this.x + deltaX, 0));
         this.y = Math.min(1, Math.max(this.y + deltaY, 0));
 
@@ -282,14 +344,8 @@ export class ColorArea extends SpectrumElement {
 
     private handleKeyup(event: KeyboardEvent): void {
         event.preventDefault();
-        const { key, code } = event;
-        if (['Shift', 'Meta', 'Control', 'Alt'].includes(key)) {
-            this.altKeys.delete(key);
-            this.altered = this.altKeys.size;
-        }
-        if (code.search('Arrow') === 0) {
-            this.activeKeys.delete(code);
-        }
+        const { code } = event;
+        this.activeKeys.delete(code);
     }
 
     private handleInput(event: Event & { target: HTMLInputElement }): void {
@@ -299,7 +355,8 @@ export class ColorArea extends SpectrumElement {
         this._color = new TinyColor({ h: this.hue, s: this.x, v: 1 - this.y });
     }
 
-    private handleChange(): void {
+    private handleChange(event: Event & { target: HTMLInputElement }): void {
+        this.handleInput(event);
         this.dispatchEvent(
             new Event('change', {
                 bubbles: true,
@@ -310,18 +367,19 @@ export class ColorArea extends SpectrumElement {
     }
 
     private boundingClientRect!: DOMRect;
+    private _pointerDown = false;
 
     private handlePointerdown(event: PointerEvent): void {
         if (event.button !== 0) {
             event.preventDefault();
             return;
         }
+        this._pointerDown = true;
         this._previousColor = this._color.clone();
         this.boundingClientRect = this.getBoundingClientRect();
-
         (event.target as HTMLElement).setPointerCapture(event.pointerId);
         if (event.pointerType === 'mouse') {
-            this.handleFocusin();
+            this.focused = true;
         }
     }
 
@@ -342,6 +400,7 @@ export class ColorArea extends SpectrumElement {
 
     private handlePointerup(event: PointerEvent): void {
         event.preventDefault();
+        this._pointerDown = false;
         (event.target as HTMLElement).releasePointerCapture(event.pointerId);
         const applyDefault = this.dispatchEvent(
             new Event('change', {
@@ -352,7 +411,7 @@ export class ColorArea extends SpectrumElement {
         );
         this.inputX.focus();
         if (event.pointerType === 'mouse') {
-            this.handleFocusout();
+            this.focused = false;
         }
         if (!applyDefault) {
             this._color = this._previousColor;
@@ -416,7 +475,9 @@ export class ColorArea extends SpectrumElement {
             </div>
 
             <sp-color-handle
-                tabindex="-1"
+                tabindex=${ifDefined(this.focused ? undefined : '0')}
+                @focus=${this.forwardFocus}
+                ?focused=${this.focused}
                 class="handle"
                 color=${this._color.toHslString()}
                 ?disabled=${this.disabled}
@@ -432,32 +493,36 @@ export class ColorArea extends SpectrumElement {
                 )}
             ></sp-color-handle>
 
-            <input
-                type="range"
-                class="slider"
-                name="x"
-                aria-label=${this.label}
-                min="0"
-                max="1"
-                step=${this.step}
-                tabindex=${this.activeAxis === 'x' ? 0 : -1}
-                .value=${String(this.x)}
-                @input=${this.handleInput}
-                @change=${this.handleChange}
-            />
-            <input
-                type="range"
-                class="slider"
-                name="y"
-                aria-label=${this.label}
-                min="0"
-                max="1"
-                step=${this.step}
-                tabindex=${this.activeAxis === 'y' ? 0 : -1}
-                .value=${String(this.y)}
-                @input=${this.handleInput}
-                @change=${this.handleChange}
-            />
+            <div>
+                <input
+                    type="range"
+                    class="slider"
+                    name="x"
+                    aria-label=${this.label}
+                    min="0"
+                    max="1"
+                    step=${this.step}
+                    tabindex="-1"
+                    .value=${String(this.x)}
+                    @input=${this.handleInput}
+                    @change=${this.handleChange}
+                />
+            </div>
+            <div>
+                <input
+                    type="range"
+                    class="slider"
+                    name="y"
+                    aria-label=${this.label}
+                    min="0"
+                    max="1"
+                    step=${this.step}
+                    tabindex="-1"
+                    .value=${String(this.y)}
+                    @input=${this.handleInput}
+                    @change=${this.handleChange}
+                />
+            </div>
         `;
     }
 
@@ -471,22 +536,46 @@ export class ColorArea extends SpectrumElement {
         this.addEventListener('keydown', this.handleKeydown);
     }
 
+    protected updated(changed: PropertyValues): void {
+        super.updated(changed);
+        if (this.x !== this.inputX.valueAsNumber) {
+            this.x = this.inputX.valueAsNumber;
+        }
+        if (this.y !== this.inputY.valueAsNumber) {
+            this.y = this.inputY.valueAsNumber;
+        }
+        if (changed.has('focused') && this.focused) {
+            // Lazily bind the `input[type="range"]` elements in shadow roots
+            // so that browsers with certain settings (Webkit) aren't allowed
+            // multiple tab stops within the Color Area.
+            const parentX = this.inputX.parentElement as HTMLDivElement;
+            const parentY = this.inputY.parentElement as HTMLDivElement;
+            if (!parentX.shadowRoot && !parentY.shadowRoot) {
+                parentX.attachShadow({ mode: 'open' });
+                parentY.attachShadow({ mode: 'open' });
+                const slot = '<div tabindex="-1"><slot></slot></div>';
+                (parentX.shadowRoot as unknown as ShadowRoot).innerHTML = slot;
+                (parentY.shadowRoot as unknown as ShadowRoot).innerHTML = slot;
+            }
+        }
+    }
+
     private observer?: WithSWCResizeObserver['ResizeObserver'];
 
     public connectedCallback(): void {
         super.connectedCallback();
         if (
             !this.observer &&
-            ((window as unknown) as WithSWCResizeObserver).ResizeObserver
+            (window as unknown as WithSWCResizeObserver).ResizeObserver
         ) {
-            this.observer = new ((window as unknown) as WithSWCResizeObserver).ResizeObserver(
-                (entries: SWCResizeObserverEntry[]) => {
-                    for (const entry of entries) {
-                        this.boundingClientRect = entry.contentRect;
-                    }
-                    this.requestUpdate();
+            this.observer = new (
+                window as unknown as WithSWCResizeObserver
+            ).ResizeObserver((entries: SWCResizeObserverEntry[]) => {
+                for (const entry of entries) {
+                    this.boundingClientRect = entry.contentRect;
                 }
-            );
+                this.requestUpdate();
+            });
         }
         this.observer?.observe(this);
     }

--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -41,10 +41,10 @@ export const Default = (): TemplateResult => {
                 const next = target.nextElementSibling as HTMLElement;
                 next.textContent = target.color as string;
                 next.style.color = target.color as string;
-                console.log('input');
+                console.log('input', target.value);
             }}
-            @change=${() => {
-                console.log('change');
+            @change=${({ target }: Event & { target: ColorArea }) => {
+                console.log('change', target.value);
             }}
         ></sp-color-area>
         <div style="color: #ff0000" aria-live="off">#ff0000</div>

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -11,18 +11,6 @@ governing permissions and limitations under the License.
 */
 
 import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
-import {
-    shiftEvent,
-    arrowUpEvent,
-    arrowDownEvent,
-    arrowLeftEvent,
-    arrowRightEvent,
-    arrowUpKeyupEvent,
-    arrowDownKeyupEvent,
-    arrowLeftKeyupEvent,
-    arrowRightKeyupEvent,
-    shiftKeyupEvent,
-} from '../../../test/testing-helpers.js';
 import { HSL, HSLA, HSV, HSVA, RGB, RGBA, TinyColor } from '@ctrl/tinycolor';
 
 import '../sp-color-area.js';
@@ -64,30 +52,33 @@ describe('ColorArea', () => {
 
         input1.focus();
 
-        expect(document.activeElement).to.equal(input1);
+        expect(document.activeElement, 'before input').to.equal(input1);
 
         await sendKeys({
             press: 'Tab',
         });
+        await elementUpdated(el);
 
-        expect(document.activeElement).to.equal(el);
-
+        expect(document.activeElement, 'element').to.equal(el);
         let value = el.value;
         await sendKeys({
             press: 'ArrowRight',
         });
+        await elementUpdated(el);
         expect(el.value).to.not.equal(value);
         await sendKeys({
             press: 'Tab',
         });
+        await elementUpdated(el);
 
-        expect(document.activeElement).to.equal(input2);
+        expect(document.activeElement, 'after input').to.equal(input2);
 
         await sendKeys({
             press: 'Shift+Tab',
         });
+        await elementUpdated(el);
 
-        expect(document.activeElement).to.equal(el);
+        expect(document.activeElement, 'element again').to.equal(el);
 
         value = el.value;
         await sendKeys({
@@ -97,8 +88,7 @@ describe('ColorArea', () => {
         await sendKeys({
             press: 'Shift+Tab',
         });
-
-        expect(document.activeElement).to.equal(input1);
+        expect(document.activeElement, 'before input again').to.equal(input1);
     });
     it('accepts "color" values as hsl', async () => {
         const el = await fixture<ColorArea>(
@@ -110,7 +100,7 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.hue, 'hue').to.equal(100);
-        expect(el.x, 'x').to.equal(0.6666666666666666);
+        expect(el.x, 'x').to.equal(0.67);
         expect(el.y, 'y').to.equal(0.25);
     });
     it('accepts "color" values as hsla', async () => {
@@ -123,7 +113,7 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.hue, 'hugh').to.equal(100);
-        expect(el.x, 'ex').to.equal(0.6666666666666666);
+        expect(el.x, 'ex').to.equal(0.67);
         expect(el.y, 'why').to.equal(0.25);
 
         el.color = 'hsla(120, 100%, 0, 1)';
@@ -169,7 +159,7 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.hue, 'hue').to.equal(100);
-        expect(el.x, 'x').to.equal(0.6666666666666666);
+        expect(el.x, 'x').to.equal(0.67);
         expect(el.y, 'y').to.equal(0.25);
 
         el.inputX.focus();
@@ -183,8 +173,8 @@ describe('ColorArea', () => {
         });
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6666666666666666);
-        expect(el.y).to.equal(0.22999999999999998);
+        expect(el.x).to.equal(0.67);
+        expect(el.y).to.equal(0.23);
 
         await sendKeys({
             press: 'ArrowRight',
@@ -195,8 +185,8 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6866666666666666);
-        expect(el.y).to.equal(0.22999999999999998);
+        expect(el.x).to.equal(0.69);
+        expect(el.y).to.equal(0.23);
 
         await sendKeys({
             press: 'ArrowDown',
@@ -207,7 +197,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6866666666666666);
+        expect(el.x).to.equal(0.69);
         expect(el.y).to.equal(0.25);
 
         await sendKeys({
@@ -219,7 +209,7 @@ describe('ColorArea', () => {
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6666666666666666);
+        expect(el.x).to.equal(0.67);
         expect(el.y).to.equal(0.25);
     });
     it('accepts "Arrow*" keypresses with alteration', async () => {
@@ -230,55 +220,73 @@ describe('ColorArea', () => {
         );
 
         await elementUpdated(el);
-
+        el.focus();
         expect(el.hue, 'hue').to.equal(100);
-        expect(el.x, 'x').to.equal(0.6666666666666666);
+        expect(el.x, 'x').to.equal(0.67);
         expect(el.y, 'y').to.equal(0.25);
 
-        el.dispatchEvent(shiftEvent);
-        el.dispatchEvent(arrowUpEvent);
-        el.dispatchEvent(arrowUpKeyupEvent);
+        await sendKeys({
+            down: 'Shift',
+        });
+        await elementUpdated(el);
+        await sendKeys({
+            press: 'ArrowUp',
+        });
         // This ensures that all the keystrokes are processed seperately
         await elementUpdated(el);
-        el.dispatchEvent(arrowUpEvent);
-        el.dispatchEvent(arrowUpKeyupEvent);
+        await sendKeys({
+            press: 'ArrowUp',
+        });
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6666666666666666);
-        expect(el.y).to.equal(0.15000000000000002);
+        expect(el.color).to.equal('hsl(100, 65%, 57%)');
+        expect(el.x, 'first').to.equal(0.67);
+        expect(el.y).to.equal(0.15);
 
-        el.dispatchEvent(arrowRightEvent);
-        el.dispatchEvent(arrowRightKeyupEvent);
+        await sendKeys({
+            press: 'ArrowRight',
+        });
         await elementUpdated(el);
-        el.dispatchEvent(arrowRightEvent);
-        el.dispatchEvent(arrowRightKeyupEvent);
-        await elementUpdated(el);
-
-        expect(el.x).to.equal(0.7666666666666667);
-        expect(el.y).to.equal(0.15000000000000002);
-
-        el.dispatchEvent(arrowDownEvent);
-        el.dispatchEvent(arrowDownKeyupEvent);
-        await elementUpdated(el);
-        el.dispatchEvent(arrowDownEvent);
-        el.dispatchEvent(arrowDownKeyupEvent);
-
+        await sendKeys({
+            press: 'ArrowRight',
+        });
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.7666666666666667);
+        expect(el.color).to.equal('hsl(100, 69%, 52%)');
+        expect(el.x).to.equal(0.77);
+        expect(el.y).to.equal(0.15);
+
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        await elementUpdated(el);
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+
+        await elementUpdated(el);
+
+        expect(el.color).to.equal('hsl(100, 63%, 46%)');
+        expect(el.x).to.equal(0.77);
         expect(el.y).to.equal(0.25);
 
-        el.dispatchEvent(arrowLeftEvent);
-        el.dispatchEvent(arrowLeftKeyupEvent);
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
         await elementUpdated(el);
-        el.dispatchEvent(arrowLeftEvent);
-        el.dispatchEvent(arrowLeftKeyupEvent);
-        el.dispatchEvent(shiftKeyupEvent);
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        await elementUpdated(el);
+        await sendKeys({
+            up: 'Shift',
+        });
 
         await elementUpdated(el);
 
-        expect(el.x).to.equal(0.6666666666666666);
+        expect(el.color).to.equal('hsl(100, 50%, 50%)');
+        expect(el.x, 'last').to.equal(0.67);
         expect(el.y).to.equal(0.25);
     });
     it('accepts pointer events', async () => {
@@ -293,7 +301,7 @@ describe('ColorArea', () => {
         await elementUpdated(el);
         await elementUpdated(el);
 
-        const { handle } = (el as unknown) as { handle: HTMLElement };
+        const { handle } = el as unknown as { handle: HTMLElement };
 
         handle.setPointerCapture = () => {
             return;
@@ -358,8 +366,8 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.hue).to.equal(0);
-        expect(el.x, 'pointerdown x').to.equal(0.4791666666666667);
-        expect(el.y, 'pointerdown y').to.equal(0.4791666666666667);
+        expect(el.x, 'pointerdown x').to.equal(0.48);
+        expect(el.y, 'pointerdown y').to.equal(0.48);
 
         handle.dispatchEvent(
             new PointerEvent('pointermove', {
@@ -385,8 +393,8 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.hue).to.equal(0);
-        expect(el.x).to.equal(0.53125);
-        expect(el.y).to.equal(0.53125);
+        expect(el.x).to.equal(0.53);
+        expect(el.y).to.equal(0.53);
     });
     it('responds to events on the internal input element', async () => {
         const inputSpy = spy();
@@ -455,7 +463,8 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         el.inputX.focus();
-
+        inputSpy.resetHistory();
+        changeSpy.resetHistory();
         await sendKeys({ press: 'ArrowRight' });
         await sendKeys({ press: 'ArrowRight' });
 
@@ -465,34 +474,36 @@ describe('ColorArea', () => {
         expect(changeSpy.callCount).to.equal(2);
 
         el.inputY.focus();
-
+        inputSpy.resetHistory();
+        changeSpy.resetHistory();
         await sendKeys({ press: 'ArrowUp' });
         await sendKeys({ press: 'ArrowUp' });
 
         await elementUpdated(el);
 
-        expect(inputSpy.callCount).to.equal(4);
-        expect(changeSpy.callCount).to.equal(4);
+        expect(inputSpy.callCount).to.equal(2);
+        expect(changeSpy.callCount).to.equal(2);
 
         el.inputY.focus();
-
+        inputSpy.resetHistory();
+        changeSpy.resetHistory();
         await sendKeys({ press: 'ArrowDown' });
         await sendKeys({ press: 'ArrowDown' });
 
         await elementUpdated(el);
 
-        expect(inputSpy.callCount).to.equal(6);
-        expect(changeSpy.callCount).to.equal(6);
+        expect(inputSpy.callCount).to.equal(2);
+        expect(changeSpy.callCount).to.equal(2);
 
         el.inputX.focus();
-
+        inputSpy.resetHistory();
+        changeSpy.resetHistory();
         await sendKeys({ press: 'ArrowLeft' });
         await sendKeys({ press: 'ArrowLeft' });
 
         await elementUpdated(el);
-
-        expect(inputSpy.callCount).to.equal(8);
-        expect(changeSpy.callCount).to.equal(8);
+        expect(inputSpy.callCount).to.equal(2);
+        expect(changeSpy.callCount).to.equal(2);
     });
     it('retains `hue` value when s = 0 in HSL string format', async () => {
         const el = await fixture<ColorArea>(
@@ -504,7 +515,7 @@ describe('ColorArea', () => {
         await elementUpdated(el);
 
         expect(el.hue, 'hue').to.equal(100);
-        expect(el.x, 'x').to.equal(0.6666666666666666);
+        expect(el.x, 'x').to.equal(0.67);
         expect(el.y, 'y').to.equal(0.25);
         expect(el.color).to.equal('hsl(100, 50%, 50%)');
 
@@ -531,7 +542,7 @@ describe('ColorArea', () => {
         const variance = 0.00005;
 
         expect(el.hue).to.equal(100);
-        expect(el.x, 'x').to.equal(0.6666666666666666);
+        expect(el.x, 'x').to.equal(0.67);
         expect(el.y, 'y').to.equal(0.25);
 
         expect(Math.abs(outputColor.h - inputColor.h)).to.be.lessThan(variance);

--- a/packages/color-handle/src/ColorHandle.ts
+++ b/packages/color-handle/src/ColorHandle.ts
@@ -50,6 +50,9 @@ export class ColorHandle extends SpectrumElement {
     public disabled = false;
 
     @property({ type: Boolean, reflect: true })
+    public focused = false;
+
+    @property({ type: Boolean, reflect: true })
     public open = false;
 
     @property({ type: String })

--- a/packages/color-handle/src/color-handle.css
+++ b/packages/color-handle/src/color-handle.css
@@ -15,3 +15,7 @@ governing permissions and limitations under the License.
 :host {
     touch-action: none;
 }
+
+:host(:focus) {
+    outline: none;
+}

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
 import {
-    shiftEvent,
     arrowUpEvent,
     arrowDownEvent,
     arrowLeftEvent,
@@ -21,7 +20,6 @@ import {
     arrowDownKeyupEvent,
     arrowLeftKeyupEvent,
     arrowRightKeyupEvent,
-    shiftKeyupEvent,
 } from '../../../test/testing-helpers.js';
 
 import '../sp-color-slider.js';
@@ -292,44 +290,54 @@ describe('ColorSlider', () => {
         );
 
         await elementUpdated(el);
-
+        el.focus();
         expect(el.sliderHandlePosition).to.equal(0);
 
-        const input = el.focusElement;
-
-        input.dispatchEvent(shiftEvent);
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
+        await sendKeys({
+            down: 'Shift',
+        });
+        await sendKeys({
+            press: 'ArrowUp',
+        });
+        await sendKeys({
+            press: 'ArrowUp',
+        });
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(20);
 
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        await sendKeys({
+            press: 'ArrowRight',
+        });
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(40);
 
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        await sendKeys({
+            press: 'ArrowDown',
+        });
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(20);
 
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
-        input.dispatchEvent(shiftKeyupEvent);
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        await sendKeys({
+            up: 'Shift',
+        });
 
         await elementUpdated(el);
 

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -17,6 +17,7 @@ import {
     property,
     query,
     PropertyValues,
+    ifDefined,
 } from '@spectrum-web-components/base';
 import { streamingListener } from '@spectrum-web-components/base/src/streaming-listener.js';
 import { WithSWCResizeObserver, SWCResizeObserverEntry } from './types';
@@ -184,8 +185,6 @@ export class ColorWheel extends Focusable {
 
     private _altered = 0;
 
-    private altKeys = new Set();
-
     @query('input')
     public input!: HTMLInputElement;
 
@@ -195,10 +194,10 @@ export class ColorWheel extends Focusable {
 
     private handleKeydown(event: KeyboardEvent): void {
         const { key } = event;
-        if (['Shift', 'Meta', 'Control', 'Alt'].includes(key)) {
-            this.altKeys.add(key);
-            this.altered = this.altKeys.size;
-        }
+        this.focused = true;
+        this.altered = [event.shiftKey, event.ctrlKey, event.altKey].filter(
+            (key) => !!key
+        ).length;
         let delta = 0;
         switch (key) {
             case 'ArrowUp':
@@ -238,15 +237,6 @@ export class ColorWheel extends Focusable {
         }
     }
 
-    private handleKeyup(event: KeyboardEvent): void {
-        event.preventDefault();
-        const { key } = event;
-        if (['Shift', 'Meta', 'Control', 'Alt'].includes(key)) {
-            this.altKeys.delete(key);
-            this.altered = this.altKeys.size;
-        }
-    }
-
     private handleInput(event: Event & { target: HTMLInputElement }): void {
         const { valueAsNumber } = event.target;
 
@@ -254,7 +244,8 @@ export class ColorWheel extends Focusable {
         this._color = new TinyColor({ ...this._color.toHsl(), h: this.value });
     }
 
-    private handleChange(): void {
+    private handleChange(event: Event & { target: HTMLInputElement }): void {
+        this.handleInput(event);
         this.dispatchEvent(
             new Event('change', {
                 bubbles: true,
@@ -263,26 +254,58 @@ export class ColorWheel extends Focusable {
         );
     }
 
+    public focus(focusOptions: FocusOptions = {}): void {
+        super.focus(focusOptions);
+        this.forwardFocus();
+    }
+
+    private forwardFocus(): void {
+        const activeElement = (this.getRootNode() as Document)
+            .activeElement as HTMLElement;
+        if (activeElement) {
+            let shouldFocus = false;
+            try {
+                // Browsers without support for the `:focus-visible`
+                // selector will throw on the following test (Safari, older things).
+                // Some won't throw, but will be focusing item rather than the menu and
+                // will rely on the polyfill to know whether focus is "visible" or not.
+                shouldFocus =
+                    activeElement.matches(':focus-visible') ||
+                    activeElement.matches('.focus-visible');
+            } catch (error) {
+                shouldFocus = activeElement.matches('.focus-visible');
+            }
+            this.focused = shouldFocus;
+        }
+        this.input.focus();
+    }
+
     private handleFocusin(): void {
         this.focused = true;
     }
 
     private handleFocusout(): void {
+        if (this._pointerDown) {
+            return;
+        }
+        this.altered = 0;
         this.focused = false;
     }
 
     private boundingClientRect!: DOMRect;
+    private _pointerDown = false;
 
     private handlePointerdown(event: PointerEvent): void {
         if (event.button !== 0) {
             event.preventDefault();
             return;
         }
+        this._pointerDown = true;
         this._previousColor = this._color.clone();
         this.boundingClientRect = this.getBoundingClientRect();
         (event.target as HTMLElement).setPointerCapture(event.pointerId);
         if (event.pointerType === 'mouse') {
-            this.handleFocusin();
+            this.focused = true;
         }
     }
 
@@ -300,7 +323,7 @@ export class ColorWheel extends Focusable {
     }
 
     private handlePointerup(event: PointerEvent): void {
-        // Retain focus on input element after mouse up to enable keyboard interactions
+        this._pointerDown = false;
         (event.target as HTMLElement).releasePointerCapture(event.pointerId);
 
         const applyDefault = this.dispatchEvent(
@@ -313,9 +336,10 @@ export class ColorWheel extends Focusable {
         if (!applyDefault) {
             this._color = this._previousColor;
         }
+        // Retain focus on input element after mouse up to enable keyboard interactions
         this.focus();
         if (event.pointerType === 'mouse') {
-            this.handleFocusout();
+            this.focused = false;
         }
     }
 
@@ -373,7 +397,9 @@ export class ColorWheel extends Focusable {
             </slot>
 
             <sp-color-handle
-                tabindex="-1"
+                tabindex=${ifDefined(this.focused ? undefined : '0')}
+                @focus=${this.forwardFocus}
+                ?focused=${this.focused}
                 class="handle"
                 color="hsl(${this.value}, 100%, 50%)"
                 ?disabled=${this.disabled}
@@ -399,7 +425,6 @@ export class ColorWheel extends Focusable {
                 @input=${this.handleInput}
                 @change=${this.handleChange}
                 @keydown=${this.handleKeydown}
-                @keyup=${this.handleKeyup}
             />
         `;
     }

--- a/packages/color-wheel/test/color-wheel.test.ts
+++ b/packages/color-wheel/test/color-wheel.test.ts
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
 import {
-    shiftEvent,
     arrowUpEvent,
     arrowDownEvent,
     arrowLeftEvent,
@@ -21,7 +20,6 @@ import {
     arrowDownKeyupEvent,
     arrowLeftKeyupEvent,
     arrowRightKeyupEvent,
-    shiftKeyupEvent,
 } from '../../../test/testing-helpers.js';
 
 import '../sp-color-wheel.js';
@@ -292,44 +290,54 @@ describe('ColorWheel', () => {
         );
 
         await elementUpdated(el);
-
+        el.focus();
         expect(el.value).to.equal(0);
 
-        const input = el.focusElement;
-
-        input.dispatchEvent(shiftEvent);
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
+        await sendKeys({
+            down: 'Shift',
+        });
+        await sendKeys({
+            press: 'ArrowUp',
+        });
+        await sendKeys({
+            press: 'ArrowUp',
+        });
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(20);
 
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        await sendKeys({
+            press: 'ArrowRight',
+        });
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(40);
 
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        await sendKeys({
+            press: 'ArrowDown',
+        });
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(20);
 
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
-        input.dispatchEvent(shiftKeyupEvent);
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        await sendKeys({
+            up: 'Shift',
+        });
 
         await elementUpdated(el);
 


### PR DESCRIPTION
## Description
- prevent `:focus` delivery on `sp-color-handle` both at the Handle level in CSS and in the usage level by removing `tabindex=-1`.
- ensure `Arrow*` keypresses activate `focused` delivery
- remove `modifier` support for `Meta` key as it prevent `keyup` events

## Related issue(s)
fixes #1701
fixes #1698

## Motivation and context
- correct visual delivery of the current focus state
- prevent functional incongruities when keydown states can't be ended

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://color-handle--spectrum-web-components.netlify.app/storybook/?path=/story/color-area--default
    2. Click the label for the `Theme` picker along the bottom
    3. Press `Shift + Tab`
    4. Ensure that the handle has enlarged.
    5. Press any of the `Arrow*` keys
    6. Ensure that the handle/value has moved/been updated
    7. Press `Shift + Tab`
    8. Ensure that after dragging the handle has returned to its original size.
    9. Press any of the `Arrow*` keys
    10. Ensure that the handle/value has not moved/been updated
    11. Press `Shift`
    12. Ensure that the handle has enlarged.
    13. Press any of the `Arrow*` keys
    14. Ensure that the handle/value has moved/been updated
    15. NOTE: Safari is particularly picky about this functionality due to how it assigns elements as "keyboard focusable" or not.
    16. REPEAT for:
      - https://color-handle--spectrum-web-components.netlify.app/storybook/?path=/story/color-slider--default
      - https://color-handle--spectrum-web-components.netlify.app/storybook/?path=/story/color-wheel--default
-   [ ] _Test case 2_
    1. Go to https://color-handle--spectrum-web-components.netlify.app/storybook/?path=/story/color-area--default
    2. Click and drag the Color Handle
    3. Ensure while dragging that the handle is enlarged.
    4. Ensure that after dragging the handle has returned to its original size.
    5. Ensure that the handle does not exhibit a "focus ring" of any kind.
    6. Press any of the `Arrow*` keys
    7. Ensure that the handle has enlarged
    8. Ensure that the handle/value has moved/been updated
    15. NOTE: Safari is particularly picky about this functionality due to how it assigns elements as "keyboard focusable" or not.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
