### PR TITLE
docs(popover): correct link URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-An `<sp-popover>` is used to display transient content (menus, options, additional actions etc.) and appears when clicking/tapping on a source (tools, buttons, etc.) It stands out via its visual style (stroke and drop shadow) and floats on top of the rest of the interface. This component does not implement the actual overlay behavior and interactions. This is handled by the [`Overlay`](overlay) system.
+An `<sp-popover>` is used to display transient content (menus, options, additional actions etc.) and appears when clicking/tapping on a source (tools, buttons, etc.) It stands out via its visual style (stroke and drop shadow) and floats on top of the rest of the interface. This component does not implement the actual overlay behavior and interactions. This is handled by the [`Overlay`](../overlay) system.
 
 ### Usage
 


### PR DESCRIPTION
## Description
Correct relative link.

## Related issue(s)
- fixes #2083

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://popover-docs--spectrum-web-components.netlify.app/components/popover/)
    2. Click the "Overlay system" link
    3. See that you go to the Overlay component page.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.