### PR TITLE
fix: add missing dependency popover for action-menu

### DIFF
--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -52,6 +52,7 @@
         "@spectrum-web-components/icons-workflow": "^0.8.5",
         "@spectrum-web-components/menu": "^0.12.4",
         "@spectrum-web-components/picker": "^0.10.5",
+        "@spectrum-web-components/popover": "^0.11.9",
         "@spectrum-web-components/shared": "^0.13.6",
         "tslib": "^2.0.0"
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Closing #2170 

When upgrading to yarn 3, a missing dependency was flagged for the action-menu:

```
(node:67254) [MODULE_NOT_FOUND] Error: @spectrum-web-components/action-menu tried to access @spectrum-web-components/popover, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Action Menu builds successfully_
-   [x] _Linking this PR to a yarn 3 project & no longer seeing the error message_

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
