### PR TITLE
action button a11y

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -21,6 +21,10 @@ import '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import type { LongpressEvent } from '@spectrum-web-components/action-button';
 import { firstFocusableIn } from '@spectrum-web-components/shared/src/first-focusable-in.js';
+import {
+    isAndroid,
+    isIOS,
+} from '@spectrum-web-components/shared/src/platform.js';
 
 import {
     OverlayOpenCloseDetail,
@@ -266,6 +270,23 @@ export class OverlayTrigger extends SpectrumElement {
                 if (!this.open && this.hoverContent) {
                     this.open = 'hover';
                 }
+                // if (this.longpressDescriptor) {
+                //     if (isIOS()) {
+                //         console.log("ios");
+                //         this.longpressDescriptor.innerHTML =
+                //             LONGPRESS_INSTRUCTIONS.touch;
+                //     }
+                //     else if (isAndroid()) {
+                //         console.log("andriod");
+                //         this.longpressDescriptor.innerHTML =
+                //             LONGPRESS_INSTRUCTIONS.touch;
+                //     }
+                //     else if (this.hasVisibleFocusInTree() && (!isIOS() || !isAndroid())){
+                //         console.log("other");
+                //         this.longpressDescriptor.innerHTML =
+                //             LONGPRESS_INSTRUCTIONS.keyboard;
+                //     }
+                // }
                 if (this.hasVisibleFocusInTree() && this.longpressDescriptor) {
                     this.longpressDescriptor.innerHTML =
                         LONGPRESS_INSTRUCTIONS.keyboard;

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -171,8 +171,7 @@ export class OverlayTrigger extends SpectrumElement {
                 this.longpressDescriptor.id = this._longpressId;
                 this.longpressDescriptor.slot = this._longpressId;
             }
-            this.longpressDescriptor.innerHTML =
-                LONGPRESS_INSTRUCTIONS.keyboard;
+            this.longpressDescriptor.innerHTML = LONGPRESS_INSTRUCTIONS.touch;
             this.appendChild(this.longpressDescriptor); // add descriptor to light DOM
             descriptors.push(this._longpressId);
         } else {

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -13,7 +13,6 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
-    LitElement,
     PropertyValues,
     SpectrumElement,
     TemplateResult,
@@ -39,6 +38,11 @@ type closeOverlay =
     | 'closeHoverOverlay'
     | 'closeLongpressOverlay';
 
+export const LONGPRESS_INSTRUCTIONS = {
+    touch: 'Double tap and long press for additional options',
+    keyboard: 'Press Space or Alt+Down Arrow for additional options',
+    mouse: 'Click and hold for additional options',
+};
 /**
  * @element overlay-trigger
  *
@@ -50,7 +54,7 @@ type closeOverlay =
  * @fires sp-opened - Announces that the overlay has been opened
  * @fires sp-closed - Announces that the overlay has been closed
  */
-export class OverlayTrigger extends LitElement {
+export class OverlayTrigger extends SpectrumElement {
     private closeClickOverlay?: Promise<() => void>;
     private closeLongpressOverlay?: Promise<() => void>;
     private closeHoverOverlay?: Promise<() => void>;
@@ -166,9 +170,9 @@ export class OverlayTrigger extends LitElement {
 
                 this.longpressDescriptor.id = this._longpressId;
                 this.longpressDescriptor.slot = this._longpressId;
-                this.longpressDescriptor.innerHTML =
-                    'Press Alt+Down Arrow for additional options';
             }
+            this.longpressDescriptor.innerHTML =
+                LONGPRESS_INSTRUCTIONS.keyboard;
             this.appendChild(this.longpressDescriptor); // add descriptor to light DOM
             descriptors.push(this._longpressId);
         } else {
@@ -260,13 +264,18 @@ export class OverlayTrigger extends LitElement {
         switch (event.type) {
             case 'mouseenter':
             case 'focusin':
-                // if (this.hasLongpressContent && this.longpressDescriptor) {
-                //     console.log("focus!");
-                //         this.longpressDescriptor.innerHTML =
-                //         'Press and hold for additional options';
-                // }
                 if (!this.open && this.hoverContent) {
                     this.open = 'hover';
+                }
+                if (this.hasVisibleFocusInTree() && this.longpressDescriptor) {
+                    this.longpressDescriptor.innerHTML =
+                        LONGPRESS_INSTRUCTIONS.keyboard;
+                } else if (
+                    !this.hasVisibleFocusInTree() &&
+                    this.longpressDescriptor
+                ) {
+                    this.longpressDescriptor.innerHTML =
+                        LONGPRESS_INSTRUCTIONS.touch;
                 }
                 return;
             case 'mouseleave':
@@ -276,7 +285,6 @@ export class OverlayTrigger extends LitElement {
                 }
                 return;
             case 'click':
-                //console.log("clikc");
                 if (this.clickContent) {
                     this.open = event.type;
                 } else if (this.closeHoverOverlay) {
@@ -284,7 +292,6 @@ export class OverlayTrigger extends LitElement {
                 }
                 return;
             case 'longpress':
-                //console.log("lawng");
                 if (this.longpressContent) {
                     this._longpressEvent = event;
                     this.open = event.type;

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -15,8 +15,10 @@ import {
     html,
     LitElement,
     PropertyValues,
+    SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
+import '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import type { LongpressEvent } from '@spectrum-web-components/action-button';
 import { firstFocusableIn } from '@spectrum-web-components/shared/src/first-focusable-in.js';
@@ -148,9 +150,9 @@ export class OverlayTrigger extends LitElement {
     }
 
     protected manageLongpressDescriptor(): void {
-        // get overlay trigger
-        const trigger = this.querySelector('[slot="trigger"]') as HTMLElement;
-
+        const trigger = this.querySelector(
+            '[slot="trigger"]'
+        ) as SpectrumElement;
         // get our current describedby attributes, if any
         const ariaDescribedby = trigger.getAttribute('aria-describedby');
         let descriptors = ariaDescribedby ? ariaDescribedby.split(/\s+/) : [];
@@ -165,10 +167,9 @@ export class OverlayTrigger extends LitElement {
                 this.longpressDescriptor.id = this._longpressId;
                 this.longpressDescriptor.slot = this._longpressId;
                 this.longpressDescriptor.innerHTML =
-                    'Long press for additional options';
+                    'Press Alt+Down Arrow for additional options';
             }
             this.appendChild(this.longpressDescriptor); // add descriptor to light DOM
-
             descriptors.push(this._longpressId);
         } else {
             // dispose longpressDescriptor if it exists already
@@ -259,6 +260,11 @@ export class OverlayTrigger extends LitElement {
         switch (event.type) {
             case 'mouseenter':
             case 'focusin':
+                // if (this.hasLongpressContent && this.longpressDescriptor) {
+                //     console.log("focus!");
+                //         this.longpressDescriptor.innerHTML =
+                //         'Press and hold for additional options';
+                // }
                 if (!this.open && this.hoverContent) {
                     this.open = 'hover';
                 }
@@ -270,6 +276,7 @@ export class OverlayTrigger extends LitElement {
                 }
                 return;
             case 'click':
+                //console.log("clikc");
                 if (this.clickContent) {
                     this.open = event.type;
                 } else if (this.closeHoverOverlay) {
@@ -277,6 +284,7 @@ export class OverlayTrigger extends LitElement {
                 }
                 return;
             case 'longpress':
+                //console.log("lawng");
                 if (this.longpressContent) {
                     this._longpressEvent = event;
                     this.open = event.type;

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -175,7 +175,13 @@ export class OverlayTrigger extends SpectrumElement {
                 this.longpressDescriptor.id = this._longpressId;
                 this.longpressDescriptor.slot = this._longpressId;
             }
-            this.longpressDescriptor.innerHTML = LONGPRESS_INSTRUCTIONS.touch;
+            if (isIOS() || isAndroid()) {
+                this.longpressDescriptor.innerHTML =
+                    LONGPRESS_INSTRUCTIONS.touch;
+            } else {
+                this.longpressDescriptor.innerHTML =
+                    LONGPRESS_INSTRUCTIONS.keyboard;
+            }
             this.appendChild(this.longpressDescriptor); // add descriptor to light DOM
             descriptors.push(this._longpressId);
         } else {
@@ -269,33 +275,6 @@ export class OverlayTrigger extends SpectrumElement {
             case 'focusin':
                 if (!this.open && this.hoverContent) {
                     this.open = 'hover';
-                }
-                // if (this.longpressDescriptor) {
-                //     if (isIOS()) {
-                //         console.log("ios");
-                //         this.longpressDescriptor.innerHTML =
-                //             LONGPRESS_INSTRUCTIONS.touch;
-                //     }
-                //     else if (isAndroid()) {
-                //         console.log("andriod");
-                //         this.longpressDescriptor.innerHTML =
-                //             LONGPRESS_INSTRUCTIONS.touch;
-                //     }
-                //     else if (this.hasVisibleFocusInTree() && (!isIOS() || !isAndroid())){
-                //         console.log("other");
-                //         this.longpressDescriptor.innerHTML =
-                //             LONGPRESS_INSTRUCTIONS.keyboard;
-                //     }
-                // }
-                if (this.hasVisibleFocusInTree() && this.longpressDescriptor) {
-                    this.longpressDescriptor.innerHTML =
-                        LONGPRESS_INSTRUCTIONS.keyboard;
-                } else if (
-                    !this.hasVisibleFocusInTree() &&
-                    this.longpressDescriptor
-                ) {
-                    this.longpressDescriptor.innerHTML =
-                        LONGPRESS_INSTRUCTIONS.touch;
                 }
                 return;
             case 'mouseleave':

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -161,12 +161,10 @@ export class OverlayTrigger extends SpectrumElement {
         const trigger = this.querySelector(
             '[slot="trigger"]'
         ) as SpectrumElement;
-        // get our current describedby attributes, if any
         const ariaDescribedby = trigger.getAttribute('aria-describedby');
         let descriptors = ariaDescribedby ? ariaDescribedby.split(/\s+/) : [];
 
         if (this.hasLongpressContent) {
-            // make an element that acts as `aria-describedby` description if it doesn't exist yet
             if (!this.longpressDescriptor) {
                 this.longpressDescriptor = document.createElement(
                     'div'
@@ -182,12 +180,10 @@ export class OverlayTrigger extends SpectrumElement {
                 this.longpressDescriptor.innerHTML =
                     LONGPRESS_INSTRUCTIONS.keyboard;
             }
-            this.appendChild(this.longpressDescriptor); // add descriptor to light DOM
+            this.appendChild(this.longpressDescriptor);
             descriptors.push(this._longpressId);
         } else {
-            // dispose longpressDescriptor if it exists already
             if (this.longpressDescriptor) this.longpressDescriptor.remove();
-            // remove longpressid from the descriptors
             descriptors = descriptors.filter(
                 (descriptor) => descriptor !== this._longpressId
             );

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -17,8 +17,10 @@ import {
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import '@spectrum-web-components/base';
-import { property } from '@spectrum-web-components/base/src/decorators.js';
+import {
+    property,
+    state,
+} from '@spectrum-web-components/base/src/decorators.js';
 import type { LongpressEvent } from '@spectrum-web-components/action-button';
 import { firstFocusableIn } from '@spectrum-web-components/shared/src/first-focusable-in.js';
 import {
@@ -86,7 +88,7 @@ export class OverlayTrigger extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public disabled = false;
 
-    @property({ type: Boolean, attribute: false })
+    @state()
     public hasLongpressContent = false;
 
     private longpressDescriptor?: HTMLElement;
@@ -95,7 +97,7 @@ export class OverlayTrigger extends SpectrumElement {
     private hoverContent?: HTMLElement;
     private targetContent?: HTMLElement;
 
-    public _longpressId = `longpress-describedby-descriptor`;
+    private _longpressId = `longpress-describedby-descriptor`;
 
     private handleClose(event?: CustomEvent<OverlayOpenCloseDetail>): void {
         if (
@@ -173,13 +175,9 @@ export class OverlayTrigger extends SpectrumElement {
                 this.longpressDescriptor.id = this._longpressId;
                 this.longpressDescriptor.slot = this._longpressId;
             }
-            if (isIOS() || isAndroid()) {
-                this.longpressDescriptor.innerHTML =
-                    LONGPRESS_INSTRUCTIONS.touch;
-            } else {
-                this.longpressDescriptor.innerHTML =
-                    LONGPRESS_INSTRUCTIONS.keyboard;
-            }
+            const messageType = isIOS() || isAndroid() ? 'touch' : 'keyboard';
+            this.longpressDescriptor.textContent =
+                LONGPRESS_INSTRUCTIONS[messageType];
             this.appendChild(this.longpressDescriptor);
             descriptors.push(this._longpressId);
         } else {

--- a/packages/overlay/test/overlay-lifecycle.test.ts
+++ b/packages/overlay/test/overlay-lifecycle.test.ts
@@ -22,6 +22,7 @@ import '@spectrum-web-components/action-button/sp-action-button.js';
 import { OverlayTrigger } from '..';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { a11ySnapshot, findAccessibilityNode } from '@web/test-runner-commands';
+import { Tooltip } from '@spectrum-web-components/tooltip';
 
 describe('Overlay Trigger - Lifecycle Methods', () => {
     it('calls the overlay lifecycle (willOpen/Close)', async () => {
@@ -123,5 +124,126 @@ describe('Overlay Trigger - Lifecycle Methods', () => {
         await waitUntil(() => {
             return el.childNodes.length === 5;
         }, 'children');
+    });
+    it('gardens `aria-describedby` in its target', async () => {
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger placement="right-start">
+                <sp-action-button slot="trigger" aria-describedby="descriptor">
+                    Button with Tooltip
+                </sp-action-button>
+                <sp-tooltip slot="hover-content" delayed>
+                    Described by this content on focus/hover. 2
+                </sp-tooltip>
+            </overlay-trigger>
+            <div id="descriptor">I'm a description!</div>
+        `);
+
+        const trigger = el.querySelector('[slot="trigger"]') as HTMLElement;
+        const tooltip = el.querySelector('sp-tooltip') as Tooltip;
+
+        await elementUpdated(el);
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal('descriptor');
+        expect(el.open).to.be.undefined;
+        expect(el.childNodes.length, 'always').to.equal(5);
+
+        const opened = oneEvent(el, 'sp-opened');
+        trigger.dispatchEvent(
+            new FocusEvent('focusin', { bubbles: true, composed: true })
+        );
+        await opened;
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal(
+            `descriptor ${
+                (tooltip as unknown as { _tooltipId: string })._tooltipId
+            }`
+        );
+
+        const closed = oneEvent(el, 'sp-closed');
+        trigger.dispatchEvent(
+            new FocusEvent('focusout', { bubbles: true, composed: true })
+        );
+        await closed;
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal('descriptor');
+    });
+    it('adds and removes `aria-describedby` attribute', async () => {
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger placement="right-start">
+                <sp-action-button slot="trigger">
+                    Button with Tooltip
+                </sp-action-button>
+                <sp-tooltip slot="hover-content" delayed>
+                    Described by this content on focus/hover. 2
+                </sp-tooltip>
+            </overlay-trigger>
+        `);
+
+        const trigger = el.querySelector('[slot="trigger"]') as HTMLElement;
+        const tooltip = el.querySelector('sp-tooltip') as Tooltip;
+
+        await elementUpdated(el);
+
+        expect(trigger.hasAttribute('aria-describedby')).to.be.false;
+        expect(el.open).to.be.undefined;
+        expect(el.childNodes.length, 'always').to.equal(5);
+
+        const opened = oneEvent(el, 'sp-opened');
+        trigger.dispatchEvent(
+            new FocusEvent('focusin', { bubbles: true, composed: true })
+        );
+        await opened;
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal(
+            `${(tooltip as unknown as { _tooltipId: string })._tooltipId}`
+        );
+
+        const closed = oneEvent(el, 'sp-closed');
+        trigger.dispatchEvent(
+            new FocusEvent('focusout', { bubbles: true, composed: true })
+        );
+        await closed;
+
+        expect(trigger.hasAttribute('aria-describedby')).to.be.false;
+    });
+    it('does not duplicate `aria-describedby` attribute', async () => {
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger placement="right-start">
+                <sp-action-button slot="trigger">
+                    Button with Tooltip
+                </sp-action-button>
+                <sp-tooltip slot="hover-content" delayed>
+                    Described by this content on focus/hover. 2
+                </sp-tooltip>
+            </overlay-trigger>
+        `);
+
+        const trigger = el.querySelector('[slot="trigger"]') as HTMLElement;
+        const tooltip = el.querySelector('sp-tooltip') as Tooltip;
+        const tooltipId = (tooltip as unknown as { _tooltipId: string })
+            ._tooltipId;
+        trigger.setAttribute('aria-describedby', tooltipId);
+
+        await elementUpdated(el);
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal(tooltipId);
+        expect(el.open).to.be.undefined;
+        expect(el.childNodes.length, 'always').to.equal(5);
+
+        const opened = oneEvent(el, 'sp-opened');
+        trigger.dispatchEvent(
+            new FocusEvent('focusin', { bubbles: true, composed: true })
+        );
+        await opened;
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal(tooltipId);
+
+        const closed = oneEvent(el, 'sp-closed');
+        trigger.dispatchEvent(
+            new FocusEvent('focusout', { bubbles: true, composed: true })
+        );
+        await closed;
+
+        expect(trigger.getAttribute('aria-describedby')).to.equal(tooltipId);
     });
 });

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -31,6 +31,7 @@ import {
     sendKeys,
 } from '@web/test-runner-commands';
 import { spy } from 'sinon';
+import '@spectrum-web-components/base';
 
 type DescribedNode = {
     name: string;
@@ -220,7 +221,7 @@ describe('Overlay Trigger - Longpress', () => {
 
         await findDescribedNode(
             'Trigger with hold affordance',
-            'Long press for additional options'
+            'Press Alt+Down Arrow for additional options'
         );
 
         const opened = oneEvent(el, 'sp-opened');
@@ -234,7 +235,7 @@ describe('Overlay Trigger - Longpress', () => {
 
         await findDescribedNode(
             'Trigger with hold affordance',
-            'Long press for additional options'
+            'Press Alt+Down Arrow for additional options'
         );
 
         const closed = oneEvent(el, 'sp-closed');
@@ -250,7 +251,7 @@ describe('Overlay Trigger - Longpress', () => {
 
         await findDescribedNode(
             'Trigger with hold affordance',
-            'Long press for additional options'
+            'Press Alt+Down Arrow for additional options'
         );
     });
     it('removes longpress `aria-describedby` description element when longpress content is removed', async () => {
@@ -298,13 +299,13 @@ describe('Overlay Trigger - Longpress', () => {
         expect(el.hasLongpressContent).to.be.false;
         expect(el.childNodes.length, 'always').to.equal(4);
 
-        el.removeAttribute('hold-affordance');
+        el.setAttribute('hold-affordance', 'true');
         el.append(content);
 
         await elementUpdated(el);
         await findDescribedNode(
             'Trigger with hold affordance',
-            'Long press for additional options'
+            'Press Alt+Down Arrow for additional options'
         );
 
         expect(el.hasLongpressContent).to.be.true;
@@ -369,11 +370,11 @@ describe('Overlay Trigger - Longpress', () => {
 
         await findDescribedNode(
             'First button',
-            'Long press for additional options'
+            'Press Alt+Down Arrow for additional options'
         );
         await findDescribedNode(
             'Second button',
-            'Long press for additional options'
+            'Press Alt+Down Arrow for additional options'
         );
     });
     // TO-DO: figure out a way to make the message different depending on the type of interaction
@@ -404,7 +405,9 @@ describe('Overlay Trigger - Longpress', () => {
                 </overlay-trigger>
             `
         );
-        const trigger = el.querySelector('sp-action-button') as ActionButton;
+        const open = oneEvent(el, 'sp-opened');
+        //const closed = oneEvent(el, 'sp-closed');
+        const trigger = el.querySelector('sp-action-button') as HTMLElement;
         const content = el.querySelector(
             '[slot="longpress-content"]'
         ) as Popover;
@@ -413,17 +416,20 @@ describe('Overlay Trigger - Longpress', () => {
 
         expect(trigger).to.not.be.null;
         expect(content).to.not.be.null;
+        expect(trigger.hasAttribute('aria-describedby')).to.be.true;
         expect(content.open).to.be.false;
 
         trigger.focus();
-        const open = oneEvent(el, 'sp-opened');
-        await sendKeys({
-            press: 'Space',
+
+        // the user... uses (keyboard, pointer, mouse, whatever)
+        sendKeys({
+            press: 'Alt+ArrowDown',
         });
         await open;
-        // the user... uses (keyboard, pointer, mouse, whatever)
         // if focus:visible --> person is using a keyboard --> tell user to activate longpress via (space/alt+down) for add. opts
-        // if focus is INVISIBLE!! --> touch --> "double tap and longpress for additional options"
-        // there's a change in SpectrumElement base class that might support this test
+        await findDescribedNode(
+            'Trigger with hold affordance',
+            'Press Alt+Down Arrow for additional options'
+        );
     });
 });

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -436,7 +436,7 @@ describe('Overlay Trigger - Longpress', () => {
 
         await findDescribedNode(
             'Trigger with hold affordance',
-            LONGPRESS_INSTRUCTIONS.touch
+            LONGPRESS_INSTRUCTIONS.keyboard
         );
     });
 });

--- a/packages/shared/src/platform.ts
+++ b/packages/shared/src/platform.ts
@@ -27,6 +27,7 @@ export function isMac(): boolean {
     return testPlatform(/^Mac/);
 }
 
+/* c8 ignore next 3 */
 export function isIPhone(): boolean {
     return testPlatform(/^iPhone/);
 }
@@ -40,7 +41,6 @@ export function isIPad(): boolean {
     );
 }
 
-/* c8 ignore next 3 */
 export function isIOS(): boolean {
     return isIPhone() || isIPad();
 }

--- a/packages/shared/src/platform.ts
+++ b/packages/shared/src/platform.ts
@@ -27,12 +27,10 @@ export function isMac(): boolean {
     return testPlatform(/^Mac/);
 }
 
-/* c8 ignore next 3 */
 export function isIPhone(): boolean {
     return testPlatform(/^iPhone/);
 }
 
-/* c8 ignore next 7 */
 export function isIPad(): boolean {
     return (
         testPlatform(/^iPad/) ||

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -132,17 +132,12 @@ export class Tooltip extends SpectrumElement {
         trigger: HTMLElement;
     }): void {
         this.setAttribute('aria-hidden', 'true');
-        if (!this._proxy) {
-            this._proxy = document.createElement('span');
-            this._proxy.textContent = this.textContent;
-            this._proxy.id = this._tooltipId;
-            this._proxy.hidden = true;
-            this._proxy.setAttribute('role', 'tooltip');
-        }
+        this.generateProxy();
+        this._proxy.textContent = this.textContent;
         const ariaDescribedby = trigger.getAttribute('aria-describedby') || '';
         this.hadTooltipId = ariaDescribedby.search(this._tooltipId) > -1;
 
-        trigger.insertAdjacentElement('beforebegin', this._proxy);
+        this.insertAdjacentElement('beforebegin', this._proxy);
 
         if (this.hadTooltipId) return;
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
So, this ended up not being so much an action-button accessibility issue... Moreso an Overlay/Tooltip issue.

This PR fixes the following issues:
- Having a tooltip on a long-press button no longer forces the `aria-describedby` attribute to be reset or removed. Multiple descriptor attributes can be added. 
- Buttons with hold affordance/long press now alert users to the secondary action in the screen reader via an `aria-describedby` attribute programatically added in `OverlayTrigger.ts`. The text of the secondary action changes depending on whether the trigger has visible focus or not. 

## Related issue(s)

fixes https://github.com/adobe/spectrum-web-components/issues/1418 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
write later
## How has this been tested?

Manually and with written tests in `overlay-trigger.test.js`
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Manually with screenreader in storybook, and via written tests 

-   [ ] _Test case 1_
    1. Go to https://halsema-action-button-a11y--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--longpress&args=placement:bottom;offset:0;colorStop:light or https://halsema-action-button-a11y--spectrum-web-components.netlify.app/components/action-button/#action-button-with-hold-affordance
    2. Turn on your screen reader
    3. Tab into the button. Screen reader text should read "Press Space or Alt+Down Arrow for additional options"
    4. Tab out of the button so that focus is no longer on it. 
    5. Click the button with your mouse. Screen reader should say "Double tap and long press for additional options."
 
- [ ] _Test case 2_
    1. Using an iOS device with screen reading capabilities enabled, go to https://halsema-action-button-a11y--spectrum-web-components.netlify.app/components/action-button/#action-button-with-hold-affordance or https://halsema-action-button-a11y--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--longpress&args=placement:bottom;offset:0;colorStop:light 
    2. Tap the button. The screen reader text should read "Double tap and long press for additional options."

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.