### PR TITLE
docs: use latest Storybook Prebuilt and leverage the actions addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
         "yargs": "^17.0.1"
     },
     "resolutions": {
-        "@web/storybook-prebuilt": "0.1.26-alpha.1",
+        "@web/storybook-prebuilt": "0.1.27-alpha.0",
         "cssnano/**/postcss-calc": "7.0.0",
         "playwright": "1.13.0"
     },

--- a/packages/checkbox/stories/checkbox-sizes.stories.ts
+++ b/packages/checkbox/stories/checkbox-sizes.stories.ts
@@ -16,58 +16,75 @@ import '../sp-checkbox.js';
 export default {
     component: 'sp-checkbox',
     title: 'Checkbox/Sizes',
+    argTypes: {
+        onClick: { action: 'click' },
+        onChange: { action: 'change' },
+    },
 };
 
 const checkbox = ({
     size,
     checked,
     indeterminate,
+    onClick,
+    onChange,
 }: {
     size: 's' | 'm' | 'l' | 'xl';
     checked?: boolean;
     indeterminate?: boolean;
+    onClick: () => void;
+    onChange: () => void;
 }): TemplateResult => {
     return html`
         <sp-checkbox
             size=${size}
             ?checked=${checked}
             ?indeterminate=${indeterminate}
-            @click="${() => console.log('Click')}"
-            @change="${() => console.log('Change')}"
+            @click="${onClick}"
+            @change="${onChange}"
         >
             Checkbox
         </sp-checkbox>
     `;
 };
 
-export const s = (): TemplateResult => checkbox({ size: 's' });
+type StoryArgs = {
+    onClick: () => void;
+    onChange: () => void;
+};
 
-export const sChecked = (): TemplateResult =>
-    checkbox({ size: 's', checked: true });
+export const s = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 's' });
 
-export const sIndeterminate = (): TemplateResult =>
-    checkbox({ size: 's', indeterminate: true });
+export const sChecked = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 's', checked: true });
 
-export const m = (): TemplateResult => checkbox({ size: 'm' });
+export const sIndeterminate = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 's', indeterminate: true });
 
-export const mChecked = (): TemplateResult =>
-    checkbox({ size: 'm', checked: true });
+export const m = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'm' });
 
-export const mIndeterminate = (): TemplateResult =>
-    checkbox({ size: 'm', indeterminate: true });
+export const mChecked = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'm', checked: true });
 
-export const l = (): TemplateResult => checkbox({ size: 'l' });
+export const mIndeterminate = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'm', indeterminate: true });
 
-export const lChecked = (): TemplateResult =>
-    checkbox({ size: 'l', checked: true });
+export const l = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'l' });
 
-export const lIndeterminate = (): TemplateResult =>
-    checkbox({ size: 'l', indeterminate: true });
+export const lChecked = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'l', checked: true });
 
-export const XL = (): TemplateResult => checkbox({ size: 'xl' });
+export const lIndeterminate = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'l', indeterminate: true });
 
-export const XLChecked = (): TemplateResult =>
-    checkbox({ size: 'xl', checked: true });
+export const XL = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'xl' });
 
-export const XLIndeterminate = (): TemplateResult =>
-    checkbox({ size: 'xl', indeterminate: true });
+export const XLChecked = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'xl', checked: true });
+
+export const XLIndeterminate = (args: StoryArgs): TemplateResult =>
+    checkbox({ ...args, size: 'xl', indeterminate: true });

--- a/packages/color-area/stories/color-area.stories.ts
+++ b/packages/color-area/stories/color-area.stories.ts
@@ -21,6 +21,8 @@ export default {
     title: 'Color/Area',
     component: 'sp-color-area',
     argTypes: {
+        onInput: { action: 'input' },
+        onChange: { action: 'change' },
         color: {
             name: 'color',
             type: { name: 'ColorValue', required: 'true' },
@@ -34,17 +36,22 @@ export default {
     },
 };
 
-export const Default = (): TemplateResult => {
+type StoryArgs = {
+    onInput: (val: string) => void;
+    onChange: (val: string) => void;
+};
+
+export const Default = ({ onChange, onInput }: StoryArgs): TemplateResult => {
     return html`
         <sp-color-area
             @input=${({ target }: Event & { target: ColorArea }) => {
                 const next = target.nextElementSibling as HTMLElement;
                 next.textContent = target.color as string;
                 next.style.color = target.color as string;
-                console.log('input', target.value);
+                onInput(target.value as string);
             }}
             @change=${({ target }: Event & { target: ColorArea }) => {
-                console.log('change', target.value);
+                onChange(target.value as string);
             }}
         ></sp-color-area>
         <div style="color: #ff0000" aria-live="off">#ff0000</div>

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -18,15 +18,52 @@ import '@spectrum-web-components/overlay/overlay-trigger.js';
 import '../sp-dialog-wrapper.js';
 import { landscape } from './images.js';
 
-const action = (msg1: string) => (msg2: string | number): void =>
-    console.log(msg1, msg2);
 export default {
     title: 'Dialog Wrapped',
     component: 'sp-dialog-wrapper',
+    argTypes: {
+        onClose: { action: 'close' },
+        onConfirm: { action: 'confirm' },
+        onSecondary: { action: 'secondary' },
+        onCancel: { action: 'cancel' },
+    },
 };
 
-export const wrapperLabeledHero = (...args: unknown[]): TemplateResult => {
-    const context = (args[1] || {}) as { viewMode?: string };
+type StoryArgs = {
+    onClose?: (event: Event) => void;
+    onConfirm?: (event: Event) => void;
+    onSecondary?: (event: Event) => void;
+    onCancel?: (event: Event) => void;
+};
+
+const handleClose =
+    ({ onClose }: StoryArgs) =>
+    (event: Event) => {
+        if (onClose) onClose(event);
+    };
+
+const handleConfirm =
+    ({ onConfirm }: StoryArgs) =>
+    (event: Event) => {
+        if (onConfirm) onConfirm(event);
+    };
+
+const handleSecondary =
+    ({ onSecondary }: StoryArgs) =>
+    (event: Event) => {
+        if (onSecondary) onSecondary(event);
+    };
+
+const handleCancel =
+    ({ onCancel }: StoryArgs) =>
+    (event: Event) => {
+        if (onCancel) onCancel(event);
+    };
+
+export const wrapperLabeledHero = (
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
+): TemplateResult => {
     const open = context.viewMode === 'docs' ? false : true;
     return html`
         <sp-dialog-wrapper
@@ -35,7 +72,7 @@ export const wrapperLabeledHero = (...args: unknown[]): TemplateResult => {
             hero-label="Hero Image Alt Text"
             dismissable
             headline="Wrapped Dialog w/ Hero Image"
-            @close=${action('close')}
+            @close=${handleClose(args)}
             size="s"
         >
             Content of the dialog
@@ -50,22 +87,17 @@ export const wrapperLabeledHero = (...args: unknown[]): TemplateResult => {
 };
 
 export const wrapperDismissable = (
-    { actionTracking = true } = {},
+    args: StoryArgs = {},
     context: { viewMode?: string } = {}
 ): TemplateResult => {
     const open = context.viewMode === 'docs' ? false : true;
-    const announceAction = actionTracking
-        ? action
-        : () => {
-              return;
-          };
     return html`
         <sp-dialog-wrapper
             ?open=${open}
             hero=${landscape}
             dismissable
             headline="Wrapped Dialog w/ Hero Image"
-            @close=${announceAction('close')}
+            @close=${handleClose(args)}
             size="s"
         >
             Content of the dialog
@@ -80,9 +112,9 @@ export const wrapperDismissable = (
 };
 
 export const wrapperDismissableUnderlay = (
-    ...args: unknown[]
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
 ): TemplateResult => {
-    const context = (args[1] || {}) as { viewMode?: string };
     const open = context.viewMode === 'docs' ? false : true;
     return html`
         <sp-button
@@ -97,7 +129,7 @@ export const wrapperDismissableUnderlay = (
             dismissable
             headline="Wrapped Dialog w/ Hero Image"
             underlay
-            @close=${action('close')}
+            @close=${handleClose(args)}
             size="s"
         >
             Content of the dialog
@@ -105,11 +137,18 @@ export const wrapperDismissableUnderlay = (
     `;
 };
 
-export const longContent = (...args: unknown[]): TemplateResult => {
-    const context = (args[1] || {}) as { viewMode?: string };
+export const longContent = (
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
+): TemplateResult => {
     const open = context.viewMode === 'docs' ? undefined : 'click';
     return html`
-        <overlay-trigger type="modal" placement="none" .open=${open}>
+        <overlay-trigger
+            type="modal"
+            placement="none"
+            @close=${handleClose(args)}
+            .open=${open}
+        >
             <sp-dialog-wrapper
                 slot="click-content"
                 headline="Dialog title"
@@ -219,9 +258,9 @@ export const longContent = (...args: unknown[]): TemplateResult => {
 };
 
 export const wrapperDismissableUnderlayError = (
-    ...args: unknown[]
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
 ): TemplateResult => {
-    const context = (args[1] || {}) as { viewMode?: string };
     const open = context.viewMode === 'docs' ? false : true;
     return html`
         <div>
@@ -238,7 +277,7 @@ export const wrapperDismissableUnderlayError = (
                 error
                 headline="Wrapped Dialog w/ Hero Image"
                 underlay
-                @close=${action('close')}
+                @close=${handleClose(args)}
                 size="s"
             >
                 Content of the dialog
@@ -248,15 +287,10 @@ export const wrapperDismissableUnderlayError = (
 };
 
 export const wrapperButtons = (
-    { actionTracking = true } = {},
+    args: StoryArgs = {},
     context: { viewMode?: string } = {}
 ): TemplateResult => {
     const open = context.viewMode === 'docs' ? false : true;
-    const announceAction = actionTracking
-        ? action
-        : () => {
-              return;
-          };
     return html`
         <sp-dialog-wrapper
             ?open=${open}
@@ -266,17 +300,20 @@ export const wrapperButtons = (
             secondary-label="Replace"
             cancel-label="Cancel"
             footer="Content for footer"
-            @confirm=${announceAction('confirm')}
-            @secondary=${announceAction('secondary')}
-            @cancel=${announceAction('cancel')}
+            @close=${handleClose(args)}
+            @confirm=${handleConfirm(args)}
+            @secondary=${handleSecondary(args)}
+            @cancel=${handleCancel(args)}
         >
             Content of the dialog
         </sp-dialog-wrapper>
     `;
 };
 
-export const wrapperButtonsUnderlay = (...args: unknown[]): TemplateResult => {
-    const context = (args[1] || {}) as { viewMode?: string };
+export const wrapperButtonsUnderlay = (
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
+): TemplateResult => {
     const open = context.viewMode === 'docs' ? false : true;
     return html`
         <sp-dialog-wrapper
@@ -288,17 +325,20 @@ export const wrapperButtonsUnderlay = (...args: unknown[]): TemplateResult => {
             secondary-label="Replace"
             cancel-label="Cancel"
             footer="Content for footer"
-            @confirm=${action('confirm')}
-            @secondary=${action('secondary')}
-            @cancel=${action('cancel')}
+            @close=${handleClose(args)}
+            @confirm=${handleConfirm(args)}
+            @secondary=${handleSecondary(args)}
+            @cancel=${handleCancel(args)}
         >
             Content of the dialog
         </sp-dialog-wrapper>
     `;
 };
 
-export const wrapperFullscreen = (...args: unknown[]): TemplateResult => {
-    const context = (args[1] || {}) as { viewMode?: string };
+export const wrapperFullscreen = (
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
+): TemplateResult => {
     const open = context.viewMode === 'docs' ? false : true;
     return html`
         <sp-dialog-wrapper
@@ -308,9 +348,10 @@ export const wrapperFullscreen = (...args: unknown[]): TemplateResult => {
             confirm-label="Keep Both"
             secondary-label="Replace"
             cancel-label="Cancel"
-            @confirm=${action('confirm')}
-            @secondary=${action('secondary')}
-            @cancel=${action('cancel')}
+            @close=${handleClose(args)}
+            @confirm=${handleConfirm(args)}
+            @secondary=${handleSecondary(args)}
+            @cancel=${handleCancel(args)}
         >
             Content of the dialog
         </sp-dialog-wrapper>

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -29,9 +29,7 @@ import {
 
 describe('Dialog Wrapper', () => {
     it('loads wrapped dialog accessibly', async () => {
-        const el = await fixture<DialogWrapper>(
-            wrapperDismissable({ actionTracking: false }, {})
-        );
+        const el = await fixture<DialogWrapper>(wrapperDismissable());
 
         await elementUpdated(el);
 
@@ -81,9 +79,7 @@ describe('Dialog Wrapper', () => {
         expect(el.open).to.be.true;
     });
     it('dismisses', async () => {
-        const el = await fixture<DialogWrapper>(
-            wrapperDismissable({ actionTracking: false }, {})
-        );
+        const el = await fixture<DialogWrapper>(wrapperDismissable());
 
         await elementUpdated(el);
         expect(el.open).to.be.true;
@@ -100,9 +96,7 @@ describe('Dialog Wrapper', () => {
         expect(el.open).to.be.false;
     });
     it('manages entry focus - dismissable', async () => {
-        const el = await fixture<DialogWrapper>(
-            wrapperDismissable({ actionTracking: false }, {})
-        );
+        const el = await fixture<DialogWrapper>(wrapperDismissable());
 
         await elementUpdated(el);
         expect(el.open).to.be.true;
@@ -128,9 +122,7 @@ describe('Dialog Wrapper', () => {
         expect(el.open).to.be.false;
     });
     it('manages entry focus - buttons', async () => {
-        const el = await fixture<DialogWrapper>(
-            wrapperButtons({ actionTracking: false }, {})
-        );
+        const el = await fixture<DialogWrapper>(wrapperButtons());
 
         await elementUpdated(el);
         expect(el.open).to.be.true;
@@ -154,9 +146,7 @@ describe('Dialog Wrapper', () => {
         const handleConfirm = (): void => confirmSpy();
         const handleCancel = (): void => cancelSpy();
         const handleSecondary = (): void => secondarySpy();
-        const el = await fixture<DialogWrapper>(
-            wrapperButtons({ actionTracking: false }, {})
-        );
+        const el = await fixture<DialogWrapper>(wrapperButtons());
         el.addEventListener('confirm', handleConfirm);
         el.addEventListener('cancel', handleCancel);
         el.addEventListener('secondary', handleSecondary);

--- a/packages/picker/stories/picker-sizes.stories.ts
+++ b/packages/picker/stories/picker-sizes.stories.ts
@@ -20,9 +20,22 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 export default {
     title: 'Picker/Sizes',
     component: 'sp-picker',
+    argTypes: {
+        onChange: { action: 'change' },
+    },
 };
 
-const picker = ({ size }: { size: 's' | 'm' | 'l' | 'xl' }): TemplateResult => {
+type StoryArgs = {
+    onChange: (val: string) => void;
+};
+
+const picker = ({
+    onChange,
+    size,
+}: {
+    onChange: (val: string) => void;
+    size: 's' | 'm' | 'l' | 'xl';
+}): TemplateResult => {
     return html`
         <sp-field-label for="picker-${size}" size=${size}>
             Where do you live?
@@ -32,7 +45,7 @@ const picker = ({ size }: { size: 's' | 'm' | 'l' | 'xl' }): TemplateResult => {
             size=${size}
             @change="${(event: Event): void => {
                 const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
+                onChange(picker.value);
             }}"
             label="Select a Country with a very long label, too long, in fact"
         >
@@ -47,10 +60,14 @@ const picker = ({ size }: { size: 's' | 'm' | 'l' | 'xl' }): TemplateResult => {
     `;
 };
 
-export const s = (): TemplateResult => picker({ size: 's' });
+export const s = (args: StoryArgs): TemplateResult =>
+    picker({ ...args, size: 's' });
 
-export const m = (): TemplateResult => picker({ size: 'm' });
+export const m = (args: StoryArgs): TemplateResult =>
+    picker({ ...args, size: 'm' });
 
-export const l = (): TemplateResult => picker({ size: 'l' });
+export const l = (args: StoryArgs): TemplateResult =>
+    picker({ ...args, size: 'l' });
 
-export const XL = (): TemplateResult => picker({ size: 'xl' });
+export const XL = (args: StoryArgs): TemplateResult =>
+    picker({ ...args, size: 'xl' });

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -33,6 +33,7 @@ export default {
         quiet: false,
     },
     argTypes: {
+        onChange: { action: 'change' },
         disabled: {
             name: 'disabled',
             type: { name: 'boolean', required: false },
@@ -87,17 +88,22 @@ interface StoryArgs {
     open?: boolean;
     quiet?: boolean;
     showText?: boolean;
+    onChange?: (val: string) => void;
 }
+
+const handleChange =
+    ({ onChange }: StoryArgs) =>
+    (event: Event): void => {
+        const picker = event.target as Picker;
+        if (onChange) onChange(picker.value);
+    };
 
 export const Default = (args: StoryArgs): TemplateResult => {
     return html`
         <sp-field-label for="picker-1">Where do you live?</sp-field-label>
         <sp-picker
             id="picker-1"
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             label="Select a Country with a very long label, too long, in fact"
             ...=${spreadProps(args)}
         >
@@ -125,10 +131,7 @@ export const quiet = (args: StoryArgs): TemplateResult => {
         <sp-picker
             ...=${spreadProps(args)}
             id="picker-quiet"
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             label="Pick an item"
         >
             <sp-menu-item value="1">Item 1</sp-menu-item>
@@ -157,10 +160,7 @@ export const icons = (args: StoryArgs): TemplateResult => {
         <sp-picker
             ...=${spreadProps(args)}
             id="picker-quiet"
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             label="Pick an action"
             value="1"
         >
@@ -188,10 +188,7 @@ export const iconsNone = (args: StoryArgs): TemplateResult => {
         <sp-picker
             ...=${spreadProps(args)}
             id="picker-quiet"
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             label="Pick an action"
             value="1"
             icons="none"
@@ -223,10 +220,7 @@ export const iconValue = (args: StoryArgs): TemplateResult => {
         <sp-picker
             ...=${spreadProps(args)}
             id="picker-quiet"
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             label="Pick an action"
             icons="only"
             style="--spectrum-picker-width: 100px"
@@ -256,10 +250,7 @@ export const iconsOnly = (args: StoryArgs): TemplateResult => {
         <sp-picker
             ...=${spreadProps(args)}
             id="picker-quiet"
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             label="Pick an action"
             style="--spectrum-picker-width: 100px"
             value="3"
@@ -297,10 +288,7 @@ export const Open = (args: StoryArgs): TemplateResult => {
                 id="picker-open"
                 label="Open picker"
                 ...=${spreadProps(args)}
-                @change="${(event: Event): void => {
-                    const picker = event.target as Picker;
-                    console.log(`Change: ${picker.value}`);
-                }}"
+                @change=${handleChange(args)}
             >
                 <span slot="label">
                     Select a Country with a very long label, too long, in fact
@@ -321,10 +309,7 @@ export const Open = (args: StoryArgs): TemplateResult => {
             <sp-picker
                 id="picker-closed"
                 label="Picker that displays below the options"
-                @change="${(event: Event): void => {
-                    const picker = event.target as Picker;
-                    console.log(`Change: ${picker.value}`);
-                }}"
+                @change=${handleChange(args)}
             >
                 <span slot="label">
                     Other menu that goes behind the open one
@@ -343,10 +328,7 @@ export const initialValue = (args: StoryArgs): TemplateResult => {
         <sp-field-label for="picker-initial">Where do you live?</sp-field-label>
         <sp-picker
             id="picker-initial"
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             value="item-2"
             ...=${spreadProps(args)}
         >
@@ -367,10 +349,7 @@ export const initialValue = (args: StoryArgs): TemplateResult => {
 export const readonly = (args: StoryArgs): TemplateResult => {
     return html`
         <sp-picker
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             readonly
             value="item-2"
             ...=${spreadProps(args)}
@@ -397,10 +376,7 @@ export const custom = (args: StoryArgs): TemplateResult => {
         </sp-field-label>
         <sp-picker
             style="width: 400px;"
-            @change="${(event: Event): void => {
-                const picker = event.target as Picker;
-                console.log(`Change: ${picker.value}`);
-            }}"
+            @change=${handleChange(args)}
             id="picker-state"
             label="Pick a state"
             ...=${spreadProps(args)}

--- a/packages/sidenav/stories/sidenav.stories.ts
+++ b/packages/sidenav/stories/sidenav.stories.ts
@@ -9,23 +9,27 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { html } from 'lit-html';
+import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '../sp-sidenav.js';
 import '../sp-sidenav-item.js';
 import '../sp-sidenav-heading.js';
-import { TemplateResult } from '@spectrum-web-components/base';
 
-const action = (msg1: string) => (msg2: string | number): void =>
-    console.log(msg1, msg2);
 export default {
     component: 'sp-sidenav',
     title: 'Sidenav',
+    argTypes: {
+        onChange: { action: 'change' },
+    },
 };
 
-export const Default = (): TemplateResult => {
+export const Default = ({
+    onChange,
+}: {
+    onChange: () => void;
+}): TemplateResult => {
     return html`
-        <sp-sidenav @change=${action('select')} value="Section 2">
+        <sp-sidenav @change=${onChange} value="Section 2">
             <sp-sidenav-item
                 value="Section 1"
                 label="Section 1"
@@ -49,13 +53,13 @@ export const Default = (): TemplateResult => {
     `;
 };
 
-export const Multilevel = (): TemplateResult => {
+export const Multilevel = ({
+    onChange,
+}: {
+    onChange: () => void;
+}): TemplateResult => {
     return html`
-        <sp-sidenav
-            variant="multilevel"
-            value="2.3.1"
-            @change=${action('select')}
-        >
+        <sp-sidenav variant="multilevel" value="2.3.1" @change=${onChange}>
             <sp-sidenav-item value="foo" label="foo"></sp-sidenav-item>
             <sp-sidenav-item value="baz" label="baz" expanded>
                 <sp-sidenav-item value="2.1" label="2.1"></sp-sidenav-item>
@@ -130,9 +134,13 @@ export const manageTabIndex = (): TemplateResult => {
     `;
 };
 
-export const Hrefs = (): TemplateResult => {
+export const Hrefs = ({
+    onChange,
+}: {
+    onChange: () => void;
+}): TemplateResult => {
     return html`
-        <sp-sidenav @change=${action('select')} value="current">
+        <sp-sidenav @change=${onChange} value="current">
             <sp-sidenav-heading label="GITHUB">
                 <sp-sidenav-item
                     href=${window.location.href}

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -9,26 +9,19 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { html } from 'lit-html';
+import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '../sp-slider.js';
 import '../sp-slider-handle.js';
-import { Slider, SliderHandle, HandleValues, variants } from '../';
-import { TemplateResult } from '@spectrum-web-components/base';
+import { Slider, SliderHandle, variants } from '../';
 import { spreadProps } from '@open-wc/lit-helpers';
-
-const action =
-    (msg1: string) =>
-    (msg2: string | HandleValues): void => {
-        const message =
-            typeof msg2 === 'string' ? msg2 : JSON.stringify(msg2, null, 2);
-        console.log(msg1, message);
-    };
 
 export default {
     component: 'sp-slider',
     title: 'Slider',
     argTypes: {
+        onInput: { action: 'input' },
+        onChange: { action: 'change' },
         variant: {
             name: 'Variant',
             description: 'Determines the style of slider.',
@@ -75,15 +68,45 @@ export interface StoryArgs {
     variant?: string;
     tickStep?: number;
     labelVisibility?: string;
+    onInput?: (val: string) => void;
+    onChange?: (val: string) => void;
 }
 
-export const Default = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
+const handleEvent =
+    ({ onInput, onChange }: StoryArgs) =>
+    (event: Event): void => {
+        const { value } = event.target as Slider;
+        if (onInput && event.type === 'input') {
+            onInput(value.toString());
+        } else if (onChange && event.type === 'change') {
+            onChange(value.toString());
         }
     };
+
+const handleHandleEvent =
+    ({ onInput, onChange }: StoryArgs) =>
+    (event: Event): void => {
+        const target = event.target as SliderHandle;
+        if (target.value != null) {
+            if (typeof target.value === 'object') {
+                const value = JSON.stringify(target.value, null, 2);
+                if (onInput && event.type === 'input') {
+                    onInput(value);
+                } else if (onChange && event.type === 'change') {
+                    onChange(value);
+                }
+            } else {
+                const value = `${target.name}: ${target.value}`;
+                if (onInput && event.type === 'input') {
+                    onInput(value);
+                } else if (onChange && event.type === 'change') {
+                    onChange(value);
+                }
+            }
+        }
+    };
+
+export const Default = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -91,8 +114,8 @@ export const Default = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value=".5"
                 step="0.01"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{ style: 'percent' }}
                 ...=${spreadProps(args)}
             >
@@ -102,13 +125,7 @@ export const Default = (args: StoryArgs): TemplateResult => {
     `;
 };
 
-export const noVisibleTextLabel = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const noVisibleTextLabel = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -116,8 +133,8 @@ export const noVisibleTextLabel = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value=".5"
                 step="0.01"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{ style: 'percent' }}
                 ...=${spreadProps(args)}
             >
@@ -130,13 +147,7 @@ noVisibleTextLabel.args = {
     labelVisibility: 'value',
 };
 
-export const noVisibleValueLabel = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const noVisibleValueLabel = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -144,8 +155,8 @@ export const noVisibleValueLabel = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value=".5"
                 step="0.01"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{ style: 'percent' }}
                 ...=${spreadProps(args)}
             >
@@ -158,13 +169,7 @@ noVisibleValueLabel.args = {
     labelVisibility: 'text',
 };
 
-export const noVisibleLabels = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const noVisibleLabels = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -172,8 +177,8 @@ export const noVisibleLabels = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value=".5"
                 step="0.01"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{ style: 'percent' }}
                 ...=${spreadProps(args)}
             >
@@ -186,13 +191,7 @@ noVisibleLabels.args = {
     labelVisibility: 'none',
 };
 
-export const px = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const px = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -200,8 +199,8 @@ export const px = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value="90"
                 step="1"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{
                     style: 'unit',
                     unit: 'px',
@@ -240,13 +239,7 @@ const editableDecorator = (story: () => TemplateResult): TemplateResult => {
     `;
 };
 
-export const editable = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const editable = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -255,8 +248,8 @@ export const editable = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value="90"
                 step="1"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{
                     style: 'unit',
                     unit: 'degree',
@@ -272,13 +265,7 @@ export const editable = (args: StoryArgs): TemplateResult => {
 
 editable.decorators = [editableDecorator];
 
-export const editableDisabled = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const editableDisabled = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -288,8 +275,8 @@ export const editableDisabled = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value="90"
                 step="1"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{
                     style: 'unit',
                     unit: 'degree',
@@ -305,13 +292,7 @@ export const editableDisabled = (args: StoryArgs): TemplateResult => {
 
 editable.decorators = [editableDecorator];
 
-export const editableCustom = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const editableCustom = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div
             style="width: 500px; margin: 12px 20px; --spectrum-slider-editable-number-field-width: 150px;"
@@ -322,8 +303,8 @@ export const editableCustom = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value="12.75"
                 step="0.25"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{ style: 'unit', unit: 'hour' }}
                 ...=${spreadProps(args)}
             >
@@ -335,13 +316,7 @@ export const editableCustom = (args: StoryArgs): TemplateResult => {
 
 editableCustom.decorators = [editableDecorator];
 
-export const hideStepper = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const hideStepper = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -351,8 +326,8 @@ export const hideStepper = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value=".5"
                 step="0.01"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 .formatOptions=${{ style: 'percent' }}
                 ...=${spreadProps(args)}
             >
@@ -364,13 +339,7 @@ export const hideStepper = (args: StoryArgs): TemplateResult => {
 
 hideStepper.decorators = [editableDecorator];
 
-export const Gradient = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as Slider;
-        if (target.value != null) {
-            action(event.type)(target.value.toString());
-        }
-    };
+export const Gradient = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div
             style="
@@ -386,8 +355,8 @@ export const Gradient = (args: StoryArgs): TemplateResult => {
                 min="0"
                 value="50"
                 id="opacity-slider"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
                 ...=${spreadProps(args)}
             ></sp-slider>
         </div>
@@ -397,7 +366,7 @@ Gradient.args = {
     variant: undefined,
 };
 
-export const tick = (args: StoryArgs): TemplateResult => {
+export const tick = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <sp-slider
             label="Slider Label"
@@ -413,7 +382,7 @@ tick.args = {
     tickStep: 5,
 };
 
-export const Disabled = (args: StoryArgs): TemplateResult => {
+export const Disabled = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -429,25 +398,15 @@ export const Disabled = (args: StoryArgs): TemplateResult => {
     `;
 };
 
-export const ExplicitHandle = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as SliderHandle;
-        if (target.value != null) {
-            if (typeof target.value === 'object') {
-                action(event.type)(target.value);
-            } else {
-                action(event.type)(`${target.name}: ${target.value}`);
-            }
-        }
-    };
+export const ExplicitHandle = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
                 step="0.5"
                 min="0"
                 max="20"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleHandleEvent(args)}
+                @change=${handleHandleEvent(args)}
                 ...=${spreadProps(args)}
             >
                 Intensity
@@ -457,17 +416,7 @@ export const ExplicitHandle = (args: StoryArgs): TemplateResult => {
     `;
 };
 
-export const TwoHandles = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as SliderHandle;
-        if (target.value != null) {
-            if (typeof target.value === 'object') {
-                action(event.type)(target.value);
-            } else {
-                action(event.type)(`${target.name}: ${target.value}`);
-            }
-        }
-    };
+export const TwoHandles = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -475,8 +424,8 @@ export const TwoHandles = (args: StoryArgs): TemplateResult => {
                 step="1"
                 min="0"
                 max="255"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleHandleEvent(args)}
+                @change=${handleHandleEvent(args)}
                 ...=${spreadProps(args)}
             >
                 Output Levels
@@ -499,17 +448,7 @@ TwoHandles.args = {
     tickStep: 10,
 };
 
-export const TwoHandlesPt = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as SliderHandle;
-        if (target.value != null) {
-            if (typeof target.value === 'object') {
-                action(event.type)(target.value);
-            } else {
-                action(event.type)(`${target.name}: ${target.value}`);
-            }
-        }
-    };
+export const TwoHandlesPt = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -517,8 +456,8 @@ export const TwoHandlesPt = (args: StoryArgs): TemplateResult => {
                 step="1"
                 min="0"
                 max="255"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleHandleEvent(args)}
+                @change=${handleHandleEvent(args)}
                 .formatOptions=${{
                     style: 'unit',
                     unit: 'pt',
@@ -545,17 +484,7 @@ TwoHandlesPt.args = {
     tickStep: 10,
 };
 
-export const ThreeHandlesPc = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as SliderHandle;
-        if (target.value != null) {
-            if (typeof target.value === 'object') {
-                action(event.type)(target.value);
-            } else {
-                action(event.type)(`${target.name}: ${target.value}`);
-            }
-        }
-    };
+export const ThreeHandlesPc = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
@@ -563,8 +492,8 @@ export const ThreeHandlesPc = (args: StoryArgs): TemplateResult => {
                 step="1"
                 min="0"
                 max="255"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleHandleEvent(args)}
+                @change=${handleHandleEvent(args)}
                 .formatOptions=${{
                     style: 'unit',
                     unit: 'pc',
@@ -580,25 +509,15 @@ export const ThreeHandlesPc = (args: StoryArgs): TemplateResult => {
     `;
 };
 
-export const ThreeHandlesOrdered = (args: StoryArgs): TemplateResult => {
-    const handleEvent = (event: Event): void => {
-        const target = event.target as SliderHandle;
-        if (target.value != null) {
-            if (typeof target.value === 'object') {
-                action(event.type)(target.value);
-            } else {
-                action(event.type)(`${target.name}: ${target.value}`);
-            }
-        }
-    };
+export const ThreeHandlesOrdered = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">
             <sp-slider
                 step="1"
                 min="0"
                 max="255"
-                @input=${handleEvent}
-                @change=${handleEvent}
+                @input=${handleHandleEvent(args)}
+                @change=${handleHandleEvent(args)}
                 ...=${spreadProps(args)}
             >
                 Output Levels
@@ -656,23 +575,35 @@ ThreeHandlesOrdered.args = {
 // One iteresting thing to note is that the normalization function
 // can also be used to enforce clamping.
 //
-export const ThreeHandlesComplex = (args: StoryArgs): TemplateResult => {
+export const ThreeHandlesComplex = (args: StoryArgs = {}): TemplateResult => {
     const values: { [key: string]: number } = {
         black: 50,
         gray: 4.98,
         white: 225,
     };
-    const handleEvent = (event: Event): void => {
-        const target = event.target as SliderHandle;
-        if (target.value != null) {
-            if (typeof target.value === 'object') {
-                action(event.type)(target.value);
-            } else {
-                action(event.type)(`${target.name}: ${target.value}`);
+    const handleEvent =
+        ({ onInput, onChange }: StoryArgs) =>
+        (event: Event): void => {
+            const target = event.target as SliderHandle;
+            if (target.value != null) {
+                if (typeof target.value === 'object') {
+                    const value = JSON.stringify(target.value, null, 2);
+                    if (onInput && event.type === 'input') {
+                        onInput(value);
+                    } else if (onChange && event.type === 'change') {
+                        onChange(value);
+                    }
+                } else {
+                    const value = `${target.name}: ${target.value}`;
+                    if (onInput && event.type === 'input') {
+                        onInput(value);
+                    } else if (onChange && event.type === 'change') {
+                        onChange(value);
+                    }
+                }
+                values[target.name] = target.value;
             }
-            values[target.name] = target.value;
-        }
-    };
+        };
     const grayNormalization = {
         toNormalized(value: number) {
             const normalizedBlack = values.black / 255;
@@ -772,7 +703,7 @@ ThreeHandlesOrdered.args = {
     tickStep: 10,
 };
 
-export const focusTabDemo = (args: StoryArgs): TemplateResult => {
+export const focusTabDemo = (args: StoryArgs = {}): TemplateResult => {
     const value = 50;
     const min = 0;
     const max = 100;

--- a/packages/slider/test/slider-editable-sync.test.ts
+++ b/packages/slider/test/slider-editable-sync.test.ts
@@ -12,16 +12,16 @@ governing permissions and limitations under the License.
 
 import '../sync/sp-slider.js';
 import { Slider } from '../';
-import { editable, hideStepper, StoryArgs } from '../stories/slider.stories.js';
+import { editable, hideStepper } from '../stories/slider.stories.js';
 import { fixture, elementUpdated, expect } from '@open-wc/testing';
 import { TemplateResult } from '@spectrum-web-components/base';
 import { sendKeys } from '@web/test-runner-commands';
 import { spy } from 'sinon';
 
 async function sliderFromFixture(
-    sliderFixture: (args: StoryArgs) => TemplateResult
+    sliderFixture: () => TemplateResult
 ): Promise<Slider> {
-    const el = await fixture<Slider>(sliderFixture({}));
+    const el = await fixture<Slider>(sliderFixture());
     const slider = el.querySelector('sp-slider') as Slider;
     return slider;
 }

--- a/packages/split-button/stories/split-button.stories.ts
+++ b/packages/split-button/stories/split-button.stories.ts
@@ -10,30 +10,38 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { TemplateResult } from '@spectrum-web-components/base';
-import { html } from 'lit-html';
+import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '../sp-split-button.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 
-const action = (msg: string) => (): void => console.log(msg);
-
 export default {
     title: 'Split Button',
     component: 'sp-split-button',
+    argTypes: {
+        onFirstItem: { action: 'click: "Option 1"' },
+        onSecondItem: { action: 'click: "Option Extended"' },
+        onThirdItem: { action: 'click: "Short"' },
+    },
+};
+
+type StoryArgs = {
+    onFirstItem?: () => void;
+    onSecondItem?: () => void;
+    onThirdItem?: () => void;
 };
 
 const menu = ({
-    firstItemHandler = action('click "Option 1"'),
-    secondItemHandler = action('click "Option Extended"'),
-    thirdItemHandler = action('click "Short"'),
-}): TemplateResult => html`
-    <sp-menu-item @click=${firstItemHandler}>Option 1</sp-menu-item>
-    <sp-menu-item @click=${secondItemHandler}>Option Extended</sp-menu-item>
-    <sp-menu-item @click=${thirdItemHandler}>Short</sp-menu-item>
+    onFirstItem,
+    onSecondItem,
+    onThirdItem,
+}: StoryArgs): TemplateResult => html`
+    <sp-menu-item @click=${onFirstItem}>Option 1</sp-menu-item>
+    <sp-menu-item @click=${onSecondItem}>Option Extended</sp-menu-item>
+    <sp-menu-item @click=${onThirdItem}>Short</sp-menu-item>
 `;
 
-export const cta = (options = {}): TemplateResult => {
+export const cta = (options: StoryArgs = {}): TemplateResult => {
     return html`
         <div>
             <sp-split-button>${menu(options)}</sp-split-button>
@@ -46,7 +54,7 @@ cta.story = {
     name: 'Field, variant: CTA',
 };
 
-export const ctaOpen = (options = {}): TemplateResult => {
+export const ctaOpen = (options: StoryArgs = {}): TemplateResult => {
     return html`
         <div>
             <sp-split-button open>${menu(options)}</sp-split-button>
@@ -58,7 +66,7 @@ ctaOpen.story = {
     name: 'Field, Open, variant: CTA',
 };
 
-export const primary = (options = {}): TemplateResult => {
+export const primary = (options: StoryArgs = {}): TemplateResult => {
     return html`
         <div>
             <sp-split-button variant="primary">
@@ -75,7 +83,7 @@ primary.story = {
     name: 'Field, variant: Primary',
 };
 
-export const secondary = (options = {}): TemplateResult => {
+export const secondary = (options: StoryArgs = {}): TemplateResult => {
     return html`
         <div>
             <sp-split-button variant="secondary">
@@ -92,7 +100,7 @@ secondary.story = {
     name: 'Field, variant: Secondary',
 };
 
-export const moreCta = (options = {}): TemplateResult => {
+export const moreCta = (options: StoryArgs = {}): TemplateResult => {
     return html`
         <div>
             <sp-split-button type="more">${menu(options)}</sp-split-button>
@@ -105,7 +113,7 @@ moreCta.story = {
     name: 'More, variant: CTA',
 };
 
-export const moreCtaOpen = (options = {}): TemplateResult => {
+export const moreCtaOpen = (options: StoryArgs = {}): TemplateResult => {
     return html`
         <div>
             <sp-split-button type="more" open>${menu(options)}</sp-split-button>
@@ -117,7 +125,7 @@ moreCtaOpen.story = {
     name: 'More, Open, variant: CTA',
 };
 
-export const morePrimary = (options = {}): TemplateResult => {
+export const morePrimary = (options: StoryArgs = {}): TemplateResult => {
     return html`
         <div>
             <sp-split-button type="more" variant="primary">
@@ -134,7 +142,7 @@ morePrimary.story = {
     name: 'More, variant: Primary',
 };
 
-export const moreSecondary = (options = {}): TemplateResult => {
+export const moreSecondary = (options: StoryArgs = {}): TemplateResult => {
     return html`
         <div>
             <sp-split-button type="more" variant="secondary">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4809,10 +4809,10 @@
   dependencies:
     "@web/polyfills-loader" "^1.1.0"
 
-"@web/storybook-prebuilt@0.1.26-alpha.1", "@web/storybook-prebuilt@^0.1.24-alpha.1":
-  version "0.1.26-alpha.1"
-  resolved "https://registry.yarnpkg.com/@web/storybook-prebuilt/-/storybook-prebuilt-0.1.26-alpha.1.tgz#58f5d14b806c7c5179e012a566113ab018d3aef8"
-  integrity sha512-N/UVggJc9QniUVqm5nfwj0tgp/vMao95VXrBmwIhp14jl3E7lWPsNmPNBZtC0PU6+I5Td/PMjfR65E80mfG3OA==
+"@web/storybook-prebuilt@0.1.27-alpha.0", "@web/storybook-prebuilt@^0.1.24-alpha.1":
+  version "0.1.27-alpha.0"
+  resolved "https://registry.yarnpkg.com/@web/storybook-prebuilt/-/storybook-prebuilt-0.1.27-alpha.0.tgz#e524850f8308ef41ab72ed1d98feb1013309412b"
+  integrity sha512-4SQBDWAOh4x4vgMBb0hE4g8h1otGzIghAZc5D13duSEY6K0VeJrB09b273MQbq1mQFta48p47NwKSt0nOZTfqQ==
 
 "@web/test-runner-chrome@^0.10.2", "@web/test-runner-chrome@^0.10.3":
   version "0.10.3"


### PR DESCRIPTION
## Description
Less `console.log()` and more built in features of Storybook makes testing simpler.

## Motivation and context
`console.log()` leaks into shared contexts where the CSF exports are leveraged, like tests.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://storybook--spectrum-web-components.netlify.app/storybook/index.html?path=/story/checkbox-sizes--s
    2. Toggle the checkbox
    3. See `change` and `click` reports in the "Actions" tab
-   [ ] _Test case 2_
    1. Go to https://storybook--spectrum-web-components.netlify.app/storybook/index.html?path=/story/color-area--default
    2. Drag the color handle around
    3. See `input` repots in the "Actions" tab
- Etc.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.