### PR TITLE
fix(color-area): remove deprecated "label" attribute/property

### DIFF
--- a/packages/color-area/README.md
+++ b/packages/color-area/README.md
@@ -69,8 +69,6 @@ An `<sp-color-area>`’s height and width can be customized appropriately for it
 An `<sp-color-area>` renders accessible labels for each axis: _"saturation"_ and _"luminosity"_.
 Specify `label-x` and `label-y` attributes to override these defaults.
 
-The `label` attribute is **deprecated** in favor of separately labeling each axis.
-
 ```html
 <sp-color-area
     label-x="Color intensity"

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -50,9 +50,6 @@ export class ColorArea extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public focused = false;
 
-    @property({ type: String })
-    public label: string | undefined;
-
     @property({ type: String, attribute: 'label-x' })
     public labelX = 'saturation';
 
@@ -487,7 +484,7 @@ export class ColorArea extends SpectrumElement {
                     type="range"
                     class="slider"
                     name="x"
-                    aria-label=${this.label ?? this.labelX}
+                    aria-label=${this.labelX}
                     min="0"
                     max="1"
                     step=${this.step}
@@ -502,7 +499,7 @@ export class ColorArea extends SpectrumElement {
                     type="range"
                     class="slider"
                     name="y"
-                    aria-label=${this.label ?? this.labelY}
+                    aria-label=${this.labelY}
                     min="0"
                     max="1"
                     step=${this.step}

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -109,20 +109,25 @@ describe('ColorArea', () => {
         expect(inputX?.getAttribute('aria-label')).to.equal('saturation');
         expect(inputY?.getAttribute('aria-label')).to.equal('luminosity');
     });
-    it('overrides both X and Y labels with a provided "label" attribute', async () => {
+    it('overrides both X and Y labels with a provided custom attributes', async () => {
         const el = await fixture<ColorArea>(
             html`
                 <sp-color-area
                     color="hsl(100, 50%, 50%)"
-                    label="something custom"
+                    label-x="something custom, saturation"
+                    label-y="something custom, luminosity"
                 ></sp-color-area>
             `
         );
         const inputX = el.shadowRoot.querySelector('input[name="x"]');
         const inputY = el.shadowRoot.querySelector('input[name="y"]');
 
-        expect(inputX?.getAttribute('aria-label')).to.equal('something custom');
-        expect(inputY?.getAttribute('aria-label')).to.equal('something custom');
+        expect(inputX?.getAttribute('aria-label')).to.equal(
+            'something custom, saturation'
+        );
+        expect(inputY?.getAttribute('aria-label')).to.equal(
+            'something custom, luminosity'
+        );
     });
     it('accepts "color" values as hsl', async () => {
         const el = await fixture<ColorArea>(


### PR DESCRIPTION
BREAKING CHANGE: set labels via the label-x/label-y attributes or labelX/labelY properties

## Description
Remove deprecated `label` attribute/property in favor of the `label-x`/`labelX` and `label-y`/labelY` attribute/properties.

## Related issue(s)

- #1802

## Motivation and context
Clean API.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://color-area-label--spectrum-web-components.netlify.app/components/color-area/
    2. Add a `label` attribute to an `sp-color-area` element
    3. See that this value isn't propagated to the internal `<input>` elements' `aria-label` attributes.

## Types of changes
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.