### PR TITLE
fix: correctly apply tab order to Accordion Items

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -49,7 +49,6 @@
         "@spectrum-web-components/base": "^0.5.5",
         "@spectrum-web-components/icon": "^0.11.6",
         "@spectrum-web-components/icons-ui": "^0.8.6",
-        "@spectrum-web-components/reactive-controllers": "^0.2.2",
         "@spectrum-web-components/shared": "^0.14.0",
         "tslib": "^2.0.0"
     },

--- a/packages/accordion/src/Accordion.ts
+++ b/packages/accordion/src/Accordion.ts
@@ -20,7 +20,6 @@ import {
     property,
     queryAssignedNodes,
 } from '@spectrum-web-components/base/src/decorators.js';
-import { RovingTabindexController } from '@spectrum-web-components/reactive-controllers/src/RovingTabindex.js';
 
 import { AccordionItem } from './AccordionItem.js';
 
@@ -50,22 +49,13 @@ export class Accordion extends SpectrumElement {
         ) as AccordionItem[];
     }
 
-    rovingTabindexController = new RovingTabindexController<AccordionItem>(
-        this,
-        {
-            focusInIndex: (elements: AccordionItem[]) => {
-                return elements.findIndex((el) => {
-                    return !el.disabled;
-                });
-            },
-            direction: 'vertical',
-            elements: () => this.items,
-            isFocusableElement: (el: AccordionItem) => !el.disabled,
-        }
-    );
-
     public focus(): void {
-        this.rovingTabindexController.focus();
+        const firstActive = this.items.find((el) => {
+            return !el.disabled;
+        });
+        if (firstActive) {
+            firstActive.focus();
+        }
     }
 
     private async onToggle(event: Event): Promise<void> {
@@ -91,16 +81,9 @@ export class Accordion extends SpectrumElement {
         });
     }
 
-    private handleSlotchange(): void {
-        this.rovingTabindexController.clearElementCache();
-    }
-
     protected render(): TemplateResult {
         return html`
-            <slot
-                @sp-accordion-item-toggle=${this.onToggle}
-                @slotchange=${this.handleSlotchange}
-            ></slot>
+            <slot @sp-accordion-item-toggle=${this.onToggle}></slot>
         `;
     }
 }

--- a/packages/accordion/test/accordion.test.ts
+++ b/packages/accordion/test/accordion.test.ts
@@ -15,11 +15,7 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import '../sp-accordion.js';
 import { Default } from '../stories/accordion.stories.js';
 import { Accordion, AccordionItem } from '@spectrum-web-components/accordion';
-import {
-    arrowDownEvent,
-    arrowUpEvent,
-    shiftTabEvent,
-} from '../../../test/testing-helpers.js';
+import { sendKeys } from '@web/test-runner-commands';
 import { spy } from 'sinon';
 
 describe('Accordion', () => {
@@ -267,28 +263,42 @@ describe('Accordion', () => {
         const secondItem = el.querySelector(
             'sp-accordion-item:nth-of-type(2)'
         ) as AccordionItem;
-        const thirdToLastItem = el.querySelector(
-            'sp-accordion-item:nth-last-of-type(3)'
+        const thirdItem = el.querySelector(
+            'sp-accordion-item:nth-of-type(3)'
         ) as AccordionItem;
-        const secondToLastItem = el.querySelector(
-            'sp-accordion-item:nth-last-of-type(2)'
+        const fourthItem = el.querySelector(
+            'sp-accordion-item:nth-of-type(4)'
         ) as AccordionItem;
+        const isSafari = /^((?!chrome|android).)*safari/i.test(
+            navigator.userAgent
+        );
+        const tab = isSafari ? 'Alt+Tab' : 'Tab';
+        const shiftTab = isSafari ? 'Alt+Shift+Tab' : 'Shift+Tab';
 
         el.focus();
 
         await elementUpdated(el);
         expect(document.activeElement === secondItem).to.be.true;
 
-        el.dispatchEvent(arrowUpEvent());
-        el.dispatchEvent(arrowUpEvent());
+        await sendKeys({
+            press: tab,
+        });
 
-        expect(document.activeElement === thirdToLastItem).to.be.true;
+        expect(document.activeElement === thirdItem).to.be.true;
 
-        el.dispatchEvent(arrowDownEvent());
+        await sendKeys({
+            press: tab,
+        });
 
-        expect(document.activeElement === secondToLastItem).to.be.true;
+        expect(document.activeElement === fourthItem).to.be.true;
 
-        el.dispatchEvent(arrowDownEvent());
+        await sendKeys({
+            press: shiftTab,
+        });
+        await sendKeys({
+            press: shiftTab,
+        });
+
         expect(document.activeElement === secondItem).to.be.true;
 
         document.body.focus();
@@ -296,7 +306,9 @@ describe('Accordion', () => {
         el.focus();
         expect(document.activeElement === secondItem).to.be.true;
 
-        secondItem.dispatchEvent(shiftTabEvent());
+        await sendKeys({
+            press: shiftTab,
+        });
         await elementUpdated(el);
 
         const outsideFocused = document.activeElement as HTMLElement;


### PR DESCRIPTION
## Description
- removed Roving Tab Index management of Accordion Items
- expanded testing of natural Tab Order access of Accordion Items

## Related issue(s)

- fixes #2273

## Motivation and context
Appropriate accessibility models.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://accordion-keys--spectrum-web-components.netlify.app/components/accordion/#example)
    2. Tab into the example.
    3. See that you can only access Accordion Items via `Tab` and not `ArrowUp/Down`

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.