### PR TITLE
refactor(overlay): exhaustive type check of OverlayContentTypes

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -29,12 +29,7 @@ import {
 import { openOverlay } from './loader.js';
 import overlayTriggerStyles from './overlay-trigger.css.js';
 
-export type OverlayContentTypes =
-    | 'click'
-    | 'hover'
-    | 'longpress'
-    | null
-    | undefined;
+export type OverlayContentTypes = 'click' | 'hover' | 'longpress';
 
 type closeOverlay =
     | 'closeClickOverlay'
@@ -161,18 +156,13 @@ export class OverlayTrigger extends LitElement {
     }
 
     private manageOpen(): void {
-        const handlers: { [k: string]: () => void } = {
+        const openHandlers: Record<OverlayContentTypes | 'none', () => void> = {
             click: () => this.onTriggerClick(),
             hover: () => this.onTriggerMouseEnter(),
             longpress: () => this.onTriggerLongpress(),
+            none: () => this.closeAllOverlays(),
         };
-        const handler = handlers[this.open || ''];
-
-        if (!handler) {
-            this.closeAllOverlays();
-            return;
-        }
-        handler();
+        openHandlers[this.open ?? 'none']();
     }
 
     private async openOverlay(


### PR DESCRIPTION
## Description

Replaces arbitrary string keys with a `Record` type to ensure that any changes to `OverlayContentTypes` will be reflected in the set of `manageOpen` handlers.

## Related issue(s)

N/A, just minor type safety

## Motivation and context

TypeScript doesn't check the keys of a `{ [k: string]: ... }` object, but it does verify that all possible values for a `Record` are matched, so nothing accidentally falls through.

## How has this been tested?

`yarn test`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
