### PR TITLE
fix: stop propagation of sp-radio "change" events at sp-radio-group boundary

### DIFF
--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -88,6 +88,9 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
     }
 
     protected activate(): void {
+        if (this.checked) {
+            return;
+        }
         this.checked = true;
         this.dispatchEvent(
             new Event('change', {

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -109,10 +109,7 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
             }
         }
 
-        this.addEventListener('change', (event: Event) => {
-            if (event.target === this) {
-                return;
-            }
+        this.shadowRoot.addEventListener('change', (event: Event) => {
             event.stopPropagation();
             const target = event.target as Radio;
             this._setSelected(target.value);

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -30,6 +30,7 @@ import {
     sendKeys,
 } from '@web/test-runner-commands';
 import { sendMouse } from '../../../test/plugins/browser.js';
+import { spy } from 'sinon';
 
 describe('Radio Group - focus control', () => {
     it('does not accept focus when empty', async () => {
@@ -605,5 +606,27 @@ describe('Radio Group', () => {
             'sp-radio-group#test-integer-value'
         ) as RadioGroup;
         expect(radioGroup.selected).to.equal('5');
+    });
+
+    it('prevents `change` events from radio buttons', async () => {
+        const changeSpy = spy();
+        const onChange = (event: Event & { target: RadioGroup }): void => {
+            changeSpy(event.target.selected);
+        };
+        const el = await fixture(html`
+            <sp-radio-group @change=${onChange}>
+                <sp-radio value="bulbasaur">Bulbasaur</sp-radio>
+                <sp-radio value="squirtle">Squirtle</sp-radio>
+                <sp-radio value="charmander">Charmander</sp-radio>
+            </sp-radio-group>
+        `);
+
+        const bulbasaur = el.querySelector('[value="bulbasaur"]') as Radio;
+        const charmander = el.querySelector('[value="charmander"]') as Radio;
+        bulbasaur.click();
+        bulbasaur.click();
+        charmander.click();
+
+        expect(changeSpy.calledWith(undefined)).to.be.false;
     });
 });


### PR DESCRIPTION
## Description
Stop propagation of `sp-radio` "change" events at the `sp-radio-group` boundary.
Prevent "change" event when `sp-radio` is already checked.

## Related issue(s)
- fixes #2199
- related #2094
- related #829

## Motivation and context
Make it easier to consume the `sp-radio-group` element in applications.

## How has this been tested?
https://webcomponents.dev/edit/jVMbK8MN5IAJnJHsJ0pL/src/index.ts?p=stories has been added to the unit test suite.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.