### PR TITLE
Popover size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 86c16ae808cdaac63ab7d305cf288bc955841d64
+        default: 200e1d4a3f4cd16a335b3453dd2564309e5aa998
 commands:
     downstream:
         steps:

--- a/packages/overlay/src/active-overlay.css
+++ b/packages/overlay/src/active-overlay.css
@@ -74,6 +74,17 @@ sp-theme,
     );
     opacity: 1;
     visibility: visible;
+    box-sizing: border-box;
+
+    /**
+     * duplicate --spectrum-overlay-animation-distance, which is out of scope
+     * rather than over write so we continue to get new values from Spectrum CSS
+     * if they are provided in the future.
+     **/
+    --swc-overlay-animation-distance: var(
+        --spectrum-picker-m-texticon-popover-offset-y,
+        var(--spectrum-global-dimension-size-75)
+    );
 }
 
 :host([actual-placement*='top']) #contents {
@@ -81,22 +92,29 @@ sp-theme,
 
     display: inline-flex;
     align-items: flex-end;
+    padding-top: var(--swc-overlay-animation-distance);
 }
 
 :host([actual-placement*='right']) #contents {
     --sp-overlay-from: translateX(
         calc(-1 * var(--spectrum-global-dimension-size-75))
     );
+
+    padding-right: var(--swc-overlay-animation-distance);
 }
 
 :host([actual-placement*='bottom']) #contents {
     --sp-overlay-from: translateY(
         calc(-1 * var(--spectrum-global-dimension-size-75))
     );
+
+    padding-bottom: var(--swc-overlay-animation-distance);
 }
 
 :host([actual-placement*='left']) #contents {
     --sp-overlay-from: translateX(var(--spectrum-global-dimension-size-75));
+
+    padding-left: var(--swc-overlay-animation-distance);
 }
 
 :host([animating]) ::slotted(*) {

--- a/packages/popover/src/popover.css
+++ b/packages/popover/src/popover.css
@@ -19,12 +19,12 @@ governing permissions and limitations under the License.
 
 :host([placement*='top']),
 :host([placement*='bottom']) {
-    max-height: calc(100% - var(--spectrum-overlay-animation-distance));
+    max-height: 100%;
 }
 
 :host([placement*='left']),
 :host([placement*='right']) {
-    max-width: calc(100% - var(--spectrum-overlay-animation-distance));
+    max-width: 100%;
 }
 
 ::slotted(*) {


### PR DESCRIPTION
## Description
Allow popovers that are not restricted by the size of the browser to take up enough width or height to not truncate or line break their content in unexpected places.

## Related issue(s)
- fixes #2150

## Motivation and context
Uniformity of delivery.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://popover-size--spectrum-web-components.netlify.app/storybook/?path=/story/menu-submenu--submenu)
    2. See that `Ft. Greene` and `S. Portland Ave` are displayed on single lines like the [VRT results](https://026cce46f8e420c49c8bcc48f25b51ca--spectrum-web-components.netlify.app/review/#SubmenuStories/submenu.png)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
