### PR TITLE
fix(tabs): ensure that "auto" attribute is respected

### DIFF
--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -105,7 +105,7 @@ export class Tabs extends SizedMixin(Focusable) {
     private _tabs: Tab[] = [];
 
     rovingTabindexController = new RovingTabindexController<Tab>(this, {
-        focusInIndex: (elements: Tab[]) => {
+        focusInIndex: (elements) => {
             let focusInIndex = 0;
             const firstFocusableElement = elements.find((el, index) => {
                 const focusInElement = this.selected
@@ -118,8 +118,14 @@ export class Tabs extends SizedMixin(Focusable) {
         },
         direction: () =>
             this.direction === 'horizontal' ? 'horizontal' : 'vertical',
+        elementEnterAction: (el) => {
+            if (!this.auto) return;
+
+            this.shouldAnimate = true;
+            this.selectTarget(el);
+        },
         elements: () => this.tabs,
-        isFocusableElement: (el: Tab) => !el.disabled,
+        isFocusableElement: (el) => !el.disabled,
         listenerScope: () => this.tabList,
     });
 

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -31,6 +31,7 @@ import {
     enterEvent,
     spaceEvent,
 } from '../../../test/testing-helpers.js';
+import { sendKeys } from '@web/test-runner-commands';
 
 const createTabs = async (): Promise<Tabs> => {
     const tabs = await fixture<Tabs>(
@@ -174,6 +175,35 @@ describe('Tabs', () => {
             () => document.activeElement === autoElement,
             'Autofocused'
         );
+    });
+
+    it('auto', async () => {
+        const el = await fixture<Tabs>(
+            html`
+                <sp-tabs selected="second" auto>
+                    <sp-tab label="Tab 1" value="first"></sp-tab>
+                    <sp-tab label="Tab 2" value="second"></sp-tab>
+                    <sp-tab label="Tab 3" value="third"></sp-tab>
+                </sp-tabs>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(el.selected).to.equal('second');
+        el.focus();
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        expect(el.selected).to.equal('first');
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        expect(el.selected).to.equal('third');
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        expect(el.selected).to.equal('first');
     });
 
     it('forces only one tab to be selected', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Without a test to confirm the `auto` functionality it regressed during the key handling update when we moved to the `RovingTabindex` controller. This adds it back and a test for the future.

## Related issue(s)

- fixes #2095

## Motivation and context
Because we broke it.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://tabs-auto--spectrum-web-components.netlify.app/components/tabs/#sizes)
    2. Click "Large"
    3. See the content switch to "Large"
    4. Press `ArrowLeft`
    5. See the content switch to "Medium"
    6. Etc.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.