### PR TITLE
feat: conditionally load focus-visible polyfill

### DIFF
--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -20,7 +20,6 @@ import {
     triggerBlurFor,
     waitUntil,
 } from '@open-wc/testing';
-import { waitForPredicate } from '../../../test/testing-helpers.js';
 import '@spectrum-web-components/shared/src/focus-visible.js';
 
 function inputForCheckbox(checkbox: Checkbox): HTMLInputElement {
@@ -70,9 +69,6 @@ describe('Checkbox', () => {
 
     it('loads', async () => {
         const el = testFixture.querySelector('sp-checkbox') as Checkbox;
-
-        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
-
         expect(el).to.not.equal(undefined);
         const textNode = labelNodeForCheckbox(el);
         const content = (textNode.textContent || '').trim();

--- a/packages/menu/test/menu-selects.test.ts
+++ b/packages/menu/test/menu-selects.test.ts
@@ -650,11 +650,16 @@ describe('Menu w/ groups [selects]', () => {
     it('manages focus', async () => {
         await elementUpdated(groupA);
         await elementUpdated(groupB);
-        options[0].focus();
-
-        await elementUpdated(el);
+        const input = document.createElement('input');
+        el.insertAdjacentElement('afterend', input);
+        input.focus();
+        expect(document.activeElement === input).to.be.true;
+        await sendKeys({ press: 'Shift+Tab' });
+        expect(document.activeElement === groupA).to.be.true;
         await sendKeys({ press: 'ArrowDown' });
         await sendKeys({ press: 'ArrowUp' });
+
+        await elementUpdated(el);
         for (const option of options) {
             const parentElement = option.parentElement as Menu;
             expect(document.activeElement === parentElement, 'parent focused')

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -39,10 +39,6 @@ describe('Menu', () => {
         );
 
         const anchor = el.querySelector('a') as HTMLAnchorElement;
-        await waitUntil(
-            () => !!window.applyFocusVisiblePolyfill,
-            'loaded polyfill'
-        );
         await elementUpdated(el);
         expect(document.activeElement === el, 'self not focused, 1').to.be
             .false;

--- a/packages/picker/test/picker-responsive.test.ts
+++ b/packages/picker/test/picker-responsive.test.ts
@@ -20,7 +20,6 @@ import {
     html,
     nextFrame,
     oneEvent,
-    waitUntil,
 } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 
@@ -49,11 +48,6 @@ describe('Picker, responsive', () => {
                     </sp-picker>
                 </div>
             `
-        );
-
-        await waitUntil(
-            () => !!window.applyFocusVisiblePolyfill,
-            'polyfill loaded'
         );
 
         return test.querySelector('sp-picker') as Picker;

--- a/packages/picker/test/picker-sync.test.ts
+++ b/packages/picker/test/picker-sync.test.ts
@@ -78,11 +78,6 @@ describe('Picker, sync', () => {
             `
         );
 
-        await waitUntil(
-            () => !!window.applyFocusVisiblePolyfill,
-            'polyfill loaded'
-        );
-
         return test.querySelector('sp-picker') as Picker;
     };
     describe('standard', () => {
@@ -641,13 +636,19 @@ describe('Picker, sync', () => {
         });
         it('refocuses on list when open', async () => {
             const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+            const input = document.createElement('input');
+            el.insertAdjacentElement('afterend', input);
 
+            el.focus();
+            await sendKeys({ press: 'Tab' });
+            expect(document.activeElement === input).to.be.true;
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(document.activeElement === el).to.be.true;
+            await sendKeys({ press: 'Enter' });
             const opened = oneEvent(el, 'sp-opened');
             el.open = true;
             await opened;
             await elementUpdated(el);
-            await sendKeys({ press: 'ArrowDown' });
-            await sendKeys({ press: 'ArrowUp' });
 
             await waitUntil(
                 () => firstItem.focused,
@@ -940,11 +941,6 @@ describe('Picker, sync', () => {
                 `
             );
 
-            await waitUntil(
-                () => !!window.applyFocusVisiblePolyfill,
-                'polyfill loaded'
-            );
-
             return test.querySelector('sp-picker') as Picker;
         };
         beforeEach(async () => {
@@ -991,11 +987,6 @@ describe('Picker, sync', () => {
                         </sp-picker>
                     </div>
                 `
-            );
-
-            await waitUntil(
-                () => !!window.applyFocusVisiblePolyfill,
-                'polyfill loaded'
             );
 
             return test.querySelector('sp-picker') as Picker;

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -78,11 +78,6 @@ describe('Picker, standard', () => {
             `
         );
 
-        await waitUntil(
-            () => !!window.applyFocusVisiblePolyfill,
-            'polyfill loaded'
-        );
-
         return test.querySelector('sp-picker') as Picker;
     };
     describe('standard', () => {
@@ -641,13 +636,19 @@ describe('Picker, standard', () => {
         });
         it('refocuses on list when open', async () => {
             const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+            const input = document.createElement('input');
+            el.insertAdjacentElement('afterend', input);
 
+            el.focus();
+            await sendKeys({ press: 'Tab' });
+            expect(document.activeElement === input).to.be.true;
+            await sendKeys({ press: 'Shift+Tab' });
+            expect(document.activeElement === el).to.be.true;
+            await sendKeys({ press: 'Enter' });
             const opened = oneEvent(el, 'sp-opened');
             el.open = true;
             await opened;
             await elementUpdated(el);
-            await sendKeys({ press: 'ArrowDown' });
-            await sendKeys({ press: 'ArrowUp' });
 
             await waitUntil(
                 () => firstItem.focused,
@@ -940,11 +941,6 @@ describe('Picker, standard', () => {
                 `
             );
 
-            await waitUntil(
-                () => !!window.applyFocusVisiblePolyfill,
-                'polyfill loaded'
-            );
-
             return test.querySelector('sp-picker') as Picker;
         };
         beforeEach(async () => {
@@ -991,11 +987,6 @@ describe('Picker, standard', () => {
                         </sp-picker>
                     </div>
                 `
-            );
-
-            await waitUntil(
-                () => !!window.applyFocusVisiblePolyfill,
-                'polyfill loaded'
             );
 
             return test.querySelector('sp-picker') as Picker;

--- a/packages/search/test/search.test.ts
+++ b/packages/search/test/search.test.ts
@@ -12,11 +12,7 @@ governing permissions and limitations under the License.
 import '../sp-search.js';
 import { Search } from '../';
 import { elementUpdated, expect, html, litFixture } from '@open-wc/testing';
-import {
-    escapeEvent,
-    spaceEvent,
-    waitForPredicate,
-} from '../../../test/testing-helpers.js';
+import { escapeEvent, spaceEvent } from '../../../test/testing-helpers.js';
 import '@spectrum-web-components/shared/src/focus-visible.js';
 import { spy } from 'sinon';
 
@@ -40,8 +36,6 @@ describe('Search', () => {
         );
 
         await elementUpdated(el);
-        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
-
         expect(el.value).to.equal('Test');
 
         const root = el.shadowRoot ? el.shadowRoot : el;
@@ -60,8 +54,6 @@ describe('Search', () => {
         );
 
         await elementUpdated(el);
-        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
-
         expect(el.value).to.equal('Test');
 
         const root = el.shadowRoot ? el.shadowRoot : el;
@@ -94,8 +86,6 @@ describe('Search', () => {
         );
 
         await elementUpdated(el);
-        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
-
         expect(el.value).to.equal('Test');
 
         const root = el.shadowRoot ? el.shadowRoot : el;
@@ -134,8 +124,6 @@ describe('Search', () => {
         );
 
         await elementUpdated(el);
-        await waitForPredicate(() => !!window.applyFocusVisiblePolyfill);
-
         expect(el.value).to.equal('Test');
         el.focusElement.dispatchEvent(spaceEvent());
 

--- a/packages/shared/src/focus-visible.ts
+++ b/packages/shared/src/focus-visible.ts
@@ -10,8 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import 'focus-visible';
-
 declare global {
     interface Window {
         applyFocusVisiblePolyfill?: (scope: Document | ShadowRoot) => void;
@@ -40,6 +38,9 @@ try {
     document.body.querySelector(':focus-visible');
 } catch (error) {
     hasFocusVisible = false;
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    import('focus-visible');
 }
 
 /**

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,7 +4,7 @@
         "composite": true,
         "rootDir": "./"
     },
-    "include": ["*.ts", "src/*.ts", "global.d.ts"],
+    "include": ["*.ts", "src/*.ts", "src/missing-types.d.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
     "references": [{ "path": "../base" }]
 }


### PR DESCRIPTION
## Description
Test perf benefits of only loading the polyfill when needed.
- use dynamic import and capability test to prevent polyfill use in Chrome and Firefox
- ungated usage can cause edge case situations like in #2071 

## Motivation and context
Perf

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://focus-visible--spectrum-web-components.netlify.app/)
    2. Navigate the site with the keyboard and see that focus visible states are triggered.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.