### PR TITLE
Slider updates

### DIFF
--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -149,16 +149,42 @@ export class HandleController implements Controller {
         return input;
     }
 
+    protected handleOrientation = (): void => {
+        this.updateBoundingRect();
+    };
+
     public hostConnected(): void {
         if (!this.observer) {
             this.observer = new MutationObserver(this.extractModelFromLightDom);
         }
         this.observer.observe(this.host, { subtree: true, childList: true });
         this.extractModelFromLightDom();
+        if ('orientation' in screen) {
+            screen.orientation.addEventListener(
+                'change',
+                this.handleOrientation
+            );
+        } else {
+            window.addEventListener(
+                'orientationchange',
+                this.handleOrientation
+            );
+        }
     }
 
     public hostDisconnected(): void {
         this.observer.disconnect();
+        if ('orientation' in screen) {
+            screen.orientation.removeEventListener(
+                'change',
+                this.handleOrientation
+            );
+        } else {
+            window.removeEventListener(
+                'orientationchange',
+                this.handleOrientation
+            );
+        }
     }
 
     public hostUpdate(): void {
@@ -241,6 +267,8 @@ export class HandleController implements Controller {
         delete this.handleRefMap;
     }
 
+    private _boundingClientRect?: DOMRect;
+
     private get boundingClientRect(): DOMRect {
         if (!this._boundingClientRect) {
             this._boundingClientRect = this.host.track.getBoundingClientRect();
@@ -251,8 +279,6 @@ export class HandleController implements Controller {
     private updateBoundingRect(): void {
         delete this._boundingClientRect;
     }
-
-    private _boundingClientRect?: DOMRect;
 
     /**
      * Receives an event from a track click and turns it into a drag

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -33,6 +33,7 @@ import '@spectrum-web-components/field-label/sp-field-label.js';
 import type { NumberField } from '@spectrum-web-components/number-field';
 import { HandleController, HandleValueDictionary } from './HandleController.js';
 import { SliderHandle } from './SliderHandle.js';
+import { streamingListener } from '@spectrum-web-components/base/src/streaming-listener.js';
 
 export const variants = ['filled', 'ramp', 'range', 'tick'];
 
@@ -330,7 +331,14 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
         ];
 
         return html`
-            <div id="track" @pointerdown=${this.handleTrackPointerdown}>
+            <div
+                id="track"
+                ${streamingListener({
+                    start: ['pointerdown', this.handlePointerdown],
+                    streamInside: ['pointermove', this.handlePointermove],
+                    end: [['pointerup', 'pointercancel'], this.handlePointerup],
+                })}
+            >
                 <div id="controls">
                     ${repeat(
                         trackItems,
@@ -342,16 +350,16 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
         `;
     }
 
-    /**
-     * Move the handle under the cursor and begin start a pointer capture when the track
-     * is moused down
-     */
-    private handleTrackPointerdown(event: PointerEvent): void {
-        const target = event.target as HTMLElement;
-        if (target.classList.contains('handle')) {
-            return;
-        }
-        this.handleController.beginTrackDrag(event);
+    protected handlePointerdown(event: PointerEvent): void {
+        this.handleController.handlePointerdown(event);
+    }
+
+    protected handlePointermove(event: PointerEvent): void {
+        this.handleController.handlePointermove(event);
+    }
+
+    protected handlePointerup(event: PointerEvent): void {
+        this.handleController.handlePointerup(event);
     }
 
     private handleNumberInput(event: Event & { target: NumberField }): void {

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -87,8 +87,14 @@ sp-field-label {
     pointer-events: none;
 }
 
-.track {
-    touch-action: none;
+:host([dragging]),
+#track {
+    touch-action: pan-x;
+    user-select: none;
+}
+
+.handle {
+    pointer-events: none;
 }
 
 .not-exact.ticks {

--- a/packages/slider/test/slider-editable-sync.test.ts
+++ b/packages/slider/test/slider-editable-sync.test.ts
@@ -124,13 +124,15 @@ describe('Slider - editable, sync', () => {
         expect(pointerId).to.equal(-1);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
-        handle.setPointerCapture = (id: number) => (pointerId = id);
-        handle.releasePointerCapture = (id: number) => (pointerId = id);
+        el.track.setPointerCapture = (id: number) => (pointerId = id);
+        el.track.releasePointerCapture = (id: number) => (pointerId = id);
         handle.dispatchEvent(
             new PointerEvent('pointerdown', {
                 button: 1,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -143,6 +145,8 @@ describe('Slider - editable, sync', () => {
                 button: 0,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -154,6 +158,8 @@ describe('Slider - editable, sync', () => {
             new PointerEvent('pointerup', {
                 pointerId: 2,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -167,6 +173,8 @@ describe('Slider - editable, sync', () => {
                 button: 0,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -178,6 +186,8 @@ describe('Slider - editable, sync', () => {
             new PointerEvent('pointercancel', {
                 pointerId: 3,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);

--- a/packages/slider/test/slider-editable.test.ts
+++ b/packages/slider/test/slider-editable.test.ts
@@ -124,13 +124,15 @@ describe('Slider - editable', () => {
         expect(pointerId).to.equal(-1);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
-        handle.setPointerCapture = (id: number) => (pointerId = id);
-        handle.releasePointerCapture = (id: number) => (pointerId = id);
+        el.track.setPointerCapture = (id: number) => (pointerId = id);
+        el.track.releasePointerCapture = (id: number) => (pointerId = id);
         handle.dispatchEvent(
             new PointerEvent('pointerdown', {
                 button: 1,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -143,6 +145,8 @@ describe('Slider - editable', () => {
                 button: 0,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -154,6 +158,8 @@ describe('Slider - editable', () => {
             new PointerEvent('pointerup', {
                 pointerId: 2,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -167,6 +173,8 @@ describe('Slider - editable', () => {
                 button: 0,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -178,6 +186,8 @@ describe('Slider - editable', () => {
             new PointerEvent('pointercancel', {
                 pointerId: 3,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -143,13 +143,15 @@ describe('Slider', () => {
         expect(pointerId).to.equal(-1);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
-        handle.setPointerCapture = (id: number) => (pointerId = id);
-        handle.releasePointerCapture = (id: number) => (pointerId = id);
+        el.track.setPointerCapture = (id: number) => (pointerId = id);
+        el.track.releasePointerCapture = (id: number) => (pointerId = id);
         handle.dispatchEvent(
             new PointerEvent('pointerdown', {
                 button: 1,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -162,6 +164,8 @@ describe('Slider', () => {
                 button: 0,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -173,6 +177,8 @@ describe('Slider', () => {
             new PointerEvent('pointerup', {
                 pointerId: 2,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -186,6 +192,8 @@ describe('Slider', () => {
                 button: 0,
                 pointerId: 1,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -197,6 +205,8 @@ describe('Slider', () => {
             new PointerEvent('pointercancel', {
                 pointerId: 3,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -220,8 +230,8 @@ describe('Slider', () => {
             '#controls'
         ) as HTMLDivElement;
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
-        handle.setPointerCapture = (id: number) => (pointerId = id);
-        handle.releasePointerCapture = (id: number) => (pointerId = id);
+        el.track.setPointerCapture = (id: number) => (pointerId = id);
+        el.track.releasePointerCapture = (id: number) => (pointerId = id);
 
         controls.dispatchEvent(
             new PointerEvent('pointerdown', {
@@ -363,6 +373,8 @@ describe('Slider', () => {
             new PointerEvent('pointermove', {
                 clientX: 0,
                 cancelable: true,
+                bubbles: true,
+                composed: true,
             })
         );
         await elementUpdated(el);
@@ -381,14 +393,16 @@ describe('Slider', () => {
         expect(el.value, 'initial').to.equal(10);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
-        handle.setPointerCapture = (id: number) => (pointerId = id);
-        handle.releasePointerCapture = (id: number) => (pointerId = id);
+        el.track.setPointerCapture = (id: number) => (pointerId = id);
+        el.track.releasePointerCapture = (id: number) => (pointerId = id);
         handle.dispatchEvent(
             new PointerEvent('pointerdown', {
                 clientX: 58,
                 cancelable: true,
                 button: 0,
                 pointerId: 100,
+                composed: true,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
@@ -396,6 +410,8 @@ describe('Slider', () => {
             new PointerEvent('pointermove', {
                 clientX: 58,
                 cancelable: true,
+                composed: true,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
@@ -410,6 +426,8 @@ describe('Slider', () => {
             new PointerEvent('pointermove', {
                 clientX: 0,
                 cancelable: true,
+                composed: true,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
@@ -420,6 +438,8 @@ describe('Slider', () => {
             new PointerEvent('pointerup', {
                 clientX: 0,
                 cancelable: true,
+                composed: true,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
@@ -431,6 +451,8 @@ describe('Slider', () => {
                 clientX: 58,
                 cancelable: true,
                 button: 0,
+                composed: true,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
@@ -438,6 +460,8 @@ describe('Slider', () => {
             new PointerEvent('pointermove', {
                 clientX: 58,
                 cancelable: true,
+                composed: true,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
@@ -451,6 +475,8 @@ describe('Slider', () => {
             new PointerEvent('pointermove', {
                 clientX: 0,
                 cancelable: true,
+                composed: true,
+                bubbles: true,
             })
         );
         await elementUpdated(el);
@@ -461,6 +487,8 @@ describe('Slider', () => {
             new PointerEvent('pointerup', {
                 clientX: 0,
                 cancelable: true,
+                composed: true,
+                bubbles: true,
             })
         );
         await elementUpdated(el);


### PR DESCRIPTION
## Description
- remeasure bounding box when the screen orientation changes
- refactor `pointer*` listeners to listed directly of the `#track` element
  - reduce scope creation by not needing to bind models into the template
  - maintain a single pointer event path rather than one for handles and one for the track
  - tweak CSS and pointer capture to maintain touch in more cases on mobile

## Related issue(s)

- fixes #1881

## Motivation and context
Things should work great in mobile.

## How has this been tested?

-   [ ] _Test case 1_
    1. On iOS Safari or a simulator
    2. Go to https://slider-updates--spectrum-web-components.netlify.app/components/slider#tick
    3. Manually update the slider value. Drag the handle, touch the track, etc.
    4. Ensure the value updates as expected
    5. Change the orientation of the iOS device
    6. Manually update the slider value. Drag the handle, touch the track, etc.
    7. Ensure the value updates as expected
-   [ ] _Test case 2_
    1. On a touch device
    2. Go to https://slider-updates--spectrum-web-components.netlify.app/components/slider#tick
    3. Manually edit the slider value by dragging the handle.
    4. Move above and below the slider while persisting your touch and see that the value continues to update.
    5. Release your touch.
    6. Manually edit the slider value by touching the track.
    7.  Ensure the that the value updates to that location
    8. Drag along the track.
    9. Ensure that the value updates as expected.
    10. (_Currently unaddressed_) Move above and below the slider while persisting your touch and see that the value continues to update. This change in cumulatively for the better and hopefully mitigates the effects of this Safari bug: https://bugs.webkit.org/show_bug.cgi?id=220196.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
