### PR TITLE
fix(picker): allow menu items to be added, updated, and removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
         "rollup": "2.56.2",
         "rollup-plugin-workbox": "6.1.1"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/packages/picker/test/picker-sync.test.ts
+++ b/packages/picker/test/picker-sync.test.ts
@@ -99,6 +99,67 @@ describe('Picker, sync', () => {
         it('loads accessibly', async () => {
             await expect(el).to.be.accessible();
         });
+        it('accepts new selected item content', async () => {
+            const option2 = el.querySelector('[value="option-2"') as MenuItem;
+            el.value = 'option-2';
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Select Inverse'
+            );
+            const itemUpdated = oneEvent(el, 'sp-menu-item-added-or-updated');
+            option2.innerHTML = 'Invert Selection';
+            await itemUpdated;
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Invert Selection'
+            );
+        });
+        it('accepts new selected item content when open', async () => {
+            const option2 = el.querySelector('[value="option-2"') as MenuItem;
+            el.value = 'option-2';
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Select Inverse'
+            );
+            const opened = oneEvent(el, 'sp-opened');
+            el.open = true;
+            await opened;
+            const itemUpdated = oneEvent(
+                option2,
+                'sp-menu-item-added-or-updated'
+            );
+            option2.innerHTML = 'Invert Selection';
+            await itemUpdated;
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Invert Selection'
+            );
+        });
+        it('unsets value when children removed', async () => {
+            el.value = 'option-2';
+
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Select Inverse'
+            );
+
+            const items = el.querySelectorAll('sp-menu-item');
+            const removals: Promise<unknown>[] = [];
+            items.forEach((item) => {
+                const removal = oneEvent(el, 'sp-menu-item-removed');
+                item.remove();
+                removals.push(removal);
+            });
+            await Promise.all(removals);
+            await elementUpdated(el);
+            expect(el.value).to.equal('');
+            expect((el.button.textContent || '').trim()).to.equal('');
+        });
         it('accepts a new item and value at the same time', async () => {
             el.value = 'option-2';
 

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -99,6 +99,67 @@ describe('Picker, sync', () => {
         it('loads accessibly', async () => {
             await expect(el).to.be.accessible();
         });
+        it('accepts new selected item content', async () => {
+            const option2 = el.querySelector('[value="option-2"') as MenuItem;
+            el.value = 'option-2';
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Select Inverse'
+            );
+            const itemUpdated = oneEvent(el, 'sp-menu-item-added-or-updated');
+            option2.innerHTML = 'Invert Selection';
+            await itemUpdated;
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Invert Selection'
+            );
+        });
+        it('accepts new selected item content when open', async () => {
+            const option2 = el.querySelector('[value="option-2"') as MenuItem;
+            el.value = 'option-2';
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Select Inverse'
+            );
+            const opened = oneEvent(el, 'sp-opened');
+            el.open = true;
+            await opened;
+            const itemUpdated = oneEvent(
+                option2,
+                'sp-menu-item-added-or-updated'
+            );
+            option2.innerHTML = 'Invert Selection';
+            await itemUpdated;
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Invert Selection'
+            );
+        });
+        it('unsets value when children removed', async () => {
+            el.value = 'option-2';
+
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(
+                'Select Inverse'
+            );
+
+            const items = el.querySelectorAll('sp-menu-item');
+            const removals: Promise<unknown>[] = [];
+            items.forEach((item) => {
+                const removal = oneEvent(el, 'sp-menu-item-removed');
+                item.remove();
+                removals.push(removal);
+            });
+            await Promise.all(removals);
+            await elementUpdated(el);
+            expect(el.value).to.equal('');
+            expect((el.button.textContent || '').trim()).to.equal('');
+        });
         it('accepts a new item and value at the same time', async () => {
             el.value = 'option-2';
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -11,14 +11,14 @@ governing permissions and limitations under the License.
 */
 import { playwrightLauncher } from '@web/test-runner-playwright';
 import {
-    sendKeysPlugin,
     a11ySnapshotPlugin,
+    sendKeysPlugin,
 } from '@web/test-runner-commands/plugins';
 import { sendMousePlugin } from './test/plugins/send-mouse-plugin.js';
 import {
+    configuredVisualRegressionPlugin,
     packages,
     vrtGroups,
-    configuredVisualRegressionPlugin,
 } from './web-test-runner.utils.js';
 import { fromRollup } from '@web/dev-server-rollup';
 import rollupJson from '@rollup/plugin-json';
@@ -44,7 +44,7 @@ export default {
     nodeResolve: true,
     concurrency: 4,
     concurrentBrowsers: 1,
-    testsFinishTimeout: 20000,
+    testsFinishTimeout: 30000,
     coverageConfig: {
         report: true,
         reportDir: 'coverage',
@@ -67,7 +67,7 @@ export default {
     },
     testFramework: {
         config: {
-            timeout: 10000,
+            timeout: 5000,
         },
     },
     groups: [


### PR DESCRIPTION
## Description
Move `selectedItemContent` caching down into `sp-menu-item` where we can more accurately react to mutations. Leverage `sp-menu-item-added-or-updated` and `sp-menu-item-removed` events to allow for reactivity in `sp-picker`:
- accepts new selected item content
- accepts new selected item content when open
- unsets value when children removed

## Related issue(s)
- fixes #1893

## Motivation and context
Lifecycle flexibility of the `sp-picker` element.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://selected-item-cache--spectrum-web-components.netlify.app/components/picker/#value
    2. Select the `[value="item-3"]` element
    3. See that its text content is applied to the Picker button
    4. Use devTools to update the text content of the `[value="item-3"]` element
    5. See that the new text is applied to the Picker button
    6. Remove the `[value="item-3"]` element from the page
    7. See that the Picker button text is reset.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.