### PR TITLE
fix: ensure "click" on "NumpadEnter" key press

### DIFF
--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -163,6 +163,7 @@ export class ButtonBase extends LikeAnchor(
         const { code } = event;
         switch (code) {
             case 'Enter':
+            case 'NumpadEnter':
                 this.click();
                 break;
             default:

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -63,7 +63,7 @@ describe('Button', () => {
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
         expect(el.textContent).to.include('Button');
-        expect(!((el as unknown) as { hasIcon: boolean }).hasIcon);
+        expect(!(el as unknown as { hasIcon: boolean }).hasIcon);
         await expect(el).to.be.accessible();
     });
     it('loads default only icon', async () => {
@@ -112,7 +112,7 @@ describe('Button', () => {
 
         await elementUpdated(el);
 
-        const labelTestableEl = (el as unknown) as TestableButtonType;
+        const labelTestableEl = el as unknown as TestableButtonType;
 
         expect(labelTestableEl.hasLabel, 'starts with label').to.be.true;
 
@@ -309,6 +309,20 @@ describe('Button', () => {
                 bubbles: true,
                 composed: true,
                 cancelable: true,
+                code: 'NumpadEnter',
+                key: 'NumpadEnter',
+            })
+        );
+
+        await elementUpdated(el);
+        expect(clickSpy.callCount).to.equal(1);
+        clickSpy.resetHistory();
+
+        el.dispatchEvent(
+            new KeyboardEvent('keypress', {
+                bubbles: true,
+                composed: true,
+                cancelable: true,
                 code: 'Space',
                 key: 'Space',
             })
@@ -451,9 +465,11 @@ describe('Button', () => {
         );
 
         await elementUpdated(el);
-        ((el as unknown) as {
-            anchorElement: HTMLAnchorElement;
-        }).anchorElement.addEventListener('click', (event: Event): void => {
+        (
+            el as unknown as {
+                anchorElement: HTMLAnchorElement;
+            }
+        ).anchorElement.addEventListener('click', (event: Event): void => {
             event.preventDefault();
             event.stopPropagation();
             clickSpy();


### PR DESCRIPTION
## Description
Listen for `NumpadEnter` keypresses, too.

## Related issue(s)
- fixes #1799 

## Motivation and context
Full keyboard support!

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go https://numpad-enter--spectrum-web-components.netlify.app/components/button
    2. Keyboard focus the "Handling events" button that says "Click me"
    3. Press the `Enter` key
    4. See a click registered in the toast
    5. Press the `NumpadEnter` key (`fn + Enter` on a Mac keyboard)
    6. See a click registered in the toast

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.