### PR TITLE
fix(slider): update "value" default to match browser native range input

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c32d1d08afc9ea82d29cbc21fdd2931d14fbcdfa
+        default: c23f22c5475f018c133837f7b5769b1ac7d522db
 commands:
     downstream:
         steps:

--- a/packages/accordion/src/AccordionItem.ts
+++ b/packages/accordion/src/AccordionItem.ts
@@ -26,6 +26,7 @@ import styles from './accordion-item.css.js';
 /**
  * @element sp-accordion-item
  * @slot - The content of the item that is hidden when the item is not open
+ * @fires sp-accordion-item-toggle - Announce that an accordion item has been toggled while allowing the event to be cancelled.
  */
 export class AccordionItem extends Focusable {
     public static get styles(): CSSResultArray {

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -38,6 +38,8 @@ import styles from './color-area.css.js';
 /**
  * @element sp-color-area
  * @slot gradient - a custom gradient visually outlining the available color values
+ * @fires input - The value of the Color Area has changed.
+ * @fires change - An alteration to the value of the Color Area has been committed by the user.
  */
 export class ColorArea extends SpectrumElement {
     public static get styles(): CSSResultArray {

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -36,6 +36,8 @@ import { TinyColor } from '@ctrl/tinycolor';
 /**
  * @element sp-color-slider
  * @slot gradient - a custom gradient visually outlining the available color values
+ * @fires input - The value of the Color Slider has changed.
+ * @fires change - An alteration to the value of the Color Slider has been committed by the user.
  */
 export class ColorSlider extends Focusable {
     public static get styles(): CSSResultArray {

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -37,6 +37,8 @@ import { TinyColor } from '@ctrl/tinycolor';
 /**
  * @element sp-color-wheel
  * @slot gradient - a custom gradient visually outlining the available color values
+ * @fires input - The value of the Color Wheel has changed.
+ * @fires change - An alteration to the value of the Color Wheel has been committed by the user.
  */
 export class ColorWheel extends Focusable {
     public static get styles(): CSSResultArray {

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -74,7 +74,7 @@ export class NumberField extends TextfieldBase {
     _forcedUnit = '';
 
     /**
-     * An `<sp-number-field>` element will process its numeric value with
+     * An `&lt;sp-number-field&gt;` element will process its numeric value with
      * `new Intl.NumberFormat(this.resolvedLanguage, this.formatOptions).format(this.valueAsNumber)`
      * in order to prepare it for visual delivery in the input. In order to customize this
      * processing supply your own `Intl.NumberFormatOptions` object here.

--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -35,7 +35,7 @@ import radioStyles from './radio.css.js';
  * @attr checked - Represents when the input is checked
  * @attr value - Identifies this radio button within its radio group
  *
- * @event sp-radio:change - When the input is interacted with and its state is changed
+ * @fires change - When the input is interacted with and its state is changed
  */
 export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public static get styles(): CSSResultArray {

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -26,6 +26,8 @@ import { Radio } from './Radio.js';
  * @slot - The `sp-radio` elements to display/manage in the group.
  * @slot help-text - default or non-negative help text to associate to your form element
  * @slot negative-help-text - negative help text to associate to your form element when `invalid`
+ *
+ * @fires change - An alteration to the value of the element has been committed by the user.
  */
 export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
     @property({ type: String })

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -34,6 +34,8 @@ const stopPropagation = (event: Event): void => event.stopPropagation();
  * @element sp-search
  * @slot help-text - default or non-negative help text to associate to your form element
  * @slot negative-help-text - negative help text to associate to your form element when `invalid`
+ *
+ * @fires submit - The search form has been submitted.
  */
 export class Search extends Textfield {
     public static get styles(): CSSResultArray {

--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -70,6 +70,9 @@ const MaxConverter = {
 
 /**
  * @element sp-slider-handle
+ *
+ * @fires input - The value of the element has changed.
+ * @fires change - An alteration to the value of the element has been committed by the user.
  */
 export class SliderHandle extends Focusable {
     public handleController?: Controller;

--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -88,8 +88,12 @@ export class SliderHandle extends Focusable {
 
     _forcedUnit = '';
 
+    /**
+     * By default, the value of a Slider Handle will be halfway between its
+     * `min` and `max` values, or the `min` value when `max` is less than `min`.
+     */
     @property({ type: Number })
-    value = 10;
+    value!: number;
 
     @property({ type: Boolean, reflect: true })
     public dragging = false;
@@ -132,6 +136,16 @@ export class SliderHandle extends Focusable {
             delete this._numberFormatCache;
         }
         super.update(changes);
+    }
+
+    protected firstUpdated(changedProperties: PropertyValues<this>): void {
+        super.firstUpdated(changedProperties);
+        const { max, min } = this as { max: number; min: number };
+        if (this.value == null) {
+            if (!isNaN(max) && !isNaN(min)) {
+                this.value = max < min ? min : min + (max - min) / 2;
+            }
+        }
     }
 
     protected updated(changedProperties: PropertyValues<this>): void {

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -98,7 +98,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(46);
         expect(el.highlight).to.be.false;
 
         el.focus();
@@ -107,14 +107,14 @@ describe('Slider', () => {
         });
         await elementUpdated(el);
 
-        expect(el.value).to.equal(9);
+        expect(el.value).to.equal(45);
         expect(el.highlight).to.be.true;
         await sendKeys({
             press: 'ArrowUp',
         });
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(46);
         expect(el.highlight).to.be.true;
     });
     it('accepts pointer events', async () => {
@@ -213,7 +213,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(35);
 
         const controls = el.shadowRoot.querySelector(
             '#controls'
@@ -235,7 +235,7 @@ describe('Slider', () => {
         await elementUpdated(el);
 
         expect(pointerId).to.equal(-1);
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(35);
         expect(el.dragging, 'handle is not yet being dragged').to.be.false;
 
         controls.dispatchEvent(
@@ -297,7 +297,7 @@ describe('Slider', () => {
 
         expect(el.dragging).to.be.false;
         expect(pointerId).to.equal(-1);
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         handle.setPointerCapture = (id: number) => (pointerId = id);
@@ -329,7 +329,7 @@ describe('Slider', () => {
         await elementUpdated(el);
 
         expect(pointerId).to.equal(-1);
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
     });
     it('accepts pointermove events', async () => {
         const el = await fixture<Slider>(
@@ -339,7 +339,7 @@ describe('Slider', () => {
         );
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         await sendMouse({
@@ -379,7 +379,7 @@ describe('Slider', () => {
         );
         await elementUpdated(el);
 
-        expect(el.value, 'initial').to.equal(10);
+        expect(el.value, 'initial').to.equal(50);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         el.track.setPointerCapture = (id: number) => (pointerId = id);
@@ -560,7 +560,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
         expect(el.dragging).to.be.false;
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
@@ -573,7 +573,7 @@ describe('Slider', () => {
         );
         await nextFrame();
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
     });
     it('responds to input events on the <input/> element', async () => {
         const el = await fixture<Slider>(
@@ -584,7 +584,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         const input = el.shadowRoot.querySelector('.input') as HTMLInputElement;
 
@@ -814,7 +814,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         el.min = 0;
         el.max = 200;

--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -68,6 +68,9 @@ export class Tab extends FocusVisiblePolyfillMixin(
     public value = '';
 
     protected handleContentChange(): void {
+        /**
+         * When the content in a tab has changed, JS powered layout related to that content may also need to be changed.
+         */
         this.dispatchEvent(
             new Event('sp-tab-contentchange', {
                 bubbles: true,

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -48,6 +48,8 @@ const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
  * @slot tab-panel - Tab Panel elements related to the listed Tab elements
  * @attr {Boolean} quiet - The tabs border is a lot smaller
  * @attr {Boolean} compact - The collection of tabs take up less space
+ *
+ * @fires change - The selected Tab child has changed.
  */
 export class Tabs extends SizedMixin(Focusable) {
     public static get styles(): CSSResultArray {

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -38,6 +38,10 @@ import checkmarkStyles from '@spectrum-web-components/icon/src/spectrum-icon-che
 const textfieldTypes = ['text', 'url', 'tel', 'email', 'password'] as const;
 export type TextfieldType = typeof textfieldTypes[number];
 
+/**
+ * @fires input - The value of the element has changed.
+ * @fires change - An alteration to the value of the element has been committed by the user.
+ */
 export class TextfieldBase extends ManageHelpText(Focusable) {
     public static get styles(): CSSResultArray {
         return [textfieldStyles, checkmarkStyles];

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -46,6 +46,8 @@ export type ToastVariants =
  *
  * @slot - The toast content
  * @slot action - button element surfacing an action in the Toast
+ *
+ * @fires close - Announces that the Toast has been closed.
  */
 
 export class Toast extends SpectrumElement {

--- a/packages/tray/src/Tray.ts
+++ b/packages/tray/src/Tray.ts
@@ -30,6 +30,8 @@ import styles from './tray.css.js';
  * @element sp-tray
  *
  * @slot - content to display within the Tray
+ *
+ * @fires close - Announces that the Tray has been closed.
  */
 export class Tray extends SpectrumElement {
     public static get styles(): CSSResultArray {

--- a/projects/documentation/scripts/component-template-parts.js
+++ b/projects/documentation/scripts/component-template-parts.js
@@ -143,13 +143,27 @@ ${
 ${
     tag.events &&
     tag.events.length &&
-    tag.events.filter((tag) => tag.privacy !== 'private').length
+    tag.events.filter(
+        (tag) =>
+            tag.privacy !== 'private' &&
+            tag.type !== 'click' &&
+            tag.description !==
+                'Trick :focus-visible polyfill into thinking keyboard based focus'
+    ).length
         ? buildTable(
               'Events',
-              tag.events.filter((tag) => tag.privacy !== 'private'),
-              ['Name', 'Description'],
+              tag.events.filter(
+                  (tag) =>
+                      tag.privacy !== 'private' &&
+                      tag.type !== 'click' &&
+                      tag.description !==
+                          'Trick :focus-visible polyfill into thinking keyboard based focus'
+              ),
+              ['Name', 'Type', 'Description'],
               [
                   (property) => `<code>${property.name}</code>`,
+                  (property) =>
+                      `<code>${property.type?.text ?? 'Event'}</code>`,
                   (property) => `<code>${property.description || ''}</code>`,
               ]
           )

--- a/projects/documentation/scripts/copy-component-docs.js
+++ b/projects/documentation/scripts/copy-component-docs.js
@@ -89,7 +89,7 @@ async function main() {
         if (!tag && componentName.startsWith('textarea')) {
             tag = findDeclaration(
                 customElements,
-                (declaration) => declaration.name === 'sp-textfield'
+                (declaration) => declaration.tagName === 'sp-textfield'
             );
         }
         if (!tag && componentName.startsWith('help-text-mixin')) {


### PR DESCRIPTION
BREAKING CHANGE: When not supplied value will now be set to halfway between min and max.

## Description
Update default `value` when no applied by the application. Update tests to match.

## Related issue(s)

- fixes #1788

## Motivation and context
Be more like native elements.

## How has this been tested?

-   [ ] _Test case 1_
    1. With unit tests...

## Types of changes
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.