### PR TITLE
fix: avoid registering lit-virtualizer globally

### DIFF
--- a/tools/grid/src/Grid.ts
+++ b/tools/grid/src/Grid.ts
@@ -16,9 +16,8 @@ import {
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
-import { LitVirtualizer } from '@lit-labs/virtualizer';
+import { LitVirtualizer } from './LitVirtualizer.js';
 import { grid } from '@lit-labs/virtualizer/layouts/grid.js';
-
 import styles from './grid.css.js';
 import { GridController } from './GridController.js';
 

--- a/tools/grid/src/GridController.ts
+++ b/tools/grid/src/GridController.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import type { ReactiveController } from 'lit';
+import type { ReactiveController, ReactiveElement } from 'lit';
 
 import { ResizeController } from '@lit-labs/observers/resize_controller.js';
 import { RovingTabindexController } from '@spectrum-web-components/reactive-controllers/src/RovingTabindex.js';
@@ -17,7 +17,6 @@ import {
     RangeChangedEvent,
     VisibilityChangedEvent,
 } from '@lit-labs/virtualizer/Virtualizer.js';
-import type { LitVirtualizer } from '@lit-labs/virtualizer';
 
 interface ItemSize {
     width: number;
@@ -27,7 +26,7 @@ interface ItemSize {
 export class GridController<T extends HTMLElement>
     implements ReactiveController
 {
-    host!: LitVirtualizer;
+    host!: ReactiveElement;
 
     resizeController!: ResizeController;
 
@@ -61,7 +60,7 @@ export class GridController<T extends HTMLElement>
     _last = 0;
 
     constructor(
-        host: LitVirtualizer,
+        host: ReactiveElement,
         {
             elements,
             itemSize,
@@ -151,7 +150,7 @@ export class GridController<T extends HTMLElement>
                 });
             });
         };
-        const scrollToFirst = (): void => this.host.scrollToIndex(0);
+        const scrollToFirst = (): void => (this.host as any).scrollToIndex(0);
         const focusIntoGrid = (): void => {
             this.focus();
             this.host.tabIndex = -1;

--- a/tools/grid/src/LitVirtualizer.ts
+++ b/tools/grid/src/LitVirtualizer.ts
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+// @lit-labs/virtualizer combines defining the LitVirtualizer class with defining `lit-virtualizer` in the global registry.
+// Grid extends LitVirtualizer and doesn't need the tag, which can conflict with other uses of lit-virtualizer in the same document.
+// This is a hack to keep lit-virtualizer from registering globally.
+
+const oldDefine = customElements.define;
+customElements.define = (name, constructor) => {
+    if (name === 'lit-virtualizer') return;
+    oldDefine.call(customElements, name, constructor);
+};
+
+const { LitVirtualizer } = await import('@lit-labs/virtualizer');
+
+customElements.define = oldDefine;
+
+export { LitVirtualizer };

--- a/tools/grid/test/grid.test.ts
+++ b/tools/grid/test/grid.test.ts
@@ -251,4 +251,24 @@ describe('Grid', () => {
 
         expect(el.selected).to.deep.equal([{ id: 4 }]);
     });
+    it('does not claim lit-virtualizer on the global registry', async () => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <div>${Default()}</div>
+            `
+        );
+        const el = test.querySelector('sp-grid') as Grid;
+
+        await elementUpdated(el);
+
+        customElements.define('lit-virtualizer', class extends HTMLElement {});
+
+        // make sure we also don't prevent *any* registration of lit-virtualizer
+        expect(() => {
+            customElements.define(
+                'lit-virtualizer',
+                class extends HTMLElement {}
+            );
+        }).to.throw();
+    });
 });


### PR DESCRIPTION
## Description

Avoid registering `lit-virtualizer` in the global custom elements namespace.

## Motivation and context

Grid depends on `LitVirtualizer`, but not on `<lit-virtualizer>`. Since other components may use the virtualizer at different versions, let's avoid registering in the global namespace which can create collisions.

## How has this been tested?

- Added unit tests

## Types of changes

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
