### PR TITLE
Update send mouse usage

### DIFF
--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -27,7 +27,7 @@ import {
 import { Checkbox } from '@spectrum-web-components/checkbox/src/Checkbox';
 import { spy } from 'sinon';
 import { spaceEvent } from '../../../test/testing-helpers.js';
-import { executeServerCommand } from '@web/test-runner-commands';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('card', () => {
     it('loads', async () => {
@@ -165,7 +165,7 @@ describe('card', () => {
 
         const img = el.querySelector('img') as HTMLImageElement;
         const boundingRect = img.getBoundingClientRect();
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -217,7 +217,7 @@ describe('card', () => {
 
         const footer = el.querySelector('[slot="footer"]') as HTMLElement;
         let boundingRect = footer.getBoundingClientRect();
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -239,7 +239,7 @@ describe('card', () => {
         ) as HTMLElement;
         link.setAttribute('style', 'display: block');
         boundingRect = link.getBoundingClientRect();
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',

--- a/packages/menu/test/menu-item.test.ts
+++ b/packages/menu/test/menu-item.test.ts
@@ -22,8 +22,8 @@ import {
     html,
     waitUntil,
 } from '@open-wc/testing';
-import { executeServerCommand } from '@web/test-runner-commands';
 import { spy } from 'sinon';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Menu item', () => {
     it('renders', async () => {
@@ -59,7 +59,7 @@ describe('Menu item', () => {
 
         const disabled = el.querySelector('[disabled]') as MenuItem;
         const boundingRect = disabled.getBoundingClientRect();
-        executeServerCommand('send-mouse', {
+        sendMouse({
             steps: [
                 {
                     type: 'move',

--- a/packages/menu/test/menu-selects.test.ts
+++ b/packages/menu/test/menu-selects.test.ts
@@ -20,8 +20,9 @@ import {
     html,
     oneEvent,
 } from '@open-wc/testing';
-import { executeServerCommand, sendKeys } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import { spy } from 'sinon';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Menu [selects]', () => {
     let el!: Menu;
@@ -43,7 +44,7 @@ describe('Menu [selects]', () => {
             const item1 = options[0];
             const boundingRect = item1.getBoundingClientRect();
             const change = oneEvent(el, 'change');
-            executeServerCommand('send-mouse', {
+            sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -170,7 +171,7 @@ describe('Menu [selects] w/ group', () => {
             const item1 = options[0];
             const boundingRect = item1.getBoundingClientRect();
             const change = oneEvent(el, 'change');
-            executeServerCommand('send-mouse', {
+            sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -298,7 +299,7 @@ describe('Menu w/ group [selects]', () => {
             const item1 = options[0];
             const boundingRect = item1.getBoundingClientRect();
             const change = oneEvent(group, 'change');
-            executeServerCommand('send-mouse', {
+            sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -438,7 +439,7 @@ describe('Menu w/ groups [selects]', () => {
             expect(groupA.value).to.equal('');
             expect(groupB.value).to.equal('');
             let change = oneEvent(el, 'change');
-            executeServerCommand('send-mouse', {
+            sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -461,7 +462,7 @@ describe('Menu w/ groups [selects]', () => {
             expect(groupB.value).to.equal('');
             change = oneEvent(el, 'change');
             const boundingRectB = item1b.getBoundingClientRect();
-            executeServerCommand('send-mouse', {
+            sendMouse({
                 steps: [
                     {
                         type: 'move',

--- a/packages/number-field/test/helpers.ts
+++ b/packages/number-field/test/helpers.ts
@@ -12,9 +12,9 @@ governing permissions and limitations under the License.
 
 import { html, TemplateResult } from '@spectrum-web-components/base';
 import { elementUpdated, fixture, nextFrame } from '@open-wc/testing';
-import { executeServerCommand } from '@web/test-runner-commands';
 import { ProvideLang } from '@spectrum-web-components/theme';
 import { NumberField } from '../';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 export async function getElFrom(test: TemplateResult): Promise<NumberField> {
     const wrapped = await fixture<HTMLDivElement>(html`
@@ -34,7 +34,7 @@ export async function clickBySelector(
 ): Promise<void> {
     const target = el.shadowRoot.querySelector(selector) as HTMLElement;
     const targetRect = target.getBoundingClientRect();
-    await executeServerCommand('send-mouse', {
+    await sendMouse({
         steps: [
             {
                 type: 'move',
@@ -51,7 +51,7 @@ export async function clickBySelector(
         ],
     });
     await nextFrame();
-    await executeServerCommand('send-mouse', {
+    await sendMouse({
         steps: [
             {
                 type: 'up',

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -25,17 +25,14 @@ import {
 } from '../stories/number-field.stories.js';
 import '../sp-number-field.js';
 import { FRAMES_PER_CHANGE, indeterminatePlaceholder, NumberField } from '..';
-import {
-    executeServerCommand,
-    sendKeys,
-    setUserAgent,
-} from '@web/test-runner-commands';
+import { sendKeys, setUserAgent } from '@web/test-runner-commands';
 import { spy } from 'sinon';
 import {
     clickBySelector,
     createLanguageContext,
     getElFrom,
 } from './helpers.js';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('NumberField', () => {
     before(async () => {
@@ -450,7 +447,7 @@ describe('NumberField', () => {
                 '.stepUp'
             ) as HTMLElement;
             const buttonUpRect = buttonUp.getBoundingClientRect();
-            const buttonUpPosition = [
+            const buttonUpPosition: [number, number] = [
                 buttonUpRect.x + buttonUpRect.width / 2,
                 buttonUpRect.y + buttonUpRect.height / 2,
             ];
@@ -458,11 +455,11 @@ describe('NumberField', () => {
                 '.stepDown'
             ) as HTMLElement;
             const buttonDownRect = buttonDown.getBoundingClientRect();
-            const buttonDownPosition = [
+            const buttonDownPosition: [number, number] = [
                 buttonDownRect.x + buttonDownRect.width / 2,
                 buttonDownRect.y + buttonDownRect.height / 2,
             ];
-            executeServerCommand('send-mouse', {
+            sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -481,7 +478,7 @@ describe('NumberField', () => {
             expect(el.value).to.equal(52);
             expect(inputSpy.callCount).to.equal(2);
             expect(changeSpy.callCount).to.equal(0);
-            executeServerCommand('send-mouse', {
+            sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -497,7 +494,7 @@ describe('NumberField', () => {
             }
             expect(inputSpy.callCount).to.equal(4);
             expect(changeSpy.callCount).to.equal(0);
-            await executeServerCommand('send-mouse', {
+            await sendMouse({
                 steps: [
                     {
                         type: 'up',
@@ -517,7 +514,7 @@ describe('NumberField', () => {
         expect(el.value).to.equal(50);
         const buttonUp = el.shadowRoot.querySelector('.stepUp') as HTMLElement;
         const buttonUpRect = buttonUp.getBoundingClientRect();
-        const buttonUpPosition = [
+        const buttonUpPosition: [number, number] = [
             buttonUpRect.x + buttonUpRect.width / 2,
             buttonUpRect.y + buttonUpRect.height / 2,
         ];
@@ -525,15 +522,15 @@ describe('NumberField', () => {
             '.stepDown'
         ) as HTMLElement;
         const buttonDownRect = buttonDown.getBoundingClientRect();
-        const buttonDownPosition = [
+        const buttonDownPosition: [number, number] = [
             buttonDownRect.x + buttonDownRect.width / 2,
             buttonDownRect.y + buttonDownRect.height / 2,
         ];
-        const outsidePosition = [
+        const outsidePosition: [number, number] = [
             buttonDownRect.x + buttonDownRect.width + 5,
             buttonDownRect.y + buttonDownRect.height + 5,
         ];
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -550,7 +547,7 @@ describe('NumberField', () => {
         expect(el.valueAsString).to.equal(String(value));
         expect(el.value).to.equal(value);
         inputSpy.resetHistory();
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -563,7 +560,7 @@ describe('NumberField', () => {
         expect(el.valueAsString).to.equal(String(value));
         expect(el.value).to.equal(value);
         inputSpy.resetHistory();
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -582,7 +579,7 @@ describe('NumberField', () => {
         expect(el.valueAsString).to.equal(String(value));
         expect(el.value).to.equal(value);
         inputSpy.resetHistory();
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'up',

--- a/packages/overlay/test/overlay-trigger-hover-click.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover-click.test.ts
@@ -12,13 +12,15 @@ governing permissions and limitations under the License.
 import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import { OverlayTrigger } from '../src/OverlayTrigger';
 import { TriggerInteractions } from '../src/overlay-types';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { ActionButton } from '@spectrum-web-components/action-button';
-import { executeServerCommand } from '@web/test-runner-commands';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Overlay Trigger - Hover and Click', () => {
     it('toggles open and closed on click', async () => {
@@ -73,7 +75,7 @@ describe('Overlay Trigger - Hover and Click', () => {
 
         // hover over the button to trigger the tooltip
         const hoveredEvent = oneEvent(el, 'sp-opened');
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',

--- a/packages/overlay/test/overlay.test.ts
+++ b/packages/overlay/test/overlay.test.ts
@@ -26,12 +26,13 @@ import {
     oneEvent,
     waitUntil,
 } from '@open-wc/testing';
-import { executeServerCommand, sendKeys } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import {
     definedOverlayElement,
     virtualElement,
 } from '../stories/overlay.stories';
 import { PopoverContent } from '../stories/overlay-story-components.js';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Overlays', () => {
     let testDiv!: HTMLDivElement;
@@ -536,7 +537,7 @@ describe('Overlay - type="modal"', () => {
         const height = window.innerHeight;
         let opened = oneEvent(document, 'sp-opened');
         // Right click to over "context menu" overlay.
-        executeServerCommand('send-mouse', {
+        sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -566,7 +567,7 @@ describe('Overlay - type="modal"', () => {
         // Right click to out of the "context menu" overlay to both close
         // the first overlay and have the event passed to the surfacing page
         // in order to open a subsequent "context menu" overlay.
-        executeServerCommand('send-mouse', {
+        sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -595,7 +596,7 @@ describe('Overlay - type="modal"', () => {
         expect(secondOverlay.isConnected).to.be.true;
         expect(secondHeadline.textContent).to.equal('Menu source: start');
         closed = oneEvent(document, 'sp-closed');
-        executeServerCommand('send-mouse', {
+        sendMouse({
             steps: [
                 {
                     type: 'move',

--- a/packages/picker/test/picker-sync.test.ts
+++ b/packages/picker/test/picker-sync.test.ts
@@ -40,11 +40,11 @@ import {
 } from '../../../test/testing-helpers.js';
 import {
     a11ySnapshot,
-    executeServerCommand,
     findAccessibilityNode,
     sendKeys,
 } from '@web/test-runner-commands';
 import { iconsOnly } from '../stories/picker.stories.js';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 const isMenuActiveElement = function (): boolean {
     return document.activeElement instanceof Menu;
@@ -310,7 +310,7 @@ describe('Picker, sync', () => {
 
             expect(firstItem.focused, 'not visually focused').to.be.false;
             let opened = oneEvent(el, 'sp-opened');
-            await executeServerCommand('send-mouse', {
+            await sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -330,7 +330,7 @@ describe('Picker, sync', () => {
             await opened;
             expect(el.open).to.be.true;
             const closed = oneEvent(el, 'sp-closed');
-            await executeServerCommand('send-mouse', {
+            await sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -351,7 +351,7 @@ describe('Picker, sync', () => {
 
             expect(el.open).to.be.false;
             opened = oneEvent(el, 'sp-opened');
-            await executeServerCommand('send-mouse', {
+            await sendMouse({
                 steps: [
                     {
                         type: 'move',

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -40,11 +40,11 @@ import {
 } from '../../../test/testing-helpers.js';
 import {
     a11ySnapshot,
-    executeServerCommand,
     findAccessibilityNode,
     sendKeys,
 } from '@web/test-runner-commands';
 import { iconsOnly } from '../stories/picker.stories.js';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 const isMenuActiveElement = function (): boolean {
     return document.activeElement instanceof Menu;
@@ -310,7 +310,7 @@ describe('Picker, sync', () => {
 
             expect(firstItem.focused, 'not visually focused').to.be.false;
             let opened = oneEvent(el, 'sp-opened');
-            await executeServerCommand('send-mouse', {
+            await sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -330,7 +330,7 @@ describe('Picker, sync', () => {
             await opened;
             expect(el.open).to.be.true;
             const closed = oneEvent(el, 'sp-closed');
-            await executeServerCommand('send-mouse', {
+            await sendMouse({
                 steps: [
                     {
                         type: 'move',
@@ -351,7 +351,7 @@ describe('Picker, sync', () => {
 
             expect(el.open).to.be.false;
             opened = oneEvent(el, 'sp-opened');
-            await executeServerCommand('send-mouse', {
+            await sendMouse({
                 steps: [
                     {
                         type: 'move',

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -26,11 +26,8 @@ import {
     pageDownEvent,
     pageUpEvent,
 } from '../../../test/testing-helpers.js';
-import {
-    a11ySnapshot,
-    executeServerCommand,
-    findAccessibilityNode,
-} from '@web/test-runner-commands';
+import { a11ySnapshot, findAccessibilityNode } from '@web/test-runner-commands';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Radio Group - focus control', () => {
     it('does not accept focus when empty', async () => {
@@ -90,7 +87,7 @@ describe('Radio Group - focus control', () => {
         expect(first.tabIndex).to.equal(-1);
 
         const firstRect = first.getBoundingClientRect();
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',

--- a/packages/radio/test/radio.test.ts
+++ b/packages/radio/test/radio.test.ts
@@ -20,7 +20,7 @@ import {
     triggerBlurFor,
     waitUntil,
 } from '@open-wc/testing';
-import { executeServerCommand } from '@web/test-runner-commands';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 function labelNodeForRadio(radio: Radio): Node {
     if (!radio.shadowRoot) throw new Error('No shadowRoot');
@@ -143,11 +143,11 @@ describe('Radio', () => {
         });
         it('imperatively', async () => {
             const boundingClientRecrt = el.getBoundingClientRect();
-            const radioPosition = [
+            const radioPosition: [number, number] = [
                 boundingClientRecrt.x + boundingClientRecrt.width / 2,
                 boundingClientRecrt.y + boundingClientRecrt.height / 2,
             ];
-            await executeServerCommand('send-mouse', {
+            await sendMouse({
                 steps: [
                     {
                         type: 'move',

--- a/packages/sidenav/test/sidenav.test.ts
+++ b/packages/sidenav/test/sidenav.test.ts
@@ -29,7 +29,7 @@ import {
 } from '@open-wc/testing';
 import { LitElement, TemplateResult } from '@spectrum-web-components/base';
 import { spy } from 'sinon';
-import { executeServerCommand } from '@web/test-runner-commands';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Sidenav', () => {
     it('loads', async () => {
@@ -370,7 +370,7 @@ describe('Sidenav', () => {
         expect(firstItem.tabIndex).to.equal(-1);
 
         const firstRect = firstItem.getBoundingClientRect();
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -22,22 +22,11 @@ import {
     nextFrame,
     oneEvent,
 } from '@open-wc/testing';
-import { executeServerCommand, sendKeys } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
 import { ProvideLang } from '@spectrum-web-components/theme';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Slider', () => {
-    // At least one browser (Webkit) maintains shared global state for the mouse,
-    // such that `send-mouse` type: 'down' without subsequently sending 'up'
-    // can prevent a subsequent test from sending 'down' correctly.
-    afterEach(async () => {
-        await executeServerCommand('send-mouse', {
-            steps: [
-                {
-                    type: 'up',
-                },
-            ],
-        });
-    });
     it('loads', async () => {
         const el = await fixture<Slider>(
             html`
@@ -353,7 +342,7 @@ describe('Slider', () => {
         expect(el.value).to.equal(10);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -504,17 +493,19 @@ describe('Slider', () => {
                 </sp-slider>
             `
         );
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
 
         expect(el.value).to.equal(10);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         const handleBoundingRect = handle.getBoundingClientRect();
-        const position = [
+        const position: [number, number] = [
             handleBoundingRect.x + handleBoundingRect.width / 2,
             handleBoundingRect.y + handleBoundingRect.height / 2,
         ];
-
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -528,11 +519,11 @@ describe('Slider', () => {
 
         await nextFrame();
 
-        expect(el.dragging, 'dragging').to.be.true;
         expect(el.highlight, 'with no highlight').to.be.false;
+        expect(el.dragging, 'dragging').to.be.true;
 
         let inputEvent = oneEvent(el, 'input');
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -548,7 +539,7 @@ describe('Slider', () => {
         expect(el.value).to.equal(8);
 
         inputEvent = oneEvent(el, 'input');
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -12,7 +12,8 @@ governing permissions and limitations under the License.
 import '../sp-textfield.js';
 import { Textfield, TextfieldType } from '../';
 import { elementUpdated, expect, html, litFixture } from '@open-wc/testing';
-import { executeServerCommand, sendKeys } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Textfield', () => {
     it('loads default textfield accessibly', async () => {
@@ -115,7 +116,7 @@ describe('Textfield', () => {
         );
         const startBounds = el.getBoundingClientRect();
 
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -151,7 +152,7 @@ describe('Textfield', () => {
         );
         const startBounds = el.getBoundingClientRect();
 
-        await executeServerCommand('send-mouse', {
+        await sendMouse({
             steps: [
                 {
                     type: 'move',

--- a/test/plugins/browser.ts
+++ b/test/plugins/browser.ts
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { executeServerCommand } from '@web/test-runner-commands';
+import type { Step } from './send-mouse-plugin.js';
+
+/**
+ * Return the mouse to the `up` position.
+ */
+async function mouseCleanup() {
+    await executeServerCommand('send-mouse', {
+        steps: [
+            {
+                type: 'up',
+            },
+        ],
+    });
+}
+
+/**
+ * If available, add cleanup work to the `afterEach` and `after` commands.
+ */
+function queueMouseCleanUp() {
+    if (mouseCleanupQueued) return;
+    /**
+     * This registers the fixture cleanup as a side effect
+     */
+    try {
+        // we should not assume that our users load mocha types globally
+        // @ts-ignore
+        if ('afterEach' in window && 'after' in window) {
+            mouseCleanupQueued = true;
+            // @ts-ignore
+            afterEach(async function () {
+                // @ts-ignore
+                await mouseCleanup();
+            });
+            // @ts-ignore
+            after(() => {
+                mouseCleanupQueued = false;
+            });
+        }
+    } catch (error) {
+        /* do nothing */
+    }
+}
+
+let mouseCleanupQueued = false;
+
+/**
+ * Call to the browser with instructions for interacting with the pointing
+ * device while queueing cleanup of those commands after the test is run.
+ */
+export function sendMouse(options: { steps: Step[] }) {
+    queueMouseCleanUp();
+    return executeServerCommand('send-mouse', options);
+}

--- a/test/plugins/send-mouse-plugin.ts
+++ b/test/plugins/send-mouse-plugin.ts
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 import type { Page } from 'playwright';
 
-type Step = {
+export type Step = {
     type: 'move' | 'down' | 'up' | 'click';
     position?: [number, number];
     options?: { button?: 'left' | 'right' | 'middle' };


### PR DESCRIPTION
## Description
Create a `sendMouse` helper method that enacts the command while also submitting a clean up call to run after the test.
- apply this helper to all `send-mouse` plugin usage locations

## Related issue(s)

- fixes #1784 

## Motivation and context
Less likely to have surprising test errors based on mouse context and location.

## How has this been tested?
-   [ ] _Test case 1_
    1. Tests ran in CI
    2. Feel free to try them locally.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
