### PR TITLE
ci: block PRs on out-of-date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
         # We can't currently run benchmarks on PRs from forked repos, because the
         # tachometer action reports results by posting a comment, and we can't post
         # comments without a github token.
-        if: github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -1,0 +1,36 @@
+name: Banch up-to-date with target
+
+on:
+    pull_request:
+        types: [opened, synchronize, edited, reopened]
+
+jobs:
+    compare:
+        name: Confirm that the branch is up-to-date with its target
+
+        # We can't currently run benchmarks on PRs from forked repos, because the
+        # tachometer action reports results by posting a comment, and we can't post
+        # comments without a github token.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node 14
+              uses: actions/setup-node@v2
+              with:
+                  node-version: '14'
+                  cache: 'yarn'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Install dependencies
+              run: yarn --frozen-lockfile --ignore-scripts
+
+            - name: Find if target has been merged
+              run: |
+                  git checkout $GITHUB_BASE_REF
+                  git checkout $GITHUB_HEAD_REF
+                  merged=$(git branch --merged)
+                  yarn is-merged --branch $GITHUB_BASE_REF --merged "$merged"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "icons": "node ./scripts/process-icons.js && pretty-quick --pattern \"packages/**/*.svg.ts\"",
         "icons:ui": "lerna run --scope @spectrum-web-components/icons-ui build",
         "icons:workflow": "lerna run --scope @spectrum-web-components/icons-workflow build",
+        "is-merged": "node ./scripts/is-merged.js",
         "lerna-publish": "lerna publish --message \"chore: release new versions\"",
         "lint": "run-p lint:js lint:docs lint:ts lint:css lint:packagejson",
         "lint:css": "stylelint \"packages/**/*.css\"",

--- a/scripts/is-merged.js
+++ b/scripts/is-merged.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { execSync } from 'child_process';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+const { branch, merged } = yargs(hideBin(process.argv)).argv;
+
+const isMerged = (branch = 'main', merged) => {
+    let mergedBranched = merged;
+    if (!merged) {
+        const command = execSync('git branch --merged');
+        mergedBranched = command.toString();
+    }
+    const isMerged = mergedBranched.search(branch) > -1;
+    if (isMerged) {
+        console.warn('This branch is up to date.');
+    } else {
+        console.warn('This branch needs to be rebased.');
+        throw new Error('This branch is not merged to its target!');
+    }
+};
+
+isMerged(branch, merged);


### PR DESCRIPTION
## Description

Test to see if we could just remove the "Update Branch" button, but still get warned when we're not up-to-date via CI....

## Motivation and context
An alternative, or partner, to #1729 

## How has this been tested?

-   [ ] _Test case 1_
    1. Open PR.
    2. This PR currently fails CI for being out-of-date.
-   [ ] _Test case 2_
    1. Rebase this branch
    2. This PR passes for being up-to-date

## Types of changes
-   [x] CI

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
