### PR TITLE
refactor(toast): allow for using Toast in a controlled context

### DIFF
--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -47,7 +47,7 @@ export type ToastVariants =
  * @slot - The toast content
  * @slot action - button element surfacing an action in the Toast
  *
- * @fires close - Announces that the Toast has been closed from within.
+ * @fires close - Announces that the Toast has been closed by the user or by its timeout.
  */
 
 export class Toast extends SpectrumElement {

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -47,7 +47,7 @@ export type ToastVariants =
  * @slot - The toast content
  * @slot action - button element surfacing an action in the Toast
  *
- * @fires close - Announces that the Toast has been closed.
+ * @fires close - Announces that the Toast has been closed from within.
  */
 
 export class Toast extends SpectrumElement {
@@ -142,7 +142,7 @@ export class Toast extends SpectrumElement {
             this.countdownStart = performance.now();
         }
         if (time - this.countdownStart > (this._timeout as number)) {
-            this.open = false;
+            this.shouldClose();
             this.countdownStart = 0;
         } else {
             this.countdown();
@@ -174,6 +174,19 @@ export class Toast extends SpectrumElement {
         this.countdownStart = 0;
     }
 
+    private shouldClose(): void {
+        const applyDefault = this.dispatchEvent(
+            new CustomEvent('close', {
+                composed: true,
+                bubbles: true,
+                cancelable: true,
+            })
+        );
+        if (applyDefault) {
+            this.close();
+        }
+    }
+
     public close(): void {
         this.open = false;
     }
@@ -191,7 +204,7 @@ export class Toast extends SpectrumElement {
                 <sp-clear-button
                     label="Close"
                     variant="overBackground"
-                    @click=${this.close}
+                    @click=${this.shouldClose}
                 ></sp-clear-button>
             </div>
         `;
@@ -207,16 +220,6 @@ export class Toast extends SpectrumElement {
             } else {
                 if (this.timeout) {
                     this.stopCountdown();
-                }
-                const applyDefault = this.dispatchEvent(
-                    new CustomEvent('close', {
-                        composed: true,
-                        bubbles: true,
-                        cancelable: true,
-                    })
-                );
-                if (!applyDefault) {
-                    this.open = true;
                 }
             }
         }

--- a/packages/toast/stories/toast.stories.ts
+++ b/packages/toast/stories/toast.stories.ts
@@ -16,11 +16,19 @@ import '@spectrum-web-components/button/sp-button.js';
 
 const toast = ({
     variant = '',
-    disappearing = false,
     open = true,
     content = '',
 }): TemplateResult => html`
-    <sp-toast variant=${variant} ?disappearing=${disappearing} ?open=${open}>
+    <sp-toast
+        variant=${variant as
+            | ''
+            | 'negative'
+            | 'positive'
+            | 'info'
+            | 'error'
+            | 'warning'}
+        ?open=${open}
+    >
         ${content}
         <sp-button slot="action" variant="overBackground" quiet>Undo</sp-button>
     </sp-toast>
@@ -59,28 +67,26 @@ export default {
 };
 
 interface Properties {
-    variant: string;
-    disappearing: boolean;
+    variant: '' | 'negative' | 'positive' | 'info' | 'error' | 'warning';
     open: boolean;
     content: string;
+    onClose: (event: Event) => void;
 }
 
 export const Default = ({
     variant,
-    disappearing,
     open,
     content,
 }: Properties): TemplateResult => {
-    return toast({ variant, disappearing, open, content });
+    return toast({ variant, open, content });
 };
 
 const variantDemo = ({
     variant,
-    disappearing,
     open,
     content,
 }: Properties): TemplateResult => {
-    return toast({ variant, disappearing, open, content });
+    return toast({ variant, open, content });
 };
 
 export const Positive = (args: Properties): TemplateResult =>

--- a/packages/toast/test/toast.test.ts
+++ b/packages/toast/test/toast.test.ts
@@ -188,6 +188,39 @@ describe('Toast', () => {
         await elementUpdated(el);
         expect(el.open).to.be.true;
     });
+    it('can be a controlled element', async () => {
+        const closeSpy = spy();
+        const handleClose = (event: CustomEvent): void => {
+            event.preventDefault();
+            closeSpy();
+        };
+        const el = await fixture<Toast>(
+            html`
+                <sp-toast open timeout="100" @close=${handleClose}>
+                    Help text.
+                </sp-toast>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
+        expect(closeSpy.callCount).to.equal(0);
+
+        const renderRoot = el.shadowRoot ? el.shadowRoot : el;
+        const clearButton = renderRoot.querySelector(
+            'sp-clear-button'
+        ) as ClearButton;
+        clearButton.click();
+
+        await elementUpdated(el);
+        expect(el.open).to.be.true;
+        expect(closeSpy.callCount).to.equal(1);
+
+        el.open = false;
+        await elementUpdated(el);
+        expect(el.open).to.be.false;
+        expect(closeSpy.callCount).to.equal(1);
+    });
     it('validates variants', async () => {
         const el = await fixture<Toast>(
             html`
@@ -250,7 +283,10 @@ describe('Toast', () => {
         await elementUpdated(el);
         expect(el.open).to.be.true;
 
-        el.open = false;
+        const closeButton = el.shadowRoot.querySelector(
+            'sp-clear-button'
+        ) as HTMLElement;
+        closeButton.click();
 
         await elementUpdated(el);
         expect(el.open).to.be.false;


### PR DESCRIPTION
## Description
Reorder code path so that internal moves to `open=false` and external ones can be managed separately. This allows for the Toast to be delivered as a controlled element.

## Motivation and context
More flexible consumption in applications.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://toast-controlled--spectrum-web-components.netlify.app/components/toast/#example)
    2. Put an event listed on the `close` event of an `sp-toast` element
    3. Manual switch `open` to `false`
    4. Notice that no `close` event is dispatched

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.