### PR TITLE
fix: prevent touch scolling on non-modal content

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -84,6 +84,9 @@ export class OverlayStack {
             #holder[hidden] {
                 display: none !important;
             }
+            #actual[aria-hidden] {
+                touch-action: none;
+            }
             #actual[tabindex="-1"] ::slotted(*) {
                 pointer-events: none;  /* just in case? */
             }

--- a/projects/documentation/src/components/side-nav.css
+++ b/projects/documentation/src/components/side-nav.css
@@ -48,6 +48,7 @@ aside {
 
     .scrim {
         z-index: 10;
+        touch-action: none;
     }
 }
 


### PR DESCRIPTION
## Description
- Prevent `touch-action` on content hidden by a modal overlay.
- Prevent `touch-action` on the `Underlay` below the mobile navigation in the docs.

## Motivation and context
The modals don't move, why should anything else?

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://modal-touch--spectrum-web-components.netlify.app/index.html on a mobile device
    2. Open one of the theme pickers
    3. Attempt to scroll the page behind while the option menu is open
    4. Profit.
-   [ ] _Test case 2_
    1. Go to https://modal-touch--spectrum-web-components.netlify.app/index.html on a mobile device
    2. Open the side navigation
    3. Attempt to scroll the page behind the Underlay
    4. Profit.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
