### PR TITLE
docs: extend accessible content guidance

### DIFF
--- a/packages/action-group/README.md
+++ b/packages/action-group/README.md
@@ -24,16 +24,41 @@ When looking to leverage the `ActionGroup` base class as a type and/or for exten
 import { ActionGroup } from '@spectrum-web-components/action-group';
 ```
 
+## Example
+
+```html
+<sp-action-group>
+    <sp-action-button>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Button 1
+    </sp-action-button>
+    <sp-action-button>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Longer Button 2
+    </sp-action-button>
+    <sp-action-button>
+        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+        Short 3
+    </sp-action-button>
+</sp-action-group>
+```
+
 ## Selects
 
 An `<sp-action-group selects="single|multiple">` will manage a `selected` property that consists on an array of the `<sp-action-button>` children that are currently selected. A `change` event is dispatched from the `<sp-action-group>` element when the value of `selected` is updated. This event can be canceled via `event.preventDefault()`, after which the value of `selected` will be returned to what it was previously.
+
+When a selection can be made, it is a good idea to supply the group of options with accessible text that names the group of buttons. This can be done in a non-visual way via the `label` attribute of the `<sp-action-group>` element. You can also associate the `<sp-action-group>` to a second, visible DOM element via the `aria-labelledby` attribute or, when available, via the `for` attribute on the second element to make the association in the other direction.
 
 ### Single
 
 An `<sp-action-group selects="single">` will manage its `<sp-action-button>` children as "radio buttons" allowing the user to select a _single_ one of the buttons presented. The `<sp-action-button>` children will only be able to turn their `selected` value on while maintaining a single selection after an intial selection is made.
 
 ```html
-<sp-action-group selects="single" emphasized>
+<sp-action-group
+    selects="single"
+    emphasized
+    label="Single Selection Demo Group"
+>
     <sp-action-button>
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Button 1
@@ -54,7 +79,11 @@ An `<sp-action-group selects="single">` will manage its `<sp-action-button>` chi
 An `<sp-action-group selects="multiple">` will manage its `<sp-action-button>` children as "chekboxes" allowing the user to select a _multiple_ of the buttons presented. The `<sp-action-button>` children will toggle their `selected` value on and off when clicked sucessively.
 
 ```html
-<sp-action-group selects="multiple" emphasized>
+<sp-action-group
+    selects="multiple"
+    emphasized
+    label="Multiple Selection Demo Group"
+>
     <sp-action-button selected>
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
         Button 1
@@ -70,7 +99,9 @@ An `<sp-action-group selects="multiple">` will manage its `<sp-action-button>` c
 </sp-action-group>
 ```
 
-## Default
+## Horizontal
+
+By default, an `<sp-action-group>` will organize its child buttons horizontally and the delivery of those buttons can be modified with the `compact`, `emphasized`, or `quiet` attributes.
 
 ```html
 <sp-action-group>
@@ -115,7 +146,7 @@ An `<sp-action-group selects="multiple">` will manage its `<sp-action-button>` c
     </sp-action-button>
 </sp-action-group>
 <br />
-<sp-action-group compact>
+<sp-action-group compact emphasized>
     <sp-action-button label="Zoom in">
         <sp-icon-magnify slot="icon"></sp-icon-magnify>
     </sp-action-button>
@@ -129,6 +160,8 @@ An `<sp-action-group selects="multiple">` will manage its `<sp-action-button>` c
 ```
 
 ## Vertical
+
+The use of the `vertical` attribute instructs the `<sp-action-group>` element to organize its child buttons vertically, while accepting the same `compact`, `emphasized`, and `quiet` attributes as modifiers.
 
 ```html
 <div style="display: flex; justify-content: space-around;">
@@ -186,6 +219,8 @@ An `<sp-action-group selects="multiple">` will manage its `<sp-action-button>` c
 ```
 
 ## Justified
+
+The `justified` attribute will cause the `<sp-action-group>` element to fill the available horizontal space and evenly distribute that space across its child button elements.
 
 ```html
 <sp-action-group justified>


### PR DESCRIPTION
## Description
Include documentation around labelling Action Group elements.

## Related issue(s)

- fixes #1419

## Motivation and context
Content should be accessible!

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://action-group-label--spectrum-web-components.netlify.app/components/action-group
    2. Consumer new label delivery documentation
-   [ ] _Test case 2_
    1. Go to  https://action-group-label--spectrum-web-components.netlify.app/components/action-group
    2. Visit the two `selects` demos with a screen reader
    3. Experience the label `Single Selection Demo Group` and `Multiple Selection Demo Group` being associated to the two groups.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.