### PR TITLE
feat: reparentChildren - insertAdjacentElement style API

### DIFF
--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -387,14 +387,17 @@ export class MenuItem extends LikeAnchor(Focusable) {
         );
         submenu.addEventListener('change', this.handleSubmenuChange);
         const popover = document.createElement('sp-popover');
-        const returnSubmenu = reparentChildren([submenu], popover, (el) => {
-            const slotName = el.slot;
-            el.tabIndex = 0;
-            el.removeAttribute('slot');
-            return (el) => {
-                el.tabIndex = -1;
-                el.slot = slotName;
-            };
+        const returnSubmenu = reparentChildren([submenu], popover, {
+            position: 'beforeend',
+            prepareCallback: (el) => {
+                const slotName = el.slot;
+                el.tabIndex = 0;
+                el.removeAttribute('slot');
+                return (el) => {
+                    el.tabIndex = -1;
+                    el.slot = slotName;
+                };
+            },
         });
         const closeOverlay = openOverlay(this, 'click', popover, {
             placement: this.isLTR ? 'right-start' : 'left-start',

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -358,14 +358,17 @@ export class ActiveOverlay extends SpectrumElement {
         element: HTMLElement & { placement: Placement }
     ): void {
         this.originalPlacement = element.getAttribute('placement') as Placement;
-        this.restoreContent = reparentChildren([element], this, (el) => {
-            const slotName = el.slot;
-            const placement = el.placement;
-            el.removeAttribute('slot');
-            return (el) => {
-                el.slot = slotName;
-                el.placement = placement;
-            };
+        this.restoreContent = reparentChildren([element], this, {
+            position: 'beforeend',
+            prepareCallback: (el) => {
+                const slotName = el.slot;
+                const placement = el.placement;
+                el.removeAttribute('slot');
+                return (el) => {
+                    el.slot = slotName;
+                    el.placement = placement;
+                };
+            },
         });
         this.stealOverlayContentResolver();
     }

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -314,12 +314,15 @@ export class PickerBase extends SizedMixin(Focusable) {
 
         this.restoreChildren = reparentChildren<
             Element & { focused?: boolean }
-        >(reparentableChildren, this.optionsMenu, () => {
-            return (el) => {
-                if (typeof el.focused !== 'undefined') {
-                    el.focused = false;
-                }
-            };
+        >(reparentableChildren, this.optionsMenu, {
+            position: 'beforeend',
+            prepareCallback: () => {
+                return (el) => {
+                    if (typeof el.focused !== 'undefined') {
+                        el.focused = false;
+                    }
+                };
+            },
         });
 
         this.sizePopover(this.popover);

--- a/packages/shared/test/reparent-children.test.ts
+++ b/packages/shared/test/reparent-children.test.ts
@@ -107,4 +107,191 @@ describe('Reparent Children', () => {
         restore();
         expect(child.getAttribute('slot')).to.equal('slot');
     });
+
+    it('beforeend - reparents and returns multiple children', async () => {
+        const context = await fixture<HTMLDivElement>(html`
+            <div>
+                <div class="source">
+                    <div class="child">1</div>
+                    <div class="child">2</div>
+                    <div class="child">3</div>
+                    <div class="child">4</div>
+                    <div class="child">5</div>
+                </div>
+                <div class="destination">
+                    <div class="marker"></div>
+                </div>
+            </div>
+        `);
+
+        const source = context.querySelector('.source') as HTMLDivElement;
+        const { children } = source;
+        const destination = context.querySelector(
+            '.destination'
+        ) as HTMLDivElement;
+
+        expect(source.children.length).to.equal(5);
+        expect(destination.children.length).to.equal(1);
+        const restore = reparentChildren(
+            [...children],
+            destination,
+            null,
+            'beforeend'
+        );
+
+        expect(source.children.length).to.equal(0);
+        expect(destination.children.length).to.equal(5 + 1);
+
+        const marker = context.querySelector('.marker') as HTMLDivElement;
+        expect(marker.previousElementSibling).to.be.null;
+        expect(marker.nextElementSibling!.textContent).to.equal('1');
+        expect(destination.lastElementChild!.textContent).to.equal('5');
+
+        restore();
+        expect(source.children.length).to.equal(5);
+        expect(destination.children.length).to.equal(1);
+
+        expect(source.firstElementChild!.textContent).to.equal('1');
+        expect(source.lastElementChild!.textContent).to.equal('5');
+    });
+
+    it('afterbegin - reparents and returns multiple children', async () => {
+        const context = await fixture<HTMLDivElement>(html`
+            <div>
+                <div class="source">
+                    <div class="child">1</div>
+                    <div class="child">2</div>
+                    <div class="child">3</div>
+                    <div class="child">4</div>
+                    <div class="child">5</div>
+                </div>
+                <div class="destination">
+                    <div class="marker"></div>
+                </div>
+            </div>
+        `);
+
+        const source = context.querySelector('.source') as HTMLDivElement;
+        const { children } = source;
+        const destination = context.querySelector(
+            '.destination'
+        ) as HTMLDivElement;
+
+        expect(source.children.length).to.equal(5);
+        expect(destination.children.length).to.equal(1);
+        const restore = reparentChildren(
+            [...children],
+            destination,
+            null,
+            'afterbegin'
+        );
+
+        expect(source.children.length).to.equal(0);
+        expect(destination.children.length).to.equal(5 + 1);
+
+        const marker = context.querySelector('.marker') as HTMLDivElement;
+        expect(marker.nextElementSibling).to.be.null;
+        expect(marker.previousElementSibling!.textContent).to.equal('5');
+        expect(destination.firstElementChild!.textContent).to.equal('1');
+
+        restore();
+        expect(source.children.length).to.equal(5);
+        expect(destination.children.length).to.equal(1);
+
+        expect(source.firstElementChild!.textContent).to.equal('1');
+        expect(source.lastElementChild!.textContent).to.equal('5');
+    });
+
+    it('beforebegin - reparents and returns multiple children', async () => {
+        const context = await fixture<HTMLDivElement>(html`
+            <div>
+                <div class="source">
+                    <div class="child">1</div>
+                    <div class="child">2</div>
+                    <div class="child">3</div>
+                    <div class="child">4</div>
+                    <div class="child">5</div>
+                </div>
+                <div class="marker"></div>
+                <div class="destination"></div>
+            </div>
+        `);
+
+        const source = context.querySelector('.source') as HTMLDivElement;
+        const { children } = source;
+        const destination = context.querySelector(
+            '.destination'
+        ) as HTMLDivElement;
+
+        expect(source.children.length).to.equal(5);
+        const restore = reparentChildren(
+            [...children],
+            destination,
+            null,
+            'beforebegin'
+        );
+
+        expect(source.children.length).to.equal(0);
+        expect(destination.children.length).to.equal(0);
+
+        const marker = context.querySelector('.marker') as HTMLDivElement;
+        expect(marker.previousElementSibling).to.not.be.null;
+        expect(marker.nextElementSibling!.textContent).to.equal('1');
+        expect(destination.previousElementSibling!.textContent).to.equal('5');
+
+        restore();
+        expect(source.children.length).to.equal(5);
+        expect(marker.nextElementSibling).to.equal(destination);
+
+        expect(source.firstElementChild!.textContent).to.equal('1');
+        expect(source.lastElementChild!.textContent).to.equal('5');
+    });
+
+    it('afterend - reparents and returns multiple children', async () => {
+        const context = await fixture<HTMLDivElement>(html`
+            <div>
+                <div class="source">
+                    <div class="child">1</div>
+                    <div class="child">2</div>
+                    <div class="child">3</div>
+                    <div class="child">4</div>
+                    <div class="child">5</div>
+                </div>
+                <div class="destination"></div>
+                <div class="marker"></div>
+            </div>
+        `);
+
+        const source = context.querySelector('.source') as HTMLDivElement;
+        const { children } = source;
+        const destination = context.querySelector(
+            '.destination'
+        ) as HTMLDivElement;
+
+        expect(source.children.length).to.equal(5);
+
+        const marker = context.querySelector('.marker') as HTMLDivElement;
+        expect(marker.previousElementSibling).to.equal(destination);
+        expect(marker.nextElementSibling).to.be.null;
+
+        const restore = reparentChildren(
+            [...children],
+            destination,
+            null,
+            'afterend'
+        );
+
+        expect(source.children.length).to.equal(0);
+        expect(destination.children.length).to.equal(0);
+
+        expect(destination.nextElementSibling!.textContent).to.equal('1');
+        expect(marker.previousElementSibling!.textContent).to.equal('5');
+
+        restore();
+        expect(source.children.length).to.equal(5);
+        expect(marker.previousElementSibling).to.equal(destination);
+
+        expect(source.firstElementChild!.textContent).to.equal('1');
+        expect(source.lastElementChild!.textContent).to.equal('5');
+    });
 });

--- a/packages/shared/test/reparent-children.test.ts
+++ b/packages/shared/test/reparent-children.test.ts
@@ -90,17 +90,16 @@ describe('Reparent Children', () => {
         ) as HTMLDivElement;
 
         expect(child.getAttribute('slot')).to.equal('slot');
-        const restore = reparentChildren(
-            [child],
-            destination,
-            (el: Element) => {
+        const restore = reparentChildren([child], destination, {
+            position: 'beforeend',
+            prepareCallback: (el: Element) => {
                 const slotName = el.slot;
                 el.removeAttribute('slot');
                 return (el: Element) => {
                     el.slot = slotName;
                 };
-            }
-        );
+            },
+        });
 
         expect(child.hasAttribute('slot')).to.be.false;
 
@@ -132,12 +131,9 @@ describe('Reparent Children', () => {
 
         expect(source.children.length).to.equal(5);
         expect(destination.children.length).to.equal(1);
-        const restore = reparentChildren(
-            [...children],
-            destination,
-            null,
-            'beforeend'
-        );
+        const restore = reparentChildren([...children], destination, {
+            position: 'beforeend',
+        });
 
         expect(source.children.length).to.equal(0);
         expect(destination.children.length).to.equal(5 + 1);
@@ -179,12 +175,9 @@ describe('Reparent Children', () => {
 
         expect(source.children.length).to.equal(5);
         expect(destination.children.length).to.equal(1);
-        const restore = reparentChildren(
-            [...children],
-            destination,
-            null,
-            'afterbegin'
-        );
+        const restore = reparentChildren([...children], destination, {
+            position: 'afterbegin',
+        });
 
         expect(source.children.length).to.equal(0);
         expect(destination.children.length).to.equal(5 + 1);
@@ -224,12 +217,9 @@ describe('Reparent Children', () => {
         ) as HTMLDivElement;
 
         expect(source.children.length).to.equal(5);
-        const restore = reparentChildren(
-            [...children],
-            destination,
-            null,
-            'beforebegin'
-        );
+        const restore = reparentChildren([...children], destination, {
+            position: 'beforebegin',
+        });
 
         expect(source.children.length).to.equal(0);
         expect(destination.children.length).to.equal(0);
@@ -274,12 +264,9 @@ describe('Reparent Children', () => {
         expect(marker.previousElementSibling).to.equal(destination);
         expect(marker.nextElementSibling).to.be.null;
 
-        const restore = reparentChildren(
-            [...children],
-            destination,
-            null,
-            'afterend'
-        );
+        const restore = reparentChildren([...children], destination, {
+            position: 'afterend',
+        });
 
         expect(source.children.length).to.equal(0);
         expect(destination.children.length).to.equal(0);

--- a/packages/shared/test/reparent-children.test.ts
+++ b/packages/shared/test/reparent-children.test.ts
@@ -140,15 +140,15 @@ describe('Reparent Children', () => {
 
         const marker = context.querySelector('.marker') as HTMLDivElement;
         expect(marker.previousElementSibling).to.be.null;
-        expect(marker.nextElementSibling!.textContent).to.equal('1');
-        expect(destination.lastElementChild!.textContent).to.equal('5');
+        expect(marker.nextElementSibling?.textContent).to.equal('1');
+        expect(destination.lastElementChild?.textContent).to.equal('5');
 
         restore();
         expect(source.children.length).to.equal(5);
         expect(destination.children.length).to.equal(1);
 
-        expect(source.firstElementChild!.textContent).to.equal('1');
-        expect(source.lastElementChild!.textContent).to.equal('5');
+        expect(source.firstElementChild?.textContent).to.equal('1');
+        expect(source.lastElementChild?.textContent).to.equal('5');
     });
 
     it('afterbegin - reparents and returns multiple children', async () => {
@@ -184,15 +184,15 @@ describe('Reparent Children', () => {
 
         const marker = context.querySelector('.marker') as HTMLDivElement;
         expect(marker.nextElementSibling).to.be.null;
-        expect(marker.previousElementSibling!.textContent).to.equal('5');
-        expect(destination.firstElementChild!.textContent).to.equal('1');
+        expect(marker.previousElementSibling?.textContent).to.equal('5');
+        expect(destination.firstElementChild?.textContent).to.equal('1');
 
         restore();
         expect(source.children.length).to.equal(5);
         expect(destination.children.length).to.equal(1);
 
-        expect(source.firstElementChild!.textContent).to.equal('1');
-        expect(source.lastElementChild!.textContent).to.equal('5');
+        expect(source.firstElementChild?.textContent).to.equal('1');
+        expect(source.lastElementChild?.textContent).to.equal('5');
     });
 
     it('beforebegin - reparents and returns multiple children', async () => {
@@ -226,15 +226,15 @@ describe('Reparent Children', () => {
 
         const marker = context.querySelector('.marker') as HTMLDivElement;
         expect(marker.previousElementSibling).to.not.be.null;
-        expect(marker.nextElementSibling!.textContent).to.equal('1');
-        expect(destination.previousElementSibling!.textContent).to.equal('5');
+        expect(marker.nextElementSibling?.textContent).to.equal('1');
+        expect(destination.previousElementSibling?.textContent).to.equal('5');
 
         restore();
         expect(source.children.length).to.equal(5);
         expect(marker.nextElementSibling).to.equal(destination);
 
-        expect(source.firstElementChild!.textContent).to.equal('1');
-        expect(source.lastElementChild!.textContent).to.equal('5');
+        expect(source.firstElementChild?.textContent).to.equal('1');
+        expect(source.lastElementChild?.textContent).to.equal('5');
     });
 
     it('afterend - reparents and returns multiple children', async () => {
@@ -271,14 +271,14 @@ describe('Reparent Children', () => {
         expect(source.children.length).to.equal(0);
         expect(destination.children.length).to.equal(0);
 
-        expect(destination.nextElementSibling!.textContent).to.equal('1');
-        expect(marker.previousElementSibling!.textContent).to.equal('5');
+        expect(destination.nextElementSibling?.textContent).to.equal('1');
+        expect(marker.previousElementSibling?.textContent).to.equal('5');
 
         restore();
         expect(source.children.length).to.equal(5);
         expect(marker.previousElementSibling).to.equal(destination);
 
-        expect(source.firstElementChild!.textContent).to.equal('1');
-        expect(source.lastElementChild!.textContent).to.equal('5');
+        expect(source.firstElementChild?.textContent).to.equal('1');
+        expect(source.lastElementChild?.textContent).to.equal('5');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
`reparentChildren()` can now receive a position argument (just like in insertAdjacentElement).
This is a non-breakable change, the default position if not specified is `beforeend` (append).

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes #2140 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

