### PR TITLE
docs: ensure that icon content is available in the documentation site build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ packages/**/*.d.ts
 packages/*/node_modules/**/*
 tools/**/*.d.ts
 tools/*/node_modules/**/*
+projects/documentation/src/icon-helpers

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/packages/icons-ui/README.md
+++ b/packages/icons-ui/README.md
@@ -46,8 +46,8 @@ const options = {
 }
 const callback = async (entries, observer) => {
     if (entries[0].intersectionRatio === 0) return;
-    import('@spectrum-web-components/iconset/stories/icons-demo.js');
-    import('@spectrum-web-components/icons-ui/stories/icon-manifest.js').then(({iconManifest}) => {
+    import('@swc-docs/src/icon-helpers/icons-demo.js');
+    import('@swc-docs/src/icon-helpers/icons-ui/icon-manifest.js').then(({iconManifest}) => {
         search.icons = iconManifest;
     });
     observer.disconnect();

--- a/packages/icons-ui/bin/build.js
+++ b/packages/icons-ui/bin/build.js
@@ -63,7 +63,25 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (error, icons) => {
         'stories',
         'icon-manifest.ts'
     );
+
+    const manifestPathDocs = path.join(
+        rootDir,
+        'projects',
+        'documentation',
+        'src',
+        'icon-helpers',
+        'icons-ui'
+    );
+    const manifestPathDocsFile = path.join(
+        manifestPathDocs,
+        'icon-manifest.ts'
+    );
     fs.writeFileSync(manifestPath, disclaimer, 'utf-8');
+    fs.mkdirSync(manifestPathDocs, { recursive: true });
+    fs.writeFileSync(manifestPathDocsFile, disclaimer, {
+        encoding: 'utf-8',
+        recursive: true,
+    });
     let manifestImports = `import {
         html,
         TemplateResult
@@ -240,7 +258,7 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (error, icons) => {
             iconRegistrationFile,
             'utf-8'
         );
-        const importStatement = `\r\nimport '../icons/${iconElementName}.js';`;
+        const importStatement = `\r\nimport '@spectrum-web-components/icons-ui/icons/${iconElementName}.js';`;
         const metadata = `{name: '${Case.sentence(
             ComponentName
         )}', tag: '<${iconElementName}>', story: (size: string): TemplateResult => html\`<${iconElementName} size=\$\{size\}></${iconElementName}>\`},\r\n`;
@@ -256,6 +274,11 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (error, icons) => {
     );
     fs.appendFileSync(
         manifestPath,
+        `${manifestImports}${manifestListings}];\r\n`,
+        'utf-8'
+    );
+    fs.appendFileSync(
+        manifestPathDocsFile,
         `${manifestImports}${manifestListings}];\r\n`,
         'utf-8'
     );

--- a/packages/icons-workflow/README.md
+++ b/packages/icons-workflow/README.md
@@ -46,8 +46,8 @@ const options = {
 }
 const callback = async (entries, observer) => {
     if (entries[0].intersectionRatio === 0) return;
-    import('@spectrum-web-components/iconset/stories/icons-demo.js');
-    import('@spectrum-web-components/icons-workflow/stories/icon-manifest.js').then(({iconManifest}) => {
+    import('/src/icon-helpers/icons-demo.js');
+    import('/src/icon-helpers/icons-workflow/stories/icon-manifest.js').then(({iconManifest}) => {
         search.icons = iconManifest;
     });
     observer.disconnect();

--- a/packages/icons-workflow/bin/build.js
+++ b/packages/icons-workflow/bin/build.js
@@ -63,7 +63,21 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (error, icons) => {
         'stories',
         'icon-manifest.ts'
     );
+    const manifestPathDocs = path.join(
+        rootDir,
+        'projects',
+        'documentation',
+        'src',
+        'icon-helpers',
+        'icons-workflow'
+    );
+    const manifestPathDocsFile = path.join(
+        manifestPathDocs,
+        'icon-manifest.ts'
+    );
     fs.writeFileSync(manifestPath, disclaimer, 'utf-8');
+    fs.mkdirSync(manifestPathDocs, { recursive: true });
+    fs.writeFileSync(manifestPathDocsFile, disclaimer, 'utf-8');
     let manifestImports = `import {
         html,
         TemplateResult
@@ -262,7 +276,7 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (error, icons) => {
             iconRegistrationFile,
             'utf-8'
         );
-        const importStatement = `\r\nimport '../icons/${iconElementName}.js';`;
+        const importStatement = `\r\nimport '@spectrum-web-components/icons-workflow/icons/${iconElementName}.js';`;
         const metadata = `{name: '${Case.sentence(
             ComponentName
         )}', tag: '<${iconElementName}>', story: (size: string): TemplateResult => html\`<${iconElementName} size=\$\{size\}></${iconElementName}>\`},\r\n`;
@@ -278,6 +292,11 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (error, icons) => {
     );
     fs.appendFileSync(
         manifestPath,
+        `${manifestImports}${manifestListings}];\r\n`,
+        'utf-8'
+    );
+    fs.appendFileSync(
+        manifestPathDocsFile,
         `${manifestImports}${manifestListings}];\r\n`,
         'utf-8'
     );

--- a/packages/iconset/stories/icons-demo.ts
+++ b/packages/iconset/stories/icons-demo.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { IconsetAddedDetail } from '../';
+import { IconsetAddedDetail } from '@spectrum-web-components/iconset';
 import {
     css,
     CSSResultGroup,

--- a/projects/documentation/.gitignore
+++ b/projects/documentation/.gitignore
@@ -18,3 +18,5 @@ src/custom-elements.json
 // rollup build directory and artifacts
 dist/
 stats.html
+
+src/icon-helpers

--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -32,6 +32,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
         "@fullhuman/postcss-purgecss": "^4.1.3",
         "@open-wc/building-rollup": "^2.0.1",
+        "@rollup/plugin-alias": "^3.1.9",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -55,7 +56,8 @@
         "rollup-plugin-minify-html-literals": "^1.2.6",
         "rollup-plugin-styles": "^4.0.0",
         "rollup-plugin-visualizer": "^5.5.4",
-        "rollup-plugin-workbox": "^6.2.0"
+        "rollup-plugin-workbox": "^6.2.0",
+        "tslib": "^2.0.0"
     },
     "sideEffects": [
         "_site/**/*.css",

--- a/projects/documentation/rollup.config.js
+++ b/projects/documentation/rollup.config.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 import { minify } from 'html-minifier-terser';
 import { copy } from '@web/rollup-plugin-copy';
+import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import styles from 'rollup-plugin-styles';
 import litcss from 'rollup-plugin-lit-css';
@@ -249,6 +250,12 @@ module.exports = async () => {
         visualizer({
             brotliSize: true,
             gzipSize: true,
+        })
+    );
+
+    mpaConfig.plugins.push(
+        alias({
+            entries: [{ find: '@swc-docs', replacement: './_site' }],
         })
     );
     return [mpaConfig];

--- a/projects/documentation/scripts/copy-component-docs.js
+++ b/projects/documentation/scripts/copy-component-docs.js
@@ -29,6 +29,11 @@ const partialPath = path.resolve(
     __dirname,
     '../content/_includes/partials/components'
 );
+const iconHelpers = path.resolve(
+    __dirname,
+    '../../../packages/iconset/stories/icons-demo.ts'
+);
+const iconHelpersPath = path.resolve(__dirname, '../src/icon-helpers');
 
 const findDeclaration = (customElements, test) => {
     let declaration;
@@ -45,6 +50,11 @@ const findDeclaration = (customElements, test) => {
 async function main() {
     fs.mkdirSync(destinationPath, { recursive: true });
     fs.mkdirSync(partialPath, { recursive: true });
+
+    fs.copyFileSync(
+        iconHelpers,
+        path.resolve(iconHelpersPath, 'icons-demo.ts')
+    );
 
     const customElementJSONPath = path.resolve(
         projectDir,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4499,6 +4499,13 @@
     string-to-template-literal "^2.0.0"
     uglifycss "^0.0.29"
 
+"@rollup/plugin-alias@^3.1.9":
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz#a5d267548fe48441f34be8323fb64d1d4a1b3fdf"
+  integrity sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==
+  dependencies:
+    slash "^3.0.0"
+
 "@rollup/plugin-babel@^5.1.0", "@rollup/plugin-babel@^5.2.0", "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"


### PR DESCRIPTION
## Description
Copy content into the docs directory to allow for it to be available at build time.

## Related issue(s)

- fixes #2116

## Motivation and context
Try not to add to the public API?

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://icons2--spectrum-web-components.netlify.app/components/icons-workflow/#find-an-icon)
    2. See the icon search UI load.
-   [ ] _Test case 2_
    1. Go [here](https://icons2--spectrum-web-components.netlify.app/components/icons-ui/#find-an-icon)
    2. See the icon search UI load.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.