### PR TITLE
fix(overlay): traverse up through shadow roots when determining parent overlay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 0abc68c15a87e8658ec16e004aa6eb8a5a638529
+        default: 98857fb2d60e7430041e1038f605d259192520c8
 commands:
     downstream:
         steps:

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -113,6 +113,18 @@ const stateTransition = (
     return stateMachine.states[state].on[event] || state;
 };
 
+const parentOverlayOf = (el: Element): ActiveOverlay | null => {
+    const closestOverlay = el.closest('active-overlay');
+    if (closestOverlay) {
+        return closestOverlay;
+    }
+    const rootNode = el.getRootNode() as ShadowRoot;
+    if (rootNode.host) {
+        return parentOverlayOf(rootNode.host);
+    }
+    return null;
+};
+
 /**
  * @element active-overlay
  *
@@ -216,7 +228,7 @@ export class ActiveOverlay extends SpectrumElement {
 
     public feature(): void {
         this.tabIndex = -1;
-        const parentOverlay = this.trigger.closest('active-overlay');
+        const parentOverlay = parentOverlayOf(this.trigger);
         const parentIsModal = parentOverlay && parentOverlay.slot === 'open';
         // If an overlay it triggered from within a "modal" overlay, it needs to continue
         // to act like one to get treated correctly in regards to tab trapping.
@@ -237,7 +249,7 @@ export class ActiveOverlay extends SpectrumElement {
             this.removeAttribute('slot');
             // Obscure upto and including the next modal root.
             if (this.interaction !== 'modal') {
-                const parentOverlay = this.trigger.closest('active-overlay');
+                const parentOverlay = parentOverlayOf(this.trigger);
                 this._modalRoot = parentOverlay?.obscure(
                     nextOverlayInteraction
                 );

--- a/packages/overlay/stories/overlay-story-components.ts
+++ b/packages/overlay/stories/overlay-story-components.ts
@@ -28,6 +28,7 @@ import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/radio/sp-radio.js';
 import '@spectrum-web-components/radio/sp-radio-group.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
+import { Picker } from '@spectrum-web-components/picker';
 
 // Prevent infinite recursion in browser
 const MAX_DEPTH = 7;
@@ -304,3 +305,74 @@ class RecursivePopover extends LitElement {
     }
 }
 customElements.define('recursive-popover', RecursivePopover);
+
+export class PopoverContent extends LitElement {
+    @query('sp-picker')
+    public picker!: Picker;
+
+    render(): TemplateResult {
+        return html`
+            <sp-field-label for="picker1">Test</sp-field-label>
+
+            <sp-picker id="picker1" focusable .label=${'test'}>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+            </sp-picker>
+
+            <sp-field-label for="picker2">Test2</sp-field-label>
+
+            <sp-picker id="picker2" focusable .label=${'test'}>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+            </sp-picker>
+
+            <sp-field-label for="picker3">Test 3</sp-field-label>
+
+            <sp-picker id="picker3" focusable .label=${'test'}>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+                <sp-menu-item value=${'timeSinceLastSynced'}>
+                    ${'test'}
+                </sp-menu-item>
+            </sp-picker>
+        `;
+    }
+}
+
+customElements.define('popover-content', PopoverContent);

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -792,3 +792,14 @@ export const detachedElement = (): TemplateResult => {
         </sp-action-button>
     `;
 };
+
+export const definedOverlayElement = (): TemplateResult => {
+    return html`
+        <overlay-trigger placement="bottom" type="modal">
+            <sp-button variant="primary" slot="trigger">Open popover</sp-button>
+            <sp-popover slot="click-content" direction="bottom" dialog>
+                <popover-content></popover-content>
+            </sp-popover>
+        </overlay-trigger>
+    `;
+};


### PR DESCRIPTION
## Description![image](https://user-images.githubusercontent.com/1156657/136106677-28762f30-6d51-4a7f-bb0f-dbf0b588d6d4.png)The immediate parent overlay of a new overlay trigger might not share the same shadow tree, so be sure to step through the host node into the parent document when needed.

## Related issue(s)

- fixes #1833 

## Motivation and context
More use cases cover, more better!

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://modal-stack--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--defined-overlay-element&args=placement:bottom;offset:0;colorStop:light
    2. Open the popover
    3. Open a picker in the popover
    4. See that the picker options are placed _over_ the previously opened popover.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1156657/136106677-28762f30-6d51-4a7f-bb0f-dbf0b588d6d4.png)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
