### PR TITLE
ci: use hashes rather than long aliases in VRT URLs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,8 @@ commands:
                   when: on_fail
                   name: Create review site
                   command: |
-                      node test/visual/review.js --commit=<< pipeline.git.revision >> --theme="<< parameters.regression_color >> << parameters.regression_scale >> << parameters.regression_dir >>"
+                      branch=$(git symbolic-ref --short HEAD)
+                      node test/visual/review.js --branch=$branch --commit=<< pipeline.git.revision >> --theme="<< parameters.regression_color >> << parameters.regression_scale >> << parameters.regression_dir >>"
                       yarn rollup -c test/visual/rollup.config.js
             - run:
                   when: on_fail
@@ -60,8 +61,9 @@ commands:
                   command: |
                       cp projects/documentation/content/favicon.ico test/visual
                       branch=$(git symbolic-ref --short HEAD)
-                      branch=$(npx slugify-cli $branch)
-                      yarn netlify deploy --alias=$branch-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >> --dir=test/visual
+                      hash=$(echo -n $branch-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >> | md5sum | cut -c 1-32)
+                      echo hash
+                      yarn netlify deploy --alias=$hash --dir=test/visual
             # move "updated" screenshot into the baseline directory before making the new cache
             - run:
                   when: always

--- a/tasks/build-preview-urls-comment.cjs
+++ b/tasks/build-preview-urls-comment.cjs
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 
 const slugify = require('@sindresorhus/slugify');
 const execSync = require('child_process').execSync;
+const crypto = require('crypto');
 
 // Duplicated from `tasks/test-changes.js` because GitHub Actions and CJS. 🤦
 const getChangedPackages = () => {
@@ -46,6 +47,28 @@ const buildPreviewURLComment = (ref) => {
     const packages = getChangedPackages();
     const branch = ref.replace('refs/heads/', '');
     const branchSlug = slugify(branch);
+    const previewLinks = [];
+    // const themes = ['Classic', 'Express']; // prepping for Spectrum Express
+    const scales = ['Medium', 'Large'];
+    const colors = ['Lightest', 'Light', 'Dark', 'Darkest'];
+    const directions = ['LTR', 'RTL'];
+    // themes.map((theme) =>
+    colors.map((color) =>
+        scales.map((scale) =>
+            directions.map((direction) => {
+                // const context = `-${theme.toLocaleLowerCase()}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
+                const context = `${branch}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
+                const md5 = crypto.createHash('md5');
+                md5.update(context);
+                const hash = md5.digest('hex');
+                previewLinks.push(`
+- [${color} | ${scale} | ${direction}](https://${hash}--spectrum-web-components.netlify.app/review/)`);
+                //              previewLinks.push(`
+                // - [${theme} | ${color} | ${scale} | ${direction}](https://${hash}--spectrum-web-components.netlify.app/review/)`);
+            })
+        )
+    );
+    // );
     let comment = `# Branch Preview
 
 - [Documentation Site](https://${branchSlug}--spectrum-web-components.netlify.app/)
@@ -54,23 +77,7 @@ const buildPreviewURLComment = (ref) => {
         comment += `
 
 When a visual regression test fails (or has previously failed while working on this branch), its results can be found in the following URLs:
-
-- [Lightest | Medium | LTR](https://${branchSlug}-lightest-medium-ltr--spectrum-web-components.netlify.app/review/)
-- [Lightest | Medium | RTL](https://${branchSlug}-lightest-medium-rtl--spectrum-web-components.netlify.app/review/)
-- [Lightest | Large | LTR](https://${branchSlug}-lightest-large-ltr--spectrum-web-components.netlify.app/review/)
-- [Lightest | Large | RTL](https://${branchSlug}-lightest-large-rtl--spectrum-web-components.netlify.app/review/)
-- [Light | Medium | LTR](https://${branchSlug}-light-medium-ltr--spectrum-web-components.netlify.app/review/)
-- [Light | Medium | RTL](https://${branchSlug}-light-medium-rtl--spectrum-web-components.netlify.app/review/)
-- [Light | Large | LTR](https://${branchSlug}-light-large-ltr--spectrum-web-components.netlify.app/review/)
-- [Light | Large | RTL](https://${branchSlug}-light-large-rtl--spectrum-web-components.netlify.app/review/)
-- [Darkest | Medium | LTR](https://${branchSlug}-darkest-medium-ltr--spectrum-web-components.netlify.app/review/)
-- [Darkest | Medium | RTL](https://${branchSlug}-darkest-medium-rtl--spectrum-web-components.netlify.app/review/)
-- [Darkest | Large | LTR](https://${branchSlug}-darkest-large-ltr--spectrum-web-components.netlify.app/review/)
-- [Darkest | Large | RTL](https://${branchSlug}-darkest-large-rtl--spectrum-web-components.netlify.app/review/)
-- [Dark | Medium | LTR](https://${branchSlug}-dark-medium-ltr--spectrum-web-components.netlify.app/review/)
-- [Dark | Medium | RTL](https://${branchSlug}-dark-medium-rtl--spectrum-web-components.netlify.app/review/)
-- [Dark | Large | LTR](https://${branchSlug}-dark-large-ltr--spectrum-web-components.netlify.app/review/)
-- [Dark | Large | RTL](https://${branchSlug}-dark-large-rtl--spectrum-web-components.netlify.app/review/)`;
+${previewLinks.join('')}`;
     }
 
     return comment;

--- a/test/visual/review.js
+++ b/test/visual/review.js
@@ -15,8 +15,36 @@ import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import crypto from 'crypto';
 
-const { commit, theme } = yargs(hideBin(process.argv)).argv;
+const { commit, theme, branch } = yargs(hideBin(process.argv)).argv;
+
+const themes = [];
+// const themes = ['Classic', 'Express']; // prepping for Spectrum Express
+const scales = ['Medium', 'Large'];
+const colors = ['Lightest', 'Light', 'Dark', 'Darkest'];
+const directions = ['LTR', 'RTL'];
+// themes.map((theme) =>
+colors.map((color) =>
+    scales.map((scale) =>
+        directions.map((direction) => {
+            // const context = `-${theme.toLocaleLowerCase()}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
+            const context = `${branch}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
+            const md5 = crypto.createHash('md5');
+            md5.update(context);
+            const hash = md5.digest('hex');
+            themes.push([
+                `${color} | ${scale} | ${direction}`,
+                `https://${hash}--spectrum-web-components.netlify.app/review/`,
+            ]);
+            // themes.push([
+            //     `${theme} | ${color} | ${scale} | ${direction}`,
+            //     `https://${hash}--spectrum-web-components.netlify.app/review/`
+            // ]);
+        })
+    )
+);
+// );
 
 function cleanURL(url) {
     return url.replace('test/visual/', '../');
@@ -140,8 +168,10 @@ async function main() {
     }
     const data = JSON.stringify({
         meta: {
+            branch,
             commit,
             theme,
+            themes,
         },
         tests,
     });

--- a/test/visual/src/review.js
+++ b/test/visual/src/review.js
@@ -31,6 +31,10 @@ function buildNavigation(tests, metadata) {
         html`
             <sp-sidenav-heading label="Results for">
                 <sp-sidenav-item
+                    label=${metadata.branch}
+                    style="user-select: all"
+                ></sp-sidenav-item>
+                <sp-sidenav-item
                     label=${metadata.theme}
                     style="user-select: all"
                 ></sp-sidenav-item>
@@ -39,6 +43,16 @@ function buildNavigation(tests, metadata) {
                     style="user-select: all"
                 ></sp-sidenav-item>
             </sp-sidenav-heading>
+            <sp-sidenav-item multilevel label="Other VRT Results">
+                ${metadata.themes.map(
+                    (theme) => html`
+                        <sp-sidenav-item
+                            label=${theme[0]}
+                            href=${theme[1]}
+                        ></sp-sidenav-item>
+                    `
+                )}
+            </sp-sidenav-item>
             ${resultTypes.map((resultType) => {
                 const groups = Object.keys(tests[resultType]).sort();
                 return html`
@@ -147,6 +161,10 @@ function placeTest(test) {
 async function run() {
     const response = await fetch('./data.json');
     const data = await response.json();
+    const decorator = document.querySelector('sp-story-decorator');
+    const theme = data.meta.theme.split(' ');
+    decorator.color = theme[0];
+    decorator.scale = theme[1];
     buildNavigation(data.tests, data.meta);
 }
 


### PR DESCRIPTION
## Description
Support VRT review regardless of branch name length.
- hash the URL so it fits
- list the branch so you know what you're connected to
- list links to all the reviews
- render the page in the same theme settings as the results under review

## Motivation and context
We shouldn't police branch names.

## How has this been tested?
Does the preview comment below work as expected?

Without package changes here's the review site ring for this: https://97ff970af06267916a46362a64b1daa1--spectrum-web-components.netlify.app/review/

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
