### PR TITLE
fix(textfield): respect resize styling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 606c73d79c7ee9d2bee8111338c1612f156cae31
+        default: 0abc68c15a87e8658ec16e004aa6eb8a5a638529
 commands:
     downstream:
         steps:

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -12,6 +12,14 @@ governing permissions and limitations under the License.
 
 @import './spectrum-textfield.css';
 
+:host([multiline]) {
+    resize: both;
+}
+
+textarea {
+    resize: inherit;
+}
+
 :host([grows]) .input {
     position: absolute;
     top: 0;

--- a/packages/textfield/stories/textarea.stories.ts
+++ b/packages/textfield/stories/textarea.stories.ts
@@ -105,3 +105,26 @@ export const readonly = (): TemplateResult => html`
         placeholder="Enter your life story"
     ></sp-textfield>
 `;
+
+export const resizeControls = (): TemplateResult => html`
+    <sp-textfield
+        multiline
+        style="resize: none;"
+        label="No resize control"
+        placeholder="No resize control"
+    ></sp-textfield>
+
+    <sp-textfield
+        multiline
+        style="resize: vertical;"
+        label="Vertical resize control"
+        placeholder="Vertical resize control"
+    ></sp-textfield>
+
+    <sp-textfield
+        multiline
+        style="resize: horizontal;"
+        label="Horizontal resize control"
+        placeholder="Horizontal resize control"
+    ></sp-textfield>
+`;

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 import '../sp-textfield.js';
 import { Textfield } from '../';
 import { litFixture, html, elementUpdated, expect } from '@open-wc/testing';
-import { sendKeys } from '@web/test-runner-commands';
+import { sendKeys, executeServerCommand } from '@web/test-runner-commands';
 
 describe('Textfield', () => {
     it('loads default textfield accessibly', async () => {
@@ -102,6 +102,89 @@ describe('Textfield', () => {
             ? el.shadowRoot.querySelector('textarea')
             : null;
         expect(input).to.not.be.null;
+    });
+    it('resizes by default', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    multiline
+                    label="No resize control"
+                    placeholder="No resize control"
+                ></sp-textfield>
+            `
+        );
+        const startBounds = el.getBoundingClientRect();
+
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        startBounds.right - 2,
+                        startBounds.bottom - 2,
+                    ],
+                },
+                {
+                    type: 'down',
+                },
+                {
+                    type: 'move',
+                    position: [
+                        startBounds.right + 50,
+                        startBounds.bottom + 50,
+                    ],
+                },
+                {
+                    type: 'up',
+                },
+            ],
+        });
+
+        const endBounds = el.getBoundingClientRect();
+        expect(endBounds.width).to.be.greaterThan(startBounds.width);
+        expect(endBounds.height).to.be.greaterThan(startBounds.height);
+    });
+    it('accepts resize styling', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    multiline
+                    style="resize: none;"
+                    label="No resize control"
+                    placeholder="No resize control"
+                ></sp-textfield>
+            `
+        );
+        const startBounds = el.getBoundingClientRect();
+
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        startBounds.right - 2,
+                        startBounds.bottom - 2,
+                    ],
+                },
+                {
+                    type: 'down',
+                },
+                {
+                    type: 'move',
+                    position: [
+                        startBounds.right + 50,
+                        startBounds.bottom + 50,
+                    ],
+                },
+                {
+                    type: 'up',
+                },
+            ],
+        });
+
+        const endBounds = el.getBoundingClientRect();
+        expect(endBounds.width).equals(startBounds.width);
+        expect(endBounds.height).equals(startBounds.height);
     });
     it('grows', async () => {
         const el = await litFixture<Textfield>(


### PR DESCRIPTION
## Description

Allow users to specify `<sp-textfield style="resize: none|both|horizontal|vertical;">`.

## Related issue(s)

Resolves https://github.com/adobe/spectrum-web-components/issues/1700

## Motivation and context

Otherwise, all multiline textfields are resizable.

## How has this been tested?

1. go to https://support-textfield-resize-none--spectrum-web-components.netlify.app/storybook/?path=/story/textarea--default
2. ensure that your browser does show resize controls
3. go to https://support-textfield-resize-none--spectrum-web-components.netlify.app/storybook/?path=/story/textarea--resize-controls
4. ensure that your browser doesn't show resize controls for the first textfield
5. `yarn test`

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/364501/136064137-29a5d744-ba29-4677-868a-7e345bc2287a.png)


## Types of changes

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
