### PR TITLE
fix(overlay): allow [type="modal"] hover overlays to be closed

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -77,8 +77,9 @@ export class OverlayTrigger extends LitElement {
 
     private handleClose(event?: CustomEvent<OverlayOpenCloseDetail>): void {
         if (
-            event?.detail.interaction !== this.open &&
-            event?.detail.interaction !== this.type
+            event &&
+            event.detail.interaction !== this.open &&
+            event.detail.interaction !== this.type
         ) {
             return;
         }

--- a/packages/overlay/test/overlay-trigger-hover.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover.test.ts
@@ -127,4 +127,40 @@ describe('Overlay Trigger - Hover', () => {
 
         expect(el.open).to.equal('longpress');
     });
+    it('closes `hover` overlay when [type="modal"]', async () => {
+        const el = await fixture<OverlayTrigger>(
+            (() => html`
+                <overlay-trigger placement="right-start" type="modal">
+                    <sp-action-button slot="trigger">
+                        <sp-icon-magnify slot="icon"></sp-icon-magnify>
+                    </sp-action-button>
+                    <sp-popover slot="hover-content" tip></sp-popover>
+                </overlay-trigger>
+            `)()
+        );
+        await elementUpdated(el);
+
+        expect(el.open).to.be.undefined;
+
+        const trigger = el.querySelector('[slot="trigger"]') as ActionButton;
+        trigger.dispatchEvent(
+            new Event('mouseenter', {
+                bubbles: true,
+            })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.open).to.equal('hover');
+
+        trigger.dispatchEvent(
+            new Event('mouseleave', {
+                bubbles: true,
+            })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.open).to.be.null;
+    });
 });


### PR DESCRIPTION
## Description
Allow hover content in an `<overlay-trigger type="modal">` parent to be closed.

## Related issue(s)

- fixes #1842

## Motivation and context
Should work as expected regardless of what other content to which it might be related.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://hover-modal--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--open-hover-content&args=placement:bottom;offset:0;colorStop:light
    2. Manually add `type="modal"` to the `<overlay-trigger>` element there in via DevTools
    3. See that the hover content opens and closes as expected.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
