### PR TITLE
ci: use approval workflow for docs publication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
                   regression_scale: << parameters.scale >>
                   regression_dir: << parameters.dir >>
 
-    publish-docs:
+    site-build:
         executor: node
 
         steps:
@@ -228,8 +228,23 @@ jobs:
                   name: Generate Docs
                   command: yarn docs:ci
             - run: touch projects/documentation/dist/.nojekyll
+            - save_cache:
+                  name: Cache docs site
+                  paths:
+                      - projects/documentation/dist
+                  key: v1-docs-site-{{ .Revision }}
+
+    site-publish:
+        executor: node
+
+        steps:
+            - checkout
+            - restore_cache:
+                  name: Restore docs site cache
+                  keys:
+                      - v1-docs-site-{{ .Revision }}
             - run: git config --global user.email "circleci@adobe.com" && git config --global user.name "CircleCI"
-            - run: yarn gh-pages -d projects/documentation/dist -m "[skip ci] update demonstration site" -t
+            - run: npx gh-pages -d projects/documentation/dist -m "[skip ci] update demonstration site" -t
 
 workflows:
     version: 2
@@ -241,7 +256,11 @@ workflows:
             - test-chromium
             - test-firefox
             - test-webkit
-            - preview-docs
+            - preview-docs:
+                  filters:
+                      branches:
+                          # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+                          ignore: /pull\/[0-9]+/
             - visual:
                   name: << matrix.theme >>-<< matrix.color >>-<< matrix.scale >>-<< matrix.dir >>
                   matrix:
@@ -254,12 +273,15 @@ workflows:
                       branches:
                           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                           ignore: /pull\/[0-9]+/
-            - publish-docs:
+            - site-build:
                   filters:
                       branches:
                           only:
                               - main
+            - site-approve:
+                  type: approval
                   requires:
-                      - test-chromium
-                      - test-firefox
-                      - test-webkit
+                      - site-build
+            - site-publish:
+                  requires:
+                      - site-approve

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,22 @@
+# Releasing a new version of SWC
+
+Users with permissions against the `@spectrum-web-components` organization on NPM can follow the following steps to create and publish a new version of the SWC library.
+
+1. merge outstanding PRs and wait for `main` show that it has completed the required CI jobs
+2. `git checkout main`
+3. `git pull`
+4. `rm -rf node_modules packages projects tools`
+5. `git checkout packages`
+6. `git checkout projects`
+7. `git checkout tools`
+8. `yarn`
+9. `npm whoami` ensure that you are logged in with the user account for the public NPM registry
+10. `yarn lerna-publish`
+11. scan the version summary for any unexpected changes
+
+-   changes to the _major_ versions number are likely to point to undesired version numbers
+-   changes to the _minor_ or _feature_ version number should be confirmed as correct against the changes that have been made since the last release
+
+12. `Y` to confirm
+13. enter npm’s 2-factor auth
+14. Go to [CircleCI](https://app.circleci.com/pipelines/github/adobe) and once the commit to `main` with the new versions is ready, press the 👍🏼 button on the "site-approve" job to publish a new version of the documentation site


### PR DESCRIPTION
## Description
- reduce CI time by building before the approval step
- prevent mismatch between docs and current `latest` by gating docs publication on a manual approval step

## Related issue(s)
- fixes #1305

## Motivation and context
Easier to consume components when the documentation site is more tightly coupled to the published code.

## How has this been tested?
Ran CI, and approved the publication: https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/11505/workflows/45e4e35b-1f8d-4e85-b600-a000d9338757

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.