### PR TITLE
fix: ensure lazily loaded focusElements do not crash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 171a620091bc04af0bdddf0457df1c4c8eaf50d6
+        default: 4dd1cb3933d1d5b8b542916d0b8e775a1d5a397e
 commands:
     downstream:
         steps:

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -164,8 +164,9 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
     }
 
     public blur(): void {
-        if (this.focusElement !== this) {
-            this.focusElement.blur();
+        const focusElement = this.focusElement || this;
+        if (focusElement !== this) {
+            focusElement.blur();
         } else {
             HTMLElement.prototype.blur.apply(this);
         }
@@ -176,8 +177,9 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
             return;
         }
 
-        if (this.focusElement !== this) {
-            this.focusElement.click();
+        const focusElement = this.focusElement || this;
+        if (focusElement !== this) {
+            focusElement.click();
         } else {
             HTMLElement.prototype.click.apply(this);
         }

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -183,6 +183,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                           step=${this.step}
                           value=${this.value}
                           ?hide-stepper=${this.hideStepper}
+                          ?disabled=${this.disabled}
                           @input=${this.handleNumberInput}
                           @change=${this.handleNumberChange}
                       ></sp-number-field>

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -17,11 +17,13 @@ import { Slider, SliderHandle, HandleValues, variants } from '../';
 import { TemplateResult } from '@spectrum-web-components/base';
 import { spreadProps } from '@open-wc/lit-helpers';
 
-const action = (msg1: string) => (msg2: string | HandleValues): void => {
-    const message =
-        typeof msg2 === 'string' ? msg2 : JSON.stringify(msg2, null, 2);
-    console.log(msg1, message);
-};
+const action =
+    (msg1: string) =>
+    (msg2: string | HandleValues): void => {
+        const message =
+            typeof msg2 === 'string' ? msg2 : JSON.stringify(msg2, null, 2);
+        console.log(msg1, message);
+    };
 
 export default {
     component: 'sp-slider',
@@ -203,6 +205,13 @@ class NumberFieldDefined extends HTMLElement {
 
 customElements.define('number-field-defined', NumberFieldDefined);
 
+const editableDecorator = (story: () => TemplateResult): TemplateResult => {
+    return html`
+        ${story()}
+        <number-field-defined></number-field-defined>
+    `;
+};
+
 export const editable = (args: StoryArgs): TemplateResult => {
     const handleEvent = (event: Event): void => {
         const target = event.target as Slider;
@@ -233,14 +242,40 @@ export const editable = (args: StoryArgs): TemplateResult => {
     `;
 };
 
-editable.decorators = [
-    (story: () => TemplateResult): TemplateResult => {
-        return html`
-            ${story()}
-            <number-field-defined></number-field-defined>
-        `;
-    },
-];
+editable.decorators = [editableDecorator];
+
+export const editableDisabled = (args: StoryArgs): TemplateResult => {
+    const handleEvent = (event: Event): void => {
+        const target = event.target as Slider;
+        if (target.value != null) {
+            action(event.type)(target.value.toString());
+        }
+    };
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                editable
+                disabled
+                max="360"
+                min="0"
+                value="90"
+                step="1"
+                @input=${handleEvent}
+                @change=${handleEvent}
+                .formatOptions=${{
+                    style: 'unit',
+                    unit: 'degree',
+                    unitDisplay: 'narrow',
+                }}
+                ...=${spreadProps(args)}
+            >
+                Angle
+            </sp-slider>
+        </div>
+    `;
+};
+
+editable.decorators = [editableDecorator];
 
 export const editableCustom = (args: StoryArgs): TemplateResult => {
     const handleEvent = (event: Event): void => {
@@ -270,14 +305,7 @@ export const editableCustom = (args: StoryArgs): TemplateResult => {
     `;
 };
 
-editableCustom.decorators = [
-    (story: () => TemplateResult): TemplateResult => {
-        return html`
-            ${story()}
-            <number-field-defined></number-field-defined>
-        `;
-    },
-];
+editableCustom.decorators = [editableDecorator];
 
 export const hideStepper = (args: StoryArgs): TemplateResult => {
     const handleEvent = (event: Event): void => {
@@ -306,14 +334,7 @@ export const hideStepper = (args: StoryArgs): TemplateResult => {
     `;
 };
 
-hideStepper.decorators = [
-    (story: () => TemplateResult): TemplateResult => {
-        return html`
-            ${story()}
-            <number-field-defined></number-field-defined>
-        `;
-    },
-];
+hideStepper.decorators = [editableDecorator];
 
 export const Gradient = (args: StoryArgs): TemplateResult => {
     const handleEvent = (event: Event): void => {

--- a/packages/slider/test/slider-editable-sync.test.ts
+++ b/packages/slider/test/slider-editable-sync.test.ts
@@ -43,6 +43,24 @@ describe('Slider - editable, sync', () => {
         await expect(el).to.be.accessible();
     });
 
+    it('loads - [disabled]', async () => {
+        const el = document.createElement('sp-slider');
+        el.editable = true;
+        el.disabled = true;
+        el.label = 'Disabled, editable, slider';
+
+        try {
+            document.body.append(el);
+        } catch (error) {
+            expect(true).to.be.false;
+        }
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+        el.remove();
+    });
+
     it('focuses `<sp-number-field>` directly', async () => {
         const el = await sliderFromFixture(editable);
 

--- a/packages/slider/test/slider-editable.test.ts
+++ b/packages/slider/test/slider-editable.test.ts
@@ -43,6 +43,24 @@ describe('Slider - editable', () => {
         await expect(el).to.be.accessible();
     });
 
+    it('loads - [disabled]', async () => {
+        const el = document.createElement('sp-slider');
+        el.editable = true;
+        el.disabled = true;
+        el.label = 'Disabled, editable, slider';
+
+        try {
+            document.body.append(el);
+        } catch (error) {
+            expect(true).to.be.false;
+        }
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+        el.remove();
+    });
+
     it('focuses `<sp-number-field>` directly', async () => {
         const el = await sliderFromFixture(editable);
 


### PR DESCRIPTION
## Description
When `disabled` and `editable` a Slider element attempts to blur a grand child element that has yet to be rendered causing a crash. Number Fields in `sp-slider[editable]` elements are the first to be loaded lazily but will likely not be the last, this adds affordances for this. Additional, testing and demos are added as well.

## Related issue(s)
- #1775 

## Motivation and context
Elements shouldn't crash.

## How has this been tested?
- unit tests
- VRTs
-   [ ] _Test case 1_
    1. Go to https://slider-editable-disabled--spectrum-web-components.netlify.app/storybook/?path=/story/slider--editable-disabled
    2. Ensure there are no errors in the console.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.