### PR TITLE
docs: use @swc-packages-internal alias to surface dev time assets in the docs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/packages/icons-ui/README.md
+++ b/packages/icons-ui/README.md
@@ -46,8 +46,8 @@ const options = {
 }
 const callback = async (entries, observer) => {
     if (entries[0].intersectionRatio === 0) return;
-    import('@spectrum-web-components/iconset/stories/icons-demo.js');
-    import('@spectrum-web-components/icons-ui/stories/icon-manifest.js').then(({iconManifest}) => {
+    import('@swc-packages-internal/iconset/stories/icons-demo.js');
+    import('@swc-packages-internal/icons-ui/stories/icon-manifest.js').then(({iconManifest}) => {
         search.icons = iconManifest;
     });
     observer.disconnect();

--- a/packages/icons-workflow/README.md
+++ b/packages/icons-workflow/README.md
@@ -46,8 +46,8 @@ const options = {
 }
 const callback = async (entries, observer) => {
     if (entries[0].intersectionRatio === 0) return;
-    import('@spectrum-web-components/iconset/stories/icons-demo.js');
-    import('@spectrum-web-components/icons-workflow/stories/icon-manifest.js').then(({iconManifest}) => {
+    import('@swc-packages-internal/iconset/stories/icons-demo.js');
+    import('@swc-packages-internal/icons-workflow/stories/icon-manifest.js').then(({iconManifest}) => {
         search.icons = iconManifest;
     });
     observer.disconnect();

--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -32,6 +32,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
         "@fullhuman/postcss-purgecss": "^4.1.3",
         "@open-wc/building-rollup": "^2.0.1",
+        "@rollup/plugin-alias": "^3.1.9",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.1.3",

--- a/projects/documentation/rollup.config.js
+++ b/projects/documentation/rollup.config.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 import { minify } from 'html-minifier-terser';
 import { copy } from '@web/rollup-plugin-copy';
+import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import styles from 'rollup-plugin-styles';
 import litcss from 'rollup-plugin-lit-css';
@@ -249,6 +250,19 @@ module.exports = async () => {
         visualizer({
             brotliSize: true,
             gzipSize: true,
+        })
+    );
+
+    // Use the `@swc-packages-internal` alias to make SWC internal
+    // files/assets available in the docs site build
+    mpaConfig.plugins.push(
+        alias({
+            entries: [
+                {
+                    find: '@swc-packages-internal',
+                    replacement: '../../packages/',
+                },
+            ],
         })
     );
     return [mpaConfig];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4499,6 +4499,13 @@
     string-to-template-literal "^2.0.0"
     uglifycss "^0.0.29"
 
+"@rollup/plugin-alias@^3.1.9":
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz#a5d267548fe48441f34be8323fb64d1d4a1b3fdf"
+  integrity sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==
+  dependencies:
+    slash "^3.0.0"
+
 "@rollup/plugin-babel@^5.1.0", "@rollup/plugin-babel@^5.2.0", "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"


### PR DESCRIPTION
## Description
Alias content into the docs build scope so dev time assets can be used there.

## Related issue(s)

- fixes #2116

## Motivation and context
Try not to add to the public API?

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://icons3--spectrum-web-components.netlify.app/components/icons-workflow/#find-an-icon)
    2. See the icon search UI load.
-   [ ] _Test case 2_
    1. Go [here](https://icons3--spectrum-web-components.netlify.app/components/icons-ui/#find-an-icon)
    2. See the icon search UI load.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.