### PR TITLE
fix(overlay): measure initial overlay data offscreen

### DIFF
--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -380,7 +380,7 @@ export class ActiveOverlay extends SpectrumElement {
 
         function roundByDPR(num: number): number {
             const dpr = window.devicePixelRatio || 1;
-            return Math.round(num * dpr) / dpr || 0;
+            return Math.round(num * dpr) / dpr || -10000;
         }
 
         // See: https://spectrum.adobe.com/page/popover/#Container-padding


### PR DESCRIPTION
## Description
Measure initial overlay data off screen such that even when resource constrained we can position the overlay without it appearing in an incorrect location during janked frames.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.