### PR TITLE
fix(number-field): process 2 byte characters as their single byte cousins

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -36,6 +36,25 @@ import styles from './number-field.css.js';
 
 export const FRAMES_PER_CHANGE = 5;
 export const indeterminatePlaceholder = '-';
+export const remapMultiByteCharacters: Record<string, string> = {
+    '１': '1',
+    '２': '2',
+    '３': '3',
+    '４': '4',
+    '５': '5',
+    '６': '6',
+    '７': '7',
+    '８': '8',
+    '９': '9',
+    '０': '0',
+    '、': ',',
+    '，': ',',
+    '。': '.',
+    '．': '.',
+    '％': '%',
+    '＋': '+',
+    ー: '-',
+};
 
 /**
  * @element sp-number-field
@@ -314,7 +333,7 @@ export class NumberField extends TextfieldBase {
     private wasIndeterminate = false;
     private indeterminateValue?: number;
 
-    protected onChange(): void {
+    protected handleChange(): void {
         const value = this.convertValueToNumber(this.inputValue);
         if (this.wasIndeterminate) {
             this.wasIndeterminate = false;
@@ -325,10 +344,10 @@ export class NumberField extends TextfieldBase {
             }
         }
         this.value = value;
-        super.onChange();
+        super.handleChange();
     }
 
-    protected onInput(): void {
+    protected handleInput(): void {
         if (this.indeterminate) {
             this.wasIndeterminate = true;
             this.indeterminateValue = this.value;
@@ -337,7 +356,11 @@ export class NumberField extends TextfieldBase {
                 ''
             );
         }
-        const { value, selectionStart } = this.inputElement;
+        const { value: originalValue, selectionStart } = this.inputElement;
+        const value = originalValue
+            .split('')
+            .map((char) => remapMultiByteCharacters[char] || char)
+            .join('');
         if (this.numberParser.isValidPartialNumber(value)) {
             const valueAsNumber = this.convertValueToNumber(value);
             if (!value && this.indeterminateValue) {
@@ -348,6 +371,7 @@ export class NumberField extends TextfieldBase {
                 this._value = this.validateInput(valueAsNumber);
             }
             this._trackingValue = value;
+            this.inputElement.value = value;
             return;
         }
         const currentLength = value.length;

--- a/packages/number-field/stories/number-field.stories.ts
+++ b/packages/number-field/stories/number-field.stories.ts
@@ -190,6 +190,7 @@ export const Default = (args: StoryArgs = {}): TemplateResult => {
         <sp-number-field
             id="default"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
             style="width: 150px"
         ></sp-number-field>
     `;
@@ -205,6 +206,7 @@ export const quiet = (args: StoryArgs = {}): TemplateResult => {
         <sp-number-field
             id="default"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
             style="width: 150px"
         ></sp-number-field>
     `;
@@ -221,6 +223,7 @@ export const indeterminate = (args: StoryArgs = {}): TemplateResult => {
         <sp-number-field
             id="default"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
             style="width: 150px"
         ></sp-number-field>
     `;
@@ -240,11 +243,12 @@ export const decimals = (args: StoryArgs): TemplateResult => {
             id="decimals"
             style="width: 200px"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
             .formatOptions=${{
                 signDisplay: 'exceptZero',
                 minimumFractionDigits: 1,
                 maximumFractionDigits: 2,
-            }}
+            } as unknown as Intl.NumberFormatOptions}
         ></sp-number-field>
     `;
 };
@@ -260,10 +264,11 @@ export const percents = (args: StoryArgs = {}): TemplateResult => {
             id="percents"
             style="width: 200px"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
             .formatOptions=${{
                 style: 'percent',
                 unitDisplay: 'narrow',
-            }}
+            } as unknown as Intl.NumberFormatOptions}
         ></sp-number-field>
     `;
 };
@@ -278,12 +283,13 @@ export const currency = (args: StoryArgs = {}): TemplateResult => {
         <sp-number-field
             style="width: 200px"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
             .formatOptions=${{
                 style: 'currency',
                 currency: 'EUR',
                 currencyDisplay: 'code',
                 currencySign: 'accounting',
-            }}
+            } as unknown as Intl.NumberFormatOptions}
         ></sp-number-field>
     `;
 };
@@ -299,11 +305,12 @@ export const units = (args: StoryArgs): TemplateResult => {
             id="units"
             style="width: 200px"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
             .formatOptions=${{
                 style: 'unit',
                 unit: 'inch',
                 unitDisplay: 'long',
-            }}
+            } as unknown as Intl.NumberFormatOptions}
         ></sp-number-field>
     `;
 };
@@ -323,6 +330,7 @@ export const pixels = (args: StoryArgs): TemplateResult => {
                 unit: 'px',
             }}
             ...=${spreadProps(args)}
+            @change=${args.onChange}
         ></sp-number-field>
     `;
 };
@@ -339,6 +347,7 @@ export const minMax = (args: StoryArgs): TemplateResult => html`
         id="min-max"
         style="width: 200px"
         ...=${spreadProps(args)}
+        @change=${args.onChange}
     ></sp-number-field>
 `;
 
@@ -356,6 +365,7 @@ export const hideStepper = (args: StoryArgs): TemplateResult => {
         <sp-number-field
             id="hideStepper"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
         ></sp-number-field>
     `;
 };
@@ -372,6 +382,7 @@ export const hideStepperQuiet = (args: StoryArgs): TemplateResult => {
         <sp-number-field
             id="hideStepper"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
         ></sp-number-field>
     `;
 };
@@ -389,6 +400,7 @@ export const disabled = (args: StoryArgs): TemplateResult => {
         <sp-number-field
             id="disabled"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
         ></sp-number-field>
     `;
 };
@@ -405,6 +417,7 @@ export const readOnly = (args: StoryArgs): TemplateResult => {
         <sp-number-field
             id="readonly"
             ...=${spreadProps(args)}
+            @change=${args.onChange}
         ></sp-number-field>
     `;
 };

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -160,7 +160,7 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
         this.inputElement.select();
     }
 
-    protected onInput(): void {
+    protected handleInput(): void {
         if (this.allowedKeys && this.inputElement.value) {
             const regExp = new RegExp(`^[${this.allowedKeys}]*$`, 'u');
             if (!regExp.test(this.inputElement.value)) {
@@ -178,7 +178,7 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
         this.value = this.inputElement.value;
     }
 
-    protected onChange(): void {
+    protected handleChange(): void {
         this.dispatchEvent(
             new Event('change', {
                 bubbles: true,
@@ -237,8 +237,8 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
                 pattern=${ifDefined(this.pattern)}
                 placeholder=${this.placeholder}
                 .value=${this.displayValue}
-                @change=${this.onChange}
-                @input=${this.onInput}
+                @change=${this.handleChange}
+                @input=${this.handleInput}
                 @focus=${this.onFocus}
                 @blur=${this.onBlur}
                 ?disabled=${this.disabled}
@@ -267,8 +267,8 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
                 pattern=${ifDefined(this.pattern)}
                 placeholder=${this.placeholder}
                 .value=${live(this.displayValue)}
-                @change=${this.onChange}
-                @input=${this.onInput}
+                @change=${this.handleChange}
+                @input=${this.handleInput}
                 @focus=${this.onFocus}
                 @blur=${this.onBlur}
                 ?disabled=${this.disabled}


### PR DESCRIPTION
## Description
Convert input of 2 byte characters to their single byte cousins as follows:
```
{
    '１': '1',
    '２': '2',
    '３': '3',
    '４': '4',
    '５': '5',
    '６': '6',
    '７': '7',
    '８': '8',
    '９': '9',
    '０': '0',
    '、': ',',
    '，': ',',
    '。': '.',
    '．': '.',
    '％': '%',
    '＋': '+',
    ー: '-',
}
```

- [x] Waiting for a full confirmation from the Internationalization team.

## Related issue(s)

- fixes #1953

## Motivation and context
Easier use of Number Field with international keyboards, specifically Chinese, Japanese and Korean.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://two-byte-chars--spectrum-web-components.netlify.app/components/number-field/#example)
    2. Paste `１、２３４，５６７。８９｀ into the Number Field
    3. See that it is processed as `1,234,567.89`
-   [ ] _Test case 2_
    1. Go [here](https://two-byte-chars--spectrum-web-components.netlify.app/components/number-field/#decimals)
    2. Paste `＋９。８７` into the Number Field
    3. See that it is processed as `+9.87`
    4. Paste `ー９．８７` into the Number Field
    5. See that it is process as `-9.87`
-   [ ] _Test case 1_
    1. Go [here](https://two-byte-chars--spectrum-web-components.netlify.app/components/number-field/#percentages)
    2. Paste `１０％｀ into the Number Field
    3. See that it is processed as `10%`

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.