### PR TITLE
fix(overlay): reduce DOM and use of "display: contents" for simplicity and accessibility

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -96,7 +96,7 @@ export class OverlayTrigger extends LitElement {
         // Keyboard event availability documented in README.md
         /* eslint-disable lit-a11y/click-events-have-key-events */
         return html`
-            <div
+            <slot
                 id="trigger"
                 @click=${this.onTrigger}
                 @longpress=${this.onTrigger}
@@ -105,12 +105,9 @@ export class OverlayTrigger extends LitElement {
                 @focusin=${this.onTrigger}
                 @focusout=${this.onTrigger}
                 @sp-closed=${this.handleClose}
-            >
-                <slot
-                    @slotchange=${this.onTargetSlotChange}
-                    name="trigger"
-                ></slot>
-            </div>
+                @slotchange=${this.onTargetSlotChange}
+                name="trigger"
+            ></slot>
             <div id="overlay-content">
                 <slot
                     @slotchange=${this.onClickSlotChange}

--- a/packages/overlay/src/overlay-trigger.css
+++ b/packages/overlay/src/overlay-trigger.css
@@ -10,11 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-#trigger {
-    display: contents;
-}
-
-:host([disabled]) #trigger {
+:host([disabled]) ::slotted([slot='trigger']) {
     pointer-events: none;
 }
 


### PR DESCRIPTION
## Description
We'd originally moved to wrapped slots in a number of places due to support with polyfills, but as we don't specifically support polyfilled delivery anymore we can move away from this practice, especially when there are bugs that come out of doing so.

As per https://bugs.chromium.org/p/chromium/issues/detail?id=1278446 the use of `display: contents` here seems to confusing the accessibility tree starting in Chrome 96, this removed the need for such usage by pushing the events down onto the `<slot>`.

## Motivation and context
Accessibility. Also running perf tests to see if this counts as more performant.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://a11y-overlay-trigger--spectrum-web-components.netlify.app/storybook/index.html?path=/story/action-group-tooltips--selects-single)
    2. Interact the the buttons in the demo with the screen reader
    3. See that in Voice Over the buttons are visible with the VO cursor
    4. See that in VO and NVDA that the buttons register as "radio" buttons that can be selected or unselected.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
