### PR TITLE
refactor(textfield): use idiomatic lit property reflection

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -20,7 +20,6 @@ import {
     nothing,
     ifDefined,
     live,
-    internalProperty,
 } from '@spectrum-web-components/base';
 
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
@@ -56,18 +55,11 @@ export class TextfieldBase extends Focusable {
     @property()
     public placeholder = '';
 
-    @property({ attribute: 'type', reflect: true })
-    private _type: TextfieldType = 'text';
+    @property({ reflect: true })
+    public type: TextfieldType = textfieldTypes[0];
 
-    @internalProperty()
-    get type(): TextfieldType {
-        return textfieldTypes.find((t) => t === this._type) ?? 'text';
-    }
-
-    set type(val: TextfieldType) {
-        const prev = this._type;
-        this._type = val;
-        this.requestUpdate('type', prev);
+    protected get validType(): TextfieldType {
+        return textfieldTypes.find((t) => t === this.type) ?? textfieldTypes[0];
     }
 
     @property()
@@ -222,7 +214,7 @@ export class TextfieldBase extends Focusable {
         return html`
             <!-- @ts-ignore -->
             <input
-                type=${this.type}
+                type=${this.validType}
                 aria-label=${this.label || this.placeholder}
                 aria-invalid=${ifDefined(this.invalid || undefined)}
                 class="input"

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -768,10 +768,19 @@ describe('Textfield', () => {
                 `
             );
             expect(el1.type).equals('text');
-            expect(el2.type).equals('text');
+            expect(el2.focusElement.type).equals('text');
 
             el1.setAttribute('type', 'submit');
-            expect(el1.type).equals('text');
+            await elementUpdated(el1);
+
+            expect(el1.focusElement.type).equals('text');
+
+            // eslint-disable-next-line
+            // @ts-ignore
+            el2.type = 'submit';
+            await elementUpdated(el2);
+
+            expect(el2.focusElement.type).equals('text');
         });
         it('reflects valid property assignments', async () => {
             const el = await litFixture<Textfield>(
@@ -799,7 +808,7 @@ describe('Textfield', () => {
             await elementUpdated(el);
 
             expect(el.getAttribute('type')).equals('range');
-            expect(el.type).equals('text');
+            expect(el.focusElement.type).equals('text');
         });
     });
 });


### PR DESCRIPTION
## Description

This is an alternative implementation of `type` that sacrifices some state validation for shorter & more idiomatic usage of Lit.

## Related issue(s)

https://github.com/lit/lit/discussions/2256

## Motivation and context

I'd like to have our cake and eat it too: spec-compliant, native-like behavior, with idiomatic Lit. That might be possible with a custom decorator or similar.

This is a straightforward way to compare the tradeoffs of the two currently-viable approaches. The diff in this PR shows the sacrifices made in the tests (vs what you can do with a native `<input>`), and the benefits in the implementation (vs the atypical `@internalProperty` and `@property` combo currently in main).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
