### PR TITLE
fix: simplify focus application in Menu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 06bbbd3e96552c01c402aa443f4cf4dc79ff1e4a
+        default: 171a620091bc04af0bdddf0457df1c4c8eaf50d6
 commands:
     downstream:
         steps:

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
         "cssnano/**/postcss-calc": "7.0.0",
         "playwright": "1.13.0"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/packages/picker/test/picker-sync.test.ts
+++ b/packages/picker/test/picker-sync.test.ts
@@ -192,7 +192,7 @@ describe('Picker, sync', () => {
 
         await elementUpdated(el);
         type NamedNode = { name: string };
-        let snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+        let snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
@@ -206,7 +206,7 @@ describe('Picker, sync', () => {
 
         el.value = 'option-2';
         await elementUpdated(el);
-        snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+        snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
@@ -227,7 +227,7 @@ describe('Picker, sync', () => {
 
         await elementUpdated(el);
         type NamedNode = { name: string };
-        let snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+        let snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
@@ -241,7 +241,7 @@ describe('Picker, sync', () => {
 
         el.value = '2';
         await elementUpdated(el);
-        snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+        snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
@@ -252,6 +252,24 @@ describe('Picker, sync', () => {
             ),
             '`name` is the label text plus the selected item text'
         ).to.not.be.null;
+    });
+
+    it('manages `aria-activedescendant`', async () => {
+        const el = await pickerFixture();
+        await elementUpdated(el);
+        const firstItem = el.querySelector('sp-menu-item:nth-child(1)');
+        const secondItem = el.querySelector('sp-menu-item:nth-child(2)');
+        const opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+        expect(el.optionsMenu.getAttribute('aria-activedescendant')).to.equal(
+            firstItem?.id
+        );
+        await sendKeys({ press: 'ArrowDown' });
+        await elementUpdated(el);
+        expect(el.optionsMenu.getAttribute('aria-activedescendant')).to.equal(
+            secondItem?.id
+        );
     });
 
     it('loads accessibly w/ slotted label', async () => {

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -192,7 +192,7 @@ describe('Picker', () => {
 
         await elementUpdated(el);
         type NamedNode = { name: string };
-        let snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+        let snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
@@ -206,7 +206,7 @@ describe('Picker', () => {
 
         el.value = 'option-2';
         await elementUpdated(el);
-        snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+        snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
@@ -227,7 +227,7 @@ describe('Picker', () => {
 
         await elementUpdated(el);
         type NamedNode = { name: string };
-        let snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+        let snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
@@ -241,7 +241,7 @@ describe('Picker', () => {
 
         el.value = '2';
         await elementUpdated(el);
-        snapshot = ((await a11ySnapshot({})) as unknown) as NamedNode & {
+        snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
@@ -252,6 +252,24 @@ describe('Picker', () => {
             ),
             '`name` is the label text plus the selected item text'
         ).to.not.be.null;
+    });
+
+    it('manages `aria-activedescendant`', async () => {
+        const el = await pickerFixture();
+        await elementUpdated(el);
+        const firstItem = el.querySelector('sp-menu-item:nth-child(1)');
+        const secondItem = el.querySelector('sp-menu-item:nth-child(2)');
+        const opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+        expect(el.optionsMenu.getAttribute('aria-activedescendant')).to.equal(
+            firstItem?.id
+        );
+        await sendKeys({ press: 'ArrowDown' });
+        await elementUpdated(el);
+        expect(el.optionsMenu.getAttribute('aria-activedescendant')).to.equal(
+            secondItem?.id
+        );
     });
 
     it('loads accessibly w/ slotted label', async () => {


### PR DESCRIPTION
## Description
Reduce the work done when focusing a Menu Item so that iOS + Voice Over doesn't thing you've left the interface by the time a Menu Item has fully received focus.
- refrain from cycles focus calls
- focus first selected, instead of last, upon Menu entry
- show `:focus-visible` styling on `Tab` key entry
- while leveraging `activedescendent` pattern surface only one tab stop per Menu root
- manage `aria-activedescendent` on Menu root

## Related issue(s)
- fixes #1766
- fixes #1767 

## Motivation and context
Accessibly surfacing this functionality in Safari for iOS with Voice Over.

## How has this been tested?
- [x] unit tests
- [x] updated VRT cache
-   [ ] _Test case 1_
    1. Go to https://picker-a11y--spectrum-web-components.netlify.app/components/menu
    2. Use the `Tab` key until you should focus a Menu
    3. See that the first item (or first selected item) is visibly focused
-   [ ] _Test case 2_
    1. Go to https://picker-a11y--spectrum-web-components.netlify.app/components/menu
    2. Use the `Tab` key until you enter the `selects="inherit"` example
    3. Press tab ONE more time
    4. See that focus has left the menu (e.g. there was only one tab stop)
-   [ ] _Test case 3_
    1. Using iOS Safari with Voice Over activated
    2. Go to https://picker-a11y--spectrum-web-components.netlify.app/components/menu
    3. Swipe right to a Picker element
    4. Double tap to enter the Picker's option list
    5. Swipe right and left through the option list
    6. Ensure that Voice Over reads each and every item in the options list

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
