### PR TITLE
Help text

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c4f40c83fab897e38f2fbd2cefe508d47a3a95e3
+        default: 666d21b55a3fd9430adbe0c2fd46c54d0af25712
 commands:
     downstream:
         steps:

--- a/packages/bundle/elements.ts
+++ b/packages/bundle/elements.ts
@@ -35,6 +35,7 @@ import '@spectrum-web-components/divider/sp-divider.js';
 import '@spectrum-web-components/dropzone/sp-dropzone.js';
 import '@spectrum-web-components/field-group/sp-field-group.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
+import '@spectrum-web-components/help-text/sp-help-text.js';
 import '@spectrum-web-components/icon/sp-icon.js';
 import '@spectrum-web-components/icons/sp-icons-large.js';
 import '@spectrum-web-components/icons/sp-icons-medium.js';

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -69,6 +69,7 @@
         "@spectrum-web-components/dropzone": "^0.9.0",
         "@spectrum-web-components/field-group": "^0.5.0",
         "@spectrum-web-components/field-label": "^0.7.0",
+        "@spectrum-web-components/help-text": "^0.0.1",
         "@spectrum-web-components/icon": "^0.11.0",
         "@spectrum-web-components/icons": "^0.8.0",
         "@spectrum-web-components/icons-ui": "^0.8.0",

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -32,6 +32,7 @@ export * from '@spectrum-web-components/divider';
 export * from '@spectrum-web-components/dropzone';
 export * from '@spectrum-web-components/field-group';
 export * from '@spectrum-web-components/field-label';
+export * from '@spectrum-web-components/help-text';
 export * from '@spectrum-web-components/icon';
 export * from '@spectrum-web-components/icons';
 export * from '@spectrum-web-components/illustrated-message';

--- a/packages/bundle/tsconfig.json
+++ b/packages/bundle/tsconfig.json
@@ -30,6 +30,7 @@
         { "path": "../dropzone" },
         { "path": "../field-group" },
         { "path": "../field-label" },
+        { "path": "../help-text" },
         { "path": "../icon" },
         { "path": "../icons" },
         { "path": "../icons-ui" },

--- a/packages/field-group/README.md
+++ b/packages/field-group/README.md
@@ -26,7 +26,10 @@ import { FieldGroup } from '@spectrum-web-components/field-group';
 ## Example
 
 ```html
-<sp-field-group horizontal>
+<sp-field-label for="horizontal">
+    Choose from horizonally placed options
+</sp-field-label>
+<sp-field-group horizontal id="horizontal">
     <sp-checkbox>Checkbox 1</sp-checkbox>
     <sp-checkbox>Checkbox 2</sp-checkbox>
     <sp-checkbox checked>Checkbox 3</sp-checkbox>
@@ -38,7 +41,10 @@ import { FieldGroup } from '@spectrum-web-components/field-group';
 ### Vertical
 
 ```html
-<sp-field-group vertical>
+<sp-field-label for="vertical">
+    Choose from vertically placed options
+</sp-field-label>
+<sp-field-group vertical id="vertical">
     <sp-checkbox>Checkbox 1</sp-checkbox>
     <sp-checkbox>Checkbox 2</sp-checkbox>
     <sp-checkbox>Checkbox 3</sp-checkbox>
@@ -46,3 +52,55 @@ import { FieldGroup } from '@spectrum-web-components/field-group';
     <sp-checkbox checked>Checkbox 5</sp-checkbox>
 </sp-field-group>
 ```
+
+## Help text
+
+Help text can be accessibly associated with an `<sp-field-group>` element by using the `help-text` or `negative-help-text` slots. When using the `negative-help-text` slot, `<sp-field-group>` will self manage the presence of this content based on the value of the `invalid` property on your `<sp-field-group>` element. Content within the `help-text` slot will be show by default. When your `<sp-field-group>` should receive help text based on state outside of the complexity of `invalid` or not, manage the content addressed to the `help-text` from above to ensure that it displays the right messaging and possesses the right `variant`.
+
+<sp-tabs selected="self" auto label="Help text usage in field groups">
+<sp-tab value="self">Self managed</sp-tab>
+<sp-tab-panel value="self">
+
+```html
+<sp-field-group horizontal id="self" label="What are your favorite fruits?">
+    <sp-checkbox value="apple">Apple</sp-checkbox>
+    <sp-checkbox
+        value="not-a-fruit"
+        onchange="javascript:this.parentElement.invalid = this.checked"
+    >
+        Lettuce
+    </sp-checkbox>
+    <sp-checkbox value="strawberry" checked>Strawberry</sp-checkbox>
+    <sp-help-text slot="help-text">One of these is not a fruit.</sp-help-text>
+    <sp-help-text slot="negative-help-text" icon>
+        Choose actual fruit(s).
+    </sp-help-text>
+</sp-field-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="above">Managed from above</sp-tab>
+<sp-tab-panel value="above">
+
+```html
+<sp-field-label for="above">What are your favorite fruits?</sp-field-label>
+<sp-field-group horizontal id="above">
+    <sp-checkbox value="apple">Apple</sp-checkbox>
+    <sp-checkbox
+        value="not-a-fruit"
+        onchange="
+            const helpText = this.parentElement.querySelector(`[slot='help-text']`);
+            helpText.icon = this.checked;
+            helpText.textContent = this.checked ? 'Choose actual fruit(s).' : 'One of these is not a fruit.';
+            helpText.variant = this.checked ? 'negative' : 'neutral';
+        "
+    >
+        Lettuce
+    </sp-checkbox>
+    <sp-checkbox value="strawberry" checked>Strawberry</sp-checkbox>
+    <sp-help-text slot="help-text">One of these is not a fruit.</sp-help-text>
+</sp-field-group>
+```
+
+</sp-tab-panel>
+</sp-tabs>

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -45,6 +45,7 @@
     ],
     "dependencies": {
         "@spectrum-web-components/base": "^0.5.0",
+        "@spectrum-web-components/help-text": "^0.0.1",
         "tslib": "^2.0.0"
     },
     "devDependencies": {

--- a/packages/field-group/src/FieldGroup.ts
+++ b/packages/field-group/src/FieldGroup.ts
@@ -13,18 +13,24 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    PropertyValues,
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
+import { ManageHelpText } from '@spectrum-web-components/help-text/src/manage-help-text.js';
 
 import styles from './field-group.css.js';
 
 /**
  * @element sp-field-group
  * @slot - the form controls that make up the group
+ * @slot help-text - default or non-negative help text to associate to your form element
+ * @slot negative-help-text - negative help text to associate to your form element when `invalid`
  */
-export class FieldGroup extends SpectrumElement {
+export class FieldGroup extends ManageHelpText(SpectrumElement, {
+    mode: 'external',
+}) {
     public static get styles(): CSSResultArray {
         return [styles];
     }
@@ -33,11 +39,31 @@ export class FieldGroup extends SpectrumElement {
     public horizontal = false;
 
     @property({ type: Boolean, reflect: true })
+    public invalid = false;
+
+    @property()
+    public label = '';
+
+    @property({ type: Boolean, reflect: true })
     public vertical = false;
 
     protected render(): TemplateResult {
         return html`
-            <slot></slot>
+            <div class="group" role="presentation">
+                <slot></slot>
+            </div>
+            ${this.renderHelpText(this.invalid)}
         `;
+    }
+
+    protected updated(changes: PropertyValues<this>): void {
+        super.updated(changes);
+        if (changes.has('label')) {
+            if (this.label) {
+                this.setAttribute('aria-label', this.label);
+            } else {
+                this.removeAttribute('aria-label');
+            }
+        }
     }
 }

--- a/packages/field-group/src/field-group.css
+++ b/packages/field-group/src/field-group.css
@@ -12,14 +12,16 @@ governing permissions and limitations under the License.
 
 @import './spectrum-field-group.css';
 
-:host([horizontal][dir='rtl']) ::slotted(*:not(:last-child)),
-:host([dir='rtl']:not([vertical])) ::slotted(*:not(:last-child)) {
+:host([horizontal][dir='rtl']) slot:not([name])::slotted(*:not(:last-child)),
+:host([dir='rtl']:not([vertical]))
+    slot:not([name])::slotted(*:not(:last-child)) {
     /* .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item+.spectrum-FieldGroup-item */
-    margin: 0 0 0 var(--spectrum-global-dimension-size-200);
+    margin: 0 0 0 var(--spectrum-fieldgroup-margin);
 }
 
-:host([horizontal][dir='ltr']) ::slotted(*:not(:last-child)),
-:host([dir='ltr']:not([vertical])) ::slotted(*:not(:last-child)) {
+:host([horizontal][dir='ltr']) slot:not([name])::slotted(*:not(:last-child)),
+:host([dir='ltr']:not([vertical]))
+    slot:not([name])::slotted(*:not(:last-child)) {
     /* .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item+.spectrum-FieldGroup-item */
-    margin: 0 var(--spectrum-global-dimension-size-200) 0 0;
+    margin: 0 var(--spectrum-fieldgroup-margin) 0 0;
 }

--- a/packages/field-group/src/spectrum-config.js
+++ b/packages/field-group/src/spectrum-config.js
@@ -17,6 +17,7 @@ const config = {
             name: 'field-group',
             host: {
                 selector: '.spectrum-FieldGroup',
+                shadowSelector: '.group',
             },
             attributes: [
                 {
@@ -32,9 +33,8 @@ const config = {
             ],
             complexSelectors: [
                 {
-                    replacement: '::slotted(:not(:last-child))',
-                    selector:
-                        '.spectrum-FieldGroup-item + .spectrum-FieldGroup-item',
+                    replacement: 'slot:not([name])::slotted(:not(:last-child))',
+                    selector: '.spectrum-FieldGroup-item:not(:last-child)',
                 },
             ],
         },

--- a/packages/field-group/src/spectrum-field-group.css
+++ b/packages/field-group/src/spectrum-field-group.css
@@ -15,22 +15,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-global-dimension-size-200
     ); /* .spectrum-FieldGroup */
 }
-:host {
+.group {
     display: flex; /* .spectrum-FieldGroup */
     flex-wrap: wrap;
     vertical-align: top;
 }
-:host([dir='ltr'][horizontal]) .spectrum-FieldGroup-item:not(:last-child) {
+:host([dir='ltr'][horizontal]) slot:not([name])::slotted(:not(:last-child)) {
     margin-right: var(
         --spectrum-fieldgroup-margin
     ); /* [dir=ltr] .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item:not(:last-child) */
 }
-:host([dir='rtl'][horizontal]) .spectrum-FieldGroup-item:not(:last-child) {
+:host([dir='rtl'][horizontal]) slot:not([name])::slotted(:not(:last-child)) {
     margin-left: var(
         --spectrum-fieldgroup-margin
     ); /* [dir=rtl] .spectrum-FieldGroup--horizontal .spectrum-FieldGroup-item:not(:last-child) */
 }
-:host([vertical]) {
+:host([vertical]) .group {
     display: inline-flex; /* .spectrum-FieldGroup--vertical */
     flex-direction: column;
 }

--- a/packages/field-group/test/field-group.test.ts
+++ b/packages/field-group/test/field-group.test.ts
@@ -11,10 +11,12 @@ governing permissions and limitations under the License.
 */
 
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
-
-import '../sp-field-group.js';
-import '@spectrum-web-components/checkbox/sp-checkbox.js';
+import { findDescribedNode } from '../../../test/testing-helpers-a11y.js';
+import { HelpText } from '@spectrum-web-components/help-text';
 import { FieldGroup } from '..';
+import '@spectrum-web-components/help-text/sp-help-text.js';
+import '@spectrum-web-components/checkbox/sp-checkbox.js';
+import '../sp-field-group.js';
 
 describe('FieldGroup', () => {
     it('loads default field-group accessibly', async () => {
@@ -33,5 +35,85 @@ describe('FieldGroup', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+    });
+
+    describe('help text', () => {
+        const name = 'This is a field group';
+        const description = 'This text helps you fill it out';
+        const descriptionNegative = 'This text helps you when invalid';
+        it('accepts help text in `slot="help-text"`', async () => {
+            const el = await fixture(html`
+                <sp-field-group label=${name}>
+                    <sp-help-text slot="help-text">${description}</sp-help-text>
+                </sp-field-group>
+            `);
+
+            await elementUpdated(el);
+
+            await findDescribedNode(name, description);
+        });
+        it('accepts help text in `slot="help-text"` w/ own ID', async () => {
+            const el = await fixture(html`
+                <sp-field-group label=${name}>
+                    <sp-help-text slot="help-text" id="help-text-id-1">
+                        ${description}
+                    </sp-help-text>
+                </sp-field-group>
+            `);
+
+            await elementUpdated(el);
+
+            await findDescribedNode(name, description);
+        });
+        it('manages neutral/negative help text pairs', async () => {
+            const el = await fixture<FieldGroup>(html`
+                <sp-field-group label=${name}>
+                    <sp-help-text slot="help-text">${description}</sp-help-text>
+                    <sp-help-text slot="negative-help-text">
+                        ${descriptionNegative}
+                    </sp-help-text>
+                </sp-field-group>
+            `);
+            const negativeHelpText = el.querySelector(
+                '[slot="negative-help-text"]'
+            ) as HelpText;
+
+            await elementUpdated(el);
+
+            expect(negativeHelpText.variant).to.equal('neutral');
+            await findDescribedNode(name, description);
+
+            el.invalid = true;
+            await elementUpdated(el);
+
+            expect(negativeHelpText.variant).to.equal('negative');
+            await findDescribedNode(name, descriptionNegative);
+        });
+        it('manages neutral/negative help text pairs w/ own IDs', async () => {
+            const el = await fixture<FieldGroup>(html`
+                <sp-field-group label=${name}>
+                    <sp-help-text slot="help-text" id="help-text-id-2">
+                        ${description}
+                    </sp-help-text>
+                    <sp-help-text slot="negative-help-text" id="help-text-id-3">
+                        ${descriptionNegative}
+                    </sp-help-text>
+                </sp-field-group>
+            `);
+            const negativeHelpText = el.querySelector(
+                '[slot="negative-help-text"]'
+            ) as HelpText;
+
+            await elementUpdated(el);
+
+            expect(negativeHelpText.variant).to.equal('neutral');
+            await findDescribedNode(name, description);
+
+            el.invalid = true;
+            await elementUpdated(el);
+
+            expect(negativeHelpText.variant).to.equal('negative');
+            await findDescribedNode(name, descriptionNegative);
+        });
     });
 });

--- a/packages/help-text/.npmignore
+++ b/packages/help-text/.npmignore
@@ -1,0 +1,2 @@
+stories
+test

--- a/packages/help-text/README.md
+++ b/packages/help-text/README.md
@@ -1,0 +1,89 @@
+## Description
+
+An `<sp-help-text>` provides either an informative description or an error message that gives more context about what a user needs to input. It's commonly used in forms.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/help-text?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/help-text)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/help-text?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/help-text)
+
+```
+yarn add @spectrum-web-components/help-text
+```
+
+Import the side effectful registration of `<sp-help-text>` via:
+
+```
+import '@spectrum-web-components/help-text/sp-help-text.js';
+```
+
+When looking to leverage the `HelpText` base class as a type and/or for extension purposes, do so via:
+
+```
+import { HelpText } from '@spectrum-web-components/help-text';
+```
+
+## Sizes
+
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
+
+```html
+<sp-help-text size="s">Passwords must be at least 8 characters.</sp-help-text>
+```
+
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
+
+```html
+<sp-help-text size="m">Passwords must be at least 8 characters.</sp-help-text>
+```
+
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
+
+```html
+<sp-help-text size="l">Passwords must be at least 8 characters.</sp-help-text>
+```
+
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
+
+```html
+<sp-help-text size="xl">Passwords must be at least 8 characters.</sp-help-text>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
+## Negative
+
+The negative variant of `<sp-help-text>` is used to convey error messages. An error message should be different than the informative message otherwise delivers to the visitor and should show a solution for correcting the error that has been encountered.
+
+```html
+<sp-help-text variant="negative">
+    Create a password with at least 8 characters.
+</sp-help-text>
+```
+
+### Icon
+
+When associated with content that does not supply an icon outlining the presence of an error, use the `icon` attribute to display one as part of the `<sp-help-text>` element.
+
+```html
+<sp-help-text variant="negative" icon>
+    Create a password with at least 8 characters.
+</sp-help-text>
+```
+
+## Disabled
+
+When associated to content the is disabled, use the `disabled` attribute to match the delivery of the `<sp-help-text>` element to that content.
+
+```html
+<sp-help-text disabled>Passwords must be at least 8 characters.</sp-help-text>
+```

--- a/packages/help-text/help-text-mixin.md
+++ b/packages/help-text/help-text-mixin.md
@@ -1,0 +1,275 @@
+## Description
+
+It is [not currently possible](https://w3c.github.io/webcomponents-cg/#cross-root-aria) to provide accessible ARIA references between elements in different shadow roots. When creating your own components, use the `ManageHelpText` mixin to associate slotted `<sp-help-text>` elements with the elements they describe. This functionality is also surfaced as a base class `HelpTextManagedElement` if you prefer to extend from there, instead.
+
+Spectrum Web Components leverages the `ManageHelpText` mixin to power elements like `sp-field-group`, `sp-number-field`, `sp-radio-group`, `sp-search` and `sp-textfield`.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/help-text?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/help-text)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/help-text?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/help-text)
+
+```
+yarn add @spectrum-web-components/help-text
+```
+
+Import `ManageHelpText` via:
+
+```
+import { ManageHelpText } from '@spectrum-web-components/help-text/mange-help-text.js';
+```
+
+When looking to leverage the `HelpTextManagedElement` base class as a type and/or for extension purposes, do so via:
+
+```
+import { HelpTextManagedElement } from '@spectrum-web-components/help-text/HelpTextManagedElement.js';
+```
+
+The `HelpTextManager` class is also available for import as:
+
+```
+import { HelpTextManager } from '@spectrum-web-components/help-text/HelpTextManager.js';
+```
+
+## ManageHelpText mixin
+
+`ManageHelpText` mixes two properties into your class:
+
+- `helpTextId`: the `id` attribute of the associated `<sp-help-text>`
+- `renderHelpText(negative?: boolean)`: a method that returns a `TemplateResult` with the `help-text` and `negative-help-text` slots
+
+## Internal
+
+To describe an element within your custom element's shadow root, use `mode: 'internal'` (the default) and set `aria-describedby` on the target element:
+
+```js
+import { SpectrumElement, html } from '@spectrum-web-components/base';
+import { ManageHelpText } from '@spectrum-web-components/help-text/src/manage-hep-text.js';
+
+export class MyElement extends ManageHelpText(SpectrumElement) {
+    invalid = false;
+
+    render() {
+        return html`
+            <input aria-describedby=${this.helpTextId} />
+            ${this.renderHelpText(this.invalid)}
+        `;
+    }
+}
+```
+
+## External
+
+To describe the custom element itself, use `mode: 'external'`. This will automatically manage the application of the `aria-describedby` atribute on `DescribedElement`:
+
+```js
+import { SpectrumElement, html } from '@spectrum-web-components/base';
+import { ManageHelpText } from '@spectrum-web-components/help-text/src/manage-help-text.js';
+
+export class MyElement extends ManageHelpText(SpectrumElement, {
+    mode: 'external',
+}) {
+    invalid = false;
+
+    render() {
+        return html`
+            ${this.renderHelpText(this.invalid)}
+        `;
+    }
+}
+```
+
+This functionality is powered by the `HelpTextManager` class which is also exported from this package and can be leveraged directly. It accepts the root element on which within which it will manage help text and a options object that accepts the `mode` by which that help text will be managed at construction time. Leveraged at render time it surfaces an `id` property and a `render(invalid?: boolean)` method for use in your template.
+
+## Usage with self managed validity
+
+Spectrum Web Components that have an `invalid` attribute, like `<sp-fieldgroup>` and `<sp-textfield>`, automatically render either the `help-text` or `negative-help-text` slot based on validity. Provide both, and the appropriate `<sp-help-text>` element will be surfaced:
+
+<sp-tabs selected="textfield" auto label="Help text usage in form elements">
+<sp-tab value="field">Field group</sp-tab>
+<sp-tab-panel value="field">
+
+```html
+<sp-field-label for="fruit">What are your favorite fruits?</sp-field-label>
+<sp-field-group horizontal id="fruit">
+    <sp-checkbox value="apple">Apple</sp-checkbox>
+    <sp-checkbox
+        value="not-a-fruit"
+        onchange="javascript:this.parentElement.invalid = this.checked"
+    >
+        Lettuce
+    </sp-checkbox>
+    <sp-checkbox value="strawberry" checked>Strawberry</sp-checkbox>
+    <sp-help-text slot="help-text">One of these is not a fruit.</sp-help-text>
+    <sp-help-text slot="negative-help-text" icon>
+        Choose actual fruit(s).
+    </sp-help-text>
+</sp-field-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="radio">Radio group</sp-tab>
+<sp-tab-panel value="radio">
+
+```html
+<sp-field-label for="icecream">
+    What is your favorite ice cream flavor?
+</sp-field-label>
+<sp-radio-group
+    is="icecream"
+    onchange="
+        this.invalid = this.value === 'fourth';
+    "
+>
+    <sp-radio value="first">Vanilla</sp-radio>
+    <sp-radio value="second">Chocolate</sp-radio>
+    <sp-radio value="third">Strawberry</sp-radio>
+    <sp-radio value="fourth">I don't like ice cream</sp-radio>
+    <sp-help-text slot="help-text">Everyone likes ice cream.</sp-help-text>
+    <sp-help-text slot="negative-help-text" icon>
+        You can't not like ice cream.
+    </sp-help-text>
+</sp-radio-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="textarea">Textarea</sp-tab>
+<sp-tab-panel value="textarea">
+
+```html
+<sp-field-label for="textarea">Stay "Positive"</sp-field-label>
+<sp-textfield
+    multiline
+    id="textarea"
+    pattern="[P][o][s][i][t][i][v][e]"
+    value="Positive"
+>
+    <sp-help-text slot="help-text">
+        Tell us how you are feeling today.
+    </sp-help-text>
+    <sp-help-text slot="negative-help-text">Please be "Positive".</sp-help-text>
+</sp-textfield>
+```
+
+</sp-tab-panel>
+<sp-tab value="textfield">Textfield</sp-tab>
+<sp-tab-panel value="textfield">
+
+```html
+<sp-field-label for="textfield">Stay "Positive"</sp-field-label>
+<sp-textfield
+    id="textfield"
+    pattern="[P][o][s][i][t][i][v][e]"
+    value="Positive"
+>
+    <sp-help-text slot="help-text">
+        Tell us how you are feeling today.
+    </sp-help-text>
+    <sp-help-text slot="negative-help-text">Please be "Positive".</sp-help-text>
+</sp-textfield>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
+## Usage with validity managed from above
+
+When the parent element does not manage its own validity, or you would prefer to leverage the parent application in deciding what content and when to deliver within your `<sp-help-text>` element, place your content in the `help-text` slot to ensure that it is available for receiving stateful content/properties across the lifecycle of the parent element in question.
+
+<sp-tabs selected="textfield" auto label="Help text usage in form elements">
+<sp-tab value="field">Field group</sp-tab>
+<sp-tab-panel value="field">
+
+```html
+<sp-field-label for="fruit">What are your favorite fruits?</sp-field-label>
+<sp-field-group horizontal id="fruit">
+    <sp-checkbox value="apple">Apple</sp-checkbox>
+    <sp-checkbox
+        value="not-a-fruit"
+        onchange="
+            const helpText = this.parentElement.querySelector(`[slot='help-text']`);
+            helpText.icon = this.checked;
+            helpText.textContent = this.checked ? 'Choose actual fruit(s).' : 'One of these is not a fruit.';
+            helpText.variant = this.checked ? 'negative' : 'neutral';
+        "
+    >
+        Lettuce
+    </sp-checkbox>
+    <sp-checkbox value="strawberry" checked>Strawberry</sp-checkbox>
+    <sp-help-text slot="help-text">One of these is not a fruit.</sp-help-text>
+</sp-field-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="radio">Radio group</sp-tab>
+<sp-tab-panel value="radio">
+
+```html
+<sp-field-label for="icecream">
+    What is your favorite ice cream flavor?
+</sp-field-label>
+<sp-radio-group
+    is="icecream"
+    onchange="
+        const helpText = this.querySelector(`[slot='help-text']`);
+        const isInvalid = this.selected === 'fourth';
+        helpText.icon = isInvalid;
+        helpText.textContent = isInvalid ? 'You can\'t not like ice cream.' : 'Everyone likes ice cream.';
+        helpText.variant = isInvalid ? 'negative' : 'neutral';
+    "
+>
+    <sp-radio value="first">Vanilla</sp-radio>
+    <sp-radio value="second">Chocolate</sp-radio>
+    <sp-radio value="third">Strawberry</sp-radio>
+    <sp-radio value="fourth">I don't like ice cream</sp-radio>
+    <sp-help-text slot="help-text">Everyone likes ice cream.</sp-help-text>
+</sp-radio-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="textarea">Textarea</sp-tab>
+<sp-tab-panel value="textarea">
+
+```html
+<sp-field-label for="textarea">Stay "Positive"</sp-field-label>
+<sp-textfield
+    multiline
+    id="textarea"
+    pattern="[P][o][s][i][t][i][v][e]"
+    value="Positive"
+    oninput='
+        const helpText = this.querySelector(`[slot="help-text"]`);
+        helpText.textContent = this.invalid ? `Please be "Positive".` : `Tell us how you are feeling today.`;
+        helpText.variant = this.invalid ? `negative` : `neutral`;
+    '
+>
+    <sp-help-text slot="help-text">
+        Tell us how you're feeling today.
+    </sp-help-text>
+</sp-textfield>
+```
+
+</sp-tab-panel>
+<sp-tab value="textfield">Textfield</sp-tab>
+<sp-tab-panel value="textfield">
+
+```html
+<sp-field-label for="textfield">Stay "Positive"</sp-field-label>
+<sp-textfield
+    id="textfield"
+    pattern="[P][o][s][i][t][i][v][e]"
+    value="Positive"
+    oninput='
+        const helpText = this.querySelector(`[slot="help-text"]`);
+        helpText.textContent = this.invalid ? `Please be "Positive".` : `Tell us how you are feeling today.`;
+        helpText.variant = this.invalid ? `negative` : `neutral`;
+    '
+>
+    <sp-help-text slot="help-text">
+        Tell us how you are feeling today.
+    </sp-help-text>
+</sp-textfield>
+```
+
+</sp-tab-panel>
+</sp-tabs>

--- a/packages/help-text/help-text-mixin.md
+++ b/packages/help-text/help-text-mixin.md
@@ -60,7 +60,7 @@ export class MyElement extends ManageHelpText(SpectrumElement) {
 
 ## External
 
-To describe the custom element itself, use `mode: 'external'`. This will automatically manage the application of the `aria-describedby` atribute on `DescribedElement`:
+To describe the custom element itself, use `mode: 'external'`. This will automatically manage the application of the `aria-describedby` atribute on `MyElement`:
 
 ```js
 import { SpectrumElement, html } from '@spectrum-web-components/base';
@@ -79,9 +79,9 @@ export class MyElement extends ManageHelpText(SpectrumElement, {
 }
 ```
 
-This functionality is powered by the `HelpTextManager` class which is also exported from this package and can be leveraged directly. It accepts the root element on which within which it will manage help text and a options object that accepts the `mode` by which that help text will be managed at construction time. Leveraged at render time it surfaces an `id` property and a `render(invalid?: boolean)` method for use in your template.
+This functionality is powered by the `HelpTextManager` class which is also exported from this package and can be leveraged directly. It accepts the root element on which it will manage help text and an options object that accepts the `mode` by which that help text will be managed at construction time. Leveraged at render time, it surfaces an `id` property and a `render(invalid?: boolean)` method for use in your template.
 
-## Usage with self managed validity
+## Usage with self-managed validity
 
 Spectrum Web Components that have an `invalid` attribute, like `<sp-fieldgroup>` and `<sp-textfield>`, automatically render either the `help-text` or `negative-help-text` slot based on validity. Provide both, and the appropriate `<sp-help-text>` element will be surfaced:
 

--- a/packages/help-text/package.json
+++ b/packages/help-text/package.json
@@ -1,0 +1,63 @@
+{
+    "name": "@spectrum-web-components/help-text",
+    "version": "0.0.1",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "Web component implementation of a Spectrum design HelpText",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adobe/spectrum-web-components.git",
+        "directory": "packages/help-text"
+    },
+    "author": "",
+    "homepage": "https://adobe.github.io/spectrum-web-components/components/help-text",
+    "bugs": {
+        "url": "https://github.com/adobe/spectrum-web-components/issues"
+    },
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        ".": "./src/index.js",
+        "./src/*": "./src/*",
+        "./help-text-manager": "./src/help-text-manager.js",
+        "./help-text-manager.js": "./src/help-text-manager.js",
+        "./HelpTextManager": "./src/HelpTextManager.js",
+        "./HelpTextManager.js": "./src/HelpTextManager.js",
+        "./package.json": "./package.json",
+        "./sp-help-text": "./sp-help-text.js",
+        "./sp-help-text.js": "./sp-help-text.js"
+    },
+    "scripts": {
+        "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
+    },
+    "files": [
+        "**/*.d.ts",
+        "**/*.js",
+        "**/*.js.map",
+        "custom-elements.json",
+        "!stories/",
+        "!test/"
+    ],
+    "keywords": [
+        "spectrum css",
+        "web components",
+        "lit-element",
+        "lit-html"
+    ],
+    "dependencies": {
+        "@spectrum-web-components/base": "^0.5.0",
+        "@spectrum-web-components/icons-workflow": "^0.8.0",
+        "tslib": "^2.0.0"
+    },
+    "devDependencies": {
+        "@spectrum-css/helptext": "^1.0.2"
+    },
+    "types": "./src/index.d.ts",
+    "customElementsManifest": "custom-elements.json",
+    "sideEffects": [
+        "./sp-*.js"
+    ]
+}

--- a/packages/help-text/sp-help-text.ts
+++ b/packages/help-text/sp-help-text.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { HelpText } from './src/HelpText.js';
+
+customElements.define('sp-help-text', HelpText);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-help-text': HelpText;
+    }
+}

--- a/packages/help-text/src/HelpText.ts
+++ b/packages/help-text/src/HelpText.ts
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    CSSResultArray,
+    html,
+    nothing,
+    SizedMixin,
+    SpectrumElement,
+    TemplateResult,
+} from '@spectrum-web-components/base';
+import { property } from '@spectrum-web-components/base/src/decorators.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
+
+import styles from './help-text.css.js';
+
+type HelpTextVariants = 'neutral' | 'negative';
+
+/**
+ * @element sp-help-text
+ */
+export class HelpText extends SizedMixin(SpectrumElement) {
+    public static get styles(): CSSResultArray {
+        return [styles];
+    }
+
+    @property({ type: Boolean, reflect: true })
+    public icon = false;
+
+    /**
+     * The visual variant to apply to this help text.
+     */
+    @property({ reflect: true })
+    public variant: HelpTextVariants = 'neutral';
+
+    protected render(): TemplateResult {
+        return html`
+            ${this.variant === 'negative' && this.icon
+                ? html`
+                      <sp-icon-alert class="icon"></sp-icon-alert>
+                  `
+                : nothing}
+            <div class="text"><slot></slot></div>
+        `;
+    }
+}

--- a/packages/help-text/src/HelpTextManagedElement.ts
+++ b/packages/help-text/src/HelpTextManagedElement.ts
@@ -1,0 +1,20 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { SpectrumElement } from '@spectrum-web-components/base';
+import { ManageHelpText } from './manage-help-text.js';
+
+/**
+ * @slot help-text - default or non-negative help text to associate to your form element
+ * @slot negative-help-text - negative help text to associate to your form element when `invalid`
+ */
+export class HelpTextManagedElement extends ManageHelpText(SpectrumElement) {}

--- a/packages/help-text/src/HelpTextManager.ts
+++ b/packages/help-text/src/HelpTextManager.ts
@@ -1,0 +1,127 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import type { HelpText } from './HelpText';
+
+export class HelpTextManager {
+    private hadId = false;
+    private host!: HTMLElement;
+    public id!: string;
+    private mode: 'internal' | 'external' = 'internal';
+    private previousTabindex?: -1 | 0 | undefined;
+    private helpTextElement!: Element;
+    private get isInternal(): boolean {
+        return this.mode === 'internal';
+    }
+
+    static instanceCount = 0;
+    instanceCount: number;
+
+    constructor(
+        host: HTMLElement,
+        { mode }: { mode: 'internal' | 'external' } = { mode: 'internal' }
+    ) {
+        this.host = host;
+        this.instanceCount = HelpTextManager.instanceCount++;
+        this.id = `sp-help-text-${this.instanceCount}`;
+        this.mode = mode;
+    }
+
+    public render(negative?: boolean): TemplateResult {
+        // `pass-through-help-text-${this.instanceCount}` makes the slot effectively unreachable from
+        // the outside allowing the `help-text` slot to be preferred while `negative === false`.
+        return html`
+            <div id=${ifDefined(this.isInternal ? this.id : undefined)}>
+                <slot
+                    name=${negative
+                        ? 'negative-help-text'
+                        : `pass-through-help-text-${this.instanceCount}`}
+                    @slotchange=${this.handleSlotchange}
+                >
+                    <slot name="help-text"></slot>
+                </slot>
+            </div>
+        `;
+    }
+
+    private addId(): void {
+        const id = this.helpTextElement ? this.helpTextElement.id : this.id;
+        const ariaDescribedby = this.host.getAttribute('aria-describedby');
+        const descriptors = ariaDescribedby ? ariaDescribedby.split(/\s+/) : [];
+        this.hadId = descriptors.indexOf(id) > -1;
+        if (this.hadId) return;
+        descriptors.push(id);
+        this.host.setAttribute('aria-describedby', descriptors.join(' '));
+        if (this.host.hasAttribute('tabindex')) {
+            this.previousTabindex = parseFloat(
+                this.host.getAttribute('tabindex') as string
+            ) as -1 | 0;
+        }
+        this.host.tabIndex = 0;
+    }
+
+    private removeId(): void {
+        const ariaDescribedby = this.host.getAttribute('aria-describedby');
+        let descriptors = ariaDescribedby ? ariaDescribedby.split(/\s+/) : [];
+        if (!this.hadId) {
+            const id = this.helpTextElement ? this.helpTextElement.id : this.id;
+            descriptors = descriptors.filter((descriptor) => descriptor !== id);
+        }
+        if (descriptors.length) {
+            this.host.setAttribute('aria-describedby', descriptors.join(' '));
+        } else {
+            this.host.removeAttribute('aria-describedby');
+        }
+        if (this.helpTextElement) return;
+        if (this.previousTabindex) {
+            this.host.tabIndex = this.previousTabindex;
+        } else {
+            this.host.removeAttribute('tabindex');
+        }
+    }
+
+    private handleSlotchange = ({
+        target,
+    }: Event & { target: HTMLSlotElement }): void => {
+        this.handleHelpText(target);
+        this.handleNegativeHelpText(target);
+    };
+
+    private handleHelpText(target: HTMLSlotElement): void {
+        if (this.isInternal) return;
+
+        if (this.helpTextElement && this.helpTextElement.id === this.id) {
+            this.helpTextElement.removeAttribute('id');
+        }
+        this.removeId();
+        const assignedElements = target.assignedElements();
+        const nextHelpTextElement = assignedElements[0];
+        this.helpTextElement = nextHelpTextElement;
+        if (nextHelpTextElement) {
+            if (!nextHelpTextElement.id) {
+                nextHelpTextElement.id = this.id;
+            }
+            this.addId();
+        }
+    }
+
+    private handleNegativeHelpText(target: HTMLSlotElement): void {
+        if (target.name !== 'negative-help-text') return;
+
+        const assignedElements = target.assignedElements();
+        assignedElements.forEach(
+            (el) => ((el as unknown as HelpText).variant = 'negative')
+        );
+    }
+}

--- a/packages/help-text/src/help-text.css
+++ b/packages/help-text/src/help-text.css
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+@import './spectrum-help-text.css';

--- a/packages/help-text/src/index.ts
+++ b/packages/help-text/src/index.ts
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export * from './HelpText.js';

--- a/packages/help-text/src/manage-help-text.ts
+++ b/packages/help-text/src/manage-help-text.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { ReactiveElement, TemplateResult } from '@spectrum-web-components/base';
+import { HelpTextManager } from './HelpTextManager.js';
+
+type Constructor<T = Record<string, unknown>> = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new (...args: any[]): T;
+    prototype: T;
+};
+
+export interface HelpTextElementInterface {
+    renderHelpText(negative?: boolean): TemplateResult;
+    helpTextId: string;
+}
+
+export function ManageHelpText<T extends Constructor<ReactiveElement>>(
+    constructor: T,
+    { mode }: { mode: 'internal' | 'external' } = { mode: 'internal' }
+): T & Constructor<HelpTextElementInterface> {
+    class HelpTextElement extends constructor {
+        helpTextManager = new HelpTextManager(this, { mode });
+        get helpTextId(): string {
+            return this.helpTextManager.id;
+        }
+        renderHelpText(negative?: boolean): TemplateResult {
+            return this.helpTextManager.render(negative);
+        }
+    }
+    return HelpTextElement;
+}

--- a/packages/help-text/src/spectrum-config.js
+++ b/packages/help-text/src/spectrum-config.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const config = {
+    spectrum: 'helptext',
+    components: [
+        {
+            name: 'help-text',
+            host: {
+                selector: '.spectrum-HelpText',
+            },
+            attributes: [
+                {
+                    type: 'boolean',
+                    name: 'disabled',
+                    selector: '.is-disabled',
+                },
+                {
+                    type: 'enum',
+                    name: 'variant',
+                    values: [
+                        '.spectrum-HelpText--neutral',
+                        '.spectrum-HelpText--negative',
+                    ],
+                },
+                {
+                    type: 'enum',
+                    name: 'size',
+                    forceOntoHost: true,
+                    values: [
+                        {
+                            name: 's',
+                            selector: '.spectrum-HelpText--sizeS',
+                        },
+                        {
+                            name: 'm',
+                            selector: '.spectrum-HelpText--sizeM',
+                        },
+                        {
+                            name: 'l',
+                            selector: '.spectrum-HelpText--sizeL',
+                        },
+                        {
+                            name: 'xl',
+                            selector: '.spectrum-HelpText--sizeXL',
+                        },
+                    ],
+                },
+            ],
+            classes: [
+                {
+                    selector: '.spectrum-HelpText-text',
+                    name: 'text',
+                },
+                {
+                    selector: '.spectrum-HelpText-validationIcon',
+                    name: 'icon',
+                },
+            ],
+        },
+    ],
+};
+
+export default config;

--- a/packages/help-text/src/spectrum-help-text.css
+++ b/packages/help-text/src/spectrum-help-text.css
@@ -1,0 +1,263 @@
+/* stylelint-disable */ /* 
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host([size='s']) {
+    --spectrum-helptext-neutral-textonly-text-padding-bottom: var(
+        --spectrum-helptext-s-neutral-textonly-text-padding-bottom
+    ); /* .spectrum-HelpText--sizeS */
+    --spectrum-helptext-neutral-texticon-text-size: var(
+        --spectrum-helptext-s-neutral-texticon-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    --spectrum-helptext-neutral-texticon-icon-gap: var(
+        --spectrum-helptext-s-neutral-texticon-icon-gap,
+        var(--spectrum-global-dimension-size-85)
+    );
+    --spectrum-helptext-negative-texticon-icon-padding-top: var(
+        --spectrum-helptext-s-negative-texticon-icon-padding-top,
+        var(--spectrum-global-dimension-size-50)
+    );
+    --spectrum-helptext-negative-texticon-icon-padding-bottom: var(
+        --spectrum-helptext-s-negative-texticon-icon-padding-bottom,
+        var(--spectrum-global-dimension-size-50)
+    );
+    --spectrum-helptext-neutral-textonly-text-transform: var(
+        --spectrum-helptext-s-neutral-textonly-text-transform,
+        none
+    );
+    --spectrum-helptext-neutral-textonly-text-padding-top: var(
+        --spectrum-helptext-s-neutral-textonly-text-padding-top,
+        var(--spectrum-global-dimension-static-size-50)
+    );
+    --spectrum-helptext-neutral-textonly-text-line-height: var(
+        --spectrum-helptext-s-neutral-textonly-text-line-height,
+        var(--spectrum-alias-component-text-line-height)
+    );
+    --spectrum-helptext-neutral-textonly-text-letter-spacing: var(
+        --spectrum-helptext-s-neutral-textonly-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+}
+:host([size='m']) {
+    --spectrum-helptext-neutral-textonly-text-padding-bottom: var(
+        --spectrum-helptext-m-neutral-textonly-text-padding-bottom
+    ); /* .spectrum-HelpText--sizeM */
+    --spectrum-helptext-neutral-texticon-text-size: var(
+        --spectrum-helptext-m-neutral-texticon-text-size,
+        var(--spectrum-global-dimension-font-size-75)
+    );
+    --spectrum-helptext-neutral-texticon-icon-gap: var(
+        --spectrum-helptext-m-neutral-texticon-icon-gap,
+        var(--spectrum-global-dimension-size-100)
+    );
+    --spectrum-helptext-negative-texticon-icon-padding-top: var(
+        --spectrum-helptext-m-negative-texticon-icon-padding-top,
+        var(--spectrum-global-dimension-size-40)
+    );
+    --spectrum-helptext-negative-texticon-icon-padding-bottom: var(
+        --spectrum-helptext-m-negative-texticon-icon-padding-bottom,
+        var(--spectrum-global-dimension-size-40)
+    );
+    --spectrum-helptext-neutral-textonly-text-transform: var(
+        --spectrum-helptext-m-neutral-textonly-text-transform,
+        none
+    );
+    --spectrum-helptext-neutral-textonly-text-padding-top: var(
+        --spectrum-helptext-m-neutral-textonly-text-padding-top,
+        var(--spectrum-global-dimension-static-size-50)
+    );
+    --spectrum-helptext-neutral-textonly-text-line-height: var(
+        --spectrum-helptext-m-neutral-textonly-text-line-height,
+        var(--spectrum-alias-component-text-line-height)
+    );
+    --spectrum-helptext-neutral-textonly-text-letter-spacing: var(
+        --spectrum-helptext-m-neutral-textonly-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+}
+:host([size='l']) {
+    --spectrum-helptext-neutral-texticon-text-size: var(
+        --spectrum-helptext-l-neutral-texticon-text-size,
+        var(--spectrum-global-dimension-font-size-100)
+    ); /* .spectrum-HelpText--sizeL */
+    --spectrum-helptext-neutral-texticon-icon-gap: var(
+        --spectrum-helptext-l-neutral-texticon-icon-gap,
+        var(--spectrum-global-dimension-size-115)
+    );
+    --spectrum-helptext-negative-texticon-icon-padding-top: var(
+        --spectrum-helptext-l-negative-texticon-icon-padding-top,
+        var(--spectrum-global-dimension-size-75)
+    );
+    --spectrum-helptext-negative-texticon-icon-padding-bottom: var(
+        --spectrum-helptext-l-negative-texticon-icon-padding-bottom,
+        var(--spectrum-global-dimension-size-75)
+    );
+    --spectrum-helptext-neutral-textonly-text-transform: var(
+        --spectrum-helptext-l-neutral-textonly-text-transform,
+        none
+    );
+    --spectrum-helptext-neutral-textonly-text-padding-top: var(
+        --spectrum-helptext-l-neutral-textonly-text-padding-top,
+        var(--spectrum-global-dimension-size-75)
+    );
+    --spectrum-helptext-neutral-textonly-text-padding-bottom: var(
+        --spectrum-helptext-l-neutral-textonly-text-padding-bottom,
+        var(--spectrum-global-dimension-size-115)
+    );
+    --spectrum-helptext-neutral-textonly-text-line-height: var(
+        --spectrum-helptext-l-neutral-textonly-text-line-height,
+        var(--spectrum-alias-component-text-line-height)
+    );
+    --spectrum-helptext-neutral-textonly-text-letter-spacing: var(
+        --spectrum-helptext-l-neutral-textonly-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+}
+:host([size='xl']) {
+    --spectrum-helptext-neutral-textonly-text-padding-top: var(
+        --spectrum-helptext-xl-neutral-textonly-text-padding-top
+    ); /* .spectrum-HelpText--sizeXL */
+    --spectrum-helptext-neutral-texticon-text-size: var(
+        --spectrum-helptext-xl-neutral-texticon-text-size,
+        var(--spectrum-global-dimension-font-size-200)
+    );
+    --spectrum-helptext-neutral-texticon-icon-gap: var(
+        --spectrum-helptext-xl-neutral-texticon-icon-gap,
+        var(--spectrum-global-dimension-size-125)
+    );
+    --spectrum-helptext-negative-texticon-icon-padding-top: var(
+        --spectrum-helptext-xl-negative-texticon-icon-padding-top,
+        var(--spectrum-global-dimension-size-115)
+    );
+    --spectrum-helptext-negative-texticon-icon-padding-bottom: var(
+        --spectrum-helptext-xl-negative-texticon-icon-padding-bottom,
+        var(--spectrum-global-dimension-size-115)
+    );
+    --spectrum-helptext-neutral-textonly-text-transform: var(
+        --spectrum-helptext-xl-neutral-textonly-text-transform,
+        none
+    );
+    --spectrum-helptext-neutral-textonly-text-padding-bottom: var(
+        --spectrum-helptext-xl-neutral-textonly-text-padding-bottom,
+        var(--spectrum-global-dimension-size-130)
+    );
+    --spectrum-helptext-neutral-textonly-text-line-height: var(
+        --spectrum-helptext-xl-neutral-textonly-text-line-height,
+        var(--spectrum-alias-component-text-line-height)
+    );
+    --spectrum-helptext-neutral-textonly-text-letter-spacing: var(
+        --spectrum-helptext-xl-neutral-textonly-text-letter-spacing,
+        var(--spectrum-global-font-letter-spacing-none)
+    );
+}
+:host {
+    display: flex; /* .spectrum-HelpText */
+    font-size: var(--spectrum-helptext-neutral-texticon-text-size);
+}
+:host([dir='ltr']) .icon {
+    margin-right: var(
+        --spectrum-helptext-neutral-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-HelpText .spectrum-HelpText-validationIcon */
+}
+:host([dir='rtl']) .icon {
+    margin-left: var(
+        --spectrum-helptext-neutral-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-HelpText .spectrum-HelpText-validationIcon */
+}
+.icon {
+    flex-shrink: 0;
+    padding-bottom: var(
+        --spectrum-helptext-negative-texticon-icon-padding-bottom
+    );
+    padding-top: var(
+        --spectrum-helptext-negative-texticon-icon-padding-top
+    ); /* .spectrum-HelpText .spectrum-HelpText-validationIcon */
+}
+:host([dir='ltr']) .text {
+    margin-right: var(
+        --spectrum-helptext-neutral-texticon-icon-gap
+    ); /* [dir=ltr] .spectrum-HelpText .spectrum-HelpText-text */
+}
+:host([dir='rtl']) .text {
+    margin-left: var(
+        --spectrum-helptext-neutral-texticon-icon-gap
+    ); /* [dir=rtl] .spectrum-HelpText .spectrum-HelpText-text */
+}
+.text {
+    letter-spacing: var(
+        --spectrum-helptext-neutral-textonly-text-letter-spacing
+    );
+    line-height: var(--spectrum-helptext-neutral-textonly-text-line-height);
+    padding-bottom: var(
+        --spectrum-helptext-neutral-textonly-text-padding-bottom
+    );
+    padding-top: var(
+        --spectrum-helptext-neutral-textonly-text-padding-top
+    ); /* .spectrum-HelpText .spectrum-HelpText-text */
+    text-transform: var(--spectrum-helptext-neutral-textonly-text-transform);
+}
+:host([variant='neutral']) {
+    --spectrum-helptext-m-texticon-text-color-disabled: var(
+        --spectrum-helptext-m-neutral-texticon-text-color-disabled,
+        var(--spectrum-alias-text-color-disabled)
+    ); /* .spectrum-HelpText--neutral */
+    --spectrum-helptext-m-texticon-icon-color-disabled: var(
+        --spectrum-helptext-m-neutral-texticon-icon-color-disabled,
+        var(--spectrum-alias-icon-color-disabled)
+    );
+    --spectrum-helptext-m-texticon-text-color: var(
+        --spectrum-helptext-m-neutral-texticon-text-color,
+        var(--spectrum-alias-label-text-color)
+    );
+    --spectrum-helptext-m-texticon-icon-color: var(
+        --spectrum-helptext-m-neutral-texticon-icon-color,
+        var(--spectrum-alias-icon-color)
+    );
+}
+:host([variant='negative']) {
+    --spectrum-helptext-m-texticon-text-color-disabled: var(
+        --spectrum-helptext-m-negative-texticon-text-color-disabled,
+        var(--spectrum-alias-text-color-disabled)
+    ); /* .spectrum-HelpText--negative */
+    --spectrum-helptext-m-texticon-icon-color-disabled: var(
+        --spectrum-helptext-m-negative-texticon-icon-color-disabled,
+        var(--spectrum-alias-icon-color-disabled)
+    );
+    --spectrum-helptext-m-texticon-text-color: var(
+        --spectrum-helptext-m-negative-texticon-text-color,
+        var(--spectrum-semantic-negative-text-color-small)
+    );
+    --spectrum-helptext-m-texticon-icon-color: var(
+        --spectrum-helptext-m-negative-texticon-icon-color,
+        var(--spectrum-semantic-negative-icon-color)
+    );
+}
+.icon {
+    color: var(
+        --spectrum-helptext-m-texticon-icon-color
+    ); /* .spectrum-HelpText .spectrum-HelpText-validationIcon */
+}
+.text {
+    color: var(
+        --spectrum-helptext-m-texticon-text-color
+    ); /* .spectrum-HelpText .spectrum-HelpText-text */
+}
+:host([disabled]) .icon {
+    color: var(
+        --spectrum-helptext-m-texticon-icon-color-disabled
+    ); /* .spectrum-HelpText.is-disabled .spectrum-HelpText-validationIcon */
+}
+:host([disabled]) .text {
+    color: var(
+        --spectrum-helptext-m-texticon-text-color-disabled
+    ); /* .spectrum-HelpText.is-disabled .spectrum-HelpText-text */
+}

--- a/packages/help-text/stories/help-text-sizes.stories.ts
+++ b/packages/help-text/stories/help-text-sizes.stories.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, TemplateResult } from '@spectrum-web-components/base';
+
+import '../sp-help-text.js';
+
+export default {
+    title: 'Help Text/Sizes',
+    component: 'sp-help-text',
+};
+
+export const s = (): TemplateResult => {
+    return html`
+        <sp-help-text size="s">
+            Passwords must be at least 8 characters.
+        </sp-help-text>
+    `;
+};
+
+export const m = (): TemplateResult => {
+    return html`
+        <sp-help-text size="m">
+            Passwords must be at least 8 characters.
+        </sp-help-text>
+    `;
+};
+
+export const l = (): TemplateResult => {
+    return html`
+        <sp-help-text size="l">
+            Passwords must be at least 8 characters.
+        </sp-help-text>
+    `;
+};
+
+export const XL = (): TemplateResult => {
+    return html`
+        <sp-help-text size="xl">
+            Passwords must be at least 8 characters.
+        </sp-help-text>
+    `;
+};

--- a/packages/help-text/stories/help-text.stories.ts
+++ b/packages/help-text/stories/help-text.stories.ts
@@ -1,0 +1,132 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, TemplateResult } from '@spectrum-web-components/base';
+
+import '../sp-help-text.js';
+
+export default {
+    title: 'Help Text',
+    component: 'sp-help-text',
+    argTypes: {
+        icon: {
+            name: 'icon',
+            type: { name: 'boolean', required: false },
+            discription: 'Whether the Help Text is delivered with an icon.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        disabled: {
+            name: 'disabled',
+            type: { name: 'boolean', required: false },
+            description: 'Help Text for disabled form elements.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        variant: {
+            name: 'variant',
+            type: { name: 'string', required: false },
+            description: 'The visual variant to apply to the Help Text.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'cta' },
+            },
+            control: {
+                type: 'inline-radio',
+                options: ['neutral', 'negative'],
+            },
+        },
+        size: {
+            name: 'size',
+            type: { name: 'string', required: false },
+            description: 'The visual variant to apply to the Help Text.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'cta' },
+            },
+            control: {
+                type: 'inline-radio',
+                options: ['s', 'm', 'l', 'xl'],
+            },
+        },
+    },
+    args: {
+        size: 'm',
+    },
+};
+
+interface Properties {
+    content?: string;
+    disabled?: boolean;
+    icon?: boolean;
+    size?: 's' | 'm' | 'l' | 'xl';
+    variant?: 'neutral' | 'negative';
+}
+
+const Template = (args: Properties): TemplateResult => html`
+    <sp-help-text
+        ?disabled=${args.disabled}
+        ?icon=${args.icon}
+        variant=${args.variant}
+        size=${args.size}
+    >
+        ${args.content}
+    </sp-help-text>
+`;
+
+export const neutral = (args: Properties = {}): TemplateResult =>
+    Template({
+        ...args,
+        content: 'Passwords must be at least 8 characters.',
+    });
+neutral.args = {
+    variant: 'neutral',
+};
+
+export const negative = (args: Properties = {}): TemplateResult =>
+    Template({
+        ...args,
+        content: 'Create a password with at least 8 characters.',
+    });
+negative.args = {
+    variant: 'negative',
+};
+
+export const negativeIcon = (args: Properties = {}): TemplateResult =>
+    Template({
+        ...args,
+        content: 'Create a password with at least 8 characters.',
+    });
+negativeIcon.args = {
+    icon: true,
+    variant: 'negative',
+};
+
+export const disabled = (args: Properties = {}): TemplateResult =>
+    Template({
+        ...args,
+        content: 'Passwords must be at least 8 characters.',
+    });
+disabled.args = {
+    disabled: true,
+    variant: 'neutral',
+};

--- a/packages/help-text/test/benchmark/basic-test.ts
+++ b/packages/help-text/test/benchmark/basic-test.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/help-text/sp-help-text.js';
+import { html } from 'lit';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-help-text></sp-help-text>
+`);

--- a/packages/help-text/test/help-text.test.ts
+++ b/packages/help-text/test/help-text.test.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+
+import '../sp-help-text.js';
+import { HelpText } from '..';
+
+describe('HelpText', () => {
+    it('loads default help-text accessibly', async () => {
+        const el = await fixture<HelpText>(
+            html`
+                <sp-help-text></sp-help-text>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+});

--- a/packages/help-text/tsconfig.json
+++ b/packages/help-text/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "./"
+    },
+    "include": ["*.ts", "src/*.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [{ "path": "../base" }]
+}

--- a/packages/iconset/stories/icons-demo.ts
+++ b/packages/iconset/stories/icons-demo.ts
@@ -27,6 +27,7 @@ import '@spectrum-web-components/search/sp-search.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import bodyStyles from '@spectrum-web-components/styles/body.js';
 import '@spectrum-web-components/icon/sp-icon.js';
+import '@spectrum-web-components/help-text/sp-help-text.js';
 
 @customElement('delayed-ready')
 export class DelayedReady extends SpectrumElement {
@@ -196,11 +197,12 @@ export class IconsDemo extends SpectrumElement {
                     .value=${this.search}
                     label="Search for icons"
                     autocomplete="off"
-                ></sp-search>
-                <p class="spectrum-Body spectrum-Body--sizeM">
-                    Showing ${matchingIcons.length} of ${this.icons.length}
-                    available icons.
-                </p>
+                >
+                    <sp-help-text slot="help-text">
+                        Showing ${matchingIcons.length} of ${this.icons.length}
+                        available icons.
+                    </sp-help-text>
+                </sp-search>
             </div>
             ${matchingIcons.map((icon) => {
                 return html`

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -57,6 +57,8 @@ export const indeterminatePlaceholder = '-';
 
 /**
  * @element sp-number-field
+ * @slot help-text - default or non-negative help text to associate to your form element
+ * @slot negative-help-text - negative help text to associate to your form element when `invalid`
  */
 export class NumberField extends TextfieldBase {
     public static get styles(): CSSResultArray {
@@ -489,10 +491,10 @@ export class NumberField extends TextfieldBase {
     private _numberParser?: NumberParser;
     private _numberParserFocused?: NumberParser;
 
-    protected render(): TemplateResult {
+    protected renderField(): TemplateResult {
         this.autocomplete = 'off';
         return html`
-            ${super.render()}
+            ${super.renderField()}
             ${this.hideStepper
                 ? html``
                 : html`

--- a/packages/number-field/src/number-field.css
+++ b/packages/number-field/src/number-field.css
@@ -12,6 +12,14 @@ governing permissions and limitations under the License.
 
 @import './spectrum-number-field.css';
 
+:host {
+    width: var(--spectrum-stepper-width);
+}
+
+#textfield {
+    width: 100%;
+}
+
 sp-field-button {
     --spectrum-dropdown-height: 100%;
     --spectrum-dropdown-padding-x: 0;

--- a/packages/number-field/src/spectrum-config.js
+++ b/packages/number-field/src/spectrum-config.js
@@ -17,6 +17,7 @@ const config = {
             name: 'number-field',
             host: {
                 selector: '.spectrum-Stepper',
+                shadowSelector: '#textfield',
             },
             attributes: [
                 {

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -45,7 +45,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-stepper-button-offset)
     );
 }
-:host {
+#textfield {
     border-radius: var(
         --spectrum-alias-border-radius-regular,
         var(--spectrum-global-dimension-size-50)
@@ -60,7 +60,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ease-in-out;
     width: var(--spectrum-stepper-width);
 }
-:host:before {
+#textfield:before {
     content: ''; /* .spectrum-Stepper:before */
 }
 :host([dir='ltr']) .buttons {
@@ -259,7 +259,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .textfield {
     min-width: 0; /* .spectrum-Stepper-textfield */
 }
-:host([quiet]) {
+:host([quiet]) #textfield {
     border-radius: var(
         --spectrum-stepper-border-radius-reset
     ); /* .spectrum-Stepper--quiet */
@@ -343,11 +343,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     position: absolute;
     width: var(--spectrum-stepper-button-offset);
 }
-:host(:hover:not([disabled]):not([invalid]):not([focused]):not([keyboard-focused]))
+:host(:not([disabled]):not([invalid]):not([focused]):not([keyboard-focused]))
+    #textfield:hover
     .input,
-:host(:hover:not([disabled]):not([invalid]):not([focused]):not([keyboard-focused]))
+:host(:not([disabled]):not([invalid]):not([focused]):not([keyboard-focused]))
+    #textfield:hover
     .stepDown,
-:host(:hover:not([disabled]):not([invalid]):not([focused]):not([keyboard-focused]))
+:host(:not([disabled]):not([invalid]):not([focused]):not([keyboard-focused]))
+    #textfield:hover
     .stepUp {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-hover,
@@ -356,56 +359,56 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Stepper:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) .spectrum-Stepper-stepDown,
    * .spectrum-Stepper:hover:not(.is-disabled):not(.is-invalid):not(.is-focused):not(.is-keyboardFocused) .spectrum-Stepper-input */
 }
-:host([focused]) {
+:host([focused]) #textfield {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-mouse-focus,
         var(--spectrum-alias-input-border-color-mouse-focus)
     ); /* .spectrum-Stepper.is-focused */
 }
-:host([focused]) .stepDown,
-:host([focused]) .stepUp {
+:host([focused]) #textfield .stepDown,
+:host([focused]) #textfield .stepUp {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-mouse-focus,
         var(--spectrum-alias-input-border-color-mouse-focus)
     ); /* .spectrum-Stepper.is-focused .spectrum-Stepper-stepUp,
    * .spectrum-Stepper.is-focused .spectrum-Stepper-stepDown */
 }
-:host([focused]) .input {
+:host([focused]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-mouse-focus,
         var(--spectrum-alias-input-border-color-mouse-focus)
     ); /* .spectrum-Stepper.is-focused .spectrum-Stepper-input */
     box-shadow: none;
 }
-:host([focused][invalid]) {
+:host([focused][invalid]) #textfield {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-mouse-focus,
         var(--spectrum-alias-input-border-color-invalid-mouse-focus)
     ); /* .spectrum-Stepper.is-focused.is-invalid */
 }
-:host([focused][invalid]) .stepDown,
-:host([focused][invalid]) .stepUp {
+:host([focused][invalid]) #textfield .stepDown,
+:host([focused][invalid]) #textfield .stepUp {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-mouse-focus,
         var(--spectrum-alias-input-border-color-invalid-mouse-focus)
     ); /* .spectrum-Stepper.is-focused.is-invalid .spectrum-Stepper-stepUp,
    * .spectrum-Stepper.is-focused.is-invalid .spectrum-Stepper-stepDown */
 }
-:host([focused][invalid]) .input {
+:host([focused][invalid]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-mouse-focus,
         var(--spectrum-alias-input-border-color-invalid-mouse-focus)
     ); /* .spectrum-Stepper.is-focused.is-invalid .spectrum-Stepper-input */
 }
-:host([keyboard-focused]) {
+:host([keyboard-focused]) #textfield {
     box-shadow: 0 0 0 1px
         var(
             --spectrum-textfield-m-texticon-border-color-key-focus,
             var(--spectrum-alias-input-border-color-key-focus)
         ); /* .spectrum-Stepper.is-keyboardFocused */
 }
-:host([keyboard-focused]) .buttons,
-:host([keyboard-focused]) .input {
+:host([keyboard-focused]) #textfield .buttons,
+:host([keyboard-focused]) #textfield .input {
     box-shadow: 0 0 0 1px
         var(
             --spectrum-textfield-m-texticon-border-color-key-focus,
@@ -413,9 +416,9 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         ); /* .spectrum-Stepper.is-keyboardFocused .spectrum-Stepper-input,
    * .spectrum-Stepper.is-keyboardFocused .spectrum-Stepper-buttons */
 }
-:host([keyboard-focused]) .input,
-:host([keyboard-focused]) .stepDown,
-:host([keyboard-focused]) .stepUp {
+:host([keyboard-focused]) #textfield .input,
+:host([keyboard-focused]) #textfield .stepDown,
+:host([keyboard-focused]) #textfield .stepUp {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-key-focus,
         var(--spectrum-alias-input-border-color-key-focus)
@@ -423,43 +426,43 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Stepper.is-keyboardFocused .spectrum-Stepper-stepUp,
    * .spectrum-Stepper.is-keyboardFocused .spectrum-Stepper-stepDown */
 }
-:host([keyboard-focused][invalid]) {
+:host([keyboard-focused][invalid]) #textfield {
     box-shadow: 0 0 0 1px
         var(
             --spectrum-textfield-m-texticon-border-color-invalid-key-focus,
             var(--spectrum-alias-input-border-color-invalid-key-focus)
         ); /* .spectrum-Stepper.is-keyboardFocused.is-invalid */
 }
-:host([keyboard-focused][invalid]) .stepDown,
-:host([keyboard-focused][invalid]) .stepUp {
+:host([keyboard-focused][invalid]) #textfield .stepDown,
+:host([keyboard-focused][invalid]) #textfield .stepUp {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-key-focus,
         var(--spectrum-alias-input-border-color-invalid-key-focus)
     ); /* .spectrum-Stepper.is-keyboardFocused.is-invalid .spectrum-Stepper-stepUp,
    * .spectrum-Stepper.is-keyboardFocused.is-invalid .spectrum-Stepper-stepDown */
 }
-:host([keyboard-focused][invalid]) .buttons {
+:host([keyboard-focused][invalid]) #textfield .buttons {
     box-shadow: 0 0 0 1px
         var(
             --spectrum-textfield-m-texticon-border-color-invalid-key-focus,
             var(--spectrum-alias-input-border-color-invalid-key-focus)
         ); /* .spectrum-Stepper.is-keyboardFocused.is-invalid .spectrum-Stepper-buttons */
 }
-:host([invalid]) .stepDown,
-:host([invalid]) .stepUp {
+:host([invalid]) #textfield .stepDown,
+:host([invalid]) #textfield .stepUp {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid,
         var(--spectrum-alias-input-border-color-invalid-default)
     ); /* .spectrum-Stepper.is-invalid .spectrum-Stepper-stepUp,
    * .spectrum-Stepper.is-invalid .spectrum-Stepper-stepDown */
 }
-:host([invalid]) .input {
+:host([invalid]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid,
         var(--spectrum-alias-input-border-color-invalid-default)
     ); /* .spectrum-Stepper.is-invalid .spectrum-Stepper-input */
 }
-:host([invalid][keyboard-focused]) .input {
+:host([invalid][keyboard-focused]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-key-focus,
         var(--spectrum-alias-input-border-color-invalid-key-focus)
@@ -470,15 +473,15 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-input-border-color-invalid-key-focus)
         );
 }
-:host([invalid][keyboard-focused]) .buttons {
+:host([invalid][keyboard-focused]) #textfield .buttons {
     box-shadow: 0 0 0 1px
         var(
             --spectrum-textfield-m-texticon-border-color-invalid-key-focus,
             var(--spectrum-alias-input-border-color-invalid-key-focus)
         ); /* .spectrum-Stepper.is-invalid.is-keyboardFocused .spectrum-Stepper-buttons */
 }
-:host([disabled]) .stepDown,
-:host([disabled]) .stepUp {
+:host([disabled]) #textfield .stepDown,
+:host([disabled]) #textfield .stepUp {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-disabled,
         var(--spectrum-alias-input-border-color-disabled)
@@ -501,8 +504,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Stepper-stepUp:disabled,
    * .spectrum-Stepper-stepDown:disabled */
 }
-:host([quiet][disabled]) .stepDown,
-:host([quiet][disabled]) .stepUp {
+:host([quiet][disabled]) #textfield .stepDown,
+:host([quiet][disabled]) #textfield .stepUp {
     border-color: var(
         --spectrum-textfield-m-quiet-texticon-border-color-disabled,
         var(--spectrum-alias-input-border-color-quiet-disabled)
@@ -528,27 +531,27 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([quiet]) .input {
     box-shadow: none; /* .spectrum-Stepper--quiet .spectrum-Stepper-input */
 }
-:host([quiet][invalid]) .input {
+:host([quiet][invalid]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid,
         var(--spectrum-alias-input-border-color-invalid-default)
     ); /* .spectrum-Stepper--quiet.is-invalid .spectrum-Stepper-input */
 }
-:host([quiet][invalid]) .stepDown {
+:host([quiet][invalid]) #textfield .stepDown {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid,
         var(--spectrum-alias-input-border-color-invalid-default)
     ); /* .spectrum-Stepper--quiet.is-invalid .spectrum-Stepper-stepDown */
 }
-:host([quiet][focused]),
-:host([quiet][keyboard-focused]) {
+:host([quiet][focused]) #textfield,
+:host([quiet][keyboard-focused]) #textfield {
     box-shadow: none; /* .spectrum-Stepper--quiet.is-keyboardFocused,
    * .spectrum-Stepper--quiet.is-focused */
 }
-:host([quiet][focused]) .buttons,
-:host([quiet][focused]) .input,
-:host([quiet][keyboard-focused]) .buttons,
-:host([quiet][keyboard-focused]) .input {
+:host([quiet][focused]) #textfield .buttons,
+:host([quiet][focused]) #textfield .input,
+:host([quiet][keyboard-focused]) #textfield .buttons,
+:host([quiet][keyboard-focused]) #textfield .input {
     box-shadow: 0 1px 0 0
         var(
             --spectrum-textfield-m-texticon-border-color-key-focus,
@@ -558,23 +561,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Stepper--quiet.is-focused .spectrum-Stepper-buttons,
    * .spectrum-Stepper--quiet.is-focused .spectrum-Stepper-input */
 }
-:host([quiet][focused]) .stepDown,
-:host([quiet][keyboard-focused]) .stepDown {
+:host([quiet][focused]) #textfield .stepDown,
+:host([quiet][keyboard-focused]) #textfield .stepDown {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-key-focus,
         var(--spectrum-alias-input-border-color-key-focus)
     ); /* .spectrum-Stepper--quiet.is-keyboardFocused .spectrum-Stepper-stepDown,
    * .spectrum-Stepper--quiet.is-focused .spectrum-Stepper-stepDown */
 }
-:host([quiet][focused][invalid]),
-:host([quiet][keyboard-focused][invalid]) {
+:host([quiet][focused][invalid]) #textfield,
+:host([quiet][keyboard-focused][invalid]) #textfield {
     box-shadow: none; /* .spectrum-Stepper--quiet.is-keyboardFocused.is-invalid,
    * .spectrum-Stepper--quiet.is-focused.is-invalid */
 }
-:host([quiet][focused][invalid]) .buttons,
-:host([quiet][focused][invalid]) .input,
-:host([quiet][keyboard-focused][invalid]) .buttons,
-:host([quiet][keyboard-focused][invalid]) .input {
+:host([quiet][focused][invalid]) #textfield .buttons,
+:host([quiet][focused][invalid]) #textfield .input,
+:host([quiet][keyboard-focused][invalid]) #textfield .buttons,
+:host([quiet][keyboard-focused][invalid]) #textfield .input {
     box-shadow: 0 1px 0 0
         var(
             --spectrum-textfield-m-texticon-border-color-invalid,
@@ -584,16 +587,16 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Stepper--quiet.is-focused.is-invalid .spectrum-Stepper-input,
    * .spectrum-Stepper--quiet.is-focused.is-invalid .spectrum-Stepper-buttons */
 }
-:host([quiet][focused][invalid]) .input,
-:host([quiet][keyboard-focused][invalid]) .input {
+:host([quiet][focused][invalid]) #textfield .input,
+:host([quiet][keyboard-focused][invalid]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid,
         var(--spectrum-alias-input-border-color-invalid-default)
     ); /* .spectrum-Stepper--quiet.is-keyboardFocused.is-invalid .spectrum-Stepper-input,
    * .spectrum-Stepper--quiet.is-focused.is-invalid .spectrum-Stepper-input */
 }
-:host([quiet][focused][invalid]) .stepDown,
-:host([quiet][keyboard-focused][invalid]) .stepDown {
+:host([quiet][focused][invalid]) #textfield .stepDown,
+:host([quiet][keyboard-focused][invalid]) #textfield .stepDown {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid,
         var(--spectrum-alias-input-border-color-invalid-default)

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -131,6 +131,64 @@ Event handlers for clicks and other user actions can be registered on an `<sp-ra
 </sp-radio>
 ```
 
+## Help text
+
+Help text can be accessibly associated with an `<sp-radio-group>` element by using the `help-text` or `negative-help-text` slots. When using the `negative-help-text` slot, `<sp-radio-group>` will self manage the presence of this content based on the value of the `invalid` property on your `<sp-radio-group>` element. Content within the `help-text` slot will be show by default. When your `<sp-radio-group>` should receive help text based on state outside of the complexity of `invalid` or not, manage the content addressed to the `help-text` from above to ensure that it displays the right messaging and possesses the right `variant`.
+
+<sp-tabs selected="self" auto label="Help text usage in radio groups">
+<sp-tab value="self">Self managed</sp-tab>
+<sp-tab-panel value="self">
+
+```html
+<sp-field-label for="self">
+    What is your favorite ice cream flavor?
+</sp-field-label>
+<sp-radio-group
+    is="self"
+    onchange="
+        this.invalid = this.selected === 'fourth';
+    "
+>
+    <sp-radio value="first">Vanilla</sp-radio>
+    <sp-radio value="second">Chocolate</sp-radio>
+    <sp-radio value="third">Strawberry</sp-radio>
+    <sp-radio value="fourth">I don't like ice cream</sp-radio>
+    <sp-help-text slot="help-text">Everyone likes ice cream.</sp-help-text>
+    <sp-help-text slot="negative-help-text" icon>
+        You can't not like ice cream.
+    </sp-help-text>
+</sp-radio-group>
+```
+
+</sp-tab-panel>
+<sp-tab value="above">Managed from above</sp-tab>
+<sp-tab-panel value="above">
+
+```html
+<sp-field-label for="managed">
+    What is your favorite ice cream flavor?
+</sp-field-label>
+<sp-radio-group
+    is="managed"
+    onchange="
+        const helpText = this.querySelector(`[slot='help-text']`);
+        const isInvalid = this.selected === 'fourth';
+        helpText.icon = isInvalid;
+        helpText.textContent = isInvalid ? 'You can\'t not like ice cream.' : 'Everyone likes ice cream.';
+        helpText.variant = isInvalid ? 'negative' : 'neutral';
+    "
+>
+    <sp-radio value="first">Vanilla</sp-radio>
+    <sp-radio value="second">Chocolate</sp-radio>
+    <sp-radio value="third">Strawberry</sp-radio>
+    <sp-radio value="fourth">I don't like ice cream</sp-radio>
+    <sp-help-text slot="help-text">Everyone likes ice cream.</sp-help-text>
+</sp-radio-group>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
 ## Accessibility
 
 Radio buttons are accessible by default, rendered in HTML using the `<input type="radio">` element. Tabbing into a group of radio buttons places the focus on the first radio button selected. If none of the radio buttons are selected, the focus is set on the first one in the group. Space selects the radio button in focus (if not already selected). Using the arrow keys moves focus and selection to the previous or next radio button in the group (last becomes first, and first becomes last). The new radio button in focus gets selected even if the previous one was not.

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -48,6 +48,7 @@
     "dependencies": {
         "@spectrum-web-components/base": "^0.5.0",
         "@spectrum-web-components/field-group": "^0.5.0",
+        "@spectrum-web-components/help-text": "^0.0.1",
         "@spectrum-web-components/shared": "^0.13.0",
         "tslib": "^2.0.0"
     },

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -10,11 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import {
-    html,
-    PropertyValues,
-    TemplateResult,
-} from '@spectrum-web-components/base';
+import { PropertyValues } from '@spectrum-web-components/base';
 import {
     property,
     queryAssignedNodes,
@@ -28,6 +24,8 @@ import { Radio } from './Radio.js';
  * @element sp-radio-group
  *
  * @slot - The `sp-radio` elements to display/manage in the group.
+ * @slot help-text - default or non-negative help text to associate to your form element
+ * @slot negative-help-text - negative help text to associate to your form element when `invalid`
  */
 export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
     @property({ type: String })
@@ -35,9 +33,6 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
 
     @queryAssignedNodes('')
     public defaultNodes!: Node[];
-
-    @property()
-    public label = '';
 
     public get buttons(): Radio[] {
         return this.defaultNodes.filter(
@@ -204,12 +199,6 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
     @property({ reflect: true })
     public selected = '';
 
-    protected render(): TemplateResult {
-        return html`
-            <slot></slot>
-        `;
-    }
-
     protected firstUpdated(changes: PropertyValues<this>): void {
         super.firstUpdated(changes);
         this.setAttribute('role', 'radiogroup');
@@ -253,13 +242,6 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
         super.updated(changes);
         if (changes.has('selected')) {
             this.validateRadios();
-        }
-        if (changes.has('label')) {
-            if (this.label) {
-                this.setAttribute('aria-label', this.label);
-            } else {
-                this.removeAttribute('aria-label');
-            }
         }
     }
 

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -32,6 +32,8 @@ const stopPropagation = (event: Event): void => event.stopPropagation();
 
 /**
  * @element sp-search
+ * @slot help-text - default or non-negative help text to associate to your form element
+ * @slot negative-help-text - negative help text to associate to your form element when `invalid`
  */
 export class Search extends Textfield {
     public static get styles(): CSSResultArray {
@@ -93,7 +95,7 @@ export class Search extends Textfield {
         );
     }
 
-    protected render(): TemplateResult {
+    protected renderField(): TemplateResult {
         return html`
             <form
                 action=${this.action}
@@ -106,7 +108,7 @@ export class Search extends Textfield {
                 <sp-icon-magnify
                     class="icon magnifier icon-workflow"
                 ></sp-icon-magnify>
-                ${super.render()}
+                ${super.renderField()}
                 ${this.value
                     ? html`
                           <sp-clear-button

--- a/packages/search/src/spectrum-config.js
+++ b/packages/search/src/spectrum-config.js
@@ -17,6 +17,7 @@ const config = {
             name: 'search',
             host: {
                 selector: '.spectrum-Search',
+                shadowSelector: '#textfield',
             },
             focus: '#input',
             attributes: [
@@ -34,6 +35,10 @@ const config = {
                 {
                     selector: '.spectrum-Search-clearButton',
                     name: 'button',
+                },
+                {
+                    selector: '.spectrum-Search-textfield',
+                    name: 'textfield',
                 },
             ],
             classes: [

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -18,7 +18,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             ) / 2 - var(--spectrum-alias-ui-icon-cross-size-100) / 2
     ); /* .spectrum-Search */
 }
-:host {
+#textfield {
     display: inline-block; /* .spectrum-Search */
     position: relative;
 }
@@ -45,23 +45,23 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     -webkit-appearance: none; /* .spectrum-Search-input::-webkit-search-cancel-button,
    * .spectrum-Search-input::-webkit-search-decoration */
 }
-.spectrum-Search-textfield:after {
+#textfield:after {
     border-radius: var(
         --spectrum-alias-search-border-radius,
         var(--spectrum-global-dimension-size-50)
     ); /* .spectrum-Search-textfield:after */
 }
-:host([dir='ltr']:not([quiet])) .icon {
+:host([dir='ltr']:not([quiet])) #textfield .icon {
     left: var(
         --spectrum-alias-search-padding-left-m
     ); /* [dir=ltr] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-icon */
 }
-:host([dir='rtl']:not([quiet])) .icon {
+:host([dir='rtl']:not([quiet])) #textfield .icon {
     right: var(
         --spectrum-alias-search-padding-left-m
     ); /* [dir=rtl] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-icon */
 }
-:host([dir='ltr']:not([quiet])) #input {
+:host([dir='ltr']:not([quiet])) #textfield #input {
     padding-left: calc(
         var(--spectrum-alias-search-padding-left-m) +
             var(
@@ -78,7 +78,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=ltr] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-input */
 }
-:host([dir='rtl']:not([quiet])) #input {
+:host([dir='rtl']:not([quiet])) #textfield #input {
     padding-right: calc(
         var(--spectrum-alias-search-padding-left-m) +
             var(
@@ -106,7 +106,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         0
     ); /* .spectrum-Search--quiet .spectrum-Search-input */
 }
-:host([quiet]) .spectrum-Search-textfield:after {
+:host([quiet]) #textfield:after {
     border-radius: var(
         --spectrum-alias-search-border-radius-quiet,
         0

--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -88,3 +88,47 @@ user affordances like mobile keyboards and obscured characters:
 ```
 
 If the `type` attribute is not specified, or if it does not match any of these values, the default type adopted is "text."
+
+## Help text
+
+Help text can be accessibly associated with an `<sp-textfield>` element by using the `help-text` or `negative-help-text` slots. When using the `negative-help-text` slot, `<sp-textfield>` will self manage the presence of this content based on the value of the `invalid` property on your `<sp-textfield>` element. Content within the `help-text` slot will be show by default. When your `<sp-textfield>` should receive help text based on state outside of the complexity of `invalid` or not, manage the content addressed to the `help-text` from above to ensure that it displays the right messaging and possesses the right `variant`.
+
+<sp-tabs selected="self" auto label="Help text usage in textfields">
+<sp-tab value="self">Self managed</sp-tab>
+<sp-tab-panel value="self">
+
+```html
+<sp-field-label for="self">Stay "Positive"</sp-field-label>
+<sp-textfield id="self" pattern="[P][o][s][i][t][i][v][e]" value="Positive">
+    <sp-help-text slot="help-text">
+        Tell us how you are feeling today.
+    </sp-help-text>
+    <sp-help-text slot="negative-help-text">Please be "Positive".</sp-help-text>
+</sp-textfield>
+```
+
+</sp-tab-panel>
+<sp-tab value="above">Managed from above</sp-tab>
+<sp-tab-panel value="above">
+
+```html
+<sp-field-label for="managed">Stay "Positive"</sp-field-label>
+<sp-textfield
+    id="managed"
+    pattern="[P][o][s][i][t][i][v][e]"
+    value="Positive"
+    oninput='
+        const helpText = this.querySelector(`[slot="help-text"]`);
+        helpText.textContent = this.invalid ? `Please be "Positive".` : `Tell us how you are feeling today.`;
+        helpText.variant = this.invalid ? `negative` : `neutral`;
+    '
+>
+    <sp-help-text slot="neutral-text">
+        Tell us how you're feeling today.
+    </sp-help-text>
+    <sp-help-text slot="help-text">Please be "Positive".</sp-help-text>
+</sp-textfield>
+```
+
+</sp-tab-panel>
+</sp-tabs>

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -45,6 +45,7 @@
     ],
     "dependencies": {
         "@spectrum-web-components/base": "^0.5.0",
+        "@spectrum-web-components/help-text": "^0.0.1",
         "@spectrum-web-components/icon": "^0.11.0",
         "@spectrum-web-components/icons-ui": "^0.8.0",
         "@spectrum-web-components/icons-workflow": "^0.8.0",

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -27,6 +27,7 @@ import {
     state,
 } from '@spectrum-web-components/base/src/decorators.js';
 
+import { ManageHelpText } from '@spectrum-web-components/help-text/src/manage-help-text.js';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-checkmark100.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
@@ -37,7 +38,7 @@ import checkmarkStyles from '@spectrum-web-components/icon/src/spectrum-icon-che
 const textfieldTypes = ['text', 'url', 'tel', 'email', 'password'] as const;
 export type TextfieldType = typeof textfieldTypes[number];
 
-export class TextfieldBase extends Focusable {
+export class TextfieldBase extends ManageHelpText(Focusable) {
     public static get styles(): CSSResultArray {
         return [textfieldStyles, checkmarkStyles];
     }
@@ -198,6 +199,7 @@ export class TextfieldBase extends Focusable {
                 : nothing}
             <!-- @ts-ignore -->
             <textarea
+                aria-describedby=${this.helpTextId}
                 aria-label=${this.label || this.placeholder}
                 aria-invalid=${ifDefined(this.invalid || undefined)}
                 class="input"
@@ -227,6 +229,7 @@ export class TextfieldBase extends Focusable {
             <!-- @ts-ignore -->
             <input
                 type=${this.type}
+                aria-describedby=${this.helpTextId}
                 aria-label=${this.label || this.placeholder}
                 aria-invalid=${ifDefined(this.invalid || undefined)}
                 class="input"
@@ -251,10 +254,17 @@ export class TextfieldBase extends Focusable {
         `;
     }
 
-    protected render(): TemplateResult {
+    protected renderField(): TemplateResult {
         return html`
             ${this.renderStateIcons()}
             ${this.multiline ? this.renderMultiline : this.renderInput}
+        `;
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            <div id="textfield">${this.renderField()}</div>
+            ${this.renderHelpText(this.invalid)}
         `;
     }
 
@@ -287,6 +297,8 @@ export class TextfieldBase extends Focusable {
 
 /**
  * @element sp-textfield
+ * @slot help-text - default or non-negative help text to associate to your form element
+ * @slot negative-help-text - negative help text to associate to your form element when `invalid`
  */
 export class Textfield extends TextfieldBase {
     @property({ type: String })

--- a/packages/textfield/src/spectrum-config.js
+++ b/packages/textfield/src/spectrum-config.js
@@ -17,6 +17,7 @@ const config = {
             name: 'textfield',
             host: {
                 selector: '.spectrum-Textfield',
+                shadowSelector: '#textfield',
             },
             classes: [
                 {

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -137,7 +137,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-textarea-text-padding-bottom
     );
 }
-:host {
+#textfield {
     display: inline-flex; /* .spectrum-Textfield */
     min-width: var(--spectrum-textfield-texticon-min-width);
     position: relative;
@@ -146,14 +146,14 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-global-dimension-size-2400)
     );
 }
-:host([quiet][multiline]) .input {
+:host([quiet][multiline]) #textfield .input {
     height: var(
         --spectrum-textfield-texticon-height
     ); /* .spectrum-Textfield.spectrum-Textfield--quiet.spectrum-Textfield--multiline
     .spectrum-Textfield-input */
     min-height: var(--spectrum-textfield-texticon-height);
 }
-:host:after {
+#textfield:after {
     border-color: transparent;
     border-radius: calc(
         var(--spectrum-textfield-texticon-border-radius) +
@@ -180,7 +180,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         border-color var(--spectrum-global-animation-duration-100, 0.13s)
             ease-in-out;
 }
-:host([quiet]):after {
+:host([quiet]) #textfield:after {
     border-radius: 0; /* .spectrum-Textfield.spectrum-Textfield--quiet:after */
 }
 .input {
@@ -250,7 +250,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 .input:-moz-ui-invalid {
     box-shadow: none; /* .spectrum-Textfield-input:-moz-ui-invalid */
 }
-:host([dir='ltr'][valid]) .input {
+:host([dir='ltr'][valid]) #textfield .input {
     padding-right: calc(
         var(--spectrum-textfield-texticon-padding-right) +
             var(--spectrum-textfield-texticon-success-icon-width) +
@@ -260,7 +260,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-input */
 }
-:host([dir='rtl'][valid]) .input {
+:host([dir='rtl'][valid]) #textfield .input {
     padding-left: calc(
         var(--spectrum-textfield-texticon-padding-right) +
             var(--spectrum-textfield-texticon-success-icon-width) +
@@ -270,7 +270,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=rtl] .spectrum-Textfield.is-valid .spectrum-Textfield-input */
 }
-:host([dir='ltr'][invalid]) .input {
+:host([dir='ltr'][invalid]) #textfield .input {
     padding-right: calc(
         var(--spectrum-textfield-texticon-padding-right) +
             var(--spectrum-textfield-texticon-invalid-icon-width) +
@@ -280,7 +280,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             )
     ); /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-input */
 }
-:host([dir='rtl'][invalid]) .input {
+:host([dir='rtl'][invalid]) #textfield .input {
     padding-left: calc(
         var(--spectrum-textfield-texticon-padding-right) +
             var(--spectrum-textfield-texticon-invalid-icon-width) +
@@ -368,19 +368,19 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host([dir='rtl'][quiet]) .icon {
     padding-left: 0; /* [dir=rtl] .spectrum-Textfield--quiet .spectrum-Textfield-validationIcon */
 }
-:host([dir='ltr'][invalid]) .icon {
+:host([dir='ltr'][invalid]) #textfield .icon {
     right: var(
         --spectrum-textfield-icon-inline-end-override,
         var(--spectrum-textfield-texticon-invalid-icon-margin-left)
     ); /* [dir=ltr] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
-:host([dir='rtl'][invalid]) .icon {
+:host([dir='rtl'][invalid]) #textfield .icon {
     left: var(
         --spectrum-textfield-icon-inline-end-override,
         var(--spectrum-textfield-texticon-invalid-icon-margin-left)
     ); /* [dir=rtl] .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
-:host([invalid]) .icon {
+:host([invalid]) #textfield .icon {
     bottom: calc(
         var(--spectrum-textfield-texticon-height) / 2 -
             var(--spectrum-textfield-texticon-invalid-icon-height) / 2
@@ -390,31 +390,31 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-textfield-texticon-invalid-icon-width
     ); /* .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
-:host([dir='ltr'][quiet][invalid]) .icon {
+:host([dir='ltr'][quiet][invalid]) #textfield .icon {
     right: var(
         --spectrum-textfield-icon-inline-end-override,
         0
     ); /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
-:host([dir='rtl'][quiet][invalid]) .icon {
+:host([dir='rtl'][quiet][invalid]) #textfield .icon {
     left: var(
         --spectrum-textfield-icon-inline-end-override,
         0
     ); /* [dir=rtl] .spectrum-Textfield--quiet.spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
-:host([dir='ltr'][valid]) .icon {
+:host([dir='ltr'][valid]) #textfield .icon {
     right: var(
         --spectrum-textfield-icon-inline-end-override,
         var(--spectrum-textfield-texticon-success-icon-margin-left)
     ); /* [dir=ltr] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
-:host([dir='rtl'][valid]) .icon {
+:host([dir='rtl'][valid]) #textfield .icon {
     left: var(
         --spectrum-textfield-icon-inline-end-override,
         var(--spectrum-textfield-texticon-success-icon-margin-left)
     ); /* [dir=rtl] .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
-:host([valid]) .icon {
+:host([valid]) #textfield .icon {
     bottom: calc(
         var(--spectrum-textfield-texticon-height) / 2 -
             var(--spectrum-textfield-texticon-success-icon-height) / 2
@@ -424,13 +424,13 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         --spectrum-textfield-texticon-success-icon-width
     ); /* .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
-:host([dir='ltr'][quiet][valid]) .icon {
+:host([dir='ltr'][quiet][valid]) #textfield .icon {
     right: var(
         --spectrum-textfield-icon-inline-end-override,
         0
     ); /* [dir=ltr] .spectrum-Textfield--quiet.spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
-:host([dir='rtl'][quiet][valid]) .icon {
+:host([dir='rtl'][quiet][valid]) #textfield .icon {
     left: var(
         --spectrum-textfield-icon-inline-end-override,
         0
@@ -511,62 +511,62 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Textfield--multiline .spectrum-Textfield-icon~.spectrum-Textfield-input */
     min-height: var(--spectrum-textfield-texticon-height);
 }
-:host(:hover) .input {
+#textfield:hover .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-hover,
         var(--spectrum-alias-input-border-color-hover)
     ); /* .spectrum-Textfield:hover .spectrum-Textfield-input */
     box-shadow: none;
 }
-:host(:hover) .input::placeholder {
+#textfield:hover .input::placeholder {
     color: var(
         --spectrum-textfield-m-texticon-placeholder-text-color-hover,
         var(--spectrum-alias-placeholder-text-color-hover)
     ); /* .spectrum-Textfield:hover .spectrum-Textfield-input::placeholder */
 }
-:host(:hover) .icon-workflow {
+#textfield:hover .icon-workflow {
     color: var(
         --spectrum-textfield-m-texticon-icon-color-hover,
         var(--spectrum-alias-component-icon-color-hover)
     ); /* .spectrum-Textfield:hover .spectrum-Textfield-icon */
 }
-:host(:active) .input {
+#textfield:active .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-down,
         var(--spectrum-alias-input-border-color-down)
     ); /* .spectrum-Textfield:active .spectrum-Textfield-input */
 }
-:host(:active) .icon-workflow {
+#textfield:active .icon-workflow {
     color: var(
         --spectrum-textfield-m-texticon-icon-color-down,
         var(--spectrum-alias-component-icon-color-down)
     ); /* .spectrum-Textfield:active .spectrum-Textfield-icon */
 }
-:host([valid]) .icon {
+:host([valid]) #textfield .icon {
     color: var(
         --spectrum-textfield-m-texticon-validation-icon-color-valid,
         var(--spectrum-semantic-positive-icon-color)
     ); /* .spectrum-Textfield.is-valid .spectrum-Textfield-validationIcon */
 }
-:host([invalid]) .icon {
+:host([invalid]) #textfield .icon {
     color: var(
         --spectrum-textfield-m-texticon-validation-icon-color-invalid,
         var(--spectrum-semantic-negative-icon-color)
     ); /* .spectrum-Textfield.is-invalid .spectrum-Textfield-validationIcon */
 }
-:host([invalid]:hover) .input {
+:host([invalid]) #textfield:hover .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-hover,
         var(--spectrum-alias-input-border-color-invalid-hover)
     ); /* .spectrum-Textfield.is-invalid:hover .spectrum-Textfield-input */
 }
-:host([disabled]) .icon {
+:host([disabled]) #textfield .icon {
     color: var(
         --spectrum-textfield-m-texticon-validation-icon-color-invalid-disabled,
         var(--spectrum-alias-background-color-transparent)
     ); /* .spectrum-Textfield.is-disabled .spectrum-Textfield-validationIcon */
 }
-:host([disabled]) .icon-workflow {
+:host([disabled]) #textfield .icon-workflow {
     color: var(
         --spectrum-textfield-m-texticon-icon-color-disabled,
         var(--spectrum-alias-component-icon-color-disabled)
@@ -583,7 +583,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     pointer-events: none; /* .spectrum-Textfield-icon,
    * .spectrum-Textfield-validationIcon */
 }
-:host([focused]):after {
+:host([focused]) #textfield:after {
     box-shadow: 0 0 0
         var(
             --spectrum-textfield-m-texticon-focus-ring-border-width,
@@ -594,10 +594,10 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-focus-ring-color)
         ); /* .spectrum-Textfield.is-keyboardFocused:after */
 }
-:host([focused][quiet]) .input {
+:host([focused][quiet]) #textfield .input {
     box-shadow: none; /* .spectrum-Textfield.is-keyboardFocused.spectrum-Textfield--quiet .spectrum-Textfield-input */
 }
-:host([focused][quiet]):after {
+:host([focused][quiet]) #textfield:after {
     border-bottom: 2px solid
         var(
             --spectrum-textfield-m-textonly-focus-ring-border-color-key-focus,
@@ -630,7 +630,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .spectrum-Textfield-input::placeholder */
 }
 .input:focus,
-:host([focused]) .input {
+:host([focused]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-down,
         var(--spectrum-alias-input-border-color-down)
@@ -638,7 +638,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Textfield-input:focus */
 }
 .input.focus-visible,
-:host([focused]) .input {
+:host([focused]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-key-focus,
         var(--spectrum-alias-input-border-color-key-focus)
@@ -646,37 +646,37 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Textfield-input.focus-ring */
 }
 .input:focus-visible,
-:host([focused]) .input {
+:host([focused]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-key-focus,
         var(--spectrum-alias-input-border-color-key-focus)
     ); /* .spectrum-Textfield.is-keyboardFocused .spectrum-Textfield-input,
    * .spectrum-Textfield-input.focus-ring */
 }
-:host([invalid]) .input {
+:host([invalid]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid,
         var(--spectrum-alias-input-border-color-invalid-default)
     ); /* .spectrum-Textfield.is-invalid .spectrum-Textfield-input */
 }
-:host([focused][invalid]) .input,
-:host([invalid]) .input:focus {
+:host([focused][invalid]) #textfield .input,
+:host([invalid]) #textfield .input:focus {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-mouse-focus,
         var(--spectrum-alias-input-border-color-invalid-mouse-focus)
     ); /* .is-focused.spectrum-Textfield.is-invalid .spectrum-Textfield-input,
    * .spectrum-Textfield.is-invalid .spectrum-Textfield-input:focus */
 }
-:host([focused][invalid]) .input,
-:host([invalid]) .input.focus-visible {
+:host([focused][invalid]) #textfield .input,
+:host([invalid]) #textfield .input.focus-visible {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-key-focus,
         var(--spectrum-alias-input-border-color-invalid-key-focus)
     ); /* .is-keyboardFocused.spectrum-Textfield.is-invalid .spectrum-Textfield-input,
    * .spectrum-Textfield.is-invalid .spectrum-Textfield-input.focus-ring */
 }
-:host([focused][invalid]) .input,
-:host([invalid]) .input:focus-visible {
+:host([focused][invalid]) #textfield .input,
+:host([invalid]) #textfield .input:focus-visible {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-invalid-key-focus,
         var(--spectrum-alias-input-border-color-invalid-key-focus)
@@ -684,8 +684,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Textfield.is-invalid .spectrum-Textfield-input.focus-ring */
 }
 .input :disabled,
-:host([disabled]) .input,
-:host([disabled]:hover) .input {
+:host([disabled]) #textfield .input,
+:host([disabled]) #textfield:hover .input {
     -webkit-text-fill-color: var(
         --spectrum-textfield-m-texticon-text-color-disabled,
         var(--spectrum-alias-component-text-color-disabled)
@@ -706,8 +706,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     );
 }
 .input :disabled::placeholder,
-:host([disabled]) .input::placeholder,
-:host([disabled]:hover) .input::placeholder {
+:host([disabled]) #textfield .input::placeholder,
+:host([disabled]) #textfield:hover .input::placeholder {
     color: var(
         --spectrum-textfield-m-texticon-placeholder-text-color-disabled,
         var(--spectrum-alias-text-color-disabled)
@@ -725,7 +725,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
         var(--spectrum-alias-input-border-color-default)
     );
 }
-:host([focused][quiet]) .input,
+:host([focused][quiet]) #textfield .input,
 :host([quiet]) .input:focus {
     border-color: var(
         --spectrum-textfield-m-quiet-texticon-border-color-mouse-focus,
@@ -733,7 +733,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
     ); /* .is-focused.spectrum-Textfield--quiet .spectrum-Textfield-input,
    * .spectrum-Textfield--quiet .spectrum-Textfield-input:focus */
 }
-:host([focused][quiet]) .input,
+:host([focused][quiet]) #textfield .input,
 :host([quiet]) .input.focus-visible {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-key-focus,
@@ -746,7 +746,7 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-input-border-color-key-focus)
         );
 }
-:host([focused][quiet]) .input,
+:host([focused][quiet]) #textfield .input,
 :host([quiet]) .input:focus-visible {
     border-color: var(
         --spectrum-textfield-m-texticon-border-color-key-focus,
@@ -759,22 +759,22 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-input-border-color-key-focus)
         );
 }
-:host([invalid][quiet]) .input {
+:host([invalid][quiet]) #textfield .input {
     border-color: var(
         --spectrum-textfield-m-quiet-texticon-border-color-invalid,
         var(--spectrum-alias-input-border-color-invalid-default)
     ); /* .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input */
 }
-:host([focused][invalid][quiet]) .input,
-:host([invalid][quiet]) .input:focus {
+:host([focused][invalid][quiet]) #textfield .input,
+:host([invalid][quiet]) #textfield .input:focus {
     border-color: var(
         --spectrum-textfield-m-quiet-texticon-border-color-invalid-mouse-focus,
         var(--spectrum-alias-input-border-color-invalid-mouse-focus)
     ); /* .is-focused.is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input,
    * .is-invalid.spectrum-Textfield--quiet .spectrum-Textfield-input:focus */
 }
-:host([focused][invalid][quiet]) .input,
-:host([invalid][quiet]) .input.focus-visible {
+:host([focused][invalid][quiet]) #textfield .input,
+:host([invalid][quiet]) #textfield .input.focus-visible {
     border-color: var(
         --spectrum-textfield-m-quiet-texticon-border-color-invalid-key-focus,
         var(--spectrum-alias-input-border-color-invalid-key-focus)
@@ -786,8 +786,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-input-border-color-invalid-key-focus)
         );
 }
-:host([focused][invalid][quiet]) .input,
-:host([invalid][quiet]) .input:focus-visible {
+:host([focused][invalid][quiet]) #textfield .input,
+:host([invalid][quiet]) #textfield .input:focus-visible {
     border-color: var(
         --spectrum-textfield-m-quiet-texticon-border-color-invalid-key-focus,
         var(--spectrum-alias-input-border-color-invalid-key-focus)
@@ -799,8 +799,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
             var(--spectrum-alias-input-border-color-invalid-key-focus)
         );
 }
-:host([disabled][quiet]) .input,
-:host([disabled][quiet]:hover) .input,
+:host([disabled][quiet]) #textfield .input,
+:host([disabled][quiet]) #textfield:hover .input,
 :host([quiet]) .input :disabled {
     background-color: var(
         --spectrum-textfield-m-quiet-texticon-background-color-disabled,

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -12,10 +12,24 @@ governing permissions and limitations under the License.
 
 @import './spectrum-textfield.css';
 
+:host {
+    display: inline-flex;
+    flex-direction: column;
+    width: var(
+        --spectrum-alias-single-line-width,
+        var(--spectrum-global-dimension-size-2400)
+    );
+}
+
 :host([multiline]) {
     resize: both;
 }
 
+#textfield {
+    width: 100%;
+}
+
+#textfield,
 textarea {
     resize: inherit;
 }

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -9,11 +9,14 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import '../sp-textfield.js';
 import { Textfield, TextfieldType } from '../';
 import { elementUpdated, expect, html, litFixture } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { sendMouse } from '../../../test/plugins/browser.js';
+import { findDescribedNode } from '../../../test/testing-helpers-a11y.js';
+import { HelpText } from '@spectrum-web-components/help-text';
+import '@spectrum-web-components/help-text/sp-help-text.js';
+import '../sp-textfield.js';
 
 describe('Textfield', () => {
     it('loads default textfield accessibly', async () => {
@@ -801,6 +804,85 @@ describe('Textfield', () => {
 
             expect(el.getAttribute('type')).equals('range');
             expect(el.type).equals('text');
+        });
+    });
+    describe('help text', () => {
+        const name = 'This is a textfield';
+        const description = 'This text helps you fill it out';
+        const descriptionNegative = 'This text helps you when invalid';
+        it('accepts help text in `slot="help-text"`', async () => {
+            const el = await litFixture(html`
+                <sp-textfield label=${name}>
+                    <sp-help-text slot="help-text">${description}</sp-help-text>
+                </sp-textfield>
+            `);
+
+            await elementUpdated(el);
+
+            await findDescribedNode(name, description);
+        });
+        it('accepts help text in `slot="help-text"` w/ own ID', async () => {
+            const el = await litFixture(html`
+                <sp-textfield label=${name}>
+                    <sp-help-text slot="help-text" id="help-text-id-1">
+                        ${description}
+                    </sp-help-text>
+                </sp-textfield>
+            `);
+
+            await elementUpdated(el);
+
+            await findDescribedNode(name, description);
+        });
+        it('manages neutral/negative help text pairs', async () => {
+            const el = await litFixture<Textfield>(html`
+                <sp-textfield label=${name}>
+                    <sp-help-text slot="help-text">${description}</sp-help-text>
+                    <sp-help-text slot="negative-help-text">
+                        ${descriptionNegative}
+                    </sp-help-text>
+                </sp-textfield>
+            `);
+            const negativeHelpText = el.querySelector(
+                '[slot="negative-help-text"]'
+            ) as HelpText;
+
+            await elementUpdated(el);
+
+            expect(negativeHelpText.variant).to.equal('neutral');
+            await findDescribedNode(name, description);
+
+            el.invalid = true;
+            await elementUpdated(el);
+
+            expect(negativeHelpText.variant).to.equal('negative');
+            await findDescribedNode(name, descriptionNegative);
+        });
+        it('manages neutral/negative help text pairs w/ own IDs', async () => {
+            const el = await litFixture<Textfield>(html`
+                <sp-textfield label=${name}>
+                    <sp-help-text slot="help-text" id="help-text-id-2">
+                        ${description}
+                    </sp-help-text>
+                    <sp-help-text slot="negative-help-text" id="help-text-id-3">
+                        ${descriptionNegative}
+                    </sp-help-text>
+                </sp-textfield>
+            `);
+            const negativeHelpText = el.querySelector(
+                '[slot="negative-help-text"]'
+            ) as HelpText;
+
+            await elementUpdated(el);
+
+            expect(negativeHelpText.variant).to.equal('neutral');
+            await findDescribedNode(name, description);
+
+            el.invalid = true;
+            await elementUpdated(el);
+
+            expect(negativeHelpText.variant).to.equal('negative');
+            await findDescribedNode(name, descriptionNegative);
         });
     });
 });

--- a/packages/textfield/textarea.md
+++ b/packages/textfield/textarea.md
@@ -119,3 +119,52 @@ Note: When leveraging the `quiet` attribute, the `grows` attribute does not effe
     </div>
 </div>
 ```
+
+## Help text
+
+Help text can be accessibly associated with an `<sp-textfield multiline>` element by using the `help-text` or `negative-help-text` slots. When using the `negative-help-text` slot, `<sp-textfield multiline>` will self manage the presence of this content based on the value of the `invalid` property on your `<sp-textfield multiline>` element. Content within the `help-text` slot will be show by default. When your `<sp-textfield multiline>` should receive help text based on state outside of the complexity of `invalid` or not, manage the content addressed to the `help-text` from above to ensure that it displays the right messaging and possesses the right `variant`.
+
+<sp-tabs selected="self" auto label="Help text usage in multiline textfields">
+<sp-tab value="self">Self managed</sp-tab>
+<sp-tab-panel value="self">
+
+```html
+<sp-field-label for="self">Stay "Positive"</sp-field-label>
+<sp-textfield
+    multiline
+    id="self"
+    pattern="[P][o][s][i][t][i][v][e]"
+    value="Positive"
+>
+    <sp-help-text slot="help-text">
+        Tell us how you are feeling today.
+    </sp-help-text>
+    <sp-help-text slot="negative-help-text">Please be "Positive".</sp-help-text>
+</sp-textfield>
+```
+
+</sp-tab-panel>
+<sp-tab value="above">Managed from above</sp-tab>
+<sp-tab-panel value="above">
+
+```html
+<sp-field-label for="managed">Stay "Positive"</sp-field-label>
+<sp-textfield
+    multiline
+    id="managed"
+    pattern="[P][o][s][i][t][i][v][e]"
+    value="Positive"
+    oninput='
+        const helpText = this.querySelector(`[slot="help-text"]`);
+        helpText.textContent = this.invalid ? `Please be "Positive".` : `Tell us how you are feeling today.`;
+        helpText.variant = this.invalid ? `negative` : `neutral`;
+    '
+>
+    <sp-help-text slot="help-text">
+        Tell us how you're feeling today.
+    </sp-help-text>
+</sp-textfield>
+```
+
+</sp-tab-panel>
+</sp-tabs>

--- a/projects/documentation/scripts/copy-component-docs.js
+++ b/projects/documentation/scripts/copy-component-docs.js
@@ -86,6 +86,19 @@ async function main() {
                 (declaration) => declaration.name === 'IconBase'
             );
         }
+        if (!tag && componentName.startsWith('textarea')) {
+            tag = findDeclaration(
+                customElements,
+                (declaration) => declaration.name === 'sp-textfield'
+            );
+        }
+        if (!tag && componentName.startsWith('help-text-mixin')) {
+            componentHeading = 'Help Text Mixin';
+            tag = findDeclaration(
+                customElements,
+                (declaration) => declaration.name === 'HelpTextManagedElement'
+            );
+        }
         const componentPath = path.resolve(destinationPath, componentName);
         fs.mkdirSync(componentPath, { recursive: true });
         // Support the full page delivery of "Examples" and "API"

--- a/projects/templates/plop-templates/package.json.hbs
+++ b/projects/templates/plop-templates/package.json.hbs
@@ -47,12 +47,6 @@
     "dependencies": {
         "tslib": "^2.0.0"
     },
-<<<<<<< HEAD
-=======
-    "devDependencies": {
-        "@spectrum-css/{{spectrumCSS name}}": "beta"
-    },
->>>>>>> chore: adopt DNA@7 base Spectrum CSS
     "types": "./src/index.d.ts",
     "sideEffects": [
         "./sp-*.js"

--- a/scripts/process-spectrum-postcss-plugin.js
+++ b/scripts/process-spectrum-postcss-plugin.js
@@ -114,7 +114,7 @@ class SpectrumProcessor {
 
         // If the first part of a selector references the host, then
         // add a :host wrapper
-        // e.g. ".spectrum-Button:hover" -> ":host(hover)"
+        // e.g. ".spectrum-Button:hover" -> ":host(:hover)"
         astTransforms.push((selector, rule) => {
             if (this.component.isRootSpectrumClass(selector.first)) {
                 const result = selector.clone();
@@ -291,7 +291,15 @@ class SpectrumProcessor {
                     node.parent.parent &&
                     node.parent.parent.type === 'pseudo'
                 ) {
-                    node.replaceWith(attribute.shadowNode.clone());
+                    if (!this.component.spectrumClassIsHost) {
+                        // Attributes in pseudo classes need to be on the :host, too.
+                        const treeRoot = node.parent.parent;
+                        treeRoot.remove();
+                        node.replaceWith(attribute.shadowNode.clone());
+                        addNodeToHost(result, treeRoot);
+                    } else {
+                        node.replaceWith(attribute.shadowNode.clone());
+                    }
                     return;
                 }
 

--- a/test/testing-helpers-a11y.ts
+++ b/test/testing-helpers-a11y.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { expect } from '@open-wc/testing';
+import { a11ySnapshot, findAccessibilityNode } from '@web/test-runner-commands';
+
+export type DescribedNode = {
+    name: string;
+    description: string;
+};
+
+export const findDescribedNode = async (
+    name: string,
+    description: string
+): Promise<void> => {
+    const isWebKit =
+        /AppleWebKit/.test(window.navigator.userAgent) &&
+        !/Chrome/.test(window.navigator.userAgent);
+
+    const snapshot = (await a11ySnapshot({})) as unknown as DescribedNode & {
+        children: DescribedNode[];
+    };
+
+    // WebKit doesn't currently associate the `aria-describedby` element to the attribute
+    // host in the accessibility tree. Give it an escape hatch for now.
+    const node = findAccessibilityNode(
+        snapshot,
+        (node) =>
+            node.name === name && (node.description === description || isWebKit)
+    );
+
+    expect(node).to.not.be.null;
+
+    if (isWebKit) {
+        // Retest WebKit without the escape hatch, expecting it to fail.
+        // This way we get notified when the results are as expected, again.
+        const iOSNode = findAccessibilityNode(
+            snapshot,
+            (node) => node.name === name && node.description === description
+        );
+        expect(iOSNode).to.be.null;
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4176,6 +4176,11 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-4.0.5.tgz#474c95381a2815f9404ae733e2aaff5d893daa8a"
   integrity sha512-q4qQaTQpOAsazvL355PZUspie6rG8U6Emcei5ZKYRigoBwO9mMmjp2T/7IHq43Dp11UU62ASFJTKHQTC+IWeOQ==
 
+"@spectrum-css/helptext@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-1.0.2.tgz#108d62e69bdfae63f83f2b66448d80d42abd2152"
+  integrity sha512-oVUb1An7W74XaGgvM/fyVHJjsXz3QJcfcl5vVVJlGhR79tb29EOYrgN+p/mhWlFM6mozDgLo3NBCKjGmtmdlAQ==
+
 "@spectrum-css/icon@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.9.tgz#6608239fb32a5c622c6c04d61fc185797e8e0410"
@@ -4326,7 +4331,7 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.17.tgz#a1a9b71d4714563ed016906be90e68f9b8809302"
   integrity sha512-Afqhc7k8HBqMZ8jkpvl1MqeWRzwrXcdFFkMHiTNPNaJrCYNETyVRlQvvZMNftXOxrzbg+49Ux6FUCFLINnwGwQ==
 
-"@spectrum-css/vars@^4.3.0":
+"@spectrum-css/vars@^4.0.2", "@spectrum-css/vars@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-4.3.0.tgz#03ddf67d3aa8a9a4cb0edbbd259465c9ced7e70d"
   integrity sha512-ZQ2XAhgu4G9yBeXQNDAz07Z8oZNnMt5o9vzf/mpBA7Teb/JI+8qXp2wt8D245SzmtNlFkG/bzRYvQc0scgZeCQ==
@@ -8131,7 +8136,7 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
-commander@^6.0.0, commander@^6.1.0:
+commander@^6.0.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
@@ -18367,27 +18372,7 @@ playwright-core@=1.16.3:
     yauzl "^2.10.0"
     yazl "^2.5.1"
 
-playwright@^1.14.0:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.15.2.tgz#b350056d1fffbe5de5b1bdaca6ab73e35758baad"
-  integrity sha512-+Z+7ckihyxR6rK5q8DWC6eUbKARfXpyxpjNcoJfgwSr64lAOzjhyFQiPC/JkdIqhsLgZjxpWfl1S7fLb+wPkgA==
-  dependencies:
-    commander "^6.1.0"
-    debug "^4.1.1"
-    extract-zip "^2.0.1"
-    https-proxy-agent "^5.0.0"
-    jpeg-js "^0.4.2"
-    mime "^2.4.6"
-    pngjs "^5.0.0"
-    progress "^2.0.3"
-    proper-lockfile "^4.1.1"
-    proxy-from-env "^1.1.0"
-    rimraf "^3.0.2"
-    stack-utils "^2.0.3"
-    ws "^7.4.6"
-    yazl "^2.5.1"
-
-playwright@^1.16.3:
+playwright@^1.14.0, playwright@^1.16.3:
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.16.3.tgz#27a292d9fa54fbac923998d3af58cd2b691f5ebe"
   integrity sha512-nfJx/OpIb/8OexL3rYGxNN687hGyaM3XNpfuMzoPlrekURItyuiHHsNhC9oQCx3JDmCn5O3EyyyFCnrZjH6MpA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,7 +4331,7 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.17.tgz#a1a9b71d4714563ed016906be90e68f9b8809302"
   integrity sha512-Afqhc7k8HBqMZ8jkpvl1MqeWRzwrXcdFFkMHiTNPNaJrCYNETyVRlQvvZMNftXOxrzbg+49Ux6FUCFLINnwGwQ==
 
-"@spectrum-css/vars@^4.0.2", "@spectrum-css/vars@^4.3.0":
+"@spectrum-css/vars@^4.3.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-4.3.0.tgz#03ddf67d3aa8a9a4cb0edbbd259465c9ced7e70d"
   integrity sha512-ZQ2XAhgu4G9yBeXQNDAz07Z8oZNnMt5o9vzf/mpBA7Teb/JI+8qXp2wt8D245SzmtNlFkG/bzRYvQc0scgZeCQ==


### PR DESCRIPTION
## Description
Add `<sp-help-text>` pattern.
- ship `HelpTextManager` helper class to support delivery of Help Text in other elements
- update `<sp-field-group>`, `<sp-number-field>`, `<sp-radio-group>`, `<sp-search>`, and `<sp-textfield>` to support this pattern
- add `findDescribedNode` helper to the unit testing suite to cover over eccentricities in WebKit support for described content

## Related issue(s)

- fixes #1704

## Motivation and context
If it's in Spectrum _AND_ Spectrum CSS it should likely be here! Also, we want to make your forms even nicer looking.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go to:
      - https://help-text--spectrum-web-components.netlify.app/components/help-text/
      - https://help-text--spectrum-web-components.netlify.app/components/field-group/
      - https://help-text--spectrum-web-components.netlify.app/components/radio/
      - https://help-text--spectrum-web-components.netlify.app/components/textfield/
      - https://help-text--spectrum-web-components.netlify.app/components/textarea/
    2. Experience the new element and its alignment with https://opensource.adobe.com/spectrum-css/helptext.html and https://spectrum.adobe.com/page/help-text/
-   [ ] _Test case 2_
    1. Go to https://help-text--spectrum-web-components.netlify.app/components/help-text/
    2. With the screen reader, make sure that the Help Text is read in association with the form element that it is placed within AS WELL AS singularly
    3. Toggle the validity to ensure that this content live updates as well

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

CC: @davidkudera 
