### PR TITLE
[ALT] Stop emitting local types into the global scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
         "stylelint-config-prettier": "^9.0.3",
         "stylelint-config-standard": "^24.0.0",
         "tachometer": "^0.5.10",
-        "typescript": "^4.4.4",
+        "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
     "resolutions": {

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -41,14 +41,6 @@ export interface PositionResult {
     positionTop: number;
 }
 
-declare global {
-    interface Document {
-        fonts?: {
-            ready: Promise<void>;
-        };
-    }
-}
-
 type OverlayStateType =
     | 'idle'
     | 'active'

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -31,14 +31,6 @@ const availableArrowsByDirection = {
     horizontal: ['ArrowLeft', 'ArrowRight'],
 };
 
-declare global {
-    interface Document {
-        fonts?: {
-            ready: Promise<void>;
-        };
-    }
-}
-
 const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
 
 /**

--- a/packages/theme/src/Theme.ts
+++ b/packages/theme/src/Theme.ts
@@ -36,10 +36,11 @@ declare global {
             };
         };
     }
-    interface ShadowRoot {
-        adoptedStyleSheets?: CSSStyleSheet[];
-    }
 }
+
+type ShadowRootWithAdoptedStyleSheets = HTMLElement['shadowRoot'] & {
+    adoptedStyleSheets?: CSSStyleSheet[];
+};
 
 type FragmentType = 'color' | 'scale' | 'core' | 'app';
 type SettableFragmentTypes = 'color' | 'scale';
@@ -106,7 +107,7 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
         }
     }
 
-    public shadowRoot!: ShadowRoot;
+    public shadowRoot!: ShadowRootWithAdoptedStyleSheets;
 
     private _color: Color | '' = '';
 

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -25,14 +25,6 @@ import { TopNavItem } from './TopNavItem.js';
 
 import tabStyles from '@spectrum-web-components/tabs/src/tabs.css.js';
 
-declare global {
-    interface Document {
-        fonts?: {
-            ready: Promise<void>;
-        };
-    }
-}
-
 const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
 
 /**
@@ -194,16 +186,7 @@ export class TopNav extends SizedMixin(SpectrumElement) {
         super.connectedCallback();
         window.addEventListener('resize', this.updateSelectionIndicator);
         if ('fonts' in document) {
-            (
-                document as unknown as {
-                    fonts: {
-                        addEventListener: (
-                            name: string,
-                            callback: () => void
-                        ) => void;
-                    };
-                }
-            ).fonts.addEventListener(
+            document.fonts.addEventListener(
                 'loadingdone',
                 this.updateSelectionIndicator
             );

--- a/projects/story-decorator/src/types.ts
+++ b/projects/story-decorator/src/types.ts
@@ -20,9 +20,4 @@ declare global {
             defaultReduceMotion: boolean;
         };
     }
-    interface Document {
-        fonts?: {
-            ready: Promise<void>;
-        };
-    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23173,6 +23173,11 @@ typescript@^3.8.3, typescript@^3.9.7:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
+typescript@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
+  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
+
 typescript@~4.3.2:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"


### PR DESCRIPTION
## Description
- use "natively" provided `doncument.fonts.ready` and `document.fonts.addEventListener` types
- make `ShadowRoot.adoptedStyleSheets` a local type

supersedes #1984

## Motivation and context
Cleaner types

## How has this been tested?
- [x] Run `tsc`
   1. `yarn build:ts:clean`
- [x] Verify Build Output
   1. manually inspected `.d.ts` files to verify that the newly defined types are not exported.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
