### PR TITLE
fix: prevent active pointer events when slider toggles to [disabled]

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -357,9 +357,7 @@ export class HandleController implements Controller {
         delete this._activePointerEventData;
         if (!model) return;
         this.host.labelEl.click();
-        model.handle.highlight = false;
-        delete this.draggingHandle;
-        model.handle.dragging = false;
+        this.cancelDrag(model);
         this.requestUpdate();
         this.host.track.releasePointerCapture(event.pointerId);
         this.dispatchChangeEvent(input, model.handle);
@@ -376,6 +374,15 @@ export class HandleController implements Controller {
         input.value = this.calculateHandlePosition(event, model).toString();
         model.handle.value = parseFloat(input.value);
         this.requestUpdate();
+    }
+
+    public cancelDrag(model?: ModelValue): void {
+        model =
+            model || this.model.find((item) => item.name === this.activeHandle);
+        if (!model) return;
+        model.handle.highlight = false;
+        delete this.draggingHandle;
+        model.handle.dragging = false;
     }
 
     /**

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -209,6 +209,9 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
 
     public update(changedProperties: Map<string, boolean>): void {
         this.handleController.hostUpdate();
+        if (changedProperties.has('disabled') && this.disabled) {
+            this.handleController.cancelDrag();
+        }
         super.update(changedProperties);
     }
 

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -371,6 +371,77 @@ describe('Slider', () => {
 
         expect(el.value).to.equal(0);
     });
+
+    it('goes [disabled] while dragging', async () => {
+        const el = await fixture<Slider>(
+            html`
+                <sp-slider></sp-slider>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(10);
+
+        const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
+        const handleBoundingRect = handle.getBoundingClientRect();
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        handleBoundingRect.x + handleBoundingRect.width / 2,
+                        handleBoundingRect.y + handleBoundingRect.height / 2,
+                    ],
+                },
+                {
+                    type: 'down',
+                },
+            ],
+        });
+        await elementUpdated(el);
+
+        expect(el.dragging, 'is dragging').to.be.true;
+        expect(el.highlight, 'not highlighted').to.be.false;
+        expect(el.value).to.equal(10);
+
+        const inputEvent = oneEvent(el, 'input');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        handleBoundingRect.x +
+                            handleBoundingRect.width / 2 +
+                            100,
+                        handleBoundingRect.y + handleBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await inputEvent;
+
+        expect(el.value).to.equal(13);
+
+        el.disabled = true;
+        await elementUpdated(el);
+
+        expect(el.dragging, 'is dragging').to.be.false;
+        expect(el.highlight, 'not highlighted').to.be.false;
+
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        0,
+                        handleBoundingRect.top + handleBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+
+        expect(el.value).to.equal(13);
+    });
     it('accepts pointermove events in separate interactions', async () => {
         let pointerId = -1;
         const el = await fixture<Slider>(


### PR DESCRIPTION
## Description
Prevent further pointer events when the Slider moves to `disabled` while a pointer event is active.

## Related issue(s)
- fixes #2268

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://slider-disabled--spectrum-web-components.netlify.app/components/slider/)
    2. Select a Slider element in DevTools
    3. Run: `const test = $0; setTimeout(() => test.disabled = true, 3000);` in the Console.
    4. Start dragging the Slider
    5. See the drag interaction end after 3 seconds.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
