### PR TITLE
Update Spectrum CSS version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 5d605f8c238b9cd74d0d191db62714c7385bedd7
+        default: 738614fb9802d7227ca7e469f9e6c0256edf0bb9
 commands:
     downstream:
         steps:

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/accordion": "^3.0.20"
+        "@spectrum-css/accordion": "^3.0.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-bar/package.json
+++ b/packages/action-bar/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbar": "^3.0.24"
+        "@spectrum-css/actionbar": "^3.0.26"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^1.1.11"
+        "@spectrum-css/actionbutton": "^1.1.12"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actiongroup": "^1.0.23"
+        "@spectrum-css/actiongroup": "^1.0.24"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -55,7 +55,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionmenu": "^3.0.24"
+        "@spectrum-css/actionmenu": "^3.0.26"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/asset": "^3.0.19"
+        "@spectrum-css/asset": "^3.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/avatar": "^5.0.15"
+        "@spectrum-css/avatar": "^5.0.16"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/buttongroup": "^5.0.9"
+        "@spectrum-css/buttongroup": "^5.0.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -57,7 +57,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/button": "^6.0.9"
+        "@spectrum-css/button": "^6.0.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/card": "^4.0.19"
+        "@spectrum-css/card": "^4.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/checkbox": "^3.1.0"
+        "@spectrum-css/checkbox": "^3.1.1"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/clear-button/package.json
+++ b/packages/clear-button/package.json
@@ -46,7 +46,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/clearbutton": "^1.2.8"
+        "@spectrum-css/clearbutton": "^1.2.9"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -46,7 +46,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/closebutton": "^1.2.8"
+        "@spectrum-css/closebutton": "^1.2.9"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/coachmark": "^5.0.9"
+        "@spectrum-css/coachmark": "^5.0.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-area/package.json
+++ b/packages/color-area/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorarea": "^1.0.19"
+        "@spectrum-css/colorarea": "^1.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-handle/package.json
+++ b/packages/color-handle/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorhandle": "^2.0.5"
+        "@spectrum-css/colorhandle": "^2.0.6"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-loupe/package.json
+++ b/packages/color-loupe/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorloupe": "^2.0.5"
+        "@spectrum-css/colorloupe": "^2.0.6"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-slider/package.json
+++ b/packages/color-slider/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorslider": "^2.0.5"
+        "@spectrum-css/colorslider": "^2.0.6"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-wheel/package.json
+++ b/packages/color-wheel/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorwheel": "^1.0.19"
+        "@spectrum-css/colorwheel": "^1.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -60,7 +60,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/dialog": "^6.0.9"
+        "@spectrum-css/dialog": "^6.0.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/divider": "^1.0.23"
+        "@spectrum-css/divider": "^1.0.24"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/dropzone": "^3.0.22"
+        "@spectrum-css/dropzone": "^3.0.23"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldgroup": "^3.1.0"
+        "@spectrum-css/fieldgroup": "^3.1.1"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldlabel": "^4.0.21"
+        "@spectrum-css/fieldlabel": "^4.0.23"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/help-text/package.json
+++ b/packages/help-text/package.json
@@ -53,7 +53,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/helptext": "^1.0.17"
+        "@spectrum-css/helptext": "^1.0.18"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^3.0.20"
+        "@spectrum-css/icon": "^3.0.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^3.0.20",
+        "@spectrum-css/icon": "^3.0.21",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fs": "^0.0.1-security",

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -50,7 +50,7 @@
     },
     "devDependencies": {
         "@adobe/spectrum-css-workflow-icons": "^1.2.1",
-        "@spectrum-css/icon": "^3.0.20",
+        "@spectrum-css/icon": "^3.0.21",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fs": "^0.0.1-security",

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/illustratedmessage": "^4.0.3"
+        "@spectrum-css/illustratedmessage": "^4.0.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/link": "^3.1.20"
+        "@spectrum-css/link": "^3.1.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -59,7 +59,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/menu": "^3.0.21"
+        "@spectrum-css/menu": "^4.0.1"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -52,6 +52,7 @@
     "dependencies": {
         "@spectrum-web-components/action-button": "^0.8.3",
         "@spectrum-web-components/base": "^0.5.5",
+        "@spectrum-web-components/divider": "^0.4.6",
         "@spectrum-web-components/icon": "^0.11.6",
         "@spectrum-web-components/icons-ui": "^0.8.6",
         "@spectrum-web-components/overlay": "^0.16.0",

--- a/packages/menu/src/MenuDivider.ts
+++ b/packages/menu/src/MenuDivider.ts
@@ -13,16 +13,18 @@ governing permissions and limitations under the License.
 import { CSSResultArray, SpectrumElement } from '@spectrum-web-components/base';
 
 import menuDividerStyles from './menu-divider.css.js';
+import dividerStyles from '@spectrum-web-components/divider/src/divider.css.js';
 
 /**
  * @element sp-menu-divider
  */
 export class MenuDivider extends SpectrumElement {
     public static get styles(): CSSResultArray {
-        return [menuDividerStyles];
+        return [dividerStyles, menuDividerStyles];
     }
 
     protected firstUpdated(): void {
         this.setAttribute('role', 'separator');
+        this.setAttribute('size', 'm');
     }
 }

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -51,7 +51,7 @@ const config = {
             complexSelectors: [
                 {
                     replacement: '::slotted(sp-menu)',
-                    selector: '.spectrum-Menu .spectrum-Menu',
+                    selector: /.spectrum-Menu .spectrum-Menu(?!-)/,
                 },
                 {
                     replacement:

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -175,8 +175,14 @@ const config = {
         {
             name: 'menu-divider',
             host: {
-                selector: '.spectrum-Menu-divider',
+                selector: '.spectrum-Menu',
             },
+            complexSelectors: [
+                {
+                    replacement: ':host',
+                    selector: '.spectrum-Menu .spectrum-Menu-divider',
+                },
+            ],
             exclude: [/\.spectrum-Menu(?!-divider)/],
         },
     ],

--- a/packages/menu/src/spectrum-menu-divider.css
+++ b/packages/menu/src/spectrum-menu-divider.css
@@ -11,3 +11,9 @@ governing permissions and limitations under the License.
 */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+:host {
+    margin: calc(var(--spectrum-listitem-texticon-divider-padding) / 2)
+        var(--spectrum-listitem-texticon-padding-y);
+    overflow: visible; /* .spectrum-Menu .spectrum-Menu-divider */
+    width: auto;
+}

--- a/packages/menu/src/spectrum-menu-divider.css
+++ b/packages/menu/src/spectrum-menu-divider.css
@@ -11,18 +11,3 @@ governing permissions and limitations under the License.
 */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-:host {
-    border: none;
-    box-sizing: content-box; /* .spectrum-Menu-divider */
-    height: var(--spectrum-listitem-texticon-divider-size);
-    margin: calc(var(--spectrum-listitem-texticon-divider-padding) / 2)
-        var(--spectrum-listitem-texticon-padding-y);
-    overflow: visible;
-    padding: 0;
-}
-:host {
-    background-color: var(
-        --spectrum-listitem-m-texticon-divider-color,
-        var(--spectrum-alias-border-color-extralight)
-    ); /* .spectrum-Menu-divider */
-}

--- a/packages/menu/src/spectrum-menu.css
+++ b/packages/menu/src/spectrum-menu.css
@@ -65,10 +65,6 @@ governing permissions and limitations under the License.
         --spectrum-listitem-m-texticon-icon-gap,
         var(--spectrum-global-dimension-size-100)
     );
-    --spectrum-listitem-texticon-divider-size: var(
-        --spectrum-listitem-m-texticon-divider-size,
-        var(--spectrum-alias-border-size-thick)
-    );
     --spectrum-listitem-texticon-divider-padding: var(
         --spectrum-listitem-m-texticon-divider-padding,
         var(--spectrum-global-dimension-static-size-40)

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^1.0.25"
+        "@spectrum-css/progressbar": "^1.0.27"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -46,7 +46,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/modal": "^3.0.19"
+        "@spectrum-css/modal": "^3.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -55,7 +55,7 @@
     },
     "devDependencies": {
         "@formatjs/intl-numberformat": "7.1.4",
-        "@spectrum-css/stepper": "^3.0.22"
+        "@spectrum-css/stepper": "^3.0.23"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -62,7 +62,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/picker": "^1.2.4"
+        "@spectrum-css/picker": "^1.2.6"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/popover": "^5.0.11"
+        "@spectrum-css/popover": "^5.0.13"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^1.0.25"
+        "@spectrum-css/progressbar": "^1.0.27"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progresscircle": "^1.0.19"
+        "@spectrum-css/progresscircle": "^1.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/quickaction": "^3.0.22"
+        "@spectrum-css/quickaction": "^3.0.23"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/radio": "^3.0.20"
+        "@spectrum-css/radio": "^3.0.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -52,7 +52,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/search": "^4.2.8"
+        "@spectrum-css/search": "^4.2.9"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/sidenav": "^3.0.20"
+        "@spectrum-css/sidenav": "^3.0.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -57,7 +57,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^3.1.3"
+        "@spectrum-css/slider": "^3.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -56,7 +56,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/splitbutton": "^5.0.9"
+        "@spectrum-css/splitbutton": "^5.0.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/splitview": "^3.0.19"
+        "@spectrum-css/splitview": "^3.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/statuslight": "^4.0.10"
+        "@spectrum-css/statuslight": "^4.0.11"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/styles/core-global.css
+++ b/packages/styles/core-global.css
@@ -47,7 +47,7 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-white: rgb(
         var(--spectrum-global-color-static-white-rgb)
     );
-    --spectrum-global-color-static-blue-rgb: 20, 115, 230;
+    --spectrum-global-color-static-blue-rgb: 0, 87, 191;
     --spectrum-global-color-static-blue: rgb(
         var(--spectrum-global-color-static-blue-rgb)
     );
@@ -63,329 +63,329 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-gray-100: rgb(
         var(--spectrum-global-color-static-gray-100-rgb)
     );
-    --spectrum-global-color-static-gray-200-rgb: 244, 244, 244;
+    --spectrum-global-color-static-gray-200-rgb: 235, 235, 235;
     --spectrum-global-color-static-gray-200: rgb(
         var(--spectrum-global-color-static-gray-200-rgb)
     );
-    --spectrum-global-color-static-gray-300-rgb: 234, 234, 234;
+    --spectrum-global-color-static-gray-300-rgb: 217, 217, 217;
     --spectrum-global-color-static-gray-300: rgb(
         var(--spectrum-global-color-static-gray-300-rgb)
     );
-    --spectrum-global-color-static-gray-400-rgb: 211, 211, 211;
+    --spectrum-global-color-static-gray-400-rgb: 179, 179, 179;
     --spectrum-global-color-static-gray-400: rgb(
         var(--spectrum-global-color-static-gray-400-rgb)
     );
-    --spectrum-global-color-static-gray-500-rgb: 188, 188, 188;
+    --spectrum-global-color-static-gray-500-rgb: 146, 146, 146;
     --spectrum-global-color-static-gray-500: rgb(
         var(--spectrum-global-color-static-gray-500-rgb)
     );
-    --spectrum-global-color-static-gray-600-rgb: 149, 149, 149;
+    --spectrum-global-color-static-gray-600-rgb: 110, 110, 110;
     --spectrum-global-color-static-gray-600: rgb(
         var(--spectrum-global-color-static-gray-600-rgb)
     );
-    --spectrum-global-color-static-gray-700-rgb: 116, 116, 116;
+    --spectrum-global-color-static-gray-700-rgb: 71, 71, 71;
     --spectrum-global-color-static-gray-700: rgb(
         var(--spectrum-global-color-static-gray-700-rgb)
     );
-    --spectrum-global-color-static-gray-800-rgb: 80, 80, 80;
+    --spectrum-global-color-static-gray-800-rgb: 34, 34, 34;
     --spectrum-global-color-static-gray-800: rgb(
         var(--spectrum-global-color-static-gray-800-rgb)
     );
-    --spectrum-global-color-static-gray-900-rgb: 50, 50, 50;
+    --spectrum-global-color-static-gray-900-rgb: 0, 0, 0;
     --spectrum-global-color-static-gray-900: rgb(
         var(--spectrum-global-color-static-gray-900-rgb)
     );
-    --spectrum-global-color-static-blue-200-rgb: 90, 169, 250;
-    --spectrum-global-color-static-blue-200: rgb(
-        var(--spectrum-global-color-static-blue-200-rgb)
-    );
-    --spectrum-global-color-static-blue-300-rgb: 75, 156, 245;
-    --spectrum-global-color-static-blue-300: rgb(
-        var(--spectrum-global-color-static-blue-300-rgb)
-    );
-    --spectrum-global-color-static-blue-400-rgb: 55, 142, 240;
-    --spectrum-global-color-static-blue-400: rgb(
-        var(--spectrum-global-color-static-blue-400-rgb)
-    );
-    --spectrum-global-color-static-blue-500-rgb: 38, 128, 235;
-    --spectrum-global-color-static-blue-500: rgb(
-        var(--spectrum-global-color-static-blue-500-rgb)
-    );
-    --spectrum-global-color-static-blue-600-rgb: 20, 115, 230;
-    --spectrum-global-color-static-blue-600: rgb(
-        var(--spectrum-global-color-static-blue-600-rgb)
-    );
-    --spectrum-global-color-static-blue-700-rgb: 13, 102, 208;
-    --spectrum-global-color-static-blue-700: rgb(
-        var(--spectrum-global-color-static-blue-700-rgb)
-    );
-    --spectrum-global-color-static-blue-800-rgb: 9, 90, 186;
-    --spectrum-global-color-static-blue-800: rgb(
-        var(--spectrum-global-color-static-blue-800-rgb)
-    );
-    --spectrum-global-color-static-red-400-rgb: 236, 91, 98;
+    --spectrum-global-color-static-red-400-rgb: 237, 64, 48;
     --spectrum-global-color-static-red-400: rgb(
         var(--spectrum-global-color-static-red-400-rgb)
     );
-    --spectrum-global-color-static-red-500-rgb: 227, 72, 80;
+    --spectrum-global-color-static-red-500-rgb: 217, 28, 21;
     --spectrum-global-color-static-red-500: rgb(
         var(--spectrum-global-color-static-red-500-rgb)
     );
-    --spectrum-global-color-static-red-600-rgb: 215, 55, 63;
+    --spectrum-global-color-static-red-600-rgb: 187, 2, 2;
     --spectrum-global-color-static-red-600: rgb(
         var(--spectrum-global-color-static-red-600-rgb)
     );
-    --spectrum-global-color-static-red-700-rgb: 201, 37, 45;
+    --spectrum-global-color-static-red-700-rgb: 154, 0, 0;
     --spectrum-global-color-static-red-700: rgb(
         var(--spectrum-global-color-static-red-700-rgb)
     );
-    --spectrum-global-color-static-red-800-rgb: 187, 18, 26;
+    --spectrum-global-color-static-red-800-rgb: 124, 0, 0;
     --spectrum-global-color-static-red-800: rgb(
         var(--spectrum-global-color-static-red-800-rgb)
     );
-    --spectrum-global-color-static-orange-400-rgb: 242, 148, 35;
+    --spectrum-global-color-static-orange-400-rgb: 250, 139, 26;
     --spectrum-global-color-static-orange-400: rgb(
         var(--spectrum-global-color-static-orange-400-rgb)
     );
-    --spectrum-global-color-static-orange-500-rgb: 230, 134, 25;
+    --spectrum-global-color-static-orange-500-rgb: 233, 117, 0;
     --spectrum-global-color-static-orange-500: rgb(
         var(--spectrum-global-color-static-orange-500-rgb)
     );
-    --spectrum-global-color-static-orange-600-rgb: 218, 123, 17;
+    --spectrum-global-color-static-orange-600-rgb: 209, 97, 0;
     --spectrum-global-color-static-orange-600: rgb(
         var(--spectrum-global-color-static-orange-600-rgb)
     );
-    --spectrum-global-color-static-orange-700-rgb: 203, 111, 16;
+    --spectrum-global-color-static-orange-700-rgb: 182, 80, 0;
     --spectrum-global-color-static-orange-700: rgb(
         var(--spectrum-global-color-static-orange-700-rgb)
     );
-    --spectrum-global-color-static-orange-800-rgb: 189, 100, 13;
+    --spectrum-global-color-static-orange-800-rgb: 155, 64, 0;
     --spectrum-global-color-static-orange-800: rgb(
         var(--spectrum-global-color-static-orange-800-rgb)
     );
-    --spectrum-global-color-static-green-400-rgb: 51, 171, 132;
-    --spectrum-global-color-static-green-400: rgb(
-        var(--spectrum-global-color-static-green-400-rgb)
-    );
-    --spectrum-global-color-static-green-500-rgb: 45, 157, 120;
-    --spectrum-global-color-static-green-500: rgb(
-        var(--spectrum-global-color-static-green-500-rgb)
-    );
-    --spectrum-global-color-static-green-600-rgb: 38, 142, 108;
-    --spectrum-global-color-static-green-600: rgb(
-        var(--spectrum-global-color-static-green-600-rgb)
-    );
-    --spectrum-global-color-static-green-700-rgb: 18, 128, 92;
-    --spectrum-global-color-static-green-700: rgb(
-        var(--spectrum-global-color-static-green-700-rgb)
-    );
-    --spectrum-global-color-static-green-800-rgb: 16, 113, 84;
-    --spectrum-global-color-static-green-800: rgb(
-        var(--spectrum-global-color-static-green-800-rgb)
-    );
-    --spectrum-global-color-static-celery-200-rgb: 88, 224, 111;
-    --spectrum-global-color-static-celery-200: rgb(
-        var(--spectrum-global-color-static-celery-200-rgb)
-    );
-    --spectrum-global-color-static-celery-300-rgb: 81, 210, 103;
-    --spectrum-global-color-static-celery-300: rgb(
-        var(--spectrum-global-color-static-celery-300-rgb)
-    );
-    --spectrum-global-color-static-celery-400-rgb: 75, 195, 95;
-    --spectrum-global-color-static-celery-400: rgb(
-        var(--spectrum-global-color-static-celery-400-rgb)
-    );
-    --spectrum-global-color-static-celery-500-rgb: 68, 181, 86;
-    --spectrum-global-color-static-celery-500: rgb(
-        var(--spectrum-global-color-static-celery-500-rgb)
-    );
-    --spectrum-global-color-static-celery-600-rgb: 61, 167, 78;
-    --spectrum-global-color-static-celery-600: rgb(
-        var(--spectrum-global-color-static-celery-600-rgb)
-    );
-    --spectrum-global-color-static-celery-700-rgb: 55, 153, 71;
-    --spectrum-global-color-static-celery-700: rgb(
-        var(--spectrum-global-color-static-celery-700-rgb)
-    );
-    --spectrum-global-color-static-celery-800-rgb: 49, 139, 64;
-    --spectrum-global-color-static-celery-800: rgb(
-        var(--spectrum-global-color-static-celery-800-rgb)
-    );
-    --spectrum-global-color-static-chartreuse-300-rgb: 155, 236, 84;
-    --spectrum-global-color-static-chartreuse-300: rgb(
-        var(--spectrum-global-color-static-chartreuse-300-rgb)
-    );
-    --spectrum-global-color-static-chartreuse-400-rgb: 142, 222, 73;
-    --spectrum-global-color-static-chartreuse-400: rgb(
-        var(--spectrum-global-color-static-chartreuse-400-rgb)
-    );
-    --spectrum-global-color-static-chartreuse-500-rgb: 133, 208, 68;
-    --spectrum-global-color-static-chartreuse-500: rgb(
-        var(--spectrum-global-color-static-chartreuse-500-rgb)
-    );
-    --spectrum-global-color-static-chartreuse-600-rgb: 124, 195, 63;
-    --spectrum-global-color-static-chartreuse-600: rgb(
-        var(--spectrum-global-color-static-chartreuse-600-rgb)
-    );
-    --spectrum-global-color-static-chartreuse-700-rgb: 115, 181, 58;
-    --spectrum-global-color-static-chartreuse-700: rgb(
-        var(--spectrum-global-color-static-chartreuse-700-rgb)
-    );
-    --spectrum-global-color-static-chartreuse-800-rgb: 106, 168, 52;
-    --spectrum-global-color-static-chartreuse-800: rgb(
-        var(--spectrum-global-color-static-chartreuse-800-rgb)
-    );
-    --spectrum-global-color-static-yellow-200-rgb: 255, 226, 46;
+    --spectrum-global-color-static-yellow-200-rgb: 250, 237, 123;
     --spectrum-global-color-static-yellow-200: rgb(
         var(--spectrum-global-color-static-yellow-200-rgb)
     );
-    --spectrum-global-color-static-yellow-300-rgb: 250, 217, 0;
+    --spectrum-global-color-static-yellow-300-rgb: 250, 224, 23;
     --spectrum-global-color-static-yellow-300: rgb(
         var(--spectrum-global-color-static-yellow-300-rgb)
     );
-    --spectrum-global-color-static-yellow-400-rgb: 237, 204, 0;
+    --spectrum-global-color-static-yellow-400-rgb: 238, 205, 0;
     --spectrum-global-color-static-yellow-400: rgb(
         var(--spectrum-global-color-static-yellow-400-rgb)
     );
-    --spectrum-global-color-static-yellow-500-rgb: 223, 191, 0;
+    --spectrum-global-color-static-yellow-500-rgb: 221, 185, 0;
     --spectrum-global-color-static-yellow-500: rgb(
         var(--spectrum-global-color-static-yellow-500-rgb)
     );
-    --spectrum-global-color-static-yellow-600-rgb: 210, 178, 0;
+    --spectrum-global-color-static-yellow-600-rgb: 201, 164, 0;
     --spectrum-global-color-static-yellow-600: rgb(
         var(--spectrum-global-color-static-yellow-600-rgb)
     );
-    --spectrum-global-color-static-yellow-700-rgb: 196, 166, 0;
+    --spectrum-global-color-static-yellow-700-rgb: 181, 144, 0;
     --spectrum-global-color-static-yellow-700: rgb(
         var(--spectrum-global-color-static-yellow-700-rgb)
     );
-    --spectrum-global-color-static-yellow-800-rgb: 183, 153, 0;
+    --spectrum-global-color-static-yellow-800-rgb: 160, 125, 0;
     --spectrum-global-color-static-yellow-800: rgb(
         var(--spectrum-global-color-static-yellow-800-rgb)
     );
-    --spectrum-global-color-static-magenta-200-rgb: 245, 107, 183;
-    --spectrum-global-color-static-magenta-200: rgb(
-        var(--spectrum-global-color-static-magenta-200-rgb)
+    --spectrum-global-color-static-chartreuse-300-rgb: 176, 222, 27;
+    --spectrum-global-color-static-chartreuse-300: rgb(
+        var(--spectrum-global-color-static-chartreuse-300-rgb)
     );
-    --spectrum-global-color-static-magenta-300-rgb: 236, 90, 170;
-    --spectrum-global-color-static-magenta-300: rgb(
-        var(--spectrum-global-color-static-magenta-300-rgb)
+    --spectrum-global-color-static-chartreuse-400-rgb: 157, 203, 13;
+    --spectrum-global-color-static-chartreuse-400: rgb(
+        var(--spectrum-global-color-static-chartreuse-400-rgb)
     );
-    --spectrum-global-color-static-magenta-400-rgb: 226, 73, 157;
-    --spectrum-global-color-static-magenta-400: rgb(
-        var(--spectrum-global-color-static-magenta-400-rgb)
+    --spectrum-global-color-static-chartreuse-500-rgb: 139, 182, 4;
+    --spectrum-global-color-static-chartreuse-500: rgb(
+        var(--spectrum-global-color-static-chartreuse-500-rgb)
     );
-    --spectrum-global-color-static-magenta-500-rgb: 216, 55, 144;
-    --spectrum-global-color-static-magenta-500: rgb(
-        var(--spectrum-global-color-static-magenta-500-rgb)
+    --spectrum-global-color-static-chartreuse-600-rgb: 122, 162, 0;
+    --spectrum-global-color-static-chartreuse-600: rgb(
+        var(--spectrum-global-color-static-chartreuse-600-rgb)
     );
-    --spectrum-global-color-static-magenta-600-rgb: 202, 41, 130;
-    --spectrum-global-color-static-magenta-600: rgb(
-        var(--spectrum-global-color-static-magenta-600-rgb)
+    --spectrum-global-color-static-chartreuse-700-rgb: 106, 141, 0;
+    --spectrum-global-color-static-chartreuse-700: rgb(
+        var(--spectrum-global-color-static-chartreuse-700-rgb)
     );
-    --spectrum-global-color-static-magenta-700-rgb: 188, 28, 116;
-    --spectrum-global-color-static-magenta-700: rgb(
-        var(--spectrum-global-color-static-magenta-700-rgb)
+    --spectrum-global-color-static-chartreuse-800-rgb: 90, 120, 0;
+    --spectrum-global-color-static-chartreuse-800: rgb(
+        var(--spectrum-global-color-static-chartreuse-800-rgb)
     );
-    --spectrum-global-color-static-magenta-800-rgb: 174, 14, 102;
-    --spectrum-global-color-static-magenta-800: rgb(
-        var(--spectrum-global-color-static-magenta-800-rgb)
+    --spectrum-global-color-static-celery-200-rgb: 126, 229, 114;
+    --spectrum-global-color-static-celery-200: rgb(
+        var(--spectrum-global-color-static-celery-200-rgb)
     );
-    --spectrum-global-color-static-fuchsia-400-rgb: 207, 62, 220;
-    --spectrum-global-color-static-fuchsia-400: rgb(
-        var(--spectrum-global-color-static-fuchsia-400-rgb)
+    --spectrum-global-color-static-celery-300-rgb: 87, 212, 86;
+    --spectrum-global-color-static-celery-300: rgb(
+        var(--spectrum-global-color-static-celery-300-rgb)
     );
-    --spectrum-global-color-static-fuchsia-500-rgb: 192, 56, 204;
-    --spectrum-global-color-static-fuchsia-500: rgb(
-        var(--spectrum-global-color-static-fuchsia-500-rgb)
+    --spectrum-global-color-static-celery-400-rgb: 48, 193, 61;
+    --spectrum-global-color-static-celery-400: rgb(
+        var(--spectrum-global-color-static-celery-400-rgb)
     );
-    --spectrum-global-color-static-fuchsia-600-rgb: 177, 48, 189;
-    --spectrum-global-color-static-fuchsia-600: rgb(
-        var(--spectrum-global-color-static-fuchsia-600-rgb)
+    --spectrum-global-color-static-celery-500-rgb: 15, 172, 38;
+    --spectrum-global-color-static-celery-500: rgb(
+        var(--spectrum-global-color-static-celery-500-rgb)
     );
-    --spectrum-global-color-static-fuchsia-700-rgb: 162, 40, 173;
-    --spectrum-global-color-static-fuchsia-700: rgb(
-        var(--spectrum-global-color-static-fuchsia-700-rgb)
+    --spectrum-global-color-static-celery-600-rgb: 0, 150, 20;
+    --spectrum-global-color-static-celery-600: rgb(
+        var(--spectrum-global-color-static-celery-600-rgb)
     );
-    --spectrum-global-color-static-fuchsia-800-rgb: 147, 33, 158;
-    --spectrum-global-color-static-fuchsia-800: rgb(
-        var(--spectrum-global-color-static-fuchsia-800-rgb)
+    --spectrum-global-color-static-celery-700-rgb: 0, 128, 15;
+    --spectrum-global-color-static-celery-700: rgb(
+        var(--spectrum-global-color-static-celery-700-rgb)
     );
-    --spectrum-global-color-static-purple-400-rgb: 157, 100, 225;
-    --spectrum-global-color-static-purple-400: rgb(
-        var(--spectrum-global-color-static-purple-400-rgb)
+    --spectrum-global-color-static-celery-800-rgb: 0, 107, 15;
+    --spectrum-global-color-static-celery-800: rgb(
+        var(--spectrum-global-color-static-celery-800-rgb)
     );
-    --spectrum-global-color-static-purple-500-rgb: 146, 86, 217;
-    --spectrum-global-color-static-purple-500: rgb(
-        var(--spectrum-global-color-static-purple-500-rgb)
+    --spectrum-global-color-static-green-400-rgb: 29, 169, 115;
+    --spectrum-global-color-static-green-400: rgb(
+        var(--spectrum-global-color-static-green-400-rgb)
     );
-    --spectrum-global-color-static-purple-600-rgb: 134, 76, 204;
-    --spectrum-global-color-static-purple-600: rgb(
-        var(--spectrum-global-color-static-purple-600-rgb)
+    --spectrum-global-color-static-green-500-rgb: 0, 148, 97;
+    --spectrum-global-color-static-green-500: rgb(
+        var(--spectrum-global-color-static-green-500-rgb)
     );
-    --spectrum-global-color-static-purple-700-rgb: 122, 66, 191;
-    --spectrum-global-color-static-purple-700: rgb(
-        var(--spectrum-global-color-static-purple-700-rgb)
+    --spectrum-global-color-static-green-600-rgb: 0, 126, 80;
+    --spectrum-global-color-static-green-600: rgb(
+        var(--spectrum-global-color-static-green-600-rgb)
     );
-    --spectrum-global-color-static-purple-800-rgb: 111, 56, 177;
-    --spectrum-global-color-static-purple-800: rgb(
-        var(--spectrum-global-color-static-purple-800-rgb)
+    --spectrum-global-color-static-green-700-rgb: 0, 105, 65;
+    --spectrum-global-color-static-green-700: rgb(
+        var(--spectrum-global-color-static-green-700-rgb)
     );
-    --spectrum-global-color-static-indigo-200-rgb: 144, 144, 250;
-    --spectrum-global-color-static-indigo-200: rgb(
-        var(--spectrum-global-color-static-indigo-200-rgb)
+    --spectrum-global-color-static-green-800-rgb: 0, 86, 53;
+    --spectrum-global-color-static-green-800: rgb(
+        var(--spectrum-global-color-static-green-800-rgb)
     );
-    --spectrum-global-color-static-indigo-300-rgb: 130, 130, 246;
-    --spectrum-global-color-static-indigo-300: rgb(
-        var(--spectrum-global-color-static-indigo-300-rgb)
-    );
-    --spectrum-global-color-static-indigo-400-rgb: 117, 117, 241;
-    --spectrum-global-color-static-indigo-400: rgb(
-        var(--spectrum-global-color-static-indigo-400-rgb)
-    );
-    --spectrum-global-color-static-indigo-500-rgb: 103, 103, 236;
-    --spectrum-global-color-static-indigo-500: rgb(
-        var(--spectrum-global-color-static-indigo-500-rgb)
-    );
-    --spectrum-global-color-static-indigo-600-rgb: 92, 92, 224;
-    --spectrum-global-color-static-indigo-600: rgb(
-        var(--spectrum-global-color-static-indigo-600-rgb)
-    );
-    --spectrum-global-color-static-indigo-700-rgb: 81, 81, 211;
-    --spectrum-global-color-static-indigo-700: rgb(
-        var(--spectrum-global-color-static-indigo-700-rgb)
-    );
-    --spectrum-global-color-static-indigo-800-rgb: 70, 70, 198;
-    --spectrum-global-color-static-indigo-800: rgb(
-        var(--spectrum-global-color-static-indigo-800-rgb)
-    );
-    --spectrum-global-color-static-seafoam-200-rgb: 38, 192, 199;
+    --spectrum-global-color-static-seafoam-200-rgb: 75, 206, 199;
     --spectrum-global-color-static-seafoam-200: rgb(
         var(--spectrum-global-color-static-seafoam-200-rgb)
     );
-    --spectrum-global-color-static-seafoam-300-rgb: 35, 178, 184;
+    --spectrum-global-color-static-seafoam-300-rgb: 32, 187, 180;
     --spectrum-global-color-static-seafoam-300: rgb(
         var(--spectrum-global-color-static-seafoam-300-rgb)
     );
-    --spectrum-global-color-static-seafoam-400-rgb: 32, 163, 168;
+    --spectrum-global-color-static-seafoam-400-rgb: 0, 166, 160;
     --spectrum-global-color-static-seafoam-400: rgb(
         var(--spectrum-global-color-static-seafoam-400-rgb)
     );
-    --spectrum-global-color-static-seafoam-500-rgb: 27, 149, 154;
+    --spectrum-global-color-static-seafoam-500-rgb: 0, 145, 139;
     --spectrum-global-color-static-seafoam-500: rgb(
         var(--spectrum-global-color-static-seafoam-500-rgb)
     );
-    --spectrum-global-color-static-seafoam-600-rgb: 22, 135, 140;
+    --spectrum-global-color-static-seafoam-600-rgb: 0, 124, 118;
     --spectrum-global-color-static-seafoam-600: rgb(
         var(--spectrum-global-color-static-seafoam-600-rgb)
     );
-    --spectrum-global-color-static-seafoam-700-rgb: 15, 121, 125;
+    --spectrum-global-color-static-seafoam-700-rgb: 0, 103, 99;
     --spectrum-global-color-static-seafoam-700: rgb(
         var(--spectrum-global-color-static-seafoam-700-rgb)
     );
-    --spectrum-global-color-static-seafoam-800-rgb: 9, 108, 111;
+    --spectrum-global-color-static-seafoam-800-rgb: 10, 83, 80;
     --spectrum-global-color-static-seafoam-800: rgb(
         var(--spectrum-global-color-static-seafoam-800-rgb)
+    );
+    --spectrum-global-color-static-blue-200-rgb: 130, 193, 251;
+    --spectrum-global-color-static-blue-200: rgb(
+        var(--spectrum-global-color-static-blue-200-rgb)
+    );
+    --spectrum-global-color-static-blue-300-rgb: 98, 173, 247;
+    --spectrum-global-color-static-blue-300: rgb(
+        var(--spectrum-global-color-static-blue-300-rgb)
+    );
+    --spectrum-global-color-static-blue-400-rgb: 66, 151, 244;
+    --spectrum-global-color-static-blue-400: rgb(
+        var(--spectrum-global-color-static-blue-400-rgb)
+    );
+    --spectrum-global-color-static-blue-500-rgb: 27, 127, 245;
+    --spectrum-global-color-static-blue-500: rgb(
+        var(--spectrum-global-color-static-blue-500-rgb)
+    );
+    --spectrum-global-color-static-blue-600-rgb: 4, 105, 227;
+    --spectrum-global-color-static-blue-600: rgb(
+        var(--spectrum-global-color-static-blue-600-rgb)
+    );
+    --spectrum-global-color-static-blue-700-rgb: 0, 87, 190;
+    --spectrum-global-color-static-blue-700: rgb(
+        var(--spectrum-global-color-static-blue-700-rgb)
+    );
+    --spectrum-global-color-static-blue-800-rgb: 0, 72, 153;
+    --spectrum-global-color-static-blue-800: rgb(
+        var(--spectrum-global-color-static-blue-800-rgb)
+    );
+    --spectrum-global-color-static-indigo-200-rgb: 178, 181, 255;
+    --spectrum-global-color-static-indigo-200: rgb(
+        var(--spectrum-global-color-static-indigo-200-rgb)
+    );
+    --spectrum-global-color-static-indigo-300-rgb: 155, 159, 255;
+    --spectrum-global-color-static-indigo-300: rgb(
+        var(--spectrum-global-color-static-indigo-300-rgb)
+    );
+    --spectrum-global-color-static-indigo-400-rgb: 132, 137, 253;
+    --spectrum-global-color-static-indigo-400: rgb(
+        var(--spectrum-global-color-static-indigo-400-rgb)
+    );
+    --spectrum-global-color-static-indigo-500-rgb: 109, 115, 246;
+    --spectrum-global-color-static-indigo-500: rgb(
+        var(--spectrum-global-color-static-indigo-500-rgb)
+    );
+    --spectrum-global-color-static-indigo-600-rgb: 87, 93, 232;
+    --spectrum-global-color-static-indigo-600: rgb(
+        var(--spectrum-global-color-static-indigo-600-rgb)
+    );
+    --spectrum-global-color-static-indigo-700-rgb: 68, 74, 208;
+    --spectrum-global-color-static-indigo-700: rgb(
+        var(--spectrum-global-color-static-indigo-700-rgb)
+    );
+    --spectrum-global-color-static-indigo-800-rgb: 68, 74, 208;
+    --spectrum-global-color-static-indigo-800: rgb(
+        var(--spectrum-global-color-static-indigo-800-rgb)
+    );
+    --spectrum-global-color-static-purple-400-rgb: 178, 121, 250;
+    --spectrum-global-color-static-purple-400: rgb(
+        var(--spectrum-global-color-static-purple-400-rgb)
+    );
+    --spectrum-global-color-static-purple-500-rgb: 161, 93, 246;
+    --spectrum-global-color-static-purple-500: rgb(
+        var(--spectrum-global-color-static-purple-500-rgb)
+    );
+    --spectrum-global-color-static-purple-600-rgb: 142, 67, 234;
+    --spectrum-global-color-static-purple-600: rgb(
+        var(--spectrum-global-color-static-purple-600-rgb)
+    );
+    --spectrum-global-color-static-purple-700-rgb: 120, 43, 216;
+    --spectrum-global-color-static-purple-700: rgb(
+        var(--spectrum-global-color-static-purple-700-rgb)
+    );
+    --spectrum-global-color-static-purple-800-rgb: 98, 23, 190;
+    --spectrum-global-color-static-purple-800: rgb(
+        var(--spectrum-global-color-static-purple-800-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-400-rgb: 228, 93, 230;
+    --spectrum-global-color-static-fuchsia-400: rgb(
+        var(--spectrum-global-color-static-fuchsia-400-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-500-rgb: 211, 63, 212;
+    --spectrum-global-color-static-fuchsia-500: rgb(
+        var(--spectrum-global-color-static-fuchsia-500-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-600-rgb: 188, 39, 187;
+    --spectrum-global-color-static-fuchsia-600: rgb(
+        var(--spectrum-global-color-static-fuchsia-600-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-700-rgb: 163, 10, 163;
+    --spectrum-global-color-static-fuchsia-700: rgb(
+        var(--spectrum-global-color-static-fuchsia-700-rgb)
+    );
+    --spectrum-global-color-static-fuchsia-800-rgb: 135, 0, 136;
+    --spectrum-global-color-static-fuchsia-800: rgb(
+        var(--spectrum-global-color-static-fuchsia-800-rgb)
+    );
+    --spectrum-global-color-static-magenta-200-rgb: 253, 127, 175;
+    --spectrum-global-color-static-magenta-200: rgb(
+        var(--spectrum-global-color-static-magenta-200-rgb)
+    );
+    --spectrum-global-color-static-magenta-300-rgb: 242, 98, 157;
+    --spectrum-global-color-static-magenta-300: rgb(
+        var(--spectrum-global-color-static-magenta-300-rgb)
+    );
+    --spectrum-global-color-static-magenta-400-rgb: 226, 68, 135;
+    --spectrum-global-color-static-magenta-400: rgb(
+        var(--spectrum-global-color-static-magenta-400-rgb)
+    );
+    --spectrum-global-color-static-magenta-500-rgb: 205, 40, 111;
+    --spectrum-global-color-static-magenta-500: rgb(
+        var(--spectrum-global-color-static-magenta-500-rgb)
+    );
+    --spectrum-global-color-static-magenta-600-rgb: 179, 15, 89;
+    --spectrum-global-color-static-magenta-600: rgb(
+        var(--spectrum-global-color-static-magenta-600-rgb)
+    );
+    --spectrum-global-color-static-magenta-700-rgb: 149, 0, 72;
+    --spectrum-global-color-static-magenta-700: rgb(
+        var(--spectrum-global-color-static-magenta-700-rgb)
+    );
+    --spectrum-global-color-static-magenta-800-rgb: 119, 0, 58;
+    --spectrum-global-color-static-magenta-800: rgb(
+        var(--spectrum-global-color-static-magenta-800-rgb)
     );
     --spectrum-global-color-static-transparent-white-200: hsla(
         0,
@@ -465,7 +465,7 @@ governing permissions and limitations under the License.
 
     /* spectrum-colorSemantics.css */
     --spectrum-semantic-negative-background-color: var(
-        --spectrum-global-color-static-red-700
+        --spectrum-global-color-static-red-600
     );
     --spectrum-semantic-negative-color-default: var(
         --spectrum-global-color-red-500
@@ -519,7 +519,7 @@ governing permissions and limitations under the License.
         --spectrum-global-color-static-red-700
     );
     --spectrum-semantic-notice-background-color: var(
-        --spectrum-global-color-static-orange-700
+        --spectrum-global-color-static-orange-600
     );
     --spectrum-semantic-notice-color-default: var(
         --spectrum-global-color-orange-500
@@ -561,7 +561,7 @@ governing permissions and limitations under the License.
         --spectrum-global-color-static-orange-700
     );
     --spectrum-semantic-positive-background-color: var(
-        --spectrum-global-color-static-green-700
+        --spectrum-global-color-static-green-600
     );
     --spectrum-semantic-positive-color-default: var(
         --spectrum-global-color-green-500
@@ -591,19 +591,19 @@ governing permissions and limitations under the License.
         --spectrum-global-color-green-400
     );
     --spectrum-semantic-positive-background-color-default: var(
-        --spectrum-global-color-static-green-700
+        --spectrum-global-color-static-green-600
     );
     --spectrum-semantic-positive-background-color-hover: var(
-        --spectrum-global-color-static-green-800
+        --spectrum-global-color-static-green-700
     );
     --spectrum-semantic-positive-background-color-down: var(
         --spectrum-global-color-static-green-800
     );
     --spectrum-semantic-positive-background-color-key-focus: var(
-        --spectrum-global-color-static-green-800
+        --spectrum-global-color-static-green-700
     );
     --spectrum-semantic-informative-background-color: var(
-        --spectrum-global-color-static-blue-700
+        --spectrum-global-color-static-blue-600
     );
     --spectrum-semantic-informative-color-default: var(
         --spectrum-global-color-blue-500
@@ -654,7 +654,7 @@ governing permissions and limitations under the License.
         --spectrum-global-color-static-blue-800
     );
     --spectrum-semantic-cta-background-color-key-focus: var(
-        --spectrum-global-color-static-blue-600
+        --spectrum-global-color-static-blue-700
     );
     --spectrum-semantic-emphasized-border-color-default: var(
         --spectrum-global-color-blue-500
@@ -2000,15 +2000,15 @@ governing permissions and limitations under the License.
     /* spectrum-colorAliases.css */
     --spectrum-alias-colorhandle-outer-border-color: rgba(0, 0, 0, 0.42);
     --spectrum-alias-transparent-blue-background-color-hover: rgba(
-        13,
-        102,
-        208,
+        0,
+        87,
+        190,
         0.15
     );
     --spectrum-alias-transparent-blue-background-color-down: rgba(
-        9,
-        90,
-        186,
+        0,
+        72,
+        153,
         0.3
     );
     --spectrum-alias-transparent-blue-background-color-key-focus: var(
@@ -2021,15 +2021,15 @@ governing permissions and limitations under the License.
         --spectrum-alias-component-text-color-default
     );
     --spectrum-alias-transparent-red-background-color-hover: rgba(
-        201,
-        37,
-        45,
+        154,
+        0,
+        0,
         0.15
     );
     --spectrum-alias-transparent-red-background-color-down: rgba(
-        187,
-        18,
-        26,
+        124,
+        0,
+        0,
         0.3
     );
     --spectrum-alias-transparent-red-background-color-key-focus: var(
@@ -2793,16 +2793,16 @@ governing permissions and limitations under the License.
         --spectrum-alias-input-border-color-invalid-default
     );
     --spectrum-alias-background-color-yellow-default: var(
-        --spectrum-global-color-static-yellow-600
+        --spectrum-global-color-static-yellow-300
     );
     --spectrum-alias-background-color-yellow-hover: var(
-        --spectrum-global-color-static-yellow-700
+        --spectrum-global-color-static-yellow-400
     );
     --spectrum-alias-background-color-yellow-key-focus: var(
-        --spectrum-global-color-static-yellow-700
+        --spectrum-global-color-static-yellow-400
     );
     --spectrum-alias-background-color-yellow-down: var(
-        --spectrum-global-color-static-yellow-800
+        --spectrum-global-color-static-yellow-500
     );
     --spectrum-alias-background-color-yellow: var(
         --spectrum-alias-background-color-yellow-default
@@ -3080,9 +3080,9 @@ governing permissions and limitations under the License.
         --spectrum-global-color-blue-500
     );
     --spectrum-alias-assetcard-overlay-background-color: rgba(
-        38,
-        128,
-        235,
+        27,
+        127,
+        245,
         0.1
     );
     --spectrum-alias-assetcard-border-color-selected: var(
@@ -3227,7 +3227,7 @@ governing permissions and limitations under the License.
     --spectrum-alias-border-color-translucent-darker: rgba(0, 0, 0, 0.1);
     --spectrum-alias-focus-color: var(--spectrum-global-color-blue-400);
     --spectrum-alias-focus-ring-color: var(--spectrum-alias-focus-color);
-    --spectrum-alias-track-color-default: var(--spectrum-global-color-gray-400);
+    --spectrum-alias-track-color-default: var(--spectrum-global-color-gray-300);
     --spectrum-alias-track-fill-color-overbackground: var(
         --spectrum-global-color-static-white
     );

--- a/packages/styles/express/core-global.css
+++ b/packages/styles/express/core-global.css
@@ -95,15 +95,15 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-gray-900: rgb(
         var(--spectrum-global-color-static-gray-900-rgb)
     );
-    --spectrum-global-color-static-red-400-rgb: 238, 64, 48;
+    --spectrum-global-color-static-red-400-rgb: 237, 64, 48;
     --spectrum-global-color-static-red-400: rgb(
         var(--spectrum-global-color-static-red-400-rgb)
     );
-    --spectrum-global-color-static-red-500-rgb: 217, 27, 20;
+    --spectrum-global-color-static-red-500-rgb: 217, 28, 21;
     --spectrum-global-color-static-red-500: rgb(
         var(--spectrum-global-color-static-red-500-rgb)
     );
-    --spectrum-global-color-static-red-600-rgb: 187, 2, 1;
+    --spectrum-global-color-static-red-600-rgb: 187, 2, 2;
     --spectrum-global-color-static-red-600: rgb(
         var(--spectrum-global-color-static-red-600-rgb)
     );
@@ -115,11 +115,11 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-red-800: rgb(
         var(--spectrum-global-color-static-red-800-rgb)
     );
-    --spectrum-global-color-static-orange-400-rgb: 251, 139, 26;
+    --spectrum-global-color-static-orange-400-rgb: 250, 139, 26;
     --spectrum-global-color-static-orange-400: rgb(
         var(--spectrum-global-color-static-orange-400-rgb)
     );
-    --spectrum-global-color-static-orange-500-rgb: 234, 116, 0;
+    --spectrum-global-color-static-orange-500-rgb: 233, 117, 0;
     --spectrum-global-color-static-orange-500: rgb(
         var(--spectrum-global-color-static-orange-500-rgb)
     );
@@ -135,15 +135,15 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-orange-800: rgb(
         var(--spectrum-global-color-static-orange-800-rgb)
     );
-    --spectrum-global-color-static-yellow-200-rgb: 251, 238, 132;
+    --spectrum-global-color-static-yellow-200-rgb: 250, 237, 123;
     --spectrum-global-color-static-yellow-200: rgb(
         var(--spectrum-global-color-static-yellow-200-rgb)
     );
-    --spectrum-global-color-static-yellow-300-rgb: 251, 224, 30;
+    --spectrum-global-color-static-yellow-300-rgb: 250, 224, 23;
     --spectrum-global-color-static-yellow-300: rgb(
         var(--spectrum-global-color-static-yellow-300-rgb)
     );
-    --spectrum-global-color-static-yellow-400-rgb: 239, 205, 0;
+    --spectrum-global-color-static-yellow-400-rgb: 238, 205, 0;
     --spectrum-global-color-static-yellow-400: rgb(
         var(--spectrum-global-color-static-yellow-400-rgb)
     );
@@ -151,11 +151,11 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-yellow-500: rgb(
         var(--spectrum-global-color-static-yellow-500-rgb)
     );
-    --spectrum-global-color-static-yellow-600-rgb: 202, 164, 0;
+    --spectrum-global-color-static-yellow-600-rgb: 201, 164, 0;
     --spectrum-global-color-static-yellow-600: rgb(
         var(--spectrum-global-color-static-yellow-600-rgb)
     );
-    --spectrum-global-color-static-yellow-700-rgb: 182, 144, 0;
+    --spectrum-global-color-static-yellow-700-rgb: 181, 144, 0;
     --spectrum-global-color-static-yellow-700: rgb(
         var(--spectrum-global-color-static-yellow-700-rgb)
     );
@@ -163,39 +163,43 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-yellow-800: rgb(
         var(--spectrum-global-color-static-yellow-800-rgb)
     );
-    --spectrum-global-color-static-chartreuse-300-rgb: 165, 223, 87;
+    --spectrum-global-color-static-chartreuse-300-rgb: 176, 222, 27;
     --spectrum-global-color-static-chartreuse-300: rgb(
         var(--spectrum-global-color-static-chartreuse-300-rgb)
     );
-    --spectrum-global-color-static-chartreuse-400-rgb: 140, 206, 59;
+    --spectrum-global-color-static-chartreuse-400-rgb: 157, 203, 13;
     --spectrum-global-color-static-chartreuse-400: rgb(
         var(--spectrum-global-color-static-chartreuse-400-rgb)
     );
-    --spectrum-global-color-static-chartreuse-500-rgb: 117, 186, 37;
+    --spectrum-global-color-static-chartreuse-500-rgb: 139, 182, 4;
     --spectrum-global-color-static-chartreuse-500: rgb(
         var(--spectrum-global-color-static-chartreuse-500-rgb)
     );
-    --spectrum-global-color-static-chartreuse-600-rgb: 100, 166, 24;
+    --spectrum-global-color-static-chartreuse-600-rgb: 122, 162, 0;
     --spectrum-global-color-static-chartreuse-600: rgb(
         var(--spectrum-global-color-static-chartreuse-600-rgb)
     );
-    --spectrum-global-color-static-chartreuse-700-rgb: 83, 144, 15;
+    --spectrum-global-color-static-chartreuse-700-rgb: 106, 141, 0;
     --spectrum-global-color-static-chartreuse-700: rgb(
         var(--spectrum-global-color-static-chartreuse-700-rgb)
     );
-    --spectrum-global-color-static-chartreuse-800-rgb: 71, 123, 11;
+    --spectrum-global-color-static-chartreuse-800-rgb: 90, 120, 0;
     --spectrum-global-color-static-chartreuse-800: rgb(
         var(--spectrum-global-color-static-chartreuse-800-rgb)
     );
-    --spectrum-global-color-static-celery-300-rgb: 88, 212, 87;
+    --spectrum-global-color-static-celery-200-rgb: 126, 229, 114;
+    --spectrum-global-color-static-celery-200: rgb(
+        var(--spectrum-global-color-static-celery-200-rgb)
+    );
+    --spectrum-global-color-static-celery-300-rgb: 87, 212, 86;
     --spectrum-global-color-static-celery-300: rgb(
         var(--spectrum-global-color-static-celery-300-rgb)
     );
-    --spectrum-global-color-static-celery-400-rgb: 49, 193, 61;
+    --spectrum-global-color-static-celery-400-rgb: 48, 193, 61;
     --spectrum-global-color-static-celery-400: rgb(
         var(--spectrum-global-color-static-celery-400-rgb)
     );
-    --spectrum-global-color-static-celery-500-rgb: 13, 172, 37;
+    --spectrum-global-color-static-celery-500-rgb: 15, 172, 38;
     --spectrum-global-color-static-celery-500: rgb(
         var(--spectrum-global-color-static-celery-500-rgb)
     );
@@ -203,189 +207,185 @@ governing permissions and limitations under the License.
     --spectrum-global-color-static-celery-600: rgb(
         var(--spectrum-global-color-static-celery-600-rgb)
     );
-    --spectrum-global-color-static-celery-700-rgb: 0, 128, 16;
+    --spectrum-global-color-static-celery-700-rgb: 0, 128, 15;
     --spectrum-global-color-static-celery-700: rgb(
         var(--spectrum-global-color-static-celery-700-rgb)
     );
-    --spectrum-global-color-static-celery-800-rgb: 0, 107, 16;
+    --spectrum-global-color-static-celery-800-rgb: 0, 107, 15;
     --spectrum-global-color-static-celery-800: rgb(
         var(--spectrum-global-color-static-celery-800-rgb)
     );
-    --spectrum-global-color-static-green-400-rgb: 0, 148, 97;
+    --spectrum-global-color-static-green-400-rgb: 29, 169, 115;
     --spectrum-global-color-static-green-400: rgb(
         var(--spectrum-global-color-static-green-400-rgb)
     );
-    --spectrum-global-color-static-green-500-rgb: 0, 126, 81;
+    --spectrum-global-color-static-green-500-rgb: 0, 148, 97;
     --spectrum-global-color-static-green-500: rgb(
         var(--spectrum-global-color-static-green-500-rgb)
     );
-    --spectrum-global-color-static-green-600-rgb: 0, 105, 67;
+    --spectrum-global-color-static-green-600-rgb: 0, 126, 80;
     --spectrum-global-color-static-green-600: rgb(
         var(--spectrum-global-color-static-green-600-rgb)
     );
-    --spectrum-global-color-static-green-700-rgb: 0, 86, 55;
+    --spectrum-global-color-static-green-700-rgb: 0, 105, 65;
     --spectrum-global-color-static-green-700: rgb(
         var(--spectrum-global-color-static-green-700-rgb)
     );
-    --spectrum-global-color-static-green-800-rgb: 8, 67, 43;
+    --spectrum-global-color-static-green-800-rgb: 0, 86, 53;
     --spectrum-global-color-static-green-800: rgb(
         var(--spectrum-global-color-static-green-800-rgb)
     );
-    --spectrum-global-color-static-seafoam-200-rgb: 79, 205, 208;
+    --spectrum-global-color-static-seafoam-200-rgb: 75, 206, 199;
     --spectrum-global-color-static-seafoam-200: rgb(
         var(--spectrum-global-color-static-seafoam-200-rgb)
     );
-    --spectrum-global-color-static-seafoam-300-rgb: 39, 185, 190;
+    --spectrum-global-color-static-seafoam-300-rgb: 32, 187, 180;
     --spectrum-global-color-static-seafoam-300: rgb(
         var(--spectrum-global-color-static-seafoam-300-rgb)
     );
-    --spectrum-global-color-static-seafoam-400-rgb: 0, 165, 172;
+    --spectrum-global-color-static-seafoam-400-rgb: 0, 166, 160;
     --spectrum-global-color-static-seafoam-400: rgb(
         var(--spectrum-global-color-static-seafoam-400-rgb)
     );
-    --spectrum-global-color-static-seafoam-500-rgb: 0, 143, 152;
+    --spectrum-global-color-static-seafoam-500-rgb: 0, 145, 139;
     --spectrum-global-color-static-seafoam-500: rgb(
         var(--spectrum-global-color-static-seafoam-500-rgb)
     );
-    --spectrum-global-color-static-seafoam-600-rgb: 0, 122, 133;
+    --spectrum-global-color-static-seafoam-600-rgb: 0, 124, 118;
     --spectrum-global-color-static-seafoam-600: rgb(
         var(--spectrum-global-color-static-seafoam-600-rgb)
     );
-    --spectrum-global-color-static-seafoam-700-rgb: 0, 101, 113;
+    --spectrum-global-color-static-seafoam-700-rgb: 0, 103, 99;
     --spectrum-global-color-static-seafoam-700: rgb(
         var(--spectrum-global-color-static-seafoam-700-rgb)
     );
-    --spectrum-global-color-static-seafoam-800-rgb: 2, 82, 93;
+    --spectrum-global-color-static-seafoam-800-rgb: 10, 83, 80;
     --spectrum-global-color-static-seafoam-800: rgb(
         var(--spectrum-global-color-static-seafoam-800-rgb)
     );
-    --spectrum-global-color-static-blue-200-rgb: 98, 172, 248;
+    --spectrum-global-color-static-blue-200-rgb: 130, 193, 251;
     --spectrum-global-color-static-blue-200: rgb(
         var(--spectrum-global-color-static-blue-200-rgb)
     );
-    --spectrum-global-color-static-blue-300-rgb: 66, 151, 245;
+    --spectrum-global-color-static-blue-300-rgb: 98, 173, 247;
     --spectrum-global-color-static-blue-300: rgb(
         var(--spectrum-global-color-static-blue-300-rgb)
     );
-    --spectrum-global-color-static-blue-400-rgb: 27, 127, 246;
+    --spectrum-global-color-static-blue-400-rgb: 66, 151, 244;
     --spectrum-global-color-static-blue-400: rgb(
         var(--spectrum-global-color-static-blue-400-rgb)
     );
-    --spectrum-global-color-static-blue-500-rgb: 5, 105, 227;
+    --spectrum-global-color-static-blue-500-rgb: 27, 127, 245;
     --spectrum-global-color-static-blue-500: rgb(
         var(--spectrum-global-color-static-blue-500-rgb)
     );
-    --spectrum-global-color-static-blue-600-rgb: 0, 87, 191;
+    --spectrum-global-color-static-blue-600-rgb: 4, 105, 227;
     --spectrum-global-color-static-blue-600: rgb(
         var(--spectrum-global-color-static-blue-600-rgb)
     );
-    --spectrum-global-color-static-blue-700-rgb: 0, 72, 153;
+    --spectrum-global-color-static-blue-700-rgb: 0, 87, 190;
     --spectrum-global-color-static-blue-700: rgb(
         var(--spectrum-global-color-static-blue-700-rgb)
     );
-    --spectrum-global-color-static-blue-800-rgb: 0, 56, 121;
+    --spectrum-global-color-static-blue-800-rgb: 0, 72, 153;
     --spectrum-global-color-static-blue-800: rgb(
         var(--spectrum-global-color-static-blue-800-rgb)
     );
-    --spectrum-global-color-static-indigo-200-rgb: 156, 159, 255;
+    --spectrum-global-color-static-indigo-200-rgb: 178, 181, 255;
     --spectrum-global-color-static-indigo-200: rgb(
         var(--spectrum-global-color-static-indigo-200-rgb)
     );
-    --spectrum-global-color-static-indigo-300-rgb: 133, 137, 254;
+    --spectrum-global-color-static-indigo-300-rgb: 155, 159, 255;
     --spectrum-global-color-static-indigo-300: rgb(
         var(--spectrum-global-color-static-indigo-300-rgb)
     );
-    --spectrum-global-color-static-indigo-400-rgb: 110, 114, 247;
+    --spectrum-global-color-static-indigo-400-rgb: 132, 137, 253;
     --spectrum-global-color-static-indigo-400: rgb(
         var(--spectrum-global-color-static-indigo-400-rgb)
     );
-    --spectrum-global-color-static-indigo-500-rgb: 87, 92, 233;
+    --spectrum-global-color-static-indigo-500-rgb: 109, 115, 246;
     --spectrum-global-color-static-indigo-500: rgb(
         var(--spectrum-global-color-static-indigo-500-rgb)
     );
-    --spectrum-global-color-static-indigo-600-rgb: 69, 73, 209;
+    --spectrum-global-color-static-indigo-600-rgb: 87, 93, 232;
     --spectrum-global-color-static-indigo-600: rgb(
         var(--spectrum-global-color-static-indigo-600-rgb)
     );
-    --spectrum-global-color-static-indigo-700-rgb: 53, 58, 176;
+    --spectrum-global-color-static-indigo-700-rgb: 68, 74, 208;
     --spectrum-global-color-static-indigo-700: rgb(
         var(--spectrum-global-color-static-indigo-700-rgb)
     );
-    --spectrum-global-color-static-indigo-800-rgb: 41, 44, 143;
+    --spectrum-global-color-static-indigo-800-rgb: 68, 74, 208;
     --spectrum-global-color-static-indigo-800: rgb(
         var(--spectrum-global-color-static-indigo-800-rgb)
     );
-    --spectrum-global-color-static-purple-400-rgb: 162, 92, 247;
+    --spectrum-global-color-static-purple-400-rgb: 178, 121, 250;
     --spectrum-global-color-static-purple-400: rgb(
         var(--spectrum-global-color-static-purple-400-rgb)
     );
-    --spectrum-global-color-static-purple-500-rgb: 142, 66, 235;
+    --spectrum-global-color-static-purple-500-rgb: 161, 93, 246;
     --spectrum-global-color-static-purple-500: rgb(
         var(--spectrum-global-color-static-purple-500-rgb)
     );
-    --spectrum-global-color-static-purple-600-rgb: 121, 42, 216;
+    --spectrum-global-color-static-purple-600-rgb: 142, 67, 234;
     --spectrum-global-color-static-purple-600: rgb(
         var(--spectrum-global-color-static-purple-600-rgb)
     );
-    --spectrum-global-color-static-purple-700-rgb: 98, 23, 190;
+    --spectrum-global-color-static-purple-700-rgb: 120, 43, 216;
     --spectrum-global-color-static-purple-700: rgb(
         var(--spectrum-global-color-static-purple-700-rgb)
     );
-    --spectrum-global-color-static-purple-800-rgb: 77, 13, 157;
+    --spectrum-global-color-static-purple-800-rgb: 98, 23, 190;
     --spectrum-global-color-static-purple-800: rgb(
         var(--spectrum-global-color-static-purple-800-rgb)
     );
-    --spectrum-global-color-static-fuchsia-400-rgb: 211, 63, 212;
+    --spectrum-global-color-static-fuchsia-400-rgb: 228, 93, 230;
     --spectrum-global-color-static-fuchsia-400: rgb(
         var(--spectrum-global-color-static-fuchsia-400-rgb)
     );
-    --spectrum-global-color-static-fuchsia-500-rgb: 188, 38, 188;
+    --spectrum-global-color-static-fuchsia-500-rgb: 211, 63, 212;
     --spectrum-global-color-static-fuchsia-500: rgb(
         var(--spectrum-global-color-static-fuchsia-500-rgb)
     );
-    --spectrum-global-color-static-fuchsia-600-rgb: 163, 9, 164;
+    --spectrum-global-color-static-fuchsia-600-rgb: 188, 39, 187;
     --spectrum-global-color-static-fuchsia-600: rgb(
         var(--spectrum-global-color-static-fuchsia-600-rgb)
     );
-    --spectrum-global-color-static-fuchsia-700-rgb: 135, 0, 136;
+    --spectrum-global-color-static-fuchsia-700-rgb: 163, 10, 163;
     --spectrum-global-color-static-fuchsia-700: rgb(
         var(--spectrum-global-color-static-fuchsia-700-rgb)
     );
-    --spectrum-global-color-static-fuchsia-800-rgb: 107, 4, 107;
+    --spectrum-global-color-static-fuchsia-800-rgb: 135, 0, 136;
     --spectrum-global-color-static-fuchsia-800: rgb(
         var(--spectrum-global-color-static-fuchsia-800-rgb)
     );
-    --spectrum-global-color-static-magenta-200-rgb: 254, 126, 175;
+    --spectrum-global-color-static-magenta-200-rgb: 253, 127, 175;
     --spectrum-global-color-static-magenta-200: rgb(
         var(--spectrum-global-color-static-magenta-200-rgb)
     );
-    --spectrum-global-color-static-magenta-300-rgb: 243, 97, 157;
+    --spectrum-global-color-static-magenta-300-rgb: 242, 98, 157;
     --spectrum-global-color-static-magenta-300: rgb(
         var(--spectrum-global-color-static-magenta-300-rgb)
     );
-    --spectrum-global-color-static-magenta-400-rgb: 227, 67, 136;
+    --spectrum-global-color-static-magenta-400-rgb: 226, 68, 135;
     --spectrum-global-color-static-magenta-400: rgb(
         var(--spectrum-global-color-static-magenta-400-rgb)
     );
-    --spectrum-global-color-static-magenta-500-rgb: 206, 39, 111;
+    --spectrum-global-color-static-magenta-500-rgb: 205, 40, 111;
     --spectrum-global-color-static-magenta-500: rgb(
         var(--spectrum-global-color-static-magenta-500-rgb)
     );
-    --spectrum-global-color-static-magenta-600-rgb: 179, 14, 89;
+    --spectrum-global-color-static-magenta-600-rgb: 179, 15, 89;
     --spectrum-global-color-static-magenta-600: rgb(
         var(--spectrum-global-color-static-magenta-600-rgb)
     );
-    --spectrum-global-color-static-magenta-700-rgb: 149, 0, 73;
+    --spectrum-global-color-static-magenta-700-rgb: 149, 0, 72;
     --spectrum-global-color-static-magenta-700: rgb(
         var(--spectrum-global-color-static-magenta-700-rgb)
     );
-    --spectrum-global-color-static-magenta-800-rgb: 119, 0, 59;
+    --spectrum-global-color-static-magenta-800-rgb: 119, 0, 58;
     --spectrum-global-color-static-magenta-800: rgb(
         var(--spectrum-global-color-static-magenta-800-rgb)
-    );
-    --spectrum-global-color-static-celery-200-rgb: 88, 224, 111;
-    --spectrum-global-color-static-celery-200: rgb(
-        var(--spectrum-global-color-static-celery-200-rgb)
     );
     --spectrum-global-color-static-transparent-white-200: hsla(
         0,
@@ -491,14 +491,8 @@ governing permissions and limitations under the License.
     --spectrum-semantic-neutral-background-color-default: var(
         --spectrum-global-color-static-gray-800
     );
-    --spectrum-semantic-informative-background-color: var(
-        --spectrum-global-color-static-blue-500
-    );
-    --spectrum-semantic-positive-background-color: var(
-        --spectrum-global-color-static-green-500
-    );
     --spectrum-semantic-negative-background-color: var(
-        --spectrum-global-color-static-red-500
+        --spectrum-global-color-static-red-600
     );
     --spectrum-semantic-negative-color-default: var(
         --spectrum-global-color-red-500
@@ -552,7 +546,7 @@ governing permissions and limitations under the License.
         --spectrum-global-color-static-red-700
     );
     --spectrum-semantic-notice-background-color: var(
-        --spectrum-global-color-static-orange-700
+        --spectrum-global-color-static-orange-600
     );
     --spectrum-semantic-notice-color-default: var(
         --spectrum-global-color-orange-500
@@ -593,6 +587,9 @@ governing permissions and limitations under the License.
     --spectrum-semantic-notice-background-color-key-focus: var(
         --spectrum-global-color-static-orange-700
     );
+    --spectrum-semantic-positive-background-color: var(
+        --spectrum-global-color-static-green-600
+    );
     --spectrum-semantic-positive-color-default: var(
         --spectrum-global-color-green-500
     );
@@ -621,16 +618,19 @@ governing permissions and limitations under the License.
         --spectrum-global-color-green-400
     );
     --spectrum-semantic-positive-background-color-default: var(
-        --spectrum-global-color-static-green-700
+        --spectrum-global-color-static-green-600
     );
     --spectrum-semantic-positive-background-color-hover: var(
-        --spectrum-global-color-static-green-800
+        --spectrum-global-color-static-green-700
     );
     --spectrum-semantic-positive-background-color-down: var(
         --spectrum-global-color-static-green-800
     );
     --spectrum-semantic-positive-background-color-key-focus: var(
-        --spectrum-global-color-static-green-800
+        --spectrum-global-color-static-green-700
+    );
+    --spectrum-semantic-informative-background-color: var(
+        --spectrum-global-color-static-blue-600
     );
     --spectrum-semantic-informative-color-default: var(
         --spectrum-global-color-blue-500
@@ -2466,7 +2466,7 @@ governing permissions and limitations under the License.
         --spectrum-alias-tabitem-text-color-emphasized-selected-default
     );
     --spectrum-alias-tabitem-selection-indicator-color-default: var(
-        --spectrum-alias-tabitem-text-color-default
+        --spectrum-global-color-gray-900
     );
     --spectrum-alias-tabitem-selection-indicator-color-emphasized: var(
         --spectrum-alias-tabitem-text-color-emphasized-selected-default
@@ -2501,7 +2501,12 @@ governing permissions and limitations under the License.
     --spectrum-alias-assetcard-selectionindicator-background-color-ordered: var(
         --spectrum-global-color-indigo-500
     );
-    --spectrum-alias-assetcard-overlay-background-color: rgba(87, 92, 233, 0.2);
+    --spectrum-alias-assetcard-overlay-background-color: rgba(
+        109,
+        115,
+        246,
+        0.2
+    );
     --spectrum-alias-assetcard-border-color-selected: var(
         --spectrum-global-color-indigo-500
     );
@@ -3043,16 +3048,16 @@ governing permissions and limitations under the License.
         --spectrum-alias-input-border-color-invalid-default
     );
     --spectrum-alias-background-color-yellow-default: var(
-        --spectrum-global-color-static-yellow-600
+        --spectrum-global-color-static-yellow-300
     );
     --spectrum-alias-background-color-yellow-hover: var(
-        --spectrum-global-color-static-yellow-700
+        --spectrum-global-color-static-yellow-400
     );
     --spectrum-alias-background-color-yellow-key-focus: var(
-        --spectrum-global-color-static-yellow-700
+        --spectrum-global-color-static-yellow-400
     );
     --spectrum-alias-background-color-yellow-down: var(
-        --spectrum-global-color-static-yellow-800
+        --spectrum-global-color-static-yellow-500
     );
     --spectrum-alias-background-color-yellow: var(
         --spectrum-alias-background-color-yellow-default

--- a/packages/styles/express/theme-dark.css
+++ b/packages/styles/express/theme-dark.css
@@ -14,6 +14,26 @@ governing permissions and limitations under the License.
 :root {
     --spectrum-global-color-status: Verified;
     --spectrum-global-color-version: 5.1.0;
+    --spectrum-global-color-opacity-100: 1;
+    --spectrum-global-color-opacity-90: 0.9;
+    --spectrum-global-color-opacity-80: 0.8;
+    --spectrum-global-color-opacity-70: 0.7;
+    --spectrum-global-color-opacity-60: 0.6;
+    --spectrum-global-color-opacity-55: 0.55;
+    --spectrum-global-color-opacity-50: 0.5;
+    --spectrum-global-color-opacity-42: 0.42;
+    --spectrum-global-color-opacity-40: 0.4;
+    --spectrum-global-color-opacity-30: 0.3;
+    --spectrum-global-color-opacity-25: 0.25;
+    --spectrum-global-color-opacity-20: 0.2;
+    --spectrum-global-color-opacity-15: 0.15;
+    --spectrum-global-color-opacity-10: 0.1;
+    --spectrum-global-color-opacity-8: 0.08;
+    --spectrum-global-color-opacity-7: 0.07;
+    --spectrum-global-color-opacity-6: 0.06;
+    --spectrum-global-color-opacity-5: 0.05;
+    --spectrum-global-color-opacity-4: 0.04;
+    --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 34, 184, 51;
     --spectrum-global-color-celery-400: rgb(
         var(--spectrum-global-color-celery-400-rgb)
@@ -218,27 +238,27 @@ governing permissions and limitations under the License.
     --spectrum-global-color-gray-100: rgb(
         var(--spectrum-global-color-gray-100-rgb)
     );
-    --spectrum-global-color-gray-200-rgb: 61, 61, 61;
+    --spectrum-global-color-gray-200-rgb: 63, 63, 63;
     --spectrum-global-color-gray-200: rgb(
         var(--spectrum-global-color-gray-200-rgb)
     );
-    --spectrum-global-color-gray-300-rgb: 78, 78, 78;
+    --spectrum-global-color-gray-300-rgb: 84, 84, 84;
     --spectrum-global-color-gray-300: rgb(
         var(--spectrum-global-color-gray-300-rgb)
     );
-    --spectrum-global-color-gray-400-rgb: 103, 103, 103;
+    --spectrum-global-color-gray-400-rgb: 112, 112, 112;
     --spectrum-global-color-gray-400: rgb(
         var(--spectrum-global-color-gray-400-rgb)
     );
-    --spectrum-global-color-gray-500-rgb: 139, 139, 139;
+    --spectrum-global-color-gray-500-rgb: 144, 144, 144;
     --spectrum-global-color-gray-500: rgb(
         var(--spectrum-global-color-gray-500-rgb)
     );
-    --spectrum-global-color-gray-600-rgb: 177, 177, 177;
+    --spectrum-global-color-gray-600-rgb: 178, 178, 178;
     --spectrum-global-color-gray-600: rgb(
         var(--spectrum-global-color-gray-600-rgb)
     );
-    --spectrum-global-color-gray-700-rgb: 211, 211, 211;
+    --spectrum-global-color-gray-700-rgb: 209, 209, 209;
     --spectrum-global-color-gray-700: rgb(
         var(--spectrum-global-color-gray-700-rgb)
     );
@@ -250,26 +270,6 @@ governing permissions and limitations under the License.
     --spectrum-global-color-gray-900: rgb(
         var(--spectrum-global-color-gray-900-rgb)
     );
-    --spectrum-global-color-opacity-100: 1;
-    --spectrum-global-color-opacity-90: 0.9;
-    --spectrum-global-color-opacity-80: 0.8;
-    --spectrum-global-color-opacity-70: 0.7;
-    --spectrum-global-color-opacity-60: 0.6;
-    --spectrum-global-color-opacity-55: 0.55;
-    --spectrum-global-color-opacity-50: 0.5;
-    --spectrum-global-color-opacity-42: 0.42;
-    --spectrum-global-color-opacity-40: 0.4;
-    --spectrum-global-color-opacity-30: 0.3;
-    --spectrum-global-color-opacity-25: 0.25;
-    --spectrum-global-color-opacity-20: 0.2;
-    --spectrum-global-color-opacity-15: 0.15;
-    --spectrum-global-color-opacity-10: 0.1;
-    --spectrum-global-color-opacity-8: 0.08;
-    --spectrum-global-color-opacity-7: 0.07;
-    --spectrum-global-color-opacity-6: 0.06;
-    --spectrum-global-color-opacity-5: 0.05;
-    --spectrum-global-color-opacity-4: 0.04;
-    --spectrum-global-color-opacity-0: 0;
     --spectrum-alias-avatar-border-color-default: hsla(0, 0%, 100%, 0.1);
     --spectrum-alias-avatar-border-color-hover: hsla(0, 0%, 100%, 0.25);
     --spectrum-alias-avatar-border-color-down: hsla(0, 0%, 100%, 0.4);

--- a/packages/styles/express/theme-light.css
+++ b/packages/styles/express/theme-light.css
@@ -14,6 +14,26 @@ governing permissions and limitations under the License.
 :root {
     --spectrum-global-color-status: Verified;
     --spectrum-global-color-version: 5.1.0;
+    --spectrum-global-color-opacity-100: 1;
+    --spectrum-global-color-opacity-90: 0.9;
+    --spectrum-global-color-opacity-80: 0.8;
+    --spectrum-global-color-opacity-70: 0.7;
+    --spectrum-global-color-opacity-60: 0.6;
+    --spectrum-global-color-opacity-55: 0.55;
+    --spectrum-global-color-opacity-50: 0.5;
+    --spectrum-global-color-opacity-42: 0.42;
+    --spectrum-global-color-opacity-40: 0.4;
+    --spectrum-global-color-opacity-30: 0.3;
+    --spectrum-global-color-opacity-25: 0.25;
+    --spectrum-global-color-opacity-20: 0.2;
+    --spectrum-global-color-opacity-15: 0.15;
+    --spectrum-global-color-opacity-10: 0.1;
+    --spectrum-global-color-opacity-8: 0.08;
+    --spectrum-global-color-opacity-7: 0.07;
+    --spectrum-global-color-opacity-6: 0.06;
+    --spectrum-global-color-opacity-5: 0.05;
+    --spectrum-global-color-opacity-4: 0.04;
+    --spectrum-global-color-opacity-0: 0;
     --spectrum-global-color-celery-400-rgb: 39, 187, 54;
     --spectrum-global-color-celery-400: rgb(
         var(--spectrum-global-color-celery-400-rgb)
@@ -214,7 +234,7 @@ governing permissions and limitations under the License.
     --spectrum-global-color-gray-75: rgb(
         var(--spectrum-global-color-gray-75-rgb)
     );
-    --spectrum-global-color-gray-100-rgb: 247, 247, 247;
+    --spectrum-global-color-gray-100-rgb: 248, 248, 248;
     --spectrum-global-color-gray-100: rgb(
         var(--spectrum-global-color-gray-100-rgb)
     );
@@ -250,26 +270,6 @@ governing permissions and limitations under the License.
     --spectrum-global-color-gray-900: rgb(
         var(--spectrum-global-color-gray-900-rgb)
     );
-    --spectrum-global-color-opacity-100: 1;
-    --spectrum-global-color-opacity-90: 0.9;
-    --spectrum-global-color-opacity-80: 0.8;
-    --spectrum-global-color-opacity-70: 0.7;
-    --spectrum-global-color-opacity-60: 0.6;
-    --spectrum-global-color-opacity-55: 0.55;
-    --spectrum-global-color-opacity-50: 0.5;
-    --spectrum-global-color-opacity-42: 0.42;
-    --spectrum-global-color-opacity-40: 0.4;
-    --spectrum-global-color-opacity-30: 0.3;
-    --spectrum-global-color-opacity-25: 0.25;
-    --spectrum-global-color-opacity-20: 0.2;
-    --spectrum-global-color-opacity-15: 0.15;
-    --spectrum-global-color-opacity-10: 0.1;
-    --spectrum-global-color-opacity-8: 0.08;
-    --spectrum-global-color-opacity-7: 0.07;
-    --spectrum-global-color-opacity-6: 0.06;
-    --spectrum-global-color-opacity-5: 0.05;
-    --spectrum-global-color-opacity-4: 0.04;
-    --spectrum-global-color-opacity-0: 0;
     --spectrum-alias-avatar-border-color-default: rgba(0, 0, 0, 0.1);
     --spectrum-alias-avatar-border-color-hover: rgba(0, 0, 0, 0.25);
     --spectrum-alias-avatar-border-color-down: rgba(0, 0, 0, 0.4);

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -73,9 +73,9 @@
     },
     "devDependencies": {
         "@spectrum-css/commons": "^3.0.5",
-        "@spectrum-css/expressvars": "^1.0.0-beta.31",
-        "@spectrum-css/typography": "^4.0.17",
-        "@spectrum-css/vars": "^7.3.0"
+        "@spectrum-css/expressvars": "^2.0.0",
+        "@spectrum-css/typography": "^4.0.18",
+        "@spectrum-css/vars": "^8.0.0"
     },
     "customElements": "custom-elements.json",
     "sideEffects": [

--- a/packages/styles/theme-dark.css
+++ b/packages/styles/theme-dark.css
@@ -34,203 +34,203 @@ governing permissions and limitations under the License.
     --spectrum-global-color-opacity-5: 0.05;
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
-    --spectrum-global-color-celery-400-rgb: 68, 181, 86;
+    --spectrum-global-color-celery-400-rgb: 34, 184, 51;
     --spectrum-global-color-celery-400: rgb(
         var(--spectrum-global-color-celery-400-rgb)
     );
-    --spectrum-global-color-celery-500-rgb: 75, 195, 95;
+    --spectrum-global-color-celery-500-rgb: 68, 202, 73;
     --spectrum-global-color-celery-500: rgb(
         var(--spectrum-global-color-celery-500-rgb)
     );
-    --spectrum-global-color-celery-600-rgb: 81, 210, 103;
+    --spectrum-global-color-celery-600-rgb: 105, 220, 99;
     --spectrum-global-color-celery-600: rgb(
         var(--spectrum-global-color-celery-600-rgb)
     );
-    --spectrum-global-color-celery-700-rgb: 88, 224, 111;
+    --spectrum-global-color-celery-700-rgb: 142, 235, 127;
     --spectrum-global-color-celery-700: rgb(
         var(--spectrum-global-color-celery-700-rgb)
     );
-    --spectrum-global-color-chartreuse-400-rgb: 133, 208, 68;
+    --spectrum-global-color-chartreuse-400-rgb: 148, 192, 8;
     --spectrum-global-color-chartreuse-400: rgb(
         var(--spectrum-global-color-chartreuse-400-rgb)
     );
-    --spectrum-global-color-chartreuse-500-rgb: 142, 222, 73;
+    --spectrum-global-color-chartreuse-500-rgb: 166, 211, 18;
     --spectrum-global-color-chartreuse-500: rgb(
         var(--spectrum-global-color-chartreuse-500-rgb)
     );
-    --spectrum-global-color-chartreuse-600-rgb: 155, 236, 84;
+    --spectrum-global-color-chartreuse-600-rgb: 184, 229, 37;
     --spectrum-global-color-chartreuse-600: rgb(
         var(--spectrum-global-color-chartreuse-600-rgb)
     );
-    --spectrum-global-color-chartreuse-700-rgb: 163, 248, 88;
+    --spectrum-global-color-chartreuse-700-rgb: 205, 245, 71;
     --spectrum-global-color-chartreuse-700: rgb(
         var(--spectrum-global-color-chartreuse-700-rgb)
     );
-    --spectrum-global-color-yellow-400-rgb: 223, 191, 0;
+    --spectrum-global-color-yellow-400-rgb: 228, 194, 0;
     --spectrum-global-color-yellow-400: rgb(
         var(--spectrum-global-color-yellow-400-rgb)
     );
-    --spectrum-global-color-yellow-500-rgb: 237, 204, 0;
+    --spectrum-global-color-yellow-500-rgb: 244, 213, 0;
     --spectrum-global-color-yellow-500: rgb(
         var(--spectrum-global-color-yellow-500-rgb)
     );
-    --spectrum-global-color-yellow-600-rgb: 250, 217, 0;
+    --spectrum-global-color-yellow-600-rgb: 249, 232, 92;
     --spectrum-global-color-yellow-600: rgb(
         var(--spectrum-global-color-yellow-600-rgb)
     );
-    --spectrum-global-color-yellow-700-rgb: 255, 226, 46;
+    --spectrum-global-color-yellow-700-rgb: 252, 246, 187;
     --spectrum-global-color-yellow-700: rgb(
         var(--spectrum-global-color-yellow-700-rgb)
     );
-    --spectrum-global-color-magenta-400-rgb: 216, 55, 144;
+    --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
     --spectrum-global-color-magenta-400: rgb(
         var(--spectrum-global-color-magenta-400-rgb)
     );
-    --spectrum-global-color-magenta-500-rgb: 226, 73, 157;
+    --spectrum-global-color-magenta-500-rgb: 237, 87, 149;
     --spectrum-global-color-magenta-500: rgb(
         var(--spectrum-global-color-magenta-500-rgb)
     );
-    --spectrum-global-color-magenta-600-rgb: 236, 90, 170;
+    --spectrum-global-color-magenta-600-rgb: 249, 114, 167;
     --spectrum-global-color-magenta-600: rgb(
         var(--spectrum-global-color-magenta-600-rgb)
     );
-    --spectrum-global-color-magenta-700-rgb: 245, 107, 183;
+    --spectrum-global-color-magenta-700-rgb: 255, 143, 185;
     --spectrum-global-color-magenta-700: rgb(
         var(--spectrum-global-color-magenta-700-rgb)
     );
-    --spectrum-global-color-fuchsia-400-rgb: 192, 56, 204;
+    --spectrum-global-color-fuchsia-400-rgb: 205, 57, 206;
     --spectrum-global-color-fuchsia-400: rgb(
         var(--spectrum-global-color-fuchsia-400-rgb)
     );
-    --spectrum-global-color-fuchsia-500-rgb: 207, 62, 220;
+    --spectrum-global-color-fuchsia-500-rgb: 223, 81, 224;
     --spectrum-global-color-fuchsia-500: rgb(
         var(--spectrum-global-color-fuchsia-500-rgb)
     );
-    --spectrum-global-color-fuchsia-600-rgb: 217, 81, 229;
+    --spectrum-global-color-fuchsia-600-rgb: 235, 110, 236;
     --spectrum-global-color-fuchsia-600: rgb(
         var(--spectrum-global-color-fuchsia-600-rgb)
     );
-    --spectrum-global-color-fuchsia-700-rgb: 227, 102, 239;
+    --spectrum-global-color-fuchsia-700-rgb: 244, 140, 242;
     --spectrum-global-color-fuchsia-700: rgb(
         var(--spectrum-global-color-fuchsia-700-rgb)
     );
-    --spectrum-global-color-purple-400-rgb: 146, 86, 217;
+    --spectrum-global-color-purple-400-rgb: 157, 87, 243;
     --spectrum-global-color-purple-400: rgb(
         var(--spectrum-global-color-purple-400-rgb)
     );
-    --spectrum-global-color-purple-500-rgb: 157, 100, 225;
+    --spectrum-global-color-purple-500-rgb: 172, 111, 249;
     --spectrum-global-color-purple-500: rgb(
         var(--spectrum-global-color-purple-500-rgb)
     );
-    --spectrum-global-color-purple-600-rgb: 168, 115, 233;
+    --spectrum-global-color-purple-600-rgb: 187, 135, 251;
     --spectrum-global-color-purple-600: rgb(
         var(--spectrum-global-color-purple-600-rgb)
     );
-    --spectrum-global-color-purple-700-rgb: 180, 131, 240;
+    --spectrum-global-color-purple-700-rgb: 202, 159, 252;
     --spectrum-global-color-purple-700: rgb(
         var(--spectrum-global-color-purple-700-rgb)
     );
-    --spectrum-global-color-indigo-400-rgb: 103, 103, 236;
+    --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
     --spectrum-global-color-indigo-400: rgb(
         var(--spectrum-global-color-indigo-400-rgb)
     );
-    --spectrum-global-color-indigo-500-rgb: 117, 117, 241;
+    --spectrum-global-color-indigo-500-rgb: 124, 129, 251;
     --spectrum-global-color-indigo-500: rgb(
         var(--spectrum-global-color-indigo-500-rgb)
     );
-    --spectrum-global-color-indigo-600-rgb: 130, 130, 246;
+    --spectrum-global-color-indigo-600-rgb: 145, 149, 255;
     --spectrum-global-color-indigo-600: rgb(
         var(--spectrum-global-color-indigo-600-rgb)
     );
-    --spectrum-global-color-indigo-700-rgb: 144, 144, 250;
+    --spectrum-global-color-indigo-700-rgb: 167, 170, 255;
     --spectrum-global-color-indigo-700: rgb(
         var(--spectrum-global-color-indigo-700-rgb)
     );
-    --spectrum-global-color-seafoam-400-rgb: 27, 149, 154;
+    --spectrum-global-color-seafoam-400-rgb: 0, 158, 152;
     --spectrum-global-color-seafoam-400: rgb(
         var(--spectrum-global-color-seafoam-400-rgb)
     );
-    --spectrum-global-color-seafoam-500-rgb: 32, 163, 168;
+    --spectrum-global-color-seafoam-500-rgb: 3, 178, 171;
     --spectrum-global-color-seafoam-500: rgb(
         var(--spectrum-global-color-seafoam-500-rgb)
     );
-    --spectrum-global-color-seafoam-600-rgb: 35, 178, 184;
+    --spectrum-global-color-seafoam-600-rgb: 54, 197, 189;
     --spectrum-global-color-seafoam-600: rgb(
         var(--spectrum-global-color-seafoam-600-rgb)
     );
-    --spectrum-global-color-seafoam-700-rgb: 38, 192, 199;
+    --spectrum-global-color-seafoam-700-rgb: 93, 214, 207;
     --spectrum-global-color-seafoam-700: rgb(
         var(--spectrum-global-color-seafoam-700-rgb)
     );
-    --spectrum-global-color-red-400-rgb: 227, 72, 80;
+    --spectrum-global-color-red-400-rgb: 234, 56, 41;
     --spectrum-global-color-red-400: rgb(
         var(--spectrum-global-color-red-400-rgb)
     );
-    --spectrum-global-color-red-500-rgb: 236, 91, 98;
+    --spectrum-global-color-red-500-rgb: 246, 88, 67;
     --spectrum-global-color-red-500: rgb(
         var(--spectrum-global-color-red-500-rgb)
     );
-    --spectrum-global-color-red-600-rgb: 247, 109, 116;
+    --spectrum-global-color-red-600-rgb: 255, 117, 94;
     --spectrum-global-color-red-600: rgb(
         var(--spectrum-global-color-red-600-rgb)
     );
-    --spectrum-global-color-red-700-rgb: 255, 123, 130;
+    --spectrum-global-color-red-700-rgb: 255, 149, 129;
     --spectrum-global-color-red-700: rgb(
         var(--spectrum-global-color-red-700-rgb)
     );
-    --spectrum-global-color-orange-400-rgb: 230, 134, 25;
+    --spectrum-global-color-orange-400-rgb: 244, 129, 12;
     --spectrum-global-color-orange-400: rgb(
         var(--spectrum-global-color-orange-400-rgb)
     );
-    --spectrum-global-color-orange-500-rgb: 242, 148, 35;
+    --spectrum-global-color-orange-500-rgb: 254, 154, 46;
     --spectrum-global-color-orange-500: rgb(
         var(--spectrum-global-color-orange-500-rgb)
     );
-    --spectrum-global-color-orange-600-rgb: 249, 164, 63;
+    --spectrum-global-color-orange-600-rgb: 255, 181, 88;
     --spectrum-global-color-orange-600: rgb(
         var(--spectrum-global-color-orange-600-rgb)
     );
-    --spectrum-global-color-orange-700-rgb: 255, 181, 91;
+    --spectrum-global-color-orange-700-rgb: 253, 206, 136;
     --spectrum-global-color-orange-700: rgb(
         var(--spectrum-global-color-orange-700-rgb)
     );
-    --spectrum-global-color-green-400-rgb: 45, 157, 120;
+    --spectrum-global-color-green-400-rgb: 18, 162, 108;
     --spectrum-global-color-green-400: rgb(
         var(--spectrum-global-color-green-400-rgb)
     );
-    --spectrum-global-color-green-500-rgb: 51, 171, 132;
+    --spectrum-global-color-green-500-rgb: 43, 180, 125;
     --spectrum-global-color-green-500: rgb(
         var(--spectrum-global-color-green-500-rgb)
     );
-    --spectrum-global-color-green-600-rgb: 57, 185, 144;
+    --spectrum-global-color-green-600-rgb: 67, 199, 143;
     --spectrum-global-color-green-600: rgb(
         var(--spectrum-global-color-green-600-rgb)
     );
-    --spectrum-global-color-green-700-rgb: 63, 200, 156;
+    --spectrum-global-color-green-700-rgb: 94, 217, 162;
     --spectrum-global-color-green-700: rgb(
         var(--spectrum-global-color-green-700-rgb)
     );
-    --spectrum-global-color-blue-400-rgb: 38, 128, 235;
+    --spectrum-global-color-blue-400-rgb: 52, 143, 244;
     --spectrum-global-color-blue-400: rgb(
         var(--spectrum-global-color-blue-400-rgb)
     );
-    --spectrum-global-color-blue-500-rgb: 55, 142, 240;
+    --spectrum-global-color-blue-500-rgb: 84, 163, 246;
     --spectrum-global-color-blue-500: rgb(
         var(--spectrum-global-color-blue-500-rgb)
     );
-    --spectrum-global-color-blue-600-rgb: 75, 156, 245;
+    --spectrum-global-color-blue-600-rgb: 114, 183, 249;
     --spectrum-global-color-blue-600: rgb(
         var(--spectrum-global-color-blue-600-rgb)
     );
-    --spectrum-global-color-blue-700-rgb: 90, 169, 250;
+    --spectrum-global-color-blue-700-rgb: 143, 202, 252;
     --spectrum-global-color-blue-700: rgb(
         var(--spectrum-global-color-blue-700-rgb)
     );
-    --spectrum-global-color-gray-50-rgb: 37, 37, 37;
+    --spectrum-global-color-gray-50-rgb: 29, 29, 29;
     --spectrum-global-color-gray-50: rgb(
         var(--spectrum-global-color-gray-50-rgb)
     );
-    --spectrum-global-color-gray-75-rgb: 47, 47, 47;
+    --spectrum-global-color-gray-75-rgb: 38, 38, 38;
     --spectrum-global-color-gray-75: rgb(
         var(--spectrum-global-color-gray-75-rgb)
     );
@@ -238,31 +238,31 @@ governing permissions and limitations under the License.
     --spectrum-global-color-gray-100: rgb(
         var(--spectrum-global-color-gray-100-rgb)
     );
-    --spectrum-global-color-gray-200-rgb: 62, 62, 62;
+    --spectrum-global-color-gray-200-rgb: 63, 63, 63;
     --spectrum-global-color-gray-200: rgb(
         var(--spectrum-global-color-gray-200-rgb)
     );
-    --spectrum-global-color-gray-300-rgb: 74, 74, 74;
+    --spectrum-global-color-gray-300-rgb: 84, 84, 84;
     --spectrum-global-color-gray-300: rgb(
         var(--spectrum-global-color-gray-300-rgb)
     );
-    --spectrum-global-color-gray-400-rgb: 90, 90, 90;
+    --spectrum-global-color-gray-400-rgb: 112, 112, 112;
     --spectrum-global-color-gray-400: rgb(
         var(--spectrum-global-color-gray-400-rgb)
     );
-    --spectrum-global-color-gray-500-rgb: 110, 110, 110;
+    --spectrum-global-color-gray-500-rgb: 144, 144, 144;
     --spectrum-global-color-gray-500: rgb(
         var(--spectrum-global-color-gray-500-rgb)
     );
-    --spectrum-global-color-gray-600-rgb: 144, 144, 144;
+    --spectrum-global-color-gray-600-rgb: 178, 178, 178;
     --spectrum-global-color-gray-600: rgb(
         var(--spectrum-global-color-gray-600-rgb)
     );
-    --spectrum-global-color-gray-700-rgb: 185, 185, 185;
+    --spectrum-global-color-gray-700-rgb: 209, 209, 209;
     --spectrum-global-color-gray-700: rgb(
         var(--spectrum-global-color-gray-700-rgb)
     );
-    --spectrum-global-color-gray-800-rgb: 227, 227, 227;
+    --spectrum-global-color-gray-800-rgb: 235, 235, 235;
     --spectrum-global-color-gray-800: rgb(
         var(--spectrum-global-color-gray-800-rgb)
     );
@@ -284,15 +284,15 @@ governing permissions and limitations under the License.
     --spectrum-alias-background-color-hover-overlay: hsla(0, 0%, 100%, 0.06);
     --spectrum-alias-highlight-hover: hsla(0, 0%, 100%, 0.07);
     --spectrum-alias-highlight-down: hsla(0, 0%, 100%, 0.1);
-    --spectrum-alias-highlight-selected: rgba(55, 142, 240, 0.15);
-    --spectrum-alias-highlight-selected-hover: rgba(55, 142, 240, 0.25);
-    --spectrum-alias-text-highlight-color: rgba(55, 142, 240, 0.25);
+    --spectrum-alias-highlight-selected: rgba(84, 163, 246, 0.15);
+    --spectrum-alias-highlight-selected-hover: rgba(84, 163, 246, 0.25);
+    --spectrum-alias-text-highlight-color: rgba(84, 163, 246, 0.25);
     --spectrum-alias-background-color-quickactions: rgba(50, 50, 50, 0.9);
     --spectrum-alias-border-color-selected: var(
         --spectrum-global-color-blue-600
     );
     --spectrum-alias-border-color-translucent: hsla(0, 0%, 100%, 0.1);
-    --spectrum-alias-radial-reaction-color-default: hsla(0, 0%, 89%, 0.6);
+    --spectrum-alias-radial-reaction-color-default: hsla(0, 0%, 92%, 0.6);
     --spectrum-alias-pasteboard-background-color: var(
         --spectrum-global-color-gray-50
     );
@@ -314,156 +314,156 @@ governing permissions and limitations under the License.
     --spectrum-slider-s-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-s-range-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-s-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-s-ramp-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-s-range-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-s-editable-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
+    --spectrum-slider-s-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-s-ramp-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-s-range-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-s-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-s-ramp-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-s-range-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
+    --spectrum-slider-s-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-m-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-m-range-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-m-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-m-ramp-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-m-range-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-m-editable-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
+    --spectrum-slider-m-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-m-ramp-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-m-range-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-m-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-m-ramp-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-m-range-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
+    --spectrum-slider-m-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-l-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-l-range-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-l-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-l-ramp-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-l-range-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-l-editable-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
+    --spectrum-slider-l-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-l-ramp-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-l-range-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-l-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-l-ramp-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-l-range-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
+    --spectrum-slider-l-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-xl-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-xl-range-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-xl-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-xl-ramp-tick-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
+    --spectrum-slider-xl-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-xl-range-tick-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-xl-editable-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
+    --spectrum-slider-xl-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-xl-ramp-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
     --spectrum-slider-xl-range-editable-radial-reaction-color: hsla(
         0,
         0%,
-        89%,
+        92%,
         0.6
     );
-    --spectrum-slider-xl-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-xl-ramp-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-slider-xl-range-radial-reaction-color: hsla(0, 0%, 89%, 0.6);
-    --spectrum-well-background-color: hsla(0, 0%, 89%, 0.02);
+    --spectrum-slider-xl-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-well-background-color: hsla(0, 0%, 92%, 0.02);
     --spectrum-well-border-color: hsla(0, 0%, 100%, 0.05);
 }

--- a/packages/styles/theme-darkest.css
+++ b/packages/styles/theme-darkest.css
@@ -34,239 +34,239 @@ governing permissions and limitations under the License.
     --spectrum-global-color-opacity-5: 0.05;
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
-    --spectrum-global-color-celery-400-rgb: 61, 167, 78;
+    --spectrum-global-color-celery-400-rgb: 13, 171, 37;
     --spectrum-global-color-celery-400: rgb(
         var(--spectrum-global-color-celery-400-rgb)
     );
-    --spectrum-global-color-celery-500-rgb: 68, 181, 86;
+    --spectrum-global-color-celery-500-rgb: 45, 191, 58;
     --spectrum-global-color-celery-500: rgb(
         var(--spectrum-global-color-celery-500-rgb)
     );
-    --spectrum-global-color-celery-600-rgb: 75, 195, 95;
+    --spectrum-global-color-celery-600-rgb: 80, 208, 82;
     --spectrum-global-color-celery-600: rgb(
         var(--spectrum-global-color-celery-600-rgb)
     );
-    --spectrum-global-color-celery-700-rgb: 81, 210, 103;
+    --spectrum-global-color-celery-700-rgb: 115, 224, 107;
     --spectrum-global-color-celery-700: rgb(
         var(--spectrum-global-color-celery-700-rgb)
     );
-    --spectrum-global-color-chartreuse-400-rgb: 124, 195, 63;
+    --spectrum-global-color-chartreuse-400-rgb: 138, 180, 3;
     --spectrum-global-color-chartreuse-400: rgb(
         var(--spectrum-global-color-chartreuse-400-rgb)
     );
-    --spectrum-global-color-chartreuse-500-rgb: 133, 208, 68;
+    --spectrum-global-color-chartreuse-500-rgb: 154, 198, 11;
     --spectrum-global-color-chartreuse-500: rgb(
         var(--spectrum-global-color-chartreuse-500-rgb)
     );
-    --spectrum-global-color-chartreuse-600-rgb: 142, 222, 73;
+    --spectrum-global-color-chartreuse-600-rgb: 170, 216, 22;
     --spectrum-global-color-chartreuse-600: rgb(
         var(--spectrum-global-color-chartreuse-600-rgb)
     );
-    --spectrum-global-color-chartreuse-700-rgb: 155, 236, 84;
+    --spectrum-global-color-chartreuse-700-rgb: 187, 232, 41;
     --spectrum-global-color-chartreuse-700: rgb(
         var(--spectrum-global-color-chartreuse-700-rgb)
     );
-    --spectrum-global-color-yellow-400-rgb: 210, 178, 0;
+    --spectrum-global-color-yellow-400-rgb: 216, 181, 0;
     --spectrum-global-color-yellow-400: rgb(
         var(--spectrum-global-color-yellow-400-rgb)
     );
-    --spectrum-global-color-yellow-500-rgb: 223, 191, 0;
+    --spectrum-global-color-yellow-500-rgb: 233, 199, 0;
     --spectrum-global-color-yellow-500: rgb(
         var(--spectrum-global-color-yellow-500-rgb)
     );
-    --spectrum-global-color-yellow-600-rgb: 237, 204, 0;
+    --spectrum-global-color-yellow-600-rgb: 247, 216, 4;
     --spectrum-global-color-yellow-600: rgb(
         var(--spectrum-global-color-yellow-600-rgb)
     );
-    --spectrum-global-color-yellow-700-rgb: 250, 217, 0;
+    --spectrum-global-color-yellow-700-rgb: 249, 233, 97;
     --spectrum-global-color-yellow-700: rgb(
         var(--spectrum-global-color-yellow-700-rgb)
     );
-    --spectrum-global-color-magenta-400-rgb: 202, 41, 150;
+    --spectrum-global-color-magenta-400-rgb: 209, 43, 114;
     --spectrum-global-color-magenta-400: rgb(
         var(--spectrum-global-color-magenta-400-rgb)
     );
-    --spectrum-global-color-magenta-500-rgb: 216, 55, 144;
+    --spectrum-global-color-magenta-500-rgb: 227, 69, 137;
     --spectrum-global-color-magenta-500: rgb(
         var(--spectrum-global-color-magenta-500-rgb)
     );
-    --spectrum-global-color-magenta-600-rgb: 226, 73, 157;
+    --spectrum-global-color-magenta-600-rgb: 241, 97, 156;
     --spectrum-global-color-magenta-600: rgb(
         var(--spectrum-global-color-magenta-600-rgb)
     );
-    --spectrum-global-color-magenta-700-rgb: 236, 90, 170;
+    --spectrum-global-color-magenta-700-rgb: 252, 124, 173;
     --spectrum-global-color-magenta-700: rgb(
         var(--spectrum-global-color-magenta-700-rgb)
     );
-    --spectrum-global-color-fuchsia-400-rgb: 177, 48, 189;
+    --spectrum-global-color-fuchsia-400-rgb: 191, 43, 191;
     --spectrum-global-color-fuchsia-400: rgb(
         var(--spectrum-global-color-fuchsia-400-rgb)
     );
-    --spectrum-global-color-fuchsia-500-rgb: 192, 56, 204;
+    --spectrum-global-color-fuchsia-500-rgb: 211, 65, 213;
     --spectrum-global-color-fuchsia-500: rgb(
         var(--spectrum-global-color-fuchsia-500-rgb)
     );
-    --spectrum-global-color-fuchsia-600-rgb: 207, 62, 220;
+    --spectrum-global-color-fuchsia-600-rgb: 228, 91, 229;
     --spectrum-global-color-fuchsia-600: rgb(
         var(--spectrum-global-color-fuchsia-600-rgb)
     );
-    --spectrum-global-color-fuchsia-700-rgb: 217, 81, 229;
+    --spectrum-global-color-fuchsia-700-rgb: 239, 120, 238;
     --spectrum-global-color-fuchsia-700: rgb(
         var(--spectrum-global-color-fuchsia-700-rgb)
     );
-    --spectrum-global-color-purple-400-rgb: 134, 76, 204;
+    --spectrum-global-color-purple-400-rgb: 145, 70, 236;
     --spectrum-global-color-purple-400: rgb(
         var(--spectrum-global-color-purple-400-rgb)
     );
-    --spectrum-global-color-purple-500-rgb: 146, 86, 217;
+    --spectrum-global-color-purple-500-rgb: 162, 94, 246;
     --spectrum-global-color-purple-500: rgb(
         var(--spectrum-global-color-purple-500-rgb)
     );
-    --spectrum-global-color-purple-600-rgb: 157, 100, 225;
+    --spectrum-global-color-purple-600-rgb: 178, 119, 250;
     --spectrum-global-color-purple-600: rgb(
         var(--spectrum-global-color-purple-600-rgb)
     );
-    --spectrum-global-color-purple-700-rgb: 168, 115, 223;
+    --spectrum-global-color-purple-700-rgb: 192, 143, 252;
     --spectrum-global-color-purple-700: rgb(
         var(--spectrum-global-color-purple-700-rgb)
     );
-    --spectrum-global-color-indigo-400-rgb: 92, 92, 224;
+    --spectrum-global-color-indigo-400-rgb: 90, 96, 235;
     --spectrum-global-color-indigo-400: rgb(
         var(--spectrum-global-color-indigo-400-rgb)
     );
-    --spectrum-global-color-indigo-500-rgb: 103, 103, 236;
+    --spectrum-global-color-indigo-500-rgb: 110, 115, 246;
     --spectrum-global-color-indigo-500: rgb(
         var(--spectrum-global-color-indigo-500-rgb)
     );
-    --spectrum-global-color-indigo-600-rgb: 117, 117, 241;
+    --spectrum-global-color-indigo-600-rgb: 132, 136, 253;
     --spectrum-global-color-indigo-600: rgb(
         var(--spectrum-global-color-indigo-600-rgb)
     );
-    --spectrum-global-color-indigo-700-rgb: 130, 130, 246;
+    --spectrum-global-color-indigo-700-rgb: 153, 157, 255;
     --spectrum-global-color-indigo-700: rgb(
         var(--spectrum-global-color-indigo-700-rgb)
     );
-    --spectrum-global-color-seafoam-400-rgb: 22, 135, 140;
+    --spectrum-global-color-seafoam-400-rgb: 0, 146, 140;
     --spectrum-global-color-seafoam-400: rgb(
         var(--spectrum-global-color-seafoam-400-rgb)
     );
-    --spectrum-global-color-seafoam-500-rgb: 27, 149, 154;
+    --spectrum-global-color-seafoam-500-rgb: 0, 165, 159;
     --spectrum-global-color-seafoam-500: rgb(
         var(--spectrum-global-color-seafoam-500-rgb)
     );
-    --spectrum-global-color-seafoam-600-rgb: 32, 163, 168;
+    --spectrum-global-color-seafoam-600-rgb: 26, 185, 178;
     --spectrum-global-color-seafoam-600: rgb(
         var(--spectrum-global-color-seafoam-600-rgb)
     );
-    --spectrum-global-color-seafoam-700-rgb: 35, 178, 184;
+    --spectrum-global-color-seafoam-700-rgb: 66, 202, 195;
     --spectrum-global-color-seafoam-700: rgb(
         var(--spectrum-global-color-seafoam-700-rgb)
     );
-    --spectrum-global-color-red-400-rgb: 215, 55, 63;
+    --spectrum-global-color-red-400-rgb: 221, 33, 24;
     --spectrum-global-color-red-400: rgb(
         var(--spectrum-global-color-red-400-rgb)
     );
-    --spectrum-global-color-red-500-rgb: 227, 72, 80;
+    --spectrum-global-color-red-500-rgb: 238, 67, 49;
     --spectrum-global-color-red-500: rgb(
         var(--spectrum-global-color-red-500-rgb)
     );
-    --spectrum-global-color-red-600-rgb: 236, 91, 98;
+    --spectrum-global-color-red-600-rgb: 249, 99, 76;
     --spectrum-global-color-red-600: rgb(
         var(--spectrum-global-color-red-600-rgb)
     );
-    --spectrum-global-color-red-700-rgb: 247, 109, 116;
+    --spectrum-global-color-red-700-rgb: 255, 129, 107;
     --spectrum-global-color-red-700: rgb(
         var(--spectrum-global-color-red-700-rgb)
     );
-    --spectrum-global-color-orange-400-rgb: 218, 123, 17;
+    --spectrum-global-color-orange-400-rgb: 232, 116, 0;
     --spectrum-global-color-orange-400: rgb(
         var(--spectrum-global-color-orange-400-rgb)
     );
-    --spectrum-global-color-orange-500-rgb: 230, 134, 25;
+    --spectrum-global-color-orange-500-rgb: 249, 137, 23;
     --spectrum-global-color-orange-500: rgb(
         var(--spectrum-global-color-orange-500-rgb)
     );
-    --spectrum-global-color-orange-600-rgb: 242, 148, 35;
+    --spectrum-global-color-orange-600-rgb: 255, 162, 59;
     --spectrum-global-color-orange-600: rgb(
         var(--spectrum-global-color-orange-600-rgb)
     );
-    --spectrum-global-color-orange-700-rgb: 249, 164, 63;
+    --spectrum-global-color-orange-700-rgb: 255, 188, 102;
     --spectrum-global-color-orange-700: rgb(
         var(--spectrum-global-color-orange-700-rgb)
     );
-    --spectrum-global-color-green-400-rgb: 38, 142, 108;
+    --spectrum-global-color-green-400-rgb: 0, 149, 98;
     --spectrum-global-color-green-400: rgb(
         var(--spectrum-global-color-green-400-rgb)
     );
-    --spectrum-global-color-green-500-rgb: 45, 157, 120;
+    --spectrum-global-color-green-500-rgb: 28, 168, 114;
     --spectrum-global-color-green-500: rgb(
         var(--spectrum-global-color-green-500-rgb)
     );
-    --spectrum-global-color-green-600-rgb: 51, 171, 132;
+    --spectrum-global-color-green-600-rgb: 52, 187, 132;
     --spectrum-global-color-green-600: rgb(
         var(--spectrum-global-color-green-600-rgb)
     );
-    --spectrum-global-color-green-700-rgb: 57, 185, 144;
+    --spectrum-global-color-green-700-rgb: 75, 205, 149;
     --spectrum-global-color-green-700: rgb(
         var(--spectrum-global-color-green-700-rgb)
     );
-    --spectrum-global-color-blue-400-rgb: 20, 115, 230;
+    --spectrum-global-color-blue-400-rgb: 29, 128, 245;
     --spectrum-global-color-blue-400: rgb(
         var(--spectrum-global-color-blue-400-rgb)
     );
-    --spectrum-global-color-blue-500-rgb: 38, 128, 235;
+    --spectrum-global-color-blue-500-rgb: 64, 150, 243;
     --spectrum-global-color-blue-500: rgb(
         var(--spectrum-global-color-blue-500-rgb)
     );
-    --spectrum-global-color-blue-600-rgb: 55, 142, 240;
+    --spectrum-global-color-blue-600-rgb: 94, 170, 247;
     --spectrum-global-color-blue-600: rgb(
         var(--spectrum-global-color-blue-600-rgb)
     );
-    --spectrum-global-color-blue-700-rgb: 75, 156, 245;
+    --spectrum-global-color-blue-700-rgb: 124, 189, 250;
     --spectrum-global-color-blue-700: rgb(
         var(--spectrum-global-color-blue-700-rgb)
     );
-    --spectrum-global-color-gray-50-rgb: 8, 8, 8;
+    --spectrum-global-color-gray-50-rgb: 0, 0, 0;
     --spectrum-global-color-gray-50: rgb(
         var(--spectrum-global-color-gray-50-rgb)
     );
-    --spectrum-global-color-gray-75-rgb: 26, 26, 26;
+    --spectrum-global-color-gray-75-rgb: 14, 14, 14;
     --spectrum-global-color-gray-75: rgb(
         var(--spectrum-global-color-gray-75-rgb)
     );
-    --spectrum-global-color-gray-100-rgb: 30, 30, 30;
+    --spectrum-global-color-gray-100-rgb: 29, 29, 29;
     --spectrum-global-color-gray-100: rgb(
         var(--spectrum-global-color-gray-100-rgb)
     );
-    --spectrum-global-color-gray-200-rgb: 44, 44, 44;
+    --spectrum-global-color-gray-200-rgb: 48, 48, 48;
     --spectrum-global-color-gray-200: rgb(
         var(--spectrum-global-color-gray-200-rgb)
     );
-    --spectrum-global-color-gray-300-rgb: 57, 57, 57;
+    --spectrum-global-color-gray-300-rgb: 75, 75, 75;
     --spectrum-global-color-gray-300: rgb(
         var(--spectrum-global-color-gray-300-rgb)
     );
-    --spectrum-global-color-gray-400-rgb: 73, 73, 73;
+    --spectrum-global-color-gray-400-rgb: 106, 106, 106;
     --spectrum-global-color-gray-400: rgb(
         var(--spectrum-global-color-gray-400-rgb)
     );
-    --spectrum-global-color-gray-500-rgb: 92, 92, 92;
+    --spectrum-global-color-gray-500-rgb: 141, 141, 141;
     --spectrum-global-color-gray-500: rgb(
         var(--spectrum-global-color-gray-500-rgb)
     );
-    --spectrum-global-color-gray-600-rgb: 124, 124, 124;
+    --spectrum-global-color-gray-600-rgb: 176, 176, 176;
     --spectrum-global-color-gray-600: rgb(
         var(--spectrum-global-color-gray-600-rgb)
     );
-    --spectrum-global-color-gray-700-rgb: 162, 162, 162;
+    --spectrum-global-color-gray-700-rgb: 208, 208, 208;
     --spectrum-global-color-gray-700: rgb(
         var(--spectrum-global-color-gray-700-rgb)
     );
-    --spectrum-global-color-gray-800-rgb: 200, 200, 200;
+    --spectrum-global-color-gray-800-rgb: 235, 235, 235;
     --spectrum-global-color-gray-800: rgb(
         var(--spectrum-global-color-gray-800-rgb)
     );
-    --spectrum-global-color-gray-900-rgb: 239, 239, 239;
+    --spectrum-global-color-gray-900-rgb: 255, 255, 255;
     --spectrum-global-color-gray-900: rgb(
         var(--spectrum-global-color-gray-900-rgb)
     );
@@ -281,18 +281,18 @@ governing permissions and limitations under the License.
     );
     --spectrum-alias-background-color-modal-overlay: rgba(0, 0, 0, 0.6);
     --spectrum-alias-dropshadow-color: rgba(0, 0, 0, 0.8);
-    --spectrum-alias-background-color-hover-overlay: hsla(0, 0%, 94%, 0.08);
-    --spectrum-alias-highlight-hover: hsla(0, 0%, 94%, 0.08);
-    --spectrum-alias-highlight-down: hsla(0, 0%, 94%, 0.15);
-    --spectrum-alias-highlight-selected: rgba(38, 128, 235, 0.2);
-    --spectrum-alias-highlight-selected-hover: rgba(38, 128, 235, 0.3);
-    --spectrum-alias-text-highlight-color: rgba(38, 128, 235, 0.3);
-    --spectrum-alias-background-color-quickactions: rgba(30, 30, 30, 0.9);
+    --spectrum-alias-background-color-hover-overlay: hsla(0, 0%, 100%, 0.08);
+    --spectrum-alias-highlight-hover: hsla(0, 0%, 100%, 0.08);
+    --spectrum-alias-highlight-down: hsla(0, 0%, 100%, 0.15);
+    --spectrum-alias-highlight-selected: rgba(64, 150, 243, 0.2);
+    --spectrum-alias-highlight-selected-hover: rgba(64, 150, 243, 0.3);
+    --spectrum-alias-text-highlight-color: rgba(64, 150, 243, 0.3);
+    --spectrum-alias-background-color-quickactions: rgba(29, 29, 29, 0.9);
     --spectrum-alias-border-color-selected: var(
         --spectrum-global-color-blue-600
     );
-    --spectrum-alias-border-color-translucent: hsla(0, 0%, 94%, 0.1);
-    --spectrum-alias-radial-reaction-color-default: hsla(0, 0%, 78%, 0.6);
+    --spectrum-alias-border-color-translucent: hsla(0, 0%, 100%, 0.1);
+    --spectrum-alias-radial-reaction-color-default: hsla(0, 0%, 92%, 0.6);
     --spectrum-alias-pasteboard-background-color: var(
         --spectrum-global-color-gray-50
     );
@@ -314,156 +314,155 @@ governing permissions and limitations under the License.
     --spectrum-slider-s-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-s-range-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-s-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-s-ramp-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-s-range-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-s-editable-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
+    --spectrum-slider-s-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-s-ramp-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-s-range-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-s-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-s-ramp-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-s-range-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
+    --spectrum-slider-s-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-s-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-m-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-m-range-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-m-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-m-ramp-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-m-range-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-m-editable-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
+    --spectrum-slider-m-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-m-ramp-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-m-range-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-m-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-m-ramp-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-m-range-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
+    --spectrum-slider-m-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-m-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-l-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-l-range-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-l-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-l-ramp-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-l-range-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-l-editable-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
+    --spectrum-slider-l-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-range-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-l-ramp-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-l-range-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-l-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-l-ramp-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-l-range-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
+    --spectrum-slider-l-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-l-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-xl-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-xl-range-tick-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-xl-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-xl-ramp-tick-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
+    --spectrum-slider-xl-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-xl-range-tick-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-xl-editable-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
+    --spectrum-slider-xl-editable-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
     --spectrum-slider-xl-ramp-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
     --spectrum-slider-xl-range-editable-radial-reaction-color: hsla(
         0,
         0%,
-        78%,
+        92%,
         0.6
     );
-    --spectrum-slider-xl-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-xl-ramp-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-slider-xl-range-radial-reaction-color: hsla(0, 0%, 78%, 0.6);
-    --spectrum-well-background-color: hsla(0, 0%, 78%, 0.02);
-    --spectrum-well-border-color: hsla(0, 0%, 94%, 0.05);
+    --spectrum-slider-xl-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-ramp-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-slider-xl-range-radial-reaction-color: hsla(0, 0%, 92%, 0.6);
+    --spectrum-well-background-color: hsla(0, 0%, 92%, 0.02);
 }

--- a/packages/styles/theme-light.css
+++ b/packages/styles/theme-light.css
@@ -34,195 +34,195 @@ governing permissions and limitations under the License.
     --spectrum-global-color-opacity-5: 0.05;
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
-    --spectrum-global-color-celery-400-rgb: 68, 181, 86;
+    --spectrum-global-color-celery-400-rgb: 39, 187, 54;
     --spectrum-global-color-celery-400: rgb(
         var(--spectrum-global-color-celery-400-rgb)
     );
-    --spectrum-global-color-celery-500-rgb: 61, 167, 78;
+    --spectrum-global-color-celery-500-rgb: 7, 167, 33;
     --spectrum-global-color-celery-500: rgb(
         var(--spectrum-global-color-celery-500-rgb)
     );
-    --spectrum-global-color-celery-600-rgb: 55, 153, 71;
+    --spectrum-global-color-celery-600-rgb: 0, 145, 18;
     --spectrum-global-color-celery-600: rgb(
         var(--spectrum-global-color-celery-600-rgb)
     );
-    --spectrum-global-color-celery-700-rgb: 49, 139, 64;
+    --spectrum-global-color-celery-700-rgb: 0, 124, 15;
     --spectrum-global-color-celery-700: rgb(
         var(--spectrum-global-color-celery-700-rgb)
     );
-    --spectrum-global-color-chartreuse-400-rgb: 133, 208, 68;
+    --spectrum-global-color-chartreuse-400-rgb: 152, 197, 10;
     --spectrum-global-color-chartreuse-400: rgb(
         var(--spectrum-global-color-chartreuse-400-rgb)
     );
-    --spectrum-global-color-chartreuse-500-rgb: 124, 195, 63;
+    --spectrum-global-color-chartreuse-500-rgb: 135, 177, 3;
     --spectrum-global-color-chartreuse-500: rgb(
         var(--spectrum-global-color-chartreuse-500-rgb)
     );
-    --spectrum-global-color-chartreuse-600-rgb: 115, 181, 58;
+    --spectrum-global-color-chartreuse-600-rgb: 118, 156, 0;
     --spectrum-global-color-chartreuse-600: rgb(
         var(--spectrum-global-color-chartreuse-600-rgb)
     );
-    --spectrum-global-color-chartreuse-700-rgb: 106, 168, 52;
+    --spectrum-global-color-chartreuse-700-rgb: 103, 136, 0;
     --spectrum-global-color-chartreuse-700: rgb(
         var(--spectrum-global-color-chartreuse-700-rgb)
     );
-    --spectrum-global-color-yellow-400-rgb: 223, 191, 0;
+    --spectrum-global-color-yellow-400-rgb: 232, 198, 0;
     --spectrum-global-color-yellow-400: rgb(
         var(--spectrum-global-color-yellow-400-rgb)
     );
-    --spectrum-global-color-yellow-500-rgb: 210, 178, 0;
+    --spectrum-global-color-yellow-500-rgb: 215, 179, 0;
     --spectrum-global-color-yellow-500: rgb(
         var(--spectrum-global-color-yellow-500-rgb)
     );
-    --spectrum-global-color-yellow-600-rgb: 196, 166, 0;
+    --spectrum-global-color-yellow-600-rgb: 196, 159, 0;
     --spectrum-global-color-yellow-600: rgb(
         var(--spectrum-global-color-yellow-600-rgb)
     );
-    --spectrum-global-color-yellow-700-rgb: 183, 153, 0;
+    --spectrum-global-color-yellow-700-rgb: 176, 140, 0;
     --spectrum-global-color-yellow-700: rgb(
         var(--spectrum-global-color-yellow-700-rgb)
     );
-    --spectrum-global-color-magenta-400-rgb: 216, 55, 144;
+    --spectrum-global-color-magenta-400-rgb: 222, 61, 130;
     --spectrum-global-color-magenta-400: rgb(
         var(--spectrum-global-color-magenta-400-rgb)
     );
-    --spectrum-global-color-magenta-500-rgb: 206, 39, 131;
+    --spectrum-global-color-magenta-500-rgb: 200, 34, 105;
     --spectrum-global-color-magenta-500: rgb(
         var(--spectrum-global-color-magenta-500-rgb)
     );
-    --spectrum-global-color-magenta-600-rgb: 188, 28, 116;
+    --spectrum-global-color-magenta-600-rgb: 173, 9, 85;
     --spectrum-global-color-magenta-600: rgb(
         var(--spectrum-global-color-magenta-600-rgb)
     );
-    --spectrum-global-color-magenta-700-rgb: 174, 14, 102;
+    --spectrum-global-color-magenta-700-rgb: 142, 0, 69;
     --spectrum-global-color-magenta-700: rgb(
         var(--spectrum-global-color-magenta-700-rgb)
     );
-    --spectrum-global-color-fuchsia-400-rgb: 192, 56, 204;
+    --spectrum-global-color-fuchsia-400-rgb: 205, 58, 206;
     --spectrum-global-color-fuchsia-400: rgb(
         var(--spectrum-global-color-fuchsia-400-rgb)
     );
-    --spectrum-global-color-fuchsia-500-rgb: 177, 48, 189;
+    --spectrum-global-color-fuchsia-500-rgb: 182, 34, 183;
     --spectrum-global-color-fuchsia-500: rgb(
         var(--spectrum-global-color-fuchsia-500-rgb)
     );
-    --spectrum-global-color-fuchsia-600-rgb: 162, 40, 173;
+    --spectrum-global-color-fuchsia-600-rgb: 157, 3, 158;
     --spectrum-global-color-fuchsia-600: rgb(
         var(--spectrum-global-color-fuchsia-600-rgb)
     );
-    --spectrum-global-color-fuchsia-700-rgb: 147, 33, 158;
+    --spectrum-global-color-fuchsia-700-rgb: 128, 0, 129;
     --spectrum-global-color-fuchsia-700: rgb(
         var(--spectrum-global-color-fuchsia-700-rgb)
     );
-    --spectrum-global-color-purple-400-rgb: 146, 86, 217;
+    --spectrum-global-color-purple-400-rgb: 157, 87, 244;
     --spectrum-global-color-purple-400: rgb(
         var(--spectrum-global-color-purple-400-rgb)
     );
-    --spectrum-global-color-purple-500-rgb: 134, 76, 204;
+    --spectrum-global-color-purple-500-rgb: 137, 61, 231;
     --spectrum-global-color-purple-500: rgb(
         var(--spectrum-global-color-purple-500-rgb)
     );
-    --spectrum-global-color-purple-600-rgb: 122, 66, 191;
+    --spectrum-global-color-purple-600-rgb: 115, 38, 211;
     --spectrum-global-color-purple-600: rgb(
         var(--spectrum-global-color-purple-600-rgb)
     );
-    --spectrum-global-color-purple-700-rgb: 111, 56, 177;
+    --spectrum-global-color-purple-700-rgb: 93, 19, 183;
     --spectrum-global-color-purple-700: rgb(
         var(--spectrum-global-color-purple-700-rgb)
     );
-    --spectrum-global-color-indigo-400-rgb: 103, 103, 236;
+    --spectrum-global-color-indigo-400-rgb: 104, 109, 244;
     --spectrum-global-color-indigo-400: rgb(
         var(--spectrum-global-color-indigo-400-rgb)
     );
-    --spectrum-global-color-indigo-500-rgb: 92, 92, 224;
+    --spectrum-global-color-indigo-500-rgb: 82, 88, 228;
     --spectrum-global-color-indigo-500: rgb(
         var(--spectrum-global-color-indigo-500-rgb)
     );
-    --spectrum-global-color-indigo-600-rgb: 81, 81, 211;
+    --spectrum-global-color-indigo-600-rgb: 64, 70, 202;
     --spectrum-global-color-indigo-600: rgb(
         var(--spectrum-global-color-indigo-600-rgb)
     );
-    --spectrum-global-color-indigo-700-rgb: 70, 70, 198;
+    --spectrum-global-color-indigo-700-rgb: 50, 54, 168;
     --spectrum-global-color-indigo-700: rgb(
         var(--spectrum-global-color-indigo-700-rgb)
     );
-    --spectrum-global-color-seafoam-400-rgb: 27, 149, 154;
+    --spectrum-global-color-seafoam-400-rgb: 0, 161, 154;
     --spectrum-global-color-seafoam-400: rgb(
         var(--spectrum-global-color-seafoam-400-rgb)
     );
-    --spectrum-global-color-seafoam-500-rgb: 22, 135, 140;
+    --spectrum-global-color-seafoam-500-rgb: 0, 140, 135;
     --spectrum-global-color-seafoam-500: rgb(
         var(--spectrum-global-color-seafoam-500-rgb)
     );
-    --spectrum-global-color-seafoam-600-rgb: 15, 121, 125;
+    --spectrum-global-color-seafoam-600-rgb: 0, 119, 114;
     --spectrum-global-color-seafoam-600: rgb(
         var(--spectrum-global-color-seafoam-600-rgb)
     );
-    --spectrum-global-color-seafoam-700-rgb: 9, 108, 111;
+    --spectrum-global-color-seafoam-700-rgb: 0, 99, 95;
     --spectrum-global-color-seafoam-700: rgb(
         var(--spectrum-global-color-seafoam-700-rgb)
     );
-    --spectrum-global-color-red-400-rgb: 227, 72, 80;
+    --spectrum-global-color-red-400-rgb: 234, 56, 41;
     --spectrum-global-color-red-400: rgb(
         var(--spectrum-global-color-red-400-rgb)
     );
-    --spectrum-global-color-red-500-rgb: 215, 55, 63;
+    --spectrum-global-color-red-500-rgb: 211, 21, 16;
     --spectrum-global-color-red-500: rgb(
         var(--spectrum-global-color-red-500-rgb)
     );
-    --spectrum-global-color-red-600-rgb: 201, 37, 45;
+    --spectrum-global-color-red-600-rgb: 180, 0, 0;
     --spectrum-global-color-red-600: rgb(
         var(--spectrum-global-color-red-600-rgb)
     );
-    --spectrum-global-color-red-700-rgb: 187, 18, 26;
+    --spectrum-global-color-red-700-rgb: 147, 0, 0;
     --spectrum-global-color-red-700: rgb(
         var(--spectrum-global-color-red-700-rgb)
     );
-    --spectrum-global-color-orange-400-rgb: 230, 134, 25;
+    --spectrum-global-color-orange-400-rgb: 246, 133, 17;
     --spectrum-global-color-orange-400: rgb(
         var(--spectrum-global-color-orange-400-rgb)
     );
-    --spectrum-global-color-orange-500-rgb: 218, 123, 17;
+    --spectrum-global-color-orange-500-rgb: 228, 111, 0;
     --spectrum-global-color-orange-500: rgb(
         var(--spectrum-global-color-orange-500-rgb)
     );
-    --spectrum-global-color-orange-600-rgb: 203, 111, 16;
+    --spectrum-global-color-orange-600-rgb: 203, 93, 0;
     --spectrum-global-color-orange-600: rgb(
         var(--spectrum-global-color-orange-600-rgb)
     );
-    --spectrum-global-color-orange-700-rgb: 189, 100, 13;
+    --spectrum-global-color-orange-700-rgb: 177, 76, 0;
     --spectrum-global-color-orange-700: rgb(
         var(--spectrum-global-color-orange-700-rgb)
     );
-    --spectrum-global-color-green-400-rgb: 45, 157, 120;
+    --spectrum-global-color-green-400-rgb: 0, 143, 93;
     --spectrum-global-color-green-400: rgb(
         var(--spectrum-global-color-green-400-rgb)
     );
-    --spectrum-global-color-green-500-rgb: 38, 142, 108;
+    --spectrum-global-color-green-500-rgb: 0, 122, 77;
     --spectrum-global-color-green-500: rgb(
         var(--spectrum-global-color-green-500-rgb)
     );
-    --spectrum-global-color-green-600-rgb: 18, 128, 92;
+    --spectrum-global-color-green-600-rgb: 0, 101, 62;
     --spectrum-global-color-green-600: rgb(
         var(--spectrum-global-color-green-600-rgb)
     );
-    --spectrum-global-color-green-700-rgb: 16, 113, 84;
+    --spectrum-global-color-green-700-rgb: 0, 81, 50;
     --spectrum-global-color-green-700: rgb(
         var(--spectrum-global-color-green-700-rgb)
     );
-    --spectrum-global-color-blue-400-rgb: 38, 128, 235;
+    --spectrum-global-color-blue-400-rgb: 20, 122, 243;
     --spectrum-global-color-blue-400: rgb(
         var(--spectrum-global-color-blue-400-rgb)
     );
-    --spectrum-global-color-blue-500-rgb: 20, 115, 230;
+    --spectrum-global-color-blue-500-rgb: 2, 101, 220;
     --spectrum-global-color-blue-500: rgb(
         var(--spectrum-global-color-blue-500-rgb)
     );
-    --spectrum-global-color-blue-600-rgb: 13, 102, 208;
+    --spectrum-global-color-blue-600-rgb: 0, 84, 182;
     --spectrum-global-color-blue-600: rgb(
         var(--spectrum-global-color-blue-600-rgb)
     );
-    --spectrum-global-color-blue-700-rgb: 9, 90, 186;
+    --spectrum-global-color-blue-700-rgb: 0, 68, 145;
     --spectrum-global-color-blue-700: rgb(
         var(--spectrum-global-color-blue-700-rgb)
     );
@@ -230,43 +230,43 @@ governing permissions and limitations under the License.
     --spectrum-global-color-gray-50: rgb(
         var(--spectrum-global-color-gray-50-rgb)
     );
-    --spectrum-global-color-gray-75-rgb: 250, 250, 250;
+    --spectrum-global-color-gray-75-rgb: 253, 253, 253;
     --spectrum-global-color-gray-75: rgb(
         var(--spectrum-global-color-gray-75-rgb)
     );
-    --spectrum-global-color-gray-100-rgb: 245, 245, 245;
+    --spectrum-global-color-gray-100-rgb: 248, 248, 248;
     --spectrum-global-color-gray-100: rgb(
         var(--spectrum-global-color-gray-100-rgb)
     );
-    --spectrum-global-color-gray-200-rgb: 234, 234, 234;
+    --spectrum-global-color-gray-200-rgb: 230, 230, 230;
     --spectrum-global-color-gray-200: rgb(
         var(--spectrum-global-color-gray-200-rgb)
     );
-    --spectrum-global-color-gray-300-rgb: 225, 225, 225;
+    --spectrum-global-color-gray-300-rgb: 213, 213, 213;
     --spectrum-global-color-gray-300: rgb(
         var(--spectrum-global-color-gray-300-rgb)
     );
-    --spectrum-global-color-gray-400-rgb: 202, 202, 202;
+    --spectrum-global-color-gray-400-rgb: 177, 177, 177;
     --spectrum-global-color-gray-400: rgb(
         var(--spectrum-global-color-gray-400-rgb)
     );
-    --spectrum-global-color-gray-500-rgb: 179, 179, 179;
+    --spectrum-global-color-gray-500-rgb: 144, 144, 144;
     --spectrum-global-color-gray-500: rgb(
         var(--spectrum-global-color-gray-500-rgb)
     );
-    --spectrum-global-color-gray-600-rgb: 142, 142, 142;
+    --spectrum-global-color-gray-600-rgb: 109, 109, 109;
     --spectrum-global-color-gray-600: rgb(
         var(--spectrum-global-color-gray-600-rgb)
     );
-    --spectrum-global-color-gray-700-rgb: 110, 110, 110;
+    --spectrum-global-color-gray-700-rgb: 70, 70, 70;
     --spectrum-global-color-gray-700: rgb(
         var(--spectrum-global-color-gray-700-rgb)
     );
-    --spectrum-global-color-gray-800-rgb: 75, 75, 75;
+    --spectrum-global-color-gray-800-rgb: 34, 34, 34;
     --spectrum-global-color-gray-800: rgb(
         var(--spectrum-global-color-gray-800-rgb)
     );
-    --spectrum-global-color-gray-900-rgb: 44, 44, 44;
+    --spectrum-global-color-gray-900-rgb: 0, 0, 0;
     --spectrum-global-color-gray-900: rgb(
         var(--spectrum-global-color-gray-900-rgb)
     );
@@ -281,18 +281,18 @@ governing permissions and limitations under the License.
     );
     --spectrum-alias-background-color-modal-overlay: rgba(0, 0, 0, 0.4);
     --spectrum-alias-dropshadow-color: rgba(0, 0, 0, 0.15);
-    --spectrum-alias-background-color-hover-overlay: rgba(44, 44, 44, 0.04);
-    --spectrum-alias-highlight-hover: rgba(44, 44, 44, 0.06);
-    --spectrum-alias-highlight-down: rgba(44, 44, 44, 0.1);
-    --spectrum-alias-highlight-selected: rgba(20, 115, 230, 0.1);
-    --spectrum-alias-highlight-selected-hover: rgba(20, 115, 230, 0.2);
-    --spectrum-alias-text-highlight-color: rgba(20, 115, 230, 0.2);
-    --spectrum-alias-background-color-quickactions: hsla(0, 0%, 96%, 0.9);
+    --spectrum-alias-background-color-hover-overlay: rgba(0, 0, 0, 0.04);
+    --spectrum-alias-highlight-hover: rgba(0, 0, 0, 0.06);
+    --spectrum-alias-highlight-down: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-highlight-selected: rgba(2, 101, 220, 0.1);
+    --spectrum-alias-highlight-selected-hover: rgba(2, 101, 220, 0.2);
+    --spectrum-alias-text-highlight-color: rgba(2, 101, 220, 0.2);
+    --spectrum-alias-background-color-quickactions: hsla(0, 0%, 97%, 0.9);
     --spectrum-alias-border-color-selected: var(
         --spectrum-global-color-blue-500
     );
-    --spectrum-alias-border-color-translucent: rgba(44, 44, 44, 0.1);
-    --spectrum-alias-radial-reaction-color-default: rgba(75, 75, 75, 0.6);
+    --spectrum-alias-border-color-translucent: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-radial-reaction-color-default: rgba(34, 34, 34, 0.6);
     --spectrum-alias-pasteboard-background-color: var(
         --spectrum-global-color-gray-300
     );
@@ -302,161 +302,6 @@ governing permissions and limitations under the License.
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-300
     );
-    --spectrum-slider-s-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-s-range-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-s-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-s-ramp-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-s-range-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-s-editable-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-s-ramp-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-s-range-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-s-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-s-ramp-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-s-range-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-m-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-m-range-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-m-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-m-ramp-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-m-range-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-m-editable-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-m-ramp-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-m-range-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-m-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-m-ramp-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-m-range-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-l-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-l-range-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-l-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-l-ramp-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-l-range-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-l-editable-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-l-ramp-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-l-range-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-l-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-l-ramp-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-l-range-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-xl-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-xl-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-xl-ramp-tick-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-xl-range-tick-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-xl-editable-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-xl-ramp-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-xl-range-editable-radial-reaction-color: rgba(
-        75,
-        75,
-        75,
-        0.6
-    );
-    --spectrum-slider-xl-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-xl-ramp-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-slider-xl-range-radial-reaction-color: rgba(75, 75, 75, 0.6);
-    --spectrum-well-background-color: rgba(75, 75, 75, 0.02);
-    --spectrum-well-border-color: rgba(44, 44, 44, 0.05);
     --spectrum-scrollbar-mac-s-track-background-color: var(
         --spectrum-global-color-gray-75
     );
@@ -466,4 +311,158 @@ governing permissions and limitations under the License.
     --spectrum-scrollbar-mac-l-track-background-color: var(
         --spectrum-global-color-gray-75
     );
+    --spectrum-slider-s-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-s-range-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-s-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-s-ramp-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-s-range-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-s-editable-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-s-ramp-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-s-range-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-s-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-s-ramp-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-s-range-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-m-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-m-range-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-m-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-m-ramp-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-m-range-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-m-editable-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-m-ramp-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-m-range-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-m-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-m-ramp-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-m-range-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-l-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-l-range-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-l-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-l-ramp-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-l-range-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-l-editable-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-l-ramp-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-l-range-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-l-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-l-ramp-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-l-range-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-xl-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-xl-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-xl-ramp-tick-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-xl-range-tick-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-xl-editable-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-xl-ramp-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-xl-range-editable-radial-reaction-color: rgba(
+        34,
+        34,
+        34,
+        0.6
+    );
+    --spectrum-slider-xl-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-xl-ramp-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-slider-xl-range-radial-reaction-color: rgba(34, 34, 34, 0.6);
+    --spectrum-well-background-color: rgba(34, 34, 34, 0.02);
 }

--- a/packages/styles/theme-lightest.css
+++ b/packages/styles/theme-lightest.css
@@ -34,195 +34,195 @@ governing permissions and limitations under the License.
     --spectrum-global-color-opacity-5: 0.05;
     --spectrum-global-color-opacity-4: 0.04;
     --spectrum-global-color-opacity-0: 0;
-    --spectrum-global-color-celery-400-rgb: 75, 195, 95;
+    --spectrum-global-color-celery-400-rgb: 48, 193, 61;
     --spectrum-global-color-celery-400: rgb(
         var(--spectrum-global-color-celery-400-rgb)
     );
-    --spectrum-global-color-celery-500-rgb: 68, 181, 86;
+    --spectrum-global-color-celery-500-rgb: 15, 172, 38;
     --spectrum-global-color-celery-500: rgb(
         var(--spectrum-global-color-celery-500-rgb)
     );
-    --spectrum-global-color-celery-600-rgb: 61, 167, 78;
+    --spectrum-global-color-celery-600-rgb: 0, 150, 20;
     --spectrum-global-color-celery-600: rgb(
         var(--spectrum-global-color-celery-600-rgb)
     );
-    --spectrum-global-color-celery-700-rgb: 55, 153, 71;
+    --spectrum-global-color-celery-700-rgb: 0, 128, 15;
     --spectrum-global-color-celery-700: rgb(
         var(--spectrum-global-color-celery-700-rgb)
     );
-    --spectrum-global-color-chartreuse-400-rgb: 142, 222, 73;
+    --spectrum-global-color-chartreuse-400-rgb: 157, 203, 13;
     --spectrum-global-color-chartreuse-400: rgb(
         var(--spectrum-global-color-chartreuse-400-rgb)
     );
-    --spectrum-global-color-chartreuse-500-rgb: 133, 208, 68;
+    --spectrum-global-color-chartreuse-500-rgb: 139, 182, 4;
     --spectrum-global-color-chartreuse-500: rgb(
         var(--spectrum-global-color-chartreuse-500-rgb)
     );
-    --spectrum-global-color-chartreuse-600-rgb: 124, 195, 63;
+    --spectrum-global-color-chartreuse-600-rgb: 122, 162, 0;
     --spectrum-global-color-chartreuse-600: rgb(
         var(--spectrum-global-color-chartreuse-600-rgb)
     );
-    --spectrum-global-color-chartreuse-700-rgb: 115, 181, 58;
+    --spectrum-global-color-chartreuse-700-rgb: 106, 141, 0;
     --spectrum-global-color-chartreuse-700: rgb(
         var(--spectrum-global-color-chartreuse-700-rgb)
     );
-    --spectrum-global-color-yellow-400-rgb: 237, 204, 0;
+    --spectrum-global-color-yellow-400-rgb: 238, 205, 0;
     --spectrum-global-color-yellow-400: rgb(
         var(--spectrum-global-color-yellow-400-rgb)
     );
-    --spectrum-global-color-yellow-500-rgb: 223, 191, 0;
+    --spectrum-global-color-yellow-500-rgb: 221, 185, 0;
     --spectrum-global-color-yellow-500: rgb(
         var(--spectrum-global-color-yellow-500-rgb)
     );
-    --spectrum-global-color-yellow-600-rgb: 210, 178, 0;
+    --spectrum-global-color-yellow-600-rgb: 201, 164, 0;
     --spectrum-global-color-yellow-600: rgb(
         var(--spectrum-global-color-yellow-600-rgb)
     );
-    --spectrum-global-color-yellow-700-rgb: 196, 166, 0;
+    --spectrum-global-color-yellow-700-rgb: 181, 144, 0;
     --spectrum-global-color-yellow-700: rgb(
         var(--spectrum-global-color-yellow-700-rgb)
     );
-    --spectrum-global-color-magenta-400-rgb: 226, 73, 157;
+    --spectrum-global-color-magenta-400-rgb: 226, 68, 135;
     --spectrum-global-color-magenta-400: rgb(
         var(--spectrum-global-color-magenta-400-rgb)
     );
-    --spectrum-global-color-magenta-500-rgb: 216, 55, 144;
+    --spectrum-global-color-magenta-500-rgb: 205, 40, 111;
     --spectrum-global-color-magenta-500: rgb(
         var(--spectrum-global-color-magenta-500-rgb)
     );
-    --spectrum-global-color-magenta-600-rgb: 202, 41, 130;
+    --spectrum-global-color-magenta-600-rgb: 179, 15, 89;
     --spectrum-global-color-magenta-600: rgb(
         var(--spectrum-global-color-magenta-600-rgb)
     );
-    --spectrum-global-color-magenta-700-rgb: 188, 28, 116;
+    --spectrum-global-color-magenta-700-rgb: 149, 0, 72;
     --spectrum-global-color-magenta-700: rgb(
         var(--spectrum-global-color-magenta-700-rgb)
     );
-    --spectrum-global-color-fuchsia-400-rgb: 207, 62, 220;
+    --spectrum-global-color-fuchsia-400-rgb: 211, 63, 212;
     --spectrum-global-color-fuchsia-400: rgb(
         var(--spectrum-global-color-fuchsia-400-rgb)
     );
-    --spectrum-global-color-fuchsia-500-rgb: 192, 56, 204;
+    --spectrum-global-color-fuchsia-500-rgb: 188, 39, 187;
     --spectrum-global-color-fuchsia-500: rgb(
         var(--spectrum-global-color-fuchsia-500-rgb)
     );
-    --spectrum-global-color-fuchsia-600-rgb: 177, 48, 189;
+    --spectrum-global-color-fuchsia-600-rgb: 163, 10, 163;
     --spectrum-global-color-fuchsia-600: rgb(
         var(--spectrum-global-color-fuchsia-600-rgb)
     );
-    --spectrum-global-color-fuchsia-700-rgb: 162, 40, 173;
+    --spectrum-global-color-fuchsia-700-rgb: 135, 0, 136;
     --spectrum-global-color-fuchsia-700: rgb(
         var(--spectrum-global-color-fuchsia-700-rgb)
     );
-    --spectrum-global-color-purple-400-rgb: 157, 100, 225;
+    --spectrum-global-color-purple-400-rgb: 161, 93, 246;
     --spectrum-global-color-purple-400: rgb(
         var(--spectrum-global-color-purple-400-rgb)
     );
-    --spectrum-global-color-purple-500-rgb: 146, 86, 217;
+    --spectrum-global-color-purple-500-rgb: 142, 67, 234;
     --spectrum-global-color-purple-500: rgb(
         var(--spectrum-global-color-purple-500-rgb)
     );
-    --spectrum-global-color-purple-600-rgb: 134, 76, 204;
+    --spectrum-global-color-purple-600-rgb: 120, 43, 216;
     --spectrum-global-color-purple-600: rgb(
         var(--spectrum-global-color-purple-600-rgb)
     );
-    --spectrum-global-color-purple-700-rgb: 122, 66, 191;
+    --spectrum-global-color-purple-700-rgb: 98, 23, 190;
     --spectrum-global-color-purple-700: rgb(
         var(--spectrum-global-color-purple-700-rgb)
     );
-    --spectrum-global-color-indigo-400-rgb: 117, 117, 241;
+    --spectrum-global-color-indigo-400-rgb: 109, 115, 246;
     --spectrum-global-color-indigo-400: rgb(
         var(--spectrum-global-color-indigo-400-rgb)
     );
-    --spectrum-global-color-indigo-500-rgb: 103, 103, 236;
+    --spectrum-global-color-indigo-500-rgb: 87, 93, 232;
     --spectrum-global-color-indigo-500: rgb(
         var(--spectrum-global-color-indigo-500-rgb)
     );
-    --spectrum-global-color-indigo-600-rgb: 92, 92, 224;
+    --spectrum-global-color-indigo-600-rgb: 68, 74, 208;
     --spectrum-global-color-indigo-600: rgb(
         var(--spectrum-global-color-indigo-600-rgb)
     );
-    --spectrum-global-color-indigo-700-rgb: 81, 81, 211;
+    --spectrum-global-color-indigo-700-rgb: 53, 58, 176;
     --spectrum-global-color-indigo-700: rgb(
         var(--spectrum-global-color-indigo-700-rgb)
     );
-    --spectrum-global-color-seafoam-400-rgb: 32, 163, 168;
+    --spectrum-global-color-seafoam-400-rgb: 0, 166, 160;
     --spectrum-global-color-seafoam-400: rgb(
         var(--spectrum-global-color-seafoam-400-rgb)
     );
-    --spectrum-global-color-seafoam-500-rgb: 27, 149, 154;
+    --spectrum-global-color-seafoam-500-rgb: 0, 145, 139;
     --spectrum-global-color-seafoam-500: rgb(
         var(--spectrum-global-color-seafoam-500-rgb)
     );
-    --spectrum-global-color-seafoam-600-rgb: 22, 135, 140;
+    --spectrum-global-color-seafoam-600-rgb: 0, 124, 118;
     --spectrum-global-color-seafoam-600: rgb(
         var(--spectrum-global-color-seafoam-600-rgb)
     );
-    --spectrum-global-color-seafoam-700-rgb: 15, 121, 125;
+    --spectrum-global-color-seafoam-700-rgb: 0, 103, 99;
     --spectrum-global-color-seafoam-700: rgb(
         var(--spectrum-global-color-seafoam-700-rgb)
     );
-    --spectrum-global-color-red-400-rgb: 236, 91, 98;
+    --spectrum-global-color-red-400-rgb: 237, 64, 48;
     --spectrum-global-color-red-400: rgb(
         var(--spectrum-global-color-red-400-rgb)
     );
-    --spectrum-global-color-red-500-rgb: 227, 72, 80;
+    --spectrum-global-color-red-500-rgb: 217, 28, 21;
     --spectrum-global-color-red-500: rgb(
         var(--spectrum-global-color-red-500-rgb)
     );
-    --spectrum-global-color-red-600-rgb: 215, 55, 63;
+    --spectrum-global-color-red-600-rgb: 187, 2, 2;
     --spectrum-global-color-red-600: rgb(
         var(--spectrum-global-color-red-600-rgb)
     );
-    --spectrum-global-color-red-700-rgb: 201, 37, 45;
+    --spectrum-global-color-red-700-rgb: 154, 0, 0;
     --spectrum-global-color-red-700: rgb(
         var(--spectrum-global-color-red-700-rgb)
     );
-    --spectrum-global-color-orange-400-rgb: 242, 148, 35;
+    --spectrum-global-color-orange-400-rgb: 250, 139, 26;
     --spectrum-global-color-orange-400: rgb(
         var(--spectrum-global-color-orange-400-rgb)
     );
-    --spectrum-global-color-orange-500-rgb: 230, 134, 25;
+    --spectrum-global-color-orange-500-rgb: 233, 117, 0;
     --spectrum-global-color-orange-500: rgb(
         var(--spectrum-global-color-orange-500-rgb)
     );
-    --spectrum-global-color-orange-600-rgb: 218, 123, 17;
+    --spectrum-global-color-orange-600-rgb: 209, 97, 0;
     --spectrum-global-color-orange-600: rgb(
         var(--spectrum-global-color-orange-600-rgb)
     );
-    --spectrum-global-color-orange-700-rgb: 203, 111, 16;
+    --spectrum-global-color-orange-700-rgb: 182, 80, 0;
     --spectrum-global-color-orange-700: rgb(
         var(--spectrum-global-color-orange-700-rgb)
     );
-    --spectrum-global-color-green-400-rgb: 51, 171, 132;
+    --spectrum-global-color-green-400-rgb: 0, 148, 97;
     --spectrum-global-color-green-400: rgb(
         var(--spectrum-global-color-green-400-rgb)
     );
-    --spectrum-global-color-green-500-rgb: 45, 157, 120;
+    --spectrum-global-color-green-500-rgb: 0, 126, 80;
     --spectrum-global-color-green-500: rgb(
         var(--spectrum-global-color-green-500-rgb)
     );
-    --spectrum-global-color-green-600-rgb: 38, 142, 108;
+    --spectrum-global-color-green-600-rgb: 0, 105, 65;
     --spectrum-global-color-green-600: rgb(
         var(--spectrum-global-color-green-600-rgb)
     );
-    --spectrum-global-color-green-700-rgb: 18, 128, 92;
+    --spectrum-global-color-green-700-rgb: 0, 86, 53;
     --spectrum-global-color-green-700: rgb(
         var(--spectrum-global-color-green-700-rgb)
     );
-    --spectrum-global-color-blue-400-rgb: 55, 142, 240;
+    --spectrum-global-color-blue-400-rgb: 27, 127, 245;
     --spectrum-global-color-blue-400: rgb(
         var(--spectrum-global-color-blue-400-rgb)
     );
-    --spectrum-global-color-blue-500-rgb: 38, 128, 235;
+    --spectrum-global-color-blue-500-rgb: 4, 105, 227;
     --spectrum-global-color-blue-500: rgb(
         var(--spectrum-global-color-blue-500-rgb)
     );
-    --spectrum-global-color-blue-600-rgb: 20, 115, 230;
+    --spectrum-global-color-blue-600-rgb: 0, 87, 190;
     --spectrum-global-color-blue-600: rgb(
         var(--spectrum-global-color-blue-600-rgb)
     );
-    --spectrum-global-color-blue-700-rgb: 13, 102, 208;
+    --spectrum-global-color-blue-700-rgb: 0, 72, 153;
     --spectrum-global-color-blue-700: rgb(
         var(--spectrum-global-color-blue-700-rgb)
     );
@@ -238,35 +238,35 @@ governing permissions and limitations under the License.
     --spectrum-global-color-gray-100: rgb(
         var(--spectrum-global-color-gray-100-rgb)
     );
-    --spectrum-global-color-gray-200-rgb: 244, 244, 244;
+    --spectrum-global-color-gray-200-rgb: 235, 235, 235;
     --spectrum-global-color-gray-200: rgb(
         var(--spectrum-global-color-gray-200-rgb)
     );
-    --spectrum-global-color-gray-300-rgb: 234, 234, 234;
+    --spectrum-global-color-gray-300-rgb: 217, 217, 217;
     --spectrum-global-color-gray-300: rgb(
         var(--spectrum-global-color-gray-300-rgb)
     );
-    --spectrum-global-color-gray-400-rgb: 211, 211, 211;
+    --spectrum-global-color-gray-400-rgb: 179, 179, 179;
     --spectrum-global-color-gray-400: rgb(
         var(--spectrum-global-color-gray-400-rgb)
     );
-    --spectrum-global-color-gray-500-rgb: 188, 188, 188;
+    --spectrum-global-color-gray-500-rgb: 146, 146, 146;
     --spectrum-global-color-gray-500: rgb(
         var(--spectrum-global-color-gray-500-rgb)
     );
-    --spectrum-global-color-gray-600-rgb: 149, 149, 149;
+    --spectrum-global-color-gray-600-rgb: 110, 110, 110;
     --spectrum-global-color-gray-600: rgb(
         var(--spectrum-global-color-gray-600-rgb)
     );
-    --spectrum-global-color-gray-700-rgb: 116, 116, 116;
+    --spectrum-global-color-gray-700-rgb: 71, 71, 71;
     --spectrum-global-color-gray-700: rgb(
         var(--spectrum-global-color-gray-700-rgb)
     );
-    --spectrum-global-color-gray-800-rgb: 80, 80, 80;
+    --spectrum-global-color-gray-800-rgb: 34, 34, 34;
     --spectrum-global-color-gray-800: rgb(
         var(--spectrum-global-color-gray-800-rgb)
     );
-    --spectrum-global-color-gray-900-rgb: 50, 50, 50;
+    --spectrum-global-color-gray-900-rgb: 0, 0, 0;
     --spectrum-global-color-gray-900: rgb(
         var(--spectrum-global-color-gray-900-rgb)
     );
@@ -281,18 +281,18 @@ governing permissions and limitations under the License.
     );
     --spectrum-alias-background-color-modal-overlay: rgba(0, 0, 0, 0.4);
     --spectrum-alias-dropshadow-color: rgba(0, 0, 0, 0.15);
-    --spectrum-alias-background-color-hover-overlay: rgba(50, 50, 50, 0.04);
-    --spectrum-alias-highlight-hover: rgba(50, 50, 50, 0.06);
-    --spectrum-alias-highlight-down: rgba(50, 50, 50, 0.1);
-    --spectrum-alias-highlight-selected: rgba(38, 128, 235, 0.1);
-    --spectrum-alias-highlight-selected-hover: rgba(38, 128, 235, 0.2);
-    --spectrum-alias-text-highlight-color: rgba(38, 128, 235, 0.2);
+    --spectrum-alias-background-color-hover-overlay: rgba(0, 0, 0, 0.04);
+    --spectrum-alias-highlight-hover: rgba(0, 0, 0, 0.06);
+    --spectrum-alias-highlight-down: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-highlight-selected: rgba(4, 105, 227, 0.1);
+    --spectrum-alias-highlight-selected-hover: rgba(4, 105, 227, 0.2);
+    --spectrum-alias-text-highlight-color: rgba(4, 105, 227, 0.2);
     --spectrum-alias-background-color-quickactions: hsla(0, 0%, 100%, 0.9);
     --spectrum-alias-border-color-selected: var(
         --spectrum-global-color-blue-500
     );
-    --spectrum-alias-border-color-translucent: rgba(50, 50, 50, 0.1);
-    --spectrum-alias-radial-reaction-color-default: rgba(80, 80, 80, 0.6);
+    --spectrum-alias-border-color-translucent: rgba(0, 0, 0, 0.1);
+    --spectrum-alias-radial-reaction-color-default: rgba(34, 34, 34, 0.6);
     --spectrum-alias-pasteboard-background-color: var(
         --spectrum-global-color-gray-300
     );
@@ -302,159 +302,4 @@ governing permissions and limitations under the License.
     --spectrum-alias-appframe-separator-color: var(
         --spectrum-global-color-gray-300
     );
-    --spectrum-slider-s-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-s-ramp-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-s-range-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-s-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-s-ramp-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-s-range-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-s-editable-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-s-ramp-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-s-range-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-s-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-s-ramp-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-s-range-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-m-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-m-ramp-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-m-range-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-m-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-m-ramp-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-m-range-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-m-editable-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-m-ramp-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-m-range-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-m-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-m-ramp-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-m-range-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-l-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-l-ramp-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-l-range-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-l-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-l-ramp-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-l-range-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-l-editable-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-l-ramp-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-l-range-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-l-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-l-ramp-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-l-range-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-xl-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-xl-ramp-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-xl-range-tick-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-xl-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-xl-ramp-tick-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-xl-range-tick-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-xl-editable-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-xl-ramp-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-xl-range-editable-radial-reaction-color: rgba(
-        80,
-        80,
-        80,
-        0.6
-    );
-    --spectrum-slider-xl-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-xl-ramp-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-slider-xl-range-radial-reaction-color: rgba(80, 80, 80, 0.6);
-    --spectrum-well-background-color: rgba(80, 80, 80, 0.02);
-    --spectrum-well-border-color: rgba(50, 50, 50, 0.05);
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/switch": "^1.0.19"
+        "@spectrum-css/switch": "^1.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tabs": "^3.2.11"
+        "@spectrum-css/tabs": "^3.2.13"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -53,8 +53,8 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tag": "^3.3.9",
-        "@spectrum-css/taggroup": "^3.3.9"
+        "@spectrum-css/tag": "^3.3.11",
+        "@spectrum-css/taggroup": "^3.3.11"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -53,7 +53,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/textfield": "^3.2.0"
+        "@spectrum-css/textfield": "^3.2.1"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/thumbnail/package.json
+++ b/packages/thumbnail/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/thumbnail": "^2.0.13"
+        "@spectrum-css/thumbnail": "^2.0.15"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/thumbnail/src/spectrum-thumbnail.css
+++ b/packages/thumbnail/src/spectrum-thumbnail.css
@@ -30,6 +30,7 @@ governing permissions and limitations under the License.
     position: relative; /* .spectrum-Thumbnail */
     vertical-align: top;
     width: var(--spectrum-thumbnail-width);
+    z-index: 0;
 }
 :host:before {
     border-radius: var(--spectrum-thumbnail-border-radius);

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/toast": "^7.0.6"
+        "@spectrum-css/toast": "^7.0.7"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tooltip": "^3.1.14"
+        "@spectrum-css/tooltip": "^3.1.15"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -52,7 +52,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tray": "^1.0.24"
+        "@spectrum-css/tray": "^1.0.25"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/underlay": "^2.0.28"
+        "@spectrum-css/underlay": "^2.0.29"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -24,7 +24,7 @@
         "watch:serve": "wds --root-dir=dist --watch"
     },
     "dependencies": {
-        "@spectrum-css/table": "^4.0.16",
+        "@spectrum-css/table": "^4.0.17",
         "@spectrum-web-components/bundle": "^0.24.11"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,302 +3796,302 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@spectrum-css/accordion@^3.0.20":
+"@spectrum-css/accordion@^3.0.21":
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-3.0.21.tgz#123ea54afea981ee3abbd2f873f272e712e8ba40"
+  integrity sha512-0F3NtYoee/FPmsVgOMiqC4dofdb/wGvIy7XR6Oc4FptMh/lCBuCgJWMqaFCawJPBvmBw0AvovxVIMpkuC6m6Zg==
+
+"@spectrum-css/actionbar@^3.0.26":
+  version "3.0.26"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-3.0.26.tgz#ed1812c2287147332f77455ab6fcbe27df4e7ffd"
+  integrity sha512-bjgz/62OJd64W6unB+VOco5OzHaGjk8mlYUTTgy8srEVHzdzGGhRD56LcErjWSri0MiPjMlhqaWs1wePAD77qg==
+
+"@spectrum-css/actionbutton@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-1.1.12.tgz#3f4de1fc5089ce772e4013b9b5c2a8b9d272a0c7"
+  integrity sha512-iUMu/zENI21rfcroQc5jWGlNxPs2S8PqqkrZEelEuSxpmBgUWZZr1uMMosk7xHBS2sWZVlDuJHKcV+rqf6xhEQ==
+
+"@spectrum-css/actiongroup@^1.0.24":
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-1.0.24.tgz#5d16a8225d6aff319c220c01b056667d511c5541"
+  integrity sha512-+XQXraDU1Kjb42kDZw/TWe40/uYLYP+f2jwITpR5YRVLMhbgC5q+CVz37g/Yfy1+uhuTeOCmCPn+pMSGw1PvVQ==
+
+"@spectrum-css/actionmenu@^3.0.26":
+  version "3.0.26"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-3.0.26.tgz#b9ee5288641671d57168b9a49aadb2dcf2c5fd84"
+  integrity sha512-Y3WB9chexG5bUnJ0YIKCCl/RPXCCEdaYpp6Lf/rgDTJgg/mbwll5OJCh5/aPWXx9M5iBhGIHF+/APHCTkKmemQ==
+
+"@spectrum-css/asset@^3.0.20":
   version "3.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-3.0.20.tgz#bfdaaf14d2511dff3b3920d0b6660f78bae8ea5e"
-  integrity sha512-0/6FlQL0Q55OrpkHiSwp45IurYezy5jQjn2daYsmUSlmvlDLpJ3iGxHzpeTyzCz92sF+igQuhFIQcgBw07VlbA==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.20.tgz#5f6a60ba062406637f8060bc620d0ef3fa0f2c9c"
+  integrity sha512-CWxSDP//w7Gzs+BYCariU0hhvi7TjOQMdb0Pru6L7VzmXUVKLcJd4mQkFeNGulFFukkldZFThMJI088WmJhB5w==
 
-"@spectrum-css/actionbar@^3.0.24":
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-3.0.24.tgz#8a7ecede32db1c6c5be25656b4d712e6dad16959"
-  integrity sha512-sneI1JJXRlRogR5m2WHqLyUtPWvjKo1K0rR/2CklRrLaxJ1dVti1Yuc0YVqGDWxX0lRCKUN1GvuzcY3tyG+J8A==
-
-"@spectrum-css/actionbutton@^1.1.11":
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-1.1.11.tgz#1efc6498fd037798762182902205053d2f6847ad"
-  integrity sha512-XBEXOZYIVj4RnL8I0Ni63gDXY/QWYGCsroqK0Ii+toAM5I8pwtX0fnbz3VlENJl2ycdx13bLkxI+t7CFP8EExg==
-
-"@spectrum-css/actiongroup@^1.0.23":
-  version "1.0.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-1.0.23.tgz#395f9a8527d7ca06d488799df43f6611dad05c5b"
-  integrity sha512-uVoVRyY3K9VSpmQXekWWrciO2NvrkYx0dWWsS/xQmEpCJRaD3fOe317dfHRzVrstPs5sFk5DFeqPLxTSrydxTA==
-
-"@spectrum-css/actionmenu@^3.0.24":
-  version "3.0.24"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-3.0.24.tgz#f818b8fa90186d62f6f31c3209044962e14ffa59"
-  integrity sha512-g64ZWWOnjs5iDKQMQaWdgW72CDkGVT9sjjXBhtTbakn7p728XZOiBjWPwuR0Rp5flCPleoEalApXbiDbLg6/lA==
-
-"@spectrum-css/asset@^3.0.19":
-  version "3.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.19.tgz#d288e4049947b09e7fa4a7583984812ae3eadc4b"
-  integrity sha512-T332rVFAc9whNSAj4VDXX+YGdB8cQoknRtXLxW+ndQIcNB5BTAmqusbyGEwcYe+PmfyCNWR3BtR5scLLifoojw==
-
-"@spectrum-css/avatar@^5.0.15":
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-5.0.15.tgz#22ec5d98ab018c0de120a4546bd69db134909e58"
-  integrity sha512-66aab9/hxfWxKdR14bWPMEa0CMmqozfjziqIvUwCcxQAx55ZGyuEJiVvkHIR+5JhVqlhvYUVs68PY55AAEr9iQ==
+"@spectrum-css/avatar@^5.0.16":
+  version "5.0.16"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-5.0.16.tgz#0e44cfc2c928988c3c694b31b4ce2f0dfa689ad2"
+  integrity sha512-0YXLOc0o5TYVG5qywFufViKaq9TPFUpu19g2i/H4vEj8VxmBdx/uEzaMmAXtgIgWfSetmCORu4sXmcxTRN8vHQ==
 
 "@spectrum-css/banner@3.0.0-beta.2":
   version "3.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-3.0.0-beta.2.tgz#df448a3dcb8ac63448bd628843a2895cec305780"
   integrity sha512-NqrT03ItWzj+L0dtqjedhop6wKOspBmaowzp9IOY/2kL561kRqYTLKR9vTteZ3cEDVD3ajKA8y+bKIW0eN+X7A==
 
-"@spectrum-css/button@^6.0.9":
-  version "6.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-6.0.9.tgz#74dc948122ff2e70fb23f99453f2c22a5efc50e7"
-  integrity sha512-QpLYQ69JtYx5ujoHL1XSSMWD1NjtwXA0N/6vQodTUPxHRV5eXiIQsKees9cH95+eWaYl4/P0g03Qeb3OfQcoJQ==
+"@spectrum-css/button@^6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-6.0.10.tgz#eabc2643cceec39a2314e3cb7be91cae7248019a"
+  integrity sha512-k3eBNBk4/FVfPJCVchMOgYOGE6gV4xdfsH+sl7G3eI5LqOaBeO1znW9ZyzB7eH3NJmLDIhImII+WSu4guY5S5w==
 
-"@spectrum-css/buttongroup@^5.0.9":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-5.0.9.tgz#187cddfe334244406ead78f54b9478b57286cf51"
-  integrity sha512-tCS7iW6fNwDIi130R5OGk9n0QXx7muAFhhFaSczHdfmiS1inZZ57wos94wXO1ayw+DA7gqLq0tkBlUOvZxJl+A==
+"@spectrum-css/buttongroup@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-5.0.10.tgz#afdcb3dcb64696a5c614c837298ef9e99e5189d5"
+  integrity sha512-KJARALayC9ZDTqlejsBENpXRg8cYOLMm82Cp4jjgS0PFWXa2QlotpfeCwtK8aRSzpHEoufgRNvibE5acOJEqWg==
 
-"@spectrum-css/card@^4.0.19":
-  version "4.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-4.0.19.tgz#e7a540f379b8c7b9cdc3f3918b05a9a2af0a59b8"
-  integrity sha512-Z8xCmPYbPqXmE9zOdOTmxsZOpxWfjWSArkS43MNUHfAiOjRD3Dib/8CkAiI95TEen6JZ8NHTYXstbg3DISRw5g==
+"@spectrum-css/card@^4.0.20":
+  version "4.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-4.0.20.tgz#8b9d1c7ec7a836abe1b28f0c9db6b31c0a9ebae7"
+  integrity sha512-Sxb3oLFtw/d35GK8q16OUYt09wgzf+kf3mokv//zW/4chZiMECeUBW5XDDDBmKpVKls6wcZeZVZtgmsfLBDDKg==
 
-"@spectrum-css/checkbox@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-3.1.0.tgz#f0b9861b8cc233a951a3c31811c93c2304735d31"
-  integrity sha512-tK3lVOQ0vyDtZ3QR1fryCEfJnBG3UBRYApNvsiFguee5g0IsXUHhohcswJO9gH5G6UVmOt9zoKVInTRTxpgjBw==
+"@spectrum-css/checkbox@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-3.1.1.tgz#21fff2406e03a1066e426b3d8624d64fd594ef8f"
+  integrity sha512-vu+2Si9shB2n8jyxCMpFJZOEMcdiBzP1Cj7miL7av1mUQyNP7uQJP+AAPS5umjIJh9Bm2SUAWL3RM76ZQUEstQ==
 
-"@spectrum-css/clearbutton@^1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.8.tgz#d57545d63ff595695c9f0c322e3e4cc351b1dbd0"
-  integrity sha512-alUN1eTQqumEDfW5IS9o9p8uGNA53WBcDwKFGJkYp0530eFLXUXLU1EpgqwFR5H721FqMFVEIQn+7Wy/34261A==
+"@spectrum-css/clearbutton@^1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.9.tgz#5966c30ebcb732a45ac6e1c71ad153589a06d524"
+  integrity sha512-911ZDLcTaor+ZklMMzJIchISewp5Uh6UWTGuqpsh/Pk9DnLbl/rZPwVVS11pyuMj9Xz+26r1GDDlUcG8OBKOVQ==
 
-"@spectrum-css/closebutton@^1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-1.2.8.tgz#323380e86f4dabdc5b5a8bc557e36983c423d9a3"
-  integrity sha512-jYfjo0irvFkzZF+8dhuCczcnuetUpt0Y5yq4q8sXbObY2vnG4DzAMP8o0Hs2ayAoO18uBkarQ3+LDUmTDfpcZw==
+"@spectrum-css/closebutton@^1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-1.2.9.tgz#4411a7b958ad4a5c3729385f1930efd2a373ec4c"
+  integrity sha512-9o+DiFvdk00et95Ps+5leute0qTT8pzDgGL2BYgqOb3hrdHjdO95GfFXs/YxFdcgIONVvPypJEr5sbR+AP9m5w==
 
-"@spectrum-css/coachmark@^5.0.9":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-5.0.9.tgz#a07ee52dee75aba7d371787b5547b487fec7db99"
-  integrity sha512-YYDKSZZgdPh2A7zD9NY9OQpPbQvOdU7v2U6c2+in7uLZVCP1xmwkM1AbQWd7sgeu4hgwDLMVVTsYQDa8TTrXbA==
+"@spectrum-css/coachmark@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-5.0.10.tgz#b77ec3b09d5a6a72a6f52a8bd597a33aec9c1ea4"
+  integrity sha512-hGrpcHgSjUCQ+VwhzMQ3Q1XNw/XkMbB6w8CbIwxWbEcTJmnrSk6pdn3wFSli4GKMskddSzk6NExwmowsiEn8tg==
 
-"@spectrum-css/colorarea@^1.0.19":
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-1.0.19.tgz#ea42547d529301e516b5b27e5710f4e8be3ad5d6"
-  integrity sha512-jnQTBBXGS4F+6GBYqHp/Fa9Awjrp4+PGTj8/GeUhYamwoPKwx88UTwWpMqt/E4FPjwwi97HxE0UX+HlKYFzbFw==
+"@spectrum-css/colorarea@^1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-1.0.20.tgz#d47fd6c5c5f09bd4ce64996253e5f0e0c88180b8"
+  integrity sha512-WWFdJ3N5iyAruAtXmp5jtWJPZl5Xx1DyOvZtEnqjL8IR3FrDoOUVln31Y0Fkw2Az0lULk2zmcgQORURBxc9Y9g==
 
-"@spectrum-css/colorhandle@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-2.0.5.tgz#c026631a04a72538cecf56b978937b6ce66471e7"
-  integrity sha512-5/YKJqRUyZuXmXQGTAUMRIdBohPnfI5nGqKawj8bwIcv76nt7FIQIZnd++cAurPmNCIYd6nqE3A+10PVbw9MTw==
+"@spectrum-css/colorhandle@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-2.0.6.tgz#c1523b3ee3009ce7378b0819cad832264fa390e5"
+  integrity sha512-BcjCmzS8Ty/G8GTdSyepDa+kj5d8dDpEuMSW5WYjZ0wOrMSr+fbQpAUH4mNOO0e9jtP304EWd8W79OrbQi854A==
 
-"@spectrum-css/colorloupe@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-2.0.5.tgz#5d3ef098f6e87da7b6be945d8ac627fb10c2c832"
-  integrity sha512-UKsvcTWdcJwhfBz6nWJaHKTharcAdTlPCtEMCxWq+ts1MPGZyAz/2Ig6/PFkDH9Dx29RohDxP4p0HdYNc95Mnw==
+"@spectrum-css/colorloupe@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-2.0.6.tgz#2813a3ee08ae7f8437657fb27d5315c93d4de1ca"
+  integrity sha512-O7AcHGfm/IQCCGDUpWUfxTB9L6fs9yNuWEIPgQv4QOOTSXYnDek07g0iiLaRd8GssWAvxvUwPiQG5p1Dl2bugQ==
 
-"@spectrum-css/colorslider@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-2.0.5.tgz#37a03a4c4ba605de0140accca540969a140c25a6"
-  integrity sha512-v6KahmSo1NXFxI37nAB+EIDdnsHLiyx1yqm6x7baqhEGp2cZ42knzlfKueycXJjkYON2cDUbDdkXwk0X+eLASQ==
+"@spectrum-css/colorslider@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-2.0.6.tgz#c41dc4fab4e98a3a94bdc2d6efd3660b640cde5d"
+  integrity sha512-/HGu4IYIh8a18PNC9ctcQNfPCteFkMxI4qVtAYJYc3LvyW5OZnxxXvA8NsdfntEH20Q1H7MK7rpDP2rGBZyhkg==
 
-"@spectrum-css/colorwheel@^1.0.19":
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-1.0.19.tgz#4cf4b331cb95a680c4e91a0299e20d245d75390d"
-  integrity sha512-KhSXvJdbAbIm1opg1/HeOfIxpScXmYBsDkbOcKqDpg/SQup8/VQWyPpmgLM/nBS8GYKNHbPuIkEqQe9KLldomA==
+"@spectrum-css/colorwheel@^1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-1.0.20.tgz#7e44d316fb029bb3b18381a9127a8b87fac1ac46"
+  integrity sha512-DmtolmSqFXhxk6BkFY2JZRh8TZVX5rY/bk2SpxJjoUz+smL2D1nKa04685Twmq4IXg3sD1yTd6/NWp9xB0sYww==
 
 "@spectrum-css/commons@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-3.0.5.tgz#25b86c97402145a6aaaf58cbf1070e1c345d4f9b"
   integrity sha512-9YcJru496pHkcQMWP8y7Njk+ySMfdcap0hBAG/Fx+Vfmlcv9Mt1WCMuyLZusQ6a/0RVU/aKI4kLnDeunphBpNQ==
 
-"@spectrum-css/dialog@^6.0.9":
-  version "6.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.9.tgz#28663b9c047d869a9f003c15d6a1b48b59b2635f"
-  integrity sha512-hqaeWX6dbew0sCxqBv8k3fZam54eg2zjLdAGIwTfA3VdUAzWE9QY/GLScogAv6POqP/KwfAb/z/ZgRNOGEpZ8Q==
+"@spectrum-css/dialog@^6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.10.tgz#28da562cc994c583f3b901d43943426ce1834742"
+  integrity sha512-cmJewHxeKDELhDsjlnuXqcl7ewSX//sczLXohuvyJkpWMT/7NQdqVITcIP09JfyPIwUlzq6U/YP9H732/qp39w==
 
-"@spectrum-css/divider@^1.0.23":
-  version "1.0.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-1.0.23.tgz#26d16cb6a5dc9fbd11ed8333753c3bc8d77694e0"
-  integrity sha512-XodVifanDrmqVROon9So79tSDMW576Ycbc3PXzlKmgGL3gjwTvpv1ZqRdpW8Fv1gbn9LioXSfwnifQ3aeE2YFQ==
-  dependencies:
-    "@spectrum-css/vars" "^7.3.0"
-
-"@spectrum-css/dropzone@^3.0.22":
-  version "3.0.22"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-3.0.22.tgz#b5be5bd95382112be2b66092c8adcd077e4a8e14"
-  integrity sha512-pC3lNvfwKJ4TUR4iSrnW/FsiThetK6IiFJpqtI0AoO9tbGzHOSjCfsMqLKefyXioshLNX5iy1xEYvQietHKE9Q==
-
-"@spectrum-css/expressvars@^1.0.0-beta.31":
-  version "1.0.0-beta.31"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-1.0.0-beta.31.tgz#c88eee0e44eea7a4eafe5ac85b420d9924da8ac7"
-  integrity sha512-TzxbDsSkRkudrF844uzNDV6XW94mOnMmaR4P8HvBo3Jwx9WbNQdWbFPlwj1PlKBMgy3jrO/sjwRWzOYM4eaFWw==
-
-"@spectrum-css/fieldgroup@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.1.0.tgz#0435554bbef0e6a6774a281a4eb1412c194ce31f"
-  integrity sha512-VjCCuzknhTVf3yY+LYAF6a2Z9sbyWtdv29ZTQ1jYwZk4dFix94AXFk5OLioJ6g8RF1DqQ4ofn4BxDSbeZR0RZQ==
-
-"@spectrum-css/fieldlabel@^4.0.21":
-  version "4.0.21"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-4.0.21.tgz#5fc213eca9f2518e25992495966e61bc9a69e09a"
-  integrity sha512-rGapuuQfmlAgatkIBQcc9a9gTglw4C5HMmgW+ZPvBuPqmnNGs/5OX7vSF9UzTmi5NSFRxE6R+dXG/JO5rKiTuQ==
-
-"@spectrum-css/helptext@^1.0.17":
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-1.0.17.tgz#28537501d763418006bc080f2046af7865b1886a"
-  integrity sha512-e1lxZF2R/zIOR1YSuuPg1LSy3rIg0tPOcaNcAMi99J9VHpdqu9f6aKVEmCa8ewWoQ/+Er9V3fNNjUTITvYIOUQ==
-
-"@spectrum-css/icon@^3.0.20":
-  version "3.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.20.tgz#f6580518aa7f54cf0b113718a20f9205ace2c87d"
-  integrity sha512-M4cYDCKm2apt9R/w2DCtdg7oKSRTbWrpi0aBswh8bDzVGIwJqln76MwlKb/0+Dm7lmbT9cvj1v15ZUHqWT7aGw==
-
-"@spectrum-css/illustratedmessage@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-4.0.3.tgz#14834c7f781c8c961ba72dff0141ad56bc7861f3"
-  integrity sha512-17QLu54nf2YVWlZk5dkgxgv7dFyihB4ms1HJYF8Jto59RGIMMh2Dsc9+EDuyBo4S55bpQDZ7tVzWOEAF2kO+fg==
-
-"@spectrum-css/link@^3.1.20":
-  version "3.1.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.20.tgz#73fe6f262910ace4380ed0648e163deb13dba788"
-  integrity sha512-3MdfGYZYrhXkwCkrIQhfk/5vCLbpInU6T2xeUKUZcHEM6eGbIgfZ2GUm18Sv1EpOORF2ZHz8kioBhoUw9k7emA==
-
-"@spectrum-css/menu@^3.0.21":
-  version "3.0.21"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-3.0.21.tgz#d1f7e6e69d30b5e1edd7ed2c86ea4e08dfd670ab"
-  integrity sha512-G5AIUO26O6IAc6HUGZu4AZgyw0QRyLfSbcKlFGu4oJHzP36cQc1S1uCh8Xp4g5d+n6mU62LxNDLSMpVbwnA00A==
-
-"@spectrum-css/modal@^3.0.19":
-  version "3.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-3.0.19.tgz#500524f7381b5c6fb1c76262100243565d9d93f4"
-  integrity sha512-V4yJ83AdRc26G4eEdr/F43mJAVyy1oUcfXZNnavw7ahU4P6dpxfhcGBxAqda5OBUcyY+ThmO8prErO1JIKGIFw==
-
-"@spectrum-css/picker@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-1.2.4.tgz#555ebb1a3d43f3a71df6070da26822d1ef6b084d"
-  integrity sha512-oXbWicYyCJcothyTktnPsIXxbW8Jxw7IhSDU+cFcofAfhqeQFUotDUTkvoJiDzcoLJqdiXEda9LWxIIX5WemUA==
-
-"@spectrum-css/popover@^5.0.11":
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-5.0.11.tgz#c2d79e0869a3244179a73961a69495f020842e7d"
-  integrity sha512-mHM9T0ttr/PB9ZJaC1hnFvIorw71bnXZaOpXjsES3C2gi8wDmqqcNdTMNM2SFpCs2/TESQ2o69lPQZlE6uLmvA==
-
-"@spectrum-css/progressbar@^1.0.25":
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-1.0.25.tgz#146618a9e6287032633faf711a1ec6f7da9dbb00"
-  integrity sha512-99fGx8+V3uUeV//wBTARWlqKyxZ6S8xVuc79ABFsv6PvtHJ65cabyhYjzU+TAnNy6TFZEWO/zmNAYxqK/zAqcA==
-
-"@spectrum-css/progresscircle@^1.0.19":
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-1.0.19.tgz#d646d8caaf4106d4a11ae315705e0d22ed46594f"
-  integrity sha512-T9GrlxobBxJjG8Rc212bHrhF7iHTHQjk9hl23R0laCDZ6KzxWQ5nUE9/DRdDD7VlmJCMX6SChh3A+yac3sylwA==
-
-"@spectrum-css/quickaction@^3.0.22":
-  version "3.0.22"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.22.tgz#e756af290520f380f248c83f6eb4bbeeb625f380"
-  integrity sha512-TLVNyrIaHZUzJ7oNu7BF/WjUsMAFD2otOMbETSGceeuL34REzyAnMPWzMVucuJmX6mj2M1RxoBen+qUoelGUag==
-
-"@spectrum-css/radio@^3.0.20":
-  version "3.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.20.tgz#a1927c43cc3d47d59c626ba5c30af4879933adfd"
-  integrity sha512-4zEnxtJp62yfMA31DZGV/hpSXMnSeLEhBpkmbUE9VJEf9GrS4G4iKhTHsf8PzOHaYd3kuNov+7pwU7lJxifR1Q==
-
-"@spectrum-css/search@^4.2.8":
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-4.2.8.tgz#d8d4080a708d72f778e079ed7bbae6b2434e379b"
-  integrity sha512-SOinYP1gq6Kc5qmCdoxoe48axbrkImcDmWVbK/QfFPAqm8ck2EeFgx5hBShJIG3rgVUebFzYTt5m45YiX8XoPA==
-
-"@spectrum-css/sidenav@^3.0.20":
-  version "3.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.20.tgz#a8d4714c20a863c8c001adc8874a16217aebaf79"
-  integrity sha512-/kYHaMBVcdOii8o17shT/tvuh/3cZTnT3oqkhBOIYKlP9YxptGW8vM/mHrfcg4ZLKTwYIzDHqAAkWkfPMWDtvQ==
-
-"@spectrum-css/slider@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.1.3.tgz#f61dc5ba5303960cb851b1cdb0830416af25a53f"
-  integrity sha512-3u1Wv4jCnDGM+vfytg1RZs5NJyyiSg5gQolH4lWvyxvLQNxlz5jZoUQZGYkfhQdi0W5emmByCcHFM6hjYJuJlw==
-
-"@spectrum-css/splitbutton@^5.0.9":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.9.tgz#3e04e01876c5b4d174998816866b56962cb928ae"
-  integrity sha512-qZdNoieZBOpS00w0IWJcHaZOKOwGc1zcJLD+4d7ans+y5aSW5j5tGaDEI11MTGqer4ujHNOCAhTPLAZICVAUew==
-
-"@spectrum-css/splitview@^3.0.19":
-  version "3.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.19.tgz#c5e054c699d3976c9f81c74d4e73ad5f7739a017"
-  integrity sha512-92yVikMQgzFA1e3Fd6GpXI8N8HAwgrJ4o+ww1AmVVcpOzK1feNQhmoL6+DaKlxE8AeykcP5XcWeg1mP4slpCXA==
-
-"@spectrum-css/statuslight@^4.0.10":
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-4.0.10.tgz#56c7e4186056980ab753380d02f92139c3d2cac5"
-  integrity sha512-t4l496qFzhUXYN8QL50974NnN8+WM9/weMxEHsXVPsD+jxR2imCRd3cPwTDjqLfukNYxyHxqY5W8LAFeLeVpgQ==
-
-"@spectrum-css/stepper@^3.0.22":
-  version "3.0.22"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.22.tgz#3bf040d803153abe1ce6e968186bb86f96dbf01f"
-  integrity sha512-zWWqZEDX/dFwl3OJfg9HcNMRIBlMifxe6+U2r+3H0wem1zf+o/clH+TaLIAl+E5Fd+ZB9hlLH8X7i5rjUEZMNQ==
-
-"@spectrum-css/switch@^1.0.19":
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-1.0.19.tgz#04cfc3ce8ccabfbf8c83dad8ba7db13513d61037"
-  integrity sha512-HYl3eM7G0oBfNRAGmPDkuHRO50vgQgsrIeKq71lE0+4QlI10nBNxS388o1MrMHrOPESo3M8ZNkHfX2ImcIPx6A==
-
-"@spectrum-css/table@^4.0.16":
-  version "4.0.16"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.16.tgz#8d221fd21af157c1002dc6dfb2bb5a05df908c5f"
-  integrity sha512-HHQjmceR4M2F9g3ChnO7VeAtN9exXGuD2PCCY8vEse9aL03kPdI0bJJOAitD0Ku5Y2JfkFDJ1R4b6i+AyBOsNw==
-
-"@spectrum-css/tabs@^3.2.11":
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.2.11.tgz#ea35973b07867fdd6a06b8fe83e40abb40811072"
-  integrity sha512-wPgC+Xin8owN0YobpKcVqXf33guXJzRyNTtEWZReoyGUAc+FuAllRkGi1eZ4dRbBnGpUPKTd0c4ZWCSCKwPL+Q==
-
-"@spectrum-css/tag@^3.3.9":
-  version "3.3.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.10.tgz#3710a29767315332078956b93e99408b781eb160"
-  integrity sha512-cwKgpEx4OYyS/WqyNDCvQhSVQUYdHhbjz3nRdg4jABaI96T8UBHcAvK07TR1/OfD5rBo+xBO+rsGqd4aH21zdA==
-
-"@spectrum-css/taggroup@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-3.3.9.tgz#d14e18b3652afe81a1af717a75904a14160d41b5"
-  integrity sha512-OCFfFPFHE7DvytOxmrNmLcyzUKxf6/wGNncwz01GfoALPi6ygITij4a21AJXDhED+tAmi1dSVXy+FlDu1e4m4A==
-
-"@spectrum-css/textfield@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.0.tgz#242628992b802c0a68b648c49f1750c8a930a847"
-  integrity sha512-9VVarhtA9e234eLkneClnHmWkaLI04kZzwphV420KaW6bUEvbKOWYv/elzZy7stJ/ZHbnfKTUC+OgpI8C1tD2A==
-
-"@spectrum-css/thumbnail@^2.0.13":
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-2.0.13.tgz#856da10f2a631b41161e9f79654970d28efde407"
-  integrity sha512-S6rJttfXcjaCV1mtDYU4g9BZ7DFUR7CeIxo6xdS/NneRPJOfC1WXDduq9eYKu8BNs3FWmBXrgEhxJd7PymPabg==
-
-"@spectrum-css/toast@^7.0.6":
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-7.0.6.tgz#64cc2aeaf47f2c7d611557f6d3bf6880cf4ee026"
-  integrity sha512-DDfEAToBRaslt5shaO+YjJfOP6nheeg3eLIJBq3RUrJ8uX6ldcehgUUDL29zbfxNlHgDpLWjAmcRdqT2QdbyBw==
-
-"@spectrum-css/tooltip@^3.1.14":
-  version "3.1.14"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.1.14.tgz#1384bc035643dbc1ab78c11e7bd4dc7ff768b608"
-  integrity sha512-jubXE+XqIMiAnRmj3P0A7nOER0LfF1BwK/eG9LI8h/l9tMpkQxc9RFMRUGzjS6ROikumt98yFuau4LifOuV90Q==
-
-"@spectrum-css/tray@^1.0.24":
+"@spectrum-css/divider@^1.0.24":
   version "1.0.24"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-1.0.24.tgz#428f609bee9d907be882c302f69521509db5a090"
-  integrity sha512-qla5S63Mmc9sZN4c4Jbi4JlNn3yWmU27nOxAHFYJwnLsGhqc6hptNoR19Klsx+B5CpC3nBKwz1YirlPhVdn8cg==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-1.0.24.tgz#743ab3f02a4b44c8eb02f971394609f9034ae4d9"
+  integrity sha512-1di+RgsCNm+HsQl20lAwXh23RPMZxLInlz8A0w+r4s9WRrwInEbTC3xHmfN6rSfBPJKQSQ5J78ipOH8qDSB0Jg==
+  dependencies:
+    "@spectrum-css/vars" "^8.0.0"
 
-"@spectrum-css/typography@^4.0.17":
+"@spectrum-css/dropzone@^3.0.23":
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-3.0.23.tgz#c606f5aff728a7bf0361a487aac178c7b66a43dd"
+  integrity sha512-qzIN09298KoOJRyGwRK7gwHQqXYfOZS55AzlvCAiODKDIFM3xDQEUCOeeedQ0+EBXA89Krv99LBuxZYM0+eUjw==
+
+"@spectrum-css/expressvars@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-2.0.0.tgz#462c1679df96d515780b3ee7fea2b8bccbd901bc"
+  integrity sha512-K8hwoWOHcZTwLo6P3Itvl/ggZ+GChFyNoj5Rvlgj8R9/p62Eb9Vp9UDx2Mcg1zCJN2sBZAiqhYRQM+WawRtx5w==
+
+"@spectrum-css/fieldgroup@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.1.1.tgz#98156aa57727a05bb08d117b11f652ce3c178e66"
+  integrity sha512-6hD1b9OJFbBjq963rzMP5/sQ23eAVPNDDnrE03VePkBxYbNHvWdJrDsQH5O2dFQIT10S1WIlIPj3w7HQjrAWdA==
+
+"@spectrum-css/fieldlabel@^4.0.23":
+  version "4.0.23"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-4.0.23.tgz#f7703782e18028b21658d0da9ead85aedfc62f5b"
+  integrity sha512-qRTtnewwWQA3mXy/RYYBcXWOjJp1Zf5Xfb1f+O2WKyNHi3+TSg+ejudXr+cdhNwHy9WAQwuO8ahUcQuU7USklw==
+
+"@spectrum-css/helptext@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-1.0.18.tgz#f0354fa1002b747d043ae167c3cf5d423f5bbcb0"
+  integrity sha512-UMe692d2RqCjOZKUWwMOdMl6VtUVFNMxrif4kD23pFNz8DYcNaxwmsDxcvsBZKztMg9CYej10JPC9+NKZDVlFA==
+
+"@spectrum-css/icon@^3.0.21":
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.21.tgz#086d30fd659975bc932e847140531dcae9a57ffd"
+  integrity sha512-GlpqVotZ2c6nsMfQOBzBb855aZ6L1mtbAcgcwhKzACJhJxw0MKUD5euA8mUzMtCnlLZ0XCgoJbU+PLNrx/yz0A==
+
+"@spectrum-css/illustratedmessage@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-4.0.4.tgz#3cea7631cdc313d126b4225250f1a465c9559176"
+  integrity sha512-GPOVNxnrfuuh3KYMvhkwx9qKAZ/IoaTgBe32da7lHkXlGOW5Je45gjX7oZFPxfO2/HmOfnyPba9utaWqtAEDDg==
+
+"@spectrum-css/link@^3.1.21":
+  version "3.1.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.21.tgz#41e815d9f15900c11e621d3992e37e04e2690178"
+  integrity sha512-iTycfJRnW3WzyDDh9CrSMH6npuNI5yaZ7TDcCmOFinoSZ6ZQPaTnz6tI3jYAtg2minEmwF2lUa7k16MtwmoUTg==
+
+"@spectrum-css/menu@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.1.tgz#679760118c092d83c0c18a6ea5b4cfa54c585e69"
+  integrity sha512-GzZHSypWHn+HI0RmFh54QTp8GphqrbYf/B5mh3w/gAV9+4OZPTpSFKP7300UAgeNwIOsDpfV9brR4OXo5IlFVw==
+
+"@spectrum-css/modal@^3.0.20":
+  version "3.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-3.0.20.tgz#351166199ecd45d6e0ef34ddced2668f6d24e53b"
+  integrity sha512-+Lrs8ybpRaXtd8pfpOHgyWWO/Xd0H9cJnckWBN8wb0Q4kyMeHGchOYnAMP9OnLNkHRowA1CToJjuWUmK3thbUA==
+
+"@spectrum-css/picker@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-1.2.6.tgz#73cb853ab2bc955fb48ca9295184fb33c3a5637d"
+  integrity sha512-eSTqgT2AhVadVV2Suc9wmMLh5uPenBfAInW6dWkBzbuLW9aO63WR04VBNeNXgacXqRwwOYXQrPsdM1mo7qNKYw==
+
+"@spectrum-css/popover@^5.0.13":
+  version "5.0.13"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-5.0.13.tgz#6ece4f39a1ca7e50ff1a46480803ecfed1e3d533"
+  integrity sha512-lzPpaOBvdTLtJMeR28qrqFuY+/u0UvFBZSmPl+0HYssPPgaN54IctHZApeKwf39+gT2xTIkQ9N95CZh22l7G+Q==
+
+"@spectrum-css/progressbar@^1.0.27":
+  version "1.0.27"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-1.0.27.tgz#28675590abe4dbf2fafbb010fd3823988c4b07cd"
+  integrity sha512-MeuZdObn6riqOetSsDx9uIGMLe+wrn8/veNJMBvfMQjuFKxrW26T7m8wB8OEIYeQP2xno2U97GkUv1XmeJp/zQ==
+
+"@spectrum-css/progresscircle@^1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-1.0.20.tgz#8a3f534d403c1a9d8a0f24d18597c58ab6c1e033"
+  integrity sha512-3IdCaZmbyytZLajkI2oXa620sGGTr6lK8Op79FQNBH/XQNyvmwFRdq/rCKdYJAtS/WVOyQzy9nn+rQba0iAoQg==
+
+"@spectrum-css/quickaction@^3.0.23":
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.23.tgz#778be186772128d8566d55dd6377a9f9acd535cf"
+  integrity sha512-XKGDfAyUSLl+TPelU+ksRU5avuEewYrIivIjG9I7fKaDw0KvrMKTM5Y+E+a8uvQkm7phldt8KjAepbzm0HTwng==
+
+"@spectrum-css/radio@^3.0.21":
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.21.tgz#810cee978b54702ebc48b64011951c94ff6d45f6"
+  integrity sha512-qGV/7FAGfONI4V/ulev61BAxMbTu5KptN8W6aK3p3NBHuk+1540mNWiacpNvdZTgQaOr2cyOH5pngYgLqHLzHA==
+
+"@spectrum-css/search@^4.2.9":
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-4.2.9.tgz#b70109df3c5f6d2383822025a8581eb98ffa72c8"
+  integrity sha512-NUwQDBfx4xZtjkF9tD+JnwLg+fGfIY0nrxrZpTOcavoj8uiK7MA6+fweadezfQvkBo/uPy9buwPg7vTPKz4Bxg==
+
+"@spectrum-css/sidenav@^3.0.21":
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.21.tgz#350ffaf53441eb15783a734b3a9aba614ff8210d"
+  integrity sha512-A3x4m3tzRkgwLRxBaDyA9Oymp5EexcvgpMmhtfWjV1ZJN66vYN0nnjG/2usbF6LOgnoNoaAEhvoRKXQyHtsdUg==
+
+"@spectrum-css/slider@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.1.4.tgz#454f623173c3d42df4c8d363f42cad0c2838f4b5"
+  integrity sha512-hjE/k+w78ttglfYhH/kxqyKmMWfO73rIe0ZCJFW6G4mREEKArwYMVqFEzjfkdc6/hjF/G65eu8yT3XMpYg5MPA==
+
+"@spectrum-css/splitbutton@^5.0.10":
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.10.tgz#c77bf56fb87ed1b6abf16a7df36ae67720671c7f"
+  integrity sha512-Jb141oHrZjm61U8SQ+2LOy2LqEp3KXTTqG81pJOBdCupzwSOd01IY0S8do+bVbdI+8dCa5n7GyBUoyNliqxj/A==
+
+"@spectrum-css/splitview@^3.0.20":
+  version "3.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.20.tgz#981d69e775d6eb776f6d5ff1ed7c39977d4d33ed"
+  integrity sha512-f2uEuenUo2aN9/5+KHiG2m7gB0U8TTHh1UqhrQjbn8hhN7v8vKJT9kj5qZRXDzmPwU+eVNL5PF8B+vz7C/IYtw==
+
+"@spectrum-css/statuslight@^4.0.11":
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-4.0.11.tgz#cced5092e9aa0f2e51888d5ce4a158f672327228"
+  integrity sha512-3j14ZKDAIgWhvET8lsimPwab0ZyKyooq/UarOPVCNvFLt5s8t3JETPUmQs4I2hMWpJi7VBjAXZDOdIY4qSEciA==
+
+"@spectrum-css/stepper@^3.0.23":
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.23.tgz#cd8ab3484c34242e1f069dc9897332fcab05c10f"
+  integrity sha512-M+q7A55wzJJDvZu/T1q9GhEmIoE/FZA2GMlSIgBtdTDF0RLD5WoSuuYOf1bhIPEMZNQi7x4EcDsLX63MI5y2UA==
+
+"@spectrum-css/switch@^1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-1.0.20.tgz#c4fcbc6dd5f3230347614fbf41e190858a12f84e"
+  integrity sha512-6eTNZsLWGXa3HHUL0c2Uli1DGvA9riQs/wZWzLJZKdKstJCnM9NU/jDNCuKbDP4M6YtxAsKxyZFW6k0ddUNJ5g==
+
+"@spectrum-css/table@^4.0.17":
   version "4.0.17"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-4.0.17.tgz#d2eaa31a750f402daa9010e27279027a0115d29d"
-  integrity sha512-ZtABINpC8se861JYRnmmYw1FyZVWssVubLaxNIDiWMsY7Kq1jHTzfll3yluVDk/LyAGZvhkfBn4g+PziBMTgDA==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.17.tgz#5a5eba1b66a620dc1e534a91d696b7b585b4a543"
+  integrity sha512-H5iJE5iKqKAyacdbeRPPUfyJFtcK956bROdRSzWCmxNpIp7Y7tnxsgsrP9lcB/wGG80rl+ECVkZfe1YZ+PQwAA==
 
-"@spectrum-css/underlay@^2.0.28":
-  version "2.0.28"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.28.tgz#34d51cc27d077ec213e8c584cd893105a77a3cbf"
-  integrity sha512-2gqaa7t2ywR6IVzJProXS9zYzUXOXZoshnLCm2p4EKykAQNtT5bdRRKuBVuB+R0ucQ64muU+7W5SnLlx23Rwaw==
+"@spectrum-css/tabs@^3.2.13":
+  version "3.2.13"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.2.13.tgz#5d7be9f3d5cec018215d02694fa9778bd7c9732a"
+  integrity sha512-/DZrZNc27XTbZuEVCHMo7mQW/0tsUVGCxH/YocY2cubUQWbbSzcovwL0C46KtF1J8YhQhEnin/wt3N2E6o32qw==
 
-"@spectrum-css/vars@^7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-7.3.0.tgz#4d7893fd4feb5ba0e73ecfb624ec48d3e3db370b"
-  integrity sha512-GYWbK9e6pbvDH1l9+IdlVWWWMqL4IwtPRhHAg1VmPq1yBcM0Hfs17s9by06lJQOcHmaUnf+H9xwStcsnOupXUQ==
+"@spectrum-css/tag@^3.3.11":
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.11.tgz#66b5f91a845df2ad232fae702ae53b3fa46cf745"
+  integrity sha512-dyDUwG4fbsScMLaVOKQgKuUvYshGEIjTS9lVNhOHCz7klZ800UIMoCzDQXieHf+0nSdiR1Wy1oHBObHMMB8sxA==
+
+"@spectrum-css/taggroup@^3.3.11":
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-3.3.11.tgz#516484ddda331a82510c927a61a344aa4a04ed62"
+  integrity sha512-Xmz024i0LGaumTmhlIFZMaqxjjWUeu3cLRHnRalR1x5aWyz/tp8SK8iD5mJM7arEzx2kIP4UUVbCBHIjsO0wew==
+
+"@spectrum-css/textfield@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.1.tgz#80f92cc5e2ba11840267388193d894e84eee64f9"
+  integrity sha512-g3oJc0QEskydrR5gQq5rYPFJfm7Y7FEI+ddjoaGPILrQhzGV/0+4s9/i+7qTUBHzSuVeSxml+5RIssNbo2DOZA==
+
+"@spectrum-css/thumbnail@^2.0.15":
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-2.0.15.tgz#33833aca05037d053fd2315105352d7c70998a5e"
+  integrity sha512-uZgyDQlr3BR3De+nO6X1sDzSDnFU/jF2IdqLC+EqVNMw9WeVSBqYkQVhDK6TTJUm+k4yqtDhON5YXBbUuaUzFw==
+
+"@spectrum-css/toast@^7.0.7":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-7.0.7.tgz#c449c62e287150949648ca909431bf53dca211fb"
+  integrity sha512-OjAIcmA/RmvmYU6m45OQD2eHhb/ivGY6Amh5W2j3ybn5oL12evQJvDni2DxL3jsUSQWNh+hZhY1pUOHLU7TvYA==
+
+"@spectrum-css/tooltip@^3.1.15":
+  version "3.1.15"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.1.15.tgz#dff6e921c0bc4acb151641be1a1871b4ce30a3d4"
+  integrity sha512-7Xzfy1lWT6zJhgtqOakEMJALHRrArNYfvVW+/d4033fybNJXb6MQlNzVErc8QI1cjYwIIVncOFLzQH7FJP0j2A==
+
+"@spectrum-css/tray@^1.0.25":
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-1.0.25.tgz#aaaf0ce66accbeccc112e6420fc65509d8e7e27c"
+  integrity sha512-oPd/oM3Og/ggS+Kyzpl6truSjxpKMpMgHkcvbiT+h3BeNJMqE5tpiPsO/34O8+9VsolLEI0MtVnnuQ7lENfDlA==
+
+"@spectrum-css/typography@^4.0.18":
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-4.0.18.tgz#ab9a68815afb42860726007198d47f9298c6bb4c"
+  integrity sha512-NRv2R3/hG6DkY/mxqnTtdu4D+NLKWohNW6s2QkafbEEiIJxl0Kvx7vkl5aaseVGyDHT/f+/hUUCgkgBYEOgt/Q==
+
+"@spectrum-css/underlay@^2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.29.tgz#488f7f03da934089e1558c87789f00d4c0df89b4"
+  integrity sha512-VMvY00YiVKi39YcgqkMIWnizmOFIXdozGeCB7Ja/ltDOGV4U1fRUl/ysKrqvZeIsnvSHaJXC/ExN0NjQ9zrIDw==
+
+"@spectrum-css/vars@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-8.0.0.tgz#b88a3b1165b63de50ab01f20ccafb42115d67443"
+  integrity sha512-cClQgNyH1VdNu6zdiZ5M7kbQDZS4/wPAclk5IPO5+nMhSzqTesUL/zfiaPB95MTCKFyVJrFpOeJ37HmUifWJ3A==
 
 "@storybook/csf-tools@^6.4.9":
   version "6.4.19"


### PR DESCRIPTION
## Description
- adopts the updated color pallet from Spectrum CSS https://spectrum.adobe.com/page/whats-new/
- updates the implementation of `<sp-menu-divider>` to leverage the `<sp-divider>` styles
- ~need to do one confirmation with Spectrum CSS of whether this should REMOVE `lightest` or merge it's values with `light` before moving forward.~

## Motivation and context
Keeping up with Spectrum

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://73874bdaecee6ea6d7a506b37d5d256d--spectrum-web-components.netlify.app/review/#MenuGroupStories/inherit.png)
    2. See the divider lines are darkened
    3. Go [here](https://spectrum-css--spectrum-web-components.netlify.app/storybook/?path=/story/menu-group--mixed)
    4. See that the darkness is persisted
-   [ ] _Test case 2_
    1. Go [here](https://73874bdaecee6ea6d7a506b37d5d256d--spectrum-web-components.netlify.app/review)
    2. See that the colors are updated across ALL of the system 🤯 

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.