### PR TITLE
docs(dropzone): clarify usage of "tabindex" and remove it from available examples

### DIFF
--- a/packages/dropzone/README.md
+++ b/packages/dropzone/README.md
@@ -29,7 +29,7 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 ## Example
 
 ```html
-<sp-dropzone id="dropzone-1" tabindex="0" style="width: 400px; height: 200px">
+<sp-dropzone id="dropzone-1" style="width: 400px; height: 200px">
     <sp-illustrated-message heading="Drag and Drop Your File">
         <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -44,32 +44,27 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
     </sp-illustrated-message>
 
     <div>
-        <div>
-            <label for="file-input" onclick="this.nextElementSibling.click()">
-                <sp-link href="javascript:;">Select a File</sp-link>
-                from your computer
-            </label>
-            <input type="file" id="file-input" style="display: none" />
-        </div>
-        <div>
-            or
-            <sp-link href="http://stock.adobe.com" target="blank">
-                Search Adobe Stock
-            </sp-link>
-        </div>
+        <label for="file-input" onclick="this.nextElementSibling.click()">
+            <sp-link href="javascript:;">Select a File</sp-link>
+            from your computer
+        </label>
+        <input type="file" id="file-input" style="display: none" />
+    </div>
+    <div>
+        or
+        <sp-link href="http://stock.adobe.com" target="blank">
+            Search Adobe Stock
+        </sp-link>
     </div>
 </sp-dropzone>
 ```
 
 ### Dragged
 
+When a file is dragged over the `<sp-dropzone>` element, it will display with the `dragged` attribute, as follows:
+
 ```html
-<sp-dropzone
-    id="dropzone"
-    tabindex="0"
-    dragged
-    style="width: 400px; height: 200px"
->
+<sp-dropzone id="dropzone" dragged style="width: 400px; height: 200px">
     <sp-illustrated-message heading="Drag and Drop Your File">
         <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -84,19 +79,21 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
     </sp-illustrated-message>
 
     <div>
-        <div>
-            <label for="file-input" onclick="this.nextElementSibling.click()">
-                <sp-link href="javascript:;">Select a File</sp-link>
-                from your computer
-            </label>
-            <input type="file" id="file-input" style="display: none" />
-        </div>
-        <div>
-            or
-            <sp-link href="http://stock.adobe.com" target="blank">
-                Search Adobe Stock
-            </sp-link>
-        </div>
+        <label for="file-input" onclick="this.nextElementSibling.click()">
+            <sp-link href="javascript:;">Select a File</sp-link>
+            from your computer
+        </label>
+        <input type="file" id="file-input" style="display: none" />
+    </div>
+    <div>
+        or
+        <sp-link href="http://stock.adobe.com" target="blank">
+            Search Adobe Stock
+        </sp-link>
     </div>
 </sp-dropzone>
 ```
+
+## Accessibility
+
+When actions, e.g. copy/paste, can be enacted directly on the `<sp-dropzone>` element itself, be sure to supply a `tabindex` so that keyboard users can find this interaction in the tab order. For screen readers, supply appropriate `role` and `aria-label` attributes to clarify what these actions are and how to complete them.


### PR DESCRIPTION
## Description
This clarifies the use of `tabindex` while not commenting on the ability to use an `<sp-dropzone>` element without text, as this process isn't fully documented by Spectrum CSS.

## Related issue(s)

- fixes #1275

## Motivation and context
More accessible default examples of our elements.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://a11y-dropzone--spectrum-web-components.netlify.app/components/dropzone/
    2. See that the Dropzone elements themselves are no longer in the tab order
-   [ ] _Test case 2_
    1. Go to https://a11y-dropzone--spectrum-web-components.netlify.app/components/dropzone/#accessibility
    2. And learn about using `tabindex` responsibly with an `<sp-dropdown>` element.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.