### PR TITLE
fix(action-button): all "selected" Action Buttons should be "aria-pressed=true"

### DIFF
--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -64,9 +64,21 @@ export class ActionButton extends SizedMixin(ButtonBase) {
     @property({ type: Boolean, reflect: true })
     public quiet = false;
 
+    @property({ reflect: true })
+    public role = 'button';
+
+    /**
+     * Whether an Action Button with `role='button'`
+     * should also be `aria-pressed='true'`
+     */
     @property({ type: Boolean, reflect: true })
     public selected = false;
 
+    /**
+     * Whether to automatically manage the `selected`
+     * attribute on interaction and whether `aria-pressed="false"`
+     * should be used when `selected === false`
+     */
     @property({ type: Boolean, reflect: true })
     public toggles = false;
 
@@ -193,11 +205,22 @@ export class ActionButton extends SizedMixin(ButtonBase) {
 
     protected updated(changes: PropertyValues): void {
         super.updated(changes);
-        if (this.toggles && changes.has('selected')) {
-            this.focusElement.setAttribute(
-                'aria-pressed',
-                this.selected ? 'true' : 'false'
-            );
+        const isButton = this.role === 'button';
+        const canBePressed = isButton && (this.selected || this.toggles);
+        if (changes.has('selected') || changes.has('role')) {
+            // When role !== 'button' then the Action Button is within
+            // an Action Group that manages selects which means the
+            // Action Button is a "checkbox" or "radio" and cannot
+            // accept the `aria-pressed` attribute.
+            if (canBePressed) {
+                this.setAttribute(
+                    'aria-pressed',
+                    this.selected ? 'true' : 'false'
+                );
+            } else {
+                // When !this.toggles the lack of "aria-pressed" is inconsequential.
+                this.removeAttribute('aria-pressed');
+            }
         }
     }
 }

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -114,6 +114,34 @@ describe('ActionButton', () => {
         expect(el.selected).to.be.false;
         expect(button.hasAttribute('aria-pressed')).to.be.false;
     });
+    it('responds to [selected]', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button>Button</sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        const button = el.focusElement;
+
+        expect(el.toggles).to.be.false;
+        expect(el.selected).to.be.false;
+        expect(button.hasAttribute('aria-pressed')).to.be.false;
+
+        el.selected = true;
+        await elementUpdated(el);
+
+        expect(el.toggles).to.be.false;
+        expect(el.selected).to.be.true;
+        expect(button.getAttribute('aria-pressed')).to.equal('true');
+
+        el.selected = false;
+        await elementUpdated(el);
+
+        expect(el.toggles).to.be.false;
+        expect(el.selected).to.be.false;
+        expect(button.hasAttribute('aria-pressed')).to.be.false;
+    });
     it('toggles', async () => {
         const el = await fixture<ActionButton>(
             html`

--- a/yarn.lock
+++ b/yarn.lock
@@ -6314,15 +6314,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^4.0.2:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.1.tgz#0c6a076e4a1c3e0544ba6a9479158f9be7a7928e"
-  integrity sha512-3WVgVPs/7OnKU3s+lqMtkv3wQlg3WxK1YifmpJSDO0E1aPBrZWlrrTO6cxRqCXLuX2aYgCljqXIQd0VnRidV0g==
-
-axe-core@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.3.tgz#b55cd8e8ddf659fe89b064680e1c6a4dceab0325"
-  integrity sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==
+axe-core@4.3.5, axe-core@^4.0.2, axe-core@^4.3.3:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
+  integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
 
 axios@0.21.1:
   version "0.21.1"


### PR DESCRIPTION
## Description
Apply `aria-pressed="true"` to all Action Buttons that `role="button"`. Avoid adding this attribute when other roles are applied as they are not part of the expected accessibility tree in that case.

## Related issue(s)

- fixes #756

## Motivation and context
More accessibility by default.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://action-button-selected--spectrum-web-components.netlify.app/components/action-button/#sizes
    2. Add the `selected` attribute to one of the Action Buttons there
    3. See that the `aria-pressed=true` attribute is also applied.
-   [ ] _Test case 2_
    1. Go to https://action-button-selected--spectrum-web-components.netlify.app/components/action-group/#single
    2. See that the Action Button there with the `selected` attribute does not have `aria-pressed=true`
-   [ ] _Test case 3_
    1. Go to https://action-button-selected--spectrum-web-components.netlify.app/components/action-button/#toggles
    2. See that the Action Button there without the `selected` attribute continue to have `aria-pressed=false`

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
