### PR TITLE
fix: export docs files so that build tools can find them

### DIFF
--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -23,7 +23,8 @@
         ".": "./src/index.js",
         "./src/*": "./src/*",
         "./icons/*": "./icons/*",
-        "./package.json": "./package.json"
+        "./package.json": "./package.json",
+        "./stories/icon-manifest.js": "./stories/icon-manifest.js"
     },
     "scripts": {
         "build": "node ./bin/build @spectrum-css/icon/medium"

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -23,7 +23,8 @@
         ".": "./src/index.js",
         "./src/*": "./src/*",
         "./icons/*": "./icons/*",
-        "./package.json": "./package.json"
+        "./package.json": "./package.json",
+        "./stories/icon-manifest.js": "./stories/icon-manifest.js"
     },
     "scripts": {
         "build": "node ./bin/build @adobe/spectrum-css-workflow-icons/dist/18"

--- a/packages/iconset/package.json
+++ b/packages/iconset/package.json
@@ -21,7 +21,8 @@
     "exports": {
         ".": "./src/index.js",
         "./src/*": "./src/*",
-        "./package.json": "./package.json"
+        "./package.json": "./package.json",
+        "./stories/icons-demo.js": "./stories/icons-demo.js"
     },
     "scripts": {
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"


### PR DESCRIPTION
## Description
Add dev time content to export maps so that it can be used in the documentation site.

## Related issue(s)
- fixes #2116 

## Motivation and context
The search is awesome and should work all the time!

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://icons--spectrum-web-components.netlify.app/components/icons-workflow/#find-an-icon)
    2. See the icon search UI load.
-   [ ] _Test case 2_
    1. Go [here](https://icons--spectrum-web-components.netlify.app/components/icons-ui/#find-an-icon)
    2. See the icon search UI load.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.