### PR TITLE
docs: add migration instructions to the first lit@2.0 releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
         "rollup": "2.56.2",
         "rollup-plugin-workbox": "6.1.1"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/projects/documentation/content/guides/migration-guide.11tydata.cjs
+++ b/projects/documentation/content/guides/migration-guide.11tydata.cjs
@@ -1,0 +1,335 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+module.exports = {
+    versions: [
+        {
+            name: '@spectrum-web-components/accordion',
+            version: '0.6.0',
+            dir: '../../components/accordion',
+        },
+        {
+            name: '@spectrum-web-components/action-bar',
+            version: '0.4.0',
+            dir: '../../components/action-bar',
+        },
+        {
+            name: '@spectrum-web-components/action-button',
+            version: '0.7.0',
+            dir: '../../components/action-button',
+        },
+        {
+            name: '@spectrum-web-components/action-group',
+            version: '0.6.0',
+            dir: '../../components/action-group',
+        },
+        {
+            name: '@spectrum-web-components/action-menu',
+            version: '0.13.0',
+            dir: '../../components/action-menu',
+        },
+        {
+            name: '@spectrum-web-components/asset',
+            version: '0.6.0',
+            dir: '../../components/asset',
+        },
+        {
+            name: '@spectrum-web-components/avatar',
+            version: '0.9.0',
+            dir: '../../components/avatar',
+        },
+        {
+            name: '@spectrum-web-components/banner',
+            version: '0.7.0',
+            dir: '../../components/banner',
+        },
+        {
+            name: '@spectrum-web-components/base',
+            version: '0.5.0',
+            dir: '../../components/base',
+        },
+        {
+            name: '@spectrum-web-components/bundle',
+            version: '0.23.0',
+            dir: '../../components/bundle',
+        },
+        {
+            name: '@spectrum-web-components/button-group',
+            version: '0.8.0',
+            dir: '../../components/button-group',
+        },
+        {
+            name: '@spectrum-web-components/button',
+            version: '0.16.0',
+            dir: '../../components/button',
+        },
+        {
+            name: '@spectrum-web-components/card',
+            version: '0.10.0',
+            dir: '../../components/card',
+        },
+        {
+            name: '@spectrum-web-components/checkbox',
+            version: '0.12.0',
+            dir: '../../components/checkbox',
+        },
+        {
+            name: '@spectrum-web-components/coachmark',
+            version: '0.8.0',
+            dir: '../../components/coachmark',
+        },
+        {
+            name: '@spectrum-web-components/color-area',
+            version: '0.4.0',
+            dir: '../../components/color-area',
+        },
+        {
+            name: '@spectrum-web-components/color-handle',
+            version: '0.3.0',
+            dir: '../../components/color-handle',
+        },
+        {
+            name: '@spectrum-web-components/color-loupe',
+            version: '0.3.0',
+            dir: '../../components/color-loupe',
+        },
+        {
+            name: '@spectrum-web-components/color-slider',
+            version: '0.3.0',
+            dir: '../../components/color-slider',
+        },
+        {
+            name: '@spectrum-web-components/color-wheel',
+            version: '0.3.0',
+            dir: '../../components/color-wheel',
+        },
+        {
+            name: '@spectrum-web-components/dialog',
+            version: '0.8.0',
+            dir: '../../components/dialog',
+        },
+        {
+            name: '@spectrum-web-components/divider',
+            version: '0.4.0',
+            dir: '../../components/divider',
+        },
+        {
+            name: '@spectrum-web-components/dropzone',
+            version: '0.9.0',
+            dir: '../../components/dropzone',
+        },
+        {
+            name: '@spectrum-web-components/field-group',
+            version: '0.5.0',
+            dir: '../../components/field-group',
+        },
+        {
+            name: '@spectrum-web-components/field-label',
+            version: '0.7.0',
+            dir: '../../components/field-label',
+        },
+        {
+            name: '@spectrum-web-components/icon',
+            version: '0.11.0',
+            dir: '../../components/icon',
+        },
+        {
+            name: '@spectrum-web-components/icons-ui',
+            version: '0.8.0',
+            dir: '../../components/icons-ui',
+        },
+        {
+            name: '@spectrum-web-components/icons-workflow',
+            version: '0.8.0',
+            dir: '../../components/icons-workflow',
+        },
+        {
+            name: '@spectrum-web-components/icons',
+            version: '0.8.0',
+            dir: '../../components/icons',
+        },
+        {
+            name: '@spectrum-web-components/iconset',
+            version: '0.6.0',
+            dir: '../../components/iconset',
+        },
+        {
+            name: '@spectrum-web-components/illustrated-message',
+            version: '0.8.0',
+            dir: '../../components/illustrated-message',
+        },
+        {
+            name: '@spectrum-web-components/link',
+            version: '0.11.0',
+            dir: '../../components/link',
+        },
+        {
+            name: '@spectrum-web-components/menu',
+            version: '0.11.0',
+            dir: '../../components/menu',
+        },
+        {
+            name: '@spectrum-web-components/meter',
+            version: '0.6.0',
+            dir: '../../components/meter',
+        },
+        {
+            name: '@spectrum-web-components/modal',
+            version: '0.5.0',
+            dir: '../../components/modal',
+        },
+        {
+            name: '@spectrum-web-components/number-field',
+            version: '0.3.0',
+            dir: '../../components/number-field',
+        },
+        {
+            name: '@spectrum-web-components/overlay',
+            version: '0.13.0',
+            dir: '../../components/overlay',
+        },
+        {
+            name: '@spectrum-web-components/picker',
+            version: '0.9.0',
+            dir: '../../components/picker',
+        },
+        {
+            name: '@spectrum-web-components/popover',
+            version: '0.11.0',
+            dir: '../../components/popover',
+        },
+        {
+            name: '@spectrum-web-components/progress-bar',
+            version: '0.5.0',
+            dir: '../../components/progress-bar',
+        },
+        {
+            name: '@spectrum-web-components/progress-circle',
+            version: '0.4.0',
+            dir: '../../components/progress-circle',
+        },
+        {
+            name: '@spectrum-web-components/quick-actions',
+            version: '0.6.0',
+            dir: '../../components/quick-actions',
+        },
+        {
+            name: '@spectrum-web-components/radio',
+            version: '0.9.0',
+            dir: '../../components/radio',
+        },
+        {
+            name: '@spectrum-web-components/search',
+            version: '0.10.0',
+            dir: '../../components/search',
+        },
+        {
+            name: '@spectrum-web-components/shared',
+            version: '0.13.0',
+            dir: '../../components/shared',
+        },
+        {
+            name: '@spectrum-web-components/sidenav',
+            version: '0.12.0',
+            dir: '../../components/sidenav',
+        },
+        {
+            name: '@spectrum-web-components/slider',
+            version: '0.12.0',
+            dir: '../../components/slider',
+        },
+        {
+            name: '@spectrum-web-components/split-button',
+            version: '0.7.0',
+            dir: '../../components/split-button',
+        },
+        {
+            name: '@spectrum-web-components/split-view',
+            version: '0.4.0',
+            dir: '../../components/split-view',
+        },
+        {
+            name: '@spectrum-web-components/status-light',
+            version: '0.10.0',
+            dir: '../../components/status-light',
+        },
+        {
+            name: '@spectrum-web-components/styles',
+            version: '0.11.0',
+            dir: '../../components/styles',
+        },
+        {
+            name: '@spectrum-web-components/switch',
+            version: '0.9.0',
+            dir: '../../components/switch',
+        },
+        {
+            name: '@spectrum-web-components/tabs',
+            version: '0.8.0',
+            dir: '../../components/tabs',
+        },
+        {
+            name: '@spectrum-web-components/tags',
+            version: '0.8.0',
+            dir: '../../components/tags',
+        },
+        {
+            name: '@spectrum-web-components/textfield',
+            version: '0.10.0',
+            dir: '../../components/textfield',
+        },
+        {
+            name: '@spectrum-web-components/theme',
+            version: '0.9.0',
+            dir: '../../components/theme',
+        },
+        {
+            name: '@spectrum-web-components/thumbnail',
+            version: '0.4.0',
+            dir: '../../components/thumbnail',
+        },
+        {
+            name: '@spectrum-web-components/toast',
+            version: '0.10.0',
+            dir: '../../components/toast',
+        },
+        {
+            name: '@spectrum-web-components/tooltip',
+            version: '0.10.0',
+            dir: '../../components/tooltip',
+        },
+        {
+            name: '@spectrum-web-components/top-nav',
+            version: '0.5.0',
+            dir: '../../components/top-nav',
+        },
+        {
+            name: '@spectrum-web-components/tray',
+            version: '0.2.0',
+            dir: '../../components/tray',
+        },
+        {
+            name: '@spectrum-web-components/underlay',
+            version: '0.8.0',
+            dir: '../../components/underlay',
+        },
+        {
+            name: '@spectrum-web-components/story-decorator',
+            version: '0.4.0',
+            dir: '/Users/wesjohns/Documents/repos/spectrum-web-components/projects/story-decorator',
+        },
+        {
+            name: '@spectrum-web-components/vrt-compare',
+            version: '0.1.0',
+            dir: '/Users/wesjohns/Documents/repos/spectrum-web-components/projects/vrt-compare',
+        },
+    ],
+};

--- a/projects/documentation/content/guides/migration-guide.md
+++ b/projects/documentation/content/guides/migration-guide.md
@@ -1,0 +1,132 @@
+---
+layout: guide.njk
+title: 'Migration Guide: Spectrum Web Components'
+displayName: Migration Guide
+slug: migration-guide
+---
+
+## Migration: 8/11/2021
+
+As of 8/11/2021, Spectrum Web Components will cease to leverage `lit-element` and `lit-html` dependencies directly in favor of [`lit2.0`](https://lit.dev/blog/2021-09-21-announcing-lit-2/). For most of you this will be a 100% transparent change as the usage of these libraries is encapsulated within our elements and consuming these new versions within your HTML of Javascript application should do little more than pass the bundle size and performance benefits of this change on to your applications. If you are currently using any of the following package version you should be seeing these benefits in your applications today. In the case that you are using those packages in concert with versions before those listed below we highly suggest that you align your version consumption to the most recent versions as soon as is comfortable for your project.
+
+<details>
+	<summary><strong>Package Versions</strong></summary>
+	<div class="table-container">
+		<table class="spectrum-Table spectrum-Table--sizeM">
+			<thead class="spectrum-Table-head">
+				<tr>
+					<th class="spectrum-Table-headCell">Package</th>
+					<th class="spectrum-Table-headCell">Version</th>
+				</tr>
+			</thead>
+			<tbody class="spectrum-Table-body">
+				{% for pkg in versions %}<tr class="spectrum-Table-row">
+					<td class="spectrum-Table-cell">
+						<a href="{{ pkg.dir }}">{{ pkg.name }}</a>
+					</td>
+					<td class="spectrum-Table-cell">
+						<a href="https://www.npmjs.com/package/{{ pkg.name }}/bundle/v/{{ pkg.version }}">{{ pkg.version }}</a>
+					</td>
+				<tr>{% endfor %}
+			</tbody>
+		</table>
+	</div>
+</details>
+
+### Using `lit@2.0` inside of `lit-html` and/or `LitElement`
+
+If you are currently using `lit-html@1.x` and/or `lit-element@2.x` within your project and are looking to consume these new package versions without updating to `lit` as well, you should generally have no issue. Manual migration may be required in the case that your application is consuming template literal versions of the icons available in `@spectrum-web-components/icons-ui` or `@spectrum-web-components/icons-workflow` directly from their default exports as follows:
+
+```js
+import { LitElement } from 'lit-element';
+import { html } from 'lit-html';
+import '@spectrum-web-components/icon/sp-icon.js';
+import { RedoIcon } from '@spectrum-web-components/icons-workflow';
+
+export class ElementWithicon extends LitElement {
+    render() {
+        return html`
+            // ...
+            <sp-icon>${RedoIcon()}</sp-icon>
+            // ...
+        `;
+    }
+}
+```
+
+In this case the `RedoIcon()` literal will be wrapped in the `html` template literal tag as supplied by `@spectrum-web-components/icons-workflow`. After this update, the version of this tag will no longer be compatible with the `html` template literal tag applied in the `render()` method of your custom element. You can correct this by applying your local value for `html` to the icon literals:
+
+```js
+import { html } from 'lit-html';
+import {
+    RedoIcon,
+    setCustomTemplateLiteralTag,
+} from '@spectrum-web-components/icons-workflow';
+
+setCustomTemplateLiteralTag(html);
+```
+
+Or, you can avoid running into issues like this in the future, while leveraging more performant icon delivery, by leveraging fully registered icon elements instead:
+
+```js
+import { LitElement } from 'lit-element';
+import { html } from 'lit-html';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-redo.js';
+
+export class ElementWithicon extends LitElement {
+    render() {
+        return html`
+            // ...
+            <sp-icon-redo></sp-icon-redo>
+            // ...
+        `;
+    }
+}
+```
+
+### Javascript re-exports
+
+Previously, `@spectrum-web-components/base` re-exported a number of things from the `lit-element` and `lit-html` packages like so:
+
+```js
+// @spectrum-web-components/base
+export * from 'lit-element';
+export { nothing } from 'lit-html';
+export { ifDefined } from 'lit-html/directives/if-defined.js';
+export { repeat } from 'lit-html/directives/repeat.js';
+export { classMap } from 'lit-html/directives/class-map.js';
+export { styleMap } from 'lit-html/directives/style-map.js';
+export { until } from 'lit-html/directives/until.js';
+export { live } from 'lit-html/directives/live.js';
+```
+
+With the move the `lit` greater care is being taken to ensure that importing JS from this package delivers only what you might need in your application, so we have updated the entrypoints on this package to the following: `@spectrum-web-components/base`, `@spectrum-web-components/base/decorators.js`, `@spectrum-web-components/base/html.js`, and `@spectrum-web-components/base/directives.js`. These files will re-export `lit` values as follows:
+
+```js
+// @spectrum-web-components/base
+export * from 'lit';
+```
+
+```js
+// @spectrum-web-components/base/decorators.js
+export * from 'lit/decorators.js';
+```
+
+```js
+// @spectrum-web-components/base/html.js
+export { nothing, render } from 'lit/html.js';
+```
+
+```js
+// @spectrum-web-components/base/directives.js
+export { ifDefined } from 'lit/directives/if-defined.js';
+export { repeat } from 'lit/directives/repeat.js';
+export { classMap } from 'lit/directives/class-map.js';
+export type { ClassInfo } from 'lit/directives/class-map.js';
+export { styleMap } from 'lit/directives/style-map.js';
+export type { StyleInfo } from 'lit/directives/style-map.js';
+export { until } from 'lit/directives/until.js';
+export { live } from 'lit/directives/live.js';
+```
+
+Additional `lit` exports can be acquired directly from that package and with the reduction of `instanceof`-centric checking within the `lit-html` library it is possible that overtime we lean towards that being the preferred path towards acquiring this values.

--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "build": "yarn build:tsc && yarn build-search-index && yarn build:move-css && yarn build:eleventy && yarn build:postcss && yarn build:rollup",
         "build-search-index": "node scripts/build-search-index.js",
-        "build:eleventy": "eleventy --config=.eleventy.cjs",
+        "build:eleventy": "eleventy --config=.eleventy.cjs --incremental",
         "build:move-css": "cp src/components/*.css _site/src/components/",
         "build:postcss": "postcss src/components/{styles,fonts}.css -d dist/ --config src/postcss.config.cjs",
         "build:production": "SWC_DIR=spectrum-web-components yarn build",


### PR DESCRIPTION
## Description
Add migration instructions for the pending `lit@2.0` release!

## Motivation and context
Docs are great.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to https://lit-migration--spectrum-web-components.netlify.app/guides/migration-guide/
    2. Read the page.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
