### PR TITLE
Use handleName field consistently in HandleController

### DIFF
--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -91,7 +91,7 @@ export class HandleController implements Controller {
             return input;
         }
         /* c8 ignore next 2 */
-        throw new Error(`No input for handle "${handle.name}"`);
+        throw new Error(`No input for handle "${handle.handleName}"`);
     }
 
     public requestUpdate(): void {
@@ -208,7 +208,7 @@ export class HandleController implements Controller {
         handles.forEach((handle, index) => {
             /* c8 ignore next */
             if (!handle.handleName?.length) {
-                handle.name = `handle${index + 1}`;
+                handle.handleName = `handle${index + 1}`;
             }
             this.handles.set(handle.handleName, handle);
             this.handleOrder.push(handle.handleName);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There are two instances of `handle.name` that should be `handle.handleName` so that the handle map is populated correctly.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #2035

## Motivation and context

I haven't nailed down the exact conditions, but sometimes when adding `sp-slider`s dynamically from an HTML template only one instance of `sp-slider-handle` will be added because the handle map key is undefined. (I finally tracked down the behaviour when I started getting `First slider handle cannot have attribute min="previous"` after adding `max="next"` to the first `sp-slider-handle` and `min="previous"` to the second.)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I'm afraid I don't have a reduced test case, but I was able to track down the behaviour in my (currently non-public) app. The code does something like this (which doesn't reproduce the issue in isolation, but is fixed by the change in this PR):

```js
const sliders = document.createElement('div');
arr.forEach(parms => {
  const el = sliderTemplate.content.cloneNode(true);
  const slider = el.querySelector('sp-slider');
  slider.setAttribute('label', parms.description);
  slider.querySelector('[name=min]').setAttribute('value', parms.min);
  slider.querySelector('[name=max]').setAttribute('value', parms.max);
  sliders.appendChild(slider);
});
document.body.appendChild(sliders);
```

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
