### PR TITLE
docs: add spectrum design tokens to component inventory

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -1,81 +1,107 @@
-
 # Component Inventory
 
-Availability of components in [Spectrum CSS](https://opensource.adobe.com/spectrum-css/)
+Availability of [Spectrum](https://spectrum.adobe.com) components in [Spectrum CSS](https://opensource.adobe.com/spectrum-css/)
 and [Spectrum Web Components](https://opensource.adobe.com/spectrum-web-components/).
 
-| Component | Spectrum CSS (69) | Spectrum Web Components (51) |
-|-|-|-|
-| accordion | [📄](https://opensource.adobe.com/spectrum-css/accordion.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/accordion) |
-| actionbar | [📄](https://opensource.adobe.com/spectrum-css/actionbar.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/action-bar) |
-| actionbutton | [📄](https://opensource.adobe.com/spectrum-css/actionbutton.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/action-button) |
-| actiongroup | [📄](https://opensource.adobe.com/spectrum-css/actiongroup.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/action-group) |
-| actionmenu | [📄](https://opensource.adobe.com/spectrum-css/actionmenu.html) | ❌ |
-| asset | [📄](https://opensource.adobe.com/spectrum-css/asset.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/asset) |
-| assetlist | [📄](https://opensource.adobe.com/spectrum-css/assetlist.html) | ❌ |
-| avatar | [📄](https://opensource.adobe.com/spectrum-css/avatar.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/avatar) |
-| badge | [📄](https://opensource.adobe.com/spectrum-css/badge.html) | ❌ |
-| banner |  | [📄](https://opensource.adobe.com/spectrum-web-components/components/banner) |
-| breadcrumb | [📄](https://opensource.adobe.com/spectrum-css/breadcrumb.html) | ❌ |
-| button | [📄](https://opensource.adobe.com/spectrum-css/logicbutton.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/button) |
-| buttongroup | [📄](https://opensource.adobe.com/spectrum-css/buttongroup.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/button-group) |
-| calendar | [📄](https://opensource.adobe.com/spectrum-css/calendar.html) | ❌ |
-| card | [📄](https://opensource.adobe.com/spectrum-css/card.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/card) |
-| checkbox | [📄](https://opensource.adobe.com/spectrum-css/checkbox.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/checkbox) |
-| coachmark | [📄](https://opensource.adobe.com/spectrum-css/coachmark.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/coachmark) |
-| colorarea | [📄](https://opensource.adobe.com/spectrum-css/colorarea.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-area) |
-| colorhandle | [📄](https://opensource.adobe.com/spectrum-css/colorhandle.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-handle) |
-| colorloupe | [📄](https://opensource.adobe.com/spectrum-css/colorloupe.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-loupe) |
-| colorslider | [📄](https://opensource.adobe.com/spectrum-css/colorslider.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-slider) |
-| colorwheel | [📄](https://opensource.adobe.com/spectrum-css/colorwheel.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-wheel) |
-| cyclebutton | [📄](https://opensource.adobe.com/spectrum-css/cyclebutton.html) | ❌ |
-| dial | [📄](https://opensource.adobe.com/spectrum-css/dial.html) | ❌ |
-| dialog | [📄](https://opensource.adobe.com/spectrum-css/dialog.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/dialog) |
-| divider | [📄](https://opensource.adobe.com/spectrum-css/divider.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/divider) |
-| dropindicator | [📄](https://opensource.adobe.com/spectrum-css/dropindicator.html) | ❌ |
-| dropzone | [📄](https://opensource.adobe.com/spectrum-css/dropzone.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/dropzone) |
-| fieldgroup | [📄](https://opensource.adobe.com/spectrum-css/fieldgroup.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/field-group) |
-| fieldlabel | [📄](https://opensource.adobe.com/spectrum-css/form.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/field-label) |
-| helptext | [📄](https://opensource.adobe.com/spectrum-css/helptext.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/help-text) |
-| icon |  | [📄](https://opensource.adobe.com/spectrum-web-components/components/icon) |
-| illustratedmessage | [📄](https://opensource.adobe.com/spectrum-css/illustratedmessage.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/illustrated-message) |
-| inlinealert | [📄](https://opensource.adobe.com/spectrum-css/inlinealert.html) | ❌ |
-| inputgroup | [📄](https://opensource.adobe.com/spectrum-css/datepicker.html) | ❌ |
-| link | [📄](https://opensource.adobe.com/spectrum-css/link.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/link) |
-| menu | [📄](https://opensource.adobe.com/spectrum-css/menu.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/menu) |
-| miller | [📄](https://opensource.adobe.com/spectrum-css/miller.html) | ❌ |
-| modal | [📄](https://opensource.adobe.com/spectrum-css/modal.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/modal) |
-| page | [📄](https://opensource.adobe.com/spectrum-css/page.html) | ❌ |
-| pagination | [📄](https://opensource.adobe.com/spectrum-css/pagination-listing.html) | ❌ |
-| picker | [📄](https://opensource.adobe.com/spectrum-css/picker.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/picker) |
-| pickerbutton | [📄](https://opensource.adobe.com/spectrum-css/pickerbutton.html) | ❌ |
-| popover | [📄](https://opensource.adobe.com/spectrum-css/popover.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/popover) |
-| progressbar | [📄](https://opensource.adobe.com/spectrum-css/progressbar.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/progress-bar) |
-| progresscircle | [📄](https://opensource.adobe.com/spectrum-css/progresscircle.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/progress-circle) |
-| quickaction | [📄](https://opensource.adobe.com/spectrum-css/quickaction.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/quick-actions) |
-| radio | [📄](https://opensource.adobe.com/spectrum-css/radio.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/radio) |
-| rating | [📄](https://opensource.adobe.com/spectrum-css/rating.html) | ❌ |
-| search | [📄](https://opensource.adobe.com/spectrum-css/search.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/search) |
-| searchwithin | [📄](https://opensource.adobe.com/spectrum-css/searchwithin.html) | ❌ |
-| sidenav | [📄](https://opensource.adobe.com/spectrum-css/sidenav.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/sidenav) |
-| slider | [📄](https://opensource.adobe.com/spectrum-css/slider.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/slider) |
-| splitbutton | [📄](https://opensource.adobe.com/spectrum-css/splitbutton.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/split-button) |
-| splitview | [📄](https://opensource.adobe.com/spectrum-css/splitview.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/split-view) |
-| statuslight | [📄](https://opensource.adobe.com/spectrum-css/statuslight.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/status-light) |
-| steplist | [📄](https://opensource.adobe.com/spectrum-css/steplist.html) | ❌ |
-| stepper | [📄](https://opensource.adobe.com/spectrum-css/stepper.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/number-field) |
-| switch | [📄](https://opensource.adobe.com/spectrum-css/switch.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/switch) |
-| table | [📄](https://opensource.adobe.com/spectrum-css/table.html) | ❌ |
-| tabs | [📄](https://opensource.adobe.com/spectrum-css/tabs.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/tabs) |
-| tag | [📄](https://opensource.adobe.com/spectrum-css/tag.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/tags) |
-| taggroup | [📄](https://opensource.adobe.com/spectrum-css/taggroup.html) | ❌ |
-| textfield | [📄](https://opensource.adobe.com/spectrum-css/textfield.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/textfield) |
-| thumbnail | [📄](https://opensource.adobe.com/spectrum-css/thumbnail.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/thumbnail) |
-| toast | [📄](https://opensource.adobe.com/spectrum-css/toast.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/toast) |
-| tooltip | [📄](https://opensource.adobe.com/spectrum-css/tooltip.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/tooltip) |
-| tray | [📄](https://opensource.adobe.com/spectrum-css/tray.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/tray) |
-| treeview | [📄](https://opensource.adobe.com/spectrum-css/treeview.html) | ❌ |
-| typography | [📄](https://opensource.adobe.com/spectrum-css/typography.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/styles) |
-| underlay |  | [📄](https://opensource.adobe.com/spectrum-web-components/components/underlay) |
-| well | [📄](https://opensource.adobe.com/spectrum-css/well.html) | ❌ |
-    
+| Component           | Design tokens (86) | CSS (69)                                                                | Web Components (51)                                                                       |
+| ------------------- | ------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| accordion           | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/accordion.html)          | [📄](https://opensource.adobe.com/spectrum-web-components/components/accordion)           |
+| actionbar           | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/actionbar.html)          | [📄](https://opensource.adobe.com/spectrum-web-components/components/action-bar)          |
+| actionbutton        | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/actionbutton.html)       | [📄](https://opensource.adobe.com/spectrum-web-components/components/action-button)       |
+| actiongroup         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/actiongroup.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/action-group)        |
+| actionmenu          |                    | [📄](https://opensource.adobe.com/spectrum-css/actionmenu.html)         | ❌                                                                                        |
+| alertbanner         | ✅                 |                                                                         |                                                                                           |
+| artboard            | ✅                 |                                                                         |                                                                                           |
+| asset               | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/asset.html)              | [📄](https://opensource.adobe.com/spectrum-web-components/components/asset)               |
+| assetlist           | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/assetlist.html)          | ❌                                                                                        |
+| avatar              | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/avatar.html)             | [📄](https://opensource.adobe.com/spectrum-web-components/components/avatar)              |
+| badge               | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/badge.html)              | ❌                                                                                        |
+| banner              |                    |                                                                         | [📄](https://opensource.adobe.com/spectrum-web-components/components/banner)              |
+| body                | ✅                 |                                                                         |                                                                                           |
+| bottomnavigation    | ✅                 |                                                                         |                                                                                           |
+| breadcrumb          | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/breadcrumb.html)         | ❌                                                                                        |
+| button              | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/logicbutton.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/button)              |
+| buttongroup         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/buttongroup.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/button-group)        |
+| calendar            | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/calendar.html)           | ❌                                                                                        |
+| card                | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/card.html)               | [📄](https://opensource.adobe.com/spectrum-web-components/components/card)                |
+| checkbox            | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/checkbox.html)           | [📄](https://opensource.adobe.com/spectrum-web-components/components/checkbox)            |
+| clearbutton         | ✅                 |                                                                         |                                                                                           |
+| closebutton         | ✅                 |                                                                         |                                                                                           |
+| coachmark           | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/coachmark.html)          | [📄](https://opensource.adobe.com/spectrum-web-components/components/coachmark)           |
+| code                | ✅                 |                                                                         |                                                                                           |
+| colorarea           | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/colorarea.html)          | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-area)          |
+| colorhandle         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/colorhandle.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-handle)        |
+| colorloupe          | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/colorloupe.html)         | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-loupe)         |
+| colorslider         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/colorslider.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-slider)        |
+| colorwheel          | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/colorwheel.html)         | [📄](https://opensource.adobe.com/spectrum-web-components/components/color-wheel)         |
+| combobox            | ✅                 |                                                                         |                                                                                           |
+| cyclebutton         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/cyclebutton.html)        | ❌                                                                                        |
+| detail              | ✅                 |                                                                         |                                                                                           |
+| dial                | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/dial.html)               | ❌                                                                                        |
+| dialog              | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/dialog.html)             | [📄](https://opensource.adobe.com/spectrum-web-components/components/dialog)              |
+| divider             | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/divider.html)            | [📄](https://opensource.adobe.com/spectrum-web-components/components/divider)             |
+| drag                | ✅                 |                                                                         |                                                                                           |
+| dragbar             | ✅                 |                                                                         |                                                                                           |
+| dragthumb           | ✅                 |                                                                         |                                                                                           |
+| drawer              | ✅                 |                                                                         |                                                                                           |
+| dropindicator       | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/dropindicator.html)      | ❌                                                                                        |
+| dropzone            | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/dropzone.html)           | [📄](https://opensource.adobe.com/spectrum-web-components/components/dropzone)            |
+| fieldgroup          |                    | [📄](https://opensource.adobe.com/spectrum-css/fieldgroup.html)         | [📄](https://opensource.adobe.com/spectrum-web-components/components/field-group)         |
+| fieldlabel          | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/form.html)               | [📄](https://opensource.adobe.com/spectrum-web-components/components/field-label)         |
+| heading             | ✅                 |                                                                         |                                                                                           |
+| helptext            | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/helptext.html)           | [📄](https://opensource.adobe.com/spectrum-web-components/components/help-text)           |
+| icon                |                    |                                                                         | [📄](https://opensource.adobe.com/spectrum-web-components/components/icon)                |
+| illustratedmessage  | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/illustratedmessage.html) | [📄](https://opensource.adobe.com/spectrum-web-components/components/illustrated-message) |
+| infieldbutton       | ✅                 |                                                                         |                                                                                           |
+| inlinealert         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/inlinealert.html)        | ❌                                                                                        |
+| inputgroup          |                    | [📄](https://opensource.adobe.com/spectrum-css/datepicker.html)         | ❌                                                                                        |
+| label               | ✅                 |                                                                         |                                                                                           |
+| link                | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/link.html)               | [📄](https://opensource.adobe.com/spectrum-web-components/components/link)                |
+| listitem            | ✅                 |                                                                         |                                                                                           |
+| logicbutton         | ✅                 |                                                                         |                                                                                           |
+| menu                |                    | [📄](https://opensource.adobe.com/spectrum-css/menu.html)               | [📄](https://opensource.adobe.com/spectrum-web-components/components/menu)                |
+| meter               | ✅                 |                                                                         |                                                                                           |
+| miller              |                    | [📄](https://opensource.adobe.com/spectrum-css/miller.html)             | ❌                                                                                        |
+| millercolumn        | ✅                 |                                                                         |                                                                                           |
+| modal               |                    | [📄](https://opensource.adobe.com/spectrum-css/modal.html)              | [📄](https://opensource.adobe.com/spectrum-web-components/components/modal)               |
+| opacitycheckerboard | ✅                 |                                                                         |                                                                                           |
+| page                |                    | [📄](https://opensource.adobe.com/spectrum-css/page.html)               | ❌                                                                                        |
+| pagination          | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/pagination-listing.html) | ❌                                                                                        |
+| panel               | ✅                 |                                                                         |                                                                                           |
+| picker              | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/picker.html)             | [📄](https://opensource.adobe.com/spectrum-web-components/components/picker)              |
+| pickerbutton        | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/pickerbutton.html)       | ❌                                                                                        |
+| popover             | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/popover.html)            | [📄](https://opensource.adobe.com/spectrum-web-components/components/popover)             |
+| progressbar         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/progressbar.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/progress-bar)        |
+| progresscircle      | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/progresscircle.html)     | [📄](https://opensource.adobe.com/spectrum-web-components/components/progress-circle)     |
+| quickaction         |                    | [📄](https://opensource.adobe.com/spectrum-css/quickaction.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/quick-actions)       |
+| quickactions        | ✅                 |                                                                         |                                                                                           |
+| radio               | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/radio.html)              | [📄](https://opensource.adobe.com/spectrum-web-components/components/radio)               |
+| radiogroup          | ✅                 |                                                                         |                                                                                           |
+| rating              | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/rating.html)             | ❌                                                                                        |
+| scrollbar           | ✅                 |                                                                         |                                                                                           |
+| search              | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/search.html)             | [📄](https://opensource.adobe.com/spectrum-web-components/components/search)              |
+| searchwithin        | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/searchwithin.html)       | ❌                                                                                        |
+| sidenav             | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/sidenav.html)            | [📄](https://opensource.adobe.com/spectrum-web-components/components/sidenav)             |
+| slider              | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/slider.html)             | [📄](https://opensource.adobe.com/spectrum-web-components/components/slider)              |
+| splitbutton         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/splitbutton.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/split-button)        |
+| splitview           |                    | [📄](https://opensource.adobe.com/spectrum-css/splitview.html)          | [📄](https://opensource.adobe.com/spectrum-web-components/components/split-view)          |
+| statuslight         | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/statuslight.html)        | [📄](https://opensource.adobe.com/spectrum-web-components/components/status-light)        |
+| steplist            | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/steplist.html)           | ❌                                                                                        |
+| stepper             |                    | [📄](https://opensource.adobe.com/spectrum-css/stepper.html)            | [📄](https://opensource.adobe.com/spectrum-web-components/components/number-field)        |
+| stepperbutton       | ✅                 |                                                                         |                                                                                           |
+| switch              | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/switch.html)             | [📄](https://opensource.adobe.com/spectrum-web-components/components/switch)              |
+| tabbar              | ✅                 |                                                                         |                                                                                           |
+| table               | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/table.html)              | ❌                                                                                        |
+| tabs                | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/tabs.html)               | [📄](https://opensource.adobe.com/spectrum-web-components/components/tabs)                |
+| tag                 | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/tag.html)                | [📄](https://opensource.adobe.com/spectrum-web-components/components/tags)                |
+| taggroup            | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/taggroup.html)           | ❌                                                                                        |
+| textarea            | ✅                 |                                                                         |                                                                                           |
+| textfield           | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/textfield.html)          | [📄](https://opensource.adobe.com/spectrum-web-components/components/textfield)           |
+| thumbnail           | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/thumbnail.html)          | [📄](https://opensource.adobe.com/spectrum-web-components/components/thumbnail)           |
+| toast               | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/toast.html)              | [📄](https://opensource.adobe.com/spectrum-web-components/components/toast)               |
+| tooltip             | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/tooltip.html)            | [📄](https://opensource.adobe.com/spectrum-web-components/components/tooltip)             |
+| tray                | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/tray.html)               | [📄](https://opensource.adobe.com/spectrum-web-components/components/tray)                |
+| treeview            | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/treeview.html)           | ❌                                                                                        |
+| typography          |                    | [📄](https://opensource.adobe.com/spectrum-css/typography.html)         | [📄](https://opensource.adobe.com/spectrum-web-components/components/styles)              |
+| underlay            |                    |                                                                         | [📄](https://opensource.adobe.com/spectrum-web-components/components/underlay)            |
+| well                | ✅                 | [📄](https://opensource.adobe.com/spectrum-css/well.html)               | ❌                                                                                        |

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
         "fs-extra": "^10.0.0",
         "gh-pages": "^3.2.3",
         "globby": "^11.0.3",
+        "gunzip-maybe": "^1.4.2",
         "husky": "^7.0.4",
         "lerna": "^4.0.0",
         "lit": "^2.0.0",
@@ -176,6 +177,7 @@
         "stylelint-config-prettier": "^9.0.3",
         "stylelint-config-standard": "^24.0.0",
         "tachometer": "^0.5.10",
+        "tar-stream": "^2.2.0",
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6863,6 +6863,13 @@ browser-sync@^2.27.7:
     ua-parser-js "1.0.2"
     yargs "^15.4.1"
 
+browserify-zlib@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
+  integrity sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=
+  dependencies:
+    pako "~0.2.0"
+
 browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.0, browserslist@^4.16.3, browserslist@^4.16.6, browserslist@^4.16.8, browserslist@^4.17.3, browserslist@^4.17.5:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
@@ -9599,6 +9606,16 @@ duplexer@^0.1.1, duplexer@^0.1.2, duplexer@~0.1.1:
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
+duplexify@^3.5.0, duplexify@^3.6.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
+  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
 dynamic-import-polyfill@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dynamic-import-polyfill/-/dynamic-import-polyfill-0.1.1.tgz#e1f9eb1876ee242bd56572f8ed4df768e143083f"
@@ -11888,6 +11905,18 @@ gray-matter@^4.0.3:
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
 
+gunzip-maybe@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz#b913564ae3be0eda6f3de36464837a9cd94b98ac"
+  integrity sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==
+  dependencies:
+    browserify-zlib "^0.1.4"
+    is-deflate "^1.0.0"
+    is-gzip "^1.0.0"
+    peek-stream "^1.1.0"
+    pumpify "^1.3.3"
+    through2 "^2.0.3"
+
 gzip-size@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
@@ -13215,6 +13244,11 @@ is-decimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
   integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
+is-deflate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-deflate/-/is-deflate-1.0.0.tgz#c862901c3c161fb09dac7cdc7e784f80e98f2f14"
+  integrity sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ=
+
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
@@ -13320,6 +13354,11 @@ is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-gzip@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-gzip/-/is-gzip-1.0.0.tgz#6ca8b07b99c77998025900e555ced8ed80879a83"
+  integrity sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=
 
 is-hexadecimal@^1.0.0:
   version "1.0.4"
@@ -17383,6 +17422,11 @@ pacote@^11.2.6:
     ssri "^8.0.1"
     tar "^6.1.0"
 
+pako@~0.2.0:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+  integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
+
 pako@~1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -17771,6 +17815,15 @@ pause-stream@0.0.11:
   integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
   dependencies:
     through "~2.3"
+
+peek-stream@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/peek-stream/-/peek-stream-1.1.3.tgz#3b35d84b7ccbbd262fff31dc10da56856ead6d67"
+  integrity sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==
+  dependencies:
+    buffer-from "^1.0.0"
+    duplexify "^3.5.0"
+    through2 "^2.0.3"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -19423,6 +19476,14 @@ pump@^1.0.0, pump@^1.0.1:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+pump@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -19430,6 +19491,15 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+pumpify@^1.3.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -21579,6 +21649,11 @@ stream-combiner@~0.0.4:
   dependencies:
     duplexer "~0.1.1"
 
+stream-shift@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
+  integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
 stream-throttle@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/stream-throttle/-/stream-throttle-0.1.3.tgz#add57c8d7cc73a81630d31cd55d3961cfafba9c3"
@@ -22455,7 +22530,7 @@ through2@2.0.0:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-through2@^2.0.0, through2@^2.0.1, through2@~2.0.0:
+through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==


### PR DESCRIPTION
## Description

This adds a left column to the component inventory that lists all of the spectrum design tokens from `@adobe/spectrum-tokens`.

## Motivation and context

A more complete understanding of upstream projects & dependencies.

## How has this been tested?

- Check out [the generated table](https://github.com/adobe/spectrum-web-components/blob/add-spectrum-tokens-to-inventory/INVENTORY.md)

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/364501/146277617-21b8d342-be13-4d14-b61b-dd829c2d9de1.png)

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
