### PR TITLE
chore: warn about slotting in a single sp-slider-handle

### DIFF
--- a/packages/slider/slider-handle.md
+++ b/packages/slider/slider-handle.md
@@ -1,7 +1,12 @@
 ## Description
 
 Some advanced slider uses require more than one handle. One example of this is the
-range slider above. `sp-slider` supports an arbitrary number of handles via the `<sp-slider-handle>` sub-component, although it would be very rare to ever require more than two handles.
+range slider above. `<sp-slider>` supports multiple handles via the `<sp-slider-handle>` sub-component, although it would be very rare to ever require more than two handles.
+
+### Single Handles
+
+`<sp-slider-handle>` is unnecessary for single-handle sliders. Always slot two or more `<sp-slider-handle>` components together.
+To customize the properties of a single-handle slider (`normalization`, `value`, etc), set them on the `<sp-slider>` element directly.
 
 ### Usage
 


### PR DESCRIPTION
## Description

Document the limitation discovered in https://github.com/adobe/spectrum-web-components/issues/1781

## Related issue

https://github.com/adobe/spectrum-web-components/issues/1781

## Motivation and context

It's not currently clear that `<sp-slider-handle>` must be added to `<sp-slider>` in groups of two or more.

## How has this been tested?

1. visit https://add-single-slider-handle-warning--spectrum-web-components.netlify.app/components/slider-handle

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
