### PR TITLE
fix: close modal overlays with contextmenu events and pass those to the underlying page

### DIFF
--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -40,7 +40,9 @@ import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
 import '../../../projects/story-decorator/src/types.js';
 
-import './overlay-story-components';
+import './overlay-story-components.js';
+import { render } from 'lit-html';
+import { Popover } from '@spectrum-web-components/popover';
 
 const storyStyles = html`
     <style>
@@ -268,7 +270,7 @@ export const modalLoose = (): TemplateResult => {
         <overlay-trigger type="modal" placement="none">
             <sp-button slot="trigger">Open</sp-button>
             <sp-dialog
-                size="small"
+                size="s"
                 dismissable
                 slot="click-content"
                 @closed=${(event: Event & { target: DialogWrapper }) =>
@@ -663,29 +665,7 @@ export const superComplexModal = (): TemplateResult => {
 };
 
 export const virtualElement = (args: Properties): TemplateResult => {
-    const pointerenter = async (event: PointerEvent): Promise<void> => {
-        event.preventDefault();
-        const trigger = event.target as HTMLElement;
-        const virtualTrigger = new VirtualTrigger(event.clientX, event.clientY);
-        openOverlay(
-            trigger,
-            'modal',
-            trigger.nextElementSibling as HTMLElement,
-            {
-                placement: args.placement,
-                receivesFocus: 'auto',
-                virtualTrigger,
-            }
-        );
-    };
-    return html`
-        <style>
-            .app-root {
-                position: absolute;
-                inset: 0;
-            }
-        </style>
-        <div class="app-root" @contextmenu=${pointerenter}></div>
+    const contextMenuTemplate = (): TemplateResult => html`
         <sp-popover
             style="max-width: 33vw;"
             @click=${(event: Event) =>
@@ -704,10 +684,32 @@ export const virtualElement = (args: Properties): TemplateResult => {
             </sp-menu>
         </sp-popover>
     `;
+    const pointerenter = async (event: PointerEvent): Promise<void> => {
+        event.preventDefault();
+        const trigger = event.target as HTMLElement;
+        const virtualTrigger = new VirtualTrigger(event.clientX, event.clientY);
+        const fragment = document.createDocumentFragment();
+        render(contextMenuTemplate(), fragment);
+        const popover = fragment.querySelector('sp-popover') as Popover;
+        openOverlay(trigger, 'modal', popover, {
+            placement: args.placement,
+            receivesFocus: 'auto',
+            virtualTrigger,
+        });
+    };
+    return html`
+        <style>
+            .app-root {
+                position: absolute;
+                inset: 0;
+            }
+        </style>
+        <div class="app-root" @contextmenu=${pointerenter}></div>
+    `;
 };
 
 virtualElement.args = {
-    placement: 'right-end',
+    placement: 'right-end' as Placement,
 };
 
 export const detachedElement = (): TemplateResult => {


### PR DESCRIPTION
## Description
When in an overlay of type `modal` allow `contextmenu` events on non-overlaid content to both close the overlay _AND_ interact with the content that had been previously made "inert". This will allow for synthetic context menus to trap the tab order while still affording the user to open a context menu on another piece of content.

## Related issue(s)
fixes #1559 

## Motivation and context
Better support for synthetic context menu overlays.

## How has this been tested?

-   [ ] _Test case 1_
    1. Visit https://overlay-context-menu--spectrum-web-components.netlify.app/storybook/index.html?path=/story/overlay--virtual-element
    2. Use a right click to open a "context menu" in the Story frame
    3. Right click somewhere else on the Story frame to close to first "context menu" and open a new one.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.