### PR TITLE
fix(split-view): end drag on pointerleave

### DIFF
--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -199,7 +199,11 @@ export class SplitView extends SpectrumElement {
                               start: ['pointerdown', this.onPointerdown],
                               streamInside: ['pointermove', this.onPointermove],
                               end: [
-                                  ['pointerup', 'pointercancel'],
+                                  [
+                                      'pointerup',
+                                      'pointercancel',
+                                      'pointerleave',
+                                  ],
                                   this.onPointerup,
                               ],
                           })}


### PR DESCRIPTION
## Description

Ends the split-view's drag on `pointerleave`

## Related issue(s)

Fixes https://github.com/adobe/spectrum-web-components/issues/2101

## How has this been tested?

1. Go to https://opensource.adobe.com/spectrum-web-components/components/split-view/
2. Start dragging
3. Right-click
4. Release the mouse button and click the left mouse button to close the context menu
5. Move the mouse over the drag divider and see that it tries to follow the mouse
---
1. Go to https://fix-split-view-pointerleave--spectrum-web-components.netlify.app/components/split-view/
2. Start dragging
3. Right-click
4. Release the mouse button and click the left mouse button to close the context menu
5. Move the mouse over the drag divider and see that it doesn't try to follow the mouse

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

