### PR TITLE
fix: correct add/remove timing of overlay events

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -43,6 +43,7 @@ export class OverlayStack {
     private trappingInited = false;
     private tabTrapper!: HTMLElement;
     private overlayHolder!: HTMLElement;
+    private _eventsAreBound = false;
 
     private initTabTrapping(): void {
         /* c8 ignore next 4 */
@@ -187,21 +188,12 @@ export class OverlayStack {
     }
 
     private addEventListeners(): void {
+        if (this._eventsAreBound) return;
+        this._eventsAreBound = true;
         this.document.addEventListener('click', this.handleMouseCapture, true);
         this.document.addEventListener('click', this.handleMouse);
         this.document.addEventListener('keyup', this.handleKeyUp);
         window.addEventListener('resize', this.handleResize);
-    }
-
-    private removeEventListeners(): void {
-        this.document.removeEventListener(
-            'click',
-            this.handleMouseCapture,
-            true
-        );
-        this.document.removeEventListener('click', this.handleMouse);
-        this.document.removeEventListener('keyup', this.handleKeyUp);
-        window.removeEventListener('resize', this.handleResize);
     }
 
     private isClickOverlayActiveForTrigger(trigger: HTMLElement): boolean {
@@ -211,9 +203,7 @@ export class OverlayStack {
     }
 
     public async openOverlay(details: OverlayOpenDetail): Promise<boolean> {
-        if (!this.overlays.length) {
-            this.addEventListeners();
-        }
+        this.addEventListeners();
         if (this.findOverlayForContent(details.content)) {
             return false;
         }
@@ -477,10 +467,6 @@ export class OverlayStack {
                     },
                 })
             );
-
-            if (!this.overlays.length) {
-                this.removeEventListeners();
-            }
         }
     }
 


### PR DESCRIPTION
## Description
Close the hole that exists between adding and removing overlay events due to events being added at the beginning of an asynchronous process and them being removed at the end of another which could prevent users from being able to close overlays after interactions of a specific timing.

## Motivation and context
Overlays should be closable.

## How has this been tested?

-   See unit test, it's difficult to recreate the context that causes this without a fairly complex user interface

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.