### PR TITLE
Fix overlay open close symmetry

### DIFF
--- a/packages/overlay/src/loader.ts
+++ b/packages/overlay/src/loader.ts
@@ -19,5 +19,5 @@ export const openOverlay = async (
     options: OverlayOptions
 ): Promise<() => void> => {
     const { Overlay } = await import('./overlay.js');
-    return await Overlay.open(target, interaction, content, options);
+    return Overlay.open(target, interaction, content, options);
 };

--- a/packages/overlay/sync/overlay-trigger.ts
+++ b/packages/overlay/sync/overlay-trigger.ts
@@ -20,5 +20,5 @@ OverlayTrigger.openOverlay = async (
     content: HTMLElement,
     options: OverlayOptions
 ): Promise<() => void> => {
-    return await Overlay.open(target, interaction, content, options);
+    return Overlay.open(target, interaction, content, options);
 };

--- a/packages/overlay/test/overlay-trigger-hover-click.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover-click.test.ts
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { fixture, html, expect, oneEvent } from '@open-wc/testing';
+import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import { OverlayTrigger } from '../src/OverlayTrigger';
+import { TriggerInteractions } from '../src/overlay-types';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import { ActionButton } from '@spectrum-web-components/action-button';
+import { executeServerCommand } from '@web/test-runner-commands';
+
+describe('Overlay Trigger - Hover and Click', () => {
+    it('toggles open and closed on click', async () => {
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger>
+                <sp-button slot="trigger">Click and hover</sp-button>
+                <sp-popover slot="click-content" dialog tip>
+                    Popover content
+                </sp-popover>
+                <sp-tooltip slot="hover-content" delayed>
+                    Tooltip content
+                </sp-tooltip>
+            </overlay-trigger>
+        `);
+        const trigger = el.querySelector(
+            '[slot=trigger]'
+        ) as unknown as ActionButton;
+        let interaction: TriggerInteractions;
+
+        // repeatedly click to toggle the popover
+        for (let i = 0; i < 3; i++) {
+            const openedEvent = oneEvent(el, 'sp-opened');
+            trigger.click();
+            interaction = (await openedEvent).detail.interaction;
+
+            expect(interaction).equals('click');
+
+            const closedEvent = oneEvent(el, 'sp-closed');
+            trigger.click();
+            interaction = (await closedEvent).detail.interaction;
+
+            expect(interaction).equals('click');
+        }
+    });
+    it('toggles on click after hover', async () => {
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger>
+                <sp-button slot="trigger">Click and hover</sp-button>
+                <sp-popover slot="click-content" dialog tip>
+                    Popover content
+                </sp-popover>
+                <sp-tooltip slot="hover-content" delayed>
+                    Tooltip content
+                </sp-tooltip>
+            </overlay-trigger>
+        `);
+        const trigger = el.querySelector(
+            '[slot=trigger]'
+        ) as unknown as ActionButton;
+        const bounds = el.getBoundingClientRect();
+        let interaction: TriggerInteractions;
+
+        // hover over the button to trigger the tooltip
+        const hoveredEvent = oneEvent(el, 'sp-opened');
+        await executeServerCommand('send-mouse', {
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        bounds.left + bounds.width / 2,
+                        bounds.top + bounds.height / 2,
+                    ],
+                },
+            ],
+        });
+        interaction = (await hoveredEvent).detail.interaction;
+
+        expect(interaction).equals('hover');
+
+        // repeatedly click to toggle the popover
+        for (let i = 0; i < 3; i++) {
+            const openedEvent = oneEvent(el, 'sp-opened');
+            trigger.click();
+            interaction = (await openedEvent).detail.interaction;
+
+            expect(interaction).equals('click');
+
+            const closedEvent = oneEvent(el, 'sp-closed');
+            trigger.click();
+            interaction = (await closedEvent).detail.interaction;
+
+            expect(interaction).equals('click');
+        }
+    });
+});

--- a/packages/overlay/test/overlay-trigger-sync.test.ts
+++ b/packages/overlay/test/overlay-trigger-sync.test.ts
@@ -9,8 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { waitForPredicate, isVisible } from '../../../test/testing-helpers.js';
-import { spy } from 'sinon';
+import { isVisible } from '../../../test/testing-helpers.js';
 import {
     fixture,
     aTimeout,
@@ -23,12 +22,7 @@ import {
 } from '@open-wc/testing';
 
 import '../sync/overlay-trigger.js';
-import {
-    OverlayTrigger,
-    ActiveOverlay,
-    TriggerInteractions,
-    OverlayOpenCloseDetail,
-} from '../';
+import { OverlayTrigger, ActiveOverlay, TriggerInteractions } from '../';
 import '@spectrum-web-components/button/sp-button.js';
 import { Button } from '@spectrum-web-components/button';
 import '@spectrum-web-components/popover/sp-popover.js';
@@ -49,8 +43,9 @@ function pressKey(code: string): void {
 const pressEscape = (): void => pressKey('Escape');
 const pressSpace = (): void => pressKey('Space');
 
-describe('Overlay Trigger', () => {
+describe('Overlay Trigger - sync', () => {
     describe('open/close', () => {
+
         let testDiv!: HTMLDivElement;
         let innerTrigger!: OverlayTrigger;
         let outerTrigger!: OverlayTrigger;
@@ -61,6 +56,7 @@ describe('Overlay Trigger', () => {
         let hoverContent!: HTMLDivElement;
 
         beforeEach(async () => {
+
             testDiv = await fixture<HTMLDivElement>(
                 html`
                     <div>
@@ -129,7 +125,6 @@ describe('Overlay Trigger', () => {
                     </div>
                 `
             );
-            await elementUpdated(testDiv);
 
             innerTrigger = testDiv.querySelector(
                 '#inner-trigger'
@@ -149,6 +144,7 @@ describe('Overlay Trigger', () => {
         });
 
         afterEach(async () => {
+
             outerTrigger.removeAttribute('type');
             if (outerTrigger.open) {
                 const closed = oneEvent(outerTrigger, 'sp-closed');
@@ -164,6 +160,7 @@ describe('Overlay Trigger', () => {
         });
 
         it('loads', async () => {
+
             if (!(outerClickContent instanceof Popover))
                 throw new Error('popover is not an instance of Popover');
 
@@ -172,30 +169,20 @@ describe('Overlay Trigger', () => {
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
+
         });
 
         it('opens a popover', async () => {
-            const button = testDiv.querySelector(
-                '#outer-button'
-            ) as HTMLElement;
-            const outerPopover = testDiv.querySelector(
-                '#outer-popover'
-            ) as Popover;
+            expect(isVisible(outerClickContent)).to.be.false;
 
-            expect(isVisible(outerPopover)).to.be.false;
-
-            expect(button).to.exist;
-            button.click();
-
-            // Wait for the DOM node to be stolen and reparented into the overlay
-            await waitForPredicate(
-                () => !(outerPopover.parentElement instanceof OverlayTrigger)
-            );
-
-            expect(outerPopover.parentElement).to.not.be.an.instanceOf(
+            expect(outerButton).to.exist;
+            const open = oneEvent(outerTrigger, 'sp-opened');
+            outerButton.click();
+            await open;
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
-            expect(isVisible(outerPopover)).to.be.true;
+            expect(isVisible(outerClickContent)).to.be.true;
         });
 
         it('[disabled] closes a popover', async () => {
@@ -225,13 +212,9 @@ describe('Overlay Trigger', () => {
             expect(isVisible(outerClickContent)).to.be.false;
 
             expect(outerButton).to.exist;
+            const open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-
-            // Wait for the DOM node to be stolen and reparented into the overlay
-            await waitForPredicate(
-                () =>
-                    !(outerClickContent.parentElement instanceof OverlayTrigger)
-            );
+            await open;
 
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
@@ -258,16 +241,9 @@ describe('Overlay Trigger', () => {
                 expect(isVisible(outerClickContent)).to.be.false;
 
                 expect(outerButton).to.exist;
+                const open = oneEvent(outerTrigger, 'sp-opened');
                 outerButton.click();
-
-                // Wait for the DOM node to be stolen and reparented into the overlay
-                await waitForPredicate(
-                    () =>
-                        !(
-                            outerClickContent.parentElement instanceof
-                            OverlayTrigger
-                        )
-                );
+                await open;
 
                 expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                     OverlayTrigger
@@ -283,13 +259,9 @@ describe('Overlay Trigger', () => {
                 .false;
 
             expect(outerButton).to.exist;
+            const open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-
-            // Wait for the DOM node to be stolen and reparented into the overlay
-            await waitUntil(
-                () =>
-                    !(outerClickContent.parentElement instanceof OverlayTrigger)
-            );
+            await open;
 
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
@@ -307,10 +279,7 @@ describe('Overlay Trigger', () => {
             );
 
             await nextFrame();
-            await waitUntil(
-                () => hoverContent.parentElement instanceof OverlayTrigger,
-                'hover should not open'
-            );
+            expect(hoverContent.parentElement).to.be.instanceOf(OverlayTrigger);
 
             expect(isVisible(outerClickContent), 'outer popover visible again')
                 .to.be.true;
@@ -327,23 +296,15 @@ describe('Overlay Trigger', () => {
             ) as HTMLDivElement;
 
             expect(outerTrigger.disabled).to.be.false;
+            let open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer hoverConent stolen and reparented into the overlay'
-            );
+            await open;
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
+            let closed = oneEvent(outerTrigger, 'sp-closed');
             document.body.click();
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outter hoverConent returned to OverlayTrigger'
-            );
+            await closed;
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
@@ -353,19 +314,15 @@ describe('Overlay Trigger', () => {
 
             expect(outerTrigger.disabled).to.be.true;
             expect(outerTrigger.hasAttribute('disabled')).to.be.true;
+            // The overlay shouldn't open here.
             outerButton.click();
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outter hoverConent never left'
-            );
+            await aTimeout(200);
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
+            // The overlay shouldn't open here, either.
             triggerZone.dispatchEvent(new Event('mouseenter'));
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outter hoverConent never left'
-            );
+            await aTimeout(200);
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
@@ -375,23 +332,15 @@ describe('Overlay Trigger', () => {
 
             expect(outerTrigger.disabled).to.be.false;
             expect(outerTrigger.hasAttribute('disabled')).to.be.false;
+            open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer hoverConent stolen and reparented into the overlay'
-            );
+            await open;
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
+            closed = oneEvent(outerTrigger, 'sp-closed');
             outerButton.click();
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outter hoverConent returned to OverlayTrigger'
-            );
+            await closed;
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
@@ -402,16 +351,9 @@ describe('Overlay Trigger', () => {
             expect(isVisible(innerClickContent)).to.be.false;
 
             expect(outerButton).to.exist;
+            let open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer hoverConent stolen and reparented into the overlay'
-            );
+            await open;
 
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
@@ -419,15 +361,11 @@ describe('Overlay Trigger', () => {
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.false;
 
+            open = oneEvent(innerTrigger, 'sp-opened');
             innerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        innerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'inner hoverConent stolen and reparented into the overlay'
+            await open;
+            expect(innerClickContent.parentElement).to.not.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.true;
@@ -448,15 +386,6 @@ describe('Overlay Trigger', () => {
             outerButton.click();
             await outerOpen;
 
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer hoverConent stolen and reparented into the overlay'
-            );
-
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
@@ -468,14 +397,8 @@ describe('Overlay Trigger', () => {
             const innerOpen = oneEvent(innerButton, 'sp-opened');
             innerButton.click();
             await innerOpen;
-
-            await waitUntil(
-                () =>
-                    !(
-                        innerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'inner hoverConent stolen and reparented into the overlay'
+            expect(innerClickContent.parentElement).to.not.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent), 'outer popover stays open').to
@@ -486,10 +409,8 @@ describe('Overlay Trigger', () => {
             const innerClose = oneEvent(innerButton, 'sp-closed');
             pressEscape();
             await innerClose;
-
-            await waitUntil(
-                () => innerClickContent.parentElement instanceof OverlayTrigger,
-                'inner hoverConent returned to OverlayTrigger'
+            expect(innerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(
@@ -499,27 +420,13 @@ describe('Overlay Trigger', () => {
         });
 
         it('escape closes an open popover', async () => {
+            let open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
+            await open;
 
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer content stolen and reparented'
-            );
-
+            open = oneEvent(innerTrigger, 'sp-opened');
             innerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        innerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'inner content stolen and reparented'
-            );
+            await open;
 
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.true;
@@ -529,21 +436,21 @@ describe('Overlay Trigger', () => {
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.true;
 
+            let closed = oneEvent(innerTrigger, 'sp-closed');
             pressEscape();
-
-            await waitUntil(
-                () => innerClickContent.parentElement instanceof OverlayTrigger,
-                'inner content returned'
+            await closed;
+            expect(innerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.false;
 
+            closed = oneEvent(outerTrigger, 'sp-closed');
             pressEscape();
-
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outer content returned'
+            await closed;
+            expect(outerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.false;
@@ -551,27 +458,13 @@ describe('Overlay Trigger', () => {
         });
 
         it('click closes an open popover', async () => {
+            let open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
+            await open;
 
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer content stolen and reparented'
-            );
-
+            open = oneEvent(innerTrigger, 'sp-opened');
             innerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        innerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'inner content stolen and reparented'
-            );
+            await open;
 
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.true;
@@ -584,23 +477,21 @@ describe('Overlay Trigger', () => {
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.true;
 
+            let closed = oneEvent(innerTrigger, 'sp-closed');
             document.body.click();
-
-            // Wait for the DOM node to be put back in its original place
-            await waitUntil(
-                () => innerClickContent.parentElement instanceof OverlayTrigger,
-                'outer content returned'
+            await closed;
+            expect(innerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.false;
 
+            closed = oneEvent(outerTrigger, 'sp-closed');
             document.body.click();
-
-            // Wait for the DOM node to be put back in its original place
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'inner content returned'
+            await closed;
+            expect(outerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.false;
@@ -623,25 +514,21 @@ describe('Overlay Trigger', () => {
 
             expect(isVisible(hoverContent)).to.be.false;
 
+            const open = oneEvent(outerTrigger, 'sp-opened');
             const mouseEnter = new MouseEvent('mouseenter');
             triggerZone.dispatchEvent(mouseEnter);
-
-            // Wait for the DOM node to be stolen from its original place
-            await waitUntil(
-                () => !(hoverContent.parentElement instanceof OverlayTrigger),
-                'hoverContent stolen'
+            await open;
+            expect(hoverContent.parentElement).to.not.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(hoverContent)).to.be.true;
 
+            const close = oneEvent(outerTrigger, 'sp-closed');
             const mouseLeave = new MouseEvent('mouseleave');
             triggerZone.dispatchEvent(mouseLeave);
-
-            // Wait for the DOM node to be put back in its original place
-            await waitUntil(
-                () => hoverContent.parentElement instanceof OverlayTrigger,
-                'hoverContent returned'
-            );
+            await close;
+            expect(hoverContent.parentElement).to.be.instanceOf(OverlayTrigger);
 
             expect(isVisible(hoverContent)).to.be.false;
         });
@@ -678,51 +565,29 @@ describe('Overlay Trigger', () => {
         });
 
         it('dispatches events on open/close', async () => {
-            const openedSpy = spy();
-            const closedSpy = spy();
-
-            outerTrigger.addEventListener('sp-opened', openedSpy);
-            outerTrigger.addEventListener('sp-closed', closedSpy);
-
+            const opened = oneEvent(outerButton, 'sp-opened');
             outerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer content stolen and reparented'
-            );
-
-            await waitUntil(() => openedSpy.calledOnce, 'opened event sent');
+            const openedEvent = await opened;
 
             expect(isVisible(outerClickContent)).to.be.true;
-            expect(closed).to.be.false;
 
-            const openedEvent = openedSpy
-                .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
             expect(openedEvent.detail.interaction).to.equal('click');
 
+            const closed = oneEvent(outerButton, 'sp-closed');
             document.body.click();
-
-            // Wait for the DOM node to be put back in its original place
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'inner content returned'
+            const closedEvent = await closed;
+            expect(outerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
-
-            await waitUntil(() => closedSpy.calledOnce, 'closed event sent');
-
-            const closedEvent = closedSpy
-                .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
             expect(closedEvent.detail.interaction).to.equal('click');
 
             expect(isVisible(outerClickContent)).to.be.false;
         });
     });
     describe('System interactions', () => {
+
         afterEach(async () => {
+
             const triggers = document.querySelectorAll('overlay-trigger');
             const closes: Promise<CustomEvent<unknown>>[] = [];
             triggers.forEach((trigger) => {
@@ -735,6 +600,7 @@ describe('Overlay Trigger', () => {
             await Promise.all(closes);
         });
         it('acquires a `color` and `size` from `sp-theme`', async () => {
+
             const el = await fixture<Theme>(html`
                 <sp-theme color="dark">
                     <sp-theme color="light">

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -9,8 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { waitForPredicate, isVisible } from '../../../test/testing-helpers.js';
-import { spy } from 'sinon';
+import { isVisible } from '../../../test/testing-helpers.js';
 import {
     fixture,
     aTimeout,
@@ -23,12 +22,7 @@ import {
 } from '@open-wc/testing';
 
 import '../overlay-trigger.js';
-import {
-    OverlayTrigger,
-    ActiveOverlay,
-    TriggerInteractions,
-    OverlayOpenCloseDetail,
-} from '../';
+import { OverlayTrigger, ActiveOverlay, TriggerInteractions } from '../';
 import '@spectrum-web-components/button/sp-button.js';
 import { Button } from '@spectrum-web-components/button';
 import '@spectrum-web-components/popover/sp-popover.js';
@@ -129,7 +123,6 @@ describe('Overlay Trigger', () => {
                     </div>
                 `
             );
-            await elementUpdated(testDiv);
 
             innerTrigger = testDiv.querySelector(
                 '#inner-trigger'
@@ -175,27 +168,16 @@ describe('Overlay Trigger', () => {
         });
 
         it('opens a popover', async () => {
-            const button = testDiv.querySelector(
-                '#outer-button'
-            ) as HTMLElement;
-            const outerPopover = testDiv.querySelector(
-                '#outer-popover'
-            ) as Popover;
+            expect(isVisible(outerClickContent)).to.be.false;
 
-            expect(isVisible(outerPopover)).to.be.false;
-
-            expect(button).to.exist;
-            button.click();
-
-            // Wait for the DOM node to be stolen and reparented into the overlay
-            await waitForPredicate(
-                () => !(outerPopover.parentElement instanceof OverlayTrigger)
-            );
-
-            expect(outerPopover.parentElement).to.not.be.an.instanceOf(
+            expect(outerButton).to.exist;
+            const open = oneEvent(outerTrigger, 'sp-opened');
+            outerButton.click();
+            await open;
+            expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
-            expect(isVisible(outerPopover)).to.be.true;
+            expect(isVisible(outerClickContent)).to.be.true;
         });
 
         it('[disabled] closes a popover', async () => {
@@ -225,13 +207,9 @@ describe('Overlay Trigger', () => {
             expect(isVisible(outerClickContent)).to.be.false;
 
             expect(outerButton).to.exist;
+            const open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-
-            // Wait for the DOM node to be stolen and reparented into the overlay
-            await waitForPredicate(
-                () =>
-                    !(outerClickContent.parentElement instanceof OverlayTrigger)
-            );
+            await open;
 
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
@@ -258,16 +236,9 @@ describe('Overlay Trigger', () => {
                 expect(isVisible(outerClickContent)).to.be.false;
 
                 expect(outerButton).to.exist;
+                const open = oneEvent(outerTrigger, 'sp-opened');
                 outerButton.click();
-
-                // Wait for the DOM node to be stolen and reparented into the overlay
-                await waitForPredicate(
-                    () =>
-                        !(
-                            outerClickContent.parentElement instanceof
-                            OverlayTrigger
-                        )
-                );
+                await open;
 
                 expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                     OverlayTrigger
@@ -283,13 +254,9 @@ describe('Overlay Trigger', () => {
                 .false;
 
             expect(outerButton).to.exist;
+            const open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-
-            // Wait for the DOM node to be stolen and reparented into the overlay
-            await waitUntil(
-                () =>
-                    !(outerClickContent.parentElement instanceof OverlayTrigger)
-            );
+            await open;
 
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
@@ -307,10 +274,7 @@ describe('Overlay Trigger', () => {
             );
 
             await nextFrame();
-            await waitUntil(
-                () => hoverContent.parentElement instanceof OverlayTrigger,
-                'hover should not open'
-            );
+            expect(hoverContent.parentElement).to.be.instanceOf(OverlayTrigger);
 
             expect(isVisible(outerClickContent), 'outer popover visible again')
                 .to.be.true;
@@ -327,23 +291,15 @@ describe('Overlay Trigger', () => {
             ) as HTMLDivElement;
 
             expect(outerTrigger.disabled).to.be.false;
+            let open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer hoverConent stolen and reparented into the overlay'
-            );
+            await open;
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
+            let closed = oneEvent(outerTrigger, 'sp-closed');
             document.body.click();
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outter hoverConent returned to OverlayTrigger'
-            );
+            await closed;
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
@@ -353,19 +309,15 @@ describe('Overlay Trigger', () => {
 
             expect(outerTrigger.disabled).to.be.true;
             expect(outerTrigger.hasAttribute('disabled')).to.be.true;
+            // The overlay shouldn't open here.
             outerButton.click();
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outter hoverConent never left'
-            );
+            await aTimeout(200);
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
+            // The overlay shouldn't open here, either.
             triggerZone.dispatchEvent(new Event('mouseenter'));
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outter hoverConent never left'
-            );
+            await aTimeout(200);
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
@@ -375,23 +327,15 @@ describe('Overlay Trigger', () => {
 
             expect(outerTrigger.disabled).to.be.false;
             expect(outerTrigger.hasAttribute('disabled')).to.be.false;
+            open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer hoverConent stolen and reparented into the overlay'
-            );
+            await open;
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
+            closed = oneEvent(outerTrigger, 'sp-closed');
             outerButton.click();
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outter hoverConent returned to OverlayTrigger'
-            );
+            await closed;
             expect(outerClickContent.parentElement).to.be.an.instanceOf(
                 OverlayTrigger
             );
@@ -402,16 +346,9 @@ describe('Overlay Trigger', () => {
             expect(isVisible(innerClickContent)).to.be.false;
 
             expect(outerButton).to.exist;
+            let open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer hoverConent stolen and reparented into the overlay'
-            );
+            await open;
 
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
@@ -419,15 +356,11 @@ describe('Overlay Trigger', () => {
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.false;
 
+            open = oneEvent(innerTrigger, 'sp-opened');
             innerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        innerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'inner hoverConent stolen and reparented into the overlay'
+            await open;
+            expect(innerClickContent.parentElement).to.not.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.true;
@@ -448,15 +381,6 @@ describe('Overlay Trigger', () => {
             outerButton.click();
             await outerOpen;
 
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer hoverConent stolen and reparented into the overlay'
-            );
-
             expect(outerClickContent.parentElement).to.not.be.an.instanceOf(
                 OverlayTrigger
             );
@@ -468,14 +392,8 @@ describe('Overlay Trigger', () => {
             const innerOpen = oneEvent(innerButton, 'sp-opened');
             innerButton.click();
             await innerOpen;
-
-            await waitUntil(
-                () =>
-                    !(
-                        innerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'inner hoverConent stolen and reparented into the overlay'
+            expect(innerClickContent.parentElement).to.not.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent), 'outer popover stays open').to
@@ -486,10 +404,8 @@ describe('Overlay Trigger', () => {
             const innerClose = oneEvent(innerButton, 'sp-closed');
             pressEscape();
             await innerClose;
-
-            await waitUntil(
-                () => innerClickContent.parentElement instanceof OverlayTrigger,
-                'inner hoverConent returned to OverlayTrigger'
+            expect(innerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(
@@ -499,27 +415,13 @@ describe('Overlay Trigger', () => {
         });
 
         it('escape closes an open popover', async () => {
+            let open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
+            await open;
 
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer content stolen and reparented'
-            );
-
+            open = oneEvent(innerTrigger, 'sp-opened');
             innerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        innerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'inner content stolen and reparented'
-            );
+            await open;
 
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.true;
@@ -529,21 +431,21 @@ describe('Overlay Trigger', () => {
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.true;
 
+            let closed = oneEvent(innerTrigger, 'sp-closed');
             pressEscape();
-
-            await waitUntil(
-                () => innerClickContent.parentElement instanceof OverlayTrigger,
-                'inner content returned'
+            await closed;
+            expect(innerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.false;
 
+            closed = oneEvent(outerTrigger, 'sp-closed');
             pressEscape();
-
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'outer content returned'
+            await closed;
+            expect(outerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.false;
@@ -551,27 +453,13 @@ describe('Overlay Trigger', () => {
         });
 
         it('click closes an open popover', async () => {
+            let open = oneEvent(outerTrigger, 'sp-opened');
             outerButton.click();
+            await open;
 
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer content stolen and reparented'
-            );
-
+            open = oneEvent(innerTrigger, 'sp-opened');
             innerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        innerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'inner content stolen and reparented'
-            );
+            await open;
 
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.true;
@@ -584,23 +472,21 @@ describe('Overlay Trigger', () => {
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.true;
 
+            let closed = oneEvent(innerTrigger, 'sp-closed');
             document.body.click();
-
-            // Wait for the DOM node to be put back in its original place
-            await waitUntil(
-                () => innerClickContent.parentElement instanceof OverlayTrigger,
-                'outer content returned'
+            await closed;
+            expect(innerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.true;
             expect(isVisible(innerClickContent)).to.be.false;
 
+            closed = oneEvent(outerTrigger, 'sp-closed');
             document.body.click();
-
-            // Wait for the DOM node to be put back in its original place
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'inner content returned'
+            await closed;
+            expect(outerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(outerClickContent)).to.be.false;
@@ -623,25 +509,21 @@ describe('Overlay Trigger', () => {
 
             expect(isVisible(hoverContent)).to.be.false;
 
+            const open = oneEvent(outerTrigger, 'sp-opened');
             const mouseEnter = new MouseEvent('mouseenter');
             triggerZone.dispatchEvent(mouseEnter);
-
-            // Wait for the DOM node to be stolen from its original place
-            await waitUntil(
-                () => !(hoverContent.parentElement instanceof OverlayTrigger),
-                'hoverContent stolen'
+            await open;
+            expect(hoverContent.parentElement).to.not.be.instanceOf(
+                OverlayTrigger
             );
 
             expect(isVisible(hoverContent)).to.be.true;
 
+            const close = oneEvent(outerTrigger, 'sp-closed');
             const mouseLeave = new MouseEvent('mouseleave');
             triggerZone.dispatchEvent(mouseLeave);
-
-            // Wait for the DOM node to be put back in its original place
-            await waitUntil(
-                () => hoverContent.parentElement instanceof OverlayTrigger,
-                'hoverContent returned'
-            );
+            await close;
+            expect(hoverContent.parentElement).to.be.instanceOf(OverlayTrigger);
 
             expect(isVisible(hoverContent)).to.be.false;
         });
@@ -678,44 +560,20 @@ describe('Overlay Trigger', () => {
         });
 
         it('dispatches events on open/close', async () => {
-            const openedSpy = spy();
-            const closedSpy = spy();
-
-            outerTrigger.addEventListener('sp-opened', openedSpy);
-            outerTrigger.addEventListener('sp-closed', closedSpy);
-
+            const opened = oneEvent(outerButton, 'sp-opened');
             outerButton.click();
-
-            await waitUntil(
-                () =>
-                    !(
-                        outerClickContent.parentElement instanceof
-                        OverlayTrigger
-                    ),
-                'outer content stolen and reparented'
-            );
-
-            await waitUntil(() => openedSpy.calledOnce, 'opened event sent');
+            const openedEvent = await opened;
 
             expect(isVisible(outerClickContent)).to.be.true;
-            expect(closed).to.be.false;
 
-            const openedEvent = openedSpy
-                .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
             expect(openedEvent.detail.interaction).to.equal('click');
 
+            const closed = oneEvent(outerButton, 'sp-closed');
             document.body.click();
-
-            // Wait for the DOM node to be put back in its original place
-            await waitUntil(
-                () => outerClickContent.parentElement instanceof OverlayTrigger,
-                'inner content returned'
+            const closedEvent = await closed;
+            expect(outerClickContent.parentElement).to.be.instanceOf(
+                OverlayTrigger
             );
-
-            await waitUntil(() => closedSpy.calledOnce, 'closed event sent');
-
-            const closedEvent = closedSpy
-                .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
             expect(closedEvent.detail.interaction).to.equal('click');
 
             expect(isVisible(outerClickContent)).to.be.false;

--- a/packages/overlay/test/overlay.test.ts
+++ b/packages/overlay/test/overlay.test.ts
@@ -697,6 +697,10 @@ describe('Overlay - timing', () => {
             })
         );
         await closed;
+
+        // sometimes safari needs to wait a few frames for the open attribute to update
+        for (let i = 0; i < 3; i++) await nextFrame();
+
         expect(overlayTrigger1.hasAttribute('open')).to.be.false;
         expect(overlayTrigger2.hasAttribute('open')).to.be.false;
     });


### PR DESCRIPTION
## Description

This fixes some overlapping race conditions in the way we track which overlays are currently open. Opening and closing an overlay is an async operation, but we use the existence of `closeClickOverlay`, `closeHoverOverlay`, etc to synchronously manage overlay state.

This PR converts the close functions to `Promises` and centralizes their async usage into `closeAllOverlays`, eliminating several `await`s and `delete`s.

## Related issue(s)

Resolves https://github.com/adobe/spectrum-web-components/issues/1834

## Motivation and context

An overlay trigger that has both hover and click content should be able to open and close by repeatedly being clicked.

## How has this been tested?

1. Go to the first example in https://opensource.adobe.com/spectrum-web-components/components/overlay-trigger
2. Hover with your mouse and wait for the tooltip
3. Click repeatedly
4. Notice that the overlay does not close
---
1. Go to the first example in https://fix-overlay-open-close-symmetry--spectrum-web-components.netlify.app/components/overlay-trigger
2. Hover with your mouse and wait for the tooltip
3. Click repeatedly
4. Notice that the overlay closes
---
1. `yarn test`

## Types of changes

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
