### PR TITLE
fix: use CSS Custom Property name supplied by Spectrum for dividers

### DIFF
--- a/packages/styles/scale-large.css
+++ b/packages/styles/scale-large.css
@@ -14,5 +14,5 @@ governing permissions and limitations under the License.
 
 :host,
 :root {
-    --spectrum-global-dimension-dividers: 1px;
+    --spectrum-global-alias-appframe-border-size: 1px;
 }

--- a/packages/styles/scale-medium.css
+++ b/packages/styles/scale-medium.css
@@ -14,5 +14,5 @@ governing permissions and limitations under the License.
 
 :host,
 :root {
-    --spectrum-global-dimension-dividers: 2px;
+    --spectrum-global-alias-appframe-border-size: 2px;
 }

--- a/packages/styles/stories/styles.stories.ts
+++ b/packages/styles/stories/styles.stories.ts
@@ -27,10 +27,11 @@ export const dividers = (): TemplateResult => html`
                 'toolbar main properties';
             grid-template-columns: 50px 1fr 250px;
             grid-template-rows: 50px 1fr;
-            gap: var(--spectrum-global-dimension-dividers);
+            gap: var(--spectrum-global-alias-appframe-border-size);
             background: var(--spectrum-alias-background-color-tertiary);
         }
-        header, aside {
+        header,
+        aside {
             background: var(--spectrum-alias-background-color-secondary);
         }
         header {


### PR DESCRIPTION
## Description
Use CSS Custom Property Name name that can be replaced by upstream tooling when ready without disrupting consumers.
