### PR TITLE
fix: abstract "hasVisibleFocusInTree" functionality and return trigger focus after close

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -83,19 +83,6 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
         `;
     }
 
-    protected get renderPopover(): TemplateResult {
-        return html`
-            <sp-popover id="popover" @sp-overlay-closed=${this.onOverlayClosed}>
-                <sp-menu
-                    id="menu"
-                    role="${this.listRole}"
-                    @change=${this.handleChange}
-                    .selects=${this.selects}
-                ></sp-menu>
-            </sp-popover>
-        `;
-    }
-
     protected updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
         if (changedProperties.has('invalid')) {

--- a/packages/action-menu/test/action-menu-sync.test.ts
+++ b/packages/action-menu/test/action-menu-sync.test.ts
@@ -16,7 +16,13 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
-import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    oneEvent,
+} from '@open-wc/testing';
 
 const deprecatedActionMenuFixture = async (): Promise<ActionMenu> =>
     await fixture<ActionMenu>(
@@ -122,6 +128,29 @@ describe('Action menu', () => {
 
         expect(el.invalid).to.be.false;
     });
+    it('focus()', async () => {
+        const el = await actionMenuFixture();
+
+        await elementUpdated(el);
+
+        el.focus();
+
+        expect(document.activeElement).to.equal(el);
+        expect(el.shadowRoot.activeElement).to.equal(el.focusElement);
+
+        const opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(document.activeElement).to.not.equal(el);
+
+        const closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(document.activeElement).to.equal(el);
+        expect(el.shadowRoot.activeElement).to.equal(el.focusElement);
+    });
     it('opens unmeasured', async () => {
         const el = await actionMenuFixture();
 
@@ -141,5 +170,45 @@ describe('Action menu', () => {
         button.click();
         await elementUpdated(el);
         expect(el.open).to.be.true;
+    });
+    it('toggles open/close multiple time', async () => {
+        const el = await actionMenuFixture();
+
+        await elementUpdated(el);
+        let items = el.querySelectorAll('sp-menu-item');
+        const count = items.length;
+        expect(items.length).to.equal(count);
+
+        let opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        let closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(count);
+
+        opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(count);
     });
 });

--- a/packages/action-menu/test/action-menu.test.ts
+++ b/packages/action-menu/test/action-menu.test.ts
@@ -16,7 +16,13 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
-import { fixture, elementUpdated, html, expect } from '@open-wc/testing';
+import {
+    fixture,
+    elementUpdated,
+    html,
+    expect,
+    oneEvent,
+} from '@open-wc/testing';
 
 const deprecatedActionMenuFixture = async (): Promise<ActionMenu> =>
     await fixture<ActionMenu>(
@@ -122,6 +128,29 @@ describe('Action menu', () => {
 
         expect(el.invalid).to.be.false;
     });
+    it('focus()', async () => {
+        const el = await actionMenuFixture();
+
+        await elementUpdated(el);
+
+        el.focus();
+
+        expect(document.activeElement).to.equal(el);
+        expect(el.shadowRoot.activeElement).to.equal(el.focusElement);
+
+        const opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(document.activeElement).to.not.equal(el);
+
+        const closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(document.activeElement).to.equal(el);
+        expect(el.shadowRoot.activeElement).to.equal(el.focusElement);
+    });
     it('opens unmeasured', async () => {
         const el = await actionMenuFixture();
 
@@ -141,5 +170,45 @@ describe('Action menu', () => {
         button.click();
         await elementUpdated(el);
         expect(el.open).to.be.true;
+    });
+    it('toggles open/close multiple time', async () => {
+        const el = await actionMenuFixture();
+
+        await elementUpdated(el);
+        let items = el.querySelectorAll('sp-menu-item');
+        const count = items.length;
+        expect(items.length).to.equal(count);
+
+        let opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        let closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(count);
+
+        opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(count);
     });
 });

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -243,23 +243,7 @@ export class ColorArea extends SpectrumElement {
     }
 
     private forwardFocus(): void {
-        const activeElement = (this.getRootNode() as Document)
-            .activeElement as HTMLElement;
-        if (activeElement) {
-            let shouldFocus = false;
-            try {
-                // Browsers without support for the `:focus-visible`
-                // selector will throw on the following test (Safari, older things).
-                // Some won't throw, but will be focusing item rather than the menu and
-                // will rely on the polyfill to know whether focus is "visible" or not.
-                shouldFocus =
-                    activeElement.matches(':focus-visible') ||
-                    activeElement.matches('.focus-visible');
-            } catch (error) {
-                shouldFocus = activeElement.matches('.focus-visible');
-            }
-            this.focused = shouldFocus;
-        }
+        this.focused = this.hasVisibleFocusInTree();
         if (this.activeAxis === 'x') {
             this.inputX.focus();
         } else {

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -275,23 +275,7 @@ export class ColorSlider extends Focusable {
     }
 
     private forwardFocus(): void {
-        const activeElement = (this.getRootNode() as Document)
-            .activeElement as HTMLElement;
-        if (activeElement) {
-            let shouldFocus = false;
-            try {
-                // Browsers without support for the `:focus-visible`
-                // selector will throw on the following test (Safari, older things).
-                // Some won't throw, but will be focusing item rather than the menu and
-                // will rely on the polyfill to know whether focus is "visible" or not.
-                shouldFocus =
-                    activeElement.matches(':focus-visible') ||
-                    activeElement.matches('.focus-visible');
-            } catch (error) {
-                shouldFocus = activeElement.matches('.focus-visible');
-            }
-            this.focused = shouldFocus;
-        }
+        this.focused = this.hasVisibleFocusInTree();
         this.input.focus();
     }
 

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -260,23 +260,7 @@ export class ColorWheel extends Focusable {
     }
 
     private forwardFocus(): void {
-        const activeElement = (this.getRootNode() as Document)
-            .activeElement as HTMLElement;
-        if (activeElement) {
-            let shouldFocus = false;
-            try {
-                // Browsers without support for the `:focus-visible`
-                // selector will throw on the following test (Safari, older things).
-                // Some won't throw, but will be focusing item rather than the menu and
-                // will rely on the polyfill to know whether focus is "visible" or not.
-                shouldFocus =
-                    activeElement.matches(':focus-visible') ||
-                    activeElement.matches('.focus-visible');
-            } catch (error) {
-                shouldFocus = activeElement.matches('.focus-visible');
-            }
-            this.focused = shouldFocus;
-        }
+        this.focused = this.hasVisibleFocusInTree();
         this.input.focus();
     }
 
@@ -442,16 +426,16 @@ export class ColorWheel extends Focusable {
         super.connectedCallback();
         if (
             !this.observer &&
-            ((window as unknown) as WithSWCResizeObserver).ResizeObserver
+            (window as unknown as WithSWCResizeObserver).ResizeObserver
         ) {
-            this.observer = new ((window as unknown) as WithSWCResizeObserver).ResizeObserver(
-                (entries: SWCResizeObserverEntry[]) => {
-                    for (const entry of entries) {
-                        this.boundingClientRect = entry.contentRect;
-                    }
-                    this.requestUpdate();
+            this.observer = new (
+                window as unknown as WithSWCResizeObserver
+            ).ResizeObserver((entries: SWCResizeObserverEntry[]) => {
+                for (const entry of entries) {
+                    this.boundingClientRect = entry.contentRect;
                 }
-            );
+                this.requestUpdate();
+            });
         }
         this.observer?.observe(this);
     }

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -568,22 +568,7 @@ export class Menu extends SpectrumElement {
         if (item.menuData.focusRoot !== this) {
             return;
         }
-        const activeElement = (this.getRootNode() as Document).activeElement as
-            | MenuItem
-            | Menu;
-        let shouldFocus = false;
-        try {
-            // Browsers without support for the `:focus-visible`
-            // selector will throw on the following test (Safari, older things).
-            // Some won't throw, but will be focusing item rather than the menu and
-            // will rely on the polyfill to know whether focus is "visible" or not.
-            shouldFocus =
-                activeElement.matches(':focus-visible') ||
-                activeElement.matches('.focus-visible');
-        } catch (error) {
-            shouldFocus = activeElement.matches('.focus-visible');
-        }
-        item.focused = shouldFocus;
+        item.focused = this.hasVisibleFocusInTree();
         this.setAttribute('aria-activedescendant', item.id);
         if (
             item.menuData.selectionRoot &&

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -48,7 +48,7 @@
         "lit-html"
     ],
     "dependencies": {
-        "@popperjs/core": "^2.2.2",
+        "@popperjs/core": "^2.10.2",
         "@spectrum-web-components/action-button": "^0.6.0",
         "@spectrum-web-components/base": "^0.4.5",
         "@spectrum-web-components/shared": "^0.12.10",

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -164,21 +164,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         super.focus(options);
 
         if (!this.disabled && this.focusElement) {
-            const activeElement = (this.getRootNode() as Document)
-                .activeElement as HTMLElement;
-            let shouldFocus = false;
-            try {
-                // Browsers without support for the `:focus-visible`
-                // selector will throw on the following test (Safari, older things).
-                // Some won't throw, but will be focusing item rather than the menu and
-                // will rely on the polyfill to know whether focus is "visible" or not.
-                shouldFocus =
-                    activeElement.matches(':focus-visible') ||
-                    activeElement.matches('.focus-visible');
-            } catch (error) {
-                shouldFocus = activeElement.matches('.focus-visible');
-            }
-            this.focused = shouldFocus;
+            this.focused = this.hasVisibleFocusInTree();
         }
     }
 
@@ -457,8 +443,8 @@ export class PickerBase extends SizedMixin(Focusable) {
                 <sp-menu
                     id="menu"
                     role="${this.listRole}"
-                    selects="single"
                     @change=${this.handleChange}
+                    .selects=${this.selects}
                 ></sp-menu>
                 ${this.dismissHelper}
             </sp-popover>

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -72,16 +72,14 @@ export class SplitButton extends SizedMixin(PickerBase) {
     protected listRole: 'listbox' | 'menu' = 'menu';
     protected itemRole = 'menuitem';
 
-    public focus(): void {
-        if (this.disabled) {
-            return;
+    public get focusElement(): HTMLElement {
+        if (this.open) {
+            return this.optionsMenu;
         }
         if (this.left) {
-            this.trigger.focus();
-            return;
+            return this.trigger;
         }
-
-        super.focus();
+        return this.button;
     }
 
     protected sizePopover(popover: HTMLElement): void {
@@ -110,19 +108,6 @@ export class SplitButton extends SizedMixin(PickerBase) {
                 </div>
             `,
         ];
-    }
-
-    protected get renderPopover(): TemplateResult {
-        return html`
-            <sp-popover id="popover" @sp-overlay-closed=${this.onOverlayClosed}>
-                <sp-menu
-                    id="menu"
-                    role="${this.listRole}"
-                    @change=${this.handleChange}
-                    .selects=${this.selects}
-                ></sp-menu>
-            </sp-popover>
-        `;
     }
 
     protected update(changes: PropertyValues<this>): void {

--- a/packages/split-button/test/split-button-sync.test.ts
+++ b/packages/split-button/test/split-button-sync.test.ts
@@ -109,17 +109,96 @@ describe('Splitbutton', () => {
         await expect(el1).to.be.accessible();
         await expect(el2).to.be.accessible();
     });
+    it('[type="field"] toggles open/close multiple time', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(field(splitButtonDefault.args))
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
 
+        await elementUpdated(el);
+        let items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+
+        let opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        let closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+
+        opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+    });
+    it('[type="more"] toggles open/close multiple time', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(more({ ...splitButtonDefault.args, ...more.args }))
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+
+        await elementUpdated(el);
+        let items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+
+        let opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        let closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+
+        opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+    });
     it('receives "focus()"', async () => {
         const test = await fixture<HTMLDivElement>(
             wrapInDiv(field(splitButtonDefault.args))
         );
         const el1 = test.querySelector('sp-split-button') as SplitButton;
         const el2 = test.querySelector('sp-split-button[left]') as SplitButton;
-        const el1FocusElement = el1.focusElement;
-        const el2FocusElement = el2.shadowRoot.querySelector(
-            '.trigger'
-        ) as HTMLElement;
 
         await elementUpdated(el1);
         await elementUpdated(el2);
@@ -128,13 +207,13 @@ describe('Splitbutton', () => {
         await elementUpdated(el1);
 
         expect(document.activeElement).to.equal(el1);
-        expect(el1.shadowRoot.activeElement).to.equal(el1FocusElement);
+        expect(el1.shadowRoot.activeElement).to.equal(el1.focusElement);
 
         el2.focus();
         await elementUpdated(el2);
 
         expect(document.activeElement).to.equal(el2);
-        expect(el2.shadowRoot.activeElement).to.equal(el2FocusElement);
+        expect(el2.shadowRoot.activeElement).to.equal(el2.focusElement);
     });
     it('[type="field"] manages `selectedItem`', async () => {
         const test = await fixture<HTMLDivElement>(
@@ -168,6 +247,8 @@ describe('Splitbutton', () => {
 
         expect(el.selectedItem?.itemText).to.equal('Short');
         expect(el.open).to.be.false;
+        expect(document.activeElement).to.equal(el);
+        expect(el.shadowRoot.activeElement).to.equal(el.focusElement);
     });
     it('[type="more"] manages `selectedItem.itemText`', async () => {
         const test = await fixture<HTMLDivElement>(

--- a/packages/split-button/test/split-button.test.ts
+++ b/packages/split-button/test/split-button.test.ts
@@ -109,17 +109,96 @@ describe('Splitbutton', () => {
         await expect(el1).to.be.accessible();
         await expect(el2).to.be.accessible();
     });
+    it('[type="field"] toggles open/close multiple time', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(field(splitButtonDefault.args))
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
 
+        await elementUpdated(el);
+        let items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+
+        let opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        let closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+
+        opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+    });
+    it('[type="more"] toggles open/close multiple time', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(more({ ...splitButtonDefault.args, ...more.args }))
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+
+        await elementUpdated(el);
+        let items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+
+        let opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        let closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+
+        opened = oneEvent(el, 'sp-opened');
+        el.open = true;
+        await opened;
+
+        expect(el.open).to.be.true;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(0);
+
+        closed = oneEvent(el, 'sp-closed');
+        el.open = false;
+        await closed;
+
+        expect(el.open).to.be.false;
+        items = el.querySelectorAll('sp-menu-item');
+        expect(items.length).to.equal(3);
+    });
     it('receives "focus()"', async () => {
         const test = await fixture<HTMLDivElement>(
             wrapInDiv(field(splitButtonDefault.args))
         );
         const el1 = test.querySelector('sp-split-button') as SplitButton;
         const el2 = test.querySelector('sp-split-button[left]') as SplitButton;
-        const el1FocusElement = el1.focusElement;
-        const el2FocusElement = el2.shadowRoot.querySelector(
-            '.trigger'
-        ) as HTMLElement;
 
         await elementUpdated(el1);
         await elementUpdated(el2);
@@ -128,13 +207,13 @@ describe('Splitbutton', () => {
         await elementUpdated(el1);
 
         expect(document.activeElement).to.equal(el1);
-        expect(el1.shadowRoot.activeElement).to.equal(el1FocusElement);
+        expect(el1.shadowRoot.activeElement).to.equal(el1.focusElement);
 
         el2.focus();
         await elementUpdated(el2);
 
         expect(document.activeElement).to.equal(el2);
-        expect(el2.shadowRoot.activeElement).to.equal(el2FocusElement);
+        expect(el2.shadowRoot.activeElement).to.equal(el2.focusElement);
     });
     it('[type="field"] manages `selectedItem`', async () => {
         const test = await fixture<HTMLDivElement>(
@@ -168,6 +247,8 @@ describe('Splitbutton', () => {
 
         expect(el.selectedItem?.itemText).to.equal('Short');
         expect(el.open).to.be.false;
+        expect(document.activeElement).to.equal(el);
+        expect(el.shadowRoot.activeElement).to.equal(el.focusElement);
     });
     it('[type="more"] manages `selectedItem.itemText`', async () => {
         const test = await fixture<HTMLDivElement>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3624,10 +3624,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@popperjs/core@^2.2.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
-  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+"@popperjs/core@^2.10.2":
+  version "2.10.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
+  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
 
 "@pwrs/lit-css@^1.2.1":
   version "1.2.1"


### PR DESCRIPTION
## Description
- correct extension from Picker so that both `<sp-action-menu>` and `<sp-split-button>` can now toggle
- abstract "hasVisibleFocusInTree" functionality to base with extra protection
- update `focusElement` on `sp-split-button[left]` elements

## Related issue(s)

- fixes #1894

## Motivation and context
Was broken

## How has this been tested?
-   [ ] _Test case 1_
    1. Go to https://splitter-toggle--spectrum-web-components.netlify.app/components/action-menu/#sizes
    2. Toggle the menu open/closed a few times
-   [ ] _Test case 2_
    1. Go to https://splitter-toggle--spectrum-web-components.netlify.app/components/split-button/#sizes
    2. Toggle the menu open/closed a few times

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
