### PR TITLE
fix(menu): add support for submenu interactions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 44e305c71213e0c42b7daeee2c3fb3e03e148170
+        default: 7b3817787774698b502f679881f115940c6a179f
 commands:
     downstream:
         steps:

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
         "node-fetch": "^3.1.0",
         "npm-run-all": "^4.1.5",
         "patch-package": "^6.4.7",
-        "playwright": "^1.19.1",
+        "playwright": "^1.19.2",
         "postcss": "^8.4.5",
         "postcss-custom-properties": "^12.1.2",
         "postcss-focus-visible": "^6.0.3",
@@ -178,7 +178,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/packages/action-bar/src/ActionBar.ts
+++ b/packages/action-bar/src/ActionBar.ts
@@ -17,6 +17,7 @@ import {
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
+import '@spectrum-web-components/popover/sp-popover.js';
 import actionBarStyles from './action-bar.css.js';
 export const actionBarVariants = ['sticky', 'fixed'];
 

--- a/packages/menu/menu-item.md
+++ b/packages/menu/menu-item.md
@@ -69,6 +69,22 @@ Content assigned to the `value` slot will be placed at the end of the `<sp-menu-
 </sp-menu>
 ```
 
+### Submenu
+
+An `<sp-menu-item>` can also accept content addressed to its `submenu` slot. Using the `<sp-menu>` element with this slot name the options will be surfaced in flyout menu that can be activated by hovering over the root menu item with your pointer or focusing the menu item and pressing the appropriate `ArrowRight` or `ArrowLeft` key based on text direction to move into the submenu.
+
+```html
+<sp-menu style="width: 200px;">
+    <sp-menu-item>
+        Item with submenu
+        <sp-menu slot="submenu">
+            <sp-menu-item>Additional options</sp-menu-item>
+            <sp-menu-item>Available on request</sp-menu-item>
+        </sp-menu>
+    </sp-menu-item>
+</sp-menu>
+```
+
 ### Value attribute
 
 When displayed as a descendent of an element that manages selection (e.g. `<sp-action-menu>`, `<sp-picker>`, `<sp-split-button>`, etc.), an `<sp-menu-item>` will represent the "selected" value of that ancestor when its `value` attribute or the trimmed `textContent` (represeted by `el.itemText`) matches the `value` of the ancestor element.

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -54,6 +54,7 @@
         "@spectrum-web-components/base": "^0.5.2",
         "@spectrum-web-components/icon": "^0.11.3",
         "@spectrum-web-components/icons-ui": "^0.8.3",
+        "@spectrum-web-components/overlay": "^0.14.1",
         "@spectrum-web-components/shared": "^0.13.4",
         "tslib": "^2.0.0"
     },

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -15,7 +15,10 @@ import {
     html,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import { queryAssignedNodes } from '@spectrum-web-components/base/src/decorators.js';
+import {
+    queryAssignedNodes,
+    state,
+} from '@spectrum-web-components/base/src/decorators.js';
 
 import { Menu } from './Menu.js';
 import '../sp-menu.js';
@@ -45,6 +48,7 @@ export class MenuGroup extends Menu {
     @queryAssignedNodes('header', true)
     private headerElements!: NodeListOf<HTMLElement>;
 
+    @state()
     private headerElement?: HTMLElement;
 
     protected get ownRole(): string {
@@ -81,7 +85,11 @@ export class MenuGroup extends Menu {
 
     public render(): TemplateResult {
         return html`
-            <span class="header" aria-hidden="true">
+            <span
+                class="header"
+                aria-hidden="true"
+                ?hidden=${!this.headerElement}
+            >
                 <slot name="header" @slotchange=${this.updateLabel}></slot>
             </span>
             <sp-menu role="none">

--- a/packages/menu/src/menu-group.css
+++ b/packages/menu/src/menu-group.css
@@ -14,8 +14,9 @@ governing permissions and limitations under the License.
 
 :host {
     margin: 0;
-    display: inline;
+    display: inline-flex;
     overflow: visible;
+    flex-direction: column;
 }
 
 /**
@@ -36,5 +37,17 @@ governing permissions and limitations under the License.
 }
 
 sp-menu {
-    display: block;
+    --swc-menu-width: 100%;
+}
+
+:host(:last-child) sp-menu {
+    margin-bottom: 0;
+}
+
+:host(:first-child) .header[hidden] + sp-menu {
+    margin-top: 0;
+}
+
+[hidden] {
+    display: none !important;
 }

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -67,3 +67,8 @@ governing permissions and limitations under the License.
    * [dir=ltr] .spectrum-Menu-item .spectrum-Menu-itemIcon+.spectrum-Menu-itemLabel */
     margin-left: 0;
 }
+
+:host([dir='rtl']) .chevron {
+    padding-left: var(--spectrum-listitem-texticon-icon-gap);
+    padding-right: 0;
+}

--- a/packages/menu/src/menu.css
+++ b/packages/menu/src/menu.css
@@ -33,7 +33,6 @@ governing permissions and limitations under the License.
     outline: none;
 }
 
-:host sp-menu {
-    /* .spectrum-Menu .spectrum-Menu */
-    display: block;
+::slotted(*) {
+    --swc-menu-width: 100%;
 }

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -13,12 +13,13 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '../sp-menu.js';
 import '@spectrum-web-components/popover/sp-popover.js';
-import '@spectrum-web-components/menu/sp-menu.js';
+import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/icon/sp-icon.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark-circle.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
 
 export default {
     component: 'sp-menu',

--- a/packages/menu/stories/submenu.stories.ts
+++ b/packages/menu/stories/submenu.stories.ts
@@ -1,0 +1,340 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, render, TemplateResult } from '@spectrum-web-components/base';
+
+import '@spectrum-web-components/action-menu/sp-action-menu.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/menu/sp-menu-divider.js';
+import '@spectrum-web-components/menu/sp-menu-group.js';
+import { openOverlay, VirtualTrigger } from '@spectrum-web-components/overlay';
+import type { Popover } from '@spectrum-web-components/popover';
+import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
+import type { ActionMenu } from '@spectrum-web-components/action-menu';
+import type { Menu, MenuItem } from '..';
+
+export default {
+    component: 'sp-menu',
+    title: 'Menu/Submenu',
+};
+
+function nextFrame(): Promise<void> {
+    return new Promise((res) => requestAnimationFrame(() => res()));
+}
+
+class SubmenuReady extends HTMLElement {
+    ready!: (value: boolean | PromiseLike<boolean>) => void;
+
+    constructor() {
+        super();
+        this.readyPromise = new Promise((res) => {
+            this.ready = res;
+            this.setup();
+        });
+    }
+
+    async setup(): Promise<void> {
+        await nextFrame();
+
+        const menu = document.querySelector(`sp-action-menu`) as ActionMenu;
+        menu.addEventListener('sp-opened', this.handleMenuOpened, {
+            once: true,
+        });
+        menu.open = true;
+    }
+
+    handleMenuOpened = async (event: Event): Promise<void> => {
+        await nextFrame();
+        await (event.target as ActionMenu).updateComplete;
+
+        const submenu = document.querySelector('#submenu-item-1') as MenuItem;
+        if (!submenu) {
+            return;
+        }
+        submenu.addEventListener('sp-opened', this.handleSubmenuOpened, {
+            once: true,
+        });
+        submenu.dispatchEvent(
+            new PointerEvent('pointerenter', { bubbles: true, composed: true })
+        );
+    };
+
+    handleSubmenuOpened = async (event: Event): Promise<void> => {
+        await nextFrame();
+        await (event.target as MenuItem).updateComplete;
+
+        const submenu = document.querySelector('#submenu-item-2') as MenuItem;
+        if (!submenu) {
+            return;
+        }
+        submenu.addEventListener('sp-opened', this.handleSubmenuChildOpened, {
+            once: true,
+        });
+        submenu.dispatchEvent(
+            new PointerEvent('pointerenter', { bubbles: true, composed: true })
+        );
+    };
+
+    handleSubmenuChildOpened = async (event: Event): Promise<void> => {
+        await nextFrame();
+        await (event.target as MenuItem).updateComplete;
+
+        this.ready(true);
+    };
+
+    private readyPromise: Promise<boolean> = Promise.resolve(false);
+
+    get updateComplete(): Promise<boolean> {
+        return this.readyPromise;
+    }
+}
+
+customElements.define('submenu-ready', SubmenuReady);
+
+const submenuDecorator = (story: () => TemplateResult): TemplateResult => {
+    return html`
+        ${story()}
+        <submenu-ready></submenu-ready>
+    `;
+};
+
+export const submenu = (): TemplateResult => {
+    const getValueEls = (): {
+        root: HTMLElement;
+        first: HTMLElement;
+        second: HTMLElement;
+    } => {
+        return {
+            root: document.querySelector('#root-value') as HTMLElement,
+            first: document.querySelector('#first-value') as HTMLElement,
+            second: document.querySelector('#second-value') as HTMLElement,
+        };
+    };
+    const clearValues = (): void => {
+        const valueEls = getValueEls();
+        valueEls.root.textContent = '';
+        valueEls.first.textContent = '';
+        valueEls.second.textContent = '';
+    };
+    const handleRootChange = (event: Event & { target: ActionMenu }): void => {
+        const valueEls = getValueEls();
+        valueEls.root.textContent = event.target.value;
+    };
+    const handleFirstDescendantChange = (
+        event: Event & { target: Menu }
+    ): void => {
+        const valueEls = getValueEls();
+        valueEls.first.textContent = event.target.selected[0] || '';
+    };
+    const handleSecondDescendantChange = (
+        event: Event & { target: Menu }
+    ): void => {
+        const valueEls = getValueEls();
+        valueEls.second.textContent = event.target.selected[0] || '';
+    };
+    return html`
+        <sp-action-menu @change=${handleRootChange} @sp-opened=${clearValues}>
+            <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
+            <sp-menu-group
+                @change=${() => console.log('group change')}
+                role="none"
+            >
+                <span slot="header">New York</span>
+                <sp-menu-item>Bronx</sp-menu-item>
+                <sp-menu-item id="submenu-item-1">
+                    Brooklyn
+                    <sp-menu
+                        slot="submenu"
+                        @change=${handleFirstDescendantChange}
+                    >
+                        <sp-menu-item id="submenu-item-2">
+                            Ft. Greene
+                            <sp-menu
+                                slot="submenu"
+                                @change=${handleSecondDescendantChange}
+                            >
+                                <sp-menu-item>S. Oxford St</sp-menu-item>
+                                <sp-menu-item>S. Portland Ave</sp-menu-item>
+                                <sp-menu-item>S. Elliot Pl</sp-menu-item>
+                            </sp-menu>
+                        </sp-menu-item>
+                        <sp-menu-item disabled>Park Slope</sp-menu-item>
+                        <sp-menu-item>Williamsburg</sp-menu-item>
+                    </sp-menu>
+                </sp-menu-item>
+                <sp-menu-item>
+                    Manhattan
+                    <sp-menu
+                        slot="submenu"
+                        @change=${handleFirstDescendantChange}
+                    >
+                        <sp-menu-item disabled>SoHo</sp-menu-item>
+                        <sp-menu-item>
+                            Union Square
+                            <sp-menu
+                                slot="submenu"
+                                @change=${handleSecondDescendantChange}
+                            >
+                                <sp-menu-item>14th St</sp-menu-item>
+                                <sp-menu-item>Broadway</sp-menu-item>
+                                <sp-menu-item>Park Ave</sp-menu-item>
+                            </sp-menu>
+                        </sp-menu-item>
+                        <sp-menu-item>Upper East Side</sp-menu-item>
+                    </sp-menu>
+                </sp-menu-item>
+            </sp-menu-group>
+        </sp-action-menu>
+        <div>
+            Root value:
+            <span id="root-value"></span>
+            <br />
+            First descendant value:
+            <span id="first-value"></span>
+            <br />
+            Second descendant value:
+            <span id="second-value"></span>
+            <br />
+        </div>
+    `;
+};
+
+submenu.decorators = [submenuDecorator];
+
+export const contextMenu = (): TemplateResult => {
+    const contextMenuTemplate = (): TemplateResult => html`
+        <sp-popover
+            style="max-width: 33vw;"
+            @click=${(event: Event) =>
+                event.target?.dispatchEvent(
+                    new Event('close', { bubbles: true })
+                )}
+        >
+            <sp-menu @change=${handleRootChange}>
+                <sp-menu-group>
+                    <span slot="header">Options</span>
+                    <sp-menu-item>
+                        Copy
+                        <span slot="value">⌘​S</span>
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Paste
+                        <span slot="value">⌘​P</span>
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Cut
+                        <span slot="value">⌘​X</span>
+                    </sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>
+                        Select layer
+                        <sp-menu
+                            slot="submenu"
+                            selects="single"
+                            @change=${handleFirstDescendantChange}
+                        >
+                            <sp-menu-item selected>Ellipse 1</sp-menu-item>
+                            <sp-menu-item>Rectangle</sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Group
+                        <span slot="value">⌘​G</span>
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Unlock
+                        <span slot="value">⌘​L</span>
+                    </sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>
+                        Bring to front
+                        <span slot="value">⇧​⌘​​]</span>
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Bring forward
+                        <span slot="value">⌘​​]</span>
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Send backward
+                        <span slot="value">⌘​​[</span>
+                    </sp-menu-item>
+                    <sp-menu-item>
+                        Send to back
+                        <span slot="value">⇧​⌘​​[</span>
+                    </sp-menu-item>
+                    <sp-menu-divider></sp-menu-divider>
+                    <sp-menu-item>
+                        Delete
+                        <span slot="value">DEL</span>
+                    </sp-menu-item>
+                </sp-menu-group>
+            </sp-menu>
+        </sp-popover>
+    `;
+    const pointerenter = async (event: PointerEvent): Promise<void> => {
+        event.preventDefault();
+        const trigger = event.target as HTMLElement;
+        const virtualTrigger = new VirtualTrigger(event.clientX, event.clientY);
+        const fragment = document.createDocumentFragment();
+        render(contextMenuTemplate(), fragment);
+        const popover = fragment.querySelector('sp-popover') as Popover;
+        clearValues();
+        openOverlay(trigger, 'modal', popover, {
+            placement: 'right-start',
+            receivesFocus: 'auto',
+            virtualTrigger,
+        });
+    };
+    const getValueEls = (): { root: HTMLElement; first: HTMLElement } => {
+        return {
+            root: document.querySelector('#root-value') as HTMLElement,
+            first: document.querySelector('#first-value') as HTMLElement,
+        };
+    };
+    const clearValues = (): void => {
+        const valueEls = getValueEls();
+        valueEls.root.textContent = '';
+        valueEls.first.textContent = '';
+    };
+    const handleRootChange = (event: Event & { target: ActionMenu }): void => {
+        const valueEls = getValueEls();
+        valueEls.root.textContent = event.target.value;
+    };
+    const handleFirstDescendantChange = (
+        event: Event & { target: Menu }
+    ): void => {
+        const valueEls = getValueEls();
+        valueEls.first.textContent = event.target.selected[0] || '';
+    };
+    return html`
+        <style>
+            .app-root {
+                position: absolute;
+                inset: 0;
+            }
+            active-overlay::part(theme) {
+                --swc-menu-width: 200px;
+            }
+        </style>
+        <div class="app-root" @contextmenu=${pointerenter}>
+            <div>
+                Root value:
+                <span id="root-value"></span>
+                <br />
+                First descendant value:
+                <span id="first-value"></span>
+                <br />
+            </div>
+        </div>
+    `;
+};

--- a/packages/menu/test/menu-item.test.ts
+++ b/packages/menu/test/menu-item.test.ts
@@ -120,6 +120,12 @@ describe('Menu item', () => {
         const { anchorElement } = item as unknown as {
             anchorElement: HTMLAnchorElement;
         };
+        (
+            item as unknown as { anchorElement: HTMLAnchorElement }
+        ).anchorElement.dispatchEvent(new FocusEvent('focus'));
+
+        await elementUpdated(item);
+        expect(el === document.activeElement).to.be.true;
         item.click();
 
         expect(clickTargetSpy.calledWith(anchorElement)).to.be.true;

--- a/packages/menu/test/menu-selects.test.ts
+++ b/packages/menu/test/menu-selects.test.ts
@@ -657,9 +657,8 @@ describe('Menu w/ groups [selects]', () => {
         await sendKeys({ press: 'ArrowUp' });
         for (const option of options) {
             const parentElement = option.parentElement as Menu;
-            expect(document.activeElement, 'parent focused').to.equal(
-                parentElement
-            );
+            expect(document.activeElement === parentElement, 'parent focused')
+                .to.be.true;
             expect(option.focused, 'option visually focused').to.be.true;
             await sendKeys({ press: 'Space' });
             expect(parentElement.value).to.equal(option.value);

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -1,0 +1,441 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '../sp-menu.js';
+import '../sp-menu-item.js';
+import { Menu, MenuItem } from '@spectrum-web-components/menu';
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    html,
+    nextFrame,
+    oneEvent,
+} from '@open-wc/testing';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/src/themes.js';
+import { sendMouse } from '../../../test/plugins/browser.js';
+import { spy } from 'sinon';
+import { Theme } from '@spectrum-web-components/theme';
+import { TemplateResult } from '@spectrum-web-components/base';
+import { sendKeys } from '@web/test-runner-commands';
+
+async function styledFixture<T extends Element>(
+    story: TemplateResult,
+    dir: 'ltr' | 'rtl' | 'auto' = 'ltr'
+): Promise<T> {
+    const test = await fixture<Theme>(html`
+        <sp-theme dir=${dir} scale="medium" color="dark">${story}</sp-theme>
+    `);
+    document.documentElement.dir = dir;
+    return test.children[0] as T;
+}
+
+describe('Submenu', () => {
+    it('selects - pointer', async () => {
+        const rootChanged = spy();
+        const submenuChanged = spy();
+        const el = await styledFixture<Menu>(
+            html`
+                <sp-menu
+                    @change=${(event: Event & { target: Menu }) => {
+                        rootChanged(event.target.value);
+                    }}
+                >
+                    <sp-menu-item class="root">
+                        Has submenu
+                        <sp-menu
+                            slot="submenu"
+                            @change=${(event: Event & { target: Menu }) => {
+                                submenuChanged(event.target.value);
+                            }}
+                        >
+                            <sp-menu-item class="submenu-item-1">
+                                One
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-2">
+                                Two
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-3">
+                                Three
+                            </sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+        const rootItem = el.querySelector('.root') as MenuItem;
+        const rootItemBoundingRect = rootItem.getBoundingClientRect();
+        expect(rootItem.open).to.be.false;
+
+        const opened = oneEvent(rootItem, 'sp-opened');
+        sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await opened;
+
+        expect(rootItem.open).to.be.true;
+
+        const item2 = document.querySelector('.submenu-item-2') as MenuItem;
+        const item2BoundingRect = item2.getBoundingClientRect();
+
+        const closed = oneEvent(rootItem, 'sp-closed');
+        sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [
+                        item2BoundingRect.left + item2BoundingRect.width / 2,
+                        item2BoundingRect.top + item2BoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await closed;
+        await nextFrame();
+
+        expect(rootChanged.calledWith('Has submenu'), 'root changed').to.be
+            .true;
+        expect(submenuChanged.calledWith('Two'), 'submenu changed').to.be.true;
+    });
+    (
+        [
+            {
+                dir: 'ltr',
+                openKey: 'ArrowRight',
+                closeKey: 'ArrowLeft',
+            },
+            {
+                dir: 'rtl',
+                openKey: 'ArrowLeft',
+                closeKey: 'ArrowRight',
+            },
+        ] as {
+            dir: 'ltr' | 'rtl' | 'auto';
+            openKey: 'ArrowRight' | 'ArrowLeft';
+            closeKey: 'ArrowRight' | 'ArrowLeft';
+        }[]
+    ).map((testData) => {
+        it(`selects - keyboard: ${testData.dir}`, async () => {
+            const rootChanged = spy();
+            const submenuChanged = spy();
+            const el = await styledFixture<Menu>(
+                html`
+                    <sp-menu
+                        @change=${(event: Event & { target: Menu }) => {
+                            rootChanged(event.target.value);
+                        }}
+                    >
+                        <sp-menu-item class="root">
+                            Has submenu
+                            <sp-menu
+                                slot="submenu"
+                                @change=${(event: Event & { target: Menu }) => {
+                                    submenuChanged(event.target.value);
+                                }}
+                            >
+                                <sp-menu-item class="submenu-item-1">
+                                    One
+                                </sp-menu-item>
+                                <sp-menu-item class="submenu-item-2">
+                                    Two
+                                </sp-menu-item>
+                                <sp-menu-item class="submenu-item-3">
+                                    Three
+                                </sp-menu-item>
+                            </sp-menu>
+                        </sp-menu-item>
+                    </sp-menu>
+                `,
+                testData.dir
+            );
+
+            await elementUpdated(el);
+            const rootItem = el.querySelector('.root') as MenuItem;
+            expect(rootItem.open).to.be.false;
+            el.focus();
+            await elementUpdated(el);
+
+            let opened = oneEvent(rootItem, 'sp-opened');
+            sendKeys({
+                press: testData.openKey,
+            });
+            await opened;
+
+            expect(rootItem.open).to.be.true;
+
+            let closed = oneEvent(rootItem, 'sp-closed');
+            sendKeys({
+                press: testData.closeKey,
+            });
+            await closed;
+
+            expect(rootItem.open).to.be.false;
+
+            opened = oneEvent(rootItem, 'sp-opened');
+            sendKeys({
+                press: testData.openKey,
+            });
+            await opened;
+
+            expect(rootItem.open).to.be.true;
+
+            await sendKeys({
+                press: 'ArrowDown',
+            });
+
+            closed = oneEvent(rootItem, 'sp-closed');
+            sendKeys({
+                press: 'Enter',
+            });
+            await closed;
+
+            expect(rootChanged.calledWith('Has submenu'), 'root changed').to.be
+                .true;
+            expect(submenuChanged.calledWith('Two'), 'submenu changed').to.be
+                .true;
+        });
+    });
+    it('closes on `pointerleave`', async () => {
+        const el = await styledFixture<Menu>(
+            html`
+                <sp-menu>
+                    <sp-menu-item class="root">
+                        Has submenu
+                        <sp-menu slot="submenu">
+                            <sp-menu-item class="submenu-item-1">
+                                One
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-2">
+                                Two
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-3">
+                                Three
+                            </sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+        const rootItem = el.querySelector('.root') as MenuItem;
+        const rootItemBoundingRect = rootItem.getBoundingClientRect();
+        expect(rootItem.open).to.be.false;
+
+        const opened = oneEvent(rootItem, 'sp-opened');
+        sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await opened;
+
+        expect(rootItem.open).to.be.true;
+
+        const closed = oneEvent(rootItem, 'sp-closed');
+        sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height * 2,
+                    ],
+                },
+            ],
+        });
+        await closed;
+
+        expect(rootItem.open).to.be.false;
+    });
+    it('stays open when mousing off menu item and back again', async () => {
+        const el = await styledFixture<Menu>(
+            html`
+                <sp-menu>
+                    <sp-menu-item class="root">
+                        Has submenu
+                        <sp-menu slot="submenu">
+                            <sp-menu-item class="submenu-item-1">
+                                One
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-2">
+                                Two
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-3">
+                                Three
+                            </sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+        const rootItem = el.querySelector('.root') as MenuItem;
+        const rootItemBoundingRect = rootItem.getBoundingClientRect();
+        expect(rootItem.open).to.be.false;
+
+        const opened = oneEvent(rootItem, 'sp-opened');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height * 2,
+                    ],
+                },
+            ],
+        });
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await opened;
+
+        expect(rootItem.open).to.be.true;
+
+        const closed = oneEvent(rootItem, 'sp-closed');
+        sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height * 2,
+                    ],
+                },
+            ],
+        });
+        await closed;
+    });
+    it('stays open when mousing between menu item and submenu', async () => {
+        const el = await styledFixture<Menu>(
+            html`
+                <sp-menu>
+                    <sp-menu-item class="root">
+                        Has submenu
+                        <sp-menu slot="submenu">
+                            <sp-menu-item class="submenu-item-1">
+                                One
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-2">
+                                Two
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-3">
+                                Three
+                            </sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+        const rootItem = el.querySelector('.root') as MenuItem;
+        const rootItemBoundingRect = rootItem.getBoundingClientRect();
+        expect(rootItem.open).to.be.false;
+
+        const opened = oneEvent(rootItem, 'sp-opened');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height * 2,
+                    ],
+                },
+            ],
+        });
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width * 1.5,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await opened;
+
+        expect(rootItem.open).to.be.true;
+    });
+});

--- a/packages/menu/tsconfig.json
+++ b/packages/menu/tsconfig.json
@@ -6,5 +6,9 @@
     },
     "include": ["*.ts", "src/*.ts"],
     "exclude": ["test/*.ts", "stories/*.ts"],
-    "references": [{ "path": "../base" }, { "path": "../action-button" }]
+    "references": [
+        { "path": "../base" },
+        { "path": "../action-button" },
+        { "path": "../overlay" }
+    ]
 }

--- a/packages/overlay/src/loader.ts
+++ b/packages/overlay/src/loader.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { OverlayOptions, TriggerInteractions } from './overlay-types';
+import type { OverlayOptions, TriggerInteractions } from './overlay-types';
 
 export const openOverlay = async (
     target: HTMLElement,

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -316,8 +316,8 @@ export class OverlayStack {
         ) => {
             this.hideAndCloseOverlay(
                 activeOverlay,
-                true,
-                !!event.detail?.reason
+                true, // animated?
+                !!event.detail?.reason // clickAway?
             );
         }) as EventListener);
         switch (activeOverlay.interaction) {

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { ThemeData } from '@spectrum-web-components/theme';
+import type { ThemeData } from '@spectrum-web-components/theme/src/Theme.js';
 import type { Placement as FloatingUIPlacement } from '@floating-ui/dom';
 import type { VirtualTrigger } from './VirtualTrigger.js';
 
@@ -28,6 +28,7 @@ export interface OverlayOpenDetail {
     contentTip?: HTMLElement;
     delayed: boolean;
     offset: number;
+    skidding?: number;
     placement?: Placement;
     receivesFocus?: 'auto';
     virtualTrigger?: VirtualTrigger;
@@ -40,6 +41,11 @@ export interface OverlayOpenDetail {
 
 export interface OverlayOpenCloseDetail {
     interaction: TriggerInteractions;
+    reason?: 'external-click';
+}
+
+export interface OverlayCloseReasonDetail {
+    reason?: 'external-click';
 }
 
 /**

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -10,8 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { ThemeData } from '@spectrum-web-components/theme';
-import {
+import type { ThemeData } from '@spectrum-web-components/theme/src/Theme.js';
+import type {
     OverlayDisplayQueryDetail,
     OverlayOptions,
     TriggerInteractions,

--- a/packages/overlay/test/overlay-trigger-sync.test.ts
+++ b/packages/overlay/test/overlay-trigger-sync.test.ts
@@ -28,7 +28,7 @@ import { Button } from '@spectrum-web-components/button';
 import '@spectrum-web-components/popover/sp-popover.js';
 import { Popover } from '@spectrum-web-components/popover';
 import '@spectrum-web-components/theme/sp-theme.js';
-import { Theme } from '@spectrum-web-components/theme';
+import { Theme } from '@spectrum-web-components/theme/src/Theme.js';
 
 function pressKey(code: string): void {
     const up = new KeyboardEvent('keyup', {

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -28,7 +28,7 @@ import { Button } from '@spectrum-web-components/button';
 import '@spectrum-web-components/popover/sp-popover.js';
 import { Popover } from '@spectrum-web-components/popover';
 import '@spectrum-web-components/theme/sp-theme.js';
-import { Theme } from '@spectrum-web-components/theme';
+import { Theme } from '@spectrum-web-components/theme/src/Theme.js';
 
 function pressKey(code: string): void {
     const up = new KeyboardEvent('keyup', {

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -294,7 +294,7 @@ export class PickerBase extends SizedMixin(Focusable) {
     private async openMenu(): Promise<void> {
         /* c8 ignore next 9 */
         let reparentableChildren: Element[] = [];
-        const deprecatedMenu = this.querySelector('sp-menu');
+        const deprecatedMenu = this.querySelector(':scope > sp-menu') as Menu;
 
         await this.generatePopover(deprecatedMenu);
         if (deprecatedMenu) {

--- a/packages/popover/src/Popover.ts
+++ b/packages/popover/src/Popover.ts
@@ -18,10 +18,10 @@ import {
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
-import {
+import type {
     OverlayDisplayQueryDetail,
     Placement,
-} from '@spectrum-web-components/overlay';
+} from '@spectrum-web-components/overlay/src/overlay-types.js';
 import popoverStyles from './popover.css.js';
 
 /**
@@ -76,12 +76,18 @@ export class Popover extends SpectrumElement {
 
     public connectedCallback(): void {
         super.connectedCallback();
-        this.addEventListener('sp-overlay-query', this.onOverlayQuery);
+        this.addEventListener(
+            'sp-overlay-query',
+            this.onOverlayQuery as EventListener
+        );
     }
 
     public disconnectedCallback(): void {
         super.disconnectedCallback();
-        this.removeEventListener('sp-overlay-query', this.onOverlayQuery);
+        this.removeEventListener(
+            'sp-overlay-query',
+            this.onOverlayQuery as EventListener
+        );
     }
 
     public onOverlayQuery(event: CustomEvent<OverlayDisplayQueryDetail>): void {

--- a/packages/popover/src/popover.css
+++ b/packages/popover/src/popover.css
@@ -13,6 +13,8 @@ governing permissions and limitations under the License.
 
 :host {
     --sp-popover-tip-size: 24px;
+
+    min-width: min-content;
 }
 
 :host([placement*='top']),

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -153,6 +153,7 @@ export class LayoutElement extends LitElement {
     private updateDirection(event: Event) {
         const dir = (event.target as Picker).value;
         this.dir = dir === 'rtl' ? dir : 'ltr';
+        document.documentElement.dir = this.dir;
     }
 
     private handleTrackTheme(event: CustomEvent<TrackTheme>): void {

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -171,7 +171,7 @@ export class StoryDecorator extends SpectrumElement {
     @property({ type: String })
     public scale: Scale = window.__swc_hack_knobs__.defaultScale;
 
-    @property({ type: String })
+    @property({ type: String, reflect: true, attribute: 'dir' })
     public direction: 'ltr' | 'rtl' =
         window.__swc_hack_knobs__.defaultDirection;
 
@@ -216,6 +216,7 @@ export class StoryDecorator extends SpectrumElement {
                     dir =
                     window.__swc_hack_knobs__.defaultDirection =
                         value as 'ltr' | 'rtl';
+                document.documentElement.dir = dir;
                 break;
             case 'reduceMotion':
                 this.reduceMotion =

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -62,10 +62,10 @@ export default {
             '**/node_modules/**',
         ],
         threshold: {
-            statements: 98,
-            branches: 93,
+            statements: 99,
+            branches: 96,
             functions: 98,
-            lines: 98,
+            lines: 99,
         },
     },
     testFramework: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18237,10 +18237,10 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-playwright-core@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.19.1.tgz#d41939730170d53df26f5c8c16f5821e6328b24d"
-  integrity sha512-+ByjhWX39PlINVRXr4ef9Kle85mk5QzA2WLioCoMQc3bSUtZpLV1mbeUDtRp/bvFw6YDIEyptj4QvzzRTXN3vg==
+playwright-core@1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.19.2.tgz#90b9209554f174c649abf495952fcb4335437218"
+  integrity sha512-OsL3sJZIo1UxKNWSP7zW7sk3FyUGG06YRHxHeBw51eIOxTCQRx5t+hXd0cvXashN2CHnd3hIZTs2aKa/im4hZQ==
   dependencies:
     commander "8.3.0"
     debug "4.3.3"
@@ -18288,12 +18288,12 @@ playwright@^1.14.0:
   dependencies:
     playwright-core "=1.16.3"
 
-playwright@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.19.1.tgz#5db88245932036ba208dbc2db8d5291ca50199e1"
-  integrity sha512-h1iCJ1S2eAkZ67lZCmOxhRiT3OKa1JFGtyHLaZV30znqIjcsJLuyB/dmo78V3ajpMdz8iwxIb2xjpaSh1G+8UA==
+playwright@^1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.19.2.tgz#d9927ae8512482642356e50a286c5767dfb7a621"
+  integrity sha512-2JmGWr/Iw/Uu27bZULeHgjn8doNrRVxIYdhspMuMlfKNpzwAe/sfm7wH8uey6jiZxnPL4bC5V4ACQcF4dAGWnw==
   dependencies:
-    playwright-core "1.19.1"
+    playwright-core "1.19.2"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
## Description
Add support for submenu content in `<sp-menu-item>` elements.

### To dos:
- [x] review `<sp-menu>` width application in submenus as it relates to breaking in the middle of words
- [x] maintain "active" state on the anchor element of open submenus
- [x] ensure ALL menus are closed when clicking away after opening multiple submenus
- [x] prevent multiple sibling submenus being open at the same time
- [x] ensure submenus reopen after clicking on them the first time
- [x] expand stories
  - [x] explain eventing
  - [x] as "context menu"
- [x] add tests
- [x] fix existing tests
- [x] review file size/performance side effects
  - the perf diff seems reasonable here
  - the file size diff seems a little larger than I expected, there may be room to further optimize this, but it doesn't feel like it should be a block at this stage
- [x] add documentation

## Related issue(s)
- fixes #146

## Motivation and context
Deliver more expansive menu content accessibly.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://sub-menu--spectrum-web-components.netlify.app/storybook/?path=/story/menu-submenu--submenu)
    2. Expect the layout of the second submenu to be a little bit wonky to start, it's opened by default for the VRTs which account for the timing needed to make this work correctly, [see screen shot](https://c166d9d48e0a89bf135470b620d0cec6--spectrum-web-components.netlify.app/review/#SubmenuStories/submenu.png).
    3. Click away from the menus
    4. See that the ALL close
    5. Click the hamburger button
    6. Mouse in and out of the various menus and make a selection of `Brooklyn > Ft. Greene > S. Elliot Pl`
    7. See that the selection is represented in the page.
-   [ ] _Test case 2_
    1. Go [here](https://sub-menu--spectrum-web-components.netlify.app/storybook/?path=/story/menu-submenu--submenu)
    2. Expect the layout of the second submenu to be a little bit wonky to start, it's opened by default for the VRTs which account for the timing needed to make this work correctly, [see screen shot](https://c166d9d48e0a89bf135470b620d0cec6--spectrum-web-components.netlify.app/review/#SubmenuStories/submenu.png).
    3. Click away from the menus
    4. See that the ALL close
    5. Tab to the hamburger menu
    6. Press `Space`
    7. See the menu open
    8. Press `ArrowDown`
    9. See "Brooklyn" focused
    8. Press `ArrowDown`
    9. See "Manhattan" focused
    10. Press `ArrowRight`
    11. See the submenu open and "Union Square" focused
    12. Press `ArrowRight`
    13. See the submenu open and "14th St" focused
    14. Press `Enter`
    15. See ALL the menus close
    16. See the selection represented in the page
-   [ ] _Test case 3_
    1. Go [here](https://sub-menu--spectrum-web-components.netlify.app/storybook/?path=/story/menu-submenu--context-menu)
    2. Right click the page
    3. Use various selection methods (pointer or keyboard) to choose `Select Layer > Rectangle`
    4. See the selection represented in the page
-   [ ] _Test case 4_
    1. Go [here](https://sub-menu--spectrum-web-components.netlify.app/components/menu-item/#submenu)
    2. Interact with the submenu demo
    3. See that is opens/closes via expected interactions (pointer and keyboard)

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
