### PR TITLE
refactor: position overlays on the GPU

### DIFF
--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -432,8 +432,9 @@ export class ActiveOverlay extends SpectrumElement {
         );
 
         Object.assign(this.style, {
-            left: `${roundByDPR(x)}px`,
-            top: `${roundByDPR(y)}px`,
+            top: '0px',
+            left: '0px',
+            transform: `translate(${roundByDPR(x)}px, ${roundByDPR(y)}px)`,
         });
 
         if (placement !== this.getAttribute('actual-placement')) {

--- a/packages/overlay/src/active-overlay.css
+++ b/packages/overlay/src/active-overlay.css
@@ -39,8 +39,8 @@ governing permissions and limitations under the License.
     position: absolute;
     display: inline-block;
     pointer-events: none;
-    top: 0;
-    left: 0;
+    top: -9999em;
+    left: -9999em;
 }
 
 :host(:focus) {
@@ -52,6 +52,8 @@ governing permissions and limitations under the License.
     height: 100vh;
     height: fill-available;
     max-height: var(--swc-visual-viewport-height);
+    top: 0;
+    left: 0;
 }
 
 sp-theme,


### PR DESCRIPTION
## Description
- move overlays onto the GPU and do some extra work to get overlays off the screen for the first measurement.

## Motivation and context
Some resource constrained contexts may place the overlay at 0, 0 for a visible number of frames, and then glitch while animating the overlay into place.

## Types of changes
-   [x] refactor (new code that does the same thing but better)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
