### PR TITLE
fix: pull out rendering for Dialog into individual methods

### DIFF
--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SpectrumElement,
     TemplateResult,
@@ -118,57 +119,86 @@ export class Dialog extends FocusVisiblePolyfillMixin(
         );
     }
 
+    protected renderHero(): TemplateResult {
+        return html`
+            <slot name="hero"></slot>
+        `;
+    }
+
+    protected renderHeading(): TemplateResult {
+        return html`
+            <slot
+                name="heading"
+                class=${ifDefined(this.hasHero ? this.hasHero : undefined)}
+                @slotchange=${this.onHeadingSlotchange}
+            ></slot>
+        `;
+    }
+
+    protected renderContent(): TemplateResult {
+        return html`
+            <div class="content">
+                <slot @slotchange=${this.onContentSlotChange}></slot>
+            </div>
+        `;
+    }
+
+    protected renderFooter(): TemplateResult {
+        if (!this.hasFooter) return html``;
+        return html`
+            <div class="footer">
+                <slot name="footer"></slot>
+            </div>
+        `;
+    }
+
+    protected renderButtons(): TemplateResult {
+        if (!this.hasButtons) return html``;
+        return html`
+            <sp-button-group
+                class="button-group ${this.hasFooter
+                    ? nothing
+                    : 'button-group--noFooter'}"
+            >
+                <slot name="button"></slot>
+            </sp-button-group>
+        `;
+    }
+
+    protected renderDismiss(): TemplateResult {
+        if (!this.dismissable) return html``;
+        return html`
+            <sp-action-button
+                class="close-button"
+                label="Close"
+                quiet
+                size="m"
+                @click=${this.close}
+            >
+                <sp-icon-cross500
+                    class="spectrum-UIIcon-Cross500"
+                    slot="icon"
+                ></sp-icon-cross500>
+            </sp-action-button>
+        `;
+    }
+
     protected override render(): TemplateResult {
         return html`
             <div class="grid">
-                <slot name="hero"></slot>
-                <slot
-                    name="heading"
-                    class=${ifDefined(this.hasHero ? this.hasHero : undefined)}
-                    @slotchange=${this.onHeadingSlotchange}
-                ></slot>
+                ${this.renderHero()} ${this.renderHeading()}
                 ${this.error
                     ? html`
                           <sp-icon-alert class="type-icon"></sp-icon-alert>
                       `
-                    : html``}
+                    : nothing}
                 ${this.noDivider
-                    ? html``
+                    ? nothing
                     : html`
                           <sp-divider size="m" class="divider"></sp-divider>
                       `}
-                <div class="content">
-                    <slot @slotchange=${this.onContentSlotChange}></slot>
-                </div>
-                ${this.hasFooter
-                    ? html`
-                          <div class="footer">
-                              <slot name="footer"></slot>
-                          </div>
-                      `
-                    : html``}
-                ${this.hasButtons
-                    ? html`
-                          <sp-button-group
-                              class="button-group ${this.hasFooter
-                                  ? ''
-                                  : 'button-group--noFooter'}"
-                          >
-                              <slot name="button"></slot>
-                          </sp-button-group>
-                      `
-                    : html``}
-                ${this.dismissable
-                    ? html`
-                          <sp-close-button
-                              class="close-button"
-                              label="Close"
-                              quiet
-                              size="m"
-                              @click=${this.close}
-                          ></sp-close-button>
-                      `
-                    : html``}
+                ${this.renderContent()} ${this.renderFooter()}
+                ${this.renderButtons()} ${this.renderDismiss()}
             </div>
         `;
     }

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -22,7 +22,7 @@ import {
     property,
     query,
 } from '@spectrum-web-components/base/src/decorators.js';
-import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import { classMap } from '@spectrum-web-components/base/src/directives.js';
 import { conditionAttributeWithId } from '@spectrum-web-components/base/src/condition-attribute-with-id.js';
 
 import '@spectrum-web-components/divider/sp-divider.js';
@@ -127,11 +127,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
 
     protected renderHeading(): TemplateResult {
         return html`
-            <slot
-                name="heading"
-                class=${ifDefined(this.hasHero ? this.hasHero : undefined)}
-                @slotchange=${this.onHeadingSlotchange}
-            ></slot>
+            <slot name="heading" @slotchange=${this.onHeadingSlotchange}></slot>
         `;
     }
 
@@ -144,7 +140,6 @@ export class Dialog extends FocusVisiblePolyfillMixin(
     }
 
     protected renderFooter(): TemplateResult {
-        if (!this.hasFooter) return html``;
         return html`
             <div class="footer">
                 <slot name="footer"></slot>
@@ -153,33 +148,26 @@ export class Dialog extends FocusVisiblePolyfillMixin(
     }
 
     protected renderButtons(): TemplateResult {
-        if (!this.hasButtons) return html``;
+        const classes = {
+            'button-group': true,
+            'button-group--noFooter': !this.hasFooter,
+        };
         return html`
-            <sp-button-group
-                class="button-group ${this.hasFooter
-                    ? nothing
-                    : 'button-group--noFooter'}"
-            >
+            <sp-button-group class=${classMap(classes)}>
                 <slot name="button"></slot>
             </sp-button-group>
         `;
     }
 
     protected renderDismiss(): TemplateResult {
-        if (!this.dismissable) return html``;
         return html`
-            <sp-action-button
+            <sp-close-button
                 class="close-button"
                 label="Close"
                 quiet
                 size="m"
                 @click=${this.close}
-            >
-                <sp-icon-cross500
-                    class="spectrum-UIIcon-Cross500"
-                    slot="icon"
-                ></sp-icon-cross500>
-            </sp-action-button>
+            ></sp-close-button>
         `;
     }
 
@@ -197,8 +185,10 @@ export class Dialog extends FocusVisiblePolyfillMixin(
                     : html`
                           <sp-divider size="m" class="divider"></sp-divider>
                       `}
-                ${this.renderContent()} ${this.renderFooter()}
-                ${this.renderButtons()} ${this.renderDismiss()}
+                ${this.renderContent()}
+                ${this.hasFooter ? this.renderFooter() : nothing}
+                ${this.hasButtons ? this.renderButtons() : nothing}
+                ${this.dismissable ? this.renderDismiss() : nothing}
             </div>
         `;
     }

--- a/packages/dialog/test/dialog.test.ts
+++ b/packages/dialog/test/dialog.test.ts
@@ -80,7 +80,10 @@ describe('Dialog', () => {
     });
     it('allows hero override', async () => {
         class Override extends Dialog {
-            renderHero(): TemplateResult {
+            protected override get hasHero(): boolean {
+                return true;
+            }
+            protected override renderHero(): TemplateResult {
                 return html`
                     <div id="hero-container"></div>
                 `;
@@ -100,7 +103,7 @@ describe('Dialog', () => {
     });
     it('allows heading override', async () => {
         class Override extends Dialog {
-            renderHeading(): TemplateResult {
+            protected override renderHeading(): TemplateResult {
                 return html`
                     <h2 id="heading-container">Test</h2>
                 `;
@@ -120,7 +123,7 @@ describe('Dialog', () => {
     });
     it('allows content override', async () => {
         class Override extends Dialog {
-            renderContent(): TemplateResult {
+            protected override renderContent(): TemplateResult {
                 return html`
                     <p id="content-container">Test</p>
                 `;
@@ -140,7 +143,10 @@ describe('Dialog', () => {
     });
     it('allows footer override', async () => {
         class Override extends Dialog {
-            renderFooter(): TemplateResult {
+            protected override get hasFooter(): boolean {
+                return true;
+            }
+            protected override renderFooter(): TemplateResult {
                 return html`
                     <p id="footer-container">Test</p>
                 `;
@@ -160,7 +166,10 @@ describe('Dialog', () => {
     });
     it('allows button override', async () => {
         class Override extends Dialog {
-            renderButtons(): TemplateResult {
+            protected override get hasButtons(): boolean {
+                return true;
+            }
+            protected override renderButtons(): TemplateResult {
                 return html`
                     <p id="button-container">Test</p>
                 `;
@@ -180,7 +189,7 @@ describe('Dialog', () => {
     });
     it('allows dismiss override', async () => {
         class Override extends Dialog {
-            renderDismiss(): TemplateResult {
+            protected override renderDismiss(): TemplateResult {
                 return html`
                     <p id="dismiss-container">Test</p>
                 `;
@@ -191,7 +200,7 @@ describe('Dialog', () => {
 
         const el = await fixture<Override>(
             html`
-                <dismiss-dialog></dismiss-dialog>
+                <dismiss-dialog dismissable></dismiss-dialog>
             `
         );
 

--- a/packages/dialog/test/dialog.test.ts
+++ b/packages/dialog/test/dialog.test.ts
@@ -10,7 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { elementUpdated, expect, fixture } from '@open-wc/testing';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/dialog/sp-dialog.js';
 import { Dialog } from '@spectrum-web-components/dialog';
@@ -76,5 +77,125 @@ describe('Dialog', () => {
 
         await elementUpdated(el);
         expect(closeSpy.calledOnce).to.be.true;
+    });
+    it('allows hero override', async () => {
+        class Override extends Dialog {
+            renderHero(): TemplateResult {
+                return html`
+                    <div id="hero-container"></div>
+                `;
+            }
+        }
+
+        customElements.define('hero-dialog', Override);
+
+        const el = await fixture<Override>(
+            html`
+                <hero-dialog></hero-dialog>
+            `
+        );
+
+        const container = el.shadowRoot.querySelector('#hero-container');
+        expect(container).to.not.be.null;
+    });
+    it('allows heading override', async () => {
+        class Override extends Dialog {
+            renderHeading(): TemplateResult {
+                return html`
+                    <h2 id="heading-container">Test</h2>
+                `;
+            }
+        }
+
+        customElements.define('heading-dialog', Override);
+
+        const el = await fixture<Override>(
+            html`
+                <heading-dialog></heading-dialog>
+            `
+        );
+
+        const container = el.shadowRoot.querySelector('#heading-container');
+        expect(container).to.not.be.null;
+    });
+    it('allows content override', async () => {
+        class Override extends Dialog {
+            renderContent(): TemplateResult {
+                return html`
+                    <p id="content-container">Test</p>
+                `;
+            }
+        }
+
+        customElements.define('content-dialog', Override);
+
+        const el = await fixture<Override>(
+            html`
+                <content-dialog></content-dialog>
+            `
+        );
+
+        const container = el.shadowRoot.querySelector('#content-container');
+        expect(container).to.not.be.null;
+    });
+    it('allows footer override', async () => {
+        class Override extends Dialog {
+            renderFooter(): TemplateResult {
+                return html`
+                    <p id="footer-container">Test</p>
+                `;
+            }
+        }
+
+        customElements.define('footer-dialog', Override);
+
+        const el = await fixture<Override>(
+            html`
+                <footer-dialog></footer-dialog>
+            `
+        );
+
+        const container = el.shadowRoot.querySelector('#footer-container');
+        expect(container).to.not.be.null;
+    });
+    it('allows button override', async () => {
+        class Override extends Dialog {
+            renderButtons(): TemplateResult {
+                return html`
+                    <p id="button-container">Test</p>
+                `;
+            }
+        }
+
+        customElements.define('button-dialog', Override);
+
+        const el = await fixture<Override>(
+            html`
+                <button-dialog></button-dialog>
+            `
+        );
+
+        const container = el.shadowRoot.querySelector('#button-container');
+        expect(container).to.not.be.null;
+    });
+    it('allows dismiss override', async () => {
+        class Override extends Dialog {
+            renderDismiss(): TemplateResult {
+                return html`
+                    <p id="dismiss-container">Test</p>
+                `;
+            }
+        }
+
+        customElements.define('dismiss-dialog', Override);
+
+        const el = await fixture<Override>(
+            html`
+                <dismiss-dialog></dismiss-dialog>
+            `
+        );
+
+        const container = el.shadowRoot.querySelector('#dismiss-container');
+        expect(container).to.not.be.null;
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable template extensibility for the Dialog class by pulling out sections into separate rendering methods.

## Motivation and context

This will allow UEC to create different "flavors" of a Dialog by extending the class and customizing an individual section of the template.

## How has this been tested?

-   [x] _Check dialog for regressions: should be no change_

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] Add new tests.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
