### PR TITLE
fix(number-field): prevent interaction with stepper buttons when disabled

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -249,7 +249,7 @@ export class NumberField extends TextfieldBase {
     }
 
     private stepBy(count: number): void {
-        if (this.readonly) {
+        if (this.disabled || this.readonly) {
             return;
         }
         const min = typeof this.min !== 'undefined' ? this.min : 0;

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -1083,6 +1083,46 @@ describe('NumberField', () => {
         expect(stepUp).to.be.null;
         expect(stepDown).to.be.null;
     });
+    describe('Disabled', () => {
+        let el: NumberField;
+        beforeEach(async () => {
+            el = await getElFrom(Default({ disabled: true, value: 1337 }));
+            expect(el.formattedValue).to.equal('1,337');
+            expect(el.valueAsString).to.equal('1337');
+            expect(el.value).to.equal(1337);
+            el.focus();
+            await elementUpdated(el);
+        });
+        afterEach(async () => {
+            await elementUpdated(el);
+            expect(el.formattedValue).to.equal('1,337');
+            expect(el.valueAsString).to.equal('1337');
+            expect(el.value).to.equal(1337);
+        });
+        it('presents as `disabled`', async () => {
+            await sendKeys({ type: '12345' });
+            await elementUpdated(el);
+            await sendKeys({ press: 'Enter' });
+        });
+        it('prevents increment via keyboard', async () => {
+            await sendKeys({ press: 'ArrowUp' });
+        });
+        it('prevents decrement via keyboard', async () => {
+            await sendKeys({ press: 'ArrowDown' });
+        });
+        it('prevents increment via scroll', async () => {
+            el.dispatchEvent(new WheelEvent('wheel', { deltaY: 1 }));
+        });
+        it('prevents decrement via scroll', async () => {
+            el.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+        });
+        it('prevents increment via stepper button', async () => {
+            await clickBySelector(el, '.stepUp');
+        });
+        it('prevents decrement via stepper button', async () => {
+            await clickBySelector(el, '.stepDown');
+        });
+    });
     describe('Readonly', () => {
         let el: NumberField;
         beforeEach(async () => {


### PR DESCRIPTION
## Description
Prevent interaction with stepper buttons when disabled

## Related issue(s)

- fixes #1928

## Motivation and context
Visitors shouldn't be allowed to interact with the number field in this state.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://numberfield-disabled--spectrum-web-components.netlify.app/storybook/index.html?path=/story/number-field--disabled
    2. Attempt to interact with the up or down arrow buttons
    3. You can't.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.