### PR TITLE
fix: give Picker a focus helper to enable tab navigation in Safari

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -160,6 +160,12 @@ export class PickerBase extends SizedMixin(Focusable) {
         this.toggle();
     }
 
+    public onHelperFocus(): void {
+        // set focused to true here instead of onButtonFocus so clicks don't flash a focus outline
+        this.focused = true;
+        this.button.focus();
+    }
+
     public onButtonFocus(): void {
         (this.target as HTMLButtonElement).addEventListener(
             'keydown',
@@ -348,8 +354,15 @@ export class PickerBase extends SizedMixin(Focusable) {
         ];
     }
 
+    // a helper to throw focus to the button is needed because Safari
+    // won't include buttons in the tab order even with tabindex="0"
     protected get renderButton(): TemplateResult {
         return html`
+            <span
+                id="focus-helper"
+                tabindex="${this.focused ? '-1' : '0'}"
+                @focus=${this.onHelperFocus}
+            ></span>
             <button
                 aria-haspopup="true"
                 aria-expanded=${this.open ? 'true' : 'false'}
@@ -360,6 +373,7 @@ export class PickerBase extends SizedMixin(Focusable) {
                 @click=${this.onButtonClick}
                 @focus=${this.onButtonFocus}
                 ?disabled=${this.disabled}
+                tabindex="-1"
             >
                 ${this.buttonContent}
             </button>

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -830,38 +830,90 @@ describe('Picker', () => {
         expect(document.activeElement === menu, 'focuses something else').to.be
             .false;
     });
-    // TODO: Create a synthetic tab stop to allow this to work locally in Safari...
     it('opens its menu inline of the tab order', async () => {
+        const surroundingInput = (): HTMLInputElement => {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.tabIndex = 0;
+            return input;
+        };
         const el = await pickerFixture();
-        const input = document.createElement('input');
-        input.type = 'text';
-        input.tabIndex = 0;
+        const input1 = surroundingInput();
+        const input2 = surroundingInput();
 
-        document.body.append(input);
+        document.body.prepend(input1);
+        document.body.append(input2);
 
-        await elementUpdated(el);
+        // start at input1
+        input1.focus();
+        await nextFrame();
 
-        el.focus();
-        await elementUpdated(el);
-
+        // tab to the picker
+        let focused = oneEvent(el, 'focus');
         await sendKeys({ press: 'Tab' });
-        expect(el.open, 'closes').to.be.false;
-        expect(document.activeElement, 'focuses input 1').to.equal(input);
-        await sendKeys({ press: 'Shift+Tab' });
+        await focused;
 
-        const opened = oneEvent(el, 'sp-opened');
-        sendKeys({ press: 'ArrowDown' });
+        expect(el.focused, 'focused').to.be.true;
+        expect(el.open, 'closed').to.be.false;
+
+        // tab through the picker to input2
+        let blurred = oneEvent(el, 'blur');
+        await sendKeys({ press: 'Tab' });
+        await blurred;
+
+        expect(document.activeElement, 'focuses input 2').to.equal(input2);
+
+        // shift+tab back to the picker
+        focused = oneEvent(el, 'focus');
+        await sendKeys({ press: 'Shift+Tab' });
+        await focused;
+
+        // press down to open the picker
+        let opened = oneEvent(el, 'sp-opened');
+        await sendKeys({ press: 'ArrowDown' });
         await opened;
 
+        expect(el.open, 'closed').to.be.true;
         await waitUntil(() => isMenuActiveElement(), 'first item focused');
 
-        const closed = oneEvent(el, 'sp-closed');
-        sendKeys({ press: 'Tab' });
+        // tab to close the picker and move to input2
+        let closed = oneEvent(el, 'sp-closed');
+        await sendKeys({ press: 'Tab' });
         await closed;
 
         expect(el.open, 'closes').to.be.false;
-        expect(document.activeElement, 'focuses input 2').to.equal(input);
-        input.remove();
+        expect(document.activeElement, 'focuses input 2').to.equal(input2);
+
+        // shift + tab back to the picker
+        focused = oneEvent(el, 'focus');
+        await sendKeys({ press: 'Shift+Tab' });
+        await focused;
+
+        // press up to open the picker
+        opened = oneEvent(el, 'sp-opened');
+        await sendKeys({ press: 'ArrowUp' });
+        await opened;
+
+        expect(el.open, 'opened').to.be.true;
+        await waitUntil(() => isMenuActiveElement(), 'first item focused');
+
+        // shift + tab to move to the picker button
+        focused = oneEvent(el, 'focus');
+        await sendKeys({ press: 'Shift+Tab' });
+        await focused;
+
+        // shift + tab again to move back to input1
+        closed = oneEvent(el, 'sp-closed');
+        blurred = oneEvent(el, 'blur');
+        await sendKeys({ press: 'Shift+Tab' });
+        await blurred;
+
+        expect(el.focused, 'blurs picker').to.be.false;
+        expect(document.activeElement, 'focuses input 1').to.equal(input1);
+
+        // wait for the menu to close
+        await closed;
+        expect(el.open, 'closed').to.be.false;
     });
     it('displays selected item text by default', async () => {
         const focusSelectedSpy = spy();


### PR DESCRIPTION
## Description

Safari skips `button` elements in the tab order, so we need to provide a synthetic target with a tabindex to receive and then throw focus onto the Picker's button.

## Related issue(s)

Resolves https://github.com/adobe/spectrum-web-components/issues/1770

## Motivation and context

Fixes a bug.

## How has this been tested?

`yarn test` and manual testing in Chrome & Safari.

## Types of changes

-   [X ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [ X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ X] My code follows the code style of this project.
-   [ X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ X] I have added tests to cover my changes.
-   [ X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
