### PR TITLE
fix: replace missing globby.sync with fg.sync in build:component-inve…

### DIFF
--- a/tasks/build-component-inventory.js
+++ b/tasks/build-component-inventory.js
@@ -88,7 +88,7 @@ async function getCSSComponents() {
 
 async function getWebComponents() {
     const directoryRE = /(?:\/)([^\/]+)(?=\/src)\//;
-    const paths = globby.sync(ConfigPath);
+    const paths = fg.sync(ConfigPath);
     const componentPromises = paths.map(async (path) => {
         const config = await import(pathToFileURL(path));
         const component = config.default.spectrum;


### PR DESCRIPTION
## Description

`globby` doesn't exist anymore; use the equivalent `fg`

## Motivation and context

`yarn build:component-inventory` won't work until this is in.

This was easy to miss because I've left this as a manual script. Should we connect `yarn build:component-inventory` to a hook (maybe the one that generates docs?) in order to automate it?

## How has this been tested?

`yarn build:component-inventory`

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
