### PR TITLE
fix: use type="search" for nicer virtual keyboards

### DIFF
--- a/documentation/src/components/side-nav-search.ts
+++ b/documentation/src/components/side-nav-search.ts
@@ -149,6 +149,15 @@ class SearchComponent extends LitElement {
         }
     }
 
+    handleSubmit(event: Event): void {
+        event.preventDefault();
+        if (this.results.length < 0 || !this.searchResultsPopover) return;
+        const popoverMenu = this.searchResultsPopover.querySelector(
+            'sp-menu'
+        ) as Menu;
+        popoverMenu.focus();
+    }
+
     render(): TemplateResult {
         return html`
             <div id="search-container">
@@ -157,6 +166,7 @@ class SearchComponent extends LitElement {
                         @input=${this.handleSearchInput}
                         @change=${this.handleSearchInput}
                         @keydown=${this.handleKeydown}
+                        @submit=${this.handleSubmit}
                         autocomplete="off"
                     ></sp-search>
                 </div>

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -37,7 +37,7 @@ export class Search extends Textfield {
     }
 
     @property()
-    public action?: string;
+    public action = '';
 
     @property()
     public label = 'Search';
@@ -94,7 +94,7 @@ export class Search extends Textfield {
     protected render(): TemplateResult {
         return html`
             <form
-                action=${ifDefined(this.action)}
+                action=${this.action}
                 id="form"
                 method=${ifDefined(this.method)}
                 @submit=${this.handleSubmit}
@@ -118,6 +118,11 @@ export class Search extends Textfield {
                     : html``}
             </form>
         `;
+    }
+
+    public firstUpdated(changedProperties: PropertyValues): void {
+        super.firstUpdated(changedProperties);
+        this.inputElement.setAttribute('type', 'search');
     }
 
     public updated(changedProperties: PropertyValues): void {

--- a/packages/search/src/search.css
+++ b/packages/search/src/search.css
@@ -11,3 +11,7 @@ governing permissions and limitations under the License.
 */
 
 @import './spectrum-search.css';
+
+input::-webkit-search-cancel-button {
+    display: none;
+}


### PR DESCRIPTION
## Description
Ensure that attributes are applied correctly to deliver the "Search" button in a mobile virtual keyboard.
- add `type="search"`
- apply `action` attribute to the `<form>` even when unavailable

## Related issue(s)

- fixes #1752 

## Motivation and context
Easier use of the element in mobile.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://type-search--spectrum-web-components.netlify.app/ in mobile
    2. Open the nav drawer
    3. Type into the search field `Test`
    4. See a modified "Go"/"Submit" button
    5. Press it
    6. See that the focus has been moved into the search results on "submit"
-   [ ] _Test case 2_
    1. Go to https://type-search--spectrum-web-components.netlify.app/components/search
    2. Tap into one of the search fields
    3. See that the virtual keyboard surfaces a "Search" button

## Screenshots (if appropriate)
![Image from iOS (1)](https://user-images.githubusercontent.com/1156657/135357640-f7bfb226-7d0b-4707-91be-44f96675802a.png)

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.