### PR TITLE
Tabs updates

### DIFF
--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -67,6 +67,15 @@ export class Tab extends FocusVisiblePolyfillMixin(
     @property({ type: String, reflect: true })
     public value = '';
 
+    protected handleContentChange(): void {
+        this.dispatchEvent(
+            new Event('sp-tab-contentchange', {
+                bubbles: true,
+                composed: true,
+            })
+        );
+    }
+
     protected render(): TemplateResult {
         return html`
             ${this.hasIcon
@@ -87,10 +96,22 @@ export class Tab extends FocusVisiblePolyfillMixin(
         if (!this.hasAttribute('id')) {
             this.id = `sp-tab-${Tab.instanceCount++}`;
         }
+        // @TODO - refactor this as a ResizeObserver up to `sp-tabs` so that it can be more
+        // resiliant to Tab content changes, as well as other content slotted into the "tablist".
+        this.shadowRoot.addEventListener(
+            'slotchange',
+            this.handleContentChange
+        );
     }
 
     protected updated(changes: PropertyValues): void {
         super.updated(changes);
+        if (
+            changes.has('label') &&
+            typeof changes.get('label') !== 'undefined'
+        ) {
+            this.handleContentChange();
+        }
         if (changes.has('selected')) {
             this.setAttribute(
                 'aria-selected',

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -148,6 +148,7 @@ export class Tabs extends SizedMixin(Focusable) {
                 @keydown=${this.onKeyDown}
                 @mousedown=${this.manageFocusinType}
                 @focusin=${this.startListeningToKeyboard}
+                @sp-tab-contentchange=${this.updateSelectionIndicator}
                 id="list"
                 role="tablist"
             >

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -274,7 +274,9 @@ export class Tabs extends SizedMixin(Focusable) {
     }
 
     private onClick = (event: Event): void => {
-        const target = event.target as Tab;
+        const target = event
+            .composedPath()
+            .find((el) => (el as Tab).parentElement === this) as Tab;
         if (this.disabled || target.disabled) {
             return;
         }

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -592,4 +592,24 @@ describe('Tabs', () => {
         await elementUpdated(el);
         expect(el.selected).to.be.equal('first');
     });
+
+    it('selects through slotted DOM', async () => {
+        const el = await fixture<Tabs>(
+            html`
+                <sp-tabs selected="first">
+                    <sp-tab value="first">Tab 1</sp-tab>
+                    <sp-tab value="second"><span>Tab 2</span></sp-tab>
+                </sp-tabs>
+            `
+        );
+        const span = el.querySelector('span') as HTMLSpanElement;
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('first');
+
+        span.click();
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('second');
+    });
 });


### PR DESCRIPTION
## Description
Allow `sp-tab` to accept DOM elements when its `label` is slotted into it.
Allow `sp-tab` to notify `sp-tabs` when it has has its `label` updated so it can update the Selection Indicator

## Related issue(s)

- fixes #1867
- fixes #1920

## Motivation and context
Allow usage without edge case issues.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://tabs-updates--spectrum-web-components.netlify.app/components/tabs/#sizes
    2. Take a reference of the selected `Tab 1``sp-tab` in the "Medium" size demo
    3. Update its `el.textContent` to be much longer or shoter
    4. See that the Selection Indicator is updated
-   [ ] _Test case 2_
    1. Go to https://tabs-updates--spectrum-web-components.netlify.app/components/tabs/#sizes
    2. Take a reference of the `Tab 13``sp-tab` in the "Medium" size demo
    3. Update its `el.innerHTML` to be `<span>Some other thing</span>`
    4. Click this `sp-tab` element
    5. Ensure that selection is moved to it

## Types of changes
-   [s] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
