### PR TITLE
Use latest Playwright and latest test browsers.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 7b3817787774698b502f679881f115940c6a179f
+        default: de375e7d34f415bb0737b2925279d7e038f613d5
 commands:
     downstream:
         steps:

--- a/packages/overlay/src/overlay-trigger.css
+++ b/packages/overlay/src/overlay-trigger.css
@@ -14,6 +14,6 @@ governing permissions and limitations under the License.
     pointer-events: none;
 }
 
-#overlay-content {
+#overlay-content slot {
     display: none;
 }

--- a/packages/overlay/test/overlay-trigger-extended.test.ts
+++ b/packages/overlay/test/overlay-trigger-extended.test.ts
@@ -196,7 +196,7 @@ describe('Overlay Trigger - extended', () => {
         textfield.remove();
     });
 
-    it.only('occludes wheel interactions behind the overlay', async () => {
+    it('occludes wheel interactions behind the overlay', async () => {
         ({ overlayTrigger, button, popover } = await initTest());
         const scrollingArea = document.createElement('div');
         Object.assign(scrollingArea.style, {
@@ -236,7 +236,7 @@ describe('Overlay Trigger - extended', () => {
         // wait for scroll to complete
         await waitUntil(
             () => scrollingArea.scrollTop === distance,
-            'scroll went to 50'
+            `scroll went to ${distance}`
         );
         expect(scrollingArea.scrollTop).to.equal(distance);
 
@@ -261,26 +261,10 @@ describe('Overlay Trigger - extended', () => {
                 },
             ],
         });
-        /**
-         * The following test works in _actual_ Firefox, but fails with no clear reason
-         * in Firefox at unit test time. Because of this, I've wrapped the failure in
-         * this context as expected, and set the test to "fail" when conditions in Firefox
-         * are no longer what they are today. So, once this test starts to fail again
-         * Firefox has been "fixed". This allows us to keep the test which works as
-         * expected in Chromium and WebKit.
-         */
-        let failed = false;
-        try {
-            expect(
-                scrollingArea.scrollTop,
-                `scrollTop should be ${distance}.`
-            ).to.equal(distance);
-        } catch (error) {
-            failed = true;
-        }
-        if (navigator.userAgent.match(/firefox|fxios/i)) {
-            expect(failed).to.be.true;
-        }
+        expect(
+            scrollingArea.scrollTop,
+            `scrollTop should be ${distance}.`
+        ).to.equal(distance);
         scrollingArea.remove();
     });
 });

--- a/packages/overlay/test/overlay-trigger-hover-click.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover-click.test.ts
@@ -75,14 +75,19 @@ describe('Overlay Trigger - Hover and Click', () => {
 
         // hover over the button to trigger the tooltip
         const hoveredEvent = oneEvent(el, 'sp-opened');
-        await sendMouse({
+        sendMouse({
             steps: [
                 {
                     type: 'move',
-                    position: [
-                        bounds.left + bounds.width / 2,
-                        bounds.top + bounds.height / 2,
-                    ],
+                    position: [bounds.left - 1, bounds.top - 1],
+                },
+                {
+                    type: 'move',
+                    position: [bounds.left, bounds.top],
+                },
+                {
+                    type: 'move',
+                    position: [bounds.left + 1, bounds.top + 1],
                 },
             ],
         });

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -399,7 +399,8 @@ describe('Overlay Trigger - Longpress', () => {
             press: 'Tab',
         });
 
-        expect(document.activeElement).to.equal(trigger);
+        expect(document.activeElement === trigger, 'Trigger focused').to.be
+            .true;
 
         await findDescribedNode(
             'Trigger with hold affordance',

--- a/packages/picker/test/picker.test.ts
+++ b/packages/picker/test/picker.test.ts
@@ -303,75 +303,21 @@ describe('Picker, standard', () => {
             await waitUntil(() => !firstItem.focused, 'not visually focused');
         });
         it('opens without visible focus on a menu item on click', async () => {
-            /**
-             * Firefox will not accept a single "click" from Playwright as deactivating the
-             * :focus-visible heuristic. So, to trick it, we "click" three times! Once to
-             * open, once to close, and once to open again before taking the operative test
-             * that the first item in the menu is to given the `focused` attribute immediately.
-             */
-
             const firstItem = el.querySelector('sp-menu-item') as MenuItem;
 
             await elementUpdated(el);
             const boundingRect = el.getBoundingClientRect();
 
             expect(firstItem.focused, 'not visually focused').to.be.false;
-            let opened = oneEvent(el, 'sp-opened');
-            await sendMouse({
+            const opened = oneEvent(el, 'sp-opened');
+            sendMouse({
                 steps: [
                     {
-                        type: 'move',
+                        type: 'click',
                         position: [
                             boundingRect.x + boundingRect.width / 2,
                             boundingRect.y + boundingRect.height / 2,
                         ],
-                    },
-                    {
-                        type: 'down',
-                    },
-                    {
-                        type: 'up',
-                    },
-                ],
-            });
-            await opened;
-            expect(el.open).to.be.true;
-            const closed = oneEvent(el, 'sp-closed');
-            await sendMouse({
-                steps: [
-                    {
-                        type: 'move',
-                        position: [
-                            boundingRect.x + boundingRect.width / 2,
-                            boundingRect.y + boundingRect.height / 2,
-                        ],
-                    },
-                    {
-                        type: 'down',
-                    },
-                    {
-                        type: 'up',
-                    },
-                ],
-            });
-            await closed;
-
-            expect(el.open).to.be.false;
-            opened = oneEvent(el, 'sp-opened');
-            await sendMouse({
-                steps: [
-                    {
-                        type: 'move',
-                        position: [
-                            boundingRect.x + boundingRect.width / 2,
-                            boundingRect.y + boundingRect.height / 2,
-                        ],
-                    },
-                    {
-                        type: 'down',
-                    },
-                    {
-                        type: 'up',
                     },
                 ],
             });
@@ -1133,17 +1079,32 @@ describe('Picker, standard', () => {
 
         expect(el1.open, 'closed 1').to.be.false;
         expect(el2.open, 'closed 1').to.be.false;
+        let open = oneEvent(el1, 'sp-opened');
         el1.click();
-        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
-        await waitUntil(() => el1.open && !el2.open, '1 open, 2 closed');
+        await open;
+        expect(el1.open).to.be.true;
+        expect(el2.open).to.be.false;
 
+        open = oneEvent(el2, 'sp-opened');
+        let closed = oneEvent(el1, 'sp-closed');
         el2.click();
-        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
-        await waitUntil(() => !el1.open && el2.open, '1 closed, 2 open');
+        await Promise.all([open, closed]);
+        expect(el1.open).to.be.false;
+        expect(el2.open).to.be.true;
 
+        open = oneEvent(el1, 'sp-opened');
+        closed = oneEvent(el2, 'sp-closed');
         el1.click();
-        await Promise.all([elementUpdated(el1), elementUpdated(el2)]);
-        await waitUntil(() => el1.open && !el2.open, '1 open, 2 closed: again');
+        await Promise.all([open, closed]);
+        expect(el1.open).to.be.true;
+        expect(el2.open).to.be.false;
+
+        closed = oneEvent(el1, 'sp-closed');
+        sendKeys({
+            press: 'Escape',
+        });
+        await closed;
+        expect(el1.open).to.be.false;
     });
     it('displays selected item text by default', async () => {
         const el = await fixture<Picker>(
@@ -1180,16 +1141,24 @@ describe('Picker, standard', () => {
         expect(el.selectedItem?.itemText).to.equal('Select Inverse');
 
         el.focus();
+        await elementUpdated(el);
+        expect(
+            el === document.activeElement,
+            `activeElement is ${document.activeElement?.localName}`
+        ).to.be.true;
+
         const opened = oneEvent(el, 'sp-opened');
         sendKeys({ press: 'Enter' });
         await opened;
-
-        const menu = document.querySelector('sp-menu') as Menu;
-        await elementUpdated(menu);
+        await elementUpdated(el.optionsMenu);
+        expect(
+            el.optionsMenu === document.activeElement,
+            `activeElement is ${document.activeElement?.localName}`
+        ).to.be.true;
 
         expect(firstItem.focused, 'firstItem NOT "focused"').to.be.false;
         expect(secondItem.focused, 'secondItem "focused"').to.be.true;
-        expect(menu.getAttribute('aria-activedescendant')).to.equal(
+        expect(el.optionsMenu.getAttribute('aria-activedescendant')).to.equal(
             secondItem.id
         );
     });

--- a/packages/shared/src/focus-visible.ts
+++ b/packages/shared/src/focus-visible.ts
@@ -34,8 +34,6 @@ type MixableBaseClass = HTMLElement & OptionalLifecycleCallbacks;
 
 type EndPolyfillCoordinationCallback = () => void;
 
-import 'focus-visible';
-
 let hasFocusVisible = true;
 
 try {
@@ -121,7 +119,8 @@ export const FocusVisiblePolyfillMixin = <
     // syntax The mixin implementation assumes that the user will take the
     // appropriate steps to support both:
     class FocusVisibleCoordinator extends SuperClass {
-        private [$endPolyfillCoordination]: EndPolyfillCoordinationCallback | null = null;
+        private [$endPolyfillCoordination]: EndPolyfillCoordinationCallback | null =
+            null;
 
         // Attempt to coordinate with the polyfill when connected to the
         // document:
@@ -130,9 +129,8 @@ export const FocusVisiblePolyfillMixin = <
             if (!hasFocusVisible) {
                 requestAnimationFrame(() => {
                     if (this[$endPolyfillCoordination] == null) {
-                        this[$endPolyfillCoordination] = coordinateWithPolyfill(
-                            this
-                        );
+                        this[$endPolyfillCoordination] =
+                            coordinateWithPolyfill(this);
                     }
                 });
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8555,7 +8555,7 @@ command-line-usage@^6.1.0, command-line-usage@^6.1.1:
     table-layout "^1.0.1"
     typical "^5.2.0"
 
-commander@8.3.0, commander@^8.0.0, commander@^8.1.0, commander@^8.2.0, commander@^8.3.0:
+commander@8.3.0, commander@^8.0.0, commander@^8.1.0, commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
@@ -14226,7 +14226,7 @@ jest-worker@^27.0.6:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jpeg-js@0.4.3, jpeg-js@^0.4.2:
+jpeg-js@0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
   integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
@@ -16080,7 +16080,7 @@ mime@3.0.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
   integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
-mime@^2.3.1, mime@^2.4.6:
+mime@^2.3.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
@@ -18254,36 +18254,7 @@ playwright-core@1.19.2:
     yauzl "2.10.0"
     yazl "2.5.1"
 
-playwright-core@=1.16.3:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.16.3.tgz#f466be9acaffb698654adfb0a17a4906ba936895"
-  integrity sha512-16hF27IvQheJee+DbhC941AUZLjbJgfZFWi9YPS4LKEk/lKFhZI+9TiFD0sboYqb9eaEWvul47uR5xxTVbE4iw==
-  dependencies:
-    commander "^8.2.0"
-    debug "^4.1.1"
-    extract-zip "^2.0.1"
-    https-proxy-agent "^5.0.0"
-    jpeg-js "^0.4.2"
-    mime "^2.4.6"
-    pngjs "^5.0.0"
-    progress "^2.0.3"
-    proper-lockfile "^4.1.1"
-    proxy-from-env "^1.1.0"
-    rimraf "^3.0.2"
-    socks-proxy-agent "^6.1.0"
-    stack-utils "^2.0.3"
-    ws "^7.4.6"
-    yauzl "^2.10.0"
-    yazl "^2.5.1"
-
-playwright@^1.14.0:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.16.3.tgz#27a292d9fa54fbac923998d3af58cd2b691f5ebe"
-  integrity sha512-nfJx/OpIb/8OexL3rYGxNN687hGyaM3XNpfuMzoPlrekURItyuiHHsNhC9oQCx3JDmCn5O3EyyyFCnrZjH6MpA==
-  dependencies:
-    playwright-core "=1.16.3"
-
-playwright@^1.19.2:
+playwright@^1.14.0, playwright@^1.19.2:
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.19.2.tgz#d9927ae8512482642356e50a286c5767dfb7a621"
   integrity sha512-2JmGWr/Iw/Uu27bZULeHgjn8doNrRVxIYdhspMuMlfKNpzwAe/sfm7wH8uey6jiZxnPL4bC5V4ACQcF4dAGWnw==
@@ -18337,11 +18308,6 @@ pngjs@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-4.0.1.tgz#f803869bb2fc1bfe1bf99aa4ec21c108117cfdbe"
   integrity sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==
-
-pngjs@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
-  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
 
 portfinder@^1.0.28:
   version "1.0.28"
@@ -19228,7 +19194,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-proper-lockfile@4.1.2, proper-lockfile@^4.1.1:
+proper-lockfile@4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
   integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
@@ -21204,15 +21170,6 @@ socks-proxy-agent@^5.0.0:
     debug "4"
     socks "^2.3.3"
 
-socks-proxy-agent@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz#869cf2d7bd10fea96c7ad3111e81726855e285c3"
-  integrity sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==
-  dependencies:
-    agent-base "^6.0.2"
-    debug "^4.3.1"
-    socks "^2.6.1"
-
 socks@^2.3.3, socks@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
@@ -21474,13 +21431,6 @@ stack-utils@2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
   integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
-  dependencies:
-    escape-string-regexp "^2.0.0"
-
-stack-utils@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
-  integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
 
@@ -24116,7 +24066,7 @@ ws@8.5.0, ws@^8.1.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
   integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
-ws@>=7.4.6, ws@^7.3.1, ws@^7.4.2, ws@^7.4.6, ws@~7.4.2:
+ws@>=7.4.6, ws@^7.3.1, ws@^7.4.2, ws@~7.4.2:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
@@ -24265,7 +24215,7 @@ yauzl@2.10.0, yauzl@^2.10.0, yauzl@^2.4.2:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-yazl@2.5.1, yazl@^2.5.1:
+yazl@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
   integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==


### PR DESCRIPTION
## Description
- normalize the direct and indirect versions of Playwright to the latest version
- update VRTs for latest Chrome
- update tests for new browser versions
  - Chrome complained about the styling/content availability in `overlay-trigger` with hover content, the CSS there has been updated
- remove duplicate `focus-visible` import
- refactor Picker test to reduce flakiness

## Motivation and context
Keeping up with the v100+ browsers.
Reducing flakiness in tests.
Prepare for changes in other branches.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/11248/workflows/9af7a905-493d-44cc-bb4c-050efe3b0eaa)
    2. See that tests passed
-   [ ] _Test case 2_
    1. Go [here](https://playwright--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--longpress)
    2. Focus the button
    3. Ensure that long press instructions are not visible in the UI

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.