### PR TITLE
feat: support express flavor of Spectrum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: f59a40cb2c7d71a1fd588463b5d2e2734b87d163
+        default: 86c16ae808cdaac63ab7d305cf288bc955841d64
 commands:
     downstream:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ commands:
                   at: /
     run-regressions:
         parameters:
+            regression_theme:
+                type: string
             regression_color:
                 type: string
             regression_scale:
@@ -38,13 +40,18 @@ commands:
             - restore_cache:
                   name: Restore Golden Images Cache
                   keys:
+                      - v2-golden-images-<< pipeline.parameters.current_golden_images_hash >>-<< parameters.regression_theme >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
                       - v2-golden-images-<< pipeline.parameters.current_golden_images_hash >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
+                      - v2-golden-images-main-<< parameters.regression_theme >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
                       - v2-golden-images-main-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-
             - run:
                   name: Count baseline images
                   command: find test/visual/screenshots-baseline -type f | wc -l > count_start.txt
-            - run: |
-                  yarn test:ci --config web-test-runner.config.vrt.js --group vrt-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
+            - run:
+                  when: always
+                  name: VRT Run
+                  command: |
+                      yarn test:ci --config web-test-runner.config.vrt.js --group vrt-<< parameters.regression_theme >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>
             # store results and artifacts before rearranging things for the new cache.
             - store_test_results:
                   path: /root/project/results/
@@ -54,7 +61,7 @@ commands:
                   name: Create review site
                   command: |
                       branch=$(git symbolic-ref --short HEAD)
-                      node test/visual/review.js --branch=$branch --commit=<< pipeline.git.revision >> --theme="<< parameters.regression_color >> << parameters.regression_scale >> << parameters.regression_dir >>"
+                      node test/visual/review.js --branch=$branch --commit=<< pipeline.git.revision >> --theme="<< parameters.regression_theme >> << parameters.regression_color >> << parameters.regression_scale >> << parameters.regression_dir >>"
                       yarn rollup -c test/visual/rollup.config.js
             - run:
                   when: on_fail
@@ -62,7 +69,7 @@ commands:
                   command: |
                       cp projects/documentation/content/favicon.ico test/visual
                       branch=$(git symbolic-ref --short HEAD)
-                      hash=$(echo -n $branch-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >> | md5sum | cut -c 1-32)
+                      hash=$(echo -n $branch-<< parameters.regression_theme >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >> | md5sum | cut -c 1-32)
                       echo hash
                       yarn netlify deploy --alias=$hash --dir=test/visual
             # move "updated" screenshot into the baseline directory before making the new cache
@@ -88,12 +95,12 @@ commands:
                   name: Build Golden Images Revision Cache
                   paths:
                       - test/visual/screenshots-baseline
-                  key: v2-golden-images-{{ .Revision }}-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-{{ epoch }}
+                  key: v2-golden-images-{{ .Revision }}-<< parameters.regression_theme >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-{{ epoch }}
             - save_cache:
                   name: Build Golden Images Branch Cache
                   paths:
                       - test/visual/screenshots-baseline
-                  key: v2-golden-images-{{ .Branch }}-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-{{ epoch }}
+                  key: v2-golden-images-{{ .Branch }}-<< parameters.regression_theme >>-<< parameters.regression_color >>-<< parameters.regression_scale >>-<< parameters.regression_dir >>-{{ epoch }}
 
 jobs:
     commitlint:
@@ -140,7 +147,7 @@ jobs:
                   name: Are there changes?
                   command: git diff-files
 
-    docs-preview:
+    preview-docs:
         executor: node
 
         steps:
@@ -156,6 +163,8 @@ jobs:
     visual:
         executor: node
         parameters:
+            theme:
+                type: string
             color:
                 type: string
             scale:
@@ -165,11 +174,12 @@ jobs:
         steps:
             - downstream
             - run-regressions:
+                  regression_theme: << parameters.theme >>
                   regression_color: << parameters.color >>
                   regression_scale: << parameters.scale >>
                   regression_dir: << parameters.dir >>
 
-    docs-publish:
+    publish-docs:
         executor: node
 
         steps:
@@ -189,11 +199,12 @@ workflows:
     build:
         jobs:
             - test
-            - docs-preview
+            - preview-docs
             - visual:
-                  name: visual-<< matrix.color >>-<< matrix.scale >>-<< matrix.dir >>
+                  name: << matrix.theme >>-<< matrix.color >>-<< matrix.scale >>-<< matrix.dir >>
                   matrix:
                       parameters:
+                          theme: [classic, express]
                           color: [lightest, light, dark, darkest]
                           scale: [medium, large]
                           dir: [ltr, rtl]
@@ -201,7 +212,7 @@ workflows:
                       branches:
                           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                           ignore: /pull\/[0-9]+/
-            - docs-publish:
+            - publish-docs:
                   filters:
                       branches:
                           only:

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -37,7 +37,9 @@ async function styledFixture<T extends Element>(
     story: TemplateResult
 ): Promise<T> {
     const test = await fixture<Theme>(html`
-        <sp-theme scale="medium" color="dark">${story}</sp-theme>
+        <sp-theme theme="classic" scale="medium" color="dark">
+            ${story}
+        </sp-theme>
     `);
     return test.children[0] as T;
 }

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -21,7 +21,11 @@ import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { reparentChildren } from '@spectrum-web-components/shared/src/reparent-children.js';
 import { firstFocusableIn } from '@spectrum-web-components/shared/src/first-focusable-in.js';
-import type { Color, Scale } from '@spectrum-web-components/theme/src/Theme.js';
+import type {
+    Color,
+    Scale,
+    ThemeVariant,
+} from '@spectrum-web-components/theme/src/Theme.js';
 import styles from './active-overlay.css.js';
 import {
     OverlayOpenCloseDetail,
@@ -153,6 +157,7 @@ export class ActiveOverlay extends SpectrumElement {
         color?: Color;
         scale?: Scale;
         lang?: string;
+        theme?: ThemeVariant;
     } = {};
     @property({ attribute: false })
     public receivesFocus?: 'auto';
@@ -530,9 +535,10 @@ export class ActiveOverlay extends SpectrumElement {
     }
 
     public renderTheme(content: TemplateResult): TemplateResult {
-        const { color, scale, lang } = this.theme;
+        const { color, scale, lang, theme } = this.theme;
         return html`
             <sp-theme
+                theme=${ifDefined(theme)}
                 color=${ifDefined(color)}
                 scale=${ifDefined(scale)}
                 lang=${ifDefined(lang)}

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -109,6 +109,7 @@ export class Overlay {
             color: undefined,
             scale: undefined,
             lang: undefined,
+            theme: undefined,
         };
         const queryThemeEvent = new CustomEvent<ThemeData>('sp-query-theme', {
             bubbles: true,

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -343,11 +343,13 @@ export const deepNesting = (): TemplateResult => {
         ${storyStyles}
         <sp-theme
             color=${outter}
+            theme=${window.__swc_hack_knobs__.defaultThemeVariant}
             scale=${window.__swc_hack_knobs__.defaultScale}
             dir=${window.__swc_hack_knobs__.defaultDirection}
         >
             <sp-theme
                 color=${color}
+                theme=${window.__swc_hack_knobs__.defaultThemeVariant}
                 scale=${window.__swc_hack_knobs__.defaultScale}
                 dir=${window.__swc_hack_knobs__.defaultDirection}
             >

--- a/packages/styles/express/core-global.css
+++ b/packages/styles/express/core-global.css
@@ -1,0 +1,2156 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* stylelint-disable */
+:host,
+:root {
+    --spectrum-global-animation-linear: cubic-bezier(
+        0,
+        0,
+        1,
+        1
+    ); /* spectrum-animationGlobals.css */
+    --spectrum-global-animation-duration-0: 0ms;
+    --spectrum-global-animation-duration-100: 130ms;
+    --spectrum-global-animation-duration-200: 160ms;
+    --spectrum-global-animation-duration-300: 190ms;
+    --spectrum-global-animation-duration-400: 220ms;
+    --spectrum-global-animation-duration-500: 250ms;
+    --spectrum-global-animation-duration-600: 300ms;
+    --spectrum-global-animation-duration-700: 350ms;
+    --spectrum-global-animation-duration-800: 400ms;
+    --spectrum-global-animation-duration-900: 450ms;
+    --spectrum-global-animation-duration-1000: 500ms;
+    --spectrum-global-animation-duration-2000: 1000ms;
+    --spectrum-global-animation-duration-4000: 2000ms;
+    --spectrum-global-animation-ease-in-out: cubic-bezier(0.45, 0, 0.4, 1);
+    --spectrum-global-animation-ease-in: cubic-bezier(0.5, 0, 1, 1);
+    --spectrum-global-animation-ease-out: cubic-bezier(0, 0, 0.4, 1);
+    --spectrum-global-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
+
+    /* spectrum-colorGlobals.css */
+    --spectrum-global-color-status: Verified;
+    --spectrum-global-color-version: 5.1.0;
+    --spectrum-global-color-static-blue: #0261d6;
+    --spectrum-global-color-static-gray-50: #fff;
+    --spectrum-global-color-static-gray-75: #fff;
+    --spectrum-global-color-static-gray-100: #fff;
+    --spectrum-global-color-static-gray-200: #ebebeb;
+    --spectrum-global-color-static-gray-300: #dadada;
+    --spectrum-global-color-static-gray-400: #b3b3b3;
+    --spectrum-global-color-static-gray-500: #929292;
+    --spectrum-global-color-static-gray-600: #6e6e6e;
+    --spectrum-global-color-static-gray-700: #474747;
+    --spectrum-global-color-static-gray-800: #222;
+    --spectrum-global-color-static-gray-900: #000;
+    --spectrum-global-color-static-red-400: #fa604b;
+    --spectrum-global-color-static-red-500: #f04534;
+    --spectrum-global-color-static-red-600: #e32a1f;
+    --spectrum-global-color-static-red-700: #ce0f0b;
+    --spectrum-global-color-static-red-800: #b60000;
+    --spectrum-global-color-static-orange-400: #e87200;
+    --spectrum-global-color-static-orange-500: #d56300;
+    --spectrum-global-color-static-orange-600: #c25600;
+    --spectrum-global-color-static-orange-700: #ac4900;
+    --spectrum-global-color-static-orange-800: #963e00;
+    --spectrum-global-color-static-yellow-200: #fdf8cd;
+    --spectrum-global-color-static-yellow-300: #f9e442;
+    --spectrum-global-color-static-yellow-400: #ec0;
+    --spectrum-global-color-static-yellow-500: #dbb700;
+    --spectrum-global-color-static-yellow-600: #c8a300;
+    --spectrum-global-color-static-yellow-700: #b48f00;
+    --spectrum-global-color-static-yellow-800: #a47f00;
+    --spectrum-global-color-static-chartreuse-300: #c4f081;
+    --spectrum-global-color-static-chartreuse-400: #a6df58;
+    --spectrum-global-color-static-chartreuse-500: #8bcc39;
+    --spectrum-global-color-static-chartreuse-600: #74b824;
+    --spectrum-global-color-static-chartreuse-700: #62a416;
+    --spectrum-global-color-static-chartreuse-800: #559310;
+    --spectrum-global-color-static-celery-200: #a9f597;
+    --spectrum-global-color-static-celery-300: #7be471;
+    --spectrum-global-color-static-celery-400: #53d254;
+    --spectrum-global-color-static-celery-500: #2dbf3a;
+    --spectrum-global-color-static-celery-600: #0dab25;
+    --spectrum-global-color-static-celery-700: #009a17;
+    --spectrum-global-color-static-celery-800: #008910;
+    --spectrum-global-color-static-green-400: #1ba772;
+    --spectrum-global-color-static-green-500: #009764;
+    --spectrum-global-color-static-green-600: #008757;
+    --spectrum-global-color-static-green-700: #00764c;
+    --spectrum-global-color-static-green-800: #006641;
+    --spectrum-global-color-static-seafoam-200: #49cbcd;
+    --spectrum-global-color-static-seafoam-300: #25b8bd;
+    --spectrum-global-color-static-seafoam-400: #00a3aa;
+    --spectrum-global-color-static-seafoam-500: #00929b;
+    --spectrum-global-color-static-seafoam-600: #00828e;
+    --spectrum-global-color-static-seafoam-700: #00727e;
+    --spectrum-global-color-static-seafoam-800: #00626e;
+    --spectrum-global-color-static-blue-200: #7fbffb;
+    --spectrum-global-color-static-blue-300: #60abf8;
+    --spectrum-global-color-static-blue-400: #3e95f4;
+    --spectrum-global-color-static-blue-500: #1f82f6;
+    --spectrum-global-color-static-blue-600: #0b71ef;
+    --spectrum-global-color-static-blue-700: #0261d6;
+    --spectrum-global-color-static-blue-800: #0055b9;
+    --spectrum-global-color-static-indigo-200: #9a9dff;
+    --spectrum-global-color-static-indigo-300: #8287fd;
+    --spectrum-global-color-static-indigo-400: #7175f8;
+    --spectrum-global-color-static-indigo-500: #6165f0;
+    --spectrum-global-color-static-indigo-600: #4f54e1;
+    --spectrum-global-color-static-indigo-700: #4246cb;
+    --spectrum-global-color-static-indigo-800: #363ab2;
+    --spectrum-global-color-static-purple-400: #a460f8;
+    --spectrum-global-color-static-purple-500: #964df0;
+    --spectrum-global-color-static-purple-600: #8638e4;
+    --spectrum-global-color-static-purple-700: #7526d5;
+    --spectrum-global-color-static-purple-800: #6317bf;
+    --spectrum-global-color-static-fuchsia-400: #d642d7;
+    --spectrum-global-color-static-fuchsia-500: #c530c6;
+    --spectrum-global-color-static-fuchsia-600: #b21cb3;
+    --spectrum-global-color-static-fuchsia-700: #9f04a0;
+    --spectrum-global-color-static-fuchsia-800: #880089;
+    --spectrum-global-color-static-magenta-200: #fd7cae;
+    --spectrum-global-color-static-magenta-300: #f25e9c;
+    --spectrum-global-color-static-magenta-400: #e5478b;
+    --spectrum-global-color-static-magenta-500: #d7327a;
+    --spectrum-global-color-static-magenta-600: #c41d66;
+    --spectrum-global-color-static-magenta-700: #af0a56;
+    --spectrum-global-color-static-magenta-800: #970049;
+    --spectrum-global-color-static-black: #000;
+    --spectrum-global-color-static-white: #fff;
+    --spectrum-global-color-sequential-cerulean: #e9fff1, #c8f1e4, #a5e3d7,
+        #82d5ca, #68c5c1, #54b4ba, #3fa2b2, #2991ac, #2280a2, #1f6d98, #1d5c8d,
+        #1a4b83, #1a3979, #1a266f, #191264, #180057;
+    --spectrum-global-color-sequential-forest: #ffffdf, #e2f6ba, #c4eb95,
+        #a4e16d, #8dd366, #77c460, #5fb65a, #48a754, #36984f, #2c894d, #237a4a,
+        #196b47, #105c45, #094d41, #033f3e, #00313a;
+    --spectrum-global-color-sequential-rose: #fff4dd, #ffddd7, #ffc5d2, #feaecb,
+        #fa96c4, #f57ebd, #ef64b5, #e846ad, #d238a1, #bb2e96, #a3248c, #8a1b83,
+        #71167c, #560f74, #370b6e, #000968;
+    --spectrum-global-color-diverging-orange-yellow-seafoam: #580000, #79260b,
+        #9c4511, #bd651a, #dd8629, #f5ad52, #fed693, #ffffe0, #bbe4d1, #76c7be,
+        #3ea8a6, #208288, #076769, #00494b, #002c2d;
+    --spectrum-global-color-diverging-red-yellow-blue: #4a001e, #751232, #a52747,
+        #c65154, #e47961, #f0a882, #fad4ac, #ffffe0, #bce2cf, #89c0c4, #579eb9,
+        #397aa8, #1c5796, #163771, #10194d;
+    --spectrum-global-color-diverging-red-blue: #4a001e, #731331, #9f2945,
+        #cc415a, #e06e85, #ed9ab0, #f8c3d9, #faf0ff, #c6d0f2, #92b2de, #5d94cb,
+        #2f74b3, #265191, #163670, #0b194c;
+
+    /* spectrum-colorSemantics.css */
+    --spectrum-semantic-cta-background-color-default: var(
+        --spectrum-global-color-static-indigo-600
+    );
+    --spectrum-semantic-cta-background-color-hover: var(
+        --spectrum-global-color-static-indigo-700
+    );
+    --spectrum-semantic-cta-background-color-down: var(
+        --spectrum-global-color-static-indigo-800
+    );
+    --spectrum-semantic-cta-background-color-key-focus: var(
+        --spectrum-global-color-static-indigo-700
+    );
+    --spectrum-semantic-negative-background-color: var(
+        --spectrum-global-color-static-red-700
+    );
+    --spectrum-semantic-negative-color-default: var(
+        --spectrum-global-color-red-500
+    );
+    --spectrum-semantic-negative-color-hover: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-color-dark: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-border-color: var(
+        --spectrum-global-color-red-400
+    );
+    --spectrum-semantic-negative-icon-color: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-status-color: var(
+        --spectrum-global-color-red-400
+    );
+    --spectrum-semantic-negative-text-color-large: var(
+        --spectrum-global-color-red-500
+    );
+    --spectrum-semantic-negative-text-color-small: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-text-color-small-hover: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-semantic-negative-text-color-small-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-semantic-negative-text-color-small-key-focus: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-semantic-negative-color-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-semantic-negative-color-key-focus: var(
+        --spectrum-global-color-red-400
+    );
+    --spectrum-semantic-negative-background-color-default: var(
+        --spectrum-global-color-static-red-600
+    );
+    --spectrum-semantic-negative-background-color-hover: var(
+        --spectrum-global-color-static-red-700
+    );
+    --spectrum-semantic-negative-background-color-down: var(
+        --spectrum-global-color-static-red-800
+    );
+    --spectrum-semantic-negative-background-color-key-focus: var(
+        --spectrum-global-color-static-red-700
+    );
+    --spectrum-semantic-notice-background-color: var(
+        --spectrum-global-color-static-orange-700
+    );
+    --spectrum-semantic-notice-color-default: var(
+        --spectrum-global-color-orange-500
+    );
+    --spectrum-semantic-notice-color-dark: var(
+        --spectrum-global-color-orange-600
+    );
+    --spectrum-semantic-notice-border-color: var(
+        --spectrum-global-color-orange-400
+    );
+    --spectrum-semantic-notice-icon-color: var(
+        --spectrum-global-color-orange-600
+    );
+    --spectrum-semantic-notice-status-color: var(
+        --spectrum-global-color-orange-400
+    );
+    --spectrum-semantic-notice-text-color-large: var(
+        --spectrum-global-color-orange-500
+    );
+    --spectrum-semantic-notice-text-color-small: var(
+        --spectrum-global-color-orange-600
+    );
+    --spectrum-semantic-notice-color-down: var(
+        --spectrum-global-color-orange-700
+    );
+    --spectrum-semantic-notice-color-key-focus: var(
+        --spectrum-global-color-orange-400
+    );
+    --spectrum-semantic-notice-background-color-default: var(
+        --spectrum-global-color-static-orange-600
+    );
+    --spectrum-semantic-notice-background-color-hover: var(
+        --spectrum-global-color-static-orange-700
+    );
+    --spectrum-semantic-notice-background-color-down: var(
+        --spectrum-global-color-static-orange-800
+    );
+    --spectrum-semantic-notice-background-color-key-focus: var(
+        --spectrum-global-color-static-orange-700
+    );
+    --spectrum-semantic-positive-background-color: var(
+        --spectrum-global-color-static-green-700
+    );
+    --spectrum-semantic-positive-color-default: var(
+        --spectrum-global-color-green-500
+    );
+    --spectrum-semantic-positive-color-dark: var(
+        --spectrum-global-color-green-600
+    );
+    --spectrum-semantic-positive-border-color: var(
+        --spectrum-global-color-green-400
+    );
+    --spectrum-semantic-positive-icon-color: var(
+        --spectrum-global-color-green-600
+    );
+    --spectrum-semantic-positive-status-color: var(
+        --spectrum-global-color-green-400
+    );
+    --spectrum-semantic-positive-text-color-large: var(
+        --spectrum-global-color-green-500
+    );
+    --spectrum-semantic-positive-text-color-small: var(
+        --spectrum-global-color-green-600
+    );
+    --spectrum-semantic-positive-color-down: var(
+        --spectrum-global-color-green-700
+    );
+    --spectrum-semantic-positive-color-key-focus: var(
+        --spectrum-global-color-green-400
+    );
+    --spectrum-semantic-positive-background-color-default: var(
+        --spectrum-global-color-static-green-600
+    );
+    --spectrum-semantic-positive-background-color-hover: var(
+        --spectrum-global-color-static-green-700
+    );
+    --spectrum-semantic-positive-background-color-down: var(
+        --spectrum-global-color-static-green-800
+    );
+    --spectrum-semantic-positive-background-color-key-focus: var(
+        --spectrum-global-color-static-green-700
+    );
+    --spectrum-semantic-informative-background-color: var(
+        --spectrum-global-color-static-blue-700
+    );
+    --spectrum-semantic-informative-color-default: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-semantic-informative-color-dark: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-semantic-informative-border-color: var(
+        --spectrum-global-color-blue-400
+    );
+    --spectrum-semantic-informative-icon-color: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-semantic-informative-status-color: var(
+        --spectrum-global-color-blue-400
+    );
+    --spectrum-semantic-informative-text-color-large: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-semantic-informative-text-color-small: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-semantic-informative-color-down: var(
+        --spectrum-global-color-blue-700
+    );
+    --spectrum-semantic-informative-color-key-focus: var(
+        --spectrum-global-color-blue-400
+    );
+    --spectrum-semantic-informative-background-color-default: var(
+        --spectrum-global-color-static-blue-600
+    );
+    --spectrum-semantic-informative-background-color-hover: var(
+        --spectrum-global-color-static-blue-700
+    );
+    --spectrum-semantic-informative-background-color-down: var(
+        --spectrum-global-color-static-blue-800
+    );
+    --spectrum-semantic-informative-background-color-key-focus: var(
+        --spectrum-global-color-static-blue-700
+    );
+    --spectrum-semantic-neutral-background-color-default: var(
+        --spectrum-global-color-static-gray-700
+    );
+    --spectrum-semantic-neutral-background-color-hover: var(
+        --spectrum-global-color-static-gray-800
+    );
+    --spectrum-semantic-neutral-background-color-down: var(
+        --spectrum-global-color-static-gray-900
+    );
+    --spectrum-semantic-neutral-background-color-key-focus: var(
+        --spectrum-global-color-static-gray-800
+    );
+    --spectrum-semantic-presence-color-1: var(
+        --spectrum-global-color-static-red-500
+    );
+    --spectrum-semantic-presence-color-2: var(
+        --spectrum-global-color-static-orange-400
+    );
+    --spectrum-semantic-presence-color-3: var(
+        --spectrum-global-color-static-yellow-400
+    );
+    --spectrum-semantic-presence-color-4: #4bcca2;
+    --spectrum-semantic-presence-color-5: #00c7ff;
+    --spectrum-semantic-presence-color-6: #008cb8;
+    --spectrum-semantic-presence-color-7: #7e4bf3;
+    --spectrum-semantic-presence-color-8: var(
+        --spectrum-global-color-static-fuchsia-600
+    );
+
+    /* spectrum-dimensionGlobals.css */
+    --spectrum-global-dimension-static-percent-50: 50%;
+    --spectrum-global-dimension-static-percent-70: 70%;
+    --spectrum-global-dimension-static-percent-100: 100%;
+    --spectrum-global-dimension-static-breakpoint-xsmall: 304px;
+    --spectrum-global-dimension-static-breakpoint-small: 768px;
+    --spectrum-global-dimension-static-breakpoint-medium: 1280px;
+    --spectrum-global-dimension-static-breakpoint-large: 1768px;
+    --spectrum-global-dimension-static-breakpoint-xlarge: 2160px;
+    --spectrum-global-dimension-static-grid-columns: 12;
+    --spectrum-global-dimension-static-grid-fluid-width: 100%;
+    --spectrum-global-dimension-static-grid-fixed-max-width: 1280px;
+    --spectrum-global-dimension-static-size-0: 0px;
+    --spectrum-global-dimension-static-size-10: 1px;
+    --spectrum-global-dimension-static-size-25: 2px;
+    --spectrum-global-dimension-static-size-40: 3px;
+    --spectrum-global-dimension-static-size-50: 4px;
+    --spectrum-global-dimension-static-size-65: 5px;
+    --spectrum-global-dimension-static-size-75: 6px;
+    --spectrum-global-dimension-static-size-85: 7px;
+    --spectrum-global-dimension-static-size-100: 8px;
+    --spectrum-global-dimension-static-size-115: 9px;
+    --spectrum-global-dimension-static-size-125: 10px;
+    --spectrum-global-dimension-static-size-130: 11px;
+    --spectrum-global-dimension-static-size-150: 12px;
+    --spectrum-global-dimension-static-size-160: 13px;
+    --spectrum-global-dimension-static-size-175: 14px;
+    --spectrum-global-dimension-static-size-200: 16px;
+    --spectrum-global-dimension-static-size-225: 18px;
+    --spectrum-global-dimension-static-size-250: 20px;
+    --spectrum-global-dimension-static-size-275: 22px;
+    --spectrum-global-dimension-static-size-300: 24px;
+    --spectrum-global-dimension-static-size-325: 26px;
+    --spectrum-global-dimension-static-size-400: 32px;
+    --spectrum-global-dimension-static-size-450: 36px;
+    --spectrum-global-dimension-static-size-500: 40px;
+    --spectrum-global-dimension-static-size-550: 44px;
+    --spectrum-global-dimension-static-size-600: 48px;
+    --spectrum-global-dimension-static-size-700: 56px;
+    --spectrum-global-dimension-static-size-800: 64px;
+    --spectrum-global-dimension-static-size-900: 72px;
+    --spectrum-global-dimension-static-size-1000: 80px;
+    --spectrum-global-dimension-static-size-1200: 96px;
+    --spectrum-global-dimension-static-size-1700: 136px;
+    --spectrum-global-dimension-static-size-2400: 192px;
+    --spectrum-global-dimension-static-size-2500: 200px;
+    --spectrum-global-dimension-static-size-2600: 208px;
+    --spectrum-global-dimension-static-size-2800: 224px;
+    --spectrum-global-dimension-static-size-3200: 256px;
+    --spectrum-global-dimension-static-size-3400: 272px;
+    --spectrum-global-dimension-static-size-3500: 280px;
+    --spectrum-global-dimension-static-size-3600: 288px;
+    --spectrum-global-dimension-static-size-3800: 304px;
+    --spectrum-global-dimension-static-size-4600: 368px;
+    --spectrum-global-dimension-static-size-5000: 400px;
+    --spectrum-global-dimension-static-size-6000: 480px;
+    --spectrum-global-dimension-static-size-16000: 1280px;
+    --spectrum-global-dimension-static-font-size-50: 11px;
+    --spectrum-global-dimension-static-font-size-75: 12px;
+    --spectrum-global-dimension-static-font-size-100: 14px;
+    --spectrum-global-dimension-static-font-size-150: 15px;
+    --spectrum-global-dimension-static-font-size-200: 16px;
+    --spectrum-global-dimension-static-font-size-300: 18px;
+    --spectrum-global-dimension-static-font-size-400: 20px;
+    --spectrum-global-dimension-static-font-size-500: 22px;
+    --spectrum-global-dimension-static-font-size-600: 25px;
+    --spectrum-global-dimension-static-font-size-700: 28px;
+    --spectrum-global-dimension-static-font-size-800: 32px;
+    --spectrum-global-dimension-static-font-size-900: 36px;
+    --spectrum-global-dimension-static-font-size-1000: 40px;
+
+    /* spectrum-fontGlobals.css */
+    --spectrum-global-font-family-base: adobe-clean, 'Source Sans Pro',
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu,
+        'Trebuchet MS', 'Lucida Grande', sans-serif;
+    --spectrum-global-font-family-serif: adobe-clean-serif, 'Source Serif Pro',
+        Georgia, serif;
+    --spectrum-global-font-family-code: 'Source Code Pro', Monaco, monospace;
+    --spectrum-global-font-weight-thin: 100;
+    --spectrum-global-font-weight-ultra-light: 200;
+    --spectrum-global-font-weight-light: 300;
+    --spectrum-global-font-weight-regular: 400;
+    --spectrum-global-font-weight-medium: 500;
+    --spectrum-global-font-weight-semi-bold: 600;
+    --spectrum-global-font-weight-bold: 700;
+    --spectrum-global-font-weight-extra-bold: 800;
+    --spectrum-global-font-weight-black: 900;
+    --spectrum-global-font-style-regular: normal;
+    --spectrum-global-font-style-italic: italic;
+    --spectrum-global-font-letter-spacing-none: 0;
+    --spectrum-global-font-letter-spacing-small: 0.0125em;
+    --spectrum-global-font-letter-spacing-han: 0.05em;
+    --spectrum-global-font-letter-spacing-medium: 0.06em;
+    --spectrum-global-font-line-height-large: 1.7;
+    --spectrum-global-font-line-height-medium: 1.5;
+    --spectrum-global-font-line-height-small: 1.3;
+    --spectrum-global-font-multiplier-0: 0em;
+    --spectrum-global-font-multiplier-25: 0.25em;
+    --spectrum-global-font-multiplier-75: 0.75em;
+    --spectrum-global-font-font-family-ar: myriad-arabic, adobe-clean,
+        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
+    --spectrum-global-font-font-family-he: myriad-hebrew, adobe-clean,
+        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
+    --spectrum-global-font-font-family-zh: adobe-clean-han-traditional,
+        source-han-traditional, 'MingLiu', 'Heiti TC Light', 'sans-serif';
+    --spectrum-global-font-font-family-zhhans: adobe-clean-han-simplified-c,
+        source-han-simplified-c, 'SimSun', 'Heiti SC Light', 'sans-serif';
+    --spectrum-global-font-font-family-ko: adobe-clean-han-korean,
+        source-han-korean, 'Malgun Gothic', 'Apple Gothic', 'sans-serif';
+    --spectrum-global-font-font-family-ja: adobe-clean-han-japanese,
+        source-han-japanese, 'Yu Gothic', '\\30E1 \\30A4 \\30EA \\30AA',
+        '\\30D2 \\30E9 \\30AE \\30CE \\89D2 \\30B4  Pro W3',
+        'Hiragino Kaku Gothic Pro W3', 'Osaka',
+        '\\FF2D \\FF33 \\FF30 \\30B4 \\30B7 \\30C3 \\30AF', 'MS PGothic',
+        'sans-serif';
+    --spectrum-global-font-font-family-condensed: adobe-clean-han-traditional,
+        source-han-traditional, 'MingLiu', 'Heiti TC Light', adobe-clean,
+        'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+        Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
+
+    /* spectrum-staticAliases.css */
+    --spectrum-alias-loupe-entry-animation-duration: var(
+        --spectrum-global-animation-duration-300
+    );
+    --spectrum-alias-loupe-exit-animation-duration: var(
+        --spectrum-global-animation-duration-300
+    );
+    --spectrum-alias-heading-text-line-height: var(
+        --spectrum-global-font-line-height-small
+    );
+    --spectrum-alias-heading-text-font-weight-regular: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-heading-text-font-weight-regular-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-text-font-weight-light: var(
+        --spectrum-global-font-weight-light
+    );
+    --spectrum-alias-heading-text-font-weight-light-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-heading-text-font-weight-heavy: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-text-font-weight-heavy-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-text-font-weight-quiet: var(
+        --spectrum-global-font-weight-light
+    );
+    --spectrum-alias-heading-text-font-weight-quiet-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-heading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-text-font-weight-strong-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-heading-margin-bottom: var(
+        --spectrum-global-font-multiplier-25
+    );
+    --spectrum-alias-subheading-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-subheading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-body-text-font-family: var(
+        --spectrum-global-font-family-base
+    );
+    --spectrum-alias-body-text-line-height: var(
+        --spectrum-global-font-line-height-medium
+    );
+    --spectrum-alias-body-text-font-weight: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-body-text-font-weight-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-body-margin-bottom: var(
+        --spectrum-global-font-multiplier-75
+    );
+    --spectrum-alias-detail-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-detail-text-font-weight-regular: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-detail-text-font-weight-light: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-detail-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-article-heading-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-article-heading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-article-heading-text-font-weight-quiet: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-article-heading-text-font-weight-quiet-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-article-body-text-font-weight: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-article-body-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-article-subheading-text-font-weight: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-article-subheading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-article-detail-text-font-weight: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-article-detail-text-font-weight-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-code-text-font-family: var(
+        --spectrum-global-font-family-code
+    );
+    --spectrum-alias-code-text-font-weight-regular: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-code-text-font-weight-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-code-text-line-height: var(
+        --spectrum-global-font-line-height-medium
+    );
+    --spectrum-alias-code-margin-bottom: var(
+        --spectrum-global-font-multiplier-0
+    );
+    --spectrum-alias-font-family-ar: var(--spectrum-global-font-font-family-ar);
+    --spectrum-alias-font-family-he: var(--spectrum-global-font-font-family-he);
+    --spectrum-alias-font-family-zh: var(--spectrum-global-font-font-family-zh);
+    --spectrum-alias-font-family-zhhans: var(
+        --spectrum-global-font-font-family-zhhans
+    );
+    --spectrum-alias-font-family-ko: var(--spectrum-global-font-font-family-ko);
+    --spectrum-alias-font-family-ja: var(--spectrum-global-font-font-family-ja);
+    --spectrum-alias-font-family-condensed: var(
+        --spectrum-global-font-font-family-condensed
+    );
+    --spectrum-alias-button-text-line-height: var(
+        --spectrum-global-font-line-height-small
+    );
+    --spectrum-alias-component-text-line-height: var(
+        --spectrum-global-font-line-height-small
+    );
+    --spectrum-alias-han-component-text-line-height: var(
+        --spectrum-global-font-line-height-medium
+    );
+    --spectrum-alias-serif-text-font-family: var(
+        --spectrum-global-font-family-serif
+    );
+    --spectrum-alias-han-heading-text-line-height: var(
+        --spectrum-global-font-line-height-medium
+    );
+    --spectrum-alias-han-heading-text-font-weight-regular: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-heading-text-font-weight-regular-emphasis: var(
+        --spectrum-global-font-weight-extra-bold
+    );
+    --spectrum-alias-han-heading-text-font-weight-regular-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-heading-text-font-weight-quiet-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-heading-text-font-weight-light: var(
+        --spectrum-global-font-weight-light
+    );
+    --spectrum-alias-han-heading-text-font-weight-light-emphasis: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-han-heading-text-font-weight-light-strong: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-heading-text-font-weight-heavy: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-heading-text-font-weight-heavy-emphasis: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-heading-text-font-weight-heavy-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-body-text-line-height: var(
+        --spectrum-global-font-line-height-large
+    );
+    --spectrum-alias-han-body-text-font-weight-regular: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-han-body-text-font-weight-emphasis: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-body-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-subheading-text-font-weight-regular: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-subheading-text-font-weight-emphasis: var(
+        --spectrum-global-font-weight-extra-bold
+    );
+    --spectrum-alias-han-subheading-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+    --spectrum-alias-han-detail-text-font-weight: var(
+        --spectrum-global-font-weight-regular
+    );
+    --spectrum-alias-han-detail-text-font-weight-emphasis: var(
+        --spectrum-global-font-weight-bold
+    );
+    --spectrum-alias-han-detail-text-font-weight-strong: var(
+        --spectrum-global-font-weight-black
+    );
+}
+:host,
+:root {
+    /* spectrum-dimensionAliases.css */
+    --spectrum-alias-item-height-s: var(--spectrum-global-dimension-size-300);
+    --spectrum-alias-item-height-m: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-item-height-l: var(--spectrum-global-dimension-size-500);
+    --spectrum-alias-item-height-xl: var(--spectrum-global-dimension-size-600);
+    --spectrum-alias-item-rounded-border-radius-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-rounded-border-radius-m: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-item-rounded-border-radius-l: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-item-rounded-border-radius-xl: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-item-text-size-s: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-alias-item-text-size-m: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-item-text-size-l: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-item-text-size-xl: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-alias-item-text-padding-top-s: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-item-text-padding-top-m: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-text-padding-top-xl: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-text-padding-bottom-m: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-text-padding-bottom-l: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-item-text-padding-bottom-xl: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-item-icon-padding-top-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-item-icon-padding-top-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-icon-padding-top-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-icon-padding-top-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-icon-padding-bottom-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-item-icon-padding-bottom-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-icon-padding-bottom-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-icon-padding-bottom-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-padding-s: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-padding-m: var(--spectrum-global-dimension-size-150);
+    --spectrum-alias-item-padding-l: var(--spectrum-global-dimension-size-185);
+    --spectrum-alias-item-padding-xl: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-item-rounded-padding-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-rounded-padding-m: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-item-rounded-padding-l: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-item-rounded-padding-xl: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-item-icononly-padding-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-item-icononly-padding-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-icononly-padding-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-icononly-padding-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-control-gap-s: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-gap-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-gap-l: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-item-control-gap-xl: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-workflow-icon-gap-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-workflow-icon-gap-m: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-workflow-icon-gap-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-workflow-icon-gap-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-mark-gap-s: var(--spectrum-global-dimension-size-85);
+    --spectrum-alias-item-mark-gap-m: var(--spectrum-global-dimension-size-100);
+    --spectrum-alias-item-mark-gap-l: var(--spectrum-global-dimension-size-115);
+    --spectrum-alias-item-mark-gap-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-ui-icon-gap-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-ui-icon-gap-m: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-ui-icon-gap-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-ui-icon-gap-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-clearbutton-gap-s: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-item-clearbutton-gap-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-clearbutton-gap-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-clearbutton-gap-xl: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-workflow-padding-left-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-workflow-padding-left-l: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-workflow-padding-left-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-s: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-l: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-item-mark-padding-top-s: var(
+        --spectrum-global-dimension-size-40
+    );
+    --spectrum-alias-item-mark-padding-top-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-mark-padding-top-xl: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-item-mark-padding-bottom-s: var(
+        --spectrum-global-dimension-size-40
+    );
+    --spectrum-alias-item-mark-padding-bottom-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-mark-padding-bottom-xl: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-item-mark-padding-left-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-mark-padding-left-l: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-mark-padding-left-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-item-control-1-size-s: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-item-control-1-size-m: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-control-2-size-m: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-item-control-2-size-l: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-item-control-2-size-xl: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-item-control-2-size-xxl: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-item-control-2-border-radius-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-control-2-border-radius-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-control-2-border-radius-l: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-control-2-border-radius-xl: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-2-border-radius-xxl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-2-padding-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-control-2-padding-m: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-2-padding-l: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-control-2-padding-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-item-control-3-height-m: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-item-control-3-height-l: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-item-control-3-height-xl: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-item-control-3-border-radius-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-control-3-border-radius-m: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-item-control-3-border-radius-l: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-item-control-3-border-radius-xl: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-3-padding-s: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-item-control-3-padding-m: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-control-3-padding-l: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-control-3-padding-xl: var(
+        --spectrum-global-dimension-size-185
+    );
+    --spectrum-alias-item-mark-size-s: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-item-mark-size-l: var(
+        --spectrum-global-dimension-size-275
+    );
+    --spectrum-alias-item-mark-size-xl: var(
+        --spectrum-global-dimension-size-325
+    );
+    --spectrum-alias-heading-xxxl-text-size: var(
+        --spectrum-global-dimension-font-size-1300
+    );
+    --spectrum-alias-heading-xxl-text-size: var(
+        --spectrum-global-dimension-font-size-1100
+    );
+    --spectrum-alias-heading-xl-text-size: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading-l-text-size: var(
+        --spectrum-global-dimension-font-size-700
+    );
+    --spectrum-alias-heading-m-text-size: var(
+        --spectrum-global-dimension-font-size-500
+    );
+    --spectrum-alias-heading-s-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-alias-heading-xs-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-heading-xxs-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-heading-xxxl-margin-top: var(
+        --spectrum-global-dimension-font-size-1200
+    );
+    --spectrum-alias-heading-xxl-margin-top: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading-xl-margin-top: var(
+        --spectrum-global-dimension-font-size-800
+    );
+    --spectrum-alias-heading-l-margin-top: var(
+        --spectrum-global-dimension-font-size-600
+    );
+    --spectrum-alias-heading-m-margin-top: var(
+        --spectrum-global-dimension-font-size-400
+    );
+    --spectrum-alias-heading-s-margin-top: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-heading-xs-margin-top: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-heading-xxs-margin-top: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-alias-heading-han-xxxl-text-size: var(
+        --spectrum-global-dimension-font-size-1300
+    );
+    --spectrum-alias-heading-han-xxl-text-size: var(
+        --spectrum-global-dimension-font-size-900
+    );
+    --spectrum-alias-heading-han-xl-text-size: var(
+        --spectrum-global-dimension-font-size-800
+    );
+    --spectrum-alias-heading-han-l-text-size: var(
+        --spectrum-global-dimension-font-size-600
+    );
+    --spectrum-alias-heading-han-m-text-size: var(
+        --spectrum-global-dimension-font-size-400
+    );
+    --spectrum-alias-heading-han-s-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-alias-heading-han-xs-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-heading-han-xxs-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-heading-han-xxxl-margin-top: var(
+        --spectrum-global-dimension-font-size-1200
+    );
+    --spectrum-alias-heading-han-xxl-margin-top: var(
+        --spectrum-global-dimension-font-size-800
+    );
+    --spectrum-alias-heading-han-xl-margin-top: var(
+        --spectrum-global-dimension-font-size-700
+    );
+    --spectrum-alias-heading-han-l-margin-top: var(
+        --spectrum-global-dimension-font-size-500
+    );
+    --spectrum-alias-heading-han-m-margin-top: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-alias-heading-han-s-margin-top: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-alias-heading-han-xs-margin-top: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-heading-han-xxs-margin-top: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-alias-component-border-radius: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-component-border-radius-quiet: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-border-radius-xsmall: var(
+        --spectrum-global-dimension-size-25
+    );
+    --spectrum-alias-border-radius-small: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-alias-border-radius-regular: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-border-radius-medium: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-border-radius-large: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-control-two-size-s: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-control-two-size-m: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-control-two-size-l: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-control-two-size-xl: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-control-two-size-xxl: var(
+        --spectrum-global-dimension-size-275
+    );
+    --spectrum-alias-control-two-border-radius-s: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-alias-control-two-border-radius-m: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-control-two-border-radius-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-control-two-border-radius-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-control-two-border-radius-xxl: var(
+        --spectrum-global-dimension-size-130
+    );
+    --spectrum-alias-control-three-height-s: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-control-three-height-m: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-control-three-height-l: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-control-three-height-xl: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-control-three-width-s: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-focus-ring-gap-small: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-focus-ring-size-small: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-input-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-avatar-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-percent-50: 50%;
+    --spectrum-alias-percent-70: 70%;
+    --spectrum-alias-percent-100: 100%;
+    --spectrum-alias-breakpoint-xsmall: 304px;
+    --spectrum-alias-breakpoint-small: 768px;
+    --spectrum-alias-breakpoint-medium: 1280px;
+    --spectrum-alias-breakpoint-large: 1768px;
+    --spectrum-alias-breakpoint-xlarge: 2160px;
+    --spectrum-alias-grid-columns: 12;
+    --spectrum-alias-grid-fluid-width: 100%;
+    --spectrum-alias-grid-fixed-max-width: 1280px;
+    --spectrum-alias-border-size-thin: var(
+        --spectrum-global-dimension-static-size-10
+    );
+    --spectrum-alias-border-size-thick: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-border-size-thicker: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-border-size-thickest: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-border-offset-thin: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-border-offset-thick: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-border-offset-thicker: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-border-offset-thickest: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-baseline: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-grid-gutter-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-gutter-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-gutter-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-gutter-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-gutter-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-grid-margin-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-margin-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-margin-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-margin-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-margin-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-xsmall: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-small: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-medium: var(
+        --spectrum-global-dimension-static-size-400
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-large: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-grid-layout-region-margin-bottom-xlarge: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-alias-radial-reaction-size-default: var(
+        --spectrum-global-dimension-static-size-550
+    );
+    --spectrum-alias-focus-ring-gap: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-focus-ring-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-dropshadow-blur: var(--spectrum-global-dimension-size-50);
+    --spectrum-alias-dropshadow-offset-y: var(
+        --spectrum-global-dimension-size-10
+    );
+    --spectrum-alias-font-size-default: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-layout-label-gap-size: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-pill-button-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-alias-pill-button-text-baseline: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-single-line-height: var(
+        --spectrum-global-dimension-size-400
+    );
+    --spectrum-alias-single-line-width: var(
+        --spectrum-global-dimension-size-2400
+    );
+    --spectrum-alias-workflow-icon-size-s: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-workflow-icon-size-m: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-workflow-icon-size-xl: var(
+        --spectrum-global-dimension-size-275
+    );
+    --spectrum-alias-ui-icon-alert-size-75: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-ui-icon-alert-size-100: var(
+        --spectrum-global-dimension-size-225
+    );
+    --spectrum-alias-ui-icon-alert-size-200: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-ui-icon-alert-size-300: var(
+        --spectrum-global-dimension-size-275
+    );
+    --spectrum-alias-ui-icon-triplegripper-size-100-height: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-ui-icon-doublegripper-size-100-width: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-alias-ui-icon-singlegripper-size-100-width: var(
+        --spectrum-global-dimension-size-300
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-75: var(
+        --spectrum-global-dimension-size-65
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-200: var(
+        --spectrum-global-dimension-size-75
+    );
+    --spectrum-alias-ui-icon-asterisk-size-75: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-asterisk-size-100: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-alias-avatar-size-50: var(--spectrum-global-dimension-size-200);
+    --spectrum-alias-avatar-size-75: var(--spectrum-global-dimension-size-225);
+    --spectrum-alias-avatar-size-200: var(--spectrum-global-dimension-size-275);
+    --spectrum-alias-avatar-size-300: var(--spectrum-global-dimension-size-325);
+    --spectrum-alias-avatar-size-500: var(--spectrum-global-dimension-size-400);
+    --spectrum-alias-avatar-size-700: var(--spectrum-global-dimension-size-500);
+}
+:host,
+:root {
+    /* spectrum-colorAliases.css */
+    --spectrum-alias-colorhandle-outer-border-color: rgba(0, 0, 0, 0.42);
+    --spectrum-alias-component-text-color-selected-default: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-component-text-color-selected-hover: var(
+        --spectrum-alias-component-text-color-selected-default
+    );
+    --spectrum-alias-component-text-color-selected-down: var(
+        --spectrum-alias-component-text-color-selected-default
+    );
+    --spectrum-alias-component-text-color-selected-key-focus: var(
+        --spectrum-alias-component-text-color-selected-default
+    );
+    --spectrum-alias-component-text-color-selected-mouse-focus: var(
+        --spectrum-alias-component-text-color-selected-default
+    );
+    --spectrum-alias-component-icon-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-component-icon-color-selected: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-component-background-color-default: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-background-color-hover: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-component-background-color-down: var(
+        --spectrum-global-color-gray-400
+    );
+    --spectrum-alias-component-background-color-key-focus: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-component-background-color-quiet-hover: var(
+        --spectrum-alias-component-background-color-hover
+    );
+    --spectrum-alias-component-background-color-quiet-down: var(
+        --spectrum-alias-component-background-color-down
+    );
+    --spectrum-alias-component-background-color-quiet-key-focus: var(
+        --spectrum-alias-component-background-color-key-focus
+    );
+    --spectrum-alias-component-background-color-selected-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-component-background-color-selected-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-component-background-color-selected-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-component-background-color-selected-key-focus: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-component-border-color-default: var(
+        --spectrum-alias-component-background-color-default
+    );
+    --spectrum-alias-component-border-color-hover: var(
+        --spectrum-alias-component-background-color-hover
+    );
+    --spectrum-alias-component-border-color-down: var(
+        --spectrum-alias-component-background-color-down
+    );
+    --spectrum-alias-component-border-color-key-focus: var(
+        --spectrum-alias-component-background-color-key-focus
+    );
+    --spectrum-alias-component-border-color-selected-default: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-border-color-selected-hover: var(
+        --spectrum-alias-component-background-color-selected-hover
+    );
+    --spectrum-alias-component-border-color-selected-down: var(
+        --spectrum-alias-component-background-color-selected-down
+    );
+    --spectrum-alias-component-border-color-selected-key-focus: var(
+        --spectrum-alias-component-background-color-selected-key-focus
+    );
+    --spectrum-alias-component-border-color-quiet-key-focus: var(
+        --spectrum-alias-component-background-color-quiet-default
+    );
+    --spectrum-alias-component-border-color-quiet-selected-default: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-border-color-quiet-selected-hover: var(
+        --spectrum-alias-component-background-color-quiet-selected-hover
+    );
+    --spectrum-alias-component-border-color-quiet-selected-down: var(
+        --spectrum-alias-component-background-color-quiet-selected-down
+    );
+    --spectrum-alias-component-border-color-quiet-selected-key-focus: var(
+        --spectrum-alias-component-background-color-quiet-selected-key-focus
+    );
+    --spectrum-alias-toggle-background-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-toggle-background-color-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-toggle-background-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-toggle-background-color-key-focus: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-toggle-border-color: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-toggle-border-color-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-toggle-icon-color-selected: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-avatar-border-color-disabled: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-avatar-border-color-selected-default: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-avatar-border-color-selected-hover: var(
+        --spectrum-alias-component-background-color-selected-hover
+    );
+    --spectrum-alias-avatar-border-color-selected-down: var(
+        --spectrum-alias-component-background-color-selected-hover
+    );
+    --spectrum-alias-avatar-border-color-selected-key-focus: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-button-primary-background-color-default: var(
+        --spectrum-alias-button-primary-border-color-default
+    );
+    --spectrum-alias-button-primary-text-color-default: var(
+        --spectrum-alias-button-primary-text-color-hover
+    );
+    --spectrum-alias-button-primary-icon-color-default: var(
+        --spectrum-alias-button-primary-text-color-default
+    );
+    --spectrum-alias-button-secondary-background-color-default: var(
+        --spectrum-alias-button-secondary-border-color-default
+    );
+    --spectrum-alias-button-secondary-text-color-default: var(
+        --spectrum-alias-button-secondary-text-color-hover
+    );
+    --spectrum-alias-button-secondary-icon-color-default: var(
+        --spectrum-alias-button-secondary-text-color-default
+    );
+    --spectrum-alias-button-negative-background-color-default: var(
+        --spectrum-alias-button-negative-border-color-default
+    );
+    --spectrum-alias-button-negative-text-color-default: var(
+        --spectrum-alias-button-negative-text-color-hover
+    );
+    --spectrum-alias-button-negative-icon-color-default: var(
+        --spectrum-alias-button-negative-text-color-default
+    );
+    --spectrum-alias-input-border-color-default: var(
+        --spectrum-alias-border-color
+    );
+    --spectrum-alias-input-border-color-hover: var(
+        --spectrum-alias-border-color-hover
+    );
+    --spectrum-alias-input-border-color-down: var(
+        --spectrum-alias-border-color-mouse-focus
+    );
+    --spectrum-alias-input-border-color-key-focus: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-yellow-background-color-default: var(
+        --spectrum-global-color-static-yellow-400
+    );
+    --spectrum-alias-yellow-background-color-hover: var(
+        --spectrum-global-color-static-yellow-500
+    );
+    --spectrum-alias-yellow-background-color-key-focus: var(
+        --spectrum-global-color-static-yellow-500
+    );
+    --spectrum-alias-yellow-background-color-down: var(
+        --spectrum-global-color-static-yellow-600
+    );
+    --spectrum-alias-component-text-color-disabled: var(
+        --spectrum-global-color-gray-500
+    );
+    --spectrum-alias-component-text-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-component-text-color-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-component-text-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-component-text-color-key-focus: var(
+        --spectrum-alias-component-text-color-hover
+    );
+    --spectrum-alias-component-text-color-mouse-focus: var(
+        --spectrum-alias-component-text-color-hover
+    );
+    --spectrum-alias-component-text-color: var(
+        --spectrum-alias-component-text-color-default
+    );
+    --spectrum-alias-component-text-color-selected: var(
+        --spectrum-alias-component-text-color-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-default: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-hover: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-down: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-key-focus: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected-mouse-focus: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-emphasized-selected: var(
+        --spectrum-alias-component-text-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-text-color-error-default: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-component-text-color-error-hover: var(
+        --spectrum-semantic-negative-text-color-small-hover
+    );
+    --spectrum-alias-component-text-color-error-down: var(
+        --spectrum-semantic-negative-text-color-small-down
+    );
+    --spectrum-alias-component-text-color-error-key-focus: var(
+        --spectrum-semantic-negative-text-color-small-key-focus
+    );
+    --spectrum-alias-component-text-color-error-mouse-focus: var(
+        --spectrum-semantic-negative-text-color-small-key-focus
+    );
+    --spectrum-alias-component-text-color-error: var(
+        --spectrum-alias-component-text-color-error-default
+    );
+    --spectrum-alias-component-icon-color-disabled: var(
+        --spectrum-alias-icon-color-disabled
+    );
+    --spectrum-alias-component-icon-color-hover: var(
+        --spectrum-alias-icon-color-hover
+    );
+    --spectrum-alias-component-icon-color-down: var(
+        --spectrum-alias-icon-color-down
+    );
+    --spectrum-alias-component-icon-color-key-focus: var(
+        --spectrum-alias-icon-color-hover
+    );
+    --spectrum-alias-component-icon-color-mouse-focus: var(
+        --spectrum-alias-icon-color-down
+    );
+    --spectrum-alias-component-icon-color: var(
+        --spectrum-alias-component-icon-color-default
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected-default: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected-hover: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected-down: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected-key-focus: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-icon-color-emphasized-selected: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-background-color-disabled: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-component-background-color-quiet-disabled: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-component-background-color: var(
+        --spectrum-alias-component-background-color-default
+    );
+    --spectrum-alias-component-background-color-selected: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-background-color-quiet-default: var(
+        --spectrum-alias-background-color-transparent
+    );
+    --spectrum-alias-component-background-color-quiet: var(
+        --spectrum-alias-component-background-color-quiet-default
+    );
+    --spectrum-alias-component-background-color-quiet-selected-default: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-background-color-quiet-selected-hover: var(
+        --spectrum-alias-component-background-color-selected-hover
+    );
+    --spectrum-alias-component-background-color-quiet-selected-down: var(
+        --spectrum-alias-component-background-color-selected-down
+    );
+    --spectrum-alias-component-background-color-quiet-selected-key-focus: var(
+        --spectrum-alias-component-background-color-selected-key-focus
+    );
+    --spectrum-alias-component-background-color-quiet-selected: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-background-color-emphasized-selected-default: var(
+        --spectrum-semantic-cta-background-color-default
+    );
+    --spectrum-alias-component-background-color-emphasized-selected-hover: var(
+        --spectrum-semantic-cta-background-color-hover
+    );
+    --spectrum-alias-component-background-color-emphasized-selected-down: var(
+        --spectrum-semantic-cta-background-color-down
+    );
+    --spectrum-alias-component-background-color-emphasized-selected-key-focus: var(
+        --spectrum-semantic-cta-background-color-key-focus
+    );
+    --spectrum-alias-component-background-color-emphasized-selected: var(
+        --spectrum-alias-component-background-color-emphasized-selected-default
+    );
+    --spectrum-alias-component-border-color-disabled: var(
+        --spectrum-alias-border-color-disabled
+    );
+    --spectrum-alias-component-border-color-quiet-disabled: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-component-border-color: var(
+        --spectrum-alias-component-border-color-default
+    );
+    --spectrum-alias-component-border-color-selected: var(
+        --spectrum-alias-component-border-color-selected-default
+    );
+    --spectrum-alias-component-border-color-quiet-default: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-component-border-color-quiet-hover: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-component-border-color-quiet-down: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-component-border-color-quiet: var(
+        --spectrum-alias-component-border-color-quiet-default
+    );
+    --spectrum-alias-component-border-color-quiet-selected: var(
+        --spectrum-alias-component-background-color-selected-default
+    );
+    --spectrum-alias-component-border-color-emphasized-selected-default: var(
+        --spectrum-semantic-cta-background-color-default
+    );
+    --spectrum-alias-component-border-color-emphasized-selected-hover: var(
+        --spectrum-semantic-cta-background-color-hover
+    );
+    --spectrum-alias-component-border-color-emphasized-selected-down: var(
+        --spectrum-semantic-cta-background-color-down
+    );
+    --spectrum-alias-component-border-color-emphasized-selected-key-focus: var(
+        --spectrum-semantic-cta-background-color-key-focus
+    );
+    --spectrum-alias-component-border-color-emphasized-selected: var(
+        --spectrum-alias-component-border-color-emphasized-selected-default
+    );
+    --spectrum-alias-avatar-border-color: var(
+        --spectrum-alias-avatar-border-color-default
+    );
+    --spectrum-alias-avatar-border-color-selected: var(
+        --spectrum-alias-avatar-border-color-selected-default
+    );
+    --spectrum-alias-toggle-background-color: var(
+        --spectrum-alias-toggle-background-color-default
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected-default: var(
+        --spectrum-semantic-cta-background-color-default
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected-hover: var(
+        --spectrum-semantic-cta-background-color-hover
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected-down: var(
+        --spectrum-semantic-cta-background-color-down
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected-key-focus: var(
+        --spectrum-semantic-cta-background-color-key-focus
+    );
+    --spectrum-alias-toggle-background-color-emphasized-selected: var(
+        --spectrum-alias-toggle-background-color-emphasized-selected-default
+    );
+    --spectrum-alias-toggle-border-color-default: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-toggle-border-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-toggle-border-color-key-focus: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-toggle-icon-color-emphasized-selected: var(
+        --spectrum-alias-component-icon-color-emphasized-selected-default
+    );
+    --spectrum-alias-button-primary-background-color-hover: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-primary-background-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-button-primary-background-color-key-focus: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-primary-background-color: var(
+        --spectrum-alias-button-primary-background-color-default
+    );
+    --spectrum-alias-button-primary-border-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-primary-border-color-hover: var(
+        --spectrum-alias-button-primary-background-color-hover
+    );
+    --spectrum-alias-button-primary-border-color-down: var(
+        --spectrum-alias-button-primary-background-color-down
+    );
+    --spectrum-alias-button-primary-border-color-key-focus: var(
+        --spectrum-alias-button-primary-background-color-key-focus
+    );
+    --spectrum-alias-button-primary-border-color: var(
+        --spectrum-alias-button-primary-border-color-default
+    );
+    --spectrum-alias-button-primary-text-color-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-primary-text-color-down: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-primary-text-color-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-primary-text-color: var(
+        --spectrum-alias-button-primary-text-color-default
+    );
+    --spectrum-alias-button-primary-icon-color-hover: var(
+        --spectrum-alias-button-primary-text-color-hover
+    );
+    --spectrum-alias-button-primary-icon-color-down: var(
+        --spectrum-alias-button-primary-text-color-down
+    );
+    --spectrum-alias-button-primary-icon-color-key-focus: var(
+        --spectrum-alias-button-primary-text-color-key-focus
+    );
+    --spectrum-alias-button-primary-icon-color: var(
+        --spectrum-alias-button-primary-icon-color-default
+    );
+    --spectrum-alias-button-secondary-background-color-hover: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-button-secondary-background-color-down: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-button-secondary-background-color-key-focus: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-button-secondary-background-color: var(
+        --spectrum-alias-button-secondary-background-color-default
+    );
+    --spectrum-alias-button-secondary-border-color-default: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-button-secondary-border-color-hover: var(
+        --spectrum-alias-button-secondary-background-color-hover
+    );
+    --spectrum-alias-button-secondary-border-color-down: var(
+        --spectrum-alias-button-secondary-background-color-down
+    );
+    --spectrum-alias-button-secondary-border-color-key-focus: var(
+        --spectrum-alias-button-secondary-background-color-key-focus
+    );
+    --spectrum-alias-button-secondary-border-color: var(
+        --spectrum-alias-button-secondary-border-color-default
+    );
+    --spectrum-alias-button-secondary-text-color-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-secondary-text-color-down: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-secondary-text-color-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-secondary-text-color: var(
+        --spectrum-alias-button-secondary-text-color-default
+    );
+    --spectrum-alias-button-secondary-icon-color-hover: var(
+        --spectrum-alias-button-secondary-text-color-hover
+    );
+    --spectrum-alias-button-secondary-icon-color-down: var(
+        --spectrum-alias-button-secondary-text-color-down
+    );
+    --spectrum-alias-button-secondary-icon-color-key-focus: var(
+        --spectrum-alias-button-secondary-text-color-key-focus
+    );
+    --spectrum-alias-button-secondary-icon-color: var(
+        --spectrum-alias-button-secondary-icon-color-default
+    );
+    --spectrum-alias-button-negative-background-color-hover: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-background-color-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-alias-button-negative-background-color-key-focus: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-background-color: var(
+        --spectrum-alias-button-negative-background-color-default
+    );
+    --spectrum-alias-button-negative-border-color-default: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-border-color-hover: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-border-color-down: var(
+        --spectrum-global-color-red-700
+    );
+    --spectrum-alias-button-negative-border-color-key-focus: var(
+        --spectrum-semantic-negative-text-color-small
+    );
+    --spectrum-alias-button-negative-border-color: var(
+        --spectrum-alias-button-negative-border-color-default
+    );
+    --spectrum-alias-button-negative-text-color-hover: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-negative-text-color-down: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-negative-text-color-key-focus: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-button-negative-text-color: var(
+        --spectrum-alias-button-negative-text-color-default
+    );
+    --spectrum-alias-button-negative-icon-color-hover: var(
+        --spectrum-alias-button-negative-text-color-hover
+    );
+    --spectrum-alias-button-negative-icon-color-down: var(
+        --spectrum-alias-button-negative-text-color-down
+    );
+    --spectrum-alias-button-negative-icon-color-key-focus: var(
+        --spectrum-alias-button-negative-text-color-key-focus
+    );
+    --spectrum-alias-button-negative-icon-color: var(
+        --spectrum-alias-button-negative-icon-color-default
+    );
+    --spectrum-alias-input-border-color-disabled: var(
+        --spectrum-alias-border-color-transparent
+    );
+    --spectrum-alias-input-border-color-quiet-disabled: var(
+        --spectrum-alias-border-color-mid
+    );
+    --spectrum-alias-input-border-color-mouse-focus: var(
+        --spectrum-alias-border-color-mouse-focus
+    );
+    --spectrum-alias-input-border-color: var(
+        --spectrum-alias-input-border-color-default
+    );
+    --spectrum-alias-input-border-color-invalid-default: var(
+        --spectrum-semantic-negative-color-default
+    );
+    --spectrum-alias-input-border-color-invalid-hover: var(
+        --spectrum-semantic-negative-color-hover
+    );
+    --spectrum-alias-input-border-color-invalid-down: var(
+        --spectrum-semantic-negative-color-down
+    );
+    --spectrum-alias-input-border-color-invalid-mouse-focus: var(
+        --spectrum-semantic-negative-color-hover
+    );
+    --spectrum-alias-input-border-color-invalid-key-focus: var(
+        --spectrum-alias-border-color-key-focus
+    );
+    --spectrum-alias-input-border-color-invalid: var(
+        --spectrum-alias-input-border-color-invalid-default
+    );
+    --spectrum-alias-background-color-yellow-default: var(
+        --spectrum-global-color-static-yellow-600
+    );
+    --spectrum-alias-background-color-yellow-hover: var(
+        --spectrum-global-color-static-yellow-700
+    );
+    --spectrum-alias-background-color-yellow-key-focus: var(
+        --spectrum-global-color-static-yellow-700
+    );
+    --spectrum-alias-background-color-yellow-down: var(
+        --spectrum-global-color-static-yellow-800
+    );
+    --spectrum-alias-background-color-yellow: var(
+        --spectrum-alias-background-color-yellow-default
+    );
+    --spectrum-alias-background-color-default: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-background-color-disabled: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-background-color-transparent: transparent;
+    --spectrum-alias-background-color-overbackground-down: hsla(
+        0,
+        0%,
+        100%,
+        0.2
+    );
+    --spectrum-alias-background-color-quiet-overbackground-hover: hsla(
+        0,
+        0%,
+        100%,
+        0.1
+    );
+    --spectrum-alias-background-color-quiet-overbackground-down: hsla(
+        0,
+        0%,
+        100%,
+        0.2
+    );
+    --spectrum-alias-background-color-overbackground-disabled: hsla(
+        0,
+        0%,
+        100%,
+        0.1
+    );
+    --spectrum-alias-background-color-quickactions-overlay: rgba(0, 0, 0, 0.2);
+    --spectrum-alias-placeholder-text-color: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-placeholder-text-color-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-placeholder-text-color-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-placeholder-text-color-selected: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-label-text-color: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-text-color: var(--spectrum-global-color-gray-800);
+    --spectrum-alias-text-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-text-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-text-color-key-focus: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-text-color-mouse-focus: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-text-color-disabled: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-text-color-invalid: var(--spectrum-global-color-red-500);
+    --spectrum-alias-text-color-selected: var(--spectrum-global-color-blue-600);
+    --spectrum-alias-text-color-selected-neutral: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-text-color-overbackground: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-text-color-overbackground-disabled: hsla(0, 0%, 100%, 0.2);
+    --spectrum-alias-text-color-quiet-overbackground-disabled: hsla(
+        0,
+        0%,
+        100%,
+        0.2
+    );
+    --spectrum-alias-heading-text-color: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-border-color: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-border-color-hover: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-border-color-down: var(--spectrum-global-color-gray-500);
+    --spectrum-alias-border-color-key-focus: var(
+        --spectrum-global-color-blue-400
+    );
+    --spectrum-alias-border-color-mouse-focus: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-alias-border-color-disabled: var(
+        --spectrum-global-color-gray-200
+    );
+    --spectrum-alias-border-color-extralight: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-border-color-light: var(--spectrum-global-color-gray-200);
+    --spectrum-alias-border-color-mid: var(--spectrum-global-color-gray-300);
+    --spectrum-alias-border-color-dark: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-border-color-darker-default: var(
+        --spectrum-global-color-gray-600
+    );
+    --spectrum-alias-border-color-darker-hover: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-border-color-darker-down: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-border-color-transparent: transparent;
+    --spectrum-alias-border-color-translucent-dark: rgba(0, 0, 0, 0.05);
+    --spectrum-alias-border-color-translucent-darker: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-focus-color: var(--spectrum-global-color-blue-400);
+    --spectrum-alias-focus-ring-color: var(--spectrum-alias-focus-color);
+    --spectrum-alias-track-color-default: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-track-fill-color-overbackground: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-track-color-disabled: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-track-color-overbackground: hsla(0, 0%, 100%, 0.2);
+    --spectrum-alias-icon-color: var(--spectrum-global-color-gray-700);
+    --spectrum-alias-icon-color-overbackground: var(
+        --spectrum-global-color-static-white
+    );
+    --spectrum-alias-icon-color-hover: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-icon-color-down: var(--spectrum-global-color-gray-900);
+    --spectrum-alias-icon-color-key-focus: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-icon-color-disabled: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-icon-color-overbackground-disabled: hsla(0, 0%, 100%, 0.2);
+    --spectrum-alias-icon-color-quiet-overbackground-disabled: hsla(
+        0,
+        0%,
+        100%,
+        0.15
+    );
+    --spectrum-alias-icon-color-selected-neutral: var(
+        --spectrum-global-color-gray-900
+    );
+    --spectrum-alias-icon-color-selected-neutral-subdued: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-icon-color-selected: var(--spectrum-global-color-blue-500);
+    --spectrum-alias-icon-color-selected-hover: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-icon-color-selected-down: var(
+        --spectrum-global-color-blue-700
+    );
+    --spectrum-alias-icon-color-selected-focus: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-image-opacity-disabled: var(
+        --spectrum-global-color-opacity-30
+    );
+    --spectrum-alias-toolbar-background-color: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-code-highlight-color-default: var(
+        --spectrum-global-color-gray-800
+    );
+    --spectrum-alias-code-highlight-background-color: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-alias-code-highlight-color-keyword: var(
+        --spectrum-global-color-fuchsia-600
+    );
+    --spectrum-alias-code-highlight-color-section: var(
+        --spectrum-global-color-red-600
+    );
+    --spectrum-alias-code-highlight-color-literal: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-code-highlight-color-attribute: var(
+        --spectrum-global-color-seafoam-600
+    );
+    --spectrum-alias-code-highlight-color-class: var(
+        --spectrum-global-color-magenta-600
+    );
+    --spectrum-alias-code-highlight-color-variable: var(
+        --spectrum-global-color-purple-600
+    );
+    --spectrum-alias-code-highlight-color-title: var(
+        --spectrum-global-color-indigo-600
+    );
+    --spectrum-alias-code-highlight-color-string: var(
+        --spectrum-global-color-fuchsia-600
+    );
+    --spectrum-alias-code-highlight-color-function: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-code-highlight-color-comment: var(
+        --spectrum-global-color-gray-700
+    );
+    --spectrum-alias-categorical-color-1: var(
+        --spectrum-global-color-static-seafoam-200
+    );
+    --spectrum-alias-categorical-color-2: var(
+        --spectrum-global-color-static-indigo-700
+    );
+    --spectrum-alias-categorical-color-3: var(
+        --spectrum-global-color-static-orange-500
+    );
+    --spectrum-alias-categorical-color-4: var(
+        --spectrum-global-color-static-magenta-500
+    );
+    --spectrum-alias-categorical-color-5: var(
+        --spectrum-global-color-static-indigo-200
+    );
+    --spectrum-alias-categorical-color-6: var(
+        --spectrum-global-color-static-celery-200
+    );
+    --spectrum-alias-categorical-color-7: var(
+        --spectrum-global-color-static-blue-500
+    );
+    --spectrum-alias-categorical-color-8: var(
+        --spectrum-global-color-static-purple-800
+    );
+    --spectrum-alias-categorical-color-9: var(
+        --spectrum-global-color-static-yellow-500
+    );
+    --spectrum-alias-categorical-color-10: var(
+        --spectrum-global-color-static-orange-700
+    );
+    --spectrum-alias-categorical-color-11: var(
+        --spectrum-global-color-static-green-600
+    );
+    --spectrum-alias-categorical-color-12: var(
+        --spectrum-global-color-static-chartreuse-300
+    );
+    --spectrum-alias-categorical-color-13: var(
+        --spectrum-global-color-static-blue-200
+    );
+    --spectrum-alias-categorical-color-14: var(
+        --spectrum-global-color-static-fuchsia-500
+    );
+    --spectrum-alias-categorical-color-15: var(
+        --spectrum-global-color-static-magenta-200
+    );
+    --spectrum-alias-categorical-color-16: var(
+        --spectrum-global-color-static-yellow-200
+    );
+}
+/* stylelint-enable */

--- a/packages/styles/express/scale-large.css
+++ b/packages/styles/express/scale-large.css
@@ -10,8 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+@import './spectrum-scale-large.css';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+:host,
+:root {
+    --spectrum-global-alias-appframe-border-size: 1px;
+}

--- a/packages/styles/express/scale-medium.css
+++ b/packages/styles/express/scale-medium.css
@@ -10,8 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+@import './spectrum-scale-medium.css';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+:host,
+:root {
+    --spectrum-global-alias-appframe-border-size: 2px;
+}

--- a/packages/styles/express/spectrum-scale-large.css
+++ b/packages/styles/express/spectrum-scale-large.css
@@ -1,0 +1,4258 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* stylelint-disable */
+:host,
+:root {
+    --spectrum-global-dimension-scale-factor: 1.25;
+    --spectrum-global-dimension-size-0: 0px;
+    --spectrum-global-dimension-size-10: 1px;
+    --spectrum-global-dimension-size-25: 2px;
+    --spectrum-global-dimension-size-40: 4px;
+    --spectrum-global-dimension-size-50: 5px;
+    --spectrum-global-dimension-size-65: 6px;
+    --spectrum-global-dimension-size-75: 8px;
+    --spectrum-global-dimension-size-85: 9px;
+    --spectrum-global-dimension-size-100: 10px;
+    --spectrum-global-dimension-size-115: 11px;
+    --spectrum-global-dimension-size-125: 13px;
+    --spectrum-global-dimension-size-130: 14px;
+    --spectrum-global-dimension-size-150: 15px;
+    --spectrum-global-dimension-size-160: 16px;
+    --spectrum-global-dimension-size-175: 18px;
+    --spectrum-global-dimension-size-185: 19px;
+    --spectrum-global-dimension-size-200: 20px;
+    --spectrum-global-dimension-size-225: 22px;
+    --spectrum-global-dimension-size-250: 25px;
+    --spectrum-global-dimension-size-275: 28px;
+    --spectrum-global-dimension-size-300: 30px;
+    --spectrum-global-dimension-size-325: 32px;
+    --spectrum-global-dimension-size-350: 35px;
+    --spectrum-global-dimension-size-400: 40px;
+    --spectrum-global-dimension-size-450: 45px;
+    --spectrum-global-dimension-size-500: 50px;
+    --spectrum-global-dimension-size-550: 56px;
+    --spectrum-global-dimension-size-600: 60px;
+    --spectrum-global-dimension-size-650: 65px;
+    --spectrum-global-dimension-size-675: 68px;
+    --spectrum-global-dimension-size-700: 70px;
+    --spectrum-global-dimension-size-750: 75px;
+    --spectrum-global-dimension-size-800: 80px;
+    --spectrum-global-dimension-size-900: 90px;
+    --spectrum-global-dimension-size-1000: 100px;
+    --spectrum-global-dimension-size-1125: 112px;
+    --spectrum-global-dimension-size-1200: 120px;
+    --spectrum-global-dimension-size-1250: 125px;
+    --spectrum-global-dimension-size-1600: 160px;
+    --spectrum-global-dimension-size-1700: 170px;
+    --spectrum-global-dimension-size-1800: 180px;
+    --spectrum-global-dimension-size-2000: 200px;
+    --spectrum-global-dimension-size-2400: 240px;
+    --spectrum-global-dimension-size-2500: 250px;
+    --spectrum-global-dimension-size-3000: 300px;
+    --spectrum-global-dimension-size-3400: 340px;
+    --spectrum-global-dimension-size-3600: 360px;
+    --spectrum-global-dimension-size-4600: 460px;
+    --spectrum-global-dimension-size-5000: 500px;
+    --spectrum-global-dimension-size-6000: 600px;
+    --spectrum-global-dimension-font-size-25: 12px;
+    --spectrum-global-dimension-font-size-50: 13px;
+    --spectrum-global-dimension-font-size-75: 15px;
+    --spectrum-global-dimension-font-size-100: 17px;
+    --spectrum-global-dimension-font-size-150: 18px;
+    --spectrum-global-dimension-font-size-200: 19px;
+    --spectrum-global-dimension-font-size-300: 22px;
+    --spectrum-global-dimension-font-size-400: 24px;
+    --spectrum-global-dimension-font-size-500: 27px;
+    --spectrum-global-dimension-font-size-600: 31px;
+    --spectrum-global-dimension-font-size-700: 34px;
+    --spectrum-global-dimension-font-size-800: 39px;
+    --spectrum-global-dimension-font-size-900: 44px;
+    --spectrum-global-dimension-font-size-1000: 49px;
+    --spectrum-global-dimension-font-size-1100: 55px;
+    --spectrum-global-dimension-font-size-1200: 62px;
+    --spectrum-global-dimension-font-size-1300: 70px;
+    --spectrum-alias-item-text-padding-top-l: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-text-padding-bottom-s: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-item-workflow-padding-left-m: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-m: 17px;
+    --spectrum-alias-item-rounded-workflow-padding-left-xl: 27px;
+    --spectrum-alias-item-mark-padding-top-m: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-item-mark-padding-bottom-m: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-item-mark-padding-left-m: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-control-1-size-l: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-control-1-size-xl: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-item-control-2-size-s: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-control-3-height-s: var(
+        --spectrum-global-dimension-size-160
+    );
+    --spectrum-alias-item-control-3-width-s: var(
+        --spectrum-global-dimension-size-325
+    );
+    --spectrum-alias-item-control-3-width-m: var(
+        --spectrum-global-dimension-static-size-450
+    );
+    --spectrum-alias-item-control-3-width-l: 41px;
+    --spectrum-alias-item-control-3-width-xl: 46px;
+    --spectrum-alias-item-mark-size-m: var(
+        --spectrum-global-dimension-static-size-325
+    );
+    --spectrum-alias-control-three-width-m: 34px;
+    --spectrum-alias-control-three-width-l: 38px;
+    --spectrum-alias-control-three-width-xl: var(
+        --spectrum-global-dimension-static-size-550
+    );
+    --spectrum-alias-focus-ring-radius-default: var(
+        --spectrum-global-dimension-static-size-115
+    );
+    --spectrum-alias-workflow-icon-size-l: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-ui-icon-chevron-size-75: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-chevron-size-100: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-chevron-size-200: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-chevron-size-300: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-chevron-size-400: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-chevron-size-500: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-checkmark-size-50: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-checkmark-size-75: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-checkmark-size-100: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-checkmark-size-200: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-300: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-400: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-checkmark-size-500: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-checkmark-size-600: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-ui-icon-dash-size-50: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-dash-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-dash-size-100: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-dash-size-200: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-dash-size-300: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-dash-size-400: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-dash-size-500: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-dash-size-600: var(
+        --spectrum-global-dimension-static-size-275
+    );
+    --spectrum-alias-ui-icon-cross-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-cross-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-cross-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-cross-size-300: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-cross-size-400: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-cross-size-500: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-cross-size-600: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-arrow-size-75: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-arrow-size-100: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-arrow-size-200: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-arrow-size-300: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-arrow-size-400: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-arrow-size-500: var(
+        --spectrum-global-dimension-static-size-275
+    );
+    --spectrum-alias-ui-icon-arrow-size-600: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-asterisk-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-asterisk-size-300: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-avatar-size-100: 26px;
+    --spectrum-alias-avatar-size-400: 36px;
+    --spectrum-alias-avatar-size-600: 46px;
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-quiet-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-actionbutton-l-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-badge-s-fuchsia-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-fuchsia-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-fuchsia-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-indigo-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-informative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-magenta-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-negative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-neutral-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-positive-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-purple-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-seafoam-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-s-yellow-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-badge-m-fuchsia-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-indigo-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-informative-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-magenta-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-neutral-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-positive-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-purple-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-seafoam-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-m-yellow-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-fuchsia-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-fuchsia-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-fuchsia-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-indigo-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-indigo-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-informative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-informative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-magenta-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-magenta-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-negative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-negative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-neutral-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-neutral-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-positive-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-positive-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-purple-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-purple-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-seafoam-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-seafoam-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-badge-l-yellow-icononly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-badge-l-yellow-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-breadcrumb-s-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-multiline-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-breadcrumb-s-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-breadcrumb-s-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-m-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-multiline-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-breadcrumb-l-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-breadcrumb-l-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-breadcrumb-l-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-quiet-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-cta-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-cta-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-cta-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-cta-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-quiet-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-quiet-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-quiet-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-cta-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-cta-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-cta-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-cta-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-cta-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-quiet-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-primary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-primary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-secondary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-secondary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-quiet-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-button-s-negative-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-s-negative-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-quiet-overbackground-texticon-padding-left: 17px;
+    --spectrum-button-m-cta-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-quiet-texticon-padding-left: 17px;
+    --spectrum-button-m-cta-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-overbackground-texticon-padding-left: 17px;
+    --spectrum-button-m-cta-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-quiet-overbackground-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-quiet-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-overbackground-texticon-padding-left: 17px;
+    --spectrum-button-m-primary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-quiet-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-overbackground-texticon-padding-left: 17px;
+    --spectrum-button-m-secondary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-quiet-overbackground-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-quiet-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-overbackground-texticon-padding-left: 17px;
+    --spectrum-button-m-negative-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-texticon-padding-left: 17px;
+    --spectrum-button-m-cta-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-cta-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-primary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-secondary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-m-negative-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-quiet-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-cta-quiet-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-cta-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-cta-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-cta-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-cta-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-cta-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-cta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-cta-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-quiet-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-quiet-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-quiet-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-quiet-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-quiet-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-cta-quiet-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-cta-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-cta-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-cta-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-cta-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-cta-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-cta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-cta-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-cta-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-quiet-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-quiet-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-primary-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-primary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-primary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-secondary-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-secondary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-secondary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-quiet-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-quiet-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-button-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-button-l-negative-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-l-negative-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-quiet-overbackground-texticon-padding-left: 27px;
+    --spectrum-button-xl-cta-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-quiet-texticon-padding-left: 27px;
+    --spectrum-button-xl-cta-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-overbackground-texticon-padding-left: 27px;
+    --spectrum-button-xl-cta-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-quiet-overbackground-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-quiet-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-overbackground-texticon-padding-left: 27px;
+    --spectrum-button-xl-primary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-quiet-overbackground-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-quiet-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-overbackground-texticon-padding-left: 27px;
+    --spectrum-button-xl-secondary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-quiet-overbackground-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-quiet-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-overbackground-texticon-padding-left: 27px;
+    --spectrum-button-xl-negative-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-texticon-padding-left: 27px;
+    --spectrum-button-xl-cta-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-cta-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-primary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-secondary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-button-xl-negative-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-checkbox-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-checkbox-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-checkbox-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-checkbox-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-checkbox-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-clearbutton-s-overbackground-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-clearbutton-s-overbackground-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-clearbutton-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-clearbutton-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-clearbutton-m-overbackground-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-clearbutton-m-overbackground-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-clearbutton-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-clearbutton-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-colorloupe-colorhandle-gap: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorloupe-offset-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorslider-vertical-touch-hit-x: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorslider-touch-hit-y: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-min-size: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-colorwheel-touch-hit-outer: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-touch-hit-inner: var(
+        --spectrum-global-dimension-size-85
+    );
+    --spectrum-colorwheel-min-width: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-colorwheel-min-height: var(
+        --spectrum-global-dimension-static-size-2600
+    );
+    --spectrum-combobox-quiet-fieldbutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-combobox-quiet-fieldbutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-combobox-fieldbutton-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-combobox-fieldbutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-combobox-fieldbutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-cyclebutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-cyclebutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-dialog-confirm-title-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-dialog-confirm-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-confirm-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-confirm-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-confirm-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-destructive-title-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-dialog-destructive-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-destructive-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-destructive-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-destructive-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-error-title-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-dialog-error-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-error-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-error-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-error-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-info-title-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-dialog-info-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-info-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-info-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-info-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-fullscreen-title-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-dialog-fullscreen-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-fullscreen-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreen-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-fullscreen-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dialog-fullscreentakeover-title-text-size: var(
+        --spectrum-global-dimension-font-size-200
+    );
+    --spectrum-dialog-fullscreentakeover-description-text-size: var(
+        --spectrum-global-dimension-font-size-75
+    );
+    --spectrum-dialog-fullscreentakeover-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreentakeover-max-width: var(
+        --spectrum-global-dimension-static-size-5000
+    );
+    --spectrum-dialog-fullscreentakeover-padding: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-dragthumb-swatch-width: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-dragthumb-swatch-height: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-helptext-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-m-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-helptext-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-helptext-xl-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-helptext-xl-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-listitem-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-texticon-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textonly-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-listitem-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-listitem-l-textthumbnail-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-meter-s-negative-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-negative-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-notice-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-notice-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-positive-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-s-positive-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-meter-s-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-m-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-meter-l-negative-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-negative-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-notice-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-notice-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-positive-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-l-positive-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-meter-xl-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-meter-xl-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-pagination-page-button-line-height: 32px;
+    --spectrum-pagination-button-page-button-line-height: 32px;
+    --spectrum-pagination-explicit-page-button-line-height: 32px;
+    --spectrum-pagination-listing-page-button-line-height: 32px;
+    --spectrum-panel-s-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-s-header-height: var(--spectrum-global-dimension-size-550);
+    --spectrum-panel-s-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-s-spacious-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-header-height: var(--spectrum-global-dimension-size-550);
+    --spectrum-panel-l-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-panel-l-spacious-header-height: var(
+        --spectrum-global-dimension-size-550
+    );
+    --spectrum-picker-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-texticon-popover-offset-x: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textthumbnail-popover-offset-x: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-quiet-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-picker-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-indeterminate-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-s-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-progressbar-s-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-m-border-radius: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progressbar-l-indeterminate-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-indeterminate-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-l-value-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-progressbar-xl-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progressbar-xl-border-radius: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-progresscircle-s-indeterminate-overbackground-border-size: 3px;
+    --spectrum-progresscircle-s-indeterminate-border-size: 3px;
+    --spectrum-progresscircle-s-overbackground-border-size: 3px;
+    --spectrum-progresscircle-s-border-size: 3px;
+    --spectrum-progresscircle-m-indeterminate-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-indeterminate-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-progresscircle-m-border-size: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-radio-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-radio-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-radio-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-radio-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-radio-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-rating-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-rating-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-search-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-search-s-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-s-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-m-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-m-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-search-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-search-l-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-search-l-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-l-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-search-xl-touch-hit-x: var(--spectrum-global-dimension-size-50);
+    --spectrum-search-xl-touch-hit-y: var(--spectrum-global-dimension-size-50);
+    --spectrum-sidenav-multilevel-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-multilevel-main-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-item-touch-hit-bottom: 3px;
+    --spectrum-sidenav-main-item-touch-hit-bottom: 3px;
+    --spectrum-slider-s-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-slider-s-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-s-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-s-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-m-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-m-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-editable-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-slider-l-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-l-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-l-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-50
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-statuslight-l-celery-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-chartreuse-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-fuchsia-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-indigo-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-info-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-magenta-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-neutral-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-negative-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-notice-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-positive-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-purple-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-seafoam-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-l-yellow-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-celery-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-chartreuse-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-fuchsia-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-indigo-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-info-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-magenta-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-neutral-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-negative-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-notice-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-positive-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-purple-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-seafoam-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-statuslight-xl-yellow-dot-size: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-switch-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-switch-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-switch-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-switch-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tabs-s-quiet-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-quiet-emphasized-margin-left: -9px;
+    --spectrum-tabs-s-quiet-emphasized-margin-right: -9px;
+    --spectrum-tabs-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-quiet-margin-left: -9px;
+    --spectrum-tabs-s-quiet-margin-right: -9px;
+    --spectrum-tabs-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-emphasized-margin-left: -9px;
+    --spectrum-tabs-s-emphasized-margin-right: -9px;
+    --spectrum-tabs-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-margin-left: -9px;
+    --spectrum-tabs-s-margin-right: -9px;
+    --spectrum-tabs-s-vertical-quiet-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-vertical-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-vertical-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-vertical-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-vertical-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-vertical-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-vertical-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-vertical-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-compact-quiet-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-compact-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-compact-quiet-emphasized-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-emphasized-margin-right: -9px;
+    --spectrum-tabs-s-compact-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-compact-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-compact-quiet-margin-left: -9px;
+    --spectrum-tabs-s-compact-quiet-margin-right: -9px;
+    --spectrum-tabs-s-compact-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-compact-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-compact-emphasized-margin-left: -9px;
+    --spectrum-tabs-s-compact-emphasized-margin-right: -9px;
+    --spectrum-tabs-s-compact-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-compact-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-compact-margin-left: -9px;
+    --spectrum-tabs-s-compact-margin-right: -9px;
+    --spectrum-tabs-s-compact-vertical-quiet-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-compact-vertical-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-compact-vertical-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-compact-vertical-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-compact-vertical-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-compact-vertical-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-s-compact-vertical-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tabs-s-compact-vertical-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-quiet-emphasized-margin-left: -11px;
+    --spectrum-tabs-m-quiet-emphasized-margin-right: -11px;
+    --spectrum-tabs-m-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-quiet-margin-left: -11px;
+    --spectrum-tabs-m-quiet-margin-right: -11px;
+    --spectrum-tabs-m-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-emphasized-margin-left: -11px;
+    --spectrum-tabs-m-emphasized-margin-right: -11px;
+    --spectrum-tabs-m-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-margin-left: -11px;
+    --spectrum-tabs-m-margin-right: -11px;
+    --spectrum-tabs-m-vertical-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-vertical-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-vertical-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-vertical-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-compact-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-compact-quiet-emphasized-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-emphasized-margin-right: -11px;
+    --spectrum-tabs-m-compact-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-compact-quiet-margin-left: -11px;
+    --spectrum-tabs-m-compact-quiet-margin-right: -11px;
+    --spectrum-tabs-m-compact-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-compact-emphasized-margin-left: -11px;
+    --spectrum-tabs-m-compact-emphasized-margin-right: -11px;
+    --spectrum-tabs-m-compact-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-compact-margin-left: -11px;
+    --spectrum-tabs-m-compact-margin-right: -11px;
+    --spectrum-tabs-m-compact-vertical-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-compact-vertical-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-compact-vertical-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-m-compact-vertical-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-quiet-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-quiet-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-quiet-emphasized-margin-left: -11px;
+    --spectrum-tabs-l-quiet-emphasized-margin-right: -11px;
+    --spectrum-tabs-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-quiet-margin-left: -11px;
+    --spectrum-tabs-l-quiet-margin-right: -11px;
+    --spectrum-tabs-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-emphasized-margin-left: -11px;
+    --spectrum-tabs-l-emphasized-margin-right: -11px;
+    --spectrum-tabs-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-margin-left: -11px;
+    --spectrum-tabs-l-margin-right: -11px;
+    --spectrum-tabs-l-vertical-quiet-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-vertical-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-vertical-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-vertical-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-vertical-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-vertical-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-vertical-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-vertical-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-compact-quiet-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-compact-quiet-emphasized-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-emphasized-margin-right: -11px;
+    --spectrum-tabs-l-compact-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-compact-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-compact-quiet-margin-left: -11px;
+    --spectrum-tabs-l-compact-quiet-margin-right: -11px;
+    --spectrum-tabs-l-compact-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-compact-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-compact-emphasized-margin-left: -11px;
+    --spectrum-tabs-l-compact-emphasized-margin-right: -11px;
+    --spectrum-tabs-l-compact-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-compact-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-compact-margin-left: -11px;
+    --spectrum-tabs-l-compact-margin-right: -11px;
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-compact-vertical-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-compact-vertical-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-l-compact-vertical-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tabs-l-compact-vertical-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tabs-l-compact-vertical-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-quiet-emphasized-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-emphasized-margin-right: -12px;
+    --spectrum-tabs-xl-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-quiet-margin-left: -12px;
+    --spectrum-tabs-xl-quiet-margin-right: -12px;
+    --spectrum-tabs-xl-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-emphasized-margin-left: -12px;
+    --spectrum-tabs-xl-emphasized-margin-right: -12px;
+    --spectrum-tabs-xl-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-margin-left: -12px;
+    --spectrum-tabs-xl-margin-right: -12px;
+    --spectrum-tabs-xl-vertical-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-vertical-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-vertical-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-vertical-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-margin-right: -12px;
+    --spectrum-tabs-xl-compact-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-compact-quiet-margin-left: -12px;
+    --spectrum-tabs-xl-compact-quiet-margin-right: -12px;
+    --spectrum-tabs-xl-compact-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-compact-emphasized-margin-left: -12px;
+    --spectrum-tabs-xl-compact-emphasized-margin-right: -12px;
+    --spectrum-tabs-xl-compact-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-compact-margin-left: -12px;
+    --spectrum-tabs-xl-compact-margin-right: -12px;
+    --spectrum-tabs-xl-compact-vertical-quiet-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-compact-vertical-quiet-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-compact-vertical-emphasized-focus-ring-border-radius: 6px;
+    --spectrum-tabs-xl-compact-vertical-focus-ring-border-radius: 6px;
+    --spectrum-tag-s-removable-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tag-s-removable-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-removable-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tag-s-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-removable-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tag-s-removable-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-removable-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tag-s-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-removable-avatartext-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tag-s-removable-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-removable-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-avatartext-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-tag-s-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-s-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-removable-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-removable-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-removable-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-m-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-m-removable-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-removable-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-removable-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-removable-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-removable-avatartext-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-m-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-m-avatartext-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-l-removable-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-l-removable-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-removable-texticon-button-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-removable-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-removable-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-texticon-button-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-removable-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-l-removable-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-removable-textonly-button-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-removable-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-removable-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-textonly-button-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-removable-avatartext-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-l-removable-avatartext-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-removable-avatartext-button-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-removable-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-removable-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-avatartext-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-tag-l-avatartext-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-avatartext-button-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-tag-l-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tag-l-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textarea-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textarea-l-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textarea-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-textfield-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-texticon-padding-left: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-textfield-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-textfield-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-tooltip-neutral-padding-bottom: 6px;
+    --spectrum-tooltip-info-padding-bottom: 6px;
+    --spectrum-tooltip-positive-padding-bottom: 6px;
+    --spectrum-tooltip-negative-padding-bottom: 6px;
+    --spectrum-treeview-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-treeview-l-item-icon-size: var(
+        --spectrum-global-dimension-static-size-300
+    );
+    --spectrum-treeview-l-item-text-padding-top: var(
+        --spectrum-global-dimension-static-size-150
+    );
+}
+/* stylelint-enable */

--- a/packages/styles/express/spectrum-scale-medium.css
+++ b/packages/styles/express/spectrum-scale-medium.css
@@ -1,0 +1,4294 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* stylelint-disable */
+:host,
+:root {
+    --spectrum-global-dimension-scale-factor: 1;
+    --spectrum-global-dimension-size-0: 0px;
+    --spectrum-global-dimension-size-10: 1px;
+    --spectrum-global-dimension-size-25: 2px;
+    --spectrum-global-dimension-size-40: 3px;
+    --spectrum-global-dimension-size-50: 4px;
+    --spectrum-global-dimension-size-65: 5px;
+    --spectrum-global-dimension-size-75: 6px;
+    --spectrum-global-dimension-size-85: 7px;
+    --spectrum-global-dimension-size-100: 8px;
+    --spectrum-global-dimension-size-115: 9px;
+    --spectrum-global-dimension-size-125: 10px;
+    --spectrum-global-dimension-size-130: 11px;
+    --spectrum-global-dimension-size-150: 12px;
+    --spectrum-global-dimension-size-160: 13px;
+    --spectrum-global-dimension-size-175: 14px;
+    --spectrum-global-dimension-size-185: 15px;
+    --spectrum-global-dimension-size-200: 16px;
+    --spectrum-global-dimension-size-225: 18px;
+    --spectrum-global-dimension-size-250: 20px;
+    --spectrum-global-dimension-size-275: 22px;
+    --spectrum-global-dimension-size-300: 24px;
+    --spectrum-global-dimension-size-325: 26px;
+    --spectrum-global-dimension-size-350: 28px;
+    --spectrum-global-dimension-size-400: 32px;
+    --spectrum-global-dimension-size-450: 36px;
+    --spectrum-global-dimension-size-500: 40px;
+    --spectrum-global-dimension-size-550: 44px;
+    --spectrum-global-dimension-size-600: 48px;
+    --spectrum-global-dimension-size-650: 52px;
+    --spectrum-global-dimension-size-675: 54px;
+    --spectrum-global-dimension-size-700: 56px;
+    --spectrum-global-dimension-size-750: 60px;
+    --spectrum-global-dimension-size-800: 64px;
+    --spectrum-global-dimension-size-900: 72px;
+    --spectrum-global-dimension-size-1000: 80px;
+    --spectrum-global-dimension-size-1125: 90px;
+    --spectrum-global-dimension-size-1200: 96px;
+    --spectrum-global-dimension-size-1250: 100px;
+    --spectrum-global-dimension-size-1600: 128px;
+    --spectrum-global-dimension-size-1700: 136px;
+    --spectrum-global-dimension-size-1800: 144px;
+    --spectrum-global-dimension-size-2000: 160px;
+    --spectrum-global-dimension-size-2400: 192px;
+    --spectrum-global-dimension-size-2500: 200px;
+    --spectrum-global-dimension-size-3000: 240px;
+    --spectrum-global-dimension-size-3400: 272px;
+    --spectrum-global-dimension-size-3600: 288px;
+    --spectrum-global-dimension-size-4600: 368px;
+    --spectrum-global-dimension-size-5000: 400px;
+    --spectrum-global-dimension-size-6000: 480px;
+    --spectrum-global-dimension-font-size-25: 10px;
+    --spectrum-global-dimension-font-size-50: 11px;
+    --spectrum-global-dimension-font-size-75: 12px;
+    --spectrum-global-dimension-font-size-100: 14px;
+    --spectrum-global-dimension-font-size-150: 15px;
+    --spectrum-global-dimension-font-size-200: 16px;
+    --spectrum-global-dimension-font-size-300: 18px;
+    --spectrum-global-dimension-font-size-400: 20px;
+    --spectrum-global-dimension-font-size-500: 22px;
+    --spectrum-global-dimension-font-size-600: 25px;
+    --spectrum-global-dimension-font-size-700: 28px;
+    --spectrum-global-dimension-font-size-800: 32px;
+    --spectrum-global-dimension-font-size-900: 36px;
+    --spectrum-global-dimension-font-size-1000: 40px;
+    --spectrum-global-dimension-font-size-1100: 45px;
+    --spectrum-global-dimension-font-size-1200: 50px;
+    --spectrum-global-dimension-font-size-1300: 60px;
+    --spectrum-alias-item-text-padding-top-l: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-alias-item-text-padding-bottom-s: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-alias-item-workflow-padding-left-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-m: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-alias-item-rounded-workflow-padding-left-xl: 21px;
+    --spectrum-alias-item-mark-padding-top-m: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-alias-item-mark-padding-bottom-m: var(
+        --spectrum-global-dimension-static-size-75
+    );
+    --spectrum-alias-item-mark-padding-left-m: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-1-size-l: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-1-size-xl: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-alias-item-control-2-size-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-control-3-height-s: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-alias-item-control-3-width-s: 23px;
+    --spectrum-alias-item-control-3-width-m: var(
+        --spectrum-global-dimension-static-size-325
+    );
+    --spectrum-alias-item-control-3-width-l: 29px;
+    --spectrum-alias-item-control-3-width-xl: 33px;
+    --spectrum-alias-item-mark-size-m: var(
+        --spectrum-global-dimension-size-250
+    );
+    --spectrum-alias-control-three-width-m: 28px;
+    --spectrum-alias-control-three-width-l: var(
+        --spectrum-global-dimension-static-size-450
+    );
+    --spectrum-alias-control-three-width-xl: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-alias-focus-ring-radius-default: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-workflow-icon-size-l: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-chevron-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-chevron-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-chevron-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-chevron-size-300: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-chevron-size-400: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-chevron-size-500: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-50: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-checkmark-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-checkmark-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-checkmark-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-checkmark-size-300: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-checkmark-size-400: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-500: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-checkmark-size-600: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-dash-size-50: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-dash-size-75: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-dash-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-dash-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-dash-size-300: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-dash-size-400: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-dash-size-500: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-dash-size-600: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-cross-size-75: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-cross-size-100: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-alias-ui-icon-cross-size-200: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-cross-size-300: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-cross-size-400: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-cross-size-500: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-cross-size-600: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-arrow-size-75: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-arrow-size-100: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-arrow-size-200: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-alias-ui-icon-arrow-size-300: var(
+        --spectrum-global-dimension-static-size-175
+    );
+    --spectrum-alias-ui-icon-arrow-size-400: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-alias-ui-icon-arrow-size-500: var(
+        --spectrum-global-dimension-static-size-225
+    );
+    --spectrum-alias-ui-icon-arrow-size-600: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-alias-ui-icon-triplegripper-size-100-width: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-doublegripper-size-100-height: var(
+        --spectrum-global-dimension-static-size-50
+    );
+    --spectrum-alias-ui-icon-singlegripper-size-100-height: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-100: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-alias-ui-icon-cornertriangle-size-300: var(
+        --spectrum-global-dimension-static-size-85
+    );
+    --spectrum-alias-ui-icon-asterisk-size-200: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-ui-icon-asterisk-size-300: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-alias-avatar-size-100: var(--spectrum-global-dimension-size-250);
+    --spectrum-alias-avatar-size-400: var(--spectrum-global-dimension-size-350);
+    --spectrum-alias-avatar-size-600: var(--spectrum-global-dimension-size-450);
+    --spectrum-dragthumb-swatch-width: var(
+        --spectrum-global-dimension-static-size-150
+    );
+    --spectrum-dragthumb-swatch-height: var(
+        --spectrum-global-dimension-static-size-200
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-s-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-m-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-quiet-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-actionbutton-l-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-l-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-quiet-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-emphasized-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-actionbutton-xl-icononly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-badge-s-fuchsia-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-fuchsia-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-fuchsia-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-indigo-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-informative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-magenta-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-negative-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-neutral-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-positive-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-purple-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-seafoam-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-s-yellow-icononly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-badge-m-fuchsia-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-indigo-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-informative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-magenta-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-neutral-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-positive-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-purple-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-seafoam-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-m-yellow-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-badge-l-fuchsia-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-fuchsia-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-fuchsia-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-fuchsia-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-indigo-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-indigo-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-informative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-informative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-magenta-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-magenta-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-negative-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-negative-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-neutral-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-neutral-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-positive-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-positive-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-purple-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-purple-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-seafoam-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-seafoam-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-badge-l-yellow-icononly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-badge-l-yellow-icononly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-breadcrumb-s-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-multiline-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-breadcrumb-s-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-breadcrumb-s-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-m-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-multiline-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-multiline-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-breadcrumb-l-multiline-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-breadcrumb-l-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-breadcrumb-l-item-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-quiet-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-cta-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-cta-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-cta-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-cta-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-quiet-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-quiet-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-overbackground-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-quiet-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-cta-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-cta-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-cta-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-cta-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-cta-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-quiet-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-primary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-primary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-secondary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-secondary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-quiet-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-overbackground-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-button-s-negative-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-s-negative-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-quiet-overbackground-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-cta-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-cta-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-overbackground-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-cta-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-quiet-overbackground-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-overbackground-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-primary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-overbackground-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-secondary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-quiet-overbackground-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-quiet-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-overbackground-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-negative-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-texticon-padding-left: var(
+        --spectrum-global-dimension-size-175
+    );
+    --spectrum-button-m-cta-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-cta-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-primary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-secondary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-m-negative-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-quiet-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-cta-quiet-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-cta-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-cta-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-cta-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-cta-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-cta-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-cta-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-cta-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-quiet-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-quiet-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-quiet-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-quiet-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-overbackground-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-overbackground-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-quiet-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-cta-quiet-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-cta-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-cta-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-cta-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-cta-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-cta-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-cta-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-cta-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-cta-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-quiet-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-quiet-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-primary-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-primary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-primary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-secondary-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-secondary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-secondary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-quiet-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-quiet-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-overbackground-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-overbackground-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-button-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-button-l-negative-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-l-negative-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-quiet-overbackground-texticon-padding-left: 21px;
+    --spectrum-button-xl-cta-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-quiet-texticon-padding-left: 21px;
+    --spectrum-button-xl-cta-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-overbackground-texticon-padding-left: 21px;
+    --spectrum-button-xl-cta-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-quiet-overbackground-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-quiet-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-overbackground-texticon-padding-left: 21px;
+    --spectrum-button-xl-primary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-quiet-overbackground-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-quiet-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-overbackground-texticon-padding-left: 21px;
+    --spectrum-button-xl-secondary-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-quiet-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-quiet-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-quiet-overbackground-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-quiet-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-overbackground-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-overbackground-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-overbackground-texticon-padding-left: 21px;
+    --spectrum-button-xl-negative-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-texticon-padding-left: 21px;
+    --spectrum-button-xl-cta-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-cta-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-primary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-secondary-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-quiet-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-quiet-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-overbackground-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-overbackground-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-button-xl-negative-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-checkbox-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-checkbox-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-checkbox-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-checkbox-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-checkbox-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-clearbutton-s-overbackground-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-clearbutton-s-overbackground-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-clearbutton-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-clearbutton-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-clearbutton-m-overbackground-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-clearbutton-m-overbackground-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-clearbutton-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-clearbutton-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-colorloupe-colorhandle-gap: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-colorloupe-offset-y: var(
+        --spectrum-global-dimension-static-size-125
+    );
+    --spectrum-colorslider-vertical-touch-hit-x: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorslider-touch-hit-y: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-min-size: var(--spectrum-global-dimension-size-2400);
+    --spectrum-colorwheel-touch-hit-outer: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-touch-hit-inner: var(
+        --spectrum-global-dimension-size-150
+    );
+    --spectrum-colorwheel-min-width: var(--spectrum-global-dimension-size-2400);
+    --spectrum-colorwheel-min-height: var(
+        --spectrum-global-dimension-size-2400
+    );
+    --spectrum-combobox-quiet-fieldbutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-combobox-quiet-fieldbutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-combobox-fieldbutton-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-combobox-fieldbutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-combobox-fieldbutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-cyclebutton-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-cyclebutton-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-dialog-confirm-title-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-dialog-confirm-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-confirm-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-confirm-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-confirm-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-destructive-title-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-dialog-destructive-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-destructive-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-destructive-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-destructive-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-error-title-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-dialog-error-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-error-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-error-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-error-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-info-title-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-dialog-info-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-info-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-info-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-info-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreen-title-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-dialog-fullscreen-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-fullscreen-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-fullscreen-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-fullscreen-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-dialog-fullscreentakeover-title-text-size: var(
+        --spectrum-global-dimension-font-size-300
+    );
+    --spectrum-dialog-fullscreentakeover-description-text-size: var(
+        --spectrum-global-dimension-font-size-100
+    );
+    --spectrum-dialog-fullscreentakeover-description-margin-bottom: var(
+        --spectrum-global-dimension-static-size-600
+    );
+    --spectrum-dialog-fullscreentakeover-max-width: var(
+        --spectrum-global-dimension-static-size-6000
+    );
+    --spectrum-dialog-fullscreentakeover-padding: var(
+        --spectrum-global-dimension-static-size-500
+    );
+    --spectrum-helptext-s-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-s-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-neutral-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-negative-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-m-negative-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-helptext-l-neutral-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-negative-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-neutral-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-l-negative-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-helptext-xl-neutral-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-negative-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-helptext-xl-negative-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-listitem-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-listitem-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-listitem-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-texticon-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textonly-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-listitem-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-listitem-l-textthumbnail-thumbnail-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-meter-s-negative-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-negative-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-notice-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-notice-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-positive-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-s-positive-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-s-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-meter-m-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-m-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-meter-l-negative-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-negative-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-notice-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-notice-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-positive-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-l-positive-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-meter-xl-negative-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-negative-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-notice-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-notice-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-positive-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-meter-xl-positive-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-pagination-page-button-line-height: 26px;
+    --spectrum-pagination-button-page-button-line-height: 26px;
+    --spectrum-pagination-explicit-page-button-line-height: 26px;
+    --spectrum-pagination-listing-page-button-line-height: 26px;
+    --spectrum-panel-s-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-s-header-height: var(--spectrum-global-dimension-size-600);
+    --spectrum-panel-s-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-s-spacious-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-header-height: var(--spectrum-global-dimension-size-600);
+    --spectrum-panel-l-spacious-collapsible-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-panel-l-spacious-header-height: var(
+        --spectrum-global-dimension-size-600
+    );
+    --spectrum-picker-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textthumbnail-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-s-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-texticon-popover-offset-x: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textthumbnail-popover-offset-x: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-textthumbnail-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-m-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-quiet-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textthumbnail-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-picker-l-textthumbnail-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-l-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-quiet-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-picker-xl-textthumbnail-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-indeterminate-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-overbackground-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-s-value-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-s-border-radius: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progressbar-m-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-m-border-radius: var(
+        --spectrum-global-dimension-static-size-40
+    );
+    --spectrum-progressbar-l-indeterminate-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-indeterminate-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-overbackground-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-l-value-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-progressbar-xl-indeterminate-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-indeterminate-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-overbackground-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progressbar-xl-border-radius: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-progresscircle-s-indeterminate-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-indeterminate-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-overbackground-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-s-border-size: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-progresscircle-m-indeterminate-overbackground-border-size: 3px;
+    --spectrum-progresscircle-m-indeterminate-border-size: 3px;
+    --spectrum-progresscircle-m-overbackground-border-size: 3px;
+    --spectrum-progresscircle-m-border-size: 3px;
+    --spectrum-radio-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-radio-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-radio-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-radio-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-radio-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-radio-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-rating-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-rating-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-search-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-search-s-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-s-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-m-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-m-padding-left: var(--spectrum-global-dimension-size-125);
+    --spectrum-search-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-search-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-search-l-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-search-l-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-l-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-search-xl-touch-hit-x: var(--spectrum-global-dimension-size-100);
+    --spectrum-search-xl-touch-hit-y: var(--spectrum-global-dimension-size-100);
+    --spectrum-sidenav-multilevel-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-multilevel-main-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-sidenav-main-item-touch-hit-bottom: var(
+        --spectrum-global-dimension-static-size-25
+    );
+    --spectrum-slider-s-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-editable-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-slider-s-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-s-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-s-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-m-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-m-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-editable-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-slider-l-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-l-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-l-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-tick-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-editable-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-editable-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-ramp-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-track-touch-hit-y: var(
+        --spectrum-global-dimension-size-100
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-x: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-slider-xl-range-handle-touch-hit-y: var(
+        --spectrum-global-dimension-size-200
+    );
+    --spectrum-statuslight-l-celery-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-chartreuse-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-fuchsia-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-indigo-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-info-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-magenta-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-neutral-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-negative-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-notice-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-positive-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-purple-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-seafoam-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-l-yellow-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-celery-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-chartreuse-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-fuchsia-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-indigo-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-info-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-magenta-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-neutral-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-negative-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-notice-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-positive-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-purple-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-seafoam-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-statuslight-xl-yellow-dot-size: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-switch-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-switch-s-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-switch-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-m-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-switch-l-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-switch-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-xl-emphasized-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-switch-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tabs-s-quiet-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-quiet-emphasized-margin-left: -7px;
+    --spectrum-tabs-s-quiet-emphasized-margin-right: -7px;
+    --spectrum-tabs-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-quiet-margin-left: -7px;
+    --spectrum-tabs-s-quiet-margin-right: -7px;
+    --spectrum-tabs-s-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-emphasized-margin-left: -7px;
+    --spectrum-tabs-s-emphasized-margin-right: -7px;
+    --spectrum-tabs-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-margin-left: -7px;
+    --spectrum-tabs-s-margin-right: -7px;
+    --spectrum-tabs-s-vertical-quiet-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-vertical-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-vertical-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-vertical-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-vertical-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-vertical-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-vertical-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-vertical-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-compact-quiet-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-compact-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-compact-quiet-emphasized-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-emphasized-margin-right: -7px;
+    --spectrum-tabs-s-compact-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-compact-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-compact-quiet-margin-left: -7px;
+    --spectrum-tabs-s-compact-quiet-margin-right: -7px;
+    --spectrum-tabs-s-compact-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-compact-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-compact-emphasized-margin-left: -7px;
+    --spectrum-tabs-s-compact-emphasized-margin-right: -7px;
+    --spectrum-tabs-s-compact-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-compact-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-compact-margin-left: -7px;
+    --spectrum-tabs-s-compact-margin-right: -7px;
+    --spectrum-tabs-s-compact-vertical-quiet-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-compact-vertical-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-compact-vertical-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-compact-vertical-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-compact-vertical-emphasized-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-compact-vertical-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-s-compact-vertical-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tabs-s-compact-vertical-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-quiet-emphasized-margin-left: -8px;
+    --spectrum-tabs-m-quiet-emphasized-margin-right: -8px;
+    --spectrum-tabs-m-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-quiet-margin-left: -8px;
+    --spectrum-tabs-m-quiet-margin-right: -8px;
+    --spectrum-tabs-m-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-emphasized-margin-left: -8px;
+    --spectrum-tabs-m-emphasized-margin-right: -8px;
+    --spectrum-tabs-m-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-margin-left: -8px;
+    --spectrum-tabs-m-margin-right: -8px;
+    --spectrum-tabs-m-vertical-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-vertical-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-vertical-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-vertical-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-compact-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-compact-quiet-emphasized-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-emphasized-margin-right: -8px;
+    --spectrum-tabs-m-compact-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-compact-quiet-margin-left: -8px;
+    --spectrum-tabs-m-compact-quiet-margin-right: -8px;
+    --spectrum-tabs-m-compact-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-compact-emphasized-margin-left: -8px;
+    --spectrum-tabs-m-compact-emphasized-margin-right: -8px;
+    --spectrum-tabs-m-compact-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-compact-margin-left: -8px;
+    --spectrum-tabs-m-compact-margin-right: -8px;
+    --spectrum-tabs-m-compact-vertical-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-compact-vertical-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-compact-vertical-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-m-compact-vertical-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-quiet-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-quiet-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-quiet-emphasized-margin-left: -9px;
+    --spectrum-tabs-l-quiet-emphasized-margin-right: -9px;
+    --spectrum-tabs-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-quiet-margin-left: -9px;
+    --spectrum-tabs-l-quiet-margin-right: -9px;
+    --spectrum-tabs-l-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-emphasized-margin-left: -9px;
+    --spectrum-tabs-l-emphasized-margin-right: -9px;
+    --spectrum-tabs-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-margin-left: -9px;
+    --spectrum-tabs-l-margin-right: -9px;
+    --spectrum-tabs-l-vertical-quiet-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-vertical-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-vertical-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-vertical-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-vertical-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-vertical-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-vertical-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-vertical-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-compact-quiet-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-compact-quiet-emphasized-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-emphasized-margin-right: -9px;
+    --spectrum-tabs-l-compact-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-compact-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-compact-quiet-margin-left: -9px;
+    --spectrum-tabs-l-compact-quiet-margin-right: -9px;
+    --spectrum-tabs-l-compact-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-compact-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-compact-emphasized-margin-left: -9px;
+    --spectrum-tabs-l-compact-emphasized-margin-right: -9px;
+    --spectrum-tabs-l-compact-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-compact-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-compact-margin-left: -9px;
+    --spectrum-tabs-l-compact-margin-right: -9px;
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-compact-vertical-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-compact-vertical-emphasized-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-l-compact-vertical-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tabs-l-compact-vertical-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tabs-l-compact-vertical-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-quiet-emphasized-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-emphasized-margin-right: -10px;
+    --spectrum-tabs-xl-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-quiet-margin-left: -10px;
+    --spectrum-tabs-xl-quiet-margin-right: -10px;
+    --spectrum-tabs-xl-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-emphasized-margin-left: -10px;
+    --spectrum-tabs-xl-emphasized-margin-right: -10px;
+    --spectrum-tabs-xl-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-margin-left: -10px;
+    --spectrum-tabs-xl-margin-right: -10px;
+    --spectrum-tabs-xl-vertical-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-vertical-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-vertical-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-vertical-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-emphasized-margin-right: -10px;
+    --spectrum-tabs-xl-compact-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-compact-quiet-margin-left: -10px;
+    --spectrum-tabs-xl-compact-quiet-margin-right: -10px;
+    --spectrum-tabs-xl-compact-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-compact-emphasized-margin-left: -10px;
+    --spectrum-tabs-xl-compact-emphasized-margin-right: -10px;
+    --spectrum-tabs-xl-compact-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-compact-margin-left: -10px;
+    --spectrum-tabs-xl-compact-margin-right: -10px;
+    --spectrum-tabs-xl-compact-vertical-quiet-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-compact-vertical-quiet-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-compact-vertical-emphasized-focus-ring-border-radius: 5px;
+    --spectrum-tabs-xl-compact-vertical-focus-ring-border-radius: 5px;
+    --spectrum-tag-s-removable-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tag-s-removable-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-removable-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tag-s-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-removable-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tag-s-removable-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-removable-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tag-s-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-removable-avatartext-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tag-s-removable-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-removable-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-avatartext-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-tag-s-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-s-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-removable-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-removable-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-removable-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-tag-m-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-tag-m-removable-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-removable-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-removable-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-removable-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-removable-avatartext-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-tag-m-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-m-avatartext-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-tag-l-removable-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tag-l-removable-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-removable-texticon-button-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-removable-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-removable-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tag-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-texticon-button-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-texticon-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-texticon-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-removable-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tag-l-removable-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-removable-textonly-button-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-removable-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-removable-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tag-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-textonly-button-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-textonly-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-textonly-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-removable-avatartext-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tag-l-removable-avatartext-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-removable-avatartext-button-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-removable-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-removable-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-avatartext-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-tag-l-avatartext-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-avatartext-button-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-tag-l-avatartext-button-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tag-l-avatartext-button-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-quiet-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textarea-s-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-s-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-m-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-quiet-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textarea-l-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-l-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-quiet-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-multiline-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textarea-xl-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-texticon-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-textonly-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-textfield-s-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-s-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-texticon-padding-left: var(
+        --spectrum-global-dimension-size-125
+    );
+    --spectrum-textfield-m-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-m-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-quiet-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-texticon-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-texticon-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-textonly-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+    --spectrum-textfield-l-textonly-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-textfield-l-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-l-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-quiet-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-texticon-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-x: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-textfield-xl-textonly-touch-hit-y: var(
+        --spectrum-global-dimension-static-size-100
+    );
+    --spectrum-tooltip-neutral-padding-bottom: 5px;
+    --spectrum-tooltip-info-padding-bottom: 5px;
+    --spectrum-tooltip-positive-padding-bottom: 5px;
+    --spectrum-tooltip-negative-padding-bottom: 5px;
+    --spectrum-treeview-s-item-text-padding-bottom: var(
+        --spectrum-global-dimension-static-size-65
+    );
+    --spectrum-treeview-l-item-icon-size: var(
+        --spectrum-global-dimension-static-size-250
+    );
+    --spectrum-treeview-l-item-text-padding-top: var(
+        --spectrum-global-dimension-size-115
+    );
+}
+/* stylelint-enable */

--- a/packages/styles/express/theme-dark.css
+++ b/packages/styles/express/theme-dark.css
@@ -1,0 +1,293 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* stylelint-disable */
+:host,
+:root {
+    --spectrum-global-color-status: Verified;
+    --spectrum-global-color-version: 5.1.0;
+    --spectrum-global-color-gray-50: #000;
+    --spectrum-global-color-gray-75: #0f0f0f;
+    --spectrum-global-color-gray-100: #1d1d1d;
+    --spectrum-global-color-gray-200: #2e2e2e;
+    --spectrum-global-color-gray-300: #444;
+    --spectrum-global-color-gray-400: #616161;
+    --spectrum-global-color-gray-500: #878787;
+    --spectrum-global-color-gray-600: #afafaf;
+    --spectrum-global-color-gray-700: #d2d2d2;
+    --spectrum-global-color-gray-800: #ebebeb;
+    --spectrum-global-color-gray-900: #fff;
+    --spectrum-global-color-green-400: #008d5d;
+    --spectrum-global-color-green-500: #0a9d6a;
+    --spectrum-global-color-green-600: #27ae79;
+    --spectrum-global-color-blue-400: #1277f3;
+    --spectrum-global-color-blue-500: #2d8af5;
+    --spectrum-global-color-blue-600: #4a9cf5;
+    --spectrum-global-color-red-400: #e83326;
+    --spectrum-global-color-red-500: #f44f3c;
+    --spectrum-global-color-red-600: #fd6a54;
+    --spectrum-global-color-seafoam-400: #0099a1;
+    --spectrum-global-color-seafoam-500: #00aab0;
+    --spectrum-global-color-seafoam-600: #2abbbf;
+    --spectrum-global-color-seafoam-700: #4bccce;
+    --spectrum-global-color-indigo-400: #777cfa;
+    --spectrum-global-color-indigo-500: #8a8eff;
+    --spectrum-global-color-indigo-600: #9da0ff;
+    --spectrum-global-color-indigo-700: #b1b4ff;
+    --spectrum-global-color-purple-400: #a968f9;
+    --spectrum-global-color-purple-500: #b67efc;
+    --spectrum-global-color-purple-600: #c393fd;
+    --spectrum-global-color-purple-700: #d0a9fe;
+    --spectrum-global-color-fuchsia-400: #db4add;
+    --spectrum-global-color-fuchsia-500: #e862e9;
+    --spectrum-global-color-fuchsia-600: #f17df0;
+    --spectrum-global-color-fuchsia-700: #f898f5;
+    --spectrum-global-color-magenta-400: #ea4f91;
+    --spectrum-global-color-magenta-500: #f567a1;
+    --spectrum-global-color-magenta-600: #fe80b1;
+    --spectrum-global-color-magenta-700: #ff9cc1;
+    --spectrum-global-color-orange-400: #ee7903;
+    --spectrum-global-color-orange-500: #fc8c1c;
+    --spectrum-global-color-orange-600: #ffa640;
+    --spectrum-global-color-orange-700: #ffc06c;
+    --spectrum-global-color-yellow-400: #caa500;
+    --spectrum-global-color-yellow-500: #dbb700;
+    --spectrum-global-color-yellow-600: #ecca00;
+    --spectrum-global-color-yellow-700: #fbdf17;
+    --spectrum-global-color-chartreuse-400: #76bb26;
+    --spectrum-global-color-chartreuse-500: #8acc39;
+    --spectrum-global-color-chartreuse-600: #a1dd53;
+    --spectrum-global-color-chartreuse-700: #beed78;
+    --spectrum-global-color-celery-400: #15b12b;
+    --spectrum-global-color-celery-500: #32c23e;
+    --spectrum-global-color-celery-600: #55d356;
+    --spectrum-global-color-celery-700: #79e36f;
+    --spectrum-global-color-opacity-100: 1;
+    --spectrum-global-color-opacity-90: 0.9;
+    --spectrum-global-color-opacity-80: 0.8;
+    --spectrum-global-color-opacity-60: 0.6;
+    --spectrum-global-color-opacity-50: 0.5;
+    --spectrum-global-color-opacity-42: 0.42;
+    --spectrum-global-color-opacity-40: 0.4;
+    --spectrum-global-color-opacity-30: 0.3;
+    --spectrum-global-color-opacity-25: 0.25;
+    --spectrum-global-color-opacity-20: 0.2;
+    --spectrum-global-color-opacity-15: 0.15;
+    --spectrum-global-color-opacity-10: 0.1;
+    --spectrum-global-color-opacity-8: 0.08;
+    --spectrum-global-color-opacity-7: 0.07;
+    --spectrum-global-color-opacity-6: 0.06;
+    --spectrum-global-color-opacity-5: 0.05;
+    --spectrum-global-color-opacity-4: 0.04;
+    --spectrum-global-color-opacity-0: 0;
+    --spectrum-global-color-red-700: #ff7b82;
+    --spectrum-global-color-green-700: #3fc89c;
+    --spectrum-global-color-blue-700: #5aa9fa;
+    --spectrum-alias-avatar-border-color-default: hsla(0, 0%, 100%, 0.1);
+    --spectrum-alias-avatar-border-color-hover: hsla(0, 0%, 100%, 0.25);
+    --spectrum-alias-avatar-border-color-down: hsla(0, 0%, 100%, 0.4);
+    --spectrum-alias-avatar-border-color-key-focus: hsla(0, 0%, 100%, 0.25);
+    --spectrum-alias-avatar-border-color-selected-disabled: hsla(
+        0,
+        0%,
+        100%,
+        0.1
+    );
+    --spectrum-alias-background-color-primary: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-background-color-secondary: var(
+        --spectrum-global-color-gray-75
+    );
+    --spectrum-alias-background-color-tertiary: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-background-color-modal-overlay: rgba(0, 0, 0, 0.5);
+    --spectrum-alias-dropshadow-color: rgba(0, 0, 0, 0.5);
+    --spectrum-alias-background-color-hover-overlay: hsla(0, 0%, 100%, 0.06);
+    --spectrum-alias-highlight-hover: hsla(0, 0%, 100%, 0.07);
+    --spectrum-alias-highlight-down: hsla(0, 0%, 100%, 0.1);
+    --spectrum-alias-highlight-selected: rgba(45, 138, 245, 0.15);
+    --spectrum-alias-highlight-selected-hover: rgba(45, 138, 245, 0.25);
+    --spectrum-alias-text-highlight-color: rgba(45, 138, 245, 0.25);
+    --spectrum-alias-background-color-quickactions: rgba(29, 29, 29, 0.9);
+    --spectrum-alias-border-color-selected: var(
+        --spectrum-global-color-blue-600
+    );
+    --spectrum-alias-border-color-translucent: hsla(0, 0%, 100%, 0.1);
+    --spectrum-alias-radial-reaction-color-default: hsla(0, 0%, 92%, 0.6);
+    --spectrum-alias-pasteboard-background-color: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-appframe-border-color: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-appframe-separator-color: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-s-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-s-range-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-s-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-m-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-m-range-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-m-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-l-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-l-range-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-l-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-xl-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-range-tick-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-xl-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-xl-range-editable-radial-reaction-color: hsla(
+        0,
+        0%,
+        92%,
+        0.6
+    );
+    --spectrum-slider-xl-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-well-background-color: hsla(0, 0%, 92%, 0.02);
+    --spectrum-well-border-color: hsla(0, 0%, 100%, 0.05);
+}
+/* stylelint-enable */

--- a/packages/styles/express/theme-light.css
+++ b/packages/styles/express/theme-light.css
@@ -1,0 +1,288 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+/* stylelint-disable */
+:host,
+:root {
+    --spectrum-global-color-status: Verified;
+    --spectrum-global-color-version: 5.1.0;
+    --spectrum-global-color-gray-50: #fff;
+    --spectrum-global-color-gray-75: #fbfbfb;
+    --spectrum-global-color-gray-100: #f8f8f8;
+    --spectrum-global-color-gray-200: #e6e6e6;
+    --spectrum-global-color-gray-300: #d5d5d5;
+    --spectrum-global-color-gray-400: #b0b0b0;
+    --spectrum-global-color-gray-500: #909090;
+    --spectrum-global-color-gray-600: #6c6c6c;
+    --spectrum-global-color-gray-700: #464646;
+    --spectrum-global-color-gray-800: #212121;
+    --spectrum-global-color-gray-900: #000;
+    --spectrum-global-color-green-400: #009260;
+    --spectrum-global-color-green-500: #008254;
+    --spectrum-global-color-green-600: #007248;
+    --spectrum-global-color-blue-400: #187df5;
+    --spectrum-global-color-blue-500: #076ce9;
+    --spectrum-global-color-blue-600: #015ece;
+    --spectrum-global-color-red-400: #ed3d2e;
+    --spectrum-global-color-red-500: #de2219;
+    --spectrum-global-color-red-600: #c80a08;
+    --spectrum-global-color-seafoam-400: #007e8a;
+    --spectrum-global-color-seafoam-500: #006d79;
+    --spectrum-global-color-seafoam-600: #005e6a;
+    --spectrum-global-color-seafoam-700: #044f5a;
+    --spectrum-global-color-indigo-400: #5c60ed;
+    --spectrum-global-color-indigo-500: #4c50dc;
+    --spectrum-global-color-indigo-600: #3f43c5;
+    --spectrum-global-color-indigo-700: #3337aa;
+    --spectrum-global-color-purple-400: #9247ee;
+    --spectrum-global-color-purple-500: #8133e1;
+    --spectrum-global-color-purple-600: #7022cf;
+    --spectrum-global-color-purple-700: #5e14b8;
+    --spectrum-global-color-fuchsia-400: #c02bc0;
+    --spectrum-global-color-fuchsia-500: #ad16ae;
+    --spectrum-global-color-fuchsia-600: #99009a;
+    --spectrum-global-color-fuchsia-700: #820082;
+    --spectrum-global-color-magenta-400: #d22c74;
+    --spectrum-global-color-magenta-500: #be1961;
+    --spectrum-global-color-magenta-600: #a80353;
+    --spectrum-global-color-magenta-700: #8f0046;
+    --spectrum-global-color-orange-400: #f6830f;
+    --spectrum-global-color-orange-500: #e26e00;
+    --spectrum-global-color-orange-600: #cf5f00;
+    --spectrum-global-color-orange-700: #bb5300;
+    --spectrum-global-color-yellow-400: #e9c600;
+    --spectrum-global-color-yellow-500: #d6b100;
+    --spectrum-global-color-yellow-600: #c39d00;
+    --spectrum-global-color-yellow-700: #af8a00;
+    --spectrum-global-color-chartreuse-400: #82c631;
+    --spectrum-global-color-chartreuse-500: #6eb31f;
+    --spectrum-global-color-chartreuse-600: #5f9f14;
+    --spectrum-global-color-chartreuse-700: #538f0f;
+    --spectrum-global-color-celery-400: #23ba34;
+    --spectrum-global-color-celery-500: #04a51e;
+    --spectrum-global-color-celery-600: #009413;
+    --spectrum-global-color-celery-700: #008410;
+    --spectrum-global-color-opacity-100: 1;
+    --spectrum-global-color-opacity-90: 0.9;
+    --spectrum-global-color-opacity-80: 0.8;
+    --spectrum-global-color-opacity-60: 0.6;
+    --spectrum-global-color-opacity-50: 0.5;
+    --spectrum-global-color-opacity-42: 0.42;
+    --spectrum-global-color-opacity-40: 0.4;
+    --spectrum-global-color-opacity-30: 0.3;
+    --spectrum-global-color-opacity-25: 0.25;
+    --spectrum-global-color-opacity-20: 0.2;
+    --spectrum-global-color-opacity-15: 0.15;
+    --spectrum-global-color-opacity-10: 0.1;
+    --spectrum-global-color-opacity-8: 0.08;
+    --spectrum-global-color-opacity-7: 0.07;
+    --spectrum-global-color-opacity-6: 0.06;
+    --spectrum-global-color-opacity-5: 0.05;
+    --spectrum-global-color-opacity-4: 0.04;
+    --spectrum-global-color-opacity-0: 0;
+    --spectrum-global-color-red-700: #bb121a;
+    --spectrum-global-color-green-700: #107154;
+    --spectrum-global-color-blue-700: #095aba;
+    --spectrum-alias-avatar-border-color-default: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-avatar-border-color-hover: rgba(0, 0, 0, 0.25);
+    --spectrum-alias-avatar-border-color-down: rgba(0, 0, 0, 0.4);
+    --spectrum-alias-avatar-border-color-key-focus: rgba(0, 0, 0, 0.25);
+    --spectrum-alias-avatar-border-color-selected-disabled: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-background-color-primary: var(
+        --spectrum-global-color-gray-50
+    );
+    --spectrum-alias-background-color-secondary: var(
+        --spectrum-global-color-gray-100
+    );
+    --spectrum-alias-background-color-tertiary: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-background-color-modal-overlay: rgba(0, 0, 0, 0.4);
+    --spectrum-alias-dropshadow-color: rgba(0, 0, 0, 0.15);
+    --spectrum-alias-background-color-hover-overlay: rgba(0, 0, 0, 0.04);
+    --spectrum-alias-highlight-hover: rgba(0, 0, 0, 0.06);
+    --spectrum-alias-highlight-down: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-highlight-selected: rgba(7, 108, 233, 0.1);
+    --spectrum-alias-highlight-selected-hover: rgba(7, 108, 233, 0.2);
+    --spectrum-alias-text-highlight-color: rgba(7, 108, 233, 0.2);
+    --spectrum-alias-background-color-quickactions: hsla(0, 0%, 97%, 0.9);
+    --spectrum-alias-border-color-selected: var(
+        --spectrum-global-color-blue-500
+    );
+    --spectrum-alias-border-color-translucent: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-radial-reaction-color-default: rgba(33, 33, 33, 0.6);
+    --spectrum-alias-pasteboard-background-color: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-appframe-border-color: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-alias-appframe-separator-color: var(
+        --spectrum-global-color-gray-300
+    );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-s-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-s-range-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-s-editable-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-s-range-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-s-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-s-ramp-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-s-range-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-m-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-m-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-m-range-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-m-editable-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-m-range-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-m-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-m-ramp-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-m-range-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-l-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-l-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-l-range-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-l-editable-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-l-range-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-l-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-l-ramp-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-l-range-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-xl-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-xl-range-tick-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-xl-editable-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-xl-range-editable-radial-reaction-color: rgba(
+        33,
+        33,
+        33,
+        0.6
+    );
+    --spectrum-slider-xl-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-xl-ramp-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-slider-xl-range-radial-reaction-color: rgba(33, 33, 33, 0.6);
+    --spectrum-well-background-color: rgba(33, 33, 33, 0.02);
+    --spectrum-well-border-color: rgba(0, 0, 0, 0.05);
+}
+/* stylelint-enable */

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -72,9 +72,10 @@
         "@spectrum-web-components/base": "^0.5.4"
     },
     "devDependencies": {
-        "@spectrum-css/commons": "3.0.5",
-        "@spectrum-css/typography": "4.0.16",
-        "@spectrum-css/vars": "7.2.0"
+        "@spectrum-css/commons": "^3.0.5",
+        "@spectrum-css/expressvars": "^1.0.0-beta.30",
+        "@spectrum-css/typography": "^4.0.16",
+        "@spectrum-css/vars": "^7.2.0"
     },
     "customElements": "custom-elements.json",
     "sideEffects": [

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -25,10 +25,16 @@ When looking to leverage the `Theme` base class as a type and/or for extension p
 import { Theme } from '@spectrum-web-components/theme';
 ```
 
-The various themes can be imported en masse:
+The various Classic themes can be imported en masse:
 
 ```
 import '@spectrum-web-components/theme/src/themes.js';
+```
+
+The various Express themes can be imported en masse:
+
+```
+import '@spectrum-web-components/theme/src/express/themes.js';
 ```
 
 Or, individually:
@@ -40,6 +46,12 @@ import '@spectrum-web-components/theme/theme-light.js';
 import '@spectrum-web-components/theme/theme-lightest.js';
 import '@spectrum-web-components/theme/scale-medium.js';
 import '@spectrum-web-components/theme/scale-large.js';
+import '@spectrum-web-components/theme/express/theme-darkest.js';
+import '@spectrum-web-components/theme/express/theme-dark.js';
+import '@spectrum-web-components/theme/express/theme-light.js';
+import '@spectrum-web-components/theme/express/theme-lightest.js';
+import '@spectrum-web-components/theme/express/scale-medium.js';
+import '@spectrum-web-components/theme/express/scale-large.js';
 ```
 
 ## Quick start
@@ -55,10 +67,38 @@ The above import will get you started using the `<sp-theme>` wrapper element, an
 
 Once you've moved beyond the prototype phases of an application, it is likely that you will only use one combinatin of `color` and `scale` in your application, and even when you don't you will likely benefit from lazily loading variants that you don't leverage by default. For single combination applications or to power a _default_ theme, the following imports can be used to ensure only the code your application requires is loaded:
 
+### Classic
+
 ```js
-// Power a site using <sp-theme color="darkest" scale="large">
+/**
+ * Power a site using
+ *
+ * <sp-theme
+ *      theme="classic"
+ *      color="darkest"
+ *      scale="large"
+ * >
+ **/
 import '@spectrum-web-components/theme/theme-darkest.js';
 import '@spectrum-web-components/theme/scale-large.js';
+
+import '@spectrum-web-components/theme/sp-theme.js';
+```
+
+### Express
+
+```js
+/**
+ * Power a site using
+ *
+ * <sp-theme
+ *      theme="express"
+ *      color="light"
+ *      scale="medium"
+ * >
+ **/
+import '@spectrum-web-components/theme/express/theme-light.js';
+import '@spectrum-web-components/theme/express/scale-medium.js';
 
 import '@spectrum-web-components/theme/sp-theme.js';
 ```
@@ -102,25 +142,13 @@ The `<sp-theme>` element provides a language context for its descendents in the 
         margin-top: 2em;
     }
 </style>
-<sp-theme color="light">
-    <div id="example">
-        <div>
-            <sp-slider
-                value="5"
-                step="1"
-                min="1"
-                max="11"
-                label="Volume"
-                id="volume-slider"
-            ></sp-slider>
-        </div>
-        <div><sp-switch>Overdrive</sp-switch></div>
-        <sp-button-group id="buttons">
-            <sp-button variant="primary">Cancel</sp-button>
-            <sp-button variant="cta">Continue</sp-button>
-        </sp-button-group>
-    </div>
+<sp-theme theme="express" color="light" scale="medium">
+    <hzn-app-stuff></hzn-app-stuff>
 </sp-theme>
+
+<express-app>
+    <hzn-app-stuff></hzn-app-stuff>
+</express-app>
 ```
 
 ## Dark theme
@@ -138,25 +166,13 @@ The `<sp-theme>` element provides a language context for its descendents in the 
         margin-top: 2em;
     }
 </style>
-<sp-theme color="dark">
-    <div id="example">
-        <div>
-            <sp-slider
-                value="5"
-                step="1"
-                min="1"
-                max="11"
-                label="Volume"
-                id="volume-slider"
-            ></sp-slider>
-        </div>
-        <div><sp-switch>Overdrive</sp-switch></div>
-        <sp-button-group id="buttons">
-            <sp-button variant="primary">Cancel</sp-button>
-            <sp-button variant="cta">Continue</sp-button>
-        </sp-button-group>
-    </div>
+<sp-theme theme="express" color="dark" scale="large">
+    <hzn-app-stuff></hzn-app-stuff>
 </sp-theme>
+
+<express-app>
+    <hzn-app-stuff></hzn-app-stuff>
+</express-app>
 ```
 
 ## Large scale

--- a/packages/theme/core.ts
+++ b/packages/theme/core.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
 import { Theme } from './src/Theme.js';
-import './core.js';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+import coreStyles from './src/theme.css.js';
+
+Theme.registerThemeFragment('spectrum', 'theme', coreStyles);

--- a/packages/theme/express/scale-large.ts
+++ b/packages/theme/express/scale-large.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+import largeStyles from '../src/express/scale-large.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/express/core.js';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+Theme.registerThemeFragment('large-express', 'scale', largeStyles);

--- a/packages/theme/express/scale-medium.ts
+++ b/packages/theme/express/scale-medium.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+import mediumStyles from '../src/express/scale-medium.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/express/core.js';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+Theme.registerThemeFragment('medium-express', 'scale', mediumStyles);

--- a/packages/theme/express/theme-dark.ts
+++ b/packages/theme/express/theme-dark.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+import darkStyles from '../src/express/theme-dark.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/express/core.js';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+Theme.registerThemeFragment('dark-express', 'color', darkStyles);

--- a/packages/theme/express/theme-darkest.ts
+++ b/packages/theme/express/theme-darkest.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+import darkStyles from '../src/express/theme-dark.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/express/core.js';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+Theme.registerThemeFragment('darkest-express', 'color', darkStyles);

--- a/packages/theme/express/theme-light.ts
+++ b/packages/theme/express/theme-light.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+import lightStyles from '../src/express/theme-light.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/express/core.js';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+Theme.registerThemeFragment('light-express', 'color', lightStyles);

--- a/packages/theme/express/theme-lightest.ts
+++ b/packages/theme/express/theme-lightest.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+import lightStyles from '../src/express/theme-light.css.js';
+import { Theme } from '../src/Theme.js';
+import '../src/express/core.js';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+Theme.registerThemeFragment('lightest-express', 'color', lightStyles);

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -22,6 +22,8 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
+        "./express/*": "./express/*",
+        "./src/express/*": "./src/express/*",
         "./package.json": "./package.json",
         "./sp-theme": "./sp-theme.js",
         "./sp-theme.js": "./sp-theme.js",
@@ -66,6 +68,10 @@
         "./sp-*.js",
         "./theme-*.js",
         "./scale-*.js",
-        "./src/themes.js"
+        "./express/theme-*.js",
+        "./express/scale-*.js",
+        "./src/themes.js",
+        "./src/express/core.js",
+        "./src/express/themes.js"
     ]
 }

--- a/packages/theme/scale-medium.ts
+++ b/packages/theme/scale-medium.ts
@@ -12,5 +12,6 @@ governing permissions and limitations under the License.
 
 import mediumStyles from './src/scale-medium.css.js';
 import { Theme } from './src/Theme.js';
+import './core.js';
 
 Theme.registerThemeFragment('medium', 'scale', mediumStyles);

--- a/packages/theme/src/express/core.ts
+++ b/packages/theme/src/express/core.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+import { Theme } from '../Theme.js';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+import coreStyles from './theme.css.js';
+
+Theme.registerThemeFragment('express', 'theme', coreStyles);

--- a/packages/theme/src/express/scale-large.css
+++ b/packages/theme/src/express/scale-large.css
@@ -10,8 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
-
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+@import '@spectrum-web-components/styles/express/scale-large.css';

--- a/packages/theme/src/express/scale-medium.css
+++ b/packages/theme/src/express/scale-medium.css
@@ -10,8 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
-
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+@import '@spectrum-web-components/styles/express/scale-medium.css';

--- a/packages/theme/src/express/theme-dark.css
+++ b/packages/theme/src/express/theme-dark.css
@@ -10,8 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
-
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+@import '@spectrum-web-components/styles/express/theme-dark.css';

--- a/packages/theme/src/express/theme-light.css
+++ b/packages/theme/src/express/theme-light.css
@@ -10,8 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
-
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+@import '@spectrum-web-components/styles/express/theme-light.css';

--- a/packages/theme/src/express/theme.css
+++ b/packages/theme/src/express/theme.css
@@ -10,8 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
+@import '@spectrum-web-components/styles/express/core-global.css';
+@import '@spectrum-web-components/styles/fonts.css';
 
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+:host {
+    display: block;
+}
+
+#scale,
+#theme {
+    width: 100%;
+    height: 100%;
+}

--- a/packages/theme/src/express/themes.ts
+++ b/packages/theme/src/express/themes.ts
@@ -10,8 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import largeStyles from './src/scale-large.css.js';
-import { Theme } from './src/Theme.js';
-import './core.js';
-
-Theme.registerThemeFragment('large', 'scale', largeStyles);
+import '../../express/theme-light.js';
+import '../../express/theme-lightest.js';
+import '../../express/theme-dark.js';
+import '../../express/theme-darkest.js';
+import '../../express/scale-medium.js';
+import '../../express/scale-large.js';

--- a/packages/theme/stories/theme.stories.ts
+++ b/packages/theme/stories/theme.stories.ts
@@ -64,7 +64,10 @@ export const Default = ({
 }): TemplateResult => {
     return html`
         ${storyStyles}
-        <sp-theme color="${color}">
+        <sp-theme
+            color="${color}"
+            theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+        >
             <div id="example">
                 <div>
                     <sp-slider
@@ -101,7 +104,11 @@ export const displayFlex = (): TemplateResult => html`
             flex: 1 0;
         }
     </style>
-    <sp-theme id="flex-theme" color="dark">
+    <sp-theme
+        id="flex-theme"
+        color="dark"
+        theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+    >
         <sp-button>Start</sp-button>
         <sp-button id="middle-button">Middle</sp-button>
         <sp-button>End</sp-button>
@@ -138,7 +145,10 @@ export const nestedTheme = ({
     const inner = outer === 'light' ? 'dark' : 'light';
     return html`
         ${storyStyles}
-        <sp-theme color="${outer}">
+        <sp-theme
+            color="${outer}"
+            theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+        >
             <div id="outer">
                 <div>
                     <sp-slider
@@ -157,7 +167,11 @@ export const nestedTheme = ({
                     </sp-button>
                     <sp-button variant="accent">Continue</sp-button>
                 </sp-button-group>
-                <sp-theme color="${inner}" dir="ltr">
+                <sp-theme
+                    color="${inner}"
+                    dir="ltr"
+                    theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+                >
                     <div id="inner">
                         <div>
                             <sp-slider
@@ -209,7 +223,10 @@ export const reverseColorNestedTheme = ({
                 margin-top: 2em;
             }
         </style>
-        <sp-theme color="${inner}">
+        <sp-theme
+            color="${inner}"
+            theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+        >
             <div id="outer">
                 <div>
                     <sp-slider
@@ -228,7 +245,11 @@ export const reverseColorNestedTheme = ({
                     </sp-button>
                     <sp-button variant="accent">Continue</sp-button>
                 </sp-button-group>
-                <sp-theme color="${outer}" dir="rtl">
+                <sp-theme
+                    color="${outer}"
+                    dir="rtl"
+                    theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+                >
                     <div id="inner">
                         <div>
                             <sp-slider

--- a/packages/theme/test/theme-lazy.test.ts
+++ b/packages/theme/test/theme-lazy.test.ts
@@ -32,7 +32,7 @@ describe('Themes - lazy', () => {
             Theme as unknown as TestableThemeConstructor
         ).themeFragmentsByKind.clear();
         // Core is registered by default in `theme.ts`
-        Theme.registerThemeFragment('core', 'core', coreStyles);
+        Theme.registerThemeFragment('spectrum', 'theme', coreStyles);
     });
     after(() => {
         Theme.registerThemeFragment('light', 'color', lightStyles);

--- a/packages/theme/test/themes.test.ts
+++ b/packages/theme/test/themes.test.ts
@@ -25,7 +25,7 @@ describe('Themes', () => {
     it('loads - light', async () => {
         const el = await fixture<Theme>(
             html`
-                <sp-theme color="light"></sp-theme>
+                <sp-theme theme="classic" color="light"></sp-theme>
             `
         );
 
@@ -61,7 +61,7 @@ describe('Themes', () => {
     it('adds an instance only once', async () => {
         const el = await fixture<Theme>(
             html`
-                <sp-theme></sp-theme>
+                <sp-theme theme="express"></sp-theme>
             `
         );
 

--- a/packages/theme/theme-dark.ts
+++ b/packages/theme/theme-dark.ts
@@ -12,5 +12,6 @@ governing permissions and limitations under the License.
 
 import darkStyles from './src/theme-dark.css.js';
 import { Theme } from './src/Theme.js';
+import './core.js';
 
 Theme.registerThemeFragment('dark', 'color', darkStyles);

--- a/packages/theme/theme-darkest.ts
+++ b/packages/theme/theme-darkest.ts
@@ -12,5 +12,6 @@ governing permissions and limitations under the License.
 
 import darkStyles from './src/theme-darkest.css.js';
 import { Theme } from './src/Theme.js';
+import './core.js';
 
 Theme.registerThemeFragment('darkest', 'color', darkStyles);

--- a/packages/theme/theme-light.ts
+++ b/packages/theme/theme-light.ts
@@ -12,5 +12,6 @@ governing permissions and limitations under the License.
 
 import lightStyles from './src/theme-light.css.js';
 import { Theme } from './src/Theme.js';
+import './core.js';
 
 Theme.registerThemeFragment('light', 'color', lightStyles);

--- a/packages/theme/theme-lightest.ts
+++ b/packages/theme/theme-lightest.ts
@@ -12,5 +12,6 @@ governing permissions and limitations under the License.
 
 import lightestStyles from './src/theme-lightest.css.js';
 import { Theme } from './src/Theme.js';
+import './core.js';
 
 Theme.registerThemeFragment('lightest', 'color', lightestStyles);

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -4,7 +4,7 @@
         "composite": true,
         "rootDir": "./"
     },
-    "include": ["*.ts", "src/*.ts"],
+    "include": ["*.ts", "src/**/*.ts", "express/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
     "references": [{ "path": "../base" }]
 }

--- a/packages/tray/test/tray.test.ts
+++ b/packages/tray/test/tray.test.ts
@@ -57,7 +57,7 @@ describe('Tray', () => {
     it('closes', async () => {
         const test = await fixture<HTMLElement>(
             html`
-                <sp-theme scale="medium" color="dark">
+                <sp-theme theme="classic" scale="medium" color="dark">
                     <sp-tray></sp-tray>
                 </sp-theme>
             `

--- a/projects/documentation/src/components/code-example.css
+++ b/projects/documentation/src/components/code-example.css
@@ -15,10 +15,12 @@ governing permissions and limitations under the License.
     display: flex;
     margin: 1rem 0 2rem 0;
     flex-direction: column;
-    border-radius: 6px;
+    border-radius: var(--code-example-border-radius);
     border: 1px solid var(--spectrum-global-color-gray-100);
-    max-width: 100%;
-    box-sizing: border-box;
+    width: 100%;
+    position: relative;
+
+    --code-example-border-radius: var(--spectrum-alias-border-radius-regular);
 }
 
 .demo-example {
@@ -26,12 +28,9 @@ governing permissions and limitations under the License.
     overflow: auto;
     flex: 1;
     padding: var(--spectrum-global-dimension-size-400)
-        var(--spectrum-global-dimension-size-500)
-        var(
-            --demo-example-padding-bottom,
-            var(--spectrum-global-dimension-size-400)
-        );
-    border-radius: 6px 6px 0 0;
+        var(--spectrum-global-dimension-size-500);
+    border-radius: var(--code-example-border-radius)
+        var(--code-example-border-radius) 0 0;
     background: var(--spectrum-global-color-gray-100);
 }
 
@@ -74,6 +73,31 @@ pre {
     top: 0;
     grid-template-columns: 100%;
     grid-template-rows: 100%;
+}
+
+pre {
+    font-weight: var(
+        --spectrum-code-xs-text-font-weight,
+        var(--spectrum-alias-code-text-font-weight-regular)
+    );
+    line-height: var(
+        --spectrum-code-xs-text-line-height,
+        var(--spectrum-alias-code-text-line-height)
+    );
+    font-style: var(
+        --spectrum-code-xs-text-font-style,
+        var(--spectrum-global-font-style-regular)
+    );
+    letter-spacing: var(
+        --spectrum-code-xs-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: var(
+        --spectrum-code-xs-text-font-family,
+        var(--spectrum-alias-code-text-font-family)
+    );
 }
 
 .copy {

--- a/projects/example-project-rollup/index.html
+++ b/projects/example-project-rollup/index.html
@@ -10,178 +10,42 @@
     <base href="/" />
 
     <title>example-app</title>
-    <!-- To use the following you must have a full build of the app to draw the styles from... -->
-    <!-- <link rel="stylesheet" href="dist/styles.css" /> -->
   </head>
 
   <body>
-    <sp-theme color="light" scale="large">
-      <div>
-        <sp-button variant="primary">Primary</sp-button>
-        <sp-button variant="secondary" autofocus>secondary</sp-button>
-        <sp-button variant="cta">cta</sp-button>
-        <sp-button variant="negative">negative</sp-button>
-        <sp-button variant="action">action</sp-button>
-        <sp-button disabled>disabled</sp-button>
-      </div>
-      <div>
-        <sp-checkbox checked>checked</sp-checkbox>
-        <sp-checkbox indeterminate>indeterminate</sp-checkbox>
-        <sp-checkbox invalid>invalid</sp-checkbox>
-        <sp-checkbox disabled>disabled</sp-checkbox>
-      </div>
-      <div>
-        <sp-radio-group name="example">
-          <sp-radio invalid value="first">Option 1</sp-radio>
-          <sp-radio value="second">Option 2</sp-radio>
-          <sp-radio disabled value="third">Option 3</sp-radio>
-          <sp-radio checked value="fourth">Option 4</sp-radio>
-        </sp-radio-group>
-      </div>
-      <div>
-        <sp-picker
-          label="Select a Country with a very long label, too long in fact"
-        >
-          <sp-menu-item> Deselect </sp-menu-item>
-          <sp-menu-item> Select inverse </sp-menu-item>
-          <sp-menu-item> Feather... </sp-menu-item>
-          <sp-menu-item> Select and mask... </sp-menu-item>
+    <sp-theme theme="express" color="light" scale="medium">
+      <sp-button variant="primary">Primary</sp-button>
+      <br /><br />
+      <sp-button variant="secondary" quiet>secondary</sp-button>
+      <br /><br />
+      <sp-field-label for="picker">Where do you live?</sp-field-label>
+      <sp-picker id="picker">
+        <span slot="label">
+          Select a Country with a very long label, too long in fact
+        </span>
+        <sp-menu-item> Deselect </sp-menu-item>
+        <sp-menu-item> Select Inverse </sp-menu-item>
+        <sp-menu-item> Feather... </sp-menu-item>
+        <sp-menu-item> Select and Mask... </sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item> Save Selection </sp-menu-item>
+        <sp-menu-item disabled> Make Work Path </sp-menu-item>
+      </sp-picker>
+
+      <sp-picker dir="rtl">
+        <span slot="label">
+          Select a Country with a very long label, too long in fact
+        </span>
+        <sp-menu dir="rtl">
+          <sp-menu-item dir="rtl"> Deselect </sp-menu-item>
+          <sp-menu-item dir="rtl"> Select Inverse </sp-menu-item>
+          <sp-menu-item dir="rtl"> Feather... </sp-menu-item>
+          <sp-menu-item dir="rtl"> Select and Mask... </sp-menu-item>
           <sp-menu-divider></sp-menu-divider>
-          <sp-menu-item> Save selection </sp-menu-item>
-          <sp-menu-item disabled> Make work path </sp-menu-item>
-        </sp-picker>
-        <sp-picker invalid label="Invalid">
-          <sp-menu-item> Deselect </sp-menu-item>
-          <sp-menu-item> Select inverse </sp-menu-item>
-          <sp-menu-item> Feather... </sp-menu-item>
-          <sp-menu-item> Select and mask... </sp-menu-item>
-          <sp-menu-divider></sp-menu-divider>
-          <sp-menu-item> Save selection </sp-menu-item>
-          <sp-menu-item disabled> Make work path </sp-menu-item>
-        </sp-picker>
-        <sp-picker disabled label="Disabled">
-          <sp-menu-item> Deselect </sp-menu-item>
-          <sp-menu-item> Select inverse </sp-menu-item>
-          <sp-menu-item> Feather... </sp-menu-item>
-          <sp-menu-item> Select and mask... </sp-menu-item>
-          <sp-menu-divider></sp-menu-divider>
-          <sp-menu-item> Save selection </sp-menu-item>
-          <sp-menu-item disabled> Make work path </sp-menu-item>
-        </sp-picker>
-      </div>
-      <div>
-        This is a
-        <sp-link href="#">standard link</sp-link>
-        . This is a
-        <sp-link quiet href="#">quiet link</sp-link>
-        . This is a
-        <sp-link download="myfile.txt" href="#">download link</sp-link>
-        .
-      </div>
-      <div>
-        <sp-slider label="Slider Label"></sp-slider>
-        <sp-slider label="Slider Label - Disabled" disabled></sp-slider>
-        <sp-slider
-          label="Slider Label"
-          variant="tick"
-          tick-step="5"
-          tick-labels
-        ></sp-slider>
-        <sp-slider
-          label="Slider Label - Disabled"
-          variant="tick"
-          tick-step="5"
-          tick-labels
-          disabled
-        ></sp-slider>
-      </div>
-      <div>
-        <sp-textfield label="Name" placeholder="Enter your name"></sp-textfield>
-        <sp-textfield
-          label="Name"
-          placeholder="Enter your name"
-          invalid
-        ></sp-textfield>
-        <sp-textfield
-          label="Name"
-          placeholder="Enter your name"
-          valid
-        ></sp-textfield>
-        <sp-textfield label="Name"></sp-textfield>
-        <sp-textfield invalid label="invalid name"></sp-textfield>
-        <sp-textfield valid label="valid name"></sp-textfield>
-        <sp-textfield multiline label="multiline Name"></sp-textfield>
-        <sp-textfield
-          multiline
-          invalid
-          label="multiline invalid name"
-        ></sp-textfield>
-        <sp-textfield
-          multiline
-          valid
-          label="multiline valid name"
-        ></sp-textfield>
-      </div>
-      <div>
-        <sp-dialog-wrapper
-          id="dialog-wrapper-demo"
-          headline="Dialog title"
-          dismissible
-          underlay
-          footer="Content for footer"
-          hidden
-        >
-          Content of the dialog
-        </sp-dialog-wrapper>
-        <sp-button
-          onClick="
-    const dialogWrapper = this.previousElementSibling;
-    dialogWrapper.hidden = false;
-    dialogWrapper.open = true;
-    const handleEvent = ({type}) => {
-        alert(`Handling '${type}' event.`);
-        dialogWrapper.open = false;
-        dialogWrapper.removeEventListener('close', handleEvent);
-    }
-    dialogWrapper.addEventListener('close', handleEvent);
-  "
-          variant="primary"
-        >
-          Toggle Dialog
-        </sp-button>
-        <sp-dialog-wrapper
-          id="dialog-wrapper-demo"
-          headline="Dialog title"
-          mode="fullscreen"
-          confirm-label="Keep Both"
-          secondary-label="Replace"
-          cancel-label="Cancel"
-          footer="Content for footer"
-          hidden
-        >
-          Content of the dialog
-        </sp-dialog-wrapper>
-        <sp-button
-          onClick="
-    const dialogWrapper = this.previousElementSibling;
-    dialogWrapper.hidden = false;
-    dialogWrapper.open = true;
-    const handleEvent = ({type}) => {
-        alert(`Handling '${type}' event.`);
-        dialogWrapper.open = false;
-        dialogWrapper.removeEventListener('confirm', handleEvent);
-        dialogWrapper.removeEventListener('secondary', handleEvent);
-        dialogWrapper.removeEventListener('cancel', handleEvent);
-    }
-    dialogWrapper.addEventListener('confirm', handleEvent);
-    dialogWrapper.addEventListener('secondary', handleEvent);
-    dialogWrapper.addEventListener('cancel', handleEvent);
-  "
-          variant="primary"
-        >
-          Toggle Dialog
-        </sp-button>
-      </div>
+          <sp-menu-item dir="rtl"> Save Selection </sp-menu-item>
+          <sp-menu-item disabled dir="rtl"> Make Work Path </sp-menu-item>
+        </sp-menu>
+      </sp-picker>
     </sp-theme>
 
     <script type="module" src="./out-tsc/src/example-app.js"></script>

--- a/projects/example-project-rollup/src/example-app.ts
+++ b/projects/example-project-rollup/src/example-app.ts
@@ -11,11 +11,11 @@ governing permissions and limitations under the License.
 */
 
 // import our stylesheets
-// import './styles.css';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/express/theme-light.js';
+import '@spectrum-web-components/theme/express/scale-medium.js';
 
 // import the components we'll use in this page
-import '@spectrum-web-components/theme/sp-theme.js';
-import '@spectrum-web-components/theme/src/themes.js';
 import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/checkbox/sp-checkbox.js';
 import '@spectrum-web-components/radio/sp-radio.js';
@@ -23,7 +23,7 @@ import '@spectrum-web-components/radio/sp-radio-group.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/link/sp-link.js';
-import '@spectrum-web-components/slider/sp-slider.js';
+// import '@spectrum-web-components/slider/sp-slider.js';
 import '@spectrum-web-components/textfield/sp-textfield.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import '@spectrum-web-components/dialog/sp-dialog.js';

--- a/projects/example-project-rollup/src/styles.css
+++ b/projects/example-project-rollup/src/styles.css
@@ -11,7 +11,6 @@ governing permissions and limitations under the License.
 */
 
 /* import the global stylesheets */
-@import '@spectrum-web-components/styles/all-medium-light.css';
 
 html,
 body {

--- a/projects/example-project-webpack/package.json
+++ b/projects/example-project-webpack/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "build": "webpack",
         "build:prod": "webpack --env.NODE_ENV=production --optimize-minimize",
-        "serve": "webpack-dev-server"
+        "serve": "webpack serve"
     },
     "dependencies": {
         "@spectrum-web-components/button": "^0.17.2",

--- a/projects/example-project-webpack/src/index.html
+++ b/projects/example-project-webpack/src/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8" />
 
         <title>Example App</title>
-        <link rel="stylesheet" href="main.bundle.css" />
+        <!-- <link rel="stylesheet" href="main.bundle.css" /> -->
         <style>
             html,
             body {

--- a/projects/example-project-webpack/src/index.js
+++ b/projects/example-project-webpack/src/index.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 // import our stylesheets
-import './styles.css';
+// import './styles.css';
 
 // import the components we'll use in this page
 import '@spectrum-web-components/button/sp-button';

--- a/projects/example-project-webpack/webpack.config.js
+++ b/projects/example-project-webpack/webpack.config.js
@@ -9,19 +9,18 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-'use strict';
-
 import { join, resolve } from 'path';
 
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import { CleanWebpackPlugin } from 'clean-webpack-plugin';
-import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import CWP from 'clean-webpack-plugin';
+import BAP from 'webpack-bundle-analyzer';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
+const { CleanWebpackPlugin } = CWP;
+const { BundleAnalyzerPlugin } = BAP;
 const ENV = process.argv.find((arg) => arg.includes('NODE_ENV=production'))
     ? 'production'
     : 'development';

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -24,6 +24,7 @@ import {
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
+import '@spectrum-web-components/theme/src/express/themes.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/menu/sp-menu.js';
@@ -31,7 +32,12 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/switch/sp-switch.js';
 import { Picker } from '@spectrum-web-components/picker';
 import { Switch } from '@spectrum-web-components/switch';
-import { Color, Scale, Theme } from '@spectrum-web-components/theme';
+import {
+    Color,
+    Scale,
+    Theme,
+    ThemeVariant,
+} from '@spectrum-web-components/theme';
 import { ActiveOverlay } from '@spectrum-web-components/overlay';
 import './types.js';
 
@@ -40,11 +46,14 @@ const urlParams = new URLSearchParams(queryString);
 
 export let dir: 'ltr' | 'rtl' =
     (urlParams.get('sp_dir') as 'ltr' | 'rtl') || 'ltr';
+export let theme: ThemeVariant =
+    (urlParams.get('sp_theme') as ThemeVariant) || 'spectrum';
 export let color: Color = (urlParams.get('sp_color') as Color) || 'light';
 export let scale: Scale = (urlParams.get('sp_scale') as Scale) || 'medium';
 export let reduceMotion = urlParams.get('sp_reduceMotion') === 'true';
 
 window.__swc_hack_knobs__ = window.__swc_hack_knobs__ || {
+    defaultThemeVariant: theme,
     defaultColor: color,
     defaultScale: scale,
     defaultDirection: dir,
@@ -71,7 +80,7 @@ const reduceMotionProperties = css`
 ActiveOverlay.prototype.renderTheme = function (
     content: TemplateResult
 ): TemplateResult {
-    const { color, scale, lang } = this.theme;
+    const { color, scale, theme, lang } = this.theme;
     return html`
         ${window.__swc_hack_knobs__.defaultReduceMotion
             ? html`
@@ -83,6 +92,7 @@ ActiveOverlay.prototype.renderTheme = function (
               `
             : html``}
         <sp-theme
+            theme=${ifDefined(theme)}
             color=${ifDefined(color)}
             scale=${ifDefined(scale)}
             lang=${ifDefined(lang)}
@@ -94,76 +104,84 @@ ActiveOverlay.prototype.renderTheme = function (
 };
 
 export class StoryDecorator extends SpectrumElement {
-    static styles = [
-        css`
-            :host(:focus) {
-                outline: none;
-            }
-            sp-theme {
-                overflow-x: hidden;
-                display: block;
-                box-sizing: border-box;
-                width: 100%;
-                min-height: 100vh;
-                padding: var(--spectrum-global-dimension-size-100)
-                    var(--spectrum-global-dimension-size-100)
-                    calc(
-                        2 * var(--spectrum-alias-focus-ring-size) +
-                            var(--spectrum-alias-item-height-m)
+    static get styles() {
+        return [
+            css`
+                :host(:focus) {
+                    outline: none;
+                }
+                sp-theme {
+                    overflow-x: hidden;
+                    display: block;
+                    box-sizing: border-box;
+                    width: 100%;
+                    min-height: 100vh;
+                    padding: var(--spectrum-global-dimension-size-100)
+                        var(--spectrum-global-dimension-size-100)
+                        calc(
+                            2 * var(--spectrum-alias-focus-ring-size) +
+                                var(--spectrum-alias-item-height-m)
+                        );
+                    box-sizing: border-box;
+                    background-color: var(--spectrum-global-color-gray-100);
+                    color: var(
+                        --spectrum-body-text-color,
+                        var(--spectrum-alias-text-color)
                     );
-                background-color: var(--spectrum-global-color-gray-100);
-                color: var(
-                    --spectrum-body-text-color,
-                    var(--spectrum-alias-text-color)
-                );
-            }
-            :host([screenshot]) sp-theme {
-                padding: var(--spectrum-global-dimension-size-100);
-                --swc-test-caret-color: transparent;
-            }
-            :host([reduce-motion]) sp-theme {
-                ${reduceMotionProperties}
-            }
-            .manage-theme {
-                position: fixed;
-                bottom: 0;
-                left: var(--spectrum-global-dimension-size-200);
-                right: var(--spectrum-global-dimension-size-200);
-                display: flex;
-                align-items: center;
-                justify-content: flex-end;
-                box-sizing: border-box;
-                background-color: var(--spectrum-global-color-gray-100);
-                padding-bottom: calc(2 * var(--spectrum-alias-focus-ring-size));
-            }
-            [dir='ltr'] sp-field-label {
-                padding-left: 0;
-                padding-right: var(
-                    --spectrum-fieldlabel-side-padding-x,
-                    var(--spectrum-global-dimension-size-100)
-                );
-                margin-left: var(--spectrum-global-dimension-size-400);
-            }
-            [dir='ltr'] sp-switch {
-                margin-left: var(--spectrum-global-dimension-size-400);
-                margin-right: 0;
-                padding: 0;
-            }
-            [dir='rtl'] sp-field-label {
-                padding-right: 0;
-                padding-left: var(
-                    --spectrum-fieldlabel-side-padding-x,
-                    var(--spectrum-global-dimension-size-100)
-                );
-                margin-right: var(--spectrum-global-dimension-size-400);
-            }
-            [dir='rtl'] sp-switch {
-                margin-right: var(--spectrum-global-dimension-size-400);
-                margin-left: 0;
-                padding: 0;
-            }
-        `,
-    ];
+                }
+                :host([screenshot]) sp-theme {
+                    padding: var(--spectrum-global-dimension-size-100);
+                    --swc-test-caret-color: transparent;
+                }
+                :host([reduce-motion]) sp-theme {
+                    ${reduceMotionProperties}
+                }
+                .manage-theme {
+                    position: fixed;
+                    bottom: 0;
+                    left: var(--spectrum-global-dimension-size-200);
+                    right: var(--spectrum-global-dimension-size-200);
+                    display: flex;
+                    align-items: center;
+                    justify-content: flex-end;
+                    box-sizing: border-box;
+                    background-color: var(--spectrum-global-color-gray-100);
+                    padding-bottom: calc(
+                        2 * var(--spectrum-alias-focus-ring-size)
+                    );
+                }
+                [dir='ltr'] sp-field-label {
+                    padding-left: 0;
+                    padding-right: var(
+                        --spectrum-fieldlabel-side-padding-x,
+                        var(--spectrum-global-dimension-size-100)
+                    );
+                    margin-left: var(--spectrum-global-dimension-size-400);
+                }
+                [dir='ltr'] sp-switch {
+                    margin-left: var(--spectrum-global-dimension-size-400);
+                    margin-right: 0;
+                    padding: 0;
+                }
+                [dir='rtl'] sp-field-label {
+                    padding-right: 0;
+                    padding-left: var(
+                        --spectrum-fieldlabel-side-padding-x,
+                        var(--spectrum-global-dimension-size-100)
+                    );
+                    margin-right: var(--spectrum-global-dimension-size-400);
+                }
+                [dir='rtl'] sp-switch {
+                    margin-right: var(--spectrum-global-dimension-size-400);
+                    margin-left: 0;
+                    padding: 0;
+                }
+            `,
+        ];
+    }
+
+    @property({ type: String })
+    public theme: ThemeVariant = window.__swc_hack_knobs__.defaultThemeVariant;
 
     @property({ type: String })
     public color: Color = window.__swc_hack_knobs__.defaultColor;
@@ -182,16 +200,16 @@ export class StoryDecorator extends SpectrumElement {
     public screenshot = false;
 
     @queryAsync('sp-theme')
-    private theme!: Theme;
+    private themeRoot!: Theme;
 
     public ready = false;
 
     public async startManagingContentDirection(el: HTMLElement): Promise<void> {
-        (await this.theme).startManagingContentDirection(el);
+        (await this.themeRoot).startManagingContentDirection(el);
     }
 
     public async stopManagingContentDirection(el: HTMLElement): Promise<void> {
-        (await this.theme).stopManagingContentDirection(el);
+        (await this.themeRoot).stopManagingContentDirection(el);
     }
 
     private updateTheme({ target }: Event & { target: Picker | Switch }): void {
@@ -199,6 +217,12 @@ export class StoryDecorator extends SpectrumElement {
         const { value } = target as Picker;
         const { checked } = target as Switch;
         switch (id) {
+            case 'theme':
+                this.theme =
+                    theme =
+                    window.__swc_hack_knobs__.defaultThemeVariant =
+                        value as ThemeVariant;
+                break;
             case 'color':
                 this.color =
                     color =
@@ -238,6 +262,7 @@ export class StoryDecorator extends SpectrumElement {
     protected render(): TemplateResult {
         return html`
             <sp-theme
+                theme=${this.theme}
                 color=${this.color}
                 scale=${this.scale}
                 dir=${this.direction}
@@ -275,9 +300,25 @@ export class StoryDecorator extends SpectrumElement {
     private get manageTheme(): TemplateResult {
         return html`
             <div class="manage-theme" part="controls">
-                ${this.colorControl} ${this.scaleControl} ${this.dirControl}
-                ${this.reduceMotionControl}
+                ${this.themeControl} ${this.colorControl} ${this.scaleControl}
+                ${this.dirControl} ${this.reduceMotionControl}
             </div>
+        `;
+    }
+
+    private get themeControl(): TemplateResult {
+        return html`
+            <sp-field-label for="theme">Spectrum</sp-field-label>
+            <sp-picker
+                id="theme"
+                placement="top"
+                quiet
+                .value=${this.theme}
+                @change=${this.updateTheme}
+            >
+                <sp-menu-item value="spectrum">Classic</sp-menu-item>
+                <sp-menu-item value="express">Express</sp-menu-item>
+            </sp-picker>
         `;
     }
 

--- a/projects/story-decorator/src/types.ts
+++ b/projects/story-decorator/src/types.ts
@@ -9,11 +9,12 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { Color, Scale } from '@spectrum-web-components/theme';
+import { Color, Scale, ThemeVariant } from '@spectrum-web-components/theme';
 
 declare global {
     interface Window {
         __swc_hack_knobs__: {
+            defaultThemeVariant: ThemeVariant;
             defaultColor: Color;
             defaultScale: Scale;
             defaultDirection: 'ltr' | 'rtl';

--- a/projects/vrt-quick-link/404.html
+++ b/projects/vrt-quick-link/404.html
@@ -232,12 +232,15 @@
 
         return temp.toLowerCase();
     };
-    let destScale = 'medium';
-    let destColor = 'light';
-    let destDir = 'ltr';
-    const { pathname } = window.location;
+    const { pathname, search } = window.location;
+    const flavor = search ? search.slice(1) : 'classic';
+    const destColor = 'light';
+    const destScale = 'medium';
+    const destDir = 'ltr';
     const branch = pathname.slice(1);
-    const hash = MD5(`${branch}-${destColor}-${destScale}-${destDir}`);
+    const hash = MD5(
+        `${branch}-${flavor}-${destColor}-${destScale}-${destDir}`
+    );
     const destination = `https://${hash}--spectrum-web-components.netlify.app/review`;
     window.location = destination;
 </script>

--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -38,7 +38,7 @@ export const processCSS = async (cssPath) => {
 };
 
 const buildCSS = async () => {
-    for (const cssPath of await fg(`./packages/*/src/*.css`)) {
+    for (const cssPath of await fg(`./packages/*/src/**/*.css`)) {
         processCSS(cssPath);
     }
     for (const cssPath of await fg(`./tools/*/src/*.css`)) {

--- a/tasks/build-preview-urls-comment.cjs
+++ b/tasks/build-preview-urls-comment.cjs
@@ -48,27 +48,24 @@ const buildPreviewURLComment = (ref) => {
     const branch = ref.replace('refs/heads/', '');
     const branchSlug = slugify(branch);
     const previewLinks = [];
-    // const themes = ['Classic', 'Express']; // prepping for Spectrum Express
+    const themes = ['Classic', 'Express'];
     const scales = ['Medium', 'Large'];
     const colors = ['Lightest', 'Light', 'Dark', 'Darkest'];
     const directions = ['LTR', 'RTL'];
-    // themes.map((theme) =>
-    colors.map((color) =>
-        scales.map((scale) =>
-            directions.map((direction) => {
-                // const context = `-${theme.toLocaleLowerCase()}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
-                const context = `${branch}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
-                const md5 = crypto.createHash('md5');
-                md5.update(context);
-                const hash = md5.digest('hex');
-                previewLinks.push(`
-- [${color} | ${scale} | ${direction}](https://${hash}--spectrum-web-components.netlify.app/review/)`);
-                //              previewLinks.push(`
-                // - [${theme} | ${color} | ${scale} | ${direction}](https://${hash}--spectrum-web-components.netlify.app/review/)`);
-            })
+    themes.map((theme) =>
+        colors.map((color) =>
+            scales.map((scale) =>
+                directions.map((direction) => {
+                    const context = `${branch}-${theme.toLocaleLowerCase()}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
+                    const md5 = crypto.createHash('md5');
+                    md5.update(context);
+                    const hash = md5.digest('hex');
+                    previewLinks.push(`
+- [${theme} | ${color} | ${scale} | ${direction}](https://${hash}--spectrum-web-components.netlify.app/review/)`);
+                })
+            )
         )
     );
-    // );
     let comment = `# Branch Preview
 
 - [Documentation Site](https://${branchSlug}--spectrum-web-components.netlify.app/)

--- a/test/visual/review.js
+++ b/test/visual/review.js
@@ -19,32 +19,27 @@ import crypto from 'crypto';
 
 const { commit, theme, branch } = yargs(hideBin(process.argv)).argv;
 
-const themes = [];
-// const themes = ['Classic', 'Express']; // prepping for Spectrum Express
+const vrts = [];
+const themes = ['Classic', 'Express'];
 const scales = ['Medium', 'Large'];
 const colors = ['Lightest', 'Light', 'Dark', 'Darkest'];
 const directions = ['LTR', 'RTL'];
-// themes.map((theme) =>
-colors.map((color) =>
-    scales.map((scale) =>
-        directions.map((direction) => {
-            // const context = `-${theme.toLocaleLowerCase()}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
-            const context = `${branch}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
-            const md5 = crypto.createHash('md5');
-            md5.update(context);
-            const hash = md5.digest('hex');
-            themes.push([
-                `${color} | ${scale} | ${direction}`,
-                `https://${hash}--spectrum-web-components.netlify.app/review/`,
-            ]);
-            // themes.push([
-            //     `${theme} | ${color} | ${scale} | ${direction}`,
-            //     `https://${hash}--spectrum-web-components.netlify.app/review/`
-            // ]);
-        })
+themes.map((theme) =>
+    colors.map((color) =>
+        scales.map((scale) =>
+            directions.map((direction) => {
+                const context = `${branch}-${theme.toLocaleLowerCase()}-${color.toLocaleLowerCase()}-${scale.toLocaleLowerCase()}-${direction.toLocaleLowerCase()}`;
+                const md5 = crypto.createHash('md5');
+                md5.update(context);
+                const hash = md5.digest('hex');
+                vrts.push([
+                    `${theme} | ${color} | ${scale} | ${direction}`,
+                    `https://${hash}--spectrum-web-components.netlify.app/review/`,
+                ]);
+            })
+        )
     )
 );
-// );
 
 function cleanURL(url) {
     return url.replace('test/visual/', '../');
@@ -169,7 +164,7 @@ async function main() {
             branch,
             commit,
             theme,
-            themes,
+            vrts,
         },
         tests,
     });

--- a/test/visual/rollup.config.js
+++ b/test/visual/rollup.config.js
@@ -12,14 +12,18 @@ governing permissions and limitations under the License.
 import html from '@web/rollup-plugin-html';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { copy } from '@web/rollup-plugin-copy';
+import visualizer from 'rollup-plugin-visualizer';
 
 export default {
     input: 'test/visual/src/index.html',
     preserveEntrySignatures: false,
     output: { dir: 'test/visual/review' },
     plugins: [
-        nodeResolve(),
+        nodeResolve({
+            exportConditions: ['browser', 'production'],
+        }),
         html(),
         copy({ patterns: '**/*.json', rootDir: 'test/visual/src' }),
+        visualizer(),
     ],
 };

--- a/test/visual/src/review.js
+++ b/test/visual/src/review.js
@@ -14,7 +14,7 @@ import '@spectrum-web-components/sidenav/sp-sidenav.js';
 import '@spectrum-web-components/sidenav/sp-sidenav-item.js';
 import '@spectrum-web-components/sidenav/sp-sidenav-heading.js';
 import '@spectrum-web-components/vrt-compare/vrt-compare.js';
-import { html, render, nothing } from 'lit-html';
+import { html, nothing, render } from 'lit-html';
 
 const review = document.querySelector('vrt-compare');
 const resultTypes = ['new', 'updated', 'removed', 'passed'];
@@ -44,7 +44,7 @@ function buildNavigation(tests, metadata) {
                 ></sp-sidenav-item>
             </sp-sidenav-heading>
             <sp-sidenav-item multilevel label="Other VRT Results">
-                ${metadata.themes.map(
+                ${metadata.vrts.map(
                     (theme) => html`
                         <sp-sidenav-item
                             label=${theme[0]}
@@ -163,8 +163,9 @@ async function run() {
     const data = await response.json();
     const decorator = document.querySelector('sp-story-decorator');
     const theme = data.meta.theme.split(' ');
-    decorator.color = theme[0];
-    decorator.scale = theme[1];
+    decorator.theme = theme[0];
+    decorator.color = theme[1];
+    decorator.scale = theme[2];
     buildNavigation(data.tests, data.meta);
 }
 

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -24,7 +24,7 @@ export const packages = fs
     .concat(tools);
 
 const vrtHTML =
-    ({ color, scale, dir, reduceMotion }) =>
+    ({ themeVariant, color, scale, dir, reduceMotion }) =>
     (testFramework) =>
         `<!doctype html>
     <html dir=${dir}>
@@ -45,6 +45,7 @@ const vrtHTML =
         <body>
         <script>
             window.__swc_hack_knobs__ = {
+                defaultThemeVariant: "${themeVariant || ''}",
                 defaultColor: "${color || ''}",
                 defaultScale: "${scale || ''}",
                 defaultDirection: "${dir || ''}",
@@ -56,24 +57,28 @@ const vrtHTML =
     </html>`;
 
 export let vrtGroups = [];
+const themeVariants = ['classic', 'express'];
 const colors = ['lightest', 'light', 'dark', 'darkest'];
 const scales = ['medium', 'large'];
 const directions = ['ltr', 'rtl'];
-colors.forEach((color) => {
-    scales.forEach((scale) => {
-        directions.forEach((dir) => {
-            const reduceMotion = true;
-            const testHTML = vrtHTML({
-                color,
-                scale,
-                dir,
-                reduceMotion,
-            });
-            vrtGroups.push({
-                name: `vrt-${color}-${scale}-${dir}`,
-                files: 'packages/*/test/*.test-vrt.js',
-                testRunnerHtml: testHTML,
-                browsers: [playwrightLauncher({ product: 'chromium' })],
+themeVariants.forEach((themeVariant) => {
+    colors.forEach((color) => {
+        scales.forEach((scale) => {
+            directions.forEach((dir) => {
+                const reduceMotion = true;
+                const testHTML = vrtHTML({
+                    themeVariant,
+                    color,
+                    scale,
+                    dir,
+                    reduceMotion,
+                });
+                vrtGroups.push({
+                    name: `vrt-${themeVariant}-${color}-${scale}-${dir}`,
+                    files: 'packages/*/test/*.test-vrt.js',
+                    testRunnerHtml: testHTML,
+                    browsers: [playwrightLauncher({ product: 'chromium' })],
+                });
             });
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4796,7 +4796,7 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-1.0.18.tgz#2d1fc2107e62687a4bfaf2873f81ff8930cd4057"
   integrity sha512-qxnAHrXi2vTfyBl2rkzXYKPPpfFm0DAG2Rmwf7SWvNPetLgpnX+wI0OvmtJm7hJFLtHZrnXaEJG4/Hlfe2sysw==
 
-"@spectrum-css/commons@3.0.5":
+"@spectrum-css/commons@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-3.0.5.tgz#25b86c97402145a6aaaf58cbf1070e1c345d4f9b"
   integrity sha512-9YcJru496pHkcQMWP8y7Njk+ySMfdcap0hBAG/Fx+Vfmlcv9Mt1WCMuyLZusQ6a/0RVU/aKI4kLnDeunphBpNQ==
@@ -4817,6 +4817,11 @@
   version "3.0.21"
   resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-3.0.21.tgz#d4e532a4a829c4c3b6a23ae6edfb77bc1faba3eb"
   integrity sha512-P9uWwp3NH+RaVlF+QEa+BCqZxEe4pL0piJjrI/ei6eiW1k1IwCk8VCnrIce0XNjLk8JIoAUsOjrMvWJq14VNGQ==
+
+"@spectrum-css/expressvars@^1.0.0-beta.30":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-1.0.1.tgz#0fb973180df58cac63ee68c22673182332291a93"
+  integrity sha512-HjiFp72aqGheM2z2qaIEWI/OIIFV/oyZ+xRokrYkXo7pcmM/idfhsBsq+PNB2nOCzEoJzLsh0+wYzZVG+WJUZg==
 
 "@spectrum-css/fieldgroup@3.0.19":
   version "3.0.19"
@@ -4973,7 +4978,7 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-1.0.23.tgz#8f7e6815d3013dba7c4026484773e7a5d6973cf9"
   integrity sha512-l68ivxBmIeAPZ0UWM1QHgD5WtsI+GQipdTArqwiBSGj8z+957W7KyY9eZbI9Q2D2UMjPdaCdO8jQ4Su+qpdlHg==
 
-"@spectrum-css/typography@4.0.16":
+"@spectrum-css/typography@^4.0.16":
   version "4.0.16"
   resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-4.0.16.tgz#474264c227069250c3c87259ec30f10adae4fc7c"
   integrity sha512-O3f8W9XBgfW194ObXtbRDMh3dOkQfi/os7VviE+ToyAWmiTHAn/dh8CB1d0EouogAPbLi51qYJmKOP8P/ZaXCg==
@@ -4983,7 +4988,7 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.27.tgz#cdaff9eddd4849eb2c96da42cb31e47db1f190ea"
   integrity sha512-+eyJul9ctFed+eiKPuIAk8OVb3DmNjkFUzuPDBIt/N/P0Nz/uJY0SawuzWVa7/h5vfWodHdn+t8cv1jmRsDcKQ==
 
-"@spectrum-css/vars@7.2.0", "@spectrum-css/vars@^7.2.0":
+"@spectrum-css/vars@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-7.2.0.tgz#3fc5164bb3916cd9b5037cacc7973a6a2c16fec4"
   integrity sha512-IyXmGojZgMpxpyaSTdGNwX9wMkw53aVZ+KK5JLVWBzCcIRtHjaG4T6ATj/6XLgG3cthyOkmsyx33cjkv8BE+Yg==


### PR DESCRIPTION
## Description
Add support for the Express flavor of Spectrum design.
- `styles` process Spectrum Express Vars into consumable CSS
- `theme` add `<sp-theme theme="classic|express">`
- update appropriate stories
- update examples and documentation site
- update test pipeline and CI

## Motivation and context
Support delivering interfaces to a broader number of personas.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.