### PR TITLE
fix(button): add multiple ui icon imports to sp-button

### DIFF
--- a/packages/button/src/ClearButton.ts
+++ b/packages/button/src/ClearButton.ts
@@ -20,6 +20,9 @@ import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { StyledButton } from './StyledButton.js';
 import buttonStyles from '@spectrum-web-components/clear-button/src/clear-button.css.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-cross75.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross100.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross200.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross300.js';
 import crossMediumStyles from '@spectrum-web-components/icon/src/spectrum-icon-cross.css.js';
 
 const crossIcon: Record<string, () => TemplateResult> = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The imports for sp-clear-button's icons weren't all imported, so I added them. Bada bing, bada boom. Let me know if there's anything else. 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Consumer noticed the bug

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
