### PR TITLE
Support `self-managed` Tooltip elements with `delay`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 666d21b55a3fd9430adbe0c2fd46c54d0af25712
+        default: c32d1d08afc9ea82d29cbc21fdd2931d14fbcdfa
 commands:
     downstream:
         steps:

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
         "cssnano/**/postcss-calc": "7.0.0",
         "rollup-plugin-workbox": "6.1.1"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "new-package": "cd projects/templates && plop",
         "postcustom-element-json": "lerna exec --ignore \"{@spectrum-web-components/{base,bundle,icons-ui,icons-workflow,iconset,modal,shared,styles},documentation,example-project-rollup,example-project-webpack,swc-templates}\" -- test -f custom-elements.json",
         "postdocs:analyze": "node ./scripts/add-custom-properties.js --src=\"projects/documentation/custom-elements.json\"",
-        "postinstall": "yarn get-ready",
+        "postinstall": "patch-package && yarn get-ready",
         "postprocess-spectrum": "pretty-quick --pattern \"packages/**/*.css\"",
         "precustom-element-json": "lerna exec --ignore \"{@spectrum-web-components/{base,bundle,iconset,modal,shared,styles},documentation,example-project-rollup,example-project-webpack,swc-templates}\" -- rm custom-elements.json ||:",
         "preeleventy": "yarn docs:analyze",

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -114,14 +114,15 @@ export class Tooltip extends SpectrumElement {
     private _proxy!: HTMLElement;
 
     private generateProxy(): void {
-        if (!this._proxy) {
-            this._proxy = document.createElement('tooltip-proxy');
-            this._proxy.id = this._tooltipId;
-            this._proxy.hidden = true;
-            this._proxy.slot = 'hidden-tooltip-content';
-            this._proxy.setAttribute('role', 'tooltip');
-            this._proxy.addEventListener('disconnected', this.closeOverlay);
+        if (this._proxy) {
+            return;
         }
+        this._proxy = document.createElement('tooltip-proxy');
+        this._proxy.id = this._tooltipId;
+        this._proxy.hidden = true;
+        this._proxy.slot = 'hidden-tooltip-content';
+        this._proxy.setAttribute('role', 'tooltip');
+        this._proxy.addEventListener('disconnected', this.closeOverlay);
     }
 
     public overlayWillOpenCallback({

--- a/packages/tooltip/src/tooltip.css
+++ b/packages/tooltip/src/tooltip.css
@@ -19,10 +19,6 @@ governing permissions and limitations under the License.
     border: none;
 }
 
-:host([self-managed]:not([aria-hidden])) {
-    display: none;
-}
-
 :host([placement*='right']) #tip,
 :host([placement*='left']) #tip,
 :host([placement*='bottom']) #tip {

--- a/packages/tooltip/stories/tooltip.stories.ts
+++ b/packages/tooltip/stories/tooltip.stories.ts
@@ -259,6 +259,10 @@ const overlayStyles = html`
             flex: none;
             margin: 24px 0;
         }
+
+        .self-managed:nth-child(3) {
+            margin-left: 50px;
+        }
     </style>
 `;
 
@@ -304,7 +308,7 @@ export const selfManaged = ({
     delayed,
 }: Properties): TemplateResult => html`
     ${overlayStyles}
-    <sp-action-button>
+    <sp-action-button class="self-managed">
         This is a button.
         <sp-tooltip
             self-managed

--- a/packages/tooltip/test/tooltip.test.ts
+++ b/packages/tooltip/test/tooltip.test.ts
@@ -48,7 +48,7 @@ describe('Tooltip', () => {
         const el = button.querySelector('sp-tooltip') as Tooltip;
 
         await elementUpdated(el);
-        await expect(el).to.be.accessible();
+        await expect(button).to.be.accessible();
 
         const opened = oneEvent(button, 'sp-opened');
         button.focus();
@@ -56,7 +56,7 @@ describe('Tooltip', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.true;
-        await expect(el).to.be.accessible();
+        await expect(button).to.be.accessible();
 
         const closed = oneEvent(button, 'sp-closed');
         button.blur();
@@ -64,6 +64,36 @@ describe('Tooltip', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.false;
+    });
+    it('cleans up when self manages', async () => {
+        const button = await fixture<Button>(
+            html`
+                <sp-button>
+                    This is a button.
+                    <sp-tooltip self-managed>Help text.</sp-tooltip>
+                </sp-button>
+            `
+        );
+
+        const el = button.querySelector('sp-tooltip') as Tooltip;
+
+        await elementUpdated(el);
+
+        const opened = oneEvent(button, 'sp-opened');
+        button.focus();
+        await opened;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        let activeOverlay = document.querySelector('active-overlay');
+        expect(activeOverlay).to.not.be.null;
+
+        const closed = oneEvent(button, 'sp-closed');
+        button.remove();
+        await closed;
+
+        activeOverlay = document.querySelector('active-overlay');
+        expect(activeOverlay).to.be.null;
     });
     it('accepts variants', async () => {
         const el = await fixture<Tooltip>(

--- a/patches/@popperjs+core+2.10.2.patch
+++ b/patches/@popperjs+core+2.10.2.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@popperjs/core/dist/esm/modifiers/computeStyles.js b/node_modules/@popperjs/core/dist/esm/modifiers/computeStyles.js
+index 4434402..6379324 100644
+--- a/node_modules/@popperjs/core/dist/esm/modifiers/computeStyles.js
++++ b/node_modules/@popperjs/core/dist/esm/modifiers/computeStyles.js
+@@ -22,8 +22,8 @@ function roundOffsetsByDPR(_ref) {
+   var win = window;
+   var dpr = win.devicePixelRatio || 1;
+   return {
+-    x: round(round(x * dpr) / dpr) || 0,
+-    y: round(round(y * dpr) / dpr) || 0
++    x: round(x * dpr) / dpr || 0,
++    y: round(y * dpr) / dpr || 0,
+   };
+ }
+ 
+@@ -88,6 +88,10 @@ export function mapToStyles(_ref2) {
+     position: position
+   }, adaptive && unsetSides);
+ 
++  ({x, y} = roundOffsets === true ? roundOffsetsByDPR({x, y}) : {x, y});
++
++  console.log(x,y);
++
+   if (gpuAcceleration) {
+     var _Object$assign;
+ 


### PR DESCRIPTION
## Description
- apply a `slot` attribute whenever `self-managed` to ensure it is hidden _until_ overlaid
- support adding proxy to where `sp-tooltip` was for more predicable styling
- patch-package `@popperjs/core` to support sub-pixel fix in https://github.com/popperjs/popper-core/pull/1418
- add `tooltip-proxy` element to support knowing when an `sp-tooptip` trigger has been removed from the DOM
- reorganize code path to leverage a single proxy element
- add unit test for cleanup
- add storybook rules to confirm proxy placement in DOM

## Motivation and context
Nicer to use tooltips

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://tooltip-delay--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--self-managed&args=placement:top;offset:6;delayed:false
    2. Without interacting with the Tooltip story, navigate to a second story
    3. See the the tooltip has been cleaned up
-   [ ] _Test case 2_
    1. Go to https://tooltip-delay--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--self-managed&args=placement:top;offset:6;delayed:false
    2. Switch `delayed` to `true` in the Controls
    3. Click the page or hover out of the button to close the tooltip
    4. Wait a little bit to cool the timer
    5. Hover the button
    6. See that the button doesn't become misshapen during the delay warm up

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.