### PR TITLE
fix: allow contextmenu event passing to pierce shadow roots

### DIFF
--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -664,8 +664,32 @@ export const superComplexModal = (): TemplateResult => {
     `;
 };
 
+class StartEndContextmenu extends HTMLElement {
+    shadowRoot!: ShadowRoot;
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = `
+            <style>
+                :host {
+                    display: flex;
+                    align-items: stretch;
+                }
+                div {
+                    width: 50%;
+                    height: 100%;
+                }
+            </style>
+            <div id="start"></div>
+            <div id="end"></div>
+        `;
+    }
+}
+
+customElements.define('start-end-contextmenu', StartEndContextmenu);
+
 export const virtualElement = (args: Properties): TemplateResult => {
-    const contextMenuTemplate = (): TemplateResult => html`
+    const contextMenuTemplate = (kind = ''): TemplateResult => html`
         <sp-popover
             style="max-width: 33vw;"
             @click=${(event: Event) =>
@@ -674,22 +698,27 @@ export const virtualElement = (args: Properties): TemplateResult => {
                 )}
         >
             <sp-menu>
-                <sp-menu-item>Deselect</sp-menu-item>
-                <sp-menu-item>Select inverse</sp-menu-item>
-                <sp-menu-item>Feather...</sp-menu-item>
-                <sp-menu-item>Select and mask...</sp-menu-item>
-                <sp-menu-divider></sp-menu-divider>
-                <sp-menu-item>Save selection</sp-menu-item>
-                <sp-menu-item disabled>Make work path</sp-menu-item>
+                <sp-menu-group>
+                    <span slot="header">Menu source: ${kind}</span>
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item>Select inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and mask...</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Save selection</sp-menu-item>
+                    <sp-menu-item disabled>Make work path</sp-menu-item>
+                </sp-menu-group>
             </sp-menu>
         </sp-popover>
     `;
     const pointerenter = async (event: PointerEvent): Promise<void> => {
         event.preventDefault();
+        const source = event.composedPath()[0] as HTMLDivElement;
+        const { id } = source;
         const trigger = event.target as HTMLElement;
         const virtualTrigger = new VirtualTrigger(event.clientX, event.clientY);
         const fragment = document.createDocumentFragment();
-        render(contextMenuTemplate(), fragment);
+        render(contextMenuTemplate(id), fragment);
         const popover = fragment.querySelector('sp-popover') as Popover;
         openOverlay(trigger, 'modal', popover, {
             placement: args.placement,
@@ -704,7 +733,10 @@ export const virtualElement = (args: Properties): TemplateResult => {
                 inset: 0;
             }
         </style>
-        <div class="app-root" @contextmenu=${pointerenter}></div>
+        <start-end-contextmenu
+            class="app-root"
+            @contextmenu=${pointerenter}
+        ></start-end-contextmenu>
     `;
 };
 

--- a/packages/overlay/test/overlay.test.ts
+++ b/packages/overlay/test/overlay.test.ts
@@ -535,14 +535,14 @@ describe('Overlay - contextmenu', () => {
             steps: [
                 {
                     type: 'move',
-                    position: [width / 2, height / 2],
+                    position: [width / 2 + 50, height / 2],
                 },
                 {
                     type: 'click',
                     options: {
                         button: 'right',
                     },
-                    position: [width / 2, height / 2],
+                    position: [width / 2 + 50, height / 2],
                 },
             ],
         });
@@ -550,8 +550,12 @@ describe('Overlay - contextmenu', () => {
         const firstOverlay = document.querySelector(
             'active-overlay'
         ) as ActiveOverlay;
+        const firstHeadline = firstOverlay.querySelector(
+            '[slot="header"]'
+        ) as HTMLSpanElement;
         expect(firstOverlay, 'first overlay').to.not.be.null;
         expect(firstOverlay.isConnected).to.be.true;
+        expect(firstHeadline.textContent).to.equal('Menu source: end');
         const closed = oneEvent(document, 'sp-closed');
         opened = oneEvent(document, 'sp-opened');
         // Right click to out of the "context menu" overlay to both close
@@ -577,9 +581,13 @@ describe('Overlay - contextmenu', () => {
         const secondOverlay = document.querySelector(
             'active-overlay'
         ) as ActiveOverlay;
+        const secondHeadline = secondOverlay.querySelector(
+            '[slot="header"]'
+        ) as HTMLSpanElement;
         expect(secondOverlay, 'second overlay').to.not.be.null;
         expect(secondOverlay).to.not.equal(firstOverlay);
         expect(firstOverlay.isConnected).to.be.false;
         expect(secondOverlay.isConnected).to.be.true;
+        expect(secondHeadline.textContent).to.equal('Menu source: start');
     });
 });


### PR DESCRIPTION
## Description
Walk down shadow roots to ensure that `contextmenu` events passed to the underlying page actually hit the element at the point where the pointer interacted with the page regardless of what shadow tree it might exist in.

Thanks @OpportunityLiu for pointing this out!

## Related issue(s)
- fixes #1790

## Motivation and context
Full power `contextmenu` passing.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go to https://contextmenu-piercing--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--virtual-element&args=placement:right-end;offset:0;colorStop:light
    2. Make a "context" click (right button) on the left half of the page.
    3. Ensure that the overlay says "Menu Source: Start"
    4. **While still open**, make a "context" click on the right half of the page.
    5. Ensure that the overlay says "Menu Source: End"

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.