### PR TITLE
docs: tweak CSS for perf scoring

### DIFF
--- a/projects/documentation/src/components/layout.css
+++ b/projects/documentation/src/components/layout.css
@@ -45,12 +45,9 @@ docs-side-nav:not(:defined) {
 
     docs-side-nav:not(:defined) ::slotted([slot='side-nav']) {
         margin-top: 56px;
-        padding-right: 24px;
+        width: 216px;
         flex: 1;
         flex-grow: 1;
-        overflow: auto;
-        overflow-x: hidden;
-        overflow-y: auto;
     }
 }
 

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -77,7 +77,6 @@ body {
         right: calc(100% - var(--spectrum-global-dimension-size-2400) - 48px);
         padding: 0 24px 24px;
         height: calc(100vh - 143px);
-        overflow: auto;
     }
 
     docs-page:not(:defined) sp-tabs {
@@ -111,7 +110,7 @@ body {
         top: 0;
     }
 
-    sp-sidenav:not(:defined) {
+    docs-page:not(:defined) > sp-sidenav {
         position: absolute;
         top: auto;
         left: 0;
@@ -259,7 +258,11 @@ sp-sidenav-item:not([tabindex]) {
         0;
 }
 
-sp-sidenav-item {
+docs-page > sp-sidenav {
+    content-visibility: auto;
+}
+
+docs-page > sp-sidenav-item {
     content-visibility: auto;
     contain-intrinsic-size: 40px;
 }
@@ -628,16 +631,16 @@ docs-page:defined .section:not([selected]) {
 }
 
 docs-page:not(:defined) .section,
-sp-tabs[selected='examples'] sp-tab[value='api'],
-sp-tabs[selected='api'] sp-tab[value='examples'],
+sp-tabs[selected='examples'] sp-tab[value='api']:not(:defined),
+sp-tabs[selected='api'] sp-tab[value='examples']:not(:defined),
 sp-tabs[selected='examples'] sp-tab-panel[value='api'],
 sp-tabs[selected='api'] sp-tab-panel[value='examples'] {
     order: 2;
 }
 
 docs-page:not(:defined) .section[selected],
-sp-tabs[selected='examples'] sp-tab[value='examples'],
-sp-tabs[selected='api'] sp-tab[value='api'],
+sp-tabs[selected='examples'] sp-tab[value='examples']:not(:defined),
+sp-tabs[selected='api'] sp-tab[value='api']:not(:defined),
 sp-tabs[selected='examples'] sp-tab-panel[value='examples'],
 sp-tabs[selected='api'] sp-tab-panel[value='api'] {
     order: 1;


### PR DESCRIPTION
## Description

Reduce blocking paints across the documentation site.

## Motivation and context
Faster!

## How has this been tested?

[![image](https://user-images.githubusercontent.com/1156657/138699506-829bcfb9-024c-4c7f-ad86-fa04f9aab8fc.png)](https://lighthouse-metrics.com/one-time-tests/617582cc70eea700093bf833)
compared to
[![image](https://user-images.githubusercontent.com/1156657/138699382-a76f4669-4258-49e0-a0ec-541e0fc85c7f.png)](https://lighthouse-metrics.com/one-time-tests/6175824dc171480008edb47a)

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
