### PR TITLE
[TESTING ONLY] perf: stop crawling through shadow roots

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
         "rollup": "2.56.2",
         "rollup-plugin-workbox": "6.1.1"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -85,7 +85,11 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
 
     protected get renderPopover(): TemplateResult {
         return html`
-            <sp-popover id="popover" @sp-overlay-closed=${this.onOverlayClosed}>
+            <sp-popover
+                placement=${this.placement}
+                id="popover"
+                @sp-overlay-closed=${this.onOverlayClosed}
+            >
                 <sp-menu
                     id="menu"
                     role="${this.listRole}"

--- a/packages/overlay/src/loader.ts
+++ b/packages/overlay/src/loader.ts
@@ -11,6 +11,9 @@ governing permissions and limitations under the License.
 */
 
 import { TriggerInteractions, OverlayOptions } from './overlay-types';
+import type { Overlay as OverlayType } from './overlay.js';
+
+let Overlay: typeof OverlayType | undefined;
 
 export const openOverlay = async (
     target: HTMLElement,
@@ -18,6 +21,8 @@ export const openOverlay = async (
     content: HTMLElement,
     options: OverlayOptions
 ): Promise<() => void> => {
-    const { Overlay } = await import('./overlay.js');
+    if (!Overlay) {
+        ({ Overlay } = await import('./overlay.js'));
+    }
     return Overlay.open(target, interaction, content, options);
 };

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -120,13 +120,12 @@ export class OverlayStack {
         this.overlayHolder.hidden = false;
         requestAnimationFrame(() => {
             const bodyStyles = getComputedStyle(document.body);
-            this.tabTrapper.style.setProperty(
-                '--swc-body-margins-inline',
-                `calc(${bodyStyles.marginLeft} + ${bodyStyles.marginRight})`
-            );
-            this.tabTrapper.style.setProperty(
-                '--swc-body-margins-block',
-                `calc(${bodyStyles.marginTop} + ${bodyStyles.marginBottom})`
+            this.tabTrapper.setAttribute(
+                'style',
+                `
+                    --swc-body-margins-inline: calc(${bodyStyles.marginLeft} + ${bodyStyles.marginRight});
+                    --swc-body-margins-block: calc(${bodyStyles.marginTop} + ${bodyStyles.marginBottom});
+                `
             );
         });
     }
@@ -255,6 +254,21 @@ export class OverlayStack {
         }
 
         const activeOverlay = ActiveOverlay.create(details);
+        activeOverlay.parentOverlay = (
+            current: ActiveOverlay
+        ): ActiveOverlay | undefined => {
+            let overlayCount = this.overlays.length;
+            let parentOverlay: ActiveOverlay | undefined;
+            while (overlayCount && !parentOverlay) {
+                overlayCount -= 1;
+                if (this.overlays[overlayCount + 1] === current) {
+                    parentOverlay = this.overlays[overlayCount];
+                }
+            }
+            return this.overlays.length
+                ? this.overlays[this.overlays.length - 1]
+                : parentOverlay;
+        };
 
         if (this.overlays.length) {
             const topOverlay = this.overlays[this.overlays.length - 1];

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -179,6 +179,7 @@ const template = ({ placement, offset, open }: Properties): TemplateResult => {
                 slot="hover-content"
                 ?delayed=${open !== 'hover'}
                 tip="bottom"
+                placement="${placement}"
             >
                 Click to open a popover.
             </sp-tooltip>

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -450,6 +450,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             <sp-popover
                 id="popover"
                 role="dialog"
+                placement=${this.placement}
                 @sp-overlay-closed=${this.onOverlayClosed}
                 .overlayCloseCallback=${this.overlayCloseCallback}
             >

--- a/packages/popover/src/Popover.ts
+++ b/packages/popover/src/Popover.ts
@@ -44,7 +44,7 @@ export class Popover extends SpectrumElement {
      * @attr
      */
     @property({ reflect: true })
-    public placement: Placement = 'none';
+    public placement!: Placement;
 
     @property({ type: Boolean, reflect: true })
     public tip = false;

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -114,7 +114,11 @@ export class SplitButton extends SizedMixin(PickerBase) {
 
     protected get renderPopover(): TemplateResult {
         return html`
-            <sp-popover id="popover" @sp-overlay-closed=${this.onOverlayClosed}>
+            <sp-popover
+                placement=${this.placement}
+                id="popover"
+                @sp-overlay-closed=${this.onOverlayClosed}
+            >
                 <sp-menu
                     id="menu"
                     role="${this.listRole}"

--- a/projects/documentation/src/components/side-nav-search.ts
+++ b/projects/documentation/src/components/side-nav-search.ts
@@ -20,12 +20,14 @@ import {
     customElement,
 } from 'lit-element';
 import sideNavSearchMenuStyles from './side-nav-search.css';
-import { Search } from '@spectrum-web-components/search';
+import type { Search } from '@spectrum-web-components/search';
 import { Popover } from '@spectrum-web-components/popover';
-import type { ResultGroup } from './search-index.js';
+import type { ResultGroup, search as SearchType } from './search-index.js';
 import { Menu } from '@spectrum-web-components/menu';
 import { openOverlay } from '@spectrum-web-components/overlay';
 import '@spectrum-web-components/search/sp-search.js';
+
+let search: typeof SearchType | undefined;
 
 const stopPropagation = (event: Event): void => event.stopPropagation();
 
@@ -160,9 +162,9 @@ export class SearchComponent extends LitElement {
         }
 
         const searchParam = `${value.trim()}*`;
-        const search = await import('./search-index.js').then(
-            ({ search }) => search
-        );
+        if (!search) {
+            ({ search } = await import('./search-index.js'));
+        }
         this.results = await search(searchParam);
 
         await this.openPopover();


### PR DESCRIPTION
## Description
See how much perf could be gained from giving `ActiveOverlay` access to a data structure that was not the DOM to ascertain its overlay parent.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
