### PR TITLE
[Top Nav] Correct application of focus state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a0bc072677777a2b1e73d800bec5b4dab7ceef48
+        default: dd3a2e0c32c10a166d37b82df17bebb9f2b1b17a
 commands:
     downstream:
         steps:

--- a/packages/top-nav/src/top-nav-item.css
+++ b/packages/top-nav/src/top-nav-item.css
@@ -17,3 +17,24 @@ a {
 a:focus {
     outline: none;
 }
+
+:host(:focus-within) {
+    color: var(
+        --spectrum-tabs-m-text-color-key-focus,
+        var(--spectrum-alias-text-color-hover)
+    ); /* .spectrum-Tabs-item.focus-ring */
+}
+
+:host(:focus-within):before {
+    border-color: var(
+        --spectrum-tabs-m-focus-ring-color,
+        var(--spectrum-alias-border-color-key-focus)
+    ); /* .spectrum-Tabs-item.focus-ring:before */
+}
+
+:host(:focus-within) ::slotted([slot='icon']) {
+    color: var(
+        --spectrum-tabs-m-icon-color-key-focus,
+        var(--spectrum-alias-icon-color-key-focus)
+    ); /* .spectrum-Tabs-item.focus-ring .spectrum-Icon */
+}

--- a/packages/top-nav/stories/top-nav.stories.ts
+++ b/packages/top-nav/stories/top-nav.stories.ts
@@ -86,6 +86,46 @@ export const Selected = (): TemplateResult => {
     `;
 };
 
+class WrappedTopNav extends HTMLElement {
+    shadowRoot!: ShadowRoot;
+
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = `
+            <sp-top-nav>
+                <sp-top-nav-item href="#">Site Name</sp-top-nav-item>
+                <sp-top-nav-item href="#page-1" style="margin-inline-start: auto;">
+                    Page 1
+                </sp-top-nav-item>
+                <sp-top-nav-item href="#page-2">Page 2</sp-top-nav-item>
+                <sp-top-nav-item href="#page-3">Page 3</sp-top-nav-item>
+                <sp-top-nav-item href="#page-4" autofocus>
+                    Page with Really Long Name
+                </sp-top-nav-item>
+                <sp-action-menu label="Account" style="margin-inline-start: auto;">
+                    <sp-icon-settings slot="icon"></sp-icon-settings>
+                    <sp-menu-item>Account Settings</sp-menu-item>
+                    <sp-menu-item>My Profile</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Share</sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>Help</sp-menu-item>
+                    <sp-menu-item>Sign Out</sp-menu-item>
+                </sp-action-menu>
+            </sp-top-nav>
+        `;
+    }
+}
+
+customElements.define('wrapped-top-nav', WrappedTopNav);
+
+export const autofocus = (): TemplateResult => {
+    return html`
+        <wrapped-top-nav></wrapped-top-nav>
+    `;
+};
+
 // https://spectrum.adobe.com/page/application-frame/#Application-mode
 // https://spectrum.adobe.com/page/headers/#Anatomy
 


### PR DESCRIPTION
## Description
Focus visible for Top Nav Items was overly reliant on the Focus Visible polyfill which is needed less and less. Update the CSS so that it can exist in DOM trees where the polyfill hasn't been registered and still delivery focus states.

## Related issue(s)
- fixes #2071 

## Motivation and context
Accessibility

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://top-nav--spectrum-web-components.netlify.app/storybook/?path=/story/top-nav--autofocus)
    2. See that the shadow DOM wrapped Top Nav demo has an autofocus child with visible focus.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.