### PR TITLE
docs: update docs search paths and layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/projects/documentation/src/components/search-index.ts
+++ b/projects/documentation/src/components/search-index.ts
@@ -40,7 +40,7 @@ function label(name: string): string {
 export async function search(value: string): Promise<ResultGroup[]> {
     if (!index) {
         const searchIndexURL = new URL(
-            '../../../searchIndex.json',
+            '../../searchIndex.json',
             import.meta.url
         ).href;
         const searchIndex = await (await fetch(searchIndexURL)).json();

--- a/projects/documentation/src/components/side-nav-search.ts
+++ b/projects/documentation/src/components/side-nav-search.ts
@@ -126,7 +126,7 @@ export class SearchComponent extends LitElement {
             'click',
             popover,
             {
-                placement: 'bottom',
+                placement: 'bottom-start',
             }
         );
 
@@ -237,9 +237,8 @@ export class SearchComponent extends LitElement {
                 >
                     <style>
                         #search-results-menu {
-                            width: 368px;
+                            width: 250px;
                             max-height: calc(100vh - 200px);
-                            margin-left: 24px;
                             display: flex;
                             flex-direction: column;
                         }


### PR DESCRIPTION
## Description
Correct the applied layout of the search completion overlay.
Update the search index path to allow results in the main docs site.

## Related issue(s)
- fixes #2215 

## Motivation and context
Things should be search able

## How has this been tested?
Still works in development sites but the difference between spectrum-web-components.netlify.app and opensource.adobe.com/spectrum-web-components is difficult to fully test until in production.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.