### PR TITLE
fix(picker): make "change" event bubbling and composed

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -215,7 +215,9 @@ export class PickerBase extends SizedMixin(Focusable) {
         await this.updateComplete;
         const applyDefault = this.dispatchEvent(
             new Event('change', {
+                bubbles: true,
                 cancelable: true,
+                composed: true,
             })
         );
         if (!applyDefault) {


### PR DESCRIPTION
## Description
Make sure `change` event in Picker bubbles and is composed like `change` events on a native `<select>` element.

## Related issue(s)
- fixes #2002
- closes #2003 

## Motivation and context
Match native element patterns.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://picker-event--spectrum-web-components.netlify.app/components/picker/#sizes)
    2. Add an event listener for the `change` event on an element ancestor of a Picker
    3. Change the Picker and see the event bubble.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.