### PR TITLE
fix: ensure that "selected" can be set more than once from the outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
         "typescript": "^4.5.3",
         "yargs": "^17.2.1"
     },
-    "customElements": "projects/documentation/custom-elements.json",
+    "customElements": ".storybook/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -91,8 +91,21 @@ export class ActionGroup extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public vertical = false;
 
+    private _selected: string[] = EMPTY_SELECTION;
+
+    set selected(selected: string[]) {
+        this.requestUpdate('selected', this._selected);
+        this._selected = selected;
+        this.updateComplete.then(() => {
+            this.applySelects();
+            this.manageChildren();
+        });
+    }
+
     @property({ type: Array })
-    public selected: string[] = EMPTY_SELECTION;
+    get selected(): string[] {
+        return this._selected;
+    }
 
     private dispatchChange(old: string[]): void {
         const applyDefault = this.dispatchEvent(
@@ -104,18 +117,20 @@ export class ActionGroup extends SpectrumElement {
         );
 
         if (!applyDefault) {
-            this.selected = old;
+            this.setSelected(old);
             this.buttons.map((button) => {
                 button.selected = this.selected.includes(button.value);
             });
         }
     }
 
-    private setSelected(selected: string[]): void {
+    private setSelected(selected: string[], announce?: boolean): void {
         if (selected === this.selected) return;
 
         const old = this.selected;
-        this.selected = selected;
+        this.requestUpdate('selected', old);
+        this._selected = selected;
+        if (!announce) return;
         this.dispatchChange(old);
     }
 
@@ -145,7 +160,7 @@ export class ActionGroup extends SpectrumElement {
                 target.selected = true;
                 target.tabIndex = 0;
                 target.setAttribute('aria-checked', 'true');
-                this.setSelected([target.value]);
+                this.setSelected([target.value], true);
                 target.focus();
                 break;
             }
@@ -161,7 +176,7 @@ export class ActionGroup extends SpectrumElement {
                 } else {
                     selected.splice(this.selected.indexOf(target.value), 1);
                 }
-                this.setSelected(selected);
+                this.setSelected(selected, true);
 
                 this.buttons.forEach((button) => {
                     button.tabIndex = -1;
@@ -176,7 +191,11 @@ export class ActionGroup extends SpectrumElement {
         }
     }
 
-    private async manageSelects(): Promise<void> {
+    private async applySelects(): Promise<void> {
+        await this.manageSelects(true);
+    }
+
+    private async manageSelects(applied?: boolean): Promise<void> {
         if (!this.buttons.length) {
             return;
         }
@@ -197,13 +216,14 @@ export class ActionGroup extends SpectrumElement {
                         selections.push(option);
                     }
                 });
+                if (applied) break;
                 await Promise.all(updates);
 
                 const selected = selections.map((button) => {
                     return button.value;
                 });
 
-                this.selected = selected || EMPTY_SELECTION;
+                this.setSelected(selected || EMPTY_SELECTION);
                 break;
             }
             case 'multiple': {
@@ -222,11 +242,12 @@ export class ActionGroup extends SpectrumElement {
                         selections.push(option);
                     }
                 });
+                if (applied) break;
                 await Promise.all(updates);
                 const selected = !!selection.length
                     ? selection
                     : EMPTY_SELECTION;
-                this.selected = selected;
+                this.setSelected(selected);
                 break;
             }
             default:
@@ -244,11 +265,14 @@ export class ActionGroup extends SpectrumElement {
                             selections.push(option);
                         }
                     });
+                    if (applied) break;
                     await Promise.all(updates);
 
-                    this.selected = selections.map((button) => {
-                        return button.value;
-                    });
+                    this.setSelected(
+                        selections.map((button) => {
+                            return button.value;
+                        })
+                    );
                 } else {
                     this.buttons.forEach((option) => {
                         option.setAttribute('role', 'button');
@@ -326,7 +350,7 @@ export class ActionGroup extends SpectrumElement {
                 currentlySelectedButtons.push(button.value);
             }
         });
-        this.selected = this.selected.concat(currentlySelectedButtons);
+        this.setSelected(this.selected.concat(currentlySelectedButtons));
         this.manageChildren();
         this.manageSelects();
     };

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -537,6 +537,24 @@ describe('ActionGroup', () => {
         expect(secondButton.selected, 'second button selected').to.be.true;
     });
 
+    it('selects can be updated while [selects="single"]', async () => {
+        const el = await singleSelectedActionGroup(['first']);
+        await elementUpdated(el);
+        expect(el.selected.length).to.equal(1);
+
+        const firstButton = el.querySelector('.first') as ActionButton;
+        const secondButton = el.querySelector('.second') as ActionButton;
+        expect(firstButton.selected, 'first button selected').to.be.true;
+        expect(secondButton.selected, 'second button not selected').to.be.false;
+
+        el.selected = ['second'];
+        await elementUpdated(el);
+
+        expect(el.selected.length).to.equal(1);
+        expect(firstButton.selected, 'first button not selected').to.be.false;
+        expect(secondButton.selected, 'second button selected').to.be.true;
+    });
+
     it('selects user-passed value while [selects="multiple"]', async () => {
         const el = await fixture<ActionGroup>(
             html`
@@ -581,6 +599,55 @@ describe('ActionGroup', () => {
         await elementUpdated(el);
 
         expect(el.selected.length).to.equal(2);
+        expect(firstButton.selected, 'first button not selected').to.be.false;
+        expect(secondButton.selected, 'second button selected').to.be.true;
+        expect(thirdButton.selected, 'third button selected').to.be.true;
+    });
+
+    it('selects can be updated while [selects="multiple"]', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Multiple Group"
+                    selects="multiple"
+                    .selected=${['first', 'second']}
+                >
+                    <sp-action-button class="first" value="first">
+                        First
+                    </sp-action-button>
+                    <sp-action-button class="second" value="second">
+                        Second
+                    </sp-action-button>
+                    <sp-action-button class="third " value="third">
+                        Third
+                    </sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const firstButton = el.querySelector('.first') as ActionButton;
+        const secondButton = el.querySelector('.second') as ActionButton;
+        const thirdButton = el.querySelector('.third') as ActionButton;
+
+        expect(el.selected.length).to.equal(2);
+        expect(firstButton.selected, 'first button selected').to.be.true;
+        expect(secondButton.selected, 'second button selected').to.be.true;
+        expect(thirdButton.selected, 'third button not selected').to.be.false;
+
+        el.selected = ['first', 'second', 'third'];
+        await elementUpdated(el);
+
+        expect(el.selected.length).to.equal(3);
+        expect(firstButton.selected, 'first button selected').to.be.true;
+        expect(secondButton.selected, 'second button selected').to.be.true;
+        expect(thirdButton.selected, 'third button selected').to.be.true;
+
+        el.selected = ['second', 'third'];
+        await elementUpdated(el);
+
+        expect(el.selected.length, JSON.stringify(el.selected)).to.equal(2);
         expect(firstButton.selected, 'first button not selected').to.be.false;
         expect(secondButton.selected, 'second button selected').to.be.true;
         expect(thirdButton.selected, 'third button selected').to.be.true;


### PR DESCRIPTION
## Description
Allow `sp-action-group` to receive the value of `selected` more than once from the parent application context.

## Related issue(s)
- fixes #2163

## Motivation and context
Empowers controlled components.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://action-group-selected--spectrum-web-components.netlify.app/components/action-group/#multiple)
    2. Focus the `sp-action-group` element in the DevTools
    3. Paste `$0.selected = ['Longer Button 2']` into the console
    4. See the selection update correctly in the UI.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.