### PR TITLE
fix: include late added items in the item list for the Picker

### DIFF
--- a/packages/picker/test/picker-sync.test.ts
+++ b/packages/picker/test/picker-sync.test.ts
@@ -166,7 +166,6 @@ describe('Picker, sync', () => {
 
         await expect(el).to.be.accessible();
     });
-
     it('accepts a new item and value at the same time', async () => {
         const el = await pickerFixture();
 
@@ -182,10 +181,49 @@ describe('Picker, sync', () => {
         item.textContent = 'New Option';
 
         el.append(item);
+        await elementUpdated(el);
+
         el.value = 'option-new';
 
         await elementUpdated(el);
         expect(el.value).to.equal('option-new');
+    });
+    it('accepts a new item that can be selected', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        el.value = 'option-2';
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('option-2');
+        const item = document.createElement('sp-menu-item');
+        item.value = 'option-new';
+        item.textContent = 'New Option';
+
+        el.append(item);
+
+        await elementUpdated(item);
+        await elementUpdated(el);
+
+        let opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+        // Overlaid content is outside of the context of the Picker element
+        // and cannot be managed via its updateComplete cycle.
+        await nextFrame();
+
+        const close = oneEvent(el, 'sp-closed');
+        item.click();
+        await close;
+
+        expect(el.value, 'first time').to.equal('option-new');
+
+        opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.value, 'second time').to.equal('option-new');
     });
     it('manages its "name" value in the accessibility tree', async () => {
         const el = await pickerFixture();

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -166,7 +166,6 @@ describe('Picker', () => {
 
         await expect(el).to.be.accessible();
     });
-
     it('accepts a new item and value at the same time', async () => {
         const el = await pickerFixture();
 
@@ -182,10 +181,49 @@ describe('Picker', () => {
         item.textContent = 'New Option';
 
         el.append(item);
+        await elementUpdated(el);
+
         el.value = 'option-new';
 
         await elementUpdated(el);
         expect(el.value).to.equal('option-new');
+    });
+    it('accepts a new item that can be selected', async () => {
+        const el = await pickerFixture();
+
+        await elementUpdated(el);
+
+        el.value = 'option-2';
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('option-2');
+        const item = document.createElement('sp-menu-item');
+        item.value = 'option-new';
+        item.textContent = 'New Option';
+
+        el.append(item);
+
+        await elementUpdated(item);
+        await elementUpdated(el);
+
+        let opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+        // Overlaid content is outside of the context of the Picker element
+        // and cannot be managed via its updateComplete cycle.
+        await nextFrame();
+
+        const close = oneEvent(el, 'sp-closed');
+        item.click();
+        await close;
+
+        expect(el.value, 'first time').to.equal('option-new');
+
+        opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.value, 'second time').to.equal('option-new');
     });
     it('manages its "name" value in the accessibility tree', async () => {
         const el = await pickerFixture();


### PR DESCRIPTION
## Description
Allow for late additions of items in the Picker.

## Related issue(s)
- fixes #1865

## Motivation and context
Flexibility.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://picker-late-item--spectrum-web-components.netlify.app/components/picker/#sizes
    2. Use dev tools to add a new item to one of the available Pickers
    3. Open the picker and select the new item
    4. See the item is appropriately selected
    5. Open the picker again
    6. See that the picker button still appropriately displays the selected item text

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.