### PR TITLE
fix: flappy Slider/Color Area tests

### DIFF
--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -10,7 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    expect,
+    html,
+    oneEvent,
+    nextFrame,
+} from '@open-wc/testing';
 import { HSL, HSLA, HSV, HSVA, RGB, RGBA, TinyColor } from '@ctrl/tinycolor';
 
 import '../sp-color-area.js';
@@ -156,58 +163,65 @@ describe('ColorArea', () => {
             `
         );
 
-        await elementUpdated(el);
-
         expect(el.hue, 'hue').to.equal(100);
         expect(el.x, 'x').to.equal(0.67);
         expect(el.y, 'y').to.equal(0.25);
 
         el.inputX.focus();
+        await nextFrame();
 
+        let changeEvent = oneEvent(el, 'change');
         await sendKeys({
             press: 'ArrowUp',
         });
-        await elementUpdated(el);
+        await changeEvent;
+        changeEvent = oneEvent(el, 'change');
         await sendKeys({
             press: 'ArrowUp',
         });
-        await elementUpdated(el);
+        await changeEvent;
 
         expect(el.x).to.equal(0.67);
         expect(el.y).to.equal(0.23);
 
+        changeEvent = oneEvent(el, 'change');
         await sendKeys({
             press: 'ArrowRight',
         });
+        await changeEvent;
+        changeEvent = oneEvent(el, 'change');
         await sendKeys({
             press: 'ArrowRight',
         });
-
-        await elementUpdated(el);
+        await changeEvent;
 
         expect(el.x).to.equal(0.69);
         expect(el.y).to.equal(0.23);
 
+        changeEvent = oneEvent(el, 'change');
         await sendKeys({
             press: 'ArrowDown',
         });
+        await changeEvent;
+        changeEvent = oneEvent(el, 'change');
         await sendKeys({
             press: 'ArrowDown',
         });
-
-        await elementUpdated(el);
+        await changeEvent;
 
         expect(el.x).to.equal(0.69);
         expect(el.y).to.equal(0.25);
 
+        changeEvent = oneEvent(el, 'change');
         await sendKeys({
             press: 'ArrowLeft',
         });
+        await changeEvent;
+        changeEvent = oneEvent(el, 'change');
         await sendKeys({
             press: 'ArrowLeft',
         });
-
-        await elementUpdated(el);
+        await changeEvent;
 
         expect(el.x).to.equal(0.67);
         expect(el.y).to.equal(0.25);

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -118,7 +118,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
         return valueArray.join(', ');
     };
 
-    private get ariaValueText(): string {
+    public get ariaValueText(): string {
         if (!this.getAriaValueText) {
             return `${this.value}`;
         }


### PR DESCRIPTION
## Description

- replace `elementUpdate` with `nextFrame`, which seems more reliable, in intermittently failing tests
- fix visibility of `ariaValueText` in Slider to be compatible with its type signature

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/1772

## Motivation and context

While developing https://github.com/adobe/spectrum-web-components/pull/1771, I noticed that these tests would intermittently fail. The failures were rare and non-deterministic, which makes it difficult to know whether or not your work created a regression.

## How has this been tested?

Experimentation (by running `yarn test` repeatedly) suggests that this PR will more-reliably `await` the state changes that the tests are confirming.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ X] My code follows the code style of this project.
-   [ X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ X] I have added tests to cover my changes.
-   [ X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
