### PR TITLE
test: add time before querying accessibility tree

### DIFF
--- a/test/testing-helpers-a11y.ts
+++ b/test/testing-helpers-a11y.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { expect } from '@open-wc/testing';
+import { expect, nextFrame } from '@open-wc/testing';
 import { a11ySnapshot, findAccessibilityNode } from '@web/test-runner-commands';
 
 export type DescribedNode = {
@@ -22,6 +22,8 @@ export const findDescribedNode = async (
     name: string,
     description: string
 ): Promise<void> => {
+    await nextFrame();
+
     const isWebKit =
         /AppleWebKit/.test(window.navigator.userAgent) &&
         !/Chrome/.test(window.navigator.userAgent);


### PR DESCRIPTION
## Description
These tests were flaking, and need a little extra time being the snapshot can't be taken until after the async update cycle and the async slotchange event timing is completed. The browser also needs a little time to register the new accessibility tree, so this seems like the right call...

## Motivation and context
Tests were flaky.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://app.circleci.com/pipelines/github/adobe/spectrum-web-components?branch=help-text-timing
    2. See that all of the flaky test failures agains this branch have been _other_ flaky tests...

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.