### PR TITLE
docs: ensure presence of theme fragments

### DIFF
--- a/projects/documentation/src/components/layout.css
+++ b/projects/documentation/src/components/layout.css
@@ -103,7 +103,7 @@ docs-side-nav:not(:defined) {
     }
 }
 
-@media screen and (min-width: 458px) {
+@media screen and (min-width: 525px) {
     .manage-theme {
         display: flex;
         flex-wrap: wrap;

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -83,26 +83,23 @@ const isNarrowMediaQuery = matchMedia('screen and (max-width: 960px)');
 
 const lazyStyleFragment = (name: Color | Scale, flavor: ThemeVariant): void => {
     var fragmentName = `${name}-${flavor}`;
-    if (flavor === 'express') {
-        import('@spectrum-web-components/theme/src/express/core.js');
-    }
     switch (fragmentName) {
-        case 'darkest':
+        case 'darkest-spectrum':
             import('@spectrum-web-components/theme/theme-darkest.js');
             break;
-        case 'dark':
+        case 'dark-spectrum':
             import('@spectrum-web-components/theme/theme-dark.js');
             break;
-        case 'light':
+        case 'light-spectrum':
             import('@spectrum-web-components/theme/theme-light.js');
             break;
-        case 'lightest':
+        case 'lightest-spectrum':
             import('@spectrum-web-components/theme/theme-lightest.js');
             break;
-        case 'medium':
+        case 'medium-spectrum':
             import('@spectrum-web-components/theme/scale-medium.js');
             break;
-        case 'large':
+        case 'large-spectrum':
             import('@spectrum-web-components/theme/scale-large.js');
             break;
         case 'darkest-express':


### PR DESCRIPTION
## Description
Ensure that the docs site can use the various scales and color themes for the Spectrum Theme.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://docs-themes--spectrum-web-components.netlify.app/index.html)
    2. Try the color themes and scales.

## Types of changes
-   [x] docs

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.