### PR TITLE
docs(popover): expand dialog/open documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
         "rollup": "2.56.2",
         "rollup-plugin-workbox": "6.1.1"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/packages/popover/src/Popover.ts
+++ b/packages/popover/src/Popover.ts
@@ -28,14 +28,22 @@ import popoverStyles from './popover.css.js';
  * @element sp-popover
  *
  * @slot - content to display within the Popover
- * @attr {Boolean} open - The open state of the popover
- * @attr {Boolean} dialog - Adds some padding to the popover
  */
 export class Popover extends SpectrumElement {
     public static get styles(): CSSResultArray {
         return [popoverStyles];
     }
 
+    /**
+     * Whether the popover should manage the application
+     * of padding to its content or not.
+     */
+    @property({ type: Boolean, reflect: true })
+    public dialog = false;
+
+    /**
+     * Whether the popover is visible or not.
+     */
     @property({ type: Boolean, reflect: true })
     public open = false;
 


### PR DESCRIPTION
## Description
Expand documentation in the API table.

## Related issue(s)

- fixes #1277 

## Motivation and context
Packages should be understandable.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://a11y-popover--spectrum-web-components.netlify.app/components/popover/api/
    2. Read entry on `dialog` and `open`
    3. Be better prepared to consume this element

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
