### PR TITLE
refactor: separate Focus Group and Roving Tabindex into class extensions

### DIFF
--- a/packages/.eslintrc.json
+++ b/packages/.eslintrc.json
@@ -56,6 +56,12 @@
                     "sp-underlay"
                 ]
             }
+        ],
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                "argsIgnorePattern": "^_"
+            }
         ]
     },
     "overrides": [

--- a/packages/accordion/src/Accordion.ts
+++ b/packages/accordion/src/Accordion.ts
@@ -20,6 +20,7 @@ import {
     property,
     queryAssignedNodes,
 } from '@spectrum-web-components/base/src/decorators.js';
+import { FocusGroupController } from '@spectrum-web-components/reactive-controllers/src/FocusGroup.js';
 
 import { AccordionItem } from './AccordionItem.js';
 
@@ -49,13 +50,14 @@ export class Accordion extends SpectrumElement {
         ) as AccordionItem[];
     }
 
+    focusGroupController = new FocusGroupController<AccordionItem>(this, {
+        direction: 'vertical',
+        elements: () => this.items,
+        isFocusableElement: (el: AccordionItem) => !el.disabled,
+    });
+
     public focus(): void {
-        const firstActive = this.items.find((el) => {
-            return !el.disabled;
-        });
-        if (firstActive) {
-            firstActive.focus();
-        }
+        this.focusGroupController.focus();
     }
 
     private async onToggle(event: Event): Promise<void> {
@@ -81,9 +83,16 @@ export class Accordion extends SpectrumElement {
         });
     }
 
+    private handleSlotchange(): void {
+        this.focusGroupController.clearElementCache();
+    }
+
     protected render(): TemplateResult {
         return html`
-            <slot @sp-accordion-item-toggle=${this.onToggle}></slot>
+            <slot
+                @slotchange=${this.handleSlotchange}
+                @sp-accordion-item-toggle=${this.onToggle}
+            ></slot>
         `;
     }
 }

--- a/tools/.eslintrc.json
+++ b/tools/.eslintrc.json
@@ -56,6 +56,12 @@
                     "sp-underlay"
                 ]
             }
+        ],
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                "argsIgnorePattern": "^_"
+            }
         ]
     },
     "overrides": [

--- a/tools/reactive-controllers/src/FocusGroup.ts
+++ b/tools/reactive-controllers/src/FocusGroup.ts
@@ -1,0 +1,298 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import type { ReactiveController, ReactiveElement } from 'lit';
+
+type DirectionTypes = 'horizontal' | 'vertical' | 'both' | 'grid';
+export type FocusGroupConfig<T> = {
+    focusInIndex?: (_elements: T[]) => number;
+    direction?: DirectionTypes | (() => DirectionTypes);
+    elementEnterAction?: (el: T) => void;
+    elements: () => T[];
+    isFocusableElement?: (el: T) => boolean;
+    listenerScope?: HTMLElement | (() => HTMLElement);
+};
+
+export class FocusGroupController<T extends HTMLElement>
+    implements ReactiveController
+{
+    protected cachedElements?: T[];
+
+    get currentIndex(): number {
+        if (this._currentIndex === -1) {
+            this._currentIndex = this.focusInIndex;
+        }
+        return this._currentIndex - this.offset;
+    }
+
+    set currentIndex(currentIndex) {
+        this._currentIndex = currentIndex + this.offset;
+    }
+
+    private _currentIndex = -1;
+
+    get direction(): DirectionTypes {
+        return this._direction();
+    }
+
+    _direction = (): DirectionTypes => 'both';
+
+    public directionLength = 5;
+
+    elementEnterAction = (_el: T): void => {
+        return;
+    };
+
+    get elements(): T[] {
+        if (!this.cachedElements) {
+            this.cachedElements = this._elements();
+        }
+        return this.cachedElements;
+    }
+
+    private _elements!: () => T[];
+
+    protected set focused(focused: boolean) {
+        if (focused === this.focused) return;
+        this._focused = focused;
+    }
+
+    protected get focused(): boolean {
+        return this._focused;
+    }
+
+    private _focused = false;
+
+    get focusInElement(): T {
+        return this.elements[this.focusInIndex];
+    }
+
+    get focusInIndex(): number {
+        return this._focusInIndex(this.elements);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _focusInIndex = (_elements: T[]): number => 0;
+
+    host: ReactiveElement;
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    isFocusableElement = (_el: T): boolean => true;
+
+    isEventWithinListenerScope(event: Event): boolean {
+        if (this._listenerScope() === this.host) return true;
+        return event.composedPath().includes(this._listenerScope());
+    }
+
+    _listenerScope = (): HTMLElement => this.host;
+
+    // When elements are virtualized, the delta between the first element
+    // and the first rendered element.
+    offset = 0;
+
+    constructor(
+        host: ReactiveElement,
+        {
+            direction,
+            elementEnterAction,
+            elements,
+            focusInIndex,
+            isFocusableElement,
+            listenerScope,
+        }: FocusGroupConfig<T> = { elements: () => [] }
+    ) {
+        this.host = host;
+        this.host.addController(this);
+        this._elements = elements;
+        this.isFocusableElement = isFocusableElement || this.isFocusableElement;
+        // @TODO: abstract a method to simplify the conditional wrapping of the values as functions.
+        if (typeof direction === 'string') {
+            this._direction = () => direction;
+        } else if (typeof direction === 'function') {
+            this._direction = direction;
+        }
+        this.elementEnterAction = elementEnterAction || this.elementEnterAction;
+        if (typeof focusInIndex === 'number') {
+            this._focusInIndex = () => focusInIndex;
+        } else if (typeof focusInIndex === 'function') {
+            this._focusInIndex = focusInIndex;
+        }
+        if (typeof listenerScope === 'object') {
+            this._listenerScope = () => listenerScope;
+        } else if (typeof listenerScope === 'function') {
+            this._listenerScope = listenerScope;
+        }
+    }
+
+    update({ elements }: FocusGroupConfig<T> = { elements: () => [] }): void {
+        this.unmanage();
+        this._elements = elements;
+        this.clearElementCache();
+        this.manage();
+    }
+
+    focus(options?: FocusOptions): void {
+        let focusElement = this.elements[this.currentIndex];
+        if (!focusElement || !this.isFocusableElement(focusElement)) {
+            this.setCurrentIndexCircularly(1);
+            focusElement = this.elements[this.currentIndex];
+        }
+        if (focusElement && this.isFocusableElement(focusElement)) {
+            focusElement.focus(options);
+        }
+    }
+
+    clearElementCache(offset = 0): void {
+        delete this.cachedElements;
+        this.offset = offset;
+    }
+
+    setCurrentIndexCircularly(diff: number): void {
+        const { length } = this.elements;
+        let steps = length;
+        // start at a possibly not 0 index
+        let nextIndex = (length + this.currentIndex + diff) % length;
+        while (
+            // don't cycle the elements more than once
+            steps &&
+            this.elements[nextIndex] &&
+            !this.isFocusableElement(this.elements[nextIndex])
+        ) {
+            nextIndex = (length + nextIndex + diff) % length;
+            steps -= 1;
+        }
+        this.currentIndex = nextIndex;
+    }
+
+    hostContainsFocus(): void {
+        this.host.addEventListener('focusout', this.handleFocusout);
+        this.host.addEventListener('keydown', this.handleKeydown);
+        this.focused = true;
+    }
+
+    hostNoLongerContainsFocus(): void {
+        this.host.addEventListener('focusin', this.handleFocusin);
+        this.host.removeEventListener('focusout', this.handleFocusout);
+        this.host.removeEventListener('keydown', this.handleKeydown);
+        this.currentIndex = this.focusInIndex;
+        this.focused = false;
+    }
+
+    isRelatedTargetAnElement(event: FocusEvent): boolean {
+        const relatedTarget = event.relatedTarget as null | Element;
+        return !this.elements.includes(relatedTarget as T);
+    }
+
+    handleFocusin = (event: FocusEvent): void => {
+        if (!this.isEventWithinListenerScope(event)) return;
+        if (this.isRelatedTargetAnElement(event)) {
+            this.hostContainsFocus();
+        }
+        const path = event.composedPath() as T[];
+        let targetIndex = -1;
+        path.find((el) => {
+            targetIndex = this.elements.indexOf(el);
+            return targetIndex !== -1;
+        });
+        this.currentIndex = targetIndex > -1 ? targetIndex : this.currentIndex;
+    };
+
+    handleFocusout = (event: FocusEvent): void => {
+        if (this.isRelatedTargetAnElement(event)) {
+            this.hostNoLongerContainsFocus();
+        }
+    };
+
+    acceptsEventCode(code: string): boolean {
+        if (code === 'End' || code === 'Home') {
+            return true;
+        }
+        switch (this.direction) {
+            case 'horizontal':
+                return code === 'ArrowLeft' || code === 'ArrowRight';
+            case 'vertical':
+                return code === 'ArrowUp' || code === 'ArrowDown';
+            case 'both':
+            case 'grid':
+                return code.startsWith('Arrow');
+        }
+    }
+
+    handleKeydown = (event: KeyboardEvent): void => {
+        if (!this.acceptsEventCode(event.code) || event.defaultPrevented) {
+            return;
+        }
+        let diff = 0;
+        switch (event.code) {
+            case 'ArrowRight':
+                diff += 1;
+                break;
+            case 'ArrowDown':
+                diff += this.direction === 'grid' ? this.directionLength : 1;
+                break;
+            case 'ArrowLeft':
+                diff -= 1;
+                break;
+            case 'ArrowUp':
+                diff -= this.direction === 'grid' ? this.directionLength : 1;
+                break;
+            case 'End':
+                this.currentIndex = 0;
+                diff -= 1;
+                break;
+            case 'Home':
+                this.currentIndex = this.elements.length - 1;
+                diff += 1;
+                break;
+        }
+        event.preventDefault();
+        if (this.direction === 'grid' && this.currentIndex + diff < 0) {
+            this.currentIndex = 0;
+        } else if (
+            this.direction === 'grid' &&
+            this.currentIndex + diff > this.elements.length - 1
+        ) {
+            this.currentIndex = this.elements.length - 1;
+        } else {
+            this.setCurrentIndexCircularly(diff);
+        }
+        // To allow the `focusInIndex` to be calculated with the "after" state of the keyboard interaction
+        // do `elementEnterAction` _before_ focusing the next element.
+        this.elementEnterAction(this.elements[this.currentIndex]);
+        this.focus();
+    };
+
+    manage(): void {
+        this.addEventListeners();
+    }
+
+    unmanage(): void {
+        this.removeEventListeners();
+    }
+
+    addEventListeners(): void {
+        this.host.addEventListener('focusin', this.handleFocusin);
+    }
+
+    removeEventListeners(): void {
+        this.host.removeEventListener('focusin', this.handleFocusin);
+        this.host.removeEventListener('focusout', this.handleFocusout);
+        this.host.removeEventListener('keydown', this.handleKeydown);
+    }
+
+    hostConnected(): void {
+        this.addEventListeners();
+    }
+
+    hostDisconnected(): void {
+        this.removeEventListeners();
+    }
+}

--- a/tools/reactive-controllers/src/RovingTabindex.ts
+++ b/tools/reactive-controllers/src/RovingTabindex.ts
@@ -9,277 +9,40 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import type { ReactiveController, ReactiveElement } from 'lit';
+import { FocusGroupConfig, FocusGroupController } from './FocusGroup.js';
 
-type DirectionTypes = 'horizontal' | 'vertical' | 'both' | 'grid';
-export type RovingTabindexConfig<T> = {
-    focusInIndex?: (_elements: T[]) => number;
-    direction?: DirectionTypes | (() => DirectionTypes);
-    elementEnterAction?: (el: T) => void;
-    elements: () => T[];
-    isFocusableElement?: (el: T) => boolean;
-    listenerScope?: HTMLElement | (() => HTMLElement);
-};
+export type RovingTabindexConfig<T> = FocusGroupConfig<T>;
 interface UpdateTabIndexes {
     tabIndex: number;
     removeTabIndex?: boolean;
 }
 
-export class RovingTabindexController<T extends HTMLElement>
-    implements ReactiveController
-{
-    private cachedElements?: T[];
-
-    get currentIndex(): number {
-        if (this._currentIndex === -1) {
-            this._currentIndex = this.focusInIndex;
-        }
-        return this._currentIndex - this.offset;
-    }
-
-    set currentIndex(currentIndex) {
-        this._currentIndex = currentIndex + this.offset;
-    }
-
-    private _currentIndex = -1;
-
-    get direction(): DirectionTypes {
-        return this._direction();
-    }
-
-    _direction = (): DirectionTypes => 'both';
-
-    public directionLength = 5;
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    elementEnterAction = (_el: T): void => {
-        return;
-    };
-
-    get elements(): T[] {
-        if (!this.cachedElements) {
-            this.cachedElements = this._elements();
-        }
-        return this.cachedElements;
-    }
-
-    private _elements!: () => T[];
-
-    firstUpdated = true;
-
-    private set focused(focused: boolean) {
+export class RovingTabindexController<
+    T extends HTMLElement
+> extends FocusGroupController<T> {
+    protected set focused(focused: boolean) {
         if (focused === this.focused) return;
-        this._focused = focused;
+        super.focused = focused;
         this.manageTabindexes();
     }
 
-    private get focused(): boolean {
-        return this._focused;
+    protected get focused(): boolean {
+        return super.focused;
     }
-    private _focused = false;
-
-    get focusInElement(): T {
-        return this.elements[this.focusInIndex];
-    }
-
-    get focusInIndex(): number {
-        return this._focusInIndex(this.elements);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _focusInIndex = (_elements: T[]): number => 0;
-
-    host: ReactiveElement;
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    isFocusableElement = (_el: T): boolean => true;
-
-    isEventWithinListenerScope(event: Event): boolean {
-        if (this._listenerScope() === this.host) return true;
-        return event.composedPath().includes(this._listenerScope());
-    }
-
-    _listenerScope = (): HTMLElement => this.host;
-
-    // When elements are virtualized, the delta between the first element
-    // and the first rendered element.
-    offset = 0;
 
     private managed = true;
-
-    constructor(
-        host: ReactiveElement,
-        {
-            direction,
-            elementEnterAction,
-            elements,
-            focusInIndex,
-            isFocusableElement,
-            listenerScope,
-        }: RovingTabindexConfig<T> = { elements: () => [] }
-    ) {
-        this.host = host;
-        this.host.addController(this);
-        this._elements = elements;
-        this.isFocusableElement = isFocusableElement || this.isFocusableElement;
-        if (typeof direction === 'string') {
-            this._direction = () => direction;
-        } else if (typeof direction === 'function') {
-            this._direction = direction;
-        }
-        this.elementEnterAction = elementEnterAction || this.elementEnterAction;
-        if (typeof focusInIndex === 'number') {
-            this._focusInIndex = () => focusInIndex;
-        } else if (typeof focusInIndex === 'function') {
-            this._focusInIndex = focusInIndex;
-        }
-        if (typeof listenerScope === 'object') {
-            this._listenerScope = () => listenerScope;
-        } else if (typeof listenerScope === 'function') {
-            this._listenerScope = listenerScope;
-        }
-    }
-
-    update(
-        { elements }: RovingTabindexConfig<T> = { elements: () => [] }
-    ): void {
-        this.unmanage();
-        this._elements = elements;
-        this.clearElementCache();
-        this.manage();
-    }
-
-    focus(options?: FocusOptions): void {
-        this.elements[this.currentIndex]?.focus(options);
-    }
 
     private manageIndexesAnimationFrame = 0;
 
     clearElementCache(offset = 0): void {
-        delete this.cachedElements;
         cancelAnimationFrame(this.manageIndexesAnimationFrame);
-        this.offset = offset;
+        super.clearElementCache(offset);
         if (!this.managed) return;
 
         this.manageIndexesAnimationFrame = requestAnimationFrame(() =>
             this.manageTabindexes()
         );
     }
-
-    setCurrentIndexCircularly(diff: number): void {
-        const { length } = this.elements;
-        let steps = length;
-        // start at a possibly not 0 index
-        let nextIndex = (length + this.currentIndex + diff) % length;
-        while (
-            // don't cycle the elements more than once
-            steps &&
-            this.elements[nextIndex] &&
-            !this.isFocusableElement(this.elements[nextIndex])
-        ) {
-            nextIndex = (length + nextIndex + diff) % length;
-            steps -= 1;
-        }
-        this.currentIndex = nextIndex;
-    }
-
-    hostContainsFocus(): void {
-        this.host.addEventListener('focusout', this.handleFocusout);
-        this.host.addEventListener('keydown', this.handleKeydown);
-        this.focused = true;
-    }
-
-    hostNoLongerContainsFocus(): void {
-        this.host.addEventListener('focusin', this.handleFocusin);
-        this.host.removeEventListener('focusout', this.handleFocusout);
-        this.host.removeEventListener('keydown', this.handleKeydown);
-        this.currentIndex = this.focusInIndex;
-        this.focused = false;
-    }
-
-    isRelatedTargetAnElement(event: FocusEvent): boolean {
-        const relatedTarget = event.relatedTarget as null | Element;
-        return !this.elements.includes(relatedTarget as T);
-    }
-
-    handleFocusin = (event: FocusEvent): void => {
-        if (!this.isEventWithinListenerScope(event)) return;
-        if (this.isRelatedTargetAnElement(event)) {
-            this.hostContainsFocus();
-        }
-        const path = event.composedPath() as T[];
-        let targetIndex = -1;
-        path.find((el) => {
-            targetIndex = this.elements.indexOf(el);
-            return targetIndex !== -1;
-        });
-        this.currentIndex = targetIndex > -1 ? targetIndex : this.currentIndex;
-    };
-
-    handleFocusout = (event: FocusEvent): void => {
-        if (this.isRelatedTargetAnElement(event)) {
-            this.hostNoLongerContainsFocus();
-        }
-    };
-
-    acceptsEventCode(code: string): boolean {
-        if (code === 'End' || code === 'Home') {
-            return true;
-        }
-        switch (this.direction) {
-            case 'horizontal':
-                return code === 'ArrowLeft' || code === 'ArrowRight';
-            case 'vertical':
-                return code === 'ArrowUp' || code === 'ArrowDown';
-            case 'both':
-            case 'grid':
-                return code.startsWith('Arrow');
-        }
-    }
-
-    handleKeydown = (event: KeyboardEvent): void => {
-        if (!this.acceptsEventCode(event.code) || event.defaultPrevented) {
-            return;
-        }
-        let diff = 0;
-        switch (event.code) {
-            case 'ArrowRight':
-                diff += 1;
-                break;
-            case 'ArrowDown':
-                diff += this.direction === 'grid' ? this.directionLength : 1;
-                break;
-            case 'ArrowLeft':
-                diff -= 1;
-                break;
-            case 'ArrowUp':
-                diff -= this.direction === 'grid' ? this.directionLength : 1;
-                break;
-            case 'End':
-                this.currentIndex = 0;
-                diff -= 1;
-                break;
-            case 'Home':
-                this.currentIndex = this.elements.length - 1;
-                diff += 1;
-                break;
-        }
-        event.preventDefault();
-        if (this.direction === 'grid' && this.currentIndex + diff < 0) {
-            this.currentIndex = 0;
-        } else if (
-            this.direction === 'grid' &&
-            this.currentIndex + diff > this.elements.length - 1
-        ) {
-            this.currentIndex = this.elements.length - 1;
-        } else {
-            this.setCurrentIndexCircularly(diff);
-        }
-        // To allow the `focusInIndex` to be calculated with the "after" state of the keyboard interaction
-        // do `elementEnterAction` _before_ focusing the next element.
-        this.elementEnterAction(this.elements[this.currentIndex]);
-        this.focus();
-    };
 
     manageTabindexes(): void {
         if (this.focused) {
@@ -314,37 +77,18 @@ export class RovingTabindexController<T extends HTMLElement>
     manage(): void {
         this.managed = true;
         this.manageTabindexes();
-        this.addEventListeners();
+        super.manage();
     }
 
     unmanage(): void {
         this.managed = false;
         this.updateTabindexes(() => ({ tabIndex: 0 }));
-        this.removeEventListeners();
-    }
-
-    addEventListeners(): void {
-        this.host.addEventListener('focusin', this.handleFocusin);
-    }
-
-    removeEventListeners(): void {
-        this.host.removeEventListener('focusin', this.handleFocusin);
-        this.host.removeEventListener('focusout', this.handleFocusout);
-        this.host.removeEventListener('keydown', this.handleKeydown);
+        super.unmanage();
     }
 
     hostUpdated(): void {
-        if (this.firstUpdated) {
+        if (!this.host.hasUpdated) {
             this.manageTabindexes();
-            this.firstUpdated = false;
         }
-    }
-
-    hostConnected(): void {
-        this.addEventListeners();
-    }
-
-    hostDisconnected(): void {
-        this.removeEventListeners();
     }
 }


### PR DESCRIPTION
## Description
Split up "Focus Group" and "Roving Tabindex" functionality to support a wider number of use cases.

Apply the "Focus Group" functionality to the Accordion pattern so that the Items in the Accordion can be accessed as expected.

- referencing https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html the Accordion Items are not navigable by ArrowUp/Down keys, but as per this conversation with @jnurthen https://github.com/adobe/spectrum-web-components/pull/2278#discussion_r868588706 maintaining the _initial_ (though not current) implementation of this pattern in SWC is acceptable.


## Related issue(s)
- fixes #2273

## Motivation and context
Apply the correct accessibility model to Accordion Items and make leveraging the accessibility model elsewhere less complicated.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://focus-manager--spectrum-web-components.netlify.app/storybook/?path=/story/accordion--default)
    2. Tab through the Accordion Items
    3. Use ArrowUp/Down keys to navigate through the Accordion Items

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/) 
