### PR TITLE
refactor(overlay): reduce paint/render work when opening a modal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: b8ff3f9a1f5f5ddc8bc6586a326ebc9a3c4c2e5b
+        default: 01823d82f3c9dec541dd285a3c786d01f81849e3
 commands:
     downstream:
         steps:

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "resolutions": {
         "cssnano/**/postcss-calc": "7.0.0"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -61,7 +61,7 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
         ];
     }
 
-    protected get renderButton(): TemplateResult {
+    protected render(): TemplateResult {
         return html`
             <sp-action-button
                 quiet

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -108,7 +108,9 @@ export class Menu extends SpectrumElement {
     private updateCachedMenuItems(): MenuItem[] {
         this.cachedChildItems = [];
 
-        const slotElements = this.menuSlot.assignedElements({ flatten: true });
+        const slotElements = this.menuSlot
+            ? this.menuSlot.assignedElements({ flatten: true })
+            : [];
         for (const slotElement of slotElements) {
             const childMenuItems: MenuItem[] =
                 slotElement instanceof MenuItem

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -48,7 +48,7 @@
         "lit-html"
     ],
     "dependencies": {
-        "@popperjs/core": "^2.10.2",
+        "@popperjs/core": "^2.11.0",
         "@spectrum-web-components/action-button": "^0.7.1",
         "@spectrum-web-components/base": "^0.5.1",
         "@spectrum-web-components/shared": "^0.13.1",

--- a/packages/picker/test/picker-sync.test.ts
+++ b/packages/picker/test/picker-sync.test.ts
@@ -45,6 +45,7 @@ import {
 } from '@web/test-runner-commands';
 import { iconsOnly } from '../stories/picker.stories.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
+import type { Popover } from '@spectrum-web-components/popover';
 
 const isMenuActiveElement = function (): boolean {
     return document.activeElement instanceof Menu;
@@ -202,12 +203,18 @@ describe('Picker, sync', () => {
             const close = oneEvent(el, 'sp-closed');
             item.click();
             await close;
+            // Overlaid content is outside of the context of the Picker element
+            // and cannot be managed via its updateComplete cycle.
+            await nextFrame();
 
             expect(el.value, 'first time').to.equal('option-new');
 
             opened = oneEvent(el, 'sp-opened');
             el.open = true;
             await opened;
+            // Overlaid content is outside of the context of the Picker element
+            // and cannot be managed via its updateComplete cycle.
+            await nextFrame();
 
             expect(el.value, 'second time').to.equal('option-new');
         });
@@ -436,7 +443,7 @@ describe('Picker, sync', () => {
             const opened = oneEvent(el, 'sp-opened');
             button.click();
             await opened;
-            await elementUpdated(el);
+            await nextFrame();
 
             expect(el.open).to.be.true;
             expect(el.selectedItem?.itemText).to.be.undefined;
@@ -445,6 +452,7 @@ describe('Picker, sync', () => {
             const closed = oneEvent(el, 'sp-closed');
             secondItem.click();
             await closed;
+            await nextFrame();
 
             expect(el.open).to.be.false;
             expect(el.selectedItem?.itemText).to.equal('Select Inverse');
@@ -453,7 +461,7 @@ describe('Picker, sync', () => {
             const opened2 = oneEvent(el, 'sp-opened');
             button.click();
             await opened2;
-            await elementUpdated(el);
+            await nextFrame();
 
             expect(el.open).to.be.true;
             expect(el.selectedItem?.itemText).to.equal('Select Inverse');
@@ -462,6 +470,7 @@ describe('Picker, sync', () => {
             const closed2 = oneEvent(el, 'sp-closed');
             firstItem.click();
             await closed2;
+            await nextFrame();
 
             expect(el.open).to.be.false;
             expect(el.selectedItem?.itemText).to.equal('Deselect');
@@ -894,10 +903,9 @@ describe('Picker, sync', () => {
             expect(el.open).to.be.false;
         });
         it('scrolls selected into view on open', async () => {
-            const popover = el.shadowRoot.querySelector(
-                'sp-popover'
-            ) as HTMLElement;
-            popover.style.height = '40px';
+            (el as unknown as { generatePopover(): void }).generatePopover();
+            (el as unknown as { popover: Popover }).popover.style.height =
+                '40px';
 
             const firstItem = el.querySelector(
                 'sp-menu-item:first-child'

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -45,6 +45,7 @@ import {
 } from '@web/test-runner-commands';
 import { iconsOnly } from '../stories/picker.stories.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
+import type { Popover } from '@spectrum-web-components/popover';
 
 const isMenuActiveElement = function (): boolean {
     return document.activeElement instanceof Menu;
@@ -202,12 +203,18 @@ describe('Picker, sync', () => {
             const close = oneEvent(el, 'sp-closed');
             item.click();
             await close;
+            // Overlaid content is outside of the context of the Picker element
+            // and cannot be managed via its updateComplete cycle.
+            await nextFrame();
 
             expect(el.value, 'first time').to.equal('option-new');
 
             opened = oneEvent(el, 'sp-opened');
             el.open = true;
             await opened;
+            // Overlaid content is outside of the context of the Picker element
+            // and cannot be managed via its updateComplete cycle.
+            await nextFrame();
 
             expect(el.value, 'second time').to.equal('option-new');
         });
@@ -436,7 +443,7 @@ describe('Picker, sync', () => {
             const opened = oneEvent(el, 'sp-opened');
             button.click();
             await opened;
-            await elementUpdated(el);
+            await nextFrame();
 
             expect(el.open).to.be.true;
             expect(el.selectedItem?.itemText).to.be.undefined;
@@ -445,6 +452,7 @@ describe('Picker, sync', () => {
             const closed = oneEvent(el, 'sp-closed');
             secondItem.click();
             await closed;
+            await nextFrame();
 
             expect(el.open).to.be.false;
             expect(el.selectedItem?.itemText).to.equal('Select Inverse');
@@ -453,7 +461,7 @@ describe('Picker, sync', () => {
             const opened2 = oneEvent(el, 'sp-opened');
             button.click();
             await opened2;
-            await elementUpdated(el);
+            await nextFrame();
 
             expect(el.open).to.be.true;
             expect(el.selectedItem?.itemText).to.equal('Select Inverse');
@@ -462,6 +470,7 @@ describe('Picker, sync', () => {
             const closed2 = oneEvent(el, 'sp-closed');
             firstItem.click();
             await closed2;
+            await nextFrame();
 
             expect(el.open).to.be.false;
             expect(el.selectedItem?.itemText).to.equal('Deselect');
@@ -894,10 +903,9 @@ describe('Picker, sync', () => {
             expect(el.open).to.be.false;
         });
         it('scrolls selected into view on open', async () => {
-            const popover = el.shadowRoot.querySelector(
-                'sp-popover'
-            ) as HTMLElement;
-            popover.style.height = '40px';
+            (el as unknown as { generatePopover(): void }).generatePopover();
+            (el as unknown as { popover: Popover }).popover.style.height =
+                '40px';
 
             const firstItem = el.querySelector(
                 'sp-menu-item:first-child'

--- a/packages/split-button/stories/split-button.stories.ts
+++ b/packages/split-button/stories/split-button.stories.ts
@@ -20,7 +20,7 @@ export default {
     component: 'sp-split-button',
     argTypes: {
         onFirstItem: { action: 'click: "Option 1"' },
-        onSecondItem: { action: 'click: "Option Extended"' },
+        onSecondItem: { action: 'click: "Option Really Extended"' },
         onThirdItem: { action: 'click: "Short"' },
     },
 };
@@ -37,7 +37,7 @@ const menu = ({
     onThirdItem,
 }: StoryArgs): TemplateResult => html`
     <sp-menu-item @click=${onFirstItem}>Option 1</sp-menu-item>
-    <sp-menu-item @click=${onSecondItem}>Option Extended</sp-menu-item>
+    <sp-menu-item @click=${onSecondItem}>Option Really Extended</sp-menu-item>
     <sp-menu-item @click=${onThirdItem}>Short</sp-menu-item>
 `;
 

--- a/packages/split-button/test/benchmark/basic-test.ts
+++ b/packages/split-button/test/benchmark/basic-test.ts
@@ -11,14 +11,57 @@ governing permissions and limitations under the License.
 */
 
 import '@spectrum-web-components/split-button/sp-split-button.js';
+import type { SplitButton } from '@spectrum-web-components/split-button';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import { html } from 'lit';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
-measureFixtureCreation(html`
-    <sp-split-button open>
-        <sp-menu-item>Action 1</sp-menu-item>
-        <sp-menu-item>Action 2</sp-menu-item>
-        <sp-menu-item>Action 3</sp-menu-item>
-    </sp-split-button>
-`);
+class SplitButtonWorkflow extends HTMLElement {
+    ready!: (value: boolean | PromiseLike<boolean>) => void;
+    splitButton!: SplitButton;
+    count = 0;
+
+    constructor() {
+        super();
+        this.readyPromise = new Promise((res) => {
+            this.ready = res;
+            this.setup();
+        });
+    }
+
+    async setup(): Promise<void> {
+        this.splitButton = this.nextElementSibling as SplitButton;
+        this.splitButton.addEventListener('sp-opened', () => {
+            requestAnimationFrame(() => (this.splitButton.open = false));
+        });
+        this.splitButton.addEventListener('sp-closed', () => {
+            this.count += 1;
+            if (this.count >= 5) {
+                this.ready(true);
+                return;
+            }
+            requestAnimationFrame(() => (this.splitButton.open = true));
+        });
+        requestAnimationFrame(() => (this.splitButton.open = true));
+    }
+
+    private readyPromise: Promise<boolean> = Promise.resolve(false);
+
+    get updateComplete(): Promise<boolean> {
+        return this.readyPromise;
+    }
+}
+
+customElements.define('split-button-workflow', SplitButtonWorkflow);
+
+measureFixtureCreation(
+    html`
+        <split-button-workflow></split-button-workflow>
+        <sp-split-button>
+            <sp-menu-item>Action 1</sp-menu-item>
+            <sp-menu-item>Action 2</sp-menu-item>
+            <sp-menu-item>Action 3</sp-menu-item>
+        </sp-split-button>
+    `,
+    { numRenders: 1 }
+);

--- a/patches/@popperjs+core+2.11.0.patch
+++ b/patches/@popperjs+core+2.11.0.patch
@@ -1,19 +1,8 @@
 diff --git a/node_modules/@popperjs/core/dist/esm/modifiers/computeStyles.js b/node_modules/@popperjs/core/dist/esm/modifiers/computeStyles.js
-index 4434402..16bd6a9 100644
+index 05fa6a1..c00090b 100644
 --- a/node_modules/@popperjs/core/dist/esm/modifiers/computeStyles.js
 +++ b/node_modules/@popperjs/core/dist/esm/modifiers/computeStyles.js
-@@ -22,8 +22,8 @@ function roundOffsetsByDPR(_ref) {
-   var win = window;
-   var dpr = win.devicePixelRatio || 1;
-   return {
--    x: round(round(x * dpr) / dpr) || 0,
--    y: round(round(y * dpr) / dpr) || 0
-+      x: round(x * dpr) / dpr || 0,
-+      y: round(y * dpr) / dpr || 0,
-   };
- }
- 
-@@ -88,6 +88,8 @@ export function mapToStyles(_ref2) {
+@@ -91,6 +91,8 @@ export function mapToStyles(_ref2) {
      position: position
    }, adaptive && unsetSides);
  

--- a/test/benchmark/bench-runner.html
+++ b/test/benchmark/bench-runner.html
@@ -5,6 +5,11 @@
             href="data:image/x-icon;,"
             type="image/x-icon"
         />
+        <style>
+            body {
+                margin: 0;
+            }
+        </style>
     </head>
     <body>
         <script type="module">

--- a/test/benchmark/helpers.ts
+++ b/test/benchmark/helpers.ts
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import { html, LitElement, render, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import '@spectrum-web-components/theme/sp-theme.js';
-import '@spectrum-web-components/theme/scale-medium.js';
+import '@spectrum-web-components/theme/scale-large.js';
 import '@spectrum-web-components/theme/theme-lightest.js';
 
 declare global {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,10 +3689,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@popperjs/core@^2.10.2":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
-  integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
+"@popperjs/core@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.0.tgz#6734f8ebc106a0860dff7f92bf90df193f0935d7"
+  integrity sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ==
 
 "@pwrs/lit-css@^1.2.1":
   version "1.2.1"


### PR DESCRIPTION
## Description
- correct application of theme and remove body margin in benchmarking
- expand `<sp-split-button>` benchmark to include 5 open/close actions on one element rather than init on 100
- update `<sp-picker>` and derivatives to gather menu items on a document fragment rather than in the DOM before projecting into an overlay
- reorder and conditionalize work within the overlay process to reduce unneeded work
- update CSS to reduce paints when opening overlay

We get a small, but clear, perf benefit in our automated benchmarking. Locally, under stress, I'm seeing even better perf benefits to this change. On the order of 2 - 3 frames (32 - 48ms) during open or close actions, and I expect to see that further scale up as this is leveraged in busier and busier code paths.

## Related issue(s)

- fixes #1910

## Motivation and context
Faster is better!

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://modal-overay-refactor--spectrum-web-components.netlify.app/)
    2. Open the "Performance" tab in DevTools
    3. Start recording
    4. Open and close a theme Picker 2 or 3 times
-   [ ] _Test case 2_
    1. Go [here](https://opensource.adobe.com/spectrum-web-components/)
    2. Open the "Performance" tab in DevTools
    3. Start recording
    4. Open and close a theme Picker 2 or 3 times
-   [ ] _Test case 3_
    1. Compare the perf results of the above. Generally I get a 4ms, 14ms and 11ms series of tasks in the new code and a 5ms, 40ms, and 15ms series of tasks in the old code.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1156657/146013654-132a113c-3934-4dd5-a291-db5792805869.png)
vs
![image](https://user-images.githubusercontent.com/1156657/146013761-04da84a9-0119-4abe-948c-69ff3f7c02a0.png)

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.