### PR TITLE
docs: include description and type for all event listing in the docs

### DIFF
--- a/packages/accordion/src/AccordionItem.ts
+++ b/packages/accordion/src/AccordionItem.ts
@@ -26,6 +26,7 @@ import styles from './accordion-item.css.js';
 /**
  * @element sp-accordion-item
  * @slot - The content of the item that is hidden when the item is not open
+ * @fires sp-accordion-item-toggle - Announce that an accordion item has been toggled while allowing the event to be cancelled.
  */
 export class AccordionItem extends Focusable {
     public static get styles(): CSSResultArray {

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -38,6 +38,8 @@ import styles from './color-area.css.js';
 /**
  * @element sp-color-area
  * @slot gradient - a custom gradient visually outlining the available color values
+ * @fires input - The value of the Color Area has changed.
+ * @fires change - An alteration to the value of the Color Area has been committed by the user.
  */
 export class ColorArea extends SpectrumElement {
     public static get styles(): CSSResultArray {

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -36,6 +36,8 @@ import { TinyColor } from '@ctrl/tinycolor';
 /**
  * @element sp-color-slider
  * @slot gradient - a custom gradient visually outlining the available color values
+ * @fires input - The value of the Color Slider has changed.
+ * @fires change - An alteration to the value of the Color Slider has been committed by the user.
  */
 export class ColorSlider extends Focusable {
     public static get styles(): CSSResultArray {

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -37,6 +37,8 @@ import { TinyColor } from '@ctrl/tinycolor';
 /**
  * @element sp-color-wheel
  * @slot gradient - a custom gradient visually outlining the available color values
+ * @fires input - The value of the Color Wheel has changed.
+ * @fires change - An alteration to the value of the Color Wheel has been committed by the user.
  */
 export class ColorWheel extends Focusable {
     public static get styles(): CSSResultArray {

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -74,7 +74,7 @@ export class NumberField extends TextfieldBase {
     _forcedUnit = '';
 
     /**
-     * An `<sp-number-field>` element will process its numeric value with
+     * An `&lt;sp-number-field&gt;` element will process its numeric value with
      * `new Intl.NumberFormat(this.resolvedLanguage, this.formatOptions).format(this.valueAsNumber)`
      * in order to prepare it for visual delivery in the input. In order to customize this
      * processing supply your own `Intl.NumberFormatOptions` object here.

--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -35,7 +35,7 @@ import radioStyles from './radio.css.js';
  * @attr checked - Represents when the input is checked
  * @attr value - Identifies this radio button within its radio group
  *
- * @event sp-radio:change - When the input is interacted with and its state is changed
+ * @fires change - When the input is interacted with and its state is changed
  */
 export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public static get styles(): CSSResultArray {

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -26,6 +26,8 @@ import { Radio } from './Radio.js';
  * @slot - The `sp-radio` elements to display/manage in the group.
  * @slot help-text - default or non-negative help text to associate to your form element
  * @slot negative-help-text - negative help text to associate to your form element when `invalid`
+ *
+ * @fires change - An alteration to the value of the element has been committed by the user.
  */
 export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
     @property({ type: String })

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -34,6 +34,8 @@ const stopPropagation = (event: Event): void => event.stopPropagation();
  * @element sp-search
  * @slot help-text - default or non-negative help text to associate to your form element
  * @slot negative-help-text - negative help text to associate to your form element when `invalid`
+ *
+ * @fires submit - The search form has been submitted.
  */
 export class Search extends Textfield {
     public static get styles(): CSSResultArray {

--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -70,6 +70,9 @@ const MaxConverter = {
 
 /**
  * @element sp-slider-handle
+ *
+ * @fires input - The value of the element has changed.
+ * @fires change - An alteration to the value of the element has been committed by the user.
  */
 export class SliderHandle extends Focusable {
     public handleController?: Controller;

--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -68,6 +68,9 @@ export class Tab extends FocusVisiblePolyfillMixin(
     public value = '';
 
     protected handleContentChange(): void {
+        /**
+         * When the content in a tab has changed, JS powered layout related to that content may also need to be changed.
+         */
         this.dispatchEvent(
             new Event('sp-tab-contentchange', {
                 bubbles: true,

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -48,6 +48,8 @@ const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
  * @slot tab-panel - Tab Panel elements related to the listed Tab elements
  * @attr {Boolean} quiet - The tabs border is a lot smaller
  * @attr {Boolean} compact - The collection of tabs take up less space
+ *
+ * @fires change - The selected Tab child has changed.
  */
 export class Tabs extends SizedMixin(Focusable) {
     public static get styles(): CSSResultArray {

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -38,6 +38,10 @@ import checkmarkStyles from '@spectrum-web-components/icon/src/spectrum-icon-che
 const textfieldTypes = ['text', 'url', 'tel', 'email', 'password'] as const;
 export type TextfieldType = typeof textfieldTypes[number];
 
+/**
+ * @fires input - The value of the element has changed.
+ * @fires change - An alteration to the value of the element has been committed by the user.
+ */
 export class TextfieldBase extends ManageHelpText(Focusable) {
     public static get styles(): CSSResultArray {
         return [textfieldStyles, checkmarkStyles];

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -46,6 +46,8 @@ export type ToastVariants =
  *
  * @slot - The toast content
  * @slot action - button element surfacing an action in the Toast
+ *
+ * @fires close - Announces that the Toast has been closed.
  */
 
 export class Toast extends SpectrumElement {

--- a/packages/tray/src/Tray.ts
+++ b/packages/tray/src/Tray.ts
@@ -30,6 +30,8 @@ import styles from './tray.css.js';
  * @element sp-tray
  *
  * @slot - content to display within the Tray
+ *
+ * @fires close - Announces that the Tray has been closed.
  */
 export class Tray extends SpectrumElement {
     public static get styles(): CSSResultArray {

--- a/projects/documentation/scripts/component-template-parts.js
+++ b/projects/documentation/scripts/component-template-parts.js
@@ -143,13 +143,27 @@ ${
 ${
     tag.events &&
     tag.events.length &&
-    tag.events.filter((tag) => tag.privacy !== 'private').length
+    tag.events.filter(
+        (tag) =>
+            tag.privacy !== 'private' &&
+            tag.type !== 'click' &&
+            tag.description !==
+                'Trick :focus-visible polyfill into thinking keyboard based focus'
+    ).length
         ? buildTable(
               'Events',
-              tag.events.filter((tag) => tag.privacy !== 'private'),
-              ['Name', 'Description'],
+              tag.events.filter(
+                  (tag) =>
+                      tag.privacy !== 'private' &&
+                      tag.type !== 'click' &&
+                      tag.description !==
+                          'Trick :focus-visible polyfill into thinking keyboard based focus'
+              ),
+              ['Name', 'Type', 'Description'],
               [
                   (property) => `<code>${property.name}</code>`,
+                  (property) =>
+                      `<code>${property.type?.text ?? 'Event'}</code>`,
                   (property) => `<code>${property.description || ''}</code>`,
               ]
           )

--- a/projects/documentation/scripts/copy-component-docs.js
+++ b/projects/documentation/scripts/copy-component-docs.js
@@ -89,7 +89,7 @@ async function main() {
         if (!tag && componentName.startsWith('textarea')) {
             tag = findDeclaration(
                 customElements,
-                (declaration) => declaration.name === 'sp-textfield'
+                (declaration) => declaration.tagName === 'sp-textfield'
             );
         }
         if (!tag && componentName.startsWith('help-text-mixin')) {


### PR DESCRIPTION
## Description
Ensure that all events have both a description and type in our docs site.

## Related issue(s)

- fixes #1176

## Motivation and context
Easier to consume docs.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go to https://events-docs--spectrum-web-components.netlify.app/components/search/api/#events
    2. See that the docs have a nice description and type for each event
    3. See that other elements have the similar niceties...

## Screenshots (if appropriate)
![New version of Search component events](https://user-images.githubusercontent.com/1156657/144120337-0ea6fc75-7833-4849-96a3-3b18d98f5280.png)
vs
![Old version of Search component events](https://user-images.githubusercontent.com/1156657/144118954-9801bac2-e5d8-44aa-a85b-8fadc7efc9db.png)

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.