### PR TITLE
docs: include slot listing for "handle"

### DIFF
--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -41,6 +41,7 @@ export const variants = ['filled', 'ramp', 'range', 'tick'];
  * @element sp-slider
  *
  * @slot - text label for the Slider
+ * @slot handle - optionally accepts two or more sp-slider-handle elements
  */
 export class Slider extends ObserveSlotText(SliderHandle, '') {
     public static get styles(): CSSResultArray {


### PR DESCRIPTION
## Description
Prevent `slot="handle"` from triggering `no-unknown-slot` warnings in `lit-analyze

## Related issue(s)
- fixes #2148

## Motivation and context
Easier consumptions of patterns with `lit-analyzer`

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://slider-docs--spectrum-web-components.netlify.app/components/slider/api/#slots)
    2. See the inclusion of the `handle` slot.

## Types of changes
-   [x] docs

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.