### PR TITLE
Make sure Numberfield quiet has "square" corners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 01823d82f3c9dec541dd285a3c786d01f81849e3
+        default: a60ebceaaf594760a8d5d9c4592fab3ec2ab1e51
 commands:
     downstream:
         steps:

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -511,6 +511,7 @@ export class NumberField extends TextfieldBase {
                               this.readonly ||
                               (typeof this.max !== 'undefined' &&
                                   this.value === this.max)}
+                              ?quiet=${this.quiet}
                           >
                               <sp-icon-chevron75
                                   slot="icon"
@@ -526,6 +527,7 @@ export class NumberField extends TextfieldBase {
                               this.readonly ||
                               (typeof this.min !== 'undefined' &&
                                   this.value === this.min)}
+                              ?quiet=${this.quiet}
                           >
                               <sp-icon-chevron75
                                   slot="icon"

--- a/packages/number-field/src/number-field.css
+++ b/packages/number-field/src/number-field.css
@@ -33,7 +33,7 @@ sp-field-button {
     pointer-events: none;
 }
 
-:host([hide-stepper]) .input {
+:host([hide-stepper]:not([quiet])) .input {
     border-radius: var(
         --spectrum-alias-border-radius-regular,
         var(--spectrum-global-dimension-size-50)

--- a/packages/number-field/src/spectrum-config.js
+++ b/packages/number-field/src/spectrum-config.js
@@ -65,7 +65,7 @@ const config = {
                 },
                 {
                     selector: '.spectrum-Icon',
-                    name: 'icon',
+                    name: 'stepper-icon',
                 },
                 {
                     selector: '.spectrum-Stepper-input',

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -196,8 +196,8 @@ THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
    * .spectrum-Stepper-stepDown */
     width: var(--spectrum-stepper-button-width);
 }
-.stepDown .icon,
-.stepUp .icon {
+.stepDown .stepper-icon,
+.stepUp .stepper-icon {
     margin: 0 !important; /* .spectrum-Stepper-stepUp .spectrum-Icon,
    * .spectrum-Stepper-stepDown .spectrum-Icon */
     opacity: 1;

--- a/packages/number-field/stories/number-field.stories.ts
+++ b/packages/number-field/stories/number-field.stories.ts
@@ -199,6 +199,22 @@ Default.args = {
     value: 100,
 };
 
+export const quiet = (args: StoryArgs = {}): TemplateResult => {
+    return html`
+        <sp-field-label for="default">Enter a number</sp-field-label>
+        <sp-number-field
+            id="default"
+            ...=${spreadProps(args)}
+            style="width: 150px"
+        ></sp-number-field>
+    `;
+};
+
+quiet.args = {
+    quiet: true,
+    value: 100,
+};
+
 export const indeterminate = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <sp-field-label for="default">Enter a number</sp-field-label>
@@ -346,6 +362,23 @@ export const hideStepper = (args: StoryArgs): TemplateResult => {
 hideStepper.args = {
     hideStepper: true,
     value: 67,
+};
+
+export const hideStepperQuiet = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-field-label for="hideStepper">
+            Enter a number without the stepper UI
+        </sp-field-label>
+        <sp-number-field
+            id="hideStepper"
+            ...=${spreadProps(args)}
+        ></sp-number-field>
+    `;
+};
+hideStepperQuiet.args = {
+    hideStepper: true,
+    value: 67,
+    quiet: true,
 };
 
 export const disabled = (args: StoryArgs): TemplateResult => {


### PR DESCRIPTION
## Description
Correct style delivery and add VRT coverage to prevent regression.

## Motivation and context
Supports more complex color pickers.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://numberfield-quiet--spectrum-web-components.netlify.app/storybook/index.html?path=/story/number-field--quiet)
    2. See that the bottom border is straight.
-   [ ] _Test case 2_
    1. Go [here](https://numberfield-quiet--spectrum-web-components.netlify.app/storybook/index.html?path=/story/number-field--hide-stepper-quiet)
    2. See that the bottom border is straight.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
