### PR TITLE
fix: blocked content on sp-tray doc page

### DIFF
--- a/packages/tray/README.md
+++ b/packages/tray/README.md
@@ -26,70 +26,34 @@ import { Tray } from '@spectrum-web-components/tray';
 ## Dialog
 
 ```html
-<sp-button
-    variant="secondary"
-    onclick="
-    const trigger = this;
-    const interaction = 'modal';
-    const content = this.nextElementSibling;
-    const options = {
-        offset: 0,
-        placement: 'none',
-        receivesFocus: 'auto',
-    };
-    Overlay.open(
-        trigger, 
-        interaction,
-        content,
-        options
-    );
-"
->
-    Toggle tray
-</sp-button>
-<sp-tray>
-    <sp-dialog size="small" dismissable>
-        <h2 slot="heading">New Messages</h2>
-        You have 5 new messages.
-    </sp-dialog>
-</sp-tray>
+<overlay-trigger type="modal" placement="none">
+    <sp-button slot="trigger" variant="secondary">Toggle tray</sp-button>
+    <sp-tray slot="click-content">
+        <sp-dialog size="small" dismissable>
+            <h2 slot="heading">New Messages</h2>
+            You have 5 new messages.
+        </sp-dialog>
+    </sp-tray>
+</overlay-trigger>
 ```
 
 ## Menu
 
 ```html
-<sp-button
-    variant="secondary"
-    onclick="
-    const trigger = this;
-    const interaction = 'modal';
-    const content = this.nextElementSibling;
-    const options = {
-        offset: 0,
-        placement: 'none',
-        receivesFocus: 'auto',
-    };
-    Overlay.open(
-        trigger, 
-        interaction,
-        content,
-        options
-    );
-"
->
-    Toggle menu
-</sp-button>
-<sp-tray>
-    <sp-menu style="width: 100%">
-        <sp-menu-item selected>Deselect</sp-menu-item>
-        <sp-menu-item>Select Inverse</sp-menu-item>
-        <sp-menu-item focused>Feather...</sp-menu-item>
-        <sp-menu-item>Select and Mask...</sp-menu-item>
-        <sp-menu-divider></sp-menu-divider>
-        <sp-menu-item>Save Selection</sp-menu-item>
-        <sp-menu-item disabled>Make Work Path</sp-menu-item>
-    </sp-menu>
-</sp-tray>
+<overlay-trigger type="modal" placement="none">
+    <sp-button slot="trigger" variant="secondary">Toggle menu</sp-button>
+    <sp-tray slot="click-content">
+        <sp-menu style="width: 100%">
+            <sp-menu-item selected>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item focused>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-menu>
+    </sp-tray>
+</overlay-trigger>
 ```
 
 ## Accessibility


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Wrap &lt;sp-tray&gt; usage with &lt;overlay-trigger&gt; so documentation content won't be blocked from start.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes #2120 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Restores sp-tray doc page interactivity.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
