### PR TITLE
docs: support anchor linking and copying individual API table names

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "resolutions": {
         "cssnano/**/postcss-calc": "7.0.0"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*"

--- a/packages/iconset/stories/icons-demo.ts
+++ b/packages/iconset/stories/icons-demo.ts
@@ -167,6 +167,7 @@ export class IconsDemo extends SpectrumElement {
                 bubbles: true,
                 composed: true,
                 detail: {
+                    message: 'Import statement copied to clipboard!',
                     text: importURL,
                 },
             })

--- a/projects/documentation/scripts/component-template-parts.js
+++ b/projects/documentation/scripts/component-template-parts.js
@@ -43,7 +43,7 @@ function encodeCodeWrappedHTML(source) {
     return source.replace(codeWrappedRegex, `<code>${html}</code>`);
 }
 
-function buildTable(title, rowData, headings, cells) {
+function buildTable(title, rowData, headings, cells, copyData) {
     return `
 ### ${title}
 
@@ -67,7 +67,11 @@ ${rowData
     .sort(sortByName)
     .map(
         (property) => `
-<tr class="spectrum-Table-row">
+<tr class="spectrum-Table-row" id="${title.toLowerCase()}_${
+            property.name
+        }" data-name="${copyData.name}" data-value="${copyData.value(
+            property
+        )}">
 ${cells
     .map(
         (cell) => `
@@ -122,7 +126,11 @@ ${
                   (attribute) => `<code>${attribute.type?.text || ''}</code>`,
                   (attribute) => `<code>${attribute.default || ''}</code>`,
                   (attribute) => `${attribute.description || ''}`,
-              ]
+              ],
+              {
+                  name: 'Property',
+                  value: (attribute) => attribute.fieldName,
+              }
           )
         : ``
 }
@@ -136,7 +144,11 @@ ${
                   (property) =>
                       `<code>${property.name || 'default slot'}</code>`,
                   (property) => `${property.description || ''}`,
-              ]
+              ],
+              {
+                  name: 'Slot name',
+                  value: (attribute) => attribute.name || 'default slot',
+              }
           )
         : ``
 }
@@ -165,7 +177,11 @@ ${
                   (property) =>
                       `<code>${property.type?.text ?? 'Event'}</code>`,
                   (property) => `<code>${property.description || ''}</code>`,
-              ]
+              ],
+              {
+                  name: 'Event name',
+                  value: (attribute) => attribute.name,
+              }
           )
         : ``
 }
@@ -178,7 +194,11 @@ ${
               [
                   (property) => `<code>${property.name}</code>`,
                   (property) => `<code>${property.default || '""'}</code>`,
-              ]
+              ],
+              {
+                  name: 'CSS Custom Property',
+                  value: (attribute) => attribute.name,
+              }
           )
         : ``
 }`;

--- a/projects/documentation/src/components.ts
+++ b/projects/documentation/src/components.ts
@@ -63,3 +63,25 @@ class StyledElement extends HTMLElement {
 }
 
 customElements.define('styled-element', StyledElement);
+
+document
+    .querySelector('sp-tab-panel[value="api"]')
+    ?.addEventListener('click', (event: Event) => {
+        const path = event.composedPath();
+        const row = path.find(
+            (el) => (el as Element).localName === 'tr' && (el as Element).id
+        ) as HTMLElement;
+        if (row) {
+            location.hash = row.id;
+            (event.target as HTMLElement).dispatchEvent(
+                new CustomEvent('copy-text', {
+                    bubbles: true,
+                    composed: true,
+                    detail: {
+                        text: row.dataset.value,
+                        message: `${row.dataset.name} copied to clipboard!`,
+                    },
+                })
+            );
+        }
+    });

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -172,7 +172,6 @@ export class LayoutElement extends LitElement {
         event: CustomEvent<{ text: string; message: string }>
     ): void {
         copyText(event.detail.text);
-        event.detail.message = 'Import statement copied to clipboard!';
         this.addAlert(event);
     }
 

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -525,7 +525,8 @@ article {
 h1[id],
 h2[id],
 h3[id],
-h4[id] {
+h4[id],
+tr[id] {
     scroll-margin-top: var(--spectrum-global-dimension-static-size-1200);
     scroll-snap-margin-top: var(--spectrum-global-dimension-static-size-1200);
 }


### PR DESCRIPTION
## Description
Allow all `tr`s to be anchors in the API docs section.
Allow all `tr` to copy content into a users clipboard related to the API that it is outlining.

Is baking both of these into the same action "too much"?

## Motivation and context
Make the docs easier to share and communicate with.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://link-api-docs--spectrum-web-components.netlify.app/components/accordion/api/)
    2. Click a row in the table
    3. See that the URL updates to that anchor
    4. Paste the content that is now in your clipboard.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.