### PR TITLE
test: use factory methods for keyboard events to prevent reusing cancelled events

### DIFF
--- a/packages/accordion/test/accordion-item.test.ts
+++ b/packages/accordion/test/accordion-item.test.ts
@@ -88,7 +88,7 @@ describe('Accordion Item', () => {
 
         expect(open).to.be.false;
 
-        el.dispatchEvent(enterEvent);
+        el.dispatchEvent(enterEvent());
 
         await elementUpdated(el);
 
@@ -97,7 +97,7 @@ describe('Accordion Item', () => {
         el.disabled = false;
         await elementUpdated(el);
 
-        el.dispatchEvent(enterEvent);
+        el.dispatchEvent(enterEvent());
 
         await elementUpdated(el);
 
@@ -124,7 +124,7 @@ describe('Accordion Item', () => {
 
         expect(open).to.be.false;
 
-        el.dispatchEvent(spaceEvent);
+        el.dispatchEvent(spaceEvent());
 
         await elementUpdated(el);
 
@@ -133,7 +133,7 @@ describe('Accordion Item', () => {
         el.disabled = false;
         await elementUpdated(el);
 
-        el.dispatchEvent(spaceEvent);
+        el.dispatchEvent(spaceEvent());
 
         await elementUpdated(el);
 

--- a/packages/accordion/test/accordion.test.ts
+++ b/packages/accordion/test/accordion.test.ts
@@ -278,16 +278,16 @@ describe('Accordion', () => {
         await elementUpdated(el);
         expect(document.activeElement === secondItem).to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
+        el.dispatchEvent(arrowUpEvent());
 
         expect(document.activeElement === thirdToLastItem).to.be.true;
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
 
         expect(document.activeElement === secondToLastItem).to.be.true;
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
         expect(document.activeElement === secondItem).to.be.true;
 
         document.body.focus();
@@ -296,7 +296,7 @@ describe('Accordion', () => {
         const focused = el.focusElement as AccordionItem;
         expect(document.activeElement === focused).to.be.true;
 
-        focused.dispatchEvent(shiftTabEvent);
+        focused.dispatchEvent(shiftTabEvent());
         await elementUpdated(el);
 
         const outsideFocused = document.activeElement as HTMLElement;

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -59,7 +59,9 @@ class EmphasizedActionGroup extends LitElement {
 }
 customElements.define('emphasized-action-group', EmphasizedActionGroup);
 
-async function singleSelectedActionGroup(selected: string[]) {
+async function singleSelectedActionGroup(
+    selected: string[]
+): Promise<ActionGroup> {
     const el = await fixture<ActionGroup>(
         html`
             <sp-action-group
@@ -79,7 +81,9 @@ async function singleSelectedActionGroup(selected: string[]) {
     return el;
 }
 
-async function multipleSelectedActionGroup(selected: string[]) {
+async function multipleSelectedActionGroup(
+    selected: string[]
+): Promise<ActionGroup> {
     const el = await fixture<ActionGroup>(
         html`
             <sp-action-group
@@ -847,7 +851,7 @@ describe('ActionGroup', () => {
         expect(el.selected.length).to.equal(1);
         expect(el.selected[0]).to.equal('Third');
 
-        el.dispatchEvent(arrowRightEvent);
+        el.dispatchEvent(arrowRightEvent());
         await sendKeys({ press: 'Enter' });
 
         await elementUpdated(el);
@@ -855,14 +859,14 @@ describe('ActionGroup', () => {
         expect(el.selected.length).to.equal(1);
         expect(el.selected[0]).to.equal('First');
 
-        el.dispatchEvent(arrowLeftEvent);
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowLeftEvent());
+        el.dispatchEvent(arrowUpEvent());
         await sendKeys({ press: 'Enter' });
 
         expect(el.selected.length).to.equal(1);
         expect(el.selected[0]).to.equal('Second');
 
-        el.dispatchEvent(endEvent);
+        el.dispatchEvent(endEvent());
         await sendKeys({ press: 'Enter' });
 
         expect(el.selected.length).to.equal(1);
@@ -871,13 +875,13 @@ describe('ActionGroup', () => {
         await sendKeys({ press: 'PageUp' });
         await sendKeys({ press: 'Enter' });
 
-        el.dispatchEvent(homeEvent);
+        el.dispatchEvent(homeEvent());
         await sendKeys({ press: 'Enter' });
 
         expect(el.selected.length).to.equal(1);
         expect(el.selected[0]).to.equal('First');
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
         await sendKeys({ press: 'Enter' });
 
         expect(el.selected.length).to.equal(1);
@@ -953,7 +957,7 @@ describe('ActionGroup', () => {
         expect(el.selected.length).to.equal(1);
         expect(el.selected[0]).to.equal('Third');
 
-        el.dispatchEvent(arrowRightEvent);
+        el.dispatchEvent(arrowRightEvent());
         await sendKeys({ press: 'Enter' });
 
         await elementUpdated(el);
@@ -961,7 +965,7 @@ describe('ActionGroup', () => {
         expect(el.selected.length).to.equal(1);
         expect(el.selected[0]).to.equal('First');
 
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
         await sendKeys({ press: 'Enter' });
 
         expect(el.selected.length).to.equal(1);

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -173,7 +173,7 @@ describe('Button', () => {
 
         expect(focusedCount).to.equal(1);
 
-        el.dispatchEvent(shiftTabEvent);
+        el.dispatchEvent(shiftTabEvent());
         el.dispatchEvent(new Event('focusin'));
         await elementUpdated(el);
 

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -269,7 +269,7 @@ describe('card', () => {
         await elementUpdated(el);
         expect(el.focused, 'first time focused').to.be.true;
 
-        el.dispatchEvent(spaceEvent);
+        el.dispatchEvent(spaceEvent());
         await elementUpdated(el);
         expect(el.focused, 'still focused').to.be.true;
         expect(clickSpy.called).to.be.true;
@@ -291,14 +291,14 @@ describe('card', () => {
         expect(el.focused, 'first time focused').to.be.true;
         expect(el.selected, 'still not selected').to.be.false;
 
-        el.dispatchEvent(spaceEvent);
+        el.dispatchEvent(spaceEvent());
 
         await elementUpdated(el);
         expect(el.focused, 'still focused').to.be.true;
         expect(el.selected, 'first selected').to.be.true;
 
         el.addEventListener('change', (event: Event) => event.preventDefault());
-        el.dispatchEvent(spaceEvent);
+        el.dispatchEvent(spaceEvent());
 
         await elementUpdated(el);
         expect(el.focused, 'still focused after default prevented').to.be.true;

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -197,37 +197,37 @@ describe('ColorSlider', () => {
 
         const input = el.focusElement;
 
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
+        input.dispatchEvent(arrowUpEvent());
+        input.dispatchEvent(arrowUpKeyupEvent());
+        input.dispatchEvent(arrowUpEvent());
+        input.dispatchEvent(arrowUpKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(2);
 
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
+        input.dispatchEvent(arrowRightEvent());
+        input.dispatchEvent(arrowRightKeyupEvent());
+        input.dispatchEvent(arrowRightEvent());
+        input.dispatchEvent(arrowRightKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(3.9999999999999996);
 
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
+        input.dispatchEvent(arrowDownEvent());
+        input.dispatchEvent(arrowDownKeyupEvent());
+        input.dispatchEvent(arrowDownEvent());
+        input.dispatchEvent(arrowDownKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(1.9999999999999998);
 
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
+        input.dispatchEvent(arrowLeftEvent());
+        input.dispatchEvent(arrowLeftKeyupEvent());
+        input.dispatchEvent(arrowLeftEvent());
+        input.dispatchEvent(arrowLeftKeyupEvent());
 
         await elementUpdated(el);
 
@@ -246,37 +246,37 @@ describe('ColorSlider', () => {
 
         const input = el.focusElement;
 
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
+        input.dispatchEvent(arrowUpEvent());
+        input.dispatchEvent(arrowUpKeyupEvent());
+        input.dispatchEvent(arrowUpEvent());
+        input.dispatchEvent(arrowUpKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(2);
 
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
+        input.dispatchEvent(arrowRightEvent());
+        input.dispatchEvent(arrowRightKeyupEvent());
+        input.dispatchEvent(arrowRightEvent());
+        input.dispatchEvent(arrowRightKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(0);
 
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
+        input.dispatchEvent(arrowLeftEvent());
+        input.dispatchEvent(arrowLeftKeyupEvent());
+        input.dispatchEvent(arrowLeftEvent());
+        input.dispatchEvent(arrowLeftKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.sliderHandlePosition).to.equal(2);
 
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
+        input.dispatchEvent(arrowDownEvent());
+        input.dispatchEvent(arrowDownKeyupEvent());
+        input.dispatchEvent(arrowDownEvent());
+        input.dispatchEvent(arrowDownKeyupEvent());
 
         await elementUpdated(el);
 

--- a/packages/color-wheel/test/color-wheel.test.ts
+++ b/packages/color-wheel/test/color-wheel.test.ts
@@ -197,37 +197,37 @@ describe('ColorWheel', () => {
 
         const input = el.focusElement;
 
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
+        input.dispatchEvent(arrowUpEvent());
+        input.dispatchEvent(arrowUpKeyupEvent());
+        input.dispatchEvent(arrowUpEvent());
+        input.dispatchEvent(arrowUpKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(2);
 
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
+        input.dispatchEvent(arrowRightEvent());
+        input.dispatchEvent(arrowRightKeyupEvent());
+        input.dispatchEvent(arrowRightEvent());
+        input.dispatchEvent(arrowRightKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(4);
 
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
+        input.dispatchEvent(arrowDownEvent());
+        input.dispatchEvent(arrowDownKeyupEvent());
+        input.dispatchEvent(arrowDownEvent());
+        input.dispatchEvent(arrowDownKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(2);
 
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
+        input.dispatchEvent(arrowLeftEvent());
+        input.dispatchEvent(arrowLeftKeyupEvent());
+        input.dispatchEvent(arrowLeftEvent());
+        input.dispatchEvent(arrowLeftKeyupEvent());
 
         await elementUpdated(el);
 
@@ -246,37 +246,37 @@ describe('ColorWheel', () => {
 
         const input = el.focusElement;
 
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
-        input.dispatchEvent(arrowUpEvent);
-        input.dispatchEvent(arrowUpKeyupEvent);
+        input.dispatchEvent(arrowUpEvent());
+        input.dispatchEvent(arrowUpKeyupEvent());
+        input.dispatchEvent(arrowUpEvent());
+        input.dispatchEvent(arrowUpKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(2);
 
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
-        input.dispatchEvent(arrowRightEvent);
-        input.dispatchEvent(arrowRightKeyupEvent);
+        input.dispatchEvent(arrowRightEvent());
+        input.dispatchEvent(arrowRightKeyupEvent());
+        input.dispatchEvent(arrowRightEvent());
+        input.dispatchEvent(arrowRightKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(0);
 
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
-        input.dispatchEvent(arrowLeftEvent);
-        input.dispatchEvent(arrowLeftKeyupEvent);
+        input.dispatchEvent(arrowLeftEvent());
+        input.dispatchEvent(arrowLeftKeyupEvent());
+        input.dispatchEvent(arrowLeftEvent());
+        input.dispatchEvent(arrowLeftKeyupEvent());
 
         await elementUpdated(el);
 
         expect(el.value).to.equal(2);
 
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
-        input.dispatchEvent(arrowDownEvent);
-        input.dispatchEvent(arrowDownKeyupEvent);
+        input.dispatchEvent(arrowDownEvent());
+        input.dispatchEvent(arrowDownKeyupEvent());
+        input.dispatchEvent(arrowDownEvent());
+        input.dispatchEvent(arrowDownKeyupEvent());
 
         await elementUpdated(el);
 

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -219,14 +219,14 @@ describe('Menu', () => {
         expect(document.activeElement === el).to.be.true;
         expect(firstItem.focused).to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
-        el.dispatchEvent(arrowUpEvent);
-        el.dispatchEvent(tEvent);
+        el.dispatchEvent(arrowUpEvent());
+        el.dispatchEvent(arrowUpEvent());
+        el.dispatchEvent(tEvent());
 
         expect(document.activeElement === el).to.be.true;
         expect(thirdToLastItem.focused).to.be.true;
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
 
         expect(document.activeElement === el).to.be.true;
         expect(secondToLastItem.focused).to.be.true;
@@ -293,7 +293,7 @@ describe('Menu', () => {
             .true;
         expect(prependedItem.focused, 'another visibly focused').to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
 
         expect(document.activeElement === el, 'last active element').to.be.true;
         expect(appendedItem.focused, 'last visibly focused').to.be.true;
@@ -331,11 +331,11 @@ describe('Menu', () => {
         await sendKeys({ press: 'ArrowUp' });
         expect(document.activeElement === el).to.be.true;
         expect(firstItem.focused, 'first').to.be.true;
-        el.dispatchEvent(arrowDownEvent);
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
+        el.dispatchEvent(arrowDownEvent());
         expect(thirdItem.focused, 'third').to.be.true;
         // imitate tabbing away
-        el.dispatchEvent(tabEvent);
+        el.dispatchEvent(tabEvent());
         el.dispatchEvent(
             new CustomEvent('focusout', {
                 composed: true,
@@ -346,7 +346,7 @@ describe('Menu', () => {
         // re-bind keyevents
         el.startListeningToKeyboard();
         // focus management should start again from the first item.
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
         expect(secondItem.focused, 'second').to.be.true;
     });
     it('handles focus across focused MenuItem removals', async () => {

--- a/packages/picker/test/picker-sync.test.ts
+++ b/packages/picker/test/picker-sync.test.ts
@@ -580,12 +580,12 @@ describe('Picker, sync', () => {
 
             expect(el.open, 'inially closed').to.be.false;
 
-            button.dispatchEvent(tEvent);
+            button.dispatchEvent(tEvent());
             await elementUpdated(el);
 
             expect(el.open, 'still closed').to.be.false;
 
-            button.dispatchEvent(arrowUpEvent);
+            button.dispatchEvent(arrowUpEvent());
             await elementUpdated(el);
 
             expect(el.open, 'open by ArrowUp').to.be.true;
@@ -623,7 +623,7 @@ describe('Picker, sync', () => {
             expect(el.open, 'inially closed').to.be.false;
 
             const opened = oneEvent(el, 'sp-opened');
-            button.dispatchEvent(arrowDownEvent);
+            button.dispatchEvent(arrowDownEvent());
             await opened;
             await elementUpdated(el);
 
@@ -649,25 +649,25 @@ describe('Picker, sync', () => {
             const button = el.button as HTMLButtonElement;
 
             el.focus();
-            button.dispatchEvent(arrowLeftEvent);
+            button.dispatchEvent(arrowLeftEvent());
 
             await elementUpdated(el);
 
             expect(selectionSpy.callCount).to.equal(1);
             expect(selectionSpy.calledWith('Deselected'));
-            button.dispatchEvent(arrowLeftEvent);
+            button.dispatchEvent(arrowLeftEvent());
 
             await elementUpdated(el);
             expect(selectionSpy.callCount).to.equal(1);
-            button.dispatchEvent(arrowRightEvent);
+            button.dispatchEvent(arrowRightEvent());
 
             await elementUpdated(el);
             expect(selectionSpy.calledWith('option-2'));
 
-            button.dispatchEvent(arrowRightEvent);
-            button.dispatchEvent(arrowRightEvent);
-            button.dispatchEvent(arrowRightEvent);
-            button.dispatchEvent(arrowRightEvent);
+            button.dispatchEvent(arrowRightEvent());
+            button.dispatchEvent(arrowRightEvent());
+            button.dispatchEvent(arrowRightEvent());
+            button.dispatchEvent(arrowRightEvent());
 
             await elementUpdated(el);
             expect(selectionSpy.callCount).to.equal(5);
@@ -683,7 +683,7 @@ describe('Picker, sync', () => {
             const button = el.button as HTMLButtonElement;
 
             el.focus();
-            button.dispatchEvent(arrowRightEvent);
+            button.dispatchEvent(arrowRightEvent());
 
             await elementUpdated(el);
 
@@ -960,7 +960,7 @@ describe('Picker, sync', () => {
             lastItem.dispatchEvent(
                 new FocusEvent('focusin', { bubbles: true })
             );
-            lastItem.dispatchEvent(arrowDownEvent);
+            lastItem.dispatchEvent(arrowDownEvent());
             await elementUpdated(el);
             await nextFrame();
             expect(getParentOffset(lastItem)).to.be.greaterThan(40);

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -580,12 +580,12 @@ describe('Picker, sync', () => {
 
             expect(el.open, 'inially closed').to.be.false;
 
-            button.dispatchEvent(tEvent);
+            button.dispatchEvent(tEvent());
             await elementUpdated(el);
 
             expect(el.open, 'still closed').to.be.false;
 
-            button.dispatchEvent(arrowUpEvent);
+            button.dispatchEvent(arrowUpEvent());
             await elementUpdated(el);
 
             expect(el.open, 'open by ArrowUp').to.be.true;
@@ -623,7 +623,7 @@ describe('Picker, sync', () => {
             expect(el.open, 'inially closed').to.be.false;
 
             const opened = oneEvent(el, 'sp-opened');
-            button.dispatchEvent(arrowDownEvent);
+            button.dispatchEvent(arrowDownEvent());
             await opened;
             await elementUpdated(el);
 
@@ -649,25 +649,25 @@ describe('Picker, sync', () => {
             const button = el.button as HTMLButtonElement;
 
             el.focus();
-            button.dispatchEvent(arrowLeftEvent);
+            button.dispatchEvent(arrowLeftEvent());
 
             await elementUpdated(el);
 
             expect(selectionSpy.callCount).to.equal(1);
             expect(selectionSpy.calledWith('Deselected'));
-            button.dispatchEvent(arrowLeftEvent);
+            button.dispatchEvent(arrowLeftEvent());
 
             await elementUpdated(el);
             expect(selectionSpy.callCount).to.equal(1);
-            button.dispatchEvent(arrowRightEvent);
+            button.dispatchEvent(arrowRightEvent());
 
             await elementUpdated(el);
             expect(selectionSpy.calledWith('option-2'));
 
-            button.dispatchEvent(arrowRightEvent);
-            button.dispatchEvent(arrowRightEvent);
-            button.dispatchEvent(arrowRightEvent);
-            button.dispatchEvent(arrowRightEvent);
+            button.dispatchEvent(arrowRightEvent());
+            button.dispatchEvent(arrowRightEvent());
+            button.dispatchEvent(arrowRightEvent());
+            button.dispatchEvent(arrowRightEvent());
 
             await elementUpdated(el);
             expect(selectionSpy.callCount).to.equal(5);
@@ -683,7 +683,7 @@ describe('Picker, sync', () => {
             const button = el.button as HTMLButtonElement;
 
             el.focus();
-            button.dispatchEvent(arrowRightEvent);
+            button.dispatchEvent(arrowRightEvent());
 
             await elementUpdated(el);
 
@@ -960,7 +960,7 @@ describe('Picker, sync', () => {
             lastItem.dispatchEvent(
                 new FocusEvent('focusin', { bubbles: true })
             );
-            lastItem.dispatchEvent(arrowDownEvent);
+            lastItem.dispatchEvent(arrowDownEvent());
             await elementUpdated(el);
             await nextFrame();
             expect(getParentOffset(lastItem)).to.be.greaterThan(40);

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -166,33 +166,33 @@ describe('Radio Group - focus control', () => {
         radio1.focus();
         await elementUpdated(el);
 
-        el.dispatchEvent(pageUpEvent);
-        el.dispatchEvent(arrowRightEvent);
+        el.dispatchEvent(pageUpEvent());
+        el.dispatchEvent(arrowRightEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio2).to.be.true;
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio3).to.be.true;
 
-        el.dispatchEvent(endEvent);
+        el.dispatchEvent(endEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio5).to.be.true;
 
-        el.dispatchEvent(arrowLeftEvent);
+        el.dispatchEvent(arrowLeftEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio4).to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio3).to.be.true;
 
-        el.dispatchEvent(homeEvent);
+        el.dispatchEvent(homeEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio1).to.be.true;
@@ -221,23 +221,23 @@ describe('Radio Group - focus control', () => {
         await elementUpdated(el);
         expect(document.activeElement === radio2, 'start 2').to.be.true;
 
-        el.dispatchEvent(enterEvent);
-        el.dispatchEvent(endEvent);
+        el.dispatchEvent(enterEvent());
+        el.dispatchEvent(endEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio4, 'first 4').to.be.true;
 
-        el.dispatchEvent(homeEvent);
+        el.dispatchEvent(homeEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio2, 'second 2').to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio4, 'third 4').to.be.true;
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === radio2, 'fourth 2').to.be.true;
@@ -278,19 +278,19 @@ describe('Radio Group - focus control', () => {
         ) as Radio;
 
         radio1.focus();
-        radio1.dispatchEvent(pageUpEvent);
+        radio1.dispatchEvent(pageUpEvent());
 
         expect(document.activeElement === radio4).to.be.true;
 
-        radio4.dispatchEvent(pageDownEvent);
+        radio4.dispatchEvent(pageDownEvent());
 
         expect(document.activeElement === radio1).to.be.true;
 
-        radio1.dispatchEvent(pageDownEvent);
+        radio1.dispatchEvent(pageDownEvent());
 
         expect(document.activeElement === radio2).to.be.true;
 
-        radio2.dispatchEvent(pageDownEvent);
+        radio2.dispatchEvent(pageDownEvent());
 
         expect(document.activeElement === radio4, 'Focuses `radio4`').to.be
             .true;

--- a/packages/search/test/search.test.ts
+++ b/packages/search/test/search.test.ts
@@ -66,7 +66,7 @@ describe('Search', () => {
 
         const root = el.shadowRoot ? el.shadowRoot : el;
         const clearButton = root.querySelector('#button') as HTMLButtonElement;
-        clearButton.dispatchEvent(escapeEvent);
+        clearButton.dispatchEvent(escapeEvent());
 
         await elementUpdated(el);
 
@@ -137,14 +137,14 @@ describe('Search', () => {
         await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
 
         expect(el.value).to.equal('Test');
-        el.focusElement.dispatchEvent(spaceEvent);
+        el.focusElement.dispatchEvent(spaceEvent());
 
         await elementUpdated(el);
         expect(el.value).to.equal('Test');
 
         inputSpy.resetHistory();
         changeSpy.resetHistory();
-        el.focusElement.dispatchEvent(escapeEvent);
+        el.focusElement.dispatchEvent(escapeEvent());
 
         await elementUpdated(el);
 

--- a/packages/sidenav/test/sidenav.test.ts
+++ b/packages/sidenav/test/sidenav.test.ts
@@ -173,7 +173,7 @@ describe('Sidenav', () => {
         focused.click();
         expect(focused.selected).to.be.true;
 
-        el.dispatchEvent(shiftTabEvent);
+        el.dispatchEvent(shiftTabEvent());
         const outsideFocused = document.activeElement as HTMLElement;
 
         expect(typeof outsideFocused).not.to.equal(SideNavItem);
@@ -319,7 +319,7 @@ describe('Sidenav', () => {
         expect(el.value).to.equal('Section 1');
 
         el.focus();
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
         let focused = document.activeElement as SideNavItem;
         focused.focusElement.click();
 
@@ -328,8 +328,8 @@ describe('Sidenav', () => {
         expect(el.value).to.equal('Section 0');
 
         el.focus();
-        el.dispatchEvent(arrowDownEvent);
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
+        el.dispatchEvent(arrowDownEvent());
         focused = document.activeElement as SideNavItem;
         expect(focused.expanded, 'not expanded').to.be.false;
         focused.focusElement.click();
@@ -338,7 +338,7 @@ describe('Sidenav', () => {
 
         expect(focused.expanded, 'expanded').to.be.true;
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
         await elementUpdated(el);
         focused = document.activeElement as SideNavItem;
         focused.focusElement.click();
@@ -353,7 +353,7 @@ describe('Sidenav', () => {
         focused = document.activeElement as SideNavItem;
         expect(focused.selected, 'selected').to.be.true;
 
-        el.dispatchEvent(shiftTabEvent);
+        el.dispatchEvent(shiftTabEvent());
         const outsideFocused = document.activeElement as HTMLElement;
 
         expect(typeof outsideFocused).not.to.equal(SideNavItem);
@@ -404,7 +404,7 @@ describe('Sidenav', () => {
         expect(sidenavEl.value).to.equal('Section 1');
 
         sidenavEl.focus();
-        sidenavEl.dispatchEvent(arrowUpEvent);
+        sidenavEl.dispatchEvent(arrowUpEvent());
         let focused = rootNode.activeElement as SideNavItem;
         focused.focusElement.click();
 
@@ -413,8 +413,8 @@ describe('Sidenav', () => {
         expect(sidenavEl.value).to.equal('Section 0');
 
         sidenavEl.focus();
-        sidenavEl.dispatchEvent(arrowDownEvent);
-        sidenavEl.dispatchEvent(arrowDownEvent);
+        sidenavEl.dispatchEvent(arrowDownEvent());
+        sidenavEl.dispatchEvent(arrowDownEvent());
         focused = rootNode.activeElement as SideNavItem;
         expect(focused.expanded).to.be.false;
         focused.focusElement.click();
@@ -423,7 +423,7 @@ describe('Sidenav', () => {
 
         expect(focused.expanded).to.be.true;
 
-        sidenavEl.dispatchEvent(arrowDownEvent);
+        sidenavEl.dispatchEvent(arrowDownEvent());
         await elementUpdated(sidenavEl);
         focused = rootNode.activeElement as SideNavItem;
         focused.focusElement.click();
@@ -438,7 +438,7 @@ describe('Sidenav', () => {
         focused = rootNode.activeElement as SideNavItem;
         expect(focused.selected).to.be.true;
 
-        sidenavEl.dispatchEvent(shiftTabEvent);
+        sidenavEl.dispatchEvent(shiftTabEvent());
         const outsideFocused = rootNode.activeElement as HTMLElement;
 
         expect(typeof outsideFocused).not.to.equal(SideNavItem);

--- a/packages/split-view/test/split-view.test.ts
+++ b/packages/split-view/test/split-view.test.ts
@@ -676,47 +676,47 @@ describe('SplitView', () => {
             '#splitter'
         ) as HTMLDivElement;
 
-        splitter.dispatchEvent(arrowLeftEvent);
+        splitter.dispatchEvent(arrowLeftEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos - 10);
 
-        splitter.dispatchEvent(arrowRightEvent);
+        splitter.dispatchEvent(arrowRightEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(arrowUpEvent);
+        splitter.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos + 10);
 
-        splitter.dispatchEvent(arrowDownEvent);
+        splitter.dispatchEvent(arrowDownEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(pageUpEvent);
+        splitter.dispatchEvent(pageUpEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos + 50);
 
-        splitter.dispatchEvent(pageDownEvent);
+        splitter.dispatchEvent(pageDownEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(homeEvent);
+        splitter.dispatchEvent(homeEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(50);
 
-        splitter.dispatchEvent(arrowLeftEvent);
+        splitter.dispatchEvent(arrowLeftEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(50);
 
-        splitter.dispatchEvent(endEvent);
+        splitter.dispatchEvent(endEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(splitTotalWidth - 50);
 
-        splitter.dispatchEvent(arrowRightEvent);
+        splitter.dispatchEvent(arrowRightEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(splitTotalWidth - 50);
 
-        splitter.dispatchEvent(shiftTabEvent);
+        splitter.dispatchEvent(shiftTabEvent());
         await elementUpdated(el);
         const outsideFocused = document.activeElement as HTMLElement;
         expect(typeof outsideFocused).not.to.equal(splitter);
@@ -745,39 +745,39 @@ describe('SplitView', () => {
             '#splitter'
         ) as HTMLDivElement;
 
-        splitter.dispatchEvent(arrowLeftEvent);
+        splitter.dispatchEvent(arrowLeftEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos + 10);
 
-        splitter.dispatchEvent(arrowRightEvent);
+        splitter.dispatchEvent(arrowRightEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(arrowUpEvent);
+        splitter.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos + 10);
 
-        splitter.dispatchEvent(arrowDownEvent);
+        splitter.dispatchEvent(arrowDownEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(pageUpEvent);
+        splitter.dispatchEvent(pageUpEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos + 50);
 
-        splitter.dispatchEvent(pageDownEvent);
+        splitter.dispatchEvent(pageDownEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(homeEvent);
+        splitter.dispatchEvent(homeEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(0);
 
-        splitter.dispatchEvent(endEvent);
+        splitter.dispatchEvent(endEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(splitTotalWidth - el.splitterSize);
 
-        splitter.dispatchEvent(shiftTabEvent);
+        splitter.dispatchEvent(shiftTabEvent());
         await elementUpdated(el);
         const outsideFocused = document.activeElement as HTMLElement;
         expect(typeof outsideFocused).not.to.equal(splitter);
@@ -805,41 +805,41 @@ describe('SplitView', () => {
             '#splitter'
         ) as HTMLDivElement;
 
-        splitter.dispatchEvent(arrowLeftEvent);
+        splitter.dispatchEvent(arrowLeftEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos - 10);
 
-        splitter.dispatchEvent(arrowRightEvent);
+        splitter.dispatchEvent(arrowRightEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(arrowUpEvent);
+        splitter.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos - 10);
 
-        splitter.dispatchEvent(arrowDownEvent);
+        splitter.dispatchEvent(arrowDownEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(pageUpEvent);
+        splitter.dispatchEvent(pageUpEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos - 50);
 
-        splitter.dispatchEvent(pageDownEvent);
+        splitter.dispatchEvent(pageDownEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
 
-        splitter.dispatchEvent(homeEvent);
+        splitter.dispatchEvent(homeEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(0);
 
-        splitter.dispatchEvent(endEvent);
+        splitter.dispatchEvent(endEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(
             splitTotalHeight - el.splitterSize
         );
 
-        splitter.dispatchEvent(shiftTabEvent);
+        splitter.dispatchEvent(shiftTabEvent());
         await elementUpdated(el);
         const outsideFocused = document.activeElement as HTMLElement;
         expect(typeof outsideFocused).not.to.equal(splitter);
@@ -869,11 +869,11 @@ describe('SplitView', () => {
             '#splitter'
         ) as HTMLDivElement;
 
-        splitter.dispatchEvent(homeEvent);
+        splitter.dispatchEvent(homeEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(0);
 
-        splitter.dispatchEvent(endEvent);
+        splitter.dispatchEvent(endEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(splitTotalWidth - el.splitterSize);
     });
@@ -897,7 +897,7 @@ describe('SplitView', () => {
         splitter.dispatchEvent(new PointerEvent('pointerdown'));
         await elementUpdated(el);
         //Send keyboard events to resize
-        splitter.dispatchEvent(arrowLeftEvent);
+        splitter.dispatchEvent(arrowLeftEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos);
     });
@@ -1036,7 +1036,7 @@ describe('SplitView', () => {
             '#splitter'
         ) as HTMLDivElement;
 
-        splitter.dispatchEvent(arrowLeftEvent);
+        splitter.dispatchEvent(arrowLeftEvent());
         await elementUpdated(el);
         expect(el.splitterPos || 0).to.equal(pos - 10);
         expect(changeSpy.callCount).to.equal(1);

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -389,25 +389,25 @@ describe('Tabs', () => {
         expect(document.activeElement === firstTab, 'Focus first tab').to.be
             .true;
 
-        firstTab.dispatchEvent(arrowLeftEvent);
-        firstTab.dispatchEvent(arrowUpEvent);
+        firstTab.dispatchEvent(arrowLeftEvent());
+        firstTab.dispatchEvent(arrowUpEvent());
 
         await elementUpdated(el);
         expect(document.activeElement === secondTab, 'Focus second tab').to.be
             .true;
 
-        secondTab.dispatchEvent(enterEvent);
+        secondTab.dispatchEvent(enterEvent());
 
         await elementUpdated(el);
         expect(el.selected).to.be.equal('second');
 
-        secondTab.dispatchEvent(arrowRightEvent);
+        secondTab.dispatchEvent(arrowRightEvent());
 
         await elementUpdated(el);
         expect(document.activeElement === firstTab, 'Focus first tab').to.be
             .true;
 
-        firstTab.dispatchEvent(spaceEvent);
+        firstTab.dispatchEvent(spaceEvent());
 
         await elementUpdated(el);
         expect(el.selected).to.be.equal('first');
@@ -427,7 +427,7 @@ describe('Tabs', () => {
         expect(tab2.classList.contains('focus-visible')).to.be.false;
         expect(tab3.classList.contains('focus-visible')).to.be.false;
 
-        tab1.dispatchEvent(tabEvent);
+        tab1.dispatchEvent(tabEvent());
         tab1.focus();
         await elementUpdated(tab1);
         expect(document.activeElement, 'first tab is focused').to.equal(tab1);
@@ -528,25 +528,25 @@ describe('Tabs', () => {
         let activeElement = rootNode.activeElement as Tab;
         expect(activeElement === firstTab, 'Focus first tab').to.be.true;
 
-        firstTab.dispatchEvent(arrowLeftEvent);
-        firstTab.dispatchEvent(arrowUpEvent);
+        firstTab.dispatchEvent(arrowLeftEvent());
+        firstTab.dispatchEvent(arrowUpEvent());
 
         await elementUpdated(el);
         activeElement = rootNode.activeElement as Tab;
         expect(activeElement === secondTab, 'Focus second tab').to.be.true;
 
-        secondTab.dispatchEvent(enterEvent);
+        secondTab.dispatchEvent(enterEvent());
 
         await elementUpdated(el);
         expect(tabsEl.selected).to.be.equal('second');
 
-        secondTab.dispatchEvent(arrowRightEvent);
+        secondTab.dispatchEvent(arrowRightEvent());
 
         await elementUpdated(el);
         activeElement = rootNode.activeElement as Tab;
         expect(activeElement === firstTab, 'Focus first tab').to.be.true;
 
-        firstTab.dispatchEvent(spaceEvent);
+        firstTab.dispatchEvent(spaceEvent());
 
         await elementUpdated(el);
         expect(tabsEl.selected).to.be.equal('first');
@@ -575,25 +575,25 @@ describe('Tabs', () => {
         expect(document.activeElement === firstTab, 'Focus first tab').to.be
             .true;
 
-        firstTab.dispatchEvent(arrowLeftEvent);
-        firstTab.dispatchEvent(arrowUpEvent);
+        firstTab.dispatchEvent(arrowLeftEvent());
+        firstTab.dispatchEvent(arrowUpEvent());
 
         await elementUpdated(el);
         expect(document.activeElement === secondTab, 'Focus second tab').to.be
             .true;
 
-        secondTab.dispatchEvent(enterEvent);
+        secondTab.dispatchEvent(enterEvent());
 
         await elementUpdated(el);
         expect(el.selected).to.be.equal('second');
 
-        secondTab.dispatchEvent(arrowDownEvent);
+        secondTab.dispatchEvent(arrowDownEvent());
 
         await elementUpdated(el);
         expect(document.activeElement === firstTab, 'Focus first tab').to.be
             .true;
 
-        firstTab.dispatchEvent(spaceEvent);
+        firstTab.dispatchEvent(spaceEvent());
 
         await elementUpdated(el);
         expect(el.selected).to.be.equal('first');

--- a/packages/tags/test/tag.test.ts
+++ b/packages/tags/test/tag.test.ts
@@ -146,7 +146,7 @@ describe('Tag', () => {
         el.dispatchEvent(new FocusEvent('focusin'));
         await elementUpdated(el);
 
-        el.dispatchEvent(deleteEvent);
+        el.dispatchEvent(deleteEvent());
         await elementUpdated(el);
 
         expect(deleteSpy.called).to.be.false;
@@ -154,19 +154,19 @@ describe('Tag', () => {
         el.deletable = true;
         await elementUpdated(el);
 
-        el.dispatchEvent(enterEvent);
+        el.dispatchEvent(enterEvent());
         await elementUpdated(el);
 
         expect(deleteSpy.called).to.be.false;
 
-        testKeyboardEvent(deleteEvent);
-        testKeyboardEvent(spaceEvent);
-        testKeyboardEvent(backspaceEvent);
+        testKeyboardEvent(deleteEvent());
+        testKeyboardEvent(spaceEvent());
+        testKeyboardEvent(backspaceEvent());
 
         el.dispatchEvent(new FocusEvent('focusout'));
         await elementUpdated(el);
 
-        el.dispatchEvent(deleteEvent);
+        el.dispatchEvent(deleteEvent());
         expect(
             deleteSpy.callCount,
             'Does not respond after `focusout`'

--- a/packages/tags/test/tags.test.ts
+++ b/packages/tags/test/tags.test.ts
@@ -130,33 +130,33 @@ describe('Tags', () => {
         tag1.focus();
         await elementUpdated(el);
 
-        el.dispatchEvent(pageUpEvent);
-        el.dispatchEvent(arrowRightEvent);
+        el.dispatchEvent(pageUpEvent());
+        el.dispatchEvent(arrowRightEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag2).to.be.true;
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag3).to.be.true;
 
-        el.dispatchEvent(endEvent);
+        el.dispatchEvent(endEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag5).to.be.true;
 
-        el.dispatchEvent(arrowLeftEvent);
+        el.dispatchEvent(arrowLeftEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag4).to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag3).to.be.true;
 
-        el.dispatchEvent(homeEvent);
+        el.dispatchEvent(homeEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag1).to.be.true;
@@ -184,23 +184,23 @@ describe('Tags', () => {
         tag2.focus();
         await elementUpdated(el);
 
-        el.dispatchEvent(enterEvent);
-        el.dispatchEvent(endEvent);
+        el.dispatchEvent(enterEvent());
+        el.dispatchEvent(endEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag4).to.be.true;
 
-        el.dispatchEvent(homeEvent);
+        el.dispatchEvent(homeEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag2).to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag4).to.be.true;
 
-        el.dispatchEvent(arrowDownEvent);
+        el.dispatchEvent(arrowDownEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag2).to.be.true;
@@ -226,23 +226,23 @@ describe('Tags', () => {
         tag1.focus();
         await elementUpdated(el);
 
-        el.dispatchEvent(enterEvent);
-        el.dispatchEvent(endEvent);
+        el.dispatchEvent(enterEvent());
+        el.dispatchEvent(endEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag5).to.be.true;
 
-        el.dispatchEvent(homeEvent);
+        el.dispatchEvent(homeEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag1).to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag5).to.be.true;
 
-        el.dispatchEvent(arrowUpEvent);
+        el.dispatchEvent(arrowUpEvent());
         await elementUpdated(el);
 
         expect(document.activeElement === tag1).to.be.true;
@@ -284,7 +284,7 @@ describe('Tags', () => {
         });
         expect(document.activeElement === tagA).to.be.true;
 
-        tagset2.dispatchEvent(arrowDownEvent);
+        tagset2.dispatchEvent(arrowDownEvent());
         expect(document.activeElement === tagB).to.be.true;
     });
     it('loads accepts "PageUp" and "PageDown" keys', async () => {
@@ -315,19 +315,19 @@ describe('Tags', () => {
         const tag4 = tags4.querySelector('sp-tag:not([disabled])') as Tag;
 
         tag1.focus();
-        tag1.dispatchEvent(pageUpEvent);
+        tag1.dispatchEvent(pageUpEvent());
 
         expect(document.activeElement === tag4).to.be.true;
 
-        tag4.dispatchEvent(pageDownEvent);
+        tag4.dispatchEvent(pageDownEvent());
 
         expect(document.activeElement === tag1).to.be.true;
 
-        tag1.dispatchEvent(pageDownEvent);
+        tag1.dispatchEvent(pageDownEvent());
 
         expect(document.activeElement === tag2).to.be.true;
 
-        tag2.dispatchEvent(pageDownEvent);
+        tag2.dispatchEvent(pageDownEvent());
 
         expect(document.activeElement === tag4, 'Focuses `tag4`').to.be.true;
     });

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -47,30 +47,33 @@ const keyboardEvent = (
         key: code,
     });
 };
-export const shiftTabEvent = keyboardEvent('Tab', { shiftKey: true });
-export const shiftEvent = keyboardEvent('Shift', { shiftKey: true });
-export const enterEvent = keyboardEvent('Enter');
-export const escapeEvent = keyboardEvent('Escape');
-export const arrowRightEvent = keyboardEvent('ArrowRight');
-export const arrowLeftEvent = keyboardEvent('ArrowLeft');
-export const arrowUpEvent = keyboardEvent('ArrowUp');
-export const arrowDownEvent = keyboardEvent('ArrowDown');
-export const deleteEvent = keyboardEvent('Delete');
-export const spaceEvent = keyboardEvent('Space');
-export const backspaceEvent = keyboardEvent('Backspace');
-export const endEvent = keyboardEvent('End');
-export const homeEvent = keyboardEvent('Home');
-export const pageUpEvent = keyboardEvent('PageUp');
-export const pageDownEvent = keyboardEvent('PageDown');
-export const tabEvent = keyboardEvent('Tab');
-export const tEvent = keyboardEvent('t');
+export const shiftTabEvent = (): KeyboardEvent =>
+    keyboardEvent('Tab', { shiftKey: true });
+export const shiftEvent = (): KeyboardEvent =>
+    keyboardEvent('Shift', { shiftKey: true });
+export const enterEvent = (): KeyboardEvent => keyboardEvent('Enter');
+export const escapeEvent = (): KeyboardEvent => keyboardEvent('Escape');
+export const arrowRightEvent = (): KeyboardEvent => keyboardEvent('ArrowRight');
+export const arrowLeftEvent = (): KeyboardEvent => keyboardEvent('ArrowLeft');
+export const arrowUpEvent = (): KeyboardEvent => keyboardEvent('ArrowUp');
+export const arrowDownEvent = (): KeyboardEvent => keyboardEvent('ArrowDown');
+export const deleteEvent = (): KeyboardEvent => keyboardEvent('Delete');
+export const spaceEvent = (): KeyboardEvent => keyboardEvent('Space');
+export const backspaceEvent = (): KeyboardEvent => keyboardEvent('Backspace');
+export const endEvent = (): KeyboardEvent => keyboardEvent('End');
+export const homeEvent = (): KeyboardEvent => keyboardEvent('Home');
+export const pageUpEvent = (): KeyboardEvent => keyboardEvent('PageUp');
+export const pageDownEvent = (): KeyboardEvent => keyboardEvent('PageDown');
+export const tabEvent = (): KeyboardEvent => keyboardEvent('Tab');
+export const tEvent = (): KeyboardEvent => keyboardEvent('t');
 
-export const shiftKeyupEvent = keyboardEvent(
-    'Shift',
-    { shiftKey: true },
-    'keyup'
-);
-export const arrowRightKeyupEvent = keyboardEvent('ArrowRight', {}, 'keyup');
-export const arrowLeftKeyupEvent = keyboardEvent('ArrowLeft', {}, 'keyup');
-export const arrowUpKeyupEvent = keyboardEvent('ArrowUp', {}, 'keyup');
-export const arrowDownKeyupEvent = keyboardEvent('ArrowDown', {}, 'keyup');
+export const shiftKeyupEvent = (): KeyboardEvent =>
+    keyboardEvent('Shift', { shiftKey: true }, 'keyup');
+export const arrowRightKeyupEvent = (): KeyboardEvent =>
+    keyboardEvent('ArrowRight', {}, 'keyup');
+export const arrowLeftKeyupEvent = (): KeyboardEvent =>
+    keyboardEvent('ArrowLeft', {}, 'keyup');
+export const arrowUpKeyupEvent = (): KeyboardEvent =>
+    keyboardEvent('ArrowUp', {}, 'keyup');
+export const arrowDownKeyupEvent = (): KeyboardEvent =>
+    keyboardEvent('ArrowDown', {}, 'keyup');


### PR DESCRIPTION
## Description
Found in #2017 that the non-factory approach to keyboard events in the test suite caused us to recycle events that might already have `defaultPrevented` confusing test results. This wraps all of our helpers in factory methods so we work with a new event each time.

## How has this been tested?
CI ran.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.