### PR TITLE
docs: add icon search UIs to documentation site

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.0.5",
         "@sindresorhus/slugify": "^1.1.2",
-        "@spectrum-css/table": "^4.0.0",
         "@types/chai": "^4.1.7",
         "@types/command-line-args": "^5.0.0",
         "@types/command-line-usage": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "@webcomponents/webcomponentsjs": "^2.6.0",
         "alex": "^9.0.1",
         "chalk": "^4.0.0",
-        "chromedriver": "^93.0.1",
+        "chromedriver": "^95.0.0",
         "common-tags": "^1.8.0",
         "cssnano": "^5.0.8",
         "custom-elements-manifest": "^1.0.0",

--- a/packages/icons-ui/README.md
+++ b/packages/icons-ui/README.md
@@ -1,6 +1,14 @@
 ## Description
 
-[Spectrum UI Icons](https://spectrum.adobe.com/page/icons/) delivered in a flexible template tag so that they can be leveraged across various frameworks. The default export of this package pre-applies the `html` template tag from `lit-html` for ease of use in the Spectrum Web Components library. Please remember to consult Spectrum's [Iconography Guidelines](https://spectrum.adobe.com/page/iconography/) when planning how to leverage these icons in the visual delivery of your application. For technical information on using these iconos in projects powered by various javascript frameworks, check out the "Extended use cases" sectino below.
+Deliver [Spectrum UI Icons](https://spectrum.adobe.com/page/icons/) as either:
+
+-   Registered custom elements (`<sp-icon-arrow75>`)
+-   Unregistered class definitions (`IconArrow75`)
+-   Functions with customizable template tags to be used across various frameworks (`Arrow75Icon()`)
+
+Search a full list of icons to [find an icon](#find-an-icon) for your project or find technical information about [extended use cases](#extended-use-cases), like consuming this package in various UI frameworks below.
+
+Remember to consult Spectrum's [Iconography Guidelines](https://spectrum.adobe.com/page/iconography/) when planning how to leverage these icons in the visual delivery of your application.
 
 ### Usage
 
@@ -11,18 +19,69 @@
 yarn add @spectrum-web-components/icons-ui
 ```
 
-With the default exports of the packages prepared with the `html` template tag from `lit-html`, the default value of an icon export will be as follows:
+Import the side effectful registration of a single element (e.g. `<sp-icon-arrow75>`) via:
+
+```
+import '@spectrum-web-components/icons-ui/icons/sp-icon-arrow75.js';
+```
+
+Leverage a single icon base class (e.g. `IconArrow75`) as a type, or for extension purposes, do so, via:
+
+```
+import { IconArrow75 } from '@spectrum-web-components/icons-ui/src/elements/IconArrow75.js';
+```
+
+### Find an icon
+
+Search the available Spectrum Workflow icons below.
+
+<p class="for-github">Complete search experience available at: <a href="https://opensource.adobe.com/spectrum-web-components/components/icons-ui/">https://opensource.adobe.com/spectrum-web-components/components/icons-ui/</a>.</p>
+
+<icons-demo class="icon-search" package="icons-ui" size="xxl"></icons-demo>
+
+<script type="module">
+const search = document.querySelector('.icon-search');
+const options = {
+  rootMargin: '20px'
+}
+const callback = async (entries, observer) => {
+    if (entries[0].intersectionRatio === 0) return;
+    import('@spectrum-web-components/iconset/stories/icons-demo.js');
+    import('@spectrum-web-components/icons-ui/stories/icon-manifest.js').then(({iconManifest}) => {
+        search.icons = iconManifest;
+    });
+    observer.disconnect();
+}
+const observer = new IntersectionObserver(callback, options);
+observer.observe(search);
+</script>
+
+### Alternative usage
+
+You can import raw icons (e.g. `Arrow75Icon()`) via:
+
+```js
+import { Arrow75Icon } from '@spectrum-web-components/icons-ui/src/icons/Arrow75.js';
+```
+
+`@spectrum-web-components/icons-ui` exports _all_ icons. If your build process [tree-shakes](https://rollupjs.org/guide/en/#tree-shaking) dependencies, you can import from it directly:
+
+```js
+import { Arrow75Icon } from '@spectrum-web-components/icons-ui';
+```
+
+These icon literals are prepared with the `html` template tag from `lit-html`, the default value of an icon export will be as follows:
 
 ```js
 import { LitElement, html } from 'lit-element';
 import '@spectrum-web-components/icon';
-import { AsteriskIcon } from '@spectrum-web-components/icons-ui';
+import { Arrow75Icon } from '@spectrum-web-components/icons-ui';
 
 class ElementWithIcon extends LitElement {
     protected render(): TemplateResult {
         return html`
             <sp-icon>
-                ${AsteriskIcon()}
+                ${Arrow75Icon()}
             </sp-icon>
         `
     }
@@ -47,9 +106,9 @@ Every icons can be customized via the following options:
 The default exports of this package are pre-wrapped via `setCustomTemplateLiteralTag` in the `html` template tag from `lit-html`, and work liek the following::
 
 ```js
-import { AsteriskIcon } from '@spectrum-web-components/icons-ui';
+import { Arrow75Icon } from '@spectrum-web-components/icons-ui';
 
-console.log(AsteriskIcon());
+console.log(Arrow75Icon());
 
 /***
 TemplateResult {strings: Array[1], values: Array[0], type: "html", processor: DefaultTemplateProcessor, constructor: Object}
@@ -59,9 +118,9 @@ TemplateResult {strings: Array[1], values: Array[0], type: "html", processor: De
 When working in the context of other frameworks, it is possible to import the icons with a generic template tag as follows:
 
 ```js
-import { AsteriskIcon } from '@spectrum-web-components/icons-ui/src/icons.js';
+import { Arrow75Icon } from '@spectrum-web-components/icons-ui/src/icons.js';
 
-console.log(AsteriskIcon());
+console.log(Arrow75Icon());
 
 /***
 <svg
@@ -74,7 +133,9 @@ console.log(AsteriskIcon());
     aria-hidden="false"
     aria-label="Circle"
 >
-    <circle cx="18" cy="18" r="16"></circle>
+    <path
+      d="M9.26 4.406L6.528 1.672A.84.84 0 005.34 2.859L6.64 4.16H1.396a.84.84 0 000 1.68H6.64l-1.301 1.3a.84.84 0 001.188 1.188l2.734-2.734a.84.84 0 000-1.188z"
+    />
 </svg>
 ***/
 ```
@@ -83,7 +144,7 @@ What's more, if you're already working with a specific parser in your project, y
 
 ```js
 import {
-    AsteriskIcon,
+    Arrow75Icon,
     setCustomTemplateLiteralTag,
 } from '@spectrum-web-components/icons-ui/src/icons.js';
 import htm from 'htm';
@@ -93,7 +154,7 @@ const hPreact = htm.bind(h);
 
 setCustomTemplateLiteralTag(hPreact);
 
-console.log(AsteriskIcon());
+console.log(Arrow75Icon());
 
 /***
 VNode {nodeName: "svg", children: Array[1], attributes: Object, key: undefined, constructor: Object}

--- a/packages/icons-workflow/README.md
+++ b/packages/icons-workflow/README.md
@@ -1,6 +1,14 @@
 ## Description
 
-[Spectrum Workflow Icons](https://spectrum.adobe.com/page/icons/) delivered in a flexible template tag so that they can be leveraged across various frameworks. The default export of this package pre-applies the `html` template tag from `lit-html` for ease of use in the Spectrum Web Components library. Please remember to consult Spectrum's [Iconography Guidelines](https://spectrum.adobe.com/page/iconography/) when planning how to leverage these icons in the visual delivery of your application. For technical information on using these iconos in projects powered by various javascript frameworks, check out the "Extended use cases" sectino below.
+Deliver [Spectrum Workflow Icons](https://spectrum.adobe.com/page/icons/) as either:
+
+-   Registered custom elements (`<sp-icon-abc>`)
+-   Unregistered class definitions (`IconAbc`)
+-   Functions with customizable template tags to be used across various frameworks (`AbcIcon()`)
+
+Search a full list of icons to [find an icon](#find-an-icon) for your project or find technical information about [extended use cases](#extended-use-cases), like consuming this package in various UI frameworks below.
+
+When planning how to leverage these icons in the visual delivery of your application, remember to consult Spectrum's [Iconography Guidelines](https://spectrum.adobe.com/page/iconography/).
 
 ### Usage
 
@@ -11,18 +19,69 @@
 yarn add @spectrum-web-components/icons-workflow
 ```
 
-With the default exports of the packages prepared with the `html` template tag from `lit-html`, the default value of an icon export will be as follows:
+Import the side effectful registration of a single element (e.g. `<sp-icon-abc>`) via:
+
+```
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-abc.js';
+```
+
+Leverage a single icon base class (e.g. `IconAbc`) as a type, or for extension purposes, do so, via:
+
+```
+import { IconAbc } from '@spectrum-web-components/icons-workflow/src/elements/IconAbc.js';
+```
+
+### Find an icon
+
+Search the available Spectrum Workflow icons below.
+
+<p class="for-github">Complete search experience available at: <a href="https://opensource.adobe.com/spectrum-web-components/components/icons-workflow/">https://opensource.adobe.com/spectrum-web-components/components/icons-workflow/</a>.</p>
+
+<icons-demo class="icon-search" package="icons-workflow" size="xxl"></icons-demo>
+
+<script type="module">
+const search = document.querySelector('.icon-search');
+const options = {
+  rootMargin: '20px'
+}
+const callback = async (entries, observer) => {
+    if (entries[0].intersectionRatio === 0) return;
+    import('@spectrum-web-components/iconset/stories/icons-demo.js');
+    import('@spectrum-web-components/icons-workflow/stories/icon-manifest.js').then(({iconManifest}) => {
+        search.icons = iconManifest;
+    });
+    observer.disconnect();
+}
+const observer = new IntersectionObserver(callback, options);
+observer.observe(search);
+</script>
+
+### Alternative usage
+
+You can import raw icons (e.g. `AbcIcon()`) via:
+
+```js
+import { AbcIcon } from '@spectrum-web-components/icons-workflow/src/icons/ABC.js';
+```
+
+`@spectrum-web-components/icons-workflow` exports _all_ icons. If your build process [tree-shakes](https://rollupjs.org/guide/en/#tree-shaking) dependencies, you can import from it directly:
+
+```js
+import { AbcIcon } from '@spectrum-web-components/icons-workflow';
+```
+
+These icon literals are prepared with the `html` template tag from `lit-html`, the default value of an icon export will be as follows:
 
 ```js
 import { LitElement, html } from 'lit-element';
 import '@spectrum-web-components/icon';
-import { CircleIcon } from '@spectrum-web-components/icons-workflow';
+import { AbcIcon } from '@spectrum-web-components/icons-workflow';
 
 class ElementWithIcon extends LitElement {
     protected render(): TemplateResult {
         return html`
             <sp-icon>
-                ${CircleIcon()}
+                ${AbcIcon()}
             </sp-icon>
         `
     }
@@ -47,9 +106,9 @@ Every icons can be customized via the following options:
 The default exports of this package are pre-wrapped via `setCustomTemplateLiteralTag` in the `html` template tag from `lit-html`, and work liek the following::
 
 ```js
-import { CircleIcon } from '@spectrum-web-components/icons-workflow';
+import { AbcIcon } from '@spectrum-web-components/icons-workflow';
 
-console.log(CircleIcon());
+console.log(AbcIcon());
 
 /***
 TemplateResult {strings: Array[1], values: Array[0], type: "html", processor: DefaultTemplateProcessor, constructor: Object}
@@ -59,9 +118,9 @@ TemplateResult {strings: Array[1], values: Array[0], type: "html", processor: De
 When working in the context of other frameworks, it is possible to import the icons with a generic template tag as follows:
 
 ```js
-import { CircleIcon } from '@spectrum-web-components/icons-workflow/src/icons.js';
+import { AbcIcon } from '@spectrum-web-components/icons-workflow/src/icons.js';
 
-console.log(CircleIcon());
+console.log(AbcIcon());
 
 /***
 <svg
@@ -74,7 +133,12 @@ console.log(CircleIcon());
     aria-hidden="false"
     aria-label="Circle"
 >
-    <circle cx="18" cy="18" r="16"></circle>
+    <path
+      d="M4.936 20.484l-1.1 3.322a.235.235 0 01-.259.194H.988c-.172 0-.216-.086-.172-.237 1.143-3.236 2.976-8.543 4.335-12.275a3.813 3.813 0 00.216-1.337.136.136 0 01.151-.151h3.473a.162.162 0 01.173.108c1.575 4.336 3.3 9.276 4.9 13.676.064.151.021.216-.13.216h-2.85a.193.193 0 01-.216-.151L9.66 20.484zm4.055-2.459C8.56 16.558 7.7 14.1 7.265 12.545h-.021c-.324 1.467-1.1 3.732-1.661 5.48z"
+    />
+    <path
+      d="M14.045 10.257c0-.15.022-.193.129-.214.943-.022 2.743-.043 4.565-.043 4.436 0 5.379 1.95 5.379 3.686a3.1 3.1 0 01-2.036 3v.043a3.309 3.309 0 012.572 3.236c0 2.658-2.294 4.029-6.194 4.029-1.65.022-3.386-.021-4.265-.043a.17.17 0 01-.15-.193zm2.979 5.379h1.865c1.714 0 2.25-.707 2.25-1.628 0-1.158-.772-1.629-2.422-1.629-.836 0-1.5.021-1.693.043zm0 5.937c.236 0 .729.042 1.608.042 1.8 0 2.871-.471 2.871-1.8 0-1.114-.686-1.757-2.593-1.757h-1.886zM32.752 10a7.959 7.959 0 012.946.439c.1.063.126.1.126.251v2.21c0 .189-.1.189-.188.147a7.061 7.061 0 00-2.779-.523 4.175 4.175 0 00-4.535 4.43c0 3.427 2.466 4.388 4.514 4.388a8.49 8.49 0 002.925-.5c.1-.042.167 0 .167.125v2.152c0 .147-.021.23-.167.293a8.621 8.621 0 01-3.448.588c-3.74 0-7.041-2.069-7.041-6.958 0-3.991 2.928-7.042 7.48-7.042z"
+    />
 </svg>
 ***/
 ```
@@ -83,7 +147,7 @@ What's more, if you're already working with a specific parser in your project, y
 
 ```js
 import {
-    CircleIcon,
+    AbcIcon,
     setCustomTemplateLiteralTag,
 } from '@spectrum-web-components/icons-workflow/src/icons.js';
 import htm from 'htm';
@@ -93,7 +157,7 @@ const hPreact = htm.bind(h);
 
 setCustomTemplateLiteralTag(hPreact);
 
-console.log(CircleIcon());
+console.log(AbcIcon());
 
 /***
 VNode {nodeName: "svg", children: Array[1], attributes: Object, key: undefined, constructor: Object}

--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -24,6 +24,7 @@
         "watch:serve": "wds --root-dir=dist --watch"
     },
     "dependencies": {
+        "@spectrum-css/table": "^4.0.1",
         "@spectrum-web-components/bundle": "^0.22.11"
     },
     "devDependencies": {

--- a/projects/documentation/scripts/component-template-parts.js
+++ b/projects/documentation/scripts/component-template-parts.js
@@ -33,12 +33,22 @@ function sortByName(a, b) {
     return a.name > b.name ? 1 : -1;
 }
 
+const codeWrappedRegex = /<code>(.*)<\/code>/;
+
+function encodeCodeWrappedHTML(source) {
+    const parts = codeWrappedRegex.exec(source);
+    if (!parts) return source;
+    let html = parts[1];
+    html = html.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return source.replace(codeWrappedRegex, `<code>${html}</code>`);
+}
+
 function buildTable(title, rowData, headings, cells) {
     return `
 ### ${title}
 
 <div class="table-container">
-<table class="spectrum-Table">
+<table class="spectrum-Table spectrum-Table--sizeM">
 <thead class="spectrum-Table-head">
 <tr>
 ${headings
@@ -62,7 +72,7 @@ ${cells
     .map(
         (cell) => `
 <td class="spectrum-Table-cell">
-${cell(property)}
+${encodeCodeWrappedHTML(cell(property))}
 </td>
 `
     )

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -35,6 +35,7 @@ import type { SideNav } from './side-nav.js';
 import './adobe-logo.js';
 import type { CodeExample } from './code-example.js';
 import './code-example.js';
+import { copyText } from './copy-to-clipboard.js';
 
 import layoutStyles from './layout.css';
 import { nothing } from 'lit-html';
@@ -185,6 +186,14 @@ export class LayoutElement extends LitElement {
                 callback(this.color);
             }
         }
+    }
+
+    private copyText(
+        event: CustomEvent<{ text: string; message: string }>
+    ): void {
+        copyText(event.detail.text);
+        event.detail.message = 'Import statement copied to clipboard!';
+        this.addAlert(event);
     }
 
     private addAlert(event: CustomEvent<{ message: string }>): void {
@@ -346,6 +355,7 @@ export class LayoutElement extends LitElement {
                         id="page"
                         ?inert=${this.isNarrow && this.open}
                         @alert=${this.addAlert}
+                        @copy-text=${this.copyText}
                     >
                         ${this.manageTheme}
                         <slot></slot>

--- a/projects/documentation/src/components/side-nav-search.ts
+++ b/projects/documentation/src/components/side-nav-search.ts
@@ -22,7 +22,7 @@ import {
 import sideNavSearchMenuStyles from './side-nav-search.css';
 import { Search } from '@spectrum-web-components/search';
 import { Popover } from '@spectrum-web-components/popover';
-import { ResultGroup, search } from './search-index.js';
+import type { ResultGroup } from './search-index.js';
 import { Menu } from '@spectrum-web-components/menu';
 import { openOverlay } from '@spectrum-web-components/overlay';
 import '@spectrum-web-components/search/sp-search.js';
@@ -160,6 +160,9 @@ export class SearchComponent extends LitElement {
         }
 
         const searchParam = `${value.trim()}*`;
+        const search = await import('./search-index.js').then(
+            ({ search }) => search
+        );
         this.results = await search(searchParam);
 
         await this.openPopover();

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -683,3 +683,37 @@ sp-tab-panel:not(.section):focus code-example:after {
     border-left: var(--spectrum-global-dimension-static-size-25) solid
         var(--spectrum-global-color-static-blue-600);
 }
+
+.for-github {
+    display: none;
+}
+
+icons-demo {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(115px, 1fr));
+    box-sizing: border-box;
+    width: 100%;
+    border: 2px solid;
+    border-radius: 6px;
+    padding: 0 1.5rem 0.75rem 1.5rem;
+    height: 400px;
+    overflow: hidden auto;
+    position: relative;
+    gap: var(--spectrum-global-dimension-static-size-200);
+}
+
+icons-demo::part(search) {
+    position: sticky;
+    top: 0;
+    left: 0;
+    margin: 0 -1.5em;
+    background: inherit;
+    background: var(--spectrum-global-color-gray-50);
+    padding: 0.75rem 1.5em;
+    z-index: 2;
+}
+
+icons-demo::part(icon) {
+    padding: calc(0.5 * var(--spectrum-global-dimension-static-size-200)) 0;
+    gap: var(--spectrum-global-dimension-static-size-200);
+}

--- a/projects/documentation/src/utils/posthtml-spectrum-docs-markdown.js
+++ b/projects/documentation/src/utils/posthtml-spectrum-docs-markdown.js
@@ -92,6 +92,14 @@ export default () =>
                 },
             },
             {
+                selector: '.for-github',
+                fn: (node) => {
+                    node.tag = false;
+                    node.content = [];
+                    return node;
+                },
+            },
+            {
                 // ensure `<p>`, `<ul>`, and `<ol>` tags have the `spectrum-Body3` class
                 selector: 'p,ul,ol',
                 fn: (node) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4047,10 +4047,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-1.0.4.tgz#8b37d6f6746eefb78dfe5753c05ccdb930777a29"
   integrity sha512-sHNNrmjjFRGlkzuhW7LW/FU6Nbxy2q08thfACWOvCBHpMs88hg8Aa9T/FXwDEfqluXVO3eRCROh16ThTv05hqg==
 
-"@spectrum-css/table@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.0.tgz#14ce551c1a858c40932f3a36a287fe7aaa7cedcf"
-  integrity sha512-Uuz0f1dqhKMhfMoHTtBpuADpUfevXqotFrBbbcjqraBxbNweyKsLMtX8fCzF3S4U4vnP8CDC5AfOqK9PPh9A4w==
+"@spectrum-css/table@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.1.tgz#53509f1e9587fb14667bc28930dad3bf563ccd93"
+  integrity sha512-vRWR64c4QChogn0XHVwpH47DgheT5jgSFiSGOW/bJ1Lo1S0KogEncBRRDMcE1mQO6KBKFW7b6S9igJOri79EGw==
 
 "@spectrum-css/tabs@^3.1.1":
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7539,10 +7539,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^93.0.1:
-  version "93.0.1"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-93.0.1.tgz#3ed1f7baa98a754fc1788c42ac8e4bb1ab27db32"
-  integrity sha512-KDzbW34CvQLF5aTkm3b5VdlTrvdIt4wEpCzT2p4XJIQWQZEPco5pNce7Lu9UqZQGkhQ4mpZt4Ky6NKVyIS2N8A==
+chromedriver@^95.0.0:
+  version "95.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-95.0.0.tgz#ecf854cac6df5137a651dcc132edf55612d3db7f"
+  integrity sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.21.2"


### PR DESCRIPTION
## Description
- correct API table DOM
- add some missed API tables
- update "Usage" for `icons-ui` and `icons-workflow`
- add Search UI for both
- include `IconBase` API table for both

![image](https://user-images.githubusercontent.com/1156657/139846180-3b8eef28-9907-4b0c-b12f-c01a4c1db718.png)

## Related issue(s)
- fixes #1421

## Motivation and context
Make it easier to consume the icon packages and their various offerings.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://docs-icons--spectrum-web-components.netlify.app/components/icons-workflow/#find-an-icon
    2. Search for `flag`
    3. Click the `<sp-icon-flag-exclude>` icon
    4. See the "copied to clipboard" message
    5. Paste `import '@spectrum-web-components/icons-workflow/icons/sp-icon-flag-exclude.js';` somewhere.
-   [ ] _Test case 2_
    1. Go to https://docs-icons--spectrum-web-components.netlify.app/components/icons-ui/#find-an-icon
    2. Search for `dash`
    3. Click the `<sp-icon-dash400>` icon
    4. See the "copied to clipboard" message
    5. Pase`import '@spectrum-web-components/icons-ui/icons/sp-icon-dash40.js';` somewhere

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.