### PR TITLE
feat(color-area): separate X and Y aria labels to improve accessibility

### DIFF
--- a/packages/color-area/README.md
+++ b/packages/color-area/README.md
@@ -63,3 +63,17 @@ An `<sp-color-area>`’s height and width can be customized appropriately for it
         height: var(--spectrum-global-dimension-size-900)"
 ></sp-color-area>
 ```
+
+## Labels
+
+An `<sp-color-area>` renders accessible labels for each axis: _"saturation"_ and _"luminosity"_.
+Specify `label-x` and `label-y` attributes to override these defaults.
+
+The `label` attribute is **deprecated** in favor of separately labeling each axis.
+
+```html
+<sp-color-area
+    label-x="Color intensity"
+    label-y="Color brightness"
+></sp-color-area>
+```

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -49,7 +49,13 @@ export class ColorArea extends SpectrumElement {
     public focused = false;
 
     @property({ type: String })
-    public label = 'saturation and luminosity';
+    public label: string | undefined;
+
+    @property({ type: String, attribute: 'label-x' })
+    public labelX = 'saturation';
+
+    @property({ type: String, attribute: 'label-y' })
+    public labelY = 'luminosity';
 
     @query('.handle')
     private handle!: ColorHandle;
@@ -498,7 +504,7 @@ export class ColorArea extends SpectrumElement {
                     type="range"
                     class="slider"
                     name="x"
-                    aria-label=${this.label}
+                    aria-label=${this.label ?? this.labelX}
                     min="0"
                     max="1"
                     step=${this.step}
@@ -513,7 +519,7 @@ export class ColorArea extends SpectrumElement {
                     type="range"
                     class="slider"
                     name="y"
-                    aria-label=${this.label}
+                    aria-label=${this.label ?? this.labelY}
                     min="0"
                     max="1"
                     step=${this.step}

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -97,6 +97,33 @@ describe('ColorArea', () => {
         });
         expect(document.activeElement, 'before input again').to.equal(input1);
     });
+    it('provides separate aria-labels for X and Y inputs', async () => {
+        const el = await fixture<ColorArea>(
+            html`
+                <sp-color-area color="hsl(100, 50%, 50%)"></sp-color-area>
+            `
+        );
+        const inputX = el.shadowRoot.querySelector('input[name="x"]');
+        const inputY = el.shadowRoot.querySelector('input[name="y"]');
+
+        expect(inputX?.getAttribute('aria-label')).to.equal('saturation');
+        expect(inputY?.getAttribute('aria-label')).to.equal('luminosity');
+    });
+    it('overrides both X and Y labels with a provided "label" attribute', async () => {
+        const el = await fixture<ColorArea>(
+            html`
+                <sp-color-area
+                    color="hsl(100, 50%, 50%)"
+                    label="something custom"
+                ></sp-color-area>
+            `
+        );
+        const inputX = el.shadowRoot.querySelector('input[name="x"]');
+        const inputY = el.shadowRoot.querySelector('input[name="y"]');
+
+        expect(inputX?.getAttribute('aria-label')).to.equal('something custom');
+        expect(inputY?.getAttribute('aria-label')).to.equal('something custom');
+    });
     it('accepts "color" values as hsl', async () => {
         const el = await fixture<ColorArea>(
             html`


### PR DESCRIPTION
## Description

This provides distinct aria labels for the X and Y inputs so that accessibility tools can expose them as `${saturation}, saturation` and `${luminosity}, luminosity` instead of `${saturation_or_luminosity}, saturation and luminosity`.

To ensure backwards-compatibility, so that this can be shipped as a non-breaking change, if the developer specifies a `label` attribute, it will override the `label-x` and `label-y` attributes, maintaining previous behavior.

## Related issue(s)

resolves https://github.com/adobe/spectrum-web-components/issues/1768

## Motivation and context

This makes the Color Area component accessible to users who cannot use its visual representation on a 2D graphic.

## How has this been tested?

1. go to https://separate-color-area-labels--spectrum-web-components.netlify.app/components/color-area
2. activate VoiceOver
3. ensure that you can independently read and edit the saturation / luminosity values in a color area

## Screenshots

https://user-images.githubusercontent.com/364501/133684327-7488d1b0-5935-4d79-ad87-0138e53f62c5.mov

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
