### PR TITLE
fix(textfield): correct "multiline" and "grows" delivery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c5094224659a6e73ec66f0bd28731c309fab5136
+        default: b48c59df4af377fcd40c6dbdd51a57e34192ce8c
 commands:
     downstream:
         steps:

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -219,7 +219,7 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
         return html`
             ${this.grows && !this.quiet
                 ? html`
-                      <div id="sizer">${this.value}</div>
+                      <div id="sizer">${this.value}&#8203;</div>
                   `
                 : nothing}
             <!-- @ts-ignore -->

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -34,6 +34,10 @@ textarea {
     resize: inherit;
 }
 
+.input {
+    min-width: var(--spectrum-textfield-texticon-min-width);
+}
+
 :host([grows]) .input {
     position: absolute;
     top: 0;
@@ -44,6 +48,8 @@ textarea {
 }
 
 :host([grows]) #sizer {
+    word-break: break-word;
+    white-space: pre-wrap;
     box-sizing: border-box;
     overflow-wrap: break-word;
     border: var(--spectrum-textfield-texticon-border-size) solid;
@@ -80,4 +86,35 @@ textarea {
 .icon,
 .icon-workflow {
     pointer-events: none;
+}
+
+:host([multiline]) #textfield {
+    display: inline-grid;
+}
+
+:host([multiline]) textarea {
+    transition: box-shadow var(--spectrum-global-animation-duration-100, 0.13s)
+            ease-in-out,
+        border-color var(--spectrum-global-animation-duration-100, 0.13s)
+            ease-in-out;
+}
+
+:host([multiline][focused]:not([quiet])) textarea,
+:host([multiline][focused]:not([quiet]):hover) textarea {
+    box-shadow: 0 0 0
+        calc(
+            0px +
+                var(
+                    --spectrum-textfield-m-texticon-focus-ring-border-width,
+                    var(--spectrum-alias-component-focusring-size)
+                )
+        )
+        var(
+            --spectrum-textfield-m-textonly-focus-ring-border-color-key-focus,
+            var(--spectrum-alias-focus-ring-color)
+        ) !important;
+}
+
+:host([multiline]:not([quiet])) #textfield:after {
+    box-shadow: none;
 }

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -36,6 +36,7 @@ textarea {
 
 .input {
     min-width: var(--spectrum-textfield-texticon-min-width);
+    caret-color: var(--swc-test-caret-color);
 }
 
 :host([grows]) .input {

--- a/packages/textfield/stories/textarea.stories.ts
+++ b/packages/textfield/stories/textarea.stories.ts
@@ -13,6 +13,7 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '../sp-textfield.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
+import '@spectrum-web-components/help-text/sp-help-text.js';
 
 export default {
     component: 'sp-textfield',
@@ -71,6 +72,17 @@ export const Default = (): TemplateResult => {
     `;
 };
 
+export const quiet = (): TemplateResult => html`
+    <sp-field-label for="story">Enter your life story...</sp-field-label>
+    <sp-textfield
+        autofocus
+        multiline
+        id="story"
+        quiet
+        placeholder="Enter your life story"
+    ></sp-textfield>
+`;
+
 export const grows = (): TemplateResult => html`
     <sp-field-label for="story">Enter your life story...</sp-field-label>
     <sp-textfield
@@ -80,6 +92,23 @@ export const grows = (): TemplateResult => html`
         grows
         placeholder="Enter your life story"
     ></sp-textfield>
+`;
+
+export const growsEmpty = (): TemplateResult => html`
+    <sp-field-label for="empty">
+        This textfield hasn't been used yet
+    </sp-field-label>
+    <sp-textfield
+        multiline
+        id="empty"
+        grows
+        placeholder="You can type here"
+        autofocus
+    >
+        <sp-help-text slot="help-text">
+            Even empty Textfield display correctly while waiting for content.
+        </sp-help-text>
+    </sp-textfield>
 `;
 
 export const growsWithLargeWords = (): TemplateResult => html`
@@ -126,4 +155,21 @@ export const resizeControls = (): TemplateResult => html`
         label="Horizontal resize control"
         placeholder="Horizontal resize control"
     ></sp-textfield>
+`;
+
+export const sized = (): TemplateResult => html`
+    <sp-field-label for="sized">
+        This textfield hasn't been used yet
+    </sp-field-label>
+    <sp-textfield
+        multiline
+        id="sized"
+        placeholder="You can type here"
+        autofocus
+        style="width: 400px"
+    >
+        <sp-help-text slot="help-text">
+            Even empty Textfield display correctly while waiting for content.
+        </sp-help-text>
+    </sp-textfield>
 `;

--- a/packages/textfield/stories/textfield.stories.ts
+++ b/packages/textfield/stories/textfield.stories.ts
@@ -12,6 +12,8 @@ governing permissions and limitations under the License.
 import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '../sp-textfield.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
+import '@spectrum-web-components/help-text/sp-help-text.js';
 
 export default {
     component: 'sp-textfield',
@@ -46,6 +48,18 @@ export const Default = (): TemplateResult => {
             required
             value="Not a valid input"
             disabled
+        ></sp-textfield>
+    `;
+};
+
+export const quiet = (): TemplateResult => {
+    return html`
+        <sp-field-label for="name">Enter your name</sp-field-label>
+        <sp-textfield
+            autofocus
+            id="name"
+            placeholder="This Text Field doesn't make much noise"
+            quiet
         ></sp-textfield>
     `;
 };
@@ -92,4 +106,31 @@ export const types = (): TemplateResult => html`
         type="password"
         placeholder="password"
     ></sp-textfield>
+`;
+
+export const empty = (): TemplateResult => html`
+    <sp-field-label for="empty">
+        This textfield hasn't been used yet
+    </sp-field-label>
+    <sp-textfield id="empty" placeholder="You can type here" autofocus>
+        <sp-help-text slot="help-text">
+            Even empty Textfield display correctly while waiting for content.
+        </sp-help-text>
+    </sp-textfield>
+`;
+
+export const sized = (): TemplateResult => html`
+    <sp-field-label for="sized">
+        This textfield hasn't been used yet
+    </sp-field-label>
+    <sp-textfield
+        id="sized"
+        placeholder="You can type here"
+        autofocus
+        style="width: 400px"
+    >
+        <sp-help-text slot="help-text">
+            Even empty Textfield display correctly while waiting for content.
+        </sp-help-text>
+    </sp-textfield>
 `;

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -119,6 +119,7 @@ export class StoryDecorator extends SpectrumElement {
             }
             :host([screenshot]) sp-theme {
                 padding: var(--spectrum-global-dimension-size-100);
+                --swc-test-caret-color: transparent;
             }
             :host([reduce-motion]) sp-theme {
                 ${reduceMotionProperties}


### PR DESCRIPTION
## Description

- prevent `<sp-textfield multiline grows>` with no `value` from collapsing
- ensure that `<sp-textfield multiline grows>` expands with newline white space
- ensure the the focus ring follow the actual `<textarea>` in `<sp-textfield multiline>`

## Related issue(s)

- fixes #2107
- fixes #2108

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://textfield-multiline--spectrum-web-components.netlify.app/storybook/?path=/story/textarea--quiet)
    2. Make sure the focus state looks correct
-   [ ] _Test case 2_
    1. Go [here](https://textfield-multiline--spectrum-web-components.netlify.app/storybook/?path=/story/textarea--grows-empty)
    2. See that there's only one border
-   [ ] _Test case 3_
    1. Go [here](https://textfield-multiline--spectrum-web-components.netlify.app/storybook/?path=/story/textarea--sized)
    2. See that the Textarea is larger than normal
    3. Drag to resize the Textarea smaller.
    4. See that is goes down to 50px wide before stopping
    5. See that the focus ring matches that size.
    6. Drag to resize the Textarea larger
    7. See that it can get larger than it started
    8. See that the focus ring matches the size
 -   [ ] _Test case 4_
    1. Go [here](https://textfield-multiline--spectrum-web-components.netlify.app/storybook/?path=/story/textarea--grows-with-large-words)
    2. See that the really long word is broken correctly

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
