### PR TITLE
fix: simplify touch-action application

### DIFF
--- a/packages/color-slider/src/color-slider.css
+++ b/packages/color-slider/src/color-slider.css
@@ -24,14 +24,6 @@ governing permissions and limitations under the License.
     outline: none;
 }
 
-:host(:not([vertical])) {
-    touch-action: pan-y;
-}
-
-:host([vertical]) {
-    touch-action: pan-x;
-}
-
 .gradient {
     overflow: hidden;
 }

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -89,12 +89,8 @@ sp-field-label {
 
 :host([dragging]),
 #track {
-    touch-action: pan-x;
+    touch-action: none;
     user-select: none;
-}
-
-.handle {
-    pointer-events: none;
 }
 
 .not-exact.ticks {


### PR DESCRIPTION
## Description
Normalize touch interactions in Sliders between mobile Safari and Chrome.
Allow handle focus to be changes with multi-handle Sliders.

## Related issue(s)
- fixes #2034

## Motivation and context
Mobile is all the rage...

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://touch-action--spectrum-web-components.netlify.app/components/slider-handle/)
    2. Turn on mobile emulation in Chrome DevTools 
    3. See that both of the handles in the example slider are accessible via touch.
-   [ ] _Test case 2_
    1. In Mobile Safari
    2. Go [here](https://touch-action--spectrum-web-components.netlify.app/components/slider-handle/)
    3. See that both of the handles in the example slider are accessible via touch.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.