### PR TITLE
fix(menu): disabled menu-item should not open submenu

### DIFF
--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -371,7 +371,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
     public async openOverlay({
         immediate,
     }: { immediate?: boolean } = {}): Promise<void> {
-        if (!this.hasSubmenu || this.open) {
+        if (!this.hasSubmenu || this.open || this.disabled) {
             return;
         }
         this.open = true;

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -19,6 +19,10 @@ governing permissions and limitations under the License.
     display: none;
 }
 
+:host([disabled]) {
+    pointer-events: none;
+}
+
 #button {
     position: absolute;
     inset: 0;

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -399,6 +399,51 @@ describe('Submenu', () => {
 
         expect(rootItem.open).to.be.false;
     });
+    it('not opens if disabled', async () => {
+        const el = await styledFixture<Menu>(
+            html`
+                <sp-menu>
+                    <sp-menu-item disabled class="root">
+                        Has submenu
+                        <sp-menu slot="submenu">
+                            <sp-menu-item class="submenu-item-1">
+                                One
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-2">
+                                Two
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-3">
+                                Three
+                            </sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+        const rootItem = el.querySelector('.root') as MenuItem;
+        const rootItemBoundingRect = rootItem.getBoundingClientRect();
+        expect(rootItem.open).to.be.false;
+
+        sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        // wait 200ms for open
+        await new Promise((r) => setTimeout(r, 200));
+
+        expect(rootItem.open).to.be.false;
+    });
     it('stays open when mousing off menu item and back again', async () => {
         const el = await styledFixture<Menu>(
             html`

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -399,51 +399,6 @@ describe('Submenu', () => {
 
         expect(rootItem.open).to.be.false;
     });
-    it('not opens if disabled', async () => {
-        const el = await styledFixture<Menu>(
-            html`
-                <sp-menu>
-                    <sp-menu-item disabled class="root">
-                        Has submenu
-                        <sp-menu slot="submenu">
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-2">
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu>
-            `
-        );
-
-        await elementUpdated(el);
-        const rootItem = el.querySelector('.root') as MenuItem;
-        const rootItemBoundingRect = rootItem.getBoundingClientRect();
-        expect(rootItem.open).to.be.false;
-
-        sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        // wait 200ms for open
-        await new Promise((r) => setTimeout(r, 200));
-
-        expect(rootItem.open).to.be.false;
-    });
     it('stays open when mousing off menu item and back again', async () => {
         const el = await styledFixture<Menu>(
             html`
@@ -601,5 +556,50 @@ describe('Submenu', () => {
         await opened;
 
         expect(rootItem.open).to.be.true;
+    });
+    it('not opens if disabled', async () => {
+        const el = await styledFixture<Menu>(
+            html`
+                <sp-menu>
+                    <sp-menu-item disabled class="root">
+                        Has submenu
+                        <sp-menu slot="submenu">
+                            <sp-menu-item class="submenu-item-1">
+                                One
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-2">
+                                Two
+                            </sp-menu-item>
+                            <sp-menu-item class="submenu-item-3">
+                                Three
+                            </sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-menu>
+            `
+        );
+
+        await elementUpdated(el);
+        const rootItem = el.querySelector('.root') as MenuItem;
+        const rootItemBoundingRect = rootItem.getBoundingClientRect();
+        expect(rootItem.open).to.be.false;
+
+        sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        // wait 200ms for open
+        await new Promise((r) => setTimeout(r, 200));
+
+        expect(rootItem.open).to.be.false;
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Disabled menu item should not open submenu.

@Westbrook 
There are some issues with the tests on Chrome,
I suspect the cleanup doesn't properly work because the html is reused (on the next two tests) in a buggy way (keeping the disabled attribute).
Moving the test to the end of list resolves the issue.
This doesn't happen on Firefox or WebKit, only on Chrome.
Did this happened before? I don't want to "solve" this just by changing the test position.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #2218 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.

