### PR TITLE
fix(tabs): error on click - undefined tab target

### DIFF
--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -269,10 +269,13 @@ export class Tabs extends SizedMixin(Focusable) {
     }
 
     private onClick = (event: Event): void => {
+        if (this.disabled) {
+            return;
+        }
         const target = event
             .composedPath()
             .find((el) => (el as Tab).parentElement === this) as Tab;
-        if (this.disabled || target.disabled) {
+        if (!target || target.disabled) {
             return;
         }
         this.shouldAnimate = true;

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -656,4 +656,20 @@ describe('Tabs', () => {
         expect(initialWidth).to.be.greaterThan(shorterWidth);
         expect(longerWidth).to.be.greaterThan(shorterWidth);
     });
+    it('clicks on #list do not throw', async () => {
+        const tabs = await createTabs();
+        const tabList = (tabs.shadowRoot as ShadowRoot).querySelector(
+            '#list'
+        ) as HTMLDivElement;
+        // exceptions thrown in event listeners do not propagate to caller
+        // we must catch them with window.onerror
+        let hasError = false;
+        const oldOnerror = window.onerror;
+        window.onerror = () => {
+            hasError = true;
+        };
+        tabList.dispatchEvent(new MouseEvent('click'));
+        expect(hasError, 'it should not error').to.be.false;
+        window.onerror = oldOnerror;
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A click inside sp-tabs throws if outside of a sp-tab.

## Related issue(s)

- fixes #2000 

## Motivation and context

Bugfix

## How has this been tested?

Manually

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
