### PR TITLE
fix: don't expose global DOM type definitions

### DIFF
--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -41,13 +41,11 @@ export interface PositionResult {
     positionTop: number;
 }
 
-declare global {
-    interface Document {
-        fonts?: {
-            ready: Promise<void>;
-        };
-    }
-}
+type DocumentWithFonts = typeof document & {
+    fonts?: {
+        ready: Promise<void>;
+    };
+};
 
 type OverlayStateType =
     | 'idle'
@@ -426,7 +424,8 @@ export class ActiveOverlay extends SpectrumElement {
     }
 
     public async updateOverlayPosition(): Promise<void> {
-        await (document.fonts ? document.fonts.ready : Promise.resolve());
+        const doc = document as DocumentWithFonts;
+        await (doc.fonts ? doc.fonts.ready : Promise.resolve());
         if (this.popper) {
             await this.popper.update();
         }

--- a/packages/theme/src/Theme.ts
+++ b/packages/theme/src/Theme.ts
@@ -36,10 +36,11 @@ declare global {
             };
         };
     }
-    interface ShadowRoot {
-        adoptedStyleSheets?: CSSStyleSheet[];
-    }
 }
+
+type ShadowRootWithAdoptedStyleSheets = HTMLElement['shadowRoot'] & {
+    adoptedStyleSheets?: CSSStyleSheet[];
+};
 
 type FragmentType = 'color' | 'scale' | 'core' | 'app';
 type SettableFragmentTypes = 'color' | 'scale';
@@ -349,7 +350,9 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
                     (style as CSSResult).styleSheet as CSSStyleSheet
                 );
             }
-            this.shadowRoot.adoptedStyleSheets = styleSheets;
+            (
+                this.shadowRoot as ShadowRootWithAdoptedStyleSheets
+            ).adoptedStyleSheets = styleSheets;
         } else {
             const styleNodes = this.shadowRoot.querySelectorAll('style');
             styleNodes.forEach((element) => element.remove());

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -25,13 +25,13 @@ import { TopNavItem } from './TopNavItem.js';
 
 import tabStyles from '@spectrum-web-components/tabs/src/tabs.css.js';
 
-declare global {
-    interface Document {
-        fonts?: {
-            ready: Promise<void>;
-        };
-    }
+interface DocumentFonts extends EventTarget {
+    ready: Promise<void>;
 }
+
+type DocumentWithFonts = typeof document & {
+    fonts?: DocumentFonts;
+};
 
 const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
 
@@ -172,9 +172,10 @@ export class TopNav extends SizedMixin(SpectrumElement) {
             this.selectionIndicatorStyle = noSelectionStyle;
             return;
         }
+        const doc = document as DocumentWithFonts;
         await Promise.all([
             selectedItem.updateComplete,
-            document.fonts ? document.fonts.ready : Promise.resolve(),
+            doc.fonts ? doc.fonts.ready : Promise.resolve(),
         ]);
         const itemBoundingClientRect = selectedItem.getBoundingClientRect();
         const parentBoundingClientRect = this.getBoundingClientRect();
@@ -194,16 +195,7 @@ export class TopNav extends SizedMixin(SpectrumElement) {
         super.connectedCallback();
         window.addEventListener('resize', this.updateSelectionIndicator);
         if ('fonts' in document) {
-            (
-                document as unknown as {
-                    fonts: {
-                        addEventListener: (
-                            name: string,
-                            callback: () => void
-                        ) => void;
-                    };
-                }
-            ).fonts.addEventListener(
+            (document as DocumentWithFonts).fonts.addEventListener(
                 'loadingdone',
                 this.updateSelectionIndicator
             );
@@ -213,16 +205,7 @@ export class TopNav extends SizedMixin(SpectrumElement) {
     public disconnectedCallback(): void {
         window.removeEventListener('resize', this.updateSelectionIndicator);
         if ('fonts' in document) {
-            (
-                document as unknown as {
-                    fonts: {
-                        removeEventListener: (
-                            name: string,
-                            callback: () => void
-                        ) => void;
-                    };
-                }
-            ).fonts.removeEventListener(
+            (document as DocumentWithFonts).fonts.removeEventListener(
                 'loadingdone',
                 this.updateSelectionIndicator
             );

--- a/projects/story-decorator/src/types.ts
+++ b/projects/story-decorator/src/types.ts
@@ -20,9 +20,4 @@ declare global {
             defaultReduceMotion: boolean;
         };
     }
-    interface Document {
-        fonts?: {
-            ready: Promise<void>;
-        };
-    }
 }


### PR DESCRIPTION
## Description

Removes public global TypeScript definitions of DOM / Web Platform features.

## Motivation and context

Spectrum Web Components are using some extensions to global interfaces,
in particular `DomElement` and `ShadowRoot`, to declare members that at
some point were not covered by the definitions shipping with Typescript.

In consequence, consumers of SWC may face issues when upgrading their
version of Typescript when the respective definitions differ and can’t
be merged automatically. An example error message is:

```
node_modules/typescript/lib/lib.dom.d.ts:4256:11 -
  error TS2430: Interface 'Document' incorrectly extends
      interface 'FontFaceSource'.
  Types of property 'fonts' are incompatible.
    Type '{ ready: Promise<void>; } | undefined' is not assignable to
        type 'FontFaceSet'.
      Type 'undefined' is not assignable to type 'FontFaceSet'.
```

This kind of error message is difficult to silence, or even impossible
if SWC are a transitive dependency.

As a solution, we propose to use _local_ definitions for the Web
Platform features that single components are using. None of these
definitions end up in `.d.ts` files. Consumers end up with un-augmented
type definitions, while component implementations get the definitions
they need.

## How has this been tested?

- [x] Run `tsc`
   1. `yarn build:ts:clean`
- [x] Verify Build Output
   1. manually inspected `.d.ts` files to verify that the newly defined types are not exported.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
