### PR TITLE
docs: update docs content

### DIFF
--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -58,6 +58,17 @@ export class Toast extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public open = false;
 
+    /**
+     * When a timeout is provided it represents the number of milliseconds from when
+     * the Toast was placed on the page before it will automatically dismiss itself.
+     * Accessibility concerns require that a Toast is available for at least 6000ms
+     * before being dismissed, so any timeout of less than 6000ms will be raised to
+     * that baseline. It is suggested that messages longer than 120 words should
+     * receive another 1000ms in their timeout for each additional 120 words in the
+     * message. E.G. 240 words = 7000ms, 360 words = 8000ms, etc.
+     *
+     * @param {Number} timeout
+     */
     @property({ type: Number })
     public set timeout(timeout: number | null) {
         const hasTimeout = typeof timeout !== null && (timeout as number) > 0;

--- a/projects/documentation/content/getting-started.md
+++ b/projects/documentation/content/getting-started.md
@@ -63,7 +63,7 @@ When you're ready to look into more advanced usage of the components and themes 
 
 </div>
 
-<sp-link href="components/theme">Read about the full range of style customization provided by `@spectrum-web-components/theme`.</sp-link>
+<sp-link href="../components/theme">Read about the full range of style customization provided by `@spectrum-web-components/theme`.</sp-link>
 
 ### What you can do
 


### PR DESCRIPTION
## Description
- correct link in Getting Started page
- add documentation for unexpected accessibility features in `<sp-toast>`

## Related issue(s)

- refs #2291
- refs #351

## Motivation and context
Easier to get started.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://docs-updates--spectrum-web-components.netlify.app/getting-started/#what-you-can-do)
    2. See that "Read about the full range of style customization provided by @spectrum-web-components/theme." links to the Theme page.
-   [ ] _Test case 2_
    1. Go [here](https://docs-updates--spectrum-web-components.netlify.app/components/toast/api/#attributes-and-properties)
    2. See that `toast` is documented

## Types of changes

-   [x] Docs

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)