### PR TITLE
fix(textfield): prevent IME selection misalignment in Safari when using hiragana input modality

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -147,10 +147,6 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
             }
         }
         this.value = this.inputElement.value;
-        const selectionStart = this.inputElement.selectionStart as number;
-        this.updateComplete.then(() => {
-            this.inputElement.setSelectionRange(selectionStart, selectionStart);
-        });
     }
 
     protected onChange(): void {


### PR DESCRIPTION
## Description
Prevent Safari from placing the input carat before the initial hiragana character when IME opens to resolve the implied kanji.

The removed functionality was originally applied when we moved to WTR and started testing in Safari with local failures. No tests fail when removed, so it seems that somewhere in the dependency/browser change the issue in question has been resolved outside of our input.

I can't think of a way to test IME in an automated manner, and would take input in this area if anyone had ideas.

## Related issue(s)

- fixes #2018

## Motivation and context
Internationalization

## How has this been tested?

https://user-images.githubusercontent.com/1156657/148085390-ff9819ab-b993-4b04-bf2a-a05fb9af0539.mov

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.