### PR TITLE
Slider tick labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 3cc0f88c9396dc1d4a4ae51b9609917f78afe5c7
+        default: 9366edee60b5fb9e4cb59ee2e4b1798c5e74b071
 commands:
     downstream:
         steps:

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -292,7 +292,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                             ${this.tickLabels
                                 ? html`
                                       <div class="tickLabel">
-                                          ${i * tickStep}
+                                          ${i * tickStep + this.min}
                                       </div>
                                   `
                                 : html``}

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -383,6 +383,23 @@ tick.args = {
     tickStep: 5,
 };
 
+export const tickLabels = (args: StoryArgs = {}): TemplateResult => {
+    return html`
+        <sp-slider
+            label="Slider Label"
+            tick-labels
+            variant="tick"
+            min="50"
+            max="75"
+            ...=${spreadProps(args)}
+        ></sp-slider>
+    `;
+};
+tickLabels.args = {
+    variant: 'tick',
+    tickStep: 5,
+};
+
 export const Disabled = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">


### PR DESCRIPTION
## Description
Have the tick labels in a Slider count up from `min` rather than `0`.

## Related issue(s)
- fixes #2246

## Motivation and context
Correctness.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://slider-tick-labels--spectrum-web-components.netlify.app/storybook/?path=/story/slider--tick-labels)
    2. See that the tick labels count from 50 - 75 and not 1 - 25

## Screenshots (if appropriate)

<img width="833" alt="image" src="https://user-images.githubusercontent.com/1156657/165099058-e6ab73a1-b692-44e9-939b-e1f0b3f1df49.png">

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.