### PR TITLE
fix(number-field): validate value before dispatching "change" event

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -122,7 +122,8 @@ export class NumberField extends TextfieldBase {
     public stepModifier = 10;
 
     @property({ type: Number })
-    public set value(value: number) {
+    public set value(rawValue: number) {
+        const value = this.validateInput(rawValue);
         if (value === this.value) {
             return;
         }
@@ -587,7 +588,7 @@ export class NumberField extends TextfieldBase {
             const value = this.numberParser.parse(
                 this.inputValue.replace(this._forcedUnit, '')
             );
-            this.value = this.validateInput(value);
+            this.value = value;
         }
         if (changes.has('min') || changes.has('formatOptions')) {
             let inputMode = 'numeric';

--- a/packages/number-field/stories/number-field.stories.ts
+++ b/packages/number-field/stories/number-field.stories.ts
@@ -15,6 +15,7 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 import '../sp-number-field.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import { spreadProps } from '../../../test/lit-helpers.js';
+import { NumberField } from '../src/NumberField.js';
 
 export default {
     title: 'Number Field',
@@ -181,16 +182,31 @@ interface StoryArgs {
     hideStepper?: boolean;
     readonly?: boolean;
     step?: number;
+    onChange?: (value: number) => void;
+    onInput?: (value: number) => void;
     [prop: string]: unknown;
 }
 
 export const Default = (args: StoryArgs = {}): TemplateResult => {
+    const onChange =
+        (args.onChange as (value: number) => void) ||
+        (() => {
+            return;
+        });
+    const onInput =
+        (args.onInput as (value: number) => void) ||
+        (() => {
+            return;
+        });
     return html`
         <sp-field-label for="default">Enter a number</sp-field-label>
         <sp-number-field
             id="default"
             ...=${spreadProps(args)}
-            @change=${args.onChange}
+            @input=${(event: Event) =>
+                onInput((event.target as NumberField).value)}
+            @change=${(event: Event) =>
+                onChange((event.target as NumberField).value)}
             style="width: 150px"
         ></sp-number-field>
     `;
@@ -200,34 +216,15 @@ Default.args = {
     value: 100,
 };
 
-export const quiet = (args: StoryArgs = {}): TemplateResult => {
-    return html`
-        <sp-field-label for="default">Enter a number</sp-field-label>
-        <sp-number-field
-            id="default"
-            ...=${spreadProps(args)}
-            @change=${args.onChange}
-            style="width: 150px"
-        ></sp-number-field>
-    `;
-};
+export const quiet = (args: StoryArgs = {}): TemplateResult => Default(args);
 
 quiet.args = {
     quiet: true,
     value: 100,
 };
 
-export const indeterminate = (args: StoryArgs = {}): TemplateResult => {
-    return html`
-        <sp-field-label for="default">Enter a number</sp-field-label>
-        <sp-number-field
-            id="default"
-            ...=${spreadProps(args)}
-            @change=${args.onChange}
-            style="width: 150px"
-        ></sp-number-field>
-    `;
-};
+export const indeterminate = (args: StoryArgs = {}): TemplateResult =>
+    Default(args);
 
 indeterminate.args = {
     value: 100,

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -681,8 +681,28 @@ describe('NumberField', () => {
     });
     describe('max', () => {
         let el: NumberField;
+        let lastInputValue = 0;
+        let lastChangeValue = 0;
         beforeEach(async () => {
-            el = await getElFrom(Default({ max: 10, value: 10 }));
+            el = await getElFrom(
+                Default({
+                    max: 10,
+                    value: 10,
+                    onInput: (value: number) => (lastInputValue = value),
+                    onChange: (value: number) => (lastChangeValue = value),
+                })
+            );
+            expect(el.formattedValue).to.equal('10');
+            expect(el.valueAsString).to.equal('10');
+            expect(el.value).to.equal(10);
+        });
+        it('constrains input', async () => {
+            el.focus();
+            await sendKeys({ type: '15' });
+            await sendKeys({ press: 'Enter' });
+            await elementUpdated(el);
+            expect(lastInputValue, 'last input value').to.equal(10);
+            expect(lastChangeValue, 'last change value').to.equal(10);
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
@@ -719,8 +739,30 @@ describe('NumberField', () => {
     });
     describe('min', () => {
         let el: NumberField;
+        let lastInputValue = 0;
+        let lastChangeValue = 0;
         beforeEach(async () => {
-            el = await getElFrom(Default({ min: 10, value: 10 }));
+            el = await getElFrom(
+                Default({
+                    min: 10,
+                    value: 10,
+                    onInput: (value: number) => (lastInputValue = value),
+                    onChange: (value: number) => (lastChangeValue = value),
+                })
+            );
+            expect(el.formattedValue).to.equal('10');
+            expect(el.valueAsString).to.equal('10');
+            expect(el.value).to.equal(10);
+        });
+        it('constrains input', async () => {
+            el.focus();
+            await sendKeys({ press: 'Backspace' });
+            await sendKeys({ press: 'Backspace' });
+            await sendKeys({ type: '5' });
+            await sendKeys({ press: 'Enter' });
+            await elementUpdated(el);
+            expect(lastInputValue, 'last input value').to.equal(10);
+            expect(lastChangeValue, 'last change value').to.equal(10);
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);


### PR DESCRIPTION
## Description
Validate `value` before dispatching `change` so that restraints like `min` and `max` are followed before announcing a new `value`.

## Motivation and context
Correctness.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://number-field-change--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--default)
    2. Apply a value for `max` in the "Controls" panel
    3. Switch to the "Actions" panel
    4. Type a value larger than what you applied for `max`
    5. Press `Enter`
    6. See that the final `input` and the `change` event immediately there after are bound by the value you applied to `max`.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.