### PR TITLE
Correct "sp-search" delivery when "express"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 961121fa5fbb19d8b06d0533bcc99d2b6b2553df
+        default: 3cc0f88c9396dc1d4a4ae51b9609917f78afe5c7
 commands:
     downstream:
         steps:

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/packages/search/src/spectrum-config.js
+++ b/packages/search/src/spectrum-config.js
@@ -19,7 +19,7 @@ const config = {
                 selector: '.spectrum-Search',
                 shadowSelector: '#textfield',
             },
-            focus: '#input',
+            focus: '.input',
             attributes: [
                 {
                     type: 'boolean',
@@ -28,10 +28,6 @@ const config = {
                 },
             ],
             ids: [
-                {
-                    selector: '.spectrum-Search-input',
-                    name: 'input',
-                },
                 {
                     selector: '.spectrum-Search-clearButton',
                     name: 'button',
@@ -42,6 +38,10 @@ const config = {
                 },
             ],
             classes: [
+                {
+                    selector: '.spectrum-Search-input',
+                    name: 'input',
+                },
                 {
                     selector: '.spectrum-Icon',
                     name: 'icon',

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -33,7 +33,7 @@ governing permissions and limitations under the License.
     position: absolute; /* .spectrum-Search-clearButton */
     top: 0;
 }
-#input {
+.input {
     -webkit-appearance: none; /* .spectrum-Search-input */
     border-radius: var(
         --spectrum-alias-search-border-radius,
@@ -41,8 +41,8 @@ governing permissions and limitations under the License.
     );
     outline-offset: -2px;
 }
-#input::-webkit-search-cancel-button,
-#input::-webkit-search-decoration {
+.input::-webkit-search-cancel-button,
+.input::-webkit-search-decoration {
     -webkit-appearance: none; /* .spectrum-Search-input::-webkit-search-cancel-button,
    * .spectrum-Search-input::-webkit-search-decoration */
 }
@@ -62,7 +62,7 @@ governing permissions and limitations under the License.
         --spectrum-alias-search-padding-left-m
     ); /* [dir=rtl] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-icon */
 }
-:host([dir='ltr']:not([quiet])) #textfield #input {
+:host([dir='ltr']:not([quiet])) #textfield .input {
     padding-left: calc(
         var(--spectrum-alias-search-padding-left-m) +
             var(
@@ -79,7 +79,7 @@ governing permissions and limitations under the License.
             )
     ); /* [dir=ltr] .spectrum-Search:not(.spectrum-Search--quiet) .spectrum-Search-input */
 }
-:host([dir='rtl']:not([quiet])) #textfield #input {
+:host([dir='rtl']:not([quiet])) #textfield .input {
     padding-right: calc(
         var(--spectrum-alias-search-padding-left-m) +
             var(
@@ -101,7 +101,7 @@ governing permissions and limitations under the License.
         var(--spectrum-search-quiet-button-offset)
     ); /* .spectrum-Search--quiet .spectrum-Search-clearButton */
 }
-:host([quiet]) #input {
+:host([quiet]) .input {
     border-radius: var(
         --spectrum-alias-search-border-radius-quiet,
         0
@@ -119,31 +119,31 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-component-icon-color-default)
     ); /* .spectrum-Search-icon */
 }
-#input:hover ~ .icon {
+.input:hover ~ .icon {
     color: var(
         --spectrum-search-m-icon-color-hover,
         var(--spectrum-alias-component-icon-color-hover)
     ); /* .spectrum-Search-input:hover~.spectrum-Search-icon */
 }
-#input:active ~ .icon {
+.input:active ~ .icon {
     color: var(
         --spectrum-search-m-icon-color-down,
         var(--spectrum-alias-component-icon-color-down)
     ); /* .spectrum-Search-input:active~.spectrum-Search-icon */
 }
-#input.focus-visible ~ .icon {
+.input.focus-visible ~ .icon {
     color: var(
         --spectrum-search-m-icon-color-key-focus,
         var(--spectrum-alias-component-icon-color-key-focus)
     ); /* .spectrum-Search-input.focus-ring~.spectrum-Search-icon */
 }
-#input:focus-visible ~ .icon {
+.input:focus-visible ~ .icon {
     color: var(
         --spectrum-search-m-icon-color-key-focus,
         var(--spectrum-alias-component-icon-color-key-focus)
     ); /* .spectrum-Search-input.focus-ring~.spectrum-Search-icon */
 }
-#input:disabled ~ .icon {
+.input:disabled ~ .icon {
     color: var(
         --spectrum-textfield-m-texticon-text-color-disabled,
         var(--spectrum-alias-component-text-color-disabled)

--- a/packages/search/stories/search.stories.ts
+++ b/packages/search/stories/search.stories.ts
@@ -22,6 +22,10 @@ export const Default = (): TemplateResult => html`
     <sp-search disabled></sp-search>
 `;
 
+export const autofocus = (): TemplateResult => html`
+    <sp-search autofocus></sp-search>
+`;
+
 export const Quiet = (): TemplateResult => html`
     <sp-search quiet></sp-search>
     <sp-search quiet disabled></sp-search>


### PR DESCRIPTION
## Description
- ensure CSS processing manages class conversion correctly to receive search specific textfield updates.

## Motivation and context
Who doesn't like rounded corners?

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://ccx-search--spectrum-web-components.netlify.app/)
    2. Switch to the "Express" theme
    3. See the search field get fully rounded corners.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.