### PR TITLE
chore: use latest Spectrum CSS versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: ee290395f871b22a7174ffdc25bbd0ccf82c2dc0
+        default: d5c1af3d3520f89f9effc18ea5ddee94a1c4678b
 commands:
     downstream:
         steps:

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -53,7 +53,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/accordion": "^3.0.21"
+        "@spectrum-css/accordion": "^3.0.22"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/accordion/src/AccordionItem.ts
+++ b/packages/accordion/src/AccordionItem.ts
@@ -81,8 +81,7 @@ export class AccordionItem extends Focusable {
                     ${this.label}
                 </button>
                 <sp-icon-chevron100
-                    id="indicator"
-                    class="spectrum-UIIcon-ChevronRight100"
+                    class="indicator spectrum-UIIcon-ChevronRight100"
                 ></sp-icon-chevron100>
             </h3>
             <div id="content" role="region" aria-labelledby="header">

--- a/packages/accordion/src/spectrum-accordion-item.css
+++ b/packages/accordion/src/spectrum-accordion-item.css
@@ -11,19 +11,19 @@ governing permissions and limitations under the License.
 */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-:host([dir='ltr']) #indicator {
+:host([dir='ltr']) .indicator {
     left: var(
         --spectrum-accordion-item-padding-x,
         var(--spectrum-global-dimension-size-225)
     ); /* [dir=ltr] .spectrum-Accordion-itemIndicator */
 }
-:host([dir='rtl']) #indicator {
+:host([dir='rtl']) .indicator {
     right: var(
         --spectrum-accordion-item-padding-x,
         var(--spectrum-global-dimension-size-225)
     ); /* [dir=rtl] .spectrum-Accordion-itemIndicator */
 }
-:host([dir='rtl']) #indicator {
+:host([dir='rtl']) .indicator {
     transform: matrix(
         -1,
         0,
@@ -33,7 +33,7 @@ governing permissions and limitations under the License.
         0
     ); /* [dir=rtl] .spectrum-Accordion-itemIndicator */
 }
-#indicator {
+.indicator {
     display: block; /* .spectrum-Accordion-itemIndicator */
     position: absolute;
     top: calc(
@@ -212,20 +212,20 @@ governing permissions and limitations under the License.
     );
     padding-top: 0; /* .spectrum-Accordion-itemContent */
 }
-:host([dir='ltr'][open]) > #heading > #indicator {
+:host([dir='ltr'][open]) > #heading > .indicator {
     transform: rotate(
         90deg
     ); /* [dir=ltr] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemHeading>.spectrum-Accordion-itemIndicator */
 }
-:host([dir='rtl'][open]) > #heading > #indicator {
+:host([dir='rtl'][open]) > #heading > .indicator {
     transform: matrix(-1, 0, 0, 1, 0, 0) rotate(90deg); /* [dir=rtl] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemHeading>.spectrum-Accordion-itemIndicator */
 }
-:host([dir='ltr'][open]) > #indicator {
+:host([dir='ltr'][open]) > .indicator {
     transform: rotate(
         90deg
     ); /* [dir=ltr] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemIndicator */
 }
-:host([dir='rtl'][open]) > #indicator {
+:host([dir='rtl'][open]) > .indicator {
     transform: matrix(-1, 0, 0, 1, 0, 0) rotate(90deg); /* [dir=rtl] .spectrum-Accordion-item.is-open>.spectrum-Accordion-itemIndicator */
 }
 :host([open]) > #header:after {
@@ -249,7 +249,7 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-300)
     ); /* .spectrum-Accordion-item */
 }
-#indicator {
+.indicator {
     color: var(
         --spectrum-accordion-icon-color,
         var(--spectrum-global-color-gray-600)
@@ -271,7 +271,7 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-900)
     ); /* .spectrum-Accordion-itemHeader:hover */
 }
-#header:hover + #indicator {
+#header:hover + .indicator {
     color: var(
         --spectrum-accordion-icon-color-hover,
         var(--spectrum-alias-icon-color-hover)
@@ -314,7 +314,7 @@ governing permissions and limitations under the License.
    * .spectrum-Accordion-item.is-disabled .spectrum-Accordion-itemHeader:hover,
    * .spectrum-Accordion-item.is-disabled .spectrum-Accordion-itemHeader.focus-ring */
 }
-:host([disabled]) #header + #indicator {
+:host([disabled]) #header + .indicator {
     color: var(
         --spectrum-accordion-icon-color-disabled,
         var(--spectrum-alias-icon-color-disabled)

--- a/packages/accordion/src/spectrum-accordion-item.css
+++ b/packages/accordion/src/spectrum-accordion-item.css
@@ -320,3 +320,11 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-icon-color-disabled)
     ); /* .spectrum-Accordion-item.is-disabled .spectrum-Accordion-itemHeader+.spectrum-Accordion-itemIndicator */
 }
+@media (forced-colors: active) {
+    #header.focus-visible {
+        outline: 3px solid CanvasText;
+    }
+    #header:focus-visible {
+        outline: 3px solid CanvasText;
+    }
+}

--- a/packages/accordion/src/spectrum-config.js
+++ b/packages/accordion/src/spectrum-config.js
@@ -57,10 +57,6 @@ const config = {
             ],
             ids: [
                 {
-                    selector: '.spectrum-Accordion-itemIndicator',
-                    name: 'indicator',
-                },
-                {
                     selector: '.spectrum-Accordion-itemHeading',
                     name: 'heading',
                 },
@@ -71,6 +67,12 @@ const config = {
                 {
                     selector: '.spectrum-Accordion-itemContent',
                     name: 'content',
+                },
+            ],
+            classes: [
+                {
+                    selector: '.spectrum-Accordion-itemIndicator',
+                    name: 'indicator',
                 },
             ],
         },

--- a/packages/action-bar/package.json
+++ b/packages/action-bar/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbar": "^3.0.26"
+        "@spectrum-css/actionbar": "^3.0.27"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^1.1.12"
+        "@spectrum-css/actionbutton": "^1.1.13"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/src/action-button.css
+++ b/packages/action-button/src/action-button.css
@@ -121,3 +121,55 @@ governing permissions and limitations under the License.
         --spectrum-alias-ui-icon-cornertriangle-size-300
     );
 }
+
+@media (forced-colors: active) {
+    :host([variant='black']) {
+        --spectrum-actionbutton-focus-ring-color: ButtonText;
+    }
+
+    :host([size][disabled]),
+    :host([size][variant='black'][disabled]),
+    :host([size][variant='white'][disabled]),
+    :host([size][variant='black'][disabled]:not([quiet])),
+    :host([size][variant='white'][disabled]:not([quiet])),
+    :host([size][variant='black'][disabled][emphaized]),
+    :host([size][variant='white'][disabled][emphaized]) {
+        background-color: var(
+            --spectrum-actionbutton-m-quiet-textonly-background-color-selected-disabled,
+            var(
+                --spectrum-alias-component-background-color-quiet-selected-disabled
+            )
+        );
+        border-color: var(
+            --spectrum-actionbutton-m-quiet-textonly-border-color-selected-disabled,
+            var(--spectrum-alias-component-border-color-quiet-disabled)
+        );
+    }
+
+    :host([size][disabled]) #label,
+    :host([size][disabled]) .hold-affordance,
+    :host([size][disabled]) ::slotted(*),
+    :host([size][variant='black'][disabled]) #label,
+    :host([size][variant='white'][disabled]) #label,
+    :host([size][variant='black'][disabled]:not([quiet])) #label,
+    :host([size][variant='white'][disabled]:not([quiet])) #label,
+    :host([size][variant='black'][disabled][emphaized]) #label,
+    :host([size][variant='white'][disabled][emphaized]) #label,
+    :host([size][variant='black'][disabled]) .hold-affordance,
+    :host([size][variant='white'][disabled]) .hold-affordance,
+    :host([size][variant='black'][disabled]:not([quiet])) .hold-affordance,
+    :host([size][variant='white'][disabled]:not([quiet])) .hold-affordance,
+    :host([size][variant='black'][disabled][emphaized]) .hold-affordance,
+    :host([size][variant='white'][disabled][emphaized]) .hold-affordance,
+    :host([size][variant='black'][disabled]) ::slotted(*),
+    :host([size][variant='white'][disabled]) ::slotted(*),
+    :host([size][variant='black'][disabled]:not([quiet])) ::slotted(*),
+    :host([size][variant='white'][disabled]:not([quiet])) ::slotted(*),
+    :host([size][variant='black'][disabled][emphaized]) ::slotted(*),
+    :host([size][variant='white'][disabled][emphaized]) ::slotted(*) {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected-disabled,
+            var(--spectrum-alias-component-text-color-disabled)
+        );
+    }
+}

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -560,25 +560,25 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-opacity-25)
     ); /* .spectrum-ActionButton.spectrum-ActionButton--staticWhite.spectrum-ActionButton--quiet:not(:disabled):not(.is-selected).is-keyboardFocused */
 }
-:host([variant='white'][disabled][selected]) {
+:host([size][variant='white'][disabled][selected]) {
     background-color: var(
         --spectrum-alias-actionbutton-staticWhite-background-color-disabled-selected,
         hsla(0, 0%, 100%, 0.1)
     ); /* .spectrum-ActionButton.spectrum-ActionButton--staticWhite:disabled.is-selected */
 }
-:host([variant='white'][disabled][selected]) .hold-affordance {
+:host([size][variant='white'][disabled][selected]) .hold-affordance {
     color: rgba(
         var(--spectrum-global-color-static-white-rgb, 255, 255, 255),
         var(--spectrum-global-color-opacity-40)
     ); /* .spectrum-ActionButton.spectrum-ActionButton--staticWhite:disabled.is-selected .spectrum-ActionButton-holdIcon */
 }
-:host([variant='white'][disabled][selected]) #label {
+:host([size][variant='white'][disabled][selected]) #label {
     color: rgba(
         var(--spectrum-global-color-static-white-rgb, 255, 255, 255),
         var(--spectrum-global-color-opacity-40)
     ); /* .spectrum-ActionButton.spectrum-ActionButton--staticWhite:disabled.is-selected .spectrum-ActionButton-label */
 }
-:host([variant='white'][disabled][selected]) ::slotted([slot='icon']) {
+:host([size][variant='white'][disabled][selected]) ::slotted([slot='icon']) {
     color: rgba(
         var(--spectrum-global-color-static-white-rgb, 255, 255, 255),
         var(--spectrum-global-color-opacity-40)
@@ -2074,8 +2074,8 @@ governing permissions and limitations under the License.
     :host([selected]:not([disabled])) #label {
         forced-color-adjust: none;
     }
-    :host([variant='black'][selected]:not([disabled])),
-    :host([variant='white'][selected]:not([disabled])) {
+    :host([size][variant='black'][selected]:not([disabled])),
+    :host([size][variant='white'][selected]:not([disabled])) {
         background-color: var(
             --spectrum-actionbutton-m-quiet-textonly-background-color-selected,
             var(--spectrum-alias-component-background-color-selected-default)
@@ -2089,36 +2089,37 @@ governing permissions and limitations under the License.
             var(--spectrum-alias-component-text-color-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled])) .hold-affordance,
-    :host([variant='white'][selected]:not([disabled])) .hold-affordance {
+    :host([size][variant='black'][selected]:not([disabled])) .hold-affordance,
+    :host([size][variant='white'][selected]:not([disabled])) .hold-affordance {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled])) #label,
-    :host([variant='white'][selected]:not([disabled])) #label {
+    :host([size][variant='black'][selected]:not([disabled])) #label,
+    :host([size][variant='white'][selected]:not([disabled])) #label {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         ) !important;
     }
-    :host([variant='black'][selected]:not([disabled])) ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled]))
+    :host([size][variant='black'][selected]:not([disabled]))
+        ::slotted([slot='icon']),
+    :host([size][variant='white'][selected]:not([disabled]))
         ::slotted([slot='icon']) {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         ) !important;
     }
-    :host([variant='black'][selected]:not([disabled]).focus-visible),
-    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused),
-    :host([variant='black'][selected]:not([disabled]):hover),
-    :host([variant='black'][selected]:not([disabled])[active]),
-    :host([variant='white'][selected]:not([disabled]).focus-visible),
-    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused),
-    :host([variant='white'][selected]:not([disabled]):hover),
-    :host([variant='white'][selected]:not([disabled])[active]) {
+    :host([size][variant='black'][selected]:not([disabled])).focus-visible,
+    :host([size][variant='black'][selected]:not([disabled])).is-keyboardFocused,
+    :host([size][variant='black'][selected]:not([disabled])):hover,
+    :host([size][variant='black'][selected]:not([disabled])[active]),
+    :host([size][variant='white'][selected]:not([disabled])).focus-visible,
+    :host([size][variant='white'][selected]:not([disabled])).is-keyboardFocused,
+    :host([size][variant='white'][selected]:not([disabled])):hover,
+    :host([size][variant='white'][selected]:not([disabled])[active]) {
         background-color: var(
             --spectrum-actionbutton-m-quiet-textonly-background-color-selected,
             var(--spectrum-alias-component-background-color-selected-default)
@@ -2128,14 +2129,14 @@ governing permissions and limitations under the License.
             var(--spectrum-alias-component-border-color-quiet-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused),
-    :host([variant='black'][selected]:not([disabled]):focus-visible),
-    :host([variant='black'][selected]:not([disabled]):hover),
-    :host([variant='black'][selected]:not([disabled])[active]),
-    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused),
-    :host([variant='white'][selected]:not([disabled]):focus-visible),
-    :host([variant='white'][selected]:not([disabled]):hover),
-    :host([variant='white'][selected]:not([disabled])[active]) {
+    :host([size][variant='black'][selected]:not([disabled])).is-keyboardFocused,
+    :host([size][variant='black'][selected]:not([disabled])):focus-visible,
+    :host([size][variant='black'][selected]:not([disabled])):hover,
+    :host([size][variant='black'][selected]:not([disabled])[active]),
+    :host([size][variant='white'][selected]:not([disabled])).is-keyboardFocused,
+    :host([size][variant='white'][selected]:not([disabled])):focus-visible,
+    :host([size][variant='white'][selected]:not([disabled])):hover,
+    :host([size][variant='white'][selected]:not([disabled])[active]) {
         background-color: var(
             --spectrum-actionbutton-m-quiet-textonly-background-color-selected,
             var(--spectrum-alias-component-background-color-selected-default)
@@ -2145,114 +2146,122 @@ governing permissions and limitations under the License.
             var(--spectrum-alias-component-border-color-quiet-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled]).focus-visible)
+    :host([size][variant='black'][selected]:not([disabled])).focus-visible
         .hold-affordance,
-    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])).is-keyboardFocused
         .hold-affordance,
-    :host([variant='black'][selected]:not([disabled]):hover) .hold-affordance,
-    :host([variant='black'][selected]:not([disabled])[active]) .hold-affordance,
-    :host([variant='white'][selected]:not([disabled]).focus-visible)
+    :host([size][variant='black'][selected]:not([disabled])):hover
         .hold-affordance,
-    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])[active])
         .hold-affordance,
-    :host([variant='white'][selected]:not([disabled]):hover) .hold-affordance,
-    :host([variant='white'][selected]:not([disabled])[active])
+    :host([size][variant='white'][selected]:not([disabled])).focus-visible
+        .hold-affordance,
+    :host([size][variant='white'][selected]:not([disabled])).is-keyboardFocused
+        .hold-affordance,
+    :host([size][variant='white'][selected]:not([disabled])):hover
+        .hold-affordance,
+    :host([size][variant='white'][selected]:not([disabled])[active])
         .hold-affordance {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])).is-keyboardFocused
         .hold-affordance,
-    :host([variant='black'][selected]:not([disabled]):focus-visible)
+    :host([size][variant='black'][selected]:not([disabled])):focus-visible
         .hold-affordance,
-    :host([variant='black'][selected]:not([disabled]):hover) .hold-affordance,
-    :host([variant='black'][selected]:not([disabled])[active]) .hold-affordance,
-    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])):hover
         .hold-affordance,
-    :host([variant='white'][selected]:not([disabled]):focus-visible)
+    :host([size][variant='black'][selected]:not([disabled])[active])
         .hold-affordance,
-    :host([variant='white'][selected]:not([disabled]):hover) .hold-affordance,
-    :host([variant='white'][selected]:not([disabled])[active])
+    :host([size][variant='white'][selected]:not([disabled])).is-keyboardFocused
+        .hold-affordance,
+    :host([size][variant='white'][selected]:not([disabled])):focus-visible
+        .hold-affordance,
+    :host([size][variant='white'][selected]:not([disabled])):hover
+        .hold-affordance,
+    :host([size][variant='white'][selected]:not([disabled])[active])
         .hold-affordance {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled]).focus-visible) #label,
-    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])).focus-visible
         #label,
-    :host([variant='black'][selected]:not([disabled]):hover) #label,
-    :host([variant='black'][selected]:not([disabled])[active]) #label,
-    :host([variant='white'][selected]:not([disabled]).focus-visible) #label,
-    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])).is-keyboardFocused
         #label,
-    :host([variant='white'][selected]:not([disabled]):hover) #label,
-    :host([variant='white'][selected]:not([disabled])[active]) #label {
+    :host([size][variant='black'][selected]:not([disabled])):hover #label,
+    :host([size][variant='black'][selected]:not([disabled])[active]) #label,
+    :host([size][variant='white'][selected]:not([disabled])).focus-visible
+        #label,
+    :host([size][variant='white'][selected]:not([disabled])).is-keyboardFocused
+        #label,
+    :host([size][variant='white'][selected]:not([disabled])):hover #label,
+    :host([size][variant='white'][selected]:not([disabled])[active]) #label {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])).is-keyboardFocused
         #label,
-    :host([variant='black'][selected]:not([disabled]):focus-visible) #label,
-    :host([variant='black'][selected]:not([disabled]):hover) #label,
-    :host([variant='black'][selected]:not([disabled])[active]) #label,
-    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])):focus-visible
         #label,
-    :host([variant='white'][selected]:not([disabled]):focus-visible) #label,
-    :host([variant='white'][selected]:not([disabled]):hover) #label,
-    :host([variant='white'][selected]:not([disabled])[active]) #label {
+    :host([size][variant='black'][selected]:not([disabled])):hover #label,
+    :host([size][variant='black'][selected]:not([disabled])[active]) #label,
+    :host([size][variant='white'][selected]:not([disabled])).is-keyboardFocused
+        #label,
+    :host([size][variant='white'][selected]:not([disabled])):focus-visible
+        #label,
+    :host([size][variant='white'][selected]:not([disabled])):hover #label,
+    :host([size][variant='white'][selected]:not([disabled])[active]) #label {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled]).focus-visible)
+    :host([size][variant='black'][selected]:not([disabled])).focus-visible
         ::slotted([slot='icon']),
-    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])).is-keyboardFocused
         ::slotted([slot='icon']),
-    :host([variant='black'][selected]:not([disabled]):hover)
+    :host([size][variant='black'][selected]:not([disabled])):hover
         ::slotted([slot='icon']),
-    :host([variant='black'][selected]:not([disabled])[active])
+    :host([size][variant='black'][selected]:not([disabled])[active])::slotted([slot='icon']),
+    :host([size][variant='white'][selected]:not([disabled])).focus-visible
         ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled]).focus-visible)
+    :host([size][variant='white'][selected]:not([disabled])).is-keyboardFocused
         ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='white'][selected]:not([disabled])):hover
         ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled]):hover)
-        ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled])[active])
-        ::slotted([slot='icon']) {
+    :host([size][variant='white'][selected]:not([disabled])[active])::slotted([slot='icon']) {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         );
     }
-    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='black'][selected]:not([disabled])).is-keyboardFocused
         ::slotted([slot='icon']),
-    :host([variant='black'][selected]:not([disabled]):focus-visible)
+    :host([size][variant='black'][selected]:not([disabled])):focus-visible
         ::slotted([slot='icon']),
-    :host([variant='black'][selected]:not([disabled]):hover)
+    :host([size][variant='black'][selected]:not([disabled])):hover
         ::slotted([slot='icon']),
-    :host([variant='black'][selected]:not([disabled])[active])
+    :host([size][variant='black'][selected]:not([disabled])[active])::slotted([slot='icon']),
+    :host([size][variant='white'][selected]:not([disabled])).is-keyboardFocused
         ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+    :host([size][variant='white'][selected]:not([disabled])):focus-visible
         ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled]):focus-visible)
+    :host([size][variant='white'][selected]:not([disabled])):hover
         ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled]):hover)
-        ::slotted([slot='icon']),
-    :host([variant='white'][selected]:not([disabled])[active])
-        ::slotted([slot='icon']) {
+    :host([size][variant='white'][selected]:not([disabled])[active])::slotted([slot='icon']) {
         color: var(
             --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
             var(--spectrum-alias-component-text-color-selected-default)
         );
     }
+    :host([size][variant='black'][disabled][selected]),
+    :host([size][variant='white'][disabled][selected]),
     :host([variant='black'][selected][disabled]),
     :host([variant='white'][selected][disabled]) {
         background-color: var(
@@ -2270,6 +2279,8 @@ governing permissions and limitations under the License.
             var(--spectrum-alias-component-text-color-disabled)
         );
     }
+    :host([size][variant='black'][disabled][selected]) .hold-affordance,
+    :host([size][variant='white'][disabled][selected]) .hold-affordance,
     :host([variant='black'][selected][disabled]) .hold-affordance,
     :host([variant='white'][selected][disabled]) .hold-affordance {
         color: var(
@@ -2277,6 +2288,8 @@ governing permissions and limitations under the License.
             var(--spectrum-alias-component-text-color-disabled)
         );
     }
+    :host([size][variant='black'][disabled][selected]) #label,
+    :host([size][variant='white'][disabled][selected]) #label,
     :host([variant='black'][selected][disabled]) #label,
     :host([variant='white'][selected][disabled]) #label {
         color: var(
@@ -2284,6 +2297,8 @@ governing permissions and limitations under the License.
             var(--spectrum-alias-component-text-color-disabled)
         );
     }
+    :host([size][variant='black'][disabled][selected]) ::slotted([slot='icon']),
+    :host([size][variant='white'][disabled][selected]) ::slotted([slot='icon']),
     :host([variant='black'][selected][disabled]) ::slotted([slot='icon']),
     :host([variant='white'][selected][disabled]) ::slotted([slot='icon']) {
         color: var(

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -2000,6 +2000,15 @@ governing permissions and limitations under the License.
 }
 @media (forced-colors: active) {
     :host {
+        --spectrum-actionbutton-focus-ring-gap: var(
+            --spectrum-alias-component-focusring-gap-emphasized,
+            var(--spectrum-global-dimension-static-size-25)
+        );
+        --spectrum-actionbutton-focus-ring-size: var(
+            --spectrum-alias-component-focusring-size-emphasized,
+            var(--spectrum-global-dimension-static-size-25)
+        );
+        --spectrum-actionbutton-focus-ring-color: ButtonText;
         --spectrum-actionbutton-m-emphasized-texticon-icon-color-selected: HighlightText;
         --spectrum-actionbutton-m-emphasized-texticon-icon-color-selected-disabled: GrayText;
         --spectrum-actionbutton-m-emphasized-texticon-icon-color-selected-down: HighlightText;
@@ -2020,116 +2029,266 @@ governing permissions and limitations under the License.
         --spectrum-actionbutton-m-emphasized-textonly-text-color-selected-down: HighlightText;
         --spectrum-actionbutton-m-emphasized-textonly-text-color-selected-hover: HighlightText;
         --spectrum-actionbutton-m-emphasized-textonly-text-color-selected-key-focus: HighlightText;
-        --spectrum-actionbutton-m-quiet-textonly-background-color: ButtonFace;
-        --spectrum-actionbutton-m-quiet-textonly-background-color-disabled: ButtonFace;
-        --spectrum-actionbutton-m-quiet-textonly-background-color-down: ButtonFace;
-        --spectrum-actionbutton-m-quiet-textonly-background-color-hover: ButtonFace;
-        --spectrum-actionbutton-m-quiet-textonly-background-color-key-focus: ButtonFace;
         --spectrum-actionbutton-m-quiet-textonly-background-color-selected: Highlight;
         --spectrum-actionbutton-m-quiet-textonly-background-color-selected-disabled: ButtonFace;
         --spectrum-actionbutton-m-quiet-textonly-background-color-selected-down: Highlight;
         --spectrum-actionbutton-m-quiet-textonly-background-color-selected-hover: Highlight;
         --spectrum-actionbutton-m-quiet-textonly-background-color-selected-key-focus: Highlight;
         --spectrum-actionbutton-m-quiet-textonly-border-color: ButtonFace;
-        --spectrum-actionbutton-m-quiet-textonly-border-color-disabled: ButtonFace;
-        --spectrum-actionbutton-m-quiet-textonly-border-color-down: ButtonFace;
-        --spectrum-actionbutton-m-quiet-textonly-border-color-hover: ButtonFace;
-        --spectrum-actionbutton-m-quiet-textonly-border-color-key-focus: Highlight;
+        --spectrum-actionbutton-m-quiet-textonly-border-color-down: Highlight;
+        --spectrum-actionbutton-m-quiet-textonly-border-color-hover: Highlight;
         --spectrum-actionbutton-m-quiet-textonly-border-color-selected: HighlightText;
         --spectrum-actionbutton-m-quiet-textonly-border-color-selected-disabled: GrayText;
         --spectrum-actionbutton-m-quiet-textonly-border-color-selected-down: HighlightText;
         --spectrum-actionbutton-m-quiet-textonly-border-color-selected-hover: HighlightText;
         --spectrum-actionbutton-m-quiet-textonly-border-color-selected-key-focus: HighlightText;
-        --spectrum-actionbutton-m-quiet-textonly-text-color: ButtonText;
-        --spectrum-actionbutton-m-quiet-textonly-text-color-disabled: GrayText;
-        --spectrum-actionbutton-m-quiet-textonly-text-color-down: ButtonText;
-        --spectrum-actionbutton-m-quiet-textonly-text-color-hover: ButtonText;
-        --spectrum-actionbutton-m-quiet-textonly-text-color-key-focus: ButtonText;
         --spectrum-actionbutton-m-quiet-textonly-text-color-selected: HighlightText;
         --spectrum-actionbutton-m-quiet-textonly-text-color-selected-disabled: GrayText;
         --spectrum-actionbutton-m-quiet-textonly-text-color-selected-down: HighlightText;
         --spectrum-actionbutton-m-quiet-textonly-text-color-selected-hover: HighlightText;
         --spectrum-actionbutton-m-quiet-textonly-text-color-selected-key-focus: HighlightText;
-        --spectrum-actionbutton-m-texticon-icon-color: ButtonText;
-        --spectrum-actionbutton-m-texticon-icon-color-disabled: GrayText;
-        --spectrum-actionbutton-m-texticon-icon-color-hover: ButtonText;
-        --spectrum-actionbutton-m-texticon-icon-color-key-focus: ButtonText;
         --spectrum-actionbutton-m-texticon-icon-color-selected: HighlightText;
         --spectrum-actionbutton-m-texticon-icon-color-selected-disabled: GrayText;
         --spectrum-actionbutton-m-texticon-icon-color-selected-down: HighlightText;
         --spectrum-actionbutton-m-texticon-icon-color-selected-hover: HighlightText;
         --spectrum-actionbutton-m-texticon-icon-color-selected-key-focus: HighlightText;
-        --spectrum-actionbutton-m-textonly-background-color: ButtonFace;
-        --spectrum-actionbutton-m-textonly-background-color-disabled: ButtonFace;
-        --spectrum-actionbutton-m-textonly-background-color-down: ButtonFace;
-        --spectrum-actionbutton-m-textonly-background-color-hover: ButtonFace;
-        --spectrum-actionbutton-m-textonly-background-color-key-focus: ButtonFace;
         --spectrum-actionbutton-m-textonly-background-color-selected: Highlight;
         --spectrum-actionbutton-m-textonly-background-color-selected-disabled: ButtonFace;
         --spectrum-actionbutton-m-textonly-background-color-selected-down: Highlight;
         --spectrum-actionbutton-m-textonly-background-color-selected-hover: Highlight;
         --spectrum-actionbutton-m-textonly-background-color-selected-key-focus: Highlight;
-        --spectrum-actionbutton-m-textonly-border-color: ButtonText;
-        --spectrum-actionbutton-m-textonly-border-color-disabled: GrayText;
-        --spectrum-actionbutton-m-textonly-border-color-down: ButtonText;
-        --spectrum-actionbutton-m-textonly-border-color-hover: ButtonText;
-        --spectrum-actionbutton-m-textonly-border-color-key-focus: Highlight;
         --spectrum-actionbutton-m-textonly-border-color-selected: HighlightText;
         --spectrum-actionbutton-m-textonly-border-color-selected-disabled: GrayText;
         --spectrum-actionbutton-m-textonly-border-color-selected-down: HighlightText;
         --spectrum-actionbutton-m-textonly-border-color-selected-hover: HighlightText;
         --spectrum-actionbutton-m-textonly-border-color-selected-key-focus: HighlightText;
-        --spectrum-actionbutton-m-textonly-hold-icon-color: ButtonText;
-        --spectrum-actionbutton-m-textonly-hold-icon-color-disabled: GrayText;
-        --spectrum-actionbutton-m-textonly-hold-icon-color-down: ButtonText;
-        --spectrum-actionbutton-m-textonly-hold-icon-color-hover: ButtonText;
-        --spectrum-actionbutton-m-textonly-hold-icon-color-key-focus: ButtonText;
-        --spectrum-actionbutton-m-textonly-text-color: ButtonText;
-        --spectrum-actionbutton-m-textonly-text-color-disabled: GrayText;
-        --spectrum-actionbutton-m-textonly-text-color-down: ButtonText;
-        --spectrum-actionbutton-m-textonly-text-color-hover: ButtonText;
-        --spectrum-actionbutton-m-textonly-text-color-key-focus: ButtonText;
         --spectrum-actionbutton-m-textonly-text-color-selected: HighlightText;
         --spectrum-actionbutton-m-textonly-text-color-selected-disabled: GrayText;
         --spectrum-actionbutton-m-textonly-text-color-selected-down: HighlightText;
         --spectrum-actionbutton-m-textonly-text-color-selected-hover: HighlightText;
         --spectrum-actionbutton-m-textonly-text-color-selected-key-focus: HighlightText;
+    }
+    :host:after {
         forced-color-adjust: none;
     }
-    :host([quiet][emphasized]:not([disabled]):hover) {
+    :host([selected]:not([disabled])) #label {
+        forced-color-adjust: none;
+    }
+    :host([variant='black'][selected]:not([disabled])),
+    :host([variant='white'][selected]:not([disabled])) {
         background-color: var(
-            --spectrum-actionbutton-m-emphasized-textonly-background-color-selected-hover,
-            var(
-                --spectrum-alias-component-background-color-emphasized-selected-hover
-            )
+            --spectrum-actionbutton-m-quiet-textonly-background-color-selected,
+            var(--spectrum-alias-component-background-color-selected-default)
         );
         border-color: var(
-            --spectrum-actionbutton-m-emphasized-textonly-border-color-selected-hover,
-            var(
-                --spectrum-alias-component-border-color-emphasized-selected-hover
-            )
+            --spectrum-actionbutton-m-quiet-textonly-border-color-selected,
+            var(--spectrum-alias-component-border-color-quiet-selected-default)
         );
         color: var(
-            --spectrum-actionbutton-m-emphasized-textonly-text-color-selected-hover,
-            var(--spectrum-alias-component-text-color-emphasized-selected-hover)
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
         );
     }
-    :host([quiet][emphasized]:not([disabled])[active]) {
+    :host([variant='black'][selected]:not([disabled])) .hold-affordance,
+    :host([variant='white'][selected]:not([disabled])) .hold-affordance {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        );
+    }
+    :host([variant='black'][selected]:not([disabled])) #label,
+    :host([variant='white'][selected]:not([disabled])) #label {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        ) !important;
+    }
+    :host([variant='black'][selected]:not([disabled])) ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled]))
+        ::slotted([slot='icon']) {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        ) !important;
+    }
+    :host([variant='black'][selected]:not([disabled]).focus-visible),
+    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused),
+    :host([variant='black'][selected]:not([disabled]):hover),
+    :host([variant='black'][selected]:not([disabled])[active]),
+    :host([variant='white'][selected]:not([disabled]).focus-visible),
+    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused),
+    :host([variant='white'][selected]:not([disabled]):hover),
+    :host([variant='white'][selected]:not([disabled])[active]) {
         background-color: var(
-            --spectrum-actionbutton-m-emphasized-textonly-background-color-selected-down,
+            --spectrum-actionbutton-m-quiet-textonly-background-color-selected,
+            var(--spectrum-alias-component-background-color-selected-default)
+        );
+        border-color: var(
+            --spectrum-actionbutton-m-quiet-textonly-border-color-selected,
+            var(--spectrum-alias-component-border-color-quiet-selected-default)
+        );
+    }
+    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused),
+    :host([variant='black'][selected]:not([disabled]):focus-visible),
+    :host([variant='black'][selected]:not([disabled]):hover),
+    :host([variant='black'][selected]:not([disabled])[active]),
+    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused),
+    :host([variant='white'][selected]:not([disabled]):focus-visible),
+    :host([variant='white'][selected]:not([disabled]):hover),
+    :host([variant='white'][selected]:not([disabled])[active]) {
+        background-color: var(
+            --spectrum-actionbutton-m-quiet-textonly-background-color-selected,
+            var(--spectrum-alias-component-background-color-selected-default)
+        );
+        border-color: var(
+            --spectrum-actionbutton-m-quiet-textonly-border-color-selected,
+            var(--spectrum-alias-component-border-color-quiet-selected-default)
+        );
+    }
+    :host([variant='black'][selected]:not([disabled]).focus-visible)
+        .hold-affordance,
+    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+        .hold-affordance,
+    :host([variant='black'][selected]:not([disabled]):hover) .hold-affordance,
+    :host([variant='black'][selected]:not([disabled])[active]) .hold-affordance,
+    :host([variant='white'][selected]:not([disabled]).focus-visible)
+        .hold-affordance,
+    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+        .hold-affordance,
+    :host([variant='white'][selected]:not([disabled]):hover) .hold-affordance,
+    :host([variant='white'][selected]:not([disabled])[active])
+        .hold-affordance {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        );
+    }
+    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+        .hold-affordance,
+    :host([variant='black'][selected]:not([disabled]):focus-visible)
+        .hold-affordance,
+    :host([variant='black'][selected]:not([disabled]):hover) .hold-affordance,
+    :host([variant='black'][selected]:not([disabled])[active]) .hold-affordance,
+    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+        .hold-affordance,
+    :host([variant='white'][selected]:not([disabled]):focus-visible)
+        .hold-affordance,
+    :host([variant='white'][selected]:not([disabled]):hover) .hold-affordance,
+    :host([variant='white'][selected]:not([disabled])[active])
+        .hold-affordance {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        );
+    }
+    :host([variant='black'][selected]:not([disabled]).focus-visible) #label,
+    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+        #label,
+    :host([variant='black'][selected]:not([disabled]):hover) #label,
+    :host([variant='black'][selected]:not([disabled])[active]) #label,
+    :host([variant='white'][selected]:not([disabled]).focus-visible) #label,
+    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+        #label,
+    :host([variant='white'][selected]:not([disabled]):hover) #label,
+    :host([variant='white'][selected]:not([disabled])[active]) #label {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        );
+    }
+    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+        #label,
+    :host([variant='black'][selected]:not([disabled]):focus-visible) #label,
+    :host([variant='black'][selected]:not([disabled]):hover) #label,
+    :host([variant='black'][selected]:not([disabled])[active]) #label,
+    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+        #label,
+    :host([variant='white'][selected]:not([disabled]):focus-visible) #label,
+    :host([variant='white'][selected]:not([disabled]):hover) #label,
+    :host([variant='white'][selected]:not([disabled])[active]) #label {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        );
+    }
+    :host([variant='black'][selected]:not([disabled]).focus-visible)
+        ::slotted([slot='icon']),
+    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+        ::slotted([slot='icon']),
+    :host([variant='black'][selected]:not([disabled]):hover)
+        ::slotted([slot='icon']),
+    :host([variant='black'][selected]:not([disabled])[active])
+        ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled]).focus-visible)
+        ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+        ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled]):hover)
+        ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled])[active])
+        ::slotted([slot='icon']) {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        );
+    }
+    :host([variant='black'][selected]:not([disabled]).is-keyboardFocused)
+        ::slotted([slot='icon']),
+    :host([variant='black'][selected]:not([disabled]):focus-visible)
+        ::slotted([slot='icon']),
+    :host([variant='black'][selected]:not([disabled]):hover)
+        ::slotted([slot='icon']),
+    :host([variant='black'][selected]:not([disabled])[active])
+        ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled]).is-keyboardFocused)
+        ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled]):focus-visible)
+        ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled]):hover)
+        ::slotted([slot='icon']),
+    :host([variant='white'][selected]:not([disabled])[active])
+        ::slotted([slot='icon']) {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected,
+            var(--spectrum-alias-component-text-color-selected-default)
+        );
+    }
+    :host([variant='black'][selected][disabled]),
+    :host([variant='white'][selected][disabled]) {
+        background-color: var(
+            --spectrum-actionbutton-m-quiet-textonly-background-color-selected-disabled,
             var(
-                --spectrum-alias-component-background-color-emphasized-selected-down
+                --spectrum-alias-component-background-color-quiet-selected-disabled
             )
         );
         border-color: var(
-            --spectrum-actionbutton-m-emphasized-textonly-border-color-selected-down,
-            var(
-                --spectrum-alias-component-border-color-emphasized-selected-down
-            )
+            --spectrum-actionbutton-m-quiet-textonly-border-color-selected-disabled,
+            var(--spectrum-alias-component-border-color-quiet-disabled)
         );
         color: var(
-            --spectrum-actionbutton-m-emphasized-textonly-text-color-selected-down,
-            var(--spectrum-alias-component-text-color-emphasized-selected-down)
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected-disabled,
+            var(--spectrum-alias-component-text-color-disabled)
+        );
+    }
+    :host([variant='black'][selected][disabled]) .hold-affordance,
+    :host([variant='white'][selected][disabled]) .hold-affordance {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected-disabled,
+            var(--spectrum-alias-component-text-color-disabled)
+        );
+    }
+    :host([variant='black'][selected][disabled]) #label,
+    :host([variant='white'][selected][disabled]) #label {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected-disabled,
+            var(--spectrum-alias-component-text-color-disabled)
+        );
+    }
+    :host([variant='black'][selected][disabled]) ::slotted([slot='icon']),
+    :host([variant='white'][selected][disabled]) ::slotted([slot='icon']) {
+        color: var(
+            --spectrum-actionbutton-m-quiet-textonly-text-color-selected-disabled,
+            var(--spectrum-alias-component-text-color-disabled)
         );
     }
 }

--- a/packages/action-button/src/spectrum-config.js
+++ b/packages/action-button/src/spectrum-config.js
@@ -130,6 +130,37 @@ const config = {
                     selector:
                         '.spectrum-ActionButton.spectrum-ActionButton--staticBlack:disabled.is-selected',
                 },
+                {
+                    replacement:
+                        ':host([size][variant="black"][disabled][selected])',
+                    selector:
+                        '.spectrum-ActionButton.spectrum-ActionButton--staticBlack.is-selected:disabled',
+                },
+                {
+                    replacement:
+                        ':host([size][variant="white"][disabled][selected])',
+                    selector:
+                        '.spectrum-ActionButton.spectrum-ActionButton--staticWhite:disabled.is-selected',
+                },
+                {
+                    replacement:
+                        ':host([size][variant="white"][disabled][selected])',
+                    selector:
+                        '.spectrum-ActionButton.spectrum-ActionButton--staticWhite.is-selected:disabled',
+                },
+
+                {
+                    replacement:
+                        ':host([size][variant="black"][selected]:not([disabled]))',
+                    selector:
+                        '.spectrum-ActionButton.spectrum-ActionButton--staticBlack.is-selected:not(:disabled, .is-disabled)',
+                },
+                {
+                    replacement:
+                        ':host([size][variant="white"][selected]:not([disabled]))',
+                    selector:
+                        '.spectrum-ActionButton.spectrum-ActionButton--staticWhite.is-selected:not(:disabled, .is-disabled)',
+                },
             ],
         },
     ],

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actiongroup": "^1.0.24"
+        "@spectrum-css/actiongroup": "^1.0.25"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -55,7 +55,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionmenu": "^3.0.26"
+        "@spectrum-css/actionmenu": "^3.0.27"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/avatar": "^5.0.16"
+        "@spectrum-css/avatar": "^5.0.17"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/avatar/src/spectrum-avatar.css
+++ b/packages/avatar/src/spectrum-avatar.css
@@ -229,3 +229,9 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-opacity-30)
     ); /* .spectrum-Avatar.is-disabled */
 }
+@media (forced-colors: active) {
+    :host([disabled]) {
+        opacity: 1;
+        outline: 2px solid GrayText;
+    }
+}

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/buttongroup": "^5.0.10"
+        "@spectrum-css/buttongroup": "^5.0.11"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -57,7 +57,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/button": "^6.0.10"
+        "@spectrum-css/button": "^6.0.11"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/src/button.css
+++ b/packages/button/src/button.css
@@ -71,3 +71,13 @@ governing permissions and limitations under the License.
         --spectrum-alias-ui-icon-cornertriangle-size-300
     );
 }
+
+@media (forced-colors: active) {
+    :host([treatment][disabled]) {
+        border-color: graytext;
+    }
+
+    :host([treatment]:not([disabled]):hover) {
+        border-color: highlight;
+    }
+}

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -112,6 +112,61 @@ governing permissions and limitations under the License.
 #label:empty {
     display: none; /* .spectrum-Button-label:empty */
 }
+@media (forced-colors: active) {
+    :host {
+        --spectrum-button-m-accent-fill-texticon-background-color-down: Highlight;
+        --spectrum-button-m-accent-fill-texticon-background-color-hover: Highlight;
+        --spectrum-button-m-accent-fill-texticon-background-color-key-focus: Highlight;
+        --spectrum-button-m-accent-fill-texticon-background-color: ButtonText;
+        --spectrum-button-m-accent-fill-texticon-icon-color: ButtonFace;
+        --spectrum-button-m-accent-fill-texticon-text-color: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-background-color: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-background-color-down: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-background-color-hover: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-background-color-key-focus: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-border-color: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-border-color-down: Highlight;
+        --spectrum-button-m-accent-outline-texticon-border-color-hover: Highlight;
+        --spectrum-button-m-accent-outline-texticon-border-color-key-focus: Highlight;
+        --spectrum-button-m-accent-outline-texticon-icon-color: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-icon-color-down: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-icon-color-hover: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-icon-color-key-focus: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-text-color: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-text-color-down: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-text-color-hover: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-text-color-key-focus: ButtonText;
+        --spectrum-button-m-primary-fill-texticon-icon-color-disabled: GrayText;
+        --spectrum-button-m-primary-fill-texticon-text-color-disabled: GrayText;
+        --spectrum-button-m-primary-fill-white-texticon-icon-color-disabled: GrayText;
+        --spectrum-button-m-primary-fill-white-texticon-text-color-disabled: GrayText;
+        --spectrum-button-m-secondary-fill-white-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-secondary-outline-white-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-primary-fill-black-texticon-icon-color-disabled: GrayText;
+        --spectrum-button-m-primary-fill-black-texticon-text-color-disabled: GrayText;
+        --spectrum-button-m-secondary-fill-black-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-secondary-outline-black-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-primary-fill-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-primary-outline-texticon-background-color-disabled: ButtonFace;
+    }
+    :host(.focus-visible):after,
+    :host([focused]):after {
+        box-shadow: 0 0 0
+            var(--spectrum-button-primary-fill-texticon-focus-ring-size)
+            ButtonText;
+        forced-color-adjust: none;
+    }
+    :host(:focus-visible):after,
+    :host([focused]):after {
+        box-shadow: 0 0 0
+            var(--spectrum-button-primary-fill-texticon-focus-ring-size)
+            ButtonText;
+        forced-color-adjust: none;
+    }
+    :host([variant='accent']) #label {
+        forced-color-adjust: none;
+    }
+}
 :host([size='s']) {
     --spectrum-button-primary-fill-textonly-text-padding-bottom: var(
         --spectrum-button-s-primary-fill-textonly-text-padding-bottom
@@ -499,80 +554,6 @@ governing permissions and limitations under the License.
         --spectrum-button-m-primary-fill-black-texticon-focus-ring-color-key-focus,
         var(--spectrum-global-color-static-black)
     ); /* .spectrum-Button--staticBlack */
-}
-@media (forced-colors: active) {
-    :host {
-        --spectrum-button-m-accent-fill-texticon-background-color: ButtonText;
-        --spectrum-button-m-accent-fill-texticon-background-color-down: Highlight;
-        --spectrum-button-m-accent-fill-texticon-background-color-hover: Highlight;
-        --spectrum-button-m-accent-fill-texticon-background-color-key-focus: Highlight;
-        --spectrum-button-m-accent-fill-texticon-text-color: ButtonFace;
-        --spectrum-button-m-negative-outline-texticon-background-color: ButtonFace;
-        --spectrum-button-m-negative-outline-texticon-background-color-down: ButtonFace;
-        --spectrum-button-m-negative-outline-texticon-background-color-hover: ButtonFace;
-        --spectrum-button-m-negative-outline-texticon-background-color-key-focus: ButtonFace;
-        --spectrum-button-m-negative-outline-texticon-border-color: ButtonText;
-        --spectrum-button-m-negative-outline-texticon-border-color-down: Highlight;
-        --spectrum-button-m-negative-outline-texticon-border-color-hover: Highlight;
-        --spectrum-button-m-negative-outline-texticon-border-color-key-focus: Highlight;
-        --spectrum-button-m-negative-outline-texticon-text-color: ButtonText;
-        --spectrum-button-m-negative-outline-texticon-text-color-down: ButtonText;
-        --spectrum-button-m-negative-outline-texticon-text-color-hover: ButtonText;
-        --spectrum-button-m-negative-outline-texticon-text-color-key-focus: ButtonText;
-        --spectrum-button-m-primary-outline-texticon-background-color: ButtonFace;
-        --spectrum-button-m-primary-outline-texticon-background-color-disabled: ButtonFace;
-        --spectrum-button-m-primary-outline-texticon-background-color-down: ButtonFace;
-        --spectrum-button-m-primary-outline-texticon-background-color-hover: ButtonFace;
-        --spectrum-button-m-primary-outline-texticon-background-color-key-focus: ButtonFace;
-        --spectrum-button-m-primary-outline-texticon-border-color: ButtonText;
-        --spectrum-button-m-primary-outline-texticon-border-color-disabled: GrayText;
-        --spectrum-button-m-primary-outline-texticon-border-color-down: Highlight;
-        --spectrum-button-m-primary-outline-texticon-border-color-hover: Highlight;
-        --spectrum-button-m-primary-outline-texticon-border-color-key-focus: Highlight;
-        --spectrum-button-m-primary-outline-texticon-text-color: ButtonText;
-        --spectrum-button-m-primary-outline-texticon-text-color-down: ButtonText;
-        --spectrum-button-m-primary-outline-texticon-text-color-hover: ButtonText;
-        --spectrum-button-m-primary-outline-texticon-text-color-key-focus: ButtonText;
-        --spectrum-button-m-secondary-outline-texticon-background-color: ButtonFace;
-        --spectrum-button-m-secondary-outline-texticon-background-color-down: ButtonFace;
-        --spectrum-button-m-secondary-outline-texticon-background-color-hover: ButtonFace;
-        --spectrum-button-m-secondary-outline-texticon-background-color-key-focus: ButtonFace;
-        --spectrum-button-m-secondary-outline-texticon-border-color: ButtonText;
-        --spectrum-button-m-secondary-outline-texticon-border-color-down: Highlight;
-        --spectrum-button-m-secondary-outline-texticon-border-color-hover: Highlight;
-        --spectrum-button-m-secondary-outline-texticon-border-color-key-focus: Highlight;
-        --spectrum-button-m-secondary-outline-texticon-text-color: ButtonText;
-        --spectrum-button-m-secondary-outline-texticon-text-color-down: ButtonText;
-        --spectrum-button-m-secondary-outline-texticon-text-color-hover: ButtonText;
-        --spectrum-button-m-secondary-outline-texticon-text-color-key-focus: ButtonText;
-    }
-    :host(.focus-visible):after,
-    :host([focused]):after {
-        box-shadow: 0 0 0
-            var(--spectrum-button-primary-fill-texticon-focus-ring-size)
-            Highlight;
-    }
-    :host(:focus-visible):after,
-    :host([focused]):after {
-        box-shadow: 0 0 0
-            var(--spectrum-button-primary-fill-texticon-focus-ring-size)
-            Highlight;
-    }
-    :host {
-        forced-color-adjust: none;
-    }
-    :host([active]) .spectrum-Button--overBackground {
-        color: ButtonText;
-    }
-}
-.spectrum-Button--overBackground:hover {
-    color: ButtonText; /* .spectrum-Button--overBackground:hover */
-}
-.spectrum-Button--overBackground.focus-visible {
-    color: ButtonText; /* .spectrum-Button--overBackground:focus-visible */
-}
-.spectrum-Button--overBackground:focus-visible {
-    color: ButtonText; /* .spectrum-Button--overBackground:focus-visible */
 }
 :host(:not([variant='white']):not([variant='black'])[disabled])
     ::slotted([slot='icon']) {
@@ -1830,4 +1811,59 @@ governing permissions and limitations under the License.
         --spectrum-button-m-primary-outline-texticon-border-color-disabled,
         var(--spectrum-global-color-gray-200)
     ); /* .spectrum-Button.spectrum-Button--outline:not(.spectrum-Button--staticWhite):not(.spectrum-Button--staticBlack):disabled */
+}
+@media (forced-colors: active) {
+    :host {
+        --spectrum-button-m-accent-fill-texticon-background-color-down: Highlight;
+        --spectrum-button-m-accent-fill-texticon-background-color-hover: Highlight;
+        --spectrum-button-m-accent-fill-texticon-background-color-key-focus: Highlight;
+        --spectrum-button-m-accent-fill-texticon-background-color: ButtonText;
+        --spectrum-button-m-accent-fill-texticon-icon-color: ButtonFace;
+        --spectrum-button-m-accent-fill-texticon-text-color: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-background-color: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-background-color-down: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-background-color-hover: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-background-color-key-focus: ButtonFace;
+        --spectrum-button-m-accent-outline-texticon-border-color: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-border-color-down: Highlight;
+        --spectrum-button-m-accent-outline-texticon-border-color-hover: Highlight;
+        --spectrum-button-m-accent-outline-texticon-border-color-key-focus: Highlight;
+        --spectrum-button-m-accent-outline-texticon-icon-color: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-icon-color-down: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-icon-color-hover: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-icon-color-key-focus: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-text-color: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-text-color-down: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-text-color-hover: ButtonText;
+        --spectrum-button-m-accent-outline-texticon-text-color-key-focus: ButtonText;
+        --spectrum-button-m-primary-fill-texticon-icon-color-disabled: GrayText;
+        --spectrum-button-m-primary-fill-texticon-text-color-disabled: GrayText;
+        --spectrum-button-m-primary-fill-white-texticon-icon-color-disabled: GrayText;
+        --spectrum-button-m-primary-fill-white-texticon-text-color-disabled: GrayText;
+        --spectrum-button-m-secondary-fill-white-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-secondary-outline-white-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-primary-fill-black-texticon-icon-color-disabled: GrayText;
+        --spectrum-button-m-primary-fill-black-texticon-text-color-disabled: GrayText;
+        --spectrum-button-m-secondary-fill-black-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-secondary-outline-black-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-primary-fill-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-primary-outline-texticon-background-color-disabled: ButtonFace;
+    }
+    :host(.focus-visible):after,
+    :host([focused]):after {
+        box-shadow: 0 0 0
+            var(--spectrum-button-primary-fill-texticon-focus-ring-size)
+            ButtonText;
+        forced-color-adjust: none;
+    }
+    :host(:focus-visible):after,
+    :host([focused]):after {
+        box-shadow: 0 0 0
+            var(--spectrum-button-primary-fill-texticon-focus-ring-size)
+            ButtonText;
+        forced-color-adjust: none;
+    }
+    :host([variant='accent']) #label {
+        forced-color-adjust: none;
+    }
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/card": "^4.0.20"
+        "@spectrum-css/card": "^4.0.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/clear-button/package.json
+++ b/packages/clear-button/package.json
@@ -46,7 +46,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/clearbutton": "^1.2.9"
+        "@spectrum-css/clearbutton": "^1.2.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/clear-button/src/spectrum-clear-button.css
+++ b/packages/clear-button/src/spectrum-clear-button.css
@@ -508,6 +508,36 @@ governing permissions and limitations under the License.
 }
 @media (forced-colors: active) {
     :host {
-        forced-color-adjust: none;
+        --spectrum-alias-icon-color-overbackground: ButtonText;
+        --spectrum-alias-icon-color-overbackground-disabled: GrayText;
+        --spectrum-button-m-primary-outline-white-texticon-background-color: ButtonFace;
+        --spectrum-button-m-primary-outline-white-texticon-background-color-disabled: ButtonFace;
+        --spectrum-button-m-primary-outline-white-texticon-background-color-down: ButtonFace;
+        --spectrum-button-m-primary-outline-white-texticon-background-color-hover: ButtonFace;
+        --spectrum-button-m-primary-outline-white-texticon-border-color: ButtonText;
+        --spectrum-button-m-primary-outline-white-texticon-border-color-disabled: GrayText;
+        --spectrum-button-m-primary-outline-white-texticon-border-color-down: ButtonText;
+        --spectrum-button-m-primary-outline-white-texticon-border-color-hover: ButtonText;
+        --spectrum-button-m-primary-outline-white-texticon-border-color-key-focus: ButtonText;
+        --spectrum-button-m-primary-outline-white-texticon-text-color: ButtonText;
+        --spectrum-button-m-primary-outline-white-texticon-text-color-disabled: GrayText;
+        --spectrum-button-m-primary-outline-white-texticon-text-color-down: Highlight;
+        --spectrum-button-m-primary-outline-white-texticon-text-color-hover: Highlight;
+        --spectrum-clearbutton-fill-background-color: ButtonFace;
+        --spectrum-clearbutton-fill-background-color-disabled: ButtonFace;
+        --spectrum-clearbutton-fill-background-color-down: ButtonFace;
+        --spectrum-clearbutton-fill-background-color-hover: ButtonFace;
+        --spectrum-clearbutton-fill-background-color-key-focus: ButtonFace;
+        --spectrum-clearbutton-fill-uiicon-color: ButtonText;
+        --spectrum-clearbutton-fill-uiicon-color-disabled: GrayText;
+        --spectrum-clearbutton-fill-uiicon-color-down: Highlight;
+        --spectrum-clearbutton-fill-uiicon-color-key-focus: Highlight;
+        --spectrum-clearbutton-m-fill-uiicon-color: ButtonText;
+    }
+    :host(:hover) {
+        color: var(--spectrum-clearbutton-fill-uiicon-color-key-focus);
+    }
+    :host([disabled]) {
+        color: var(--spectrum-clearbutton-fill-uiicon-color-disabled);
     }
 }

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -46,7 +46,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/closebutton": "^1.2.9"
+        "@spectrum-css/closebutton": "^1.2.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -53,6 +53,90 @@ governing permissions and limitations under the License.
 :host(:disabled) {
     cursor: default; /* .spectrum-CloseButton:disabled */
 }
+@media (forced-colors: active) {
+    :host {
+        --spectrum-alias-component-icon-color-default: ButtonText;
+        --spectrum-alias-component-icon-color-disabled: GrayText;
+        --spectrum-alias-component-icon-color-down: Highlight;
+        --spectrum-alias-component-icon-color-hover: Highlight;
+        --spectrum-alias-component-icon-color-key-focus: Highlight;
+        --spectrum-alias-component-icon-color-mouse-focus: Highlight;
+        --spectrum-closebutton-m-black-background-color-down: ButtonFace;
+        --spectrum-closebutton-m-black-background-color-hover: ButtonFace;
+        --spectrum-closebutton-m-black-background-color-key-focus: ButtonFace;
+        --spectrum-closebutton-m-black-background-color-mouse-focus: ButtonFace;
+        --spectrum-closebutton-m-black-uiicon-color: ButtonText;
+        --spectrum-closebutton-m-black-uiicon-color-disabled: GrayText;
+        --spectrum-closebutton-m-black-uiicon-color-down: Highlight;
+        --spectrum-closebutton-m-black-uiicon-color-hover: Highlight;
+        --spectrum-closebutton-m-black-uiicon-color-key-focus: Highlight;
+        --spectrum-closebutton-m-black-uiicon-color-mouse-focus: Highlight;
+        --spectrum-closebutton-m-white-background-color-down: ButtonFace;
+        --spectrum-closebutton-m-white-background-color-hover: ButtonFace;
+        --spectrum-closebutton-m-white-background-color-key-focus: ButtonFace;
+        --spectrum-closebutton-m-white-background-color-mouse-focus: ButtonFace;
+        --spectrum-closebutton-m-white-uiicon-color: ButtonText;
+        --spectrum-closebutton-m-white-uiicon-color-disabled: GrayText;
+        --spectrum-closebutton-m-white-uiicon-color-down: Highlight;
+        --spectrum-closebutton-m-white-uiicon-color-hover: Highlight;
+        --spectrum-closebutton-m-white-uiicon-color-key-focus: Highlight;
+        --spectrum-closebutton-m-white-uiicon-color-mouse-focus: Highlight;
+    }
+    :host(.focus-visible):after {
+        border-radius: 100%;
+        bottom: 0;
+        box-shadow: 0 0 0
+            var(
+                --spectrum-alias-focus-ring-size,
+                var(--spectrum-global-dimension-static-size-25)
+            )
+            var(
+                --spectrum-alias-component-icon-color-default,
+                var(--spectrum-alias-icon-color)
+            );
+        content: '';
+        display: block;
+        forced-color-adjust: none;
+        left: 0;
+        margin: var(
+            --spectrum-alias-focus-ring-gap,
+            var(--spectrum-global-dimension-static-size-25)
+        );
+        position: absolute;
+        right: 0;
+        top: 0;
+        transition: opacity var(--spectrum-global-animation-duration-100, 0.13s)
+                ease-out,
+            margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
+    }
+    :host(:focus-visible):after {
+        border-radius: 100%;
+        bottom: 0;
+        box-shadow: 0 0 0
+            var(
+                --spectrum-alias-focus-ring-size,
+                var(--spectrum-global-dimension-static-size-25)
+            )
+            var(
+                --spectrum-alias-component-icon-color-default,
+                var(--spectrum-alias-icon-color)
+            );
+        content: '';
+        display: block;
+        forced-color-adjust: none;
+        left: 0;
+        margin: var(
+            --spectrum-alias-focus-ring-gap,
+            var(--spectrum-global-dimension-static-size-25)
+        );
+        position: absolute;
+        right: 0;
+        top: 0;
+        transition: opacity var(--spectrum-global-animation-duration-100, 0.13s)
+                ease-out,
+            margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
+    }
+}
 :host {
     --spectrum-global-color-static-black-rgb: 0, 0, 0;
     --spectrum-global-color-static-white-rgb: 255, 255, 255;
@@ -396,4 +480,88 @@ governing permissions and limitations under the License.
 }
 .icon {
     margin: 0; /* .spectrum-CloseButton-UIIcon */
+}
+@media (forced-colors: active) {
+    :host {
+        --spectrum-alias-component-icon-color-default: ButtonText;
+        --spectrum-alias-component-icon-color-disabled: GrayText;
+        --spectrum-alias-component-icon-color-down: Highlight;
+        --spectrum-alias-component-icon-color-hover: Highlight;
+        --spectrum-alias-component-icon-color-key-focus: Highlight;
+        --spectrum-alias-component-icon-color-mouse-focus: Highlight;
+        --spectrum-closebutton-m-black-background-color-down: ButtonFace;
+        --spectrum-closebutton-m-black-background-color-hover: ButtonFace;
+        --spectrum-closebutton-m-black-background-color-key-focus: ButtonFace;
+        --spectrum-closebutton-m-black-background-color-mouse-focus: ButtonFace;
+        --spectrum-closebutton-m-black-uiicon-color: ButtonText;
+        --spectrum-closebutton-m-black-uiicon-color-disabled: GrayText;
+        --spectrum-closebutton-m-black-uiicon-color-down: Highlight;
+        --spectrum-closebutton-m-black-uiicon-color-hover: Highlight;
+        --spectrum-closebutton-m-black-uiicon-color-key-focus: Highlight;
+        --spectrum-closebutton-m-black-uiicon-color-mouse-focus: Highlight;
+        --spectrum-closebutton-m-white-background-color-down: ButtonFace;
+        --spectrum-closebutton-m-white-background-color-hover: ButtonFace;
+        --spectrum-closebutton-m-white-background-color-key-focus: ButtonFace;
+        --spectrum-closebutton-m-white-background-color-mouse-focus: ButtonFace;
+        --spectrum-closebutton-m-white-uiicon-color: ButtonText;
+        --spectrum-closebutton-m-white-uiicon-color-disabled: GrayText;
+        --spectrum-closebutton-m-white-uiicon-color-down: Highlight;
+        --spectrum-closebutton-m-white-uiicon-color-hover: Highlight;
+        --spectrum-closebutton-m-white-uiicon-color-key-focus: Highlight;
+        --spectrum-closebutton-m-white-uiicon-color-mouse-focus: Highlight;
+    }
+    :host(.focus-visible):after {
+        border-radius: 100%;
+        bottom: 0;
+        box-shadow: 0 0 0
+            var(
+                --spectrum-alias-focus-ring-size,
+                var(--spectrum-global-dimension-static-size-25)
+            )
+            var(
+                --spectrum-alias-component-icon-color-default,
+                var(--spectrum-alias-icon-color)
+            );
+        content: '';
+        display: block;
+        forced-color-adjust: none;
+        left: 0;
+        margin: var(
+            --spectrum-alias-focus-ring-gap,
+            var(--spectrum-global-dimension-static-size-25)
+        );
+        position: absolute;
+        right: 0;
+        top: 0;
+        transition: opacity var(--spectrum-global-animation-duration-100, 0.13s)
+                ease-out,
+            margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
+    }
+    :host(:focus-visible):after {
+        border-radius: 100%;
+        bottom: 0;
+        box-shadow: 0 0 0
+            var(
+                --spectrum-alias-focus-ring-size,
+                var(--spectrum-global-dimension-static-size-25)
+            )
+            var(
+                --spectrum-alias-component-icon-color-default,
+                var(--spectrum-alias-icon-color)
+            );
+        content: '';
+        display: block;
+        forced-color-adjust: none;
+        left: 0;
+        margin: var(
+            --spectrum-alias-focus-ring-gap,
+            var(--spectrum-global-dimension-static-size-25)
+        );
+        position: absolute;
+        right: 0;
+        top: 0;
+        transition: opacity var(--spectrum-global-animation-duration-100, 0.13s)
+                ease-out,
+            margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
+    }
 }

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/coachmark": "^5.0.10"
+        "@spectrum-css/coachmark": "^5.0.11"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -60,7 +60,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/dialog": "^6.0.10"
+        "@spectrum-css/dialog": "^6.0.11"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/divider": "^1.0.24"
+        "@spectrum-css/divider": "^1.0.25"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldgroup": "^3.1.1"
+        "@spectrum-css/fieldgroup": "^3.1.2"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldlabel": "^4.0.23"
+        "@spectrum-css/fieldlabel": "^4.0.24"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/icon/src/icon.css
+++ b/packages/icon/src/icon.css
@@ -39,4 +39,13 @@ svg,
     height: 100%;
     width: 100%;
     vertical-align: top;
+    color: inherit;
+}
+
+@media (forced-colors: active) {
+    img,
+    svg,
+    ::slotted(*) {
+        forced-color-adjust: auto;
+    }
 }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -60,7 +60,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/menu": "^4.0.1"
+        "@spectrum-css/menu": "^4.0.2"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -177,13 +177,17 @@ const config = {
             host: {
                 selector: '.spectrum-Menu',
             },
+            exclude: [/\.spectrum-Menu(?!-divider)/],
             complexSelectors: [
                 {
                     replacement: ':host',
                     selector: '.spectrum-Menu .spectrum-Menu-divider',
                 },
+                {
+                    replacement: ':host',
+                    selector: /^\.spectrum-Menu-divider/,
+                },
             ],
-            exclude: [/\.spectrum-Menu(?!-divider)/],
         },
     ],
 };

--- a/packages/menu/src/spectrum-menu-divider.css
+++ b/packages/menu/src/spectrum-menu-divider.css
@@ -17,7 +17,9 @@ governing permissions and limitations under the License.
     overflow: visible; /* .spectrum-Menu .spectrum-Menu-divider */
     width: auto;
 }
-.spectrum-Menu-divider {
-    background-color: CanvasText; /* .spectrum-Menu-divider */
-    forced-color-adjust: none;
+@media (forced-colors: active) {
+    :host {
+        background-color: CanvasText;
+        forced-color-adjust: none;
+    }
 }

--- a/packages/menu/src/spectrum-menu-divider.css
+++ b/packages/menu/src/spectrum-menu-divider.css
@@ -17,3 +17,7 @@ governing permissions and limitations under the License.
     overflow: visible; /* .spectrum-Menu .spectrum-Menu-divider */
     width: auto;
 }
+.spectrum-Menu-divider {
+    background-color: CanvasText; /* .spectrum-Menu-divider */
+    forced-color-adjust: none;
+}

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -248,3 +248,67 @@ slot[name='icon'] + #label {
     );
     cursor: default;
 }
+@media (forced-colors: active) {
+    :host {
+        --spectrum-listheading-text-color: ButtonText;
+        --spectrum-listitem-m-texticon-background-color: ButtonFace;
+        --spectrum-listitem-m-texticon-background-color-disabled: ButtonFace;
+        --spectrum-listitem-m-texticon-background-color-down: ButtonFace;
+        --spectrum-listitem-m-texticon-background-color-hover: Highlight;
+        --spectrum-listitem-m-texticon-background-color-key-focus: Highlight;
+        --spectrum-listitem-m-texticon-focus-indicator-color: Highlight;
+        --spectrum-listitem-m-texticon-text-color: ButtonText;
+        --spectrum-listitem-m-texticon-text-color-disabled: GrayText;
+        --spectrum-listitem-m-texticon-text-color-hover: HighlightText;
+        --spectrum-listitem-m-texticon-text-color-key-focus: HighlightText;
+        --spectrum-listitem-m-texticon-text-color-selected: ButtonText;
+        --spectrum-listitem-m-texticon-ui-icon-color-selected: Highlight;
+        forced-color-adjust: none;
+    }
+    :host(:not([disabled]).focus-visible),
+    :host(:not([disabled]).is-highlighted),
+    :host(:not([disabled]).is-open),
+    :host(:not([disabled]):focus),
+    :host(:not([disabled]):hover),
+    :host(:not([disabled])[focused]) {
+        background-color: var(
+            --spectrum-listitem-m-texticon-background-color-key-focus,
+            var(--spectrum-alias-background-color-hover-overlay)
+        );
+        color: var(
+            --spectrum-listitem-m-texticon-text-color-key-focus,
+            var(--spectrum-alias-component-text-color-key-focus)
+        );
+    }
+    :host(:not([disabled]).is-highlighted),
+    :host(:not([disabled]).is-open),
+    :host(:not([disabled]):focus),
+    :host(:not([disabled]):focus-visible),
+    :host(:not([disabled]):hover),
+    :host(:not([disabled])[focused]) {
+        background-color: var(
+            --spectrum-listitem-m-texticon-background-color-key-focus,
+            var(--spectrum-alias-background-color-hover-overlay)
+        );
+        color: var(
+            --spectrum-listitem-m-texticon-text-color-key-focus,
+            var(--spectrum-alias-component-text-color-key-focus)
+        );
+    }
+    :host(:not([disabled]).focus-visible[selected]) .checkmark,
+    :host(:not([disabled]).is-highlighted[selected]) .checkmark,
+    :host(:not([disabled]).is-open[selected]) .checkmark,
+    :host(:not([disabled]):focus[selected]) .checkmark,
+    :host(:not([disabled]):hover[selected]) .checkmark,
+    :host(:not([disabled])[focused][selected]) .checkmark {
+        color: HighlightText;
+    }
+    :host(:not([disabled]).is-highlighted[selected]) .checkmark,
+    :host(:not([disabled]).is-open[selected]) .checkmark,
+    :host(:not([disabled]):focus-visible[selected]) .checkmark,
+    :host(:not([disabled]):focus[selected]) .checkmark,
+    :host(:not([disabled]):hover[selected]) .checkmark,
+    :host(:not([disabled])[focused][selected]) .checkmark {
+        color: HighlightText;
+    }
+}

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^1.0.27"
+        "@spectrum-css/progressbar": "^1.0.28"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -314,3 +314,11 @@ governing permissions and limitations under the License.
     ); /* .spectrum-ProgressBar-label,
    * .spectrum-ProgressBar-percentage */
 }
+@media (forced-colors: active) {
+    .track {
+        --spectrum-progressbar-m-track-fill-color: ButtonText;
+        --spectrum-progressbar-m-track-color: ButtonFace;
+        border: 1px solid ButtonText;
+        forced-color-adjust: none;
+    }
+}

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -55,7 +55,7 @@
     },
     "devDependencies": {
         "@formatjs/intl-numberformat": "7.1.4",
-        "@spectrum-css/stepper": "^3.0.23"
+        "@spectrum-css/stepper": "^3.0.24"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -604,3 +604,63 @@ governing permissions and limitations under the License.
     ); /* .spectrum-Stepper--quiet.is-keyboardFocused.is-invalid .spectrum-Stepper-stepDown,
    * .spectrum-Stepper--quiet.is-focused.is-invalid .spectrum-Stepper-stepDown */
 }
+@media (forced-colors: active) {
+    #textfield {
+        --spectrum-textfield-m-quiet-texticon-border-color-disabled: GrayText;
+        --spectrum-textfield-m-texticon-border-color-disabled: GrayText;
+        --spectrum-textfield-m-texticon-border-color-hover: Highlight;
+        --spectrum-textfield-m-texticon-border-color-invalid: Highlight;
+        --spectrum-textfield-m-texticon-border-color-invalid-key-focus: Highlight;
+        --spectrum-textfield-m-texticon-border-color-invalid-mouse-focus: Highlight;
+        --spectrum-textfield-m-texticon-border-color-key-focus: Highlight;
+        --spectrum-textfield-m-texticon-border-color-mouse-focus: Highlight;
+        --spectrum-textfield-m-texticon-focus-ring-border-width: 2px;
+    }
+    :host([keyboard-focused]) #textfield {
+        outline: 2px solid
+            var(
+                --spectrum-textfield-m-texticon-border-color-key-focus,
+                var(--spectrum-alias-input-border-color-key-focus)
+            );
+    }
+    :host([keyboard-focused]) #textfield .buttons,
+    :host([keyboard-focused]) #textfield .input {
+        --spectrum-textfield-m-texticon-border-color: ButtonText;
+    }
+    :host([quiet][focused]) #textfield,
+    :host([quiet][keyboard-focused]) #textfield {
+        outline: none;
+    }
+    :host([quiet][focused]) #textfield .buttons,
+    :host([quiet][focused]) #textfield .input,
+    :host([quiet][keyboard-focused]) #textfield .buttons,
+    :host([quiet][keyboard-focused]) #textfield .input {
+        box-shadow: 0
+            var(
+                --spectrum-textfield-m-texticon-focus-ring-border-width,
+                var(--spectrum-alias-component-focusring-size)
+            )
+            0 0
+            var(
+                --spectrum-textfield-m-texticon-border-color-key-focus,
+                var(--spectrum-alias-input-border-color-key-focus)
+            );
+        forced-color-adjust: none;
+    }
+    :host([quiet][focused][invalid]) #textfield .buttons,
+    :host([quiet][focused][invalid]) #textfield .input,
+    :host([quiet][keyboard-focused][invalid]) #textfield .buttons,
+    :host([quiet][keyboard-focused][invalid]) #textfield .input {
+        box-shadow: 0
+            var(
+                --spectrum-textfield-m-texticon-focus-ring-border-width,
+                var(--spectrum-alias-component-focusring-size)
+            )
+            0 0
+            var(
+                --spectrum-textfield-m-texticon-border-color-invalid,
+                var(--spectrum-alias-input-border-color-invalid-default)
+            );
+        forced-color-adjust: none;
+    }
+}

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -62,7 +62,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/picker": "^1.2.6"
+        "@spectrum-css/picker": "^1.2.7"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/popover": "^5.0.13"
+        "@spectrum-css/popover": "^5.0.14"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^1.0.27"
+        "@spectrum-css/progressbar": "^1.0.28"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-bar/src/spectrum-progress-bar.css
+++ b/packages/progress-bar/src/spectrum-progress-bar.css
@@ -314,3 +314,11 @@ governing permissions and limitations under the License.
     ); /* .spectrum-ProgressBar-label,
    * .spectrum-ProgressBar-percentage */
 }
+@media (forced-colors: active) {
+    .track {
+        --spectrum-progressbar-m-track-fill-color: ButtonText;
+        --spectrum-progressbar-m-track-color: ButtonFace;
+        border: 1px solid ButtonText;
+        forced-color-adjust: none;
+    }
+}

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/progresscircle": "^1.0.20"
+        "@spectrum-css/progresscircle": "^1.0.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-circle/src/spectrum-progress-circle.css
+++ b/packages/progress-circle/src/spectrum-progress-circle.css
@@ -607,3 +607,8 @@ governing permissions and limitations under the License.
         --spectrum-progresscircle-m-over-background-track-fill-color
     ); /* .spectrum-ProgressCircle--indeterminate.spectrum-ProgressCircle--overBackground .spectrum-ProgressCircle-fill */
 }
+@media (forced-colors: active) {
+    .fill {
+        --spectrum-progresscircle-m-track-fill-color: Highlight;
+    }
+}

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/quickaction": "^3.0.23"
+        "@spectrum-css/quickaction": "^3.0.24"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/radio": "^3.0.21"
+        "@spectrum-css/radio": "^3.0.22"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -435,10 +435,12 @@ governing permissions and limitations under the License.
     :host {
         --spectrum-radio-m-circle-background-color: ButtonFace;
         --spectrum-radio-m-circle-border-color-down: Highlight;
+        --spectrum-radio-m-circle-border-color-disabled: GrayText;
         --spectrum-radio-m-circle-border-color-hover: Highlight;
         --spectrum-radio-m-circle-border-color-key-focus: Highlight;
         --spectrum-radio-m-circle-border-color-selected-down: Highlight;
         --spectrum-radio-m-circle-border-color-selected-hover: Highlight;
+        --spectrum-radio-m-circle-border-color-selected-key-focus: Highlight;
         --spectrum-radio-m-circle-border-color-selected: Highlight;
         --spectrum-radio-m-circle-border-color: ButtonText;
         --spectrum-radio-m-emphasized-circle-border-color-error-hover: Highlight;
@@ -454,6 +456,7 @@ governing permissions and limitations under the License.
         --spectrum-radio-m-text-color-down: CanvasText;
         --spectrum-radio-m-text-color-hover: CanvasText;
         --spectrum-radio-m-text-color: CanvasText;
+        --spectrum-radio-m-text-color-disabled: GrayText;
     }
     :host([invalid][checked]) #input + #button:before {
         border-color: var(

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -52,7 +52,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/search": "^4.2.9"
+        "@spectrum-css/search": "^4.2.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/sidenav": "^3.0.21"
+        "@spectrum-css/sidenav": "^3.0.22"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/sidenav/src/spectrum-config.js
+++ b/packages/sidenav/src/spectrum-config.js
@@ -81,6 +81,7 @@ const config = {
                     name: 'list',
                 },
             ],
+            exclude: [/\.spectrum-SideNav-item/],
         },
     ],
 };

--- a/packages/sidenav/src/spectrum-sidenav-heading.css
+++ b/packages/sidenav/src/spectrum-sidenav-heading.css
@@ -19,18 +19,6 @@ governing permissions and limitations under the License.
     margin: 0;
     padding: 0;
 }
-:host([dir='ltr']) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
-    margin-right: var(
-        --spectrum-sidenav-icon-gap,
-        var(--spectrum-global-dimension-size-100)
-    ); /* [dir=ltr] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
-}
-:host([dir='rtl']) .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon {
-    margin-left: var(
-        --spectrum-sidenav-icon-gap,
-        var(--spectrum-global-dimension-size-100)
-    ); /* [dir=rtl] .spectrum-SideNav-itemLink .spectrum-SideNav-itemIcon */
-}
 :host([dir='ltr']) #heading {
     margin-right: 0; /* [dir=ltr] .spectrum-SideNav-heading */
 }
@@ -47,6 +35,10 @@ governing permissions and limitations under the License.
     border-radius: var(
         --spectrum-sidenav-heading-border-radius,
         var(--spectrum-alias-border-radius-regular)
+    );
+    color: var(
+        --spectrum-sidenav-heading-text-color,
+        var(--spectrum-global-color-gray-700)
     );
     font-size: var(
         --spectrum-sidenav-heading-text-size,
@@ -87,90 +79,5 @@ governing permissions and limitations under the License.
         var(--spectrum-global-dimension-size-150)
     );
     padding-top: 0;
-    text-transform: uppercase;
-}
-:host([dir='ltr'])
-    .spectrum-SideNav--multiLevel
-    #list
-    .spectrum-SideNav-itemLink {
-    padding-left: calc(
-        var(
-                --spectrum-sidenav-multilevel-item-margin-left,
-                var(--spectrum-global-dimension-size-150)
-            ) +
-            var(
-                --spectrum-sidenav-item-padding-x,
-                var(--spectrum-global-dimension-size-150)
-            )
-    ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
-}
-:host([dir='rtl'])
-    .spectrum-SideNav--multiLevel
-    #list
-    .spectrum-SideNav-itemLink {
-    padding-right: calc(
-        var(
-                --spectrum-sidenav-multilevel-item-margin-left,
-                var(--spectrum-global-dimension-size-150)
-            ) +
-            var(
-                --spectrum-sidenav-item-padding-x,
-                var(--spectrum-global-dimension-size-150)
-            )
-    ); /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav-itemLink */
-}
-:host([dir='ltr'])
-    .spectrum-SideNav--multiLevel
-    #list
-    #list
-    .spectrum-SideNav-itemLink {
-    padding-left: calc(
-        var(
-                --spectrum-sidenav-multilevel-item-margin-left,
-                var(--spectrum-global-dimension-size-150)
-            ) +
-            var(
-                --spectrum-sidenav-item-padding-x,
-                var(--spectrum-global-dimension-size-150)
-            )
-    ); /* [dir=ltr] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
-}
-:host([dir='rtl'])
-    .spectrum-SideNav--multiLevel
-    #list
-    #list
-    .spectrum-SideNav-itemLink {
-    padding-right: calc(
-        var(
-                --spectrum-sidenav-multilevel-item-margin-left,
-                var(--spectrum-global-dimension-size-150)
-            ) +
-            var(
-                --spectrum-sidenav-item-padding-x,
-                var(--spectrum-global-dimension-size-150)
-            )
-    ); /* [dir=rtl] .spectrum-SideNav--multiLevel .spectrum-SideNav .spectrum-SideNav .spectrum-SideNav-itemLink */
-}
-#heading {
-    color: var(
-        --spectrum-sidenav-heading-text-color,
-        var(--spectrum-global-color-gray-700)
-    ); /* .spectrum-SideNav-heading */
-}
-@media (forced-colors: active) {
-    .spectrum-SideNav-item {
-        --spectrum-sidenav-item-text-color-selected: HighlightText;
-        --spectrum-sidenav-item-background-color-selected: Highlight;
-        --spectrum-sidenav-item-background-color-disabled: ButtonFace;
-        --spectrum-sidenav-item-text-color-disabled: GrayText;
-        --spectrum-sidenav-item-background-color: ButtonFace;
-        --spectrum-sidenav-item-text-color: ButtonText;
-        --spectrum-sidenav-item-background-color-hover: ButtonFace;
-        --spectrum-sidenav-item-text-color-hover: ButtonText;
-        --spectrum-sidenav-item-background-color-down: ButtonFace;
-        --spectrum-sidenav-item-background-color-key-focus: ButtonFace;
-        --spectrum-sidenav-item-text-color-key-focus: ButtonText;
-        --spectrum-sidenav-item-border-color-key-focus: ButtonText;
-        forced-color-adjust: none;
-    }
+    text-transform: uppercase; /* .spectrum-SideNav-heading */
 }

--- a/packages/sidenav/src/spectrum-sidenav-heading.css
+++ b/packages/sidenav/src/spectrum-sidenav-heading.css
@@ -157,3 +157,20 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-700)
     ); /* .spectrum-SideNav-heading */
 }
+@media (forced-colors: active) {
+    .spectrum-SideNav-item {
+        --spectrum-sidenav-item-text-color-selected: HighlightText;
+        --spectrum-sidenav-item-background-color-selected: Highlight;
+        --spectrum-sidenav-item-background-color-disabled: ButtonFace;
+        --spectrum-sidenav-item-text-color-disabled: GrayText;
+        --spectrum-sidenav-item-background-color: ButtonFace;
+        --spectrum-sidenav-item-text-color: ButtonText;
+        --spectrum-sidenav-item-background-color-hover: ButtonFace;
+        --spectrum-sidenav-item-text-color-hover: ButtonText;
+        --spectrum-sidenav-item-background-color-down: ButtonFace;
+        --spectrum-sidenav-item-background-color-key-focus: ButtonFace;
+        --spectrum-sidenav-item-text-color-key-focus: ButtonText;
+        --spectrum-sidenav-item-border-color-key-focus: ButtonText;
+        forced-color-adjust: none;
+    }
+}

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -254,3 +254,20 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-border-color-key-focus)
     ); /* .spectrum-SideNav-itemLink.focus-ring:before */
 }
+@media (forced-colors: active) {
+    :host {
+        --spectrum-sidenav-item-text-color-selected: HighlightText;
+        --spectrum-sidenav-item-background-color-selected: Highlight;
+        --spectrum-sidenav-item-background-color-disabled: ButtonFace;
+        --spectrum-sidenav-item-text-color-disabled: GrayText;
+        --spectrum-sidenav-item-background-color: ButtonFace;
+        --spectrum-sidenav-item-text-color: ButtonText;
+        --spectrum-sidenav-item-background-color-hover: ButtonFace;
+        --spectrum-sidenav-item-text-color-hover: ButtonText;
+        --spectrum-sidenav-item-background-color-down: ButtonFace;
+        --spectrum-sidenav-item-background-color-key-focus: ButtonFace;
+        --spectrum-sidenav-item-text-color-key-focus: ButtonText;
+        --spectrum-sidenav-item-border-color-key-focus: ButtonText;
+        forced-color-adjust: none;
+    }
+}

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -57,7 +57,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^3.1.4"
+        "@spectrum-css/slider": "^3.1.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -126,18 +126,24 @@ sp-field-label {
 
 :host([dir='ltr']) .track:before {
     background: var(
-        --spectrum-slider-track-color,
-        var(--spectrum-global-color-gray-300)
+        --spectrum-slider-m-track-color,
+        var(
+            --spectrum-slider-track-color,
+            var(--spectrum-global-color-gray-300)
+        )
     );
 }
 
 :host([dir='rtl']) .track:before {
     /* .spectrum-Slider-track:before */
     background: var(
-        --spectrum-slider-track-color-rtl,
+        --spectrum-slider-m-track-color,
         var(
-            --spectrum-slider-track-color,
-            var(--spectrum-global-color-gray-300)
+            --spectrum-slider-track-color-rtl,
+            var(
+                --spectrum-slider-track-color,
+                var(--spectrum-global-color-gray-300)
+            )
         )
     );
 }

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -1114,3 +1114,32 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-300)
     ); /* .spectrum-Slider.is-disabled.spectrum-Slider--range .spectrum-Slider-track:not(:first-of-type):not(:last-of-type):before */
 }
+@media (forced-colors: active) {
+    :host {
+        --spectrum-alias-background-color-default: ButtonFace;
+        --spectrum-alias-focus-color: ButtonText;
+        --spectrum-alias-label-text-color: CanvasText;
+        --spectrum-alias-text-color-disabled: GrayText;
+        --spectrum-slider-m-handle-background-color: ButtonFace;
+        --spectrum-slider-m-handle-border-color: ButtonText;
+        --spectrum-slider-m-handle-border-color-disabled: GrayText;
+        --spectrum-slider-m-handle-border-color-down: Highlight;
+        --spectrum-slider-m-handle-border-color-hover: Highlight;
+        --spectrum-slider-m-handle-border-color-key-focus: Highlight;
+        --spectrum-slider-m-handle-focus-ring-color-key-focus: ButtonText;
+        --spectrum-slider-m-label-text-color: CanvasText;
+        --spectrum-slider-m-label-text-color-disabled: GrayText;
+        --spectrum-slider-m-tick-mark-color: ButtonText;
+        --spectrum-slider-m-track-color: ButtonText;
+        --spectrum-slider-m-track-color-disabled: GrayText;
+        --spectrum-slider-m-track-fill-color: ButtonText;
+        --spectrum-slider-m-track-fill-color-disabled: GrayText;
+        --spectrum-slider-ramp-track-color-disabled: GrayText;
+    }
+    .handle:before {
+        forced-color-adjust: none;
+    }
+    :host([variant='ramp']) .handle {
+        forced-color-adjust: none;
+    }
+}

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -56,7 +56,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/splitbutton": "^5.0.10"
+        "@spectrum-css/splitbutton": "^5.0.11"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -48,7 +48,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/statuslight": "^4.0.11"
+        "@spectrum-css/statuslight": "^4.0.12"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -329,3 +329,15 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-purple-400)
     ); /* .spectrum-StatusLight--purple:before */
 }
+@media (forced-colors: active) {
+    :host([dir]) {
+        --spectrum-statuslight-m-info-text-color: CanvasText;
+        --spectrum-statuslight-m-neutral-text-color: CanvasText;
+        --spectrum-statuslight-m-info-text-color-disabled: GrayText;
+        --spectrum-statuslight-m-info-dot-color-disabled: GrayText;
+        forced-color-adjust: none;
+    }
+    :host:before {
+        border: 1px solid ButtonText;
+    }
+}

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/switch": "^1.0.20"
+        "@spectrum-css/switch": "^1.0.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -496,3 +496,68 @@ governing permissions and limitations under the License.
     ); /* .spectrum-Switch--emphasized .spectrum-Switch-input.focus-ring:checked+.spectrum-Switch-switch:before,
    * .spectrum-Switch--emphasized:hover .spectrum-Switch-input.focus-ring:checked+.spectrum-Switch-switch:before */
 }
+@media (forced-colors: active) {
+    :host {
+        --spectrum-switch-m-emphasized-handle-border-color-selected: Highlight;
+        --spectrum-switch-m-emphasized-handle-border-color-selected-down: Highlight;
+        --spectrum-switch-m-emphasized-handle-border-color-selected-hover: Highlight;
+        --spectrum-switch-m-emphasized-handle-border-color-selected-key-focus: Highlight;
+        --spectrum-switch-m-emphasized-track-color-selected: Highlight;
+        --spectrum-switch-m-emphasized-track-color-selected-down: Highlight;
+        --spectrum-switch-m-emphasized-track-color-selected-hover: Highlight;
+        --spectrum-switch-m-emphasized-track-color-selected-key-focus: Highlight;
+        --spectrum-switch-m-focus-ring-color-key-focus: ButtonText;
+        --spectrum-switch-m-handle-background-color: ButtonFace;
+        --spectrum-switch-m-handle-border-color: ButtonText;
+        --spectrum-switch-m-handle-border-color-disabled: GrayText;
+        --spectrum-switch-m-handle-border-color-down: Highlight;
+        --spectrum-switch-m-handle-border-color-hover: Highlight;
+        --spectrum-switch-m-handle-border-color-key-focus: ButtonText;
+        --spectrum-switch-m-handle-border-color-selected: Highlight;
+        --spectrum-switch-m-handle-border-color-selected-disabled: GrayText;
+        --spectrum-switch-m-handle-border-color-selected-down: Highlight;
+        --spectrum-switch-m-handle-border-color-selected-hover: Highlight;
+        --spectrum-switch-m-handle-border-color-selected-key-focus: Highlight;
+        --spectrum-switch-m-text-color: CanvasText;
+        --spectrum-switch-m-text-color-disabled: GrayText;
+        --spectrum-switch-m-text-color-down: CanvasText;
+        --spectrum-switch-m-text-color-hover: CanvasText;
+        --spectrum-switch-m-text-color-selected-disabled: GrayText;
+        --spectrum-switch-m-track-color: ButtonFace;
+        --spectrum-switch-m-track-color-disabled: ButtonFace;
+        --spectrum-switch-m-track-color-selected: Highlight;
+        --spectrum-switch-m-track-color-selected-disabled: GrayText;
+        --spectrum-switch-m-track-color-selected-down: Highlight;
+        --spectrum-switch-m-track-color-selected-hover: Highlight;
+        --spectrum-switch-m-track-color-selected-key-focus: Highlight;
+        forced-color-adjust: none;
+    }
+    #input:not([checked]) + #switch {
+        box-shadow: inset 0 0 0 1px
+            var(
+                --spectrum-switch-m-handle-border-color,
+                var(--spectrum-alias-toggle-border-color-default)
+            );
+    }
+    :host(:hover) #input:not([checked]) + #switch {
+        box-shadow: inset 0 0 0 1px
+            var(
+                --spectrum-switch-m-handle-border-color-hover,
+                var(--spectrum-alias-toggle-border-color-hover)
+            );
+    }
+    :host([disabled]) #input + #switch {
+        box-shadow: inset 0 0 0 1px
+            var(
+                --spectrum-switch-m-handle-border-color-disabled,
+                var(--spectrum-global-color-gray-400)
+            );
+    }
+    :host(:hover[disabled]) #input + #switch {
+        box-shadow: inset 0 0 0 1px
+            var(
+                --spectrum-switch-m-handle-border-color-disabled,
+                var(--spectrum-global-color-gray-400)
+            );
+    }
+}

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -54,7 +54,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tabs": "^3.2.13"
+        "@spectrum-css/tabs": "^3.2.14"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -53,8 +53,8 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tag": "^3.3.11",
-        "@spectrum-css/taggroup": "^3.3.11"
+        "@spectrum-css/tag": "^3.3.12",
+        "@spectrum-css/taggroup": "^3.3.12"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -848,3 +848,101 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-tag-text-color-error-key-focus)
     ); /* .spectrum-Tag--removable.is-selected.is-invalid */
 }
+@media (forced-colors: active) {
+    :host {
+        --spectrum-tag-s-removable-texticon-border-color-error-down: Highlight;
+        --spectrum-tag-s-removable-texticon-border-color-error-hover: Highlight;
+        --spectrum-tag-s-removable-texticon-icon-color: ButtonText;
+        --spectrum-tag-s-removable-texticon-icon-color-disabled: GrayText;
+        --spectrum-tag-s-removable-texticon-icon-color-down: ButtonText;
+        --spectrum-tag-s-removable-texticon-icon-color-error: ButtonText;
+        --spectrum-tag-s-removable-texticon-icon-color-error-down: ButtonText;
+        --spectrum-tag-s-removable-texticon-icon-color-error-hover: ButtonText;
+        --spectrum-tag-s-removable-texticon-icon-color-error-selected: HighlightText;
+        --spectrum-tag-s-removable-texticon-icon-color-hover: ButtonText;
+        --spectrum-tag-s-removable-texticon-icon-color-key-focus: ButtonText;
+        --spectrum-tag-s-removable-texticon-icon-color-selected: HighlightText;
+        --spectrum-tag-s-removable-texticon-icon-color-selected-hover: HighlightText;
+        --spectrum-tag-s-removable-texticon-icon-color-selected-key-focus: HighlightText;
+        --spectrum-tag-s-removable-texticon-text-color-down: ButtonText;
+        --spectrum-tag-s-removable-texticon-text-color-error-down: ButtonText;
+        --spectrum-tag-s-removable-texticon-text-color-error-hover: ButtonText;
+        --spectrum-tag-s-removable-texticon-text-color-error-key-focus: ButtonText;
+        --spectrum-tag-s-removable-texticon-text-color-error-selected: HighlightText;
+        --spectrum-tag-s-removable-texticon-text-color-hover: ButtonText;
+        --spectrum-tag-s-removable-texticon-text-color-key-focus: ButtonText;
+        --spectrum-tag-s-removable-texticon-text-color-selected: HighlightText;
+        --spectrum-tag-s-removable-texticon-text-color-selected-key-focus: HighlightText;
+        --spectrum-tag-s-texticon-background-color: ButtonFace;
+        --spectrum-tag-s-texticon-background-color-disabled: ButtonFace;
+        --spectrum-tag-s-texticon-background-color-error-selected: Highlight;
+        --spectrum-tag-s-texticon-background-color-error-selected-hover: Highlight;
+        --spectrum-tag-s-texticon-background-color-hover: ButtonFace;
+        --spectrum-tag-s-texticon-background-color-key-focus: ButtonFace;
+        --spectrum-tag-s-texticon-background-color-selected: Highlight;
+        --spectrum-tag-s-texticon-background-color-selected-hover: Highlight;
+        --spectrum-tag-s-texticon-border-color: ButtonText;
+        --spectrum-tag-s-texticon-border-color-disabled: GrayText;
+        --spectrum-tag-s-texticon-border-color-error: Highlight;
+        --spectrum-tag-s-texticon-border-color-error-hover: Highlight;
+        --spectrum-tag-s-texticon-border-color-error-selected: HighlightText;
+        --spectrum-tag-s-texticon-border-color-error-selected-hover: HighlightText;
+        --spectrum-tag-s-texticon-border-color-error-selected-key-focus: HighlightText;
+        --spectrum-tag-s-texticon-border-color-hover: ButtonText;
+        --spectrum-tag-s-texticon-border-color-key-focus: ButtonText;
+        --spectrum-tag-s-texticon-border-color-selected: HighlightText;
+        --spectrum-tag-s-texticon-focusring-border-color-key-focus: ButtonText;
+        --spectrum-tag-s-texticon-focusring-border-color-selected-key-focus: ButtonText;
+        --spectrum-tag-s-texticon-icon-color-disabled: GrayText;
+        --spectrum-tag-s-texticon-icon-color-error: ButtonText;
+        --spectrum-tag-s-texticon-icon-color-error-hover: ButtonText;
+        --spectrum-tag-s-texticon-icon-color-error-key-focus: ButtonText;
+        --spectrum-tag-s-texticon-icon-color-error-selected-hover: HighlightText;
+        --spectrum-tag-s-texticon-icon-color-selected: HighlightText;
+        --spectrum-tag-s-texticon-text-color: ButtonText;
+        --spectrum-tag-s-texticon-text-color-disabled: GrayText;
+        --spectrum-tag-s-texticon-text-color-hover: ButtonText;
+        --spectrum-tag-s-texticon-text-color-key-focus: ButtonText;
+        --spectrum-tag-s-texticon-text-color-selected: HighlightText;
+        --spectrum-tag-s-texticon-text-color-selected-key-focus: HighlightText;
+        forced-color-adjust: none;
+    }
+    :host([selected][invalid].focus-visible) {
+        box-shadow: 0 0 0
+            var(
+                --spectrum-alias-focus-ring-size,
+                var(--spectrum-global-dimension-static-size-25)
+            )
+            var(
+                --spectrum-tag-s-texticon-focusring-border-color-selected-key-focus,
+                var(
+                    --spectrum-alias-tag-focusring-border-color-selected-key-focus
+                )
+            );
+    }
+    :host([selected][invalid]:focus-visible) {
+        box-shadow: 0 0 0
+            var(
+                --spectrum-alias-focus-ring-size,
+                var(--spectrum-global-dimension-static-size-25)
+            )
+            var(
+                --spectrum-tag-s-texticon-focusring-border-color-selected-key-focus,
+                var(
+                    --spectrum-alias-tag-focusring-border-color-selected-key-focus
+                )
+            );
+    }
+    :host([selected][invalid].focus-visible) .clear-button {
+        color: var(
+            --spectrum-tag-s-texticon-icon-color-error-selected-hover,
+            var(--spectrum-alias-tag-icon-color-selected)
+        );
+    }
+    :host([selected][invalid]:focus-visible) .clear-button {
+        color: var(
+            --spectrum-tag-s-texticon-icon-color-error-selected-hover,
+            var(--spectrum-alias-tag-icon-color-selected)
+        );
+    }
+}

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -53,7 +53,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/textfield": "^3.2.1"
+        "@spectrum-css/textfield": "^3.2.2"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -833,3 +833,31 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-input-border-color-quiet-disabled)
     );
 }
+@media (forced-colors: active) {
+    #textfield {
+        --spectrum-textfield-m-quiet-texticon-border-color-disabled: GrayText;
+        --spectrum-textfield-m-quiet-texticon-border-color-down: Highlight;
+        --spectrum-textfield-m-quiet-texticon-border-color-hover: Highlight;
+        --spectrum-textfield-m-quiet-texticon-border-color-invalid: Highlight;
+        --spectrum-textfield-m-quiet-texticon-border-color-invalid-key-focus: Highlight;
+        --spectrum-textfield-m-quiet-texticon-border-color-invalid-mouse-focus: Highlight;
+        --spectrum-textfield-m-quiet-texticon-border-color-mouse-focus: Highlight;
+        --spectrum-textfield-m-texticon-border-color-disabled: GrayText;
+        --spectrum-textfield-m-texticon-border-color-down: Highlight;
+        --spectrum-textfield-m-texticon-border-color-hover: Highlight;
+        --spectrum-textfield-m-texticon-border-color-invalid: Highlight;
+        --spectrum-textfield-m-texticon-border-color-invalid-hover: Highlight;
+        --spectrum-textfield-m-texticon-border-color-invalid-key-focus: Highlight;
+        --spectrum-textfield-m-texticon-border-color-invalid-mouse-focus: Highlight;
+        --spectrum-textfield-m-texticon-border-color-key-focus: Highlight;
+        --spectrum-textfield-m-texticon-placeholder-text-color: GrayText;
+        --spectrum-textfield-m-texticon-placeholder-text-color-disabled: GrayText;
+        --spectrum-textfield-m-texticon-placeholder-text-color-hover: GrayText;
+        --spectrum-textfield-m-texticon-text-color-disabled: GrayText;
+        --spectrum-textfield-m-textonly-focus-ring-border-color-key-focus: Highlight;
+        --spectrum-textfield-m-texticon-focus-ring-border-width: 2px;
+    }
+    :host([focused]) #textfield:after {
+        forced-color-adjust: none;
+    }
+}

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -51,7 +51,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/toast": "^7.0.7"
+        "@spectrum-css/toast": "^7.0.8"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/toast/src/spectrum-toast.css
+++ b/packages/toast/src/spectrum-toast.css
@@ -338,3 +338,8 @@ governing permissions and limitations under the License.
     ); /* .spectrum-Toast--positive .spectrum-Toast-closeButton.focus-ring:not(:active),
    * .spectrum-Toast--success .spectrum-Toast-closeButton.focus-ring:not(:active) */
 }
+@media (forced-colors: active) {
+    :host {
+        border: 1px solid transparent;
+    }
+}

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tooltip": "^3.1.15"
+        "@spectrum-css/tooltip": "^3.1.16"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tooltip/src/spectrum-tooltip.css
+++ b/packages/tooltip/src/spectrum-tooltip.css
@@ -321,3 +321,15 @@ p {
     ); /* .spectrum-Tooltip--positive .spectrum-Tooltip-tip,
    * .spectrum-Tooltip--success .spectrum-Tooltip-tip */
 }
+@media (forced-colors: active) {
+    :host {
+        border: 1px solid transparent;
+    }
+    #tip {
+        --spectrum-tooltip-neutral-background-color: CanvasText;
+        --spectrum-tooltip-negative-background-color: CanvasText;
+        --spectrum-tooltip-info-background-color: CanvasText;
+        --spectrum-tooltip-positive-background-color: CanvasText;
+        forced-color-adjust: none;
+    }
+}

--- a/packages/tooltip/src/tooltip.css
+++ b/packages/tooltip/src/tooltip.css
@@ -86,3 +86,15 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-static-green-700)
     );
 }
+
+@media (forced-colors: active) {
+    #tip:after {
+        --spectrum-tooltip-background-color: canvastext;
+        --spectrum-tooltip-neutral-background-color: canvastext;
+        --spectrum-tooltip-negative-background-color: canvastext;
+        --spectrum-tooltip-info-background-color: canvastext;
+        --spectrum-tooltip-positive-background-color: canvastext;
+
+        forced-color-adjust: none;
+    }
+}

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -52,7 +52,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/tray": "^1.0.25"
+        "@spectrum-css/tray": "^1.0.26"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,40 +3796,40 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@spectrum-css/accordion@^3.0.21":
-  version "3.0.21"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-3.0.21.tgz#123ea54afea981ee3abbd2f873f272e712e8ba40"
-  integrity sha512-0F3NtYoee/FPmsVgOMiqC4dofdb/wGvIy7XR6Oc4FptMh/lCBuCgJWMqaFCawJPBvmBw0AvovxVIMpkuC6m6Zg==
+"@spectrum-css/accordion@^3.0.22":
+  version "3.0.22"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-3.0.22.tgz#a9da7d45952f865c953d0b81ad4b0d266b86bbf6"
+  integrity sha512-RnoXe/fgPqzd99HAWjGyOsWO5RJddD80GLdL4ktNKYiSfxKjwIw0K0pCPaWmHQTsy0n9YDKm8sG3AV8T/4dR1Q==
 
-"@spectrum-css/actionbar@^3.0.26":
-  version "3.0.26"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-3.0.26.tgz#ed1812c2287147332f77455ab6fcbe27df4e7ffd"
-  integrity sha512-bjgz/62OJd64W6unB+VOco5OzHaGjk8mlYUTTgy8srEVHzdzGGhRD56LcErjWSri0MiPjMlhqaWs1wePAD77qg==
+"@spectrum-css/actionbar@^3.0.27":
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-3.0.27.tgz#bea5a29972f7f7f6e79a5fd953f0ff41a5605c7d"
+  integrity sha512-xb+1wA1a49n1rzVzw3KMrXYFN3Ki+FgSDY7lDzgPyLSNnBEbnrdr7b8ip4gnqTDVOKoVrmmDoHvSWAB3bz0fqQ==
 
-"@spectrum-css/actionbutton@^1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-1.1.12.tgz#3f4de1fc5089ce772e4013b9b5c2a8b9d272a0c7"
-  integrity sha512-iUMu/zENI21rfcroQc5jWGlNxPs2S8PqqkrZEelEuSxpmBgUWZZr1uMMosk7xHBS2sWZVlDuJHKcV+rqf6xhEQ==
+"@spectrum-css/actionbutton@^1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-1.1.13.tgz#2150079c16465dba2fc8c9ea6c1e5c6ab6c9cea3"
+  integrity sha512-s0i7gcXLdf3UNL5RDsqHkJLbEkdC1SRbfLUHDxmra6Y5wfgcSxzk7sSGYblOOJW/RYH14YbnUbKl1npGV/UCsQ==
 
-"@spectrum-css/actiongroup@^1.0.24":
-  version "1.0.24"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-1.0.24.tgz#5d16a8225d6aff319c220c01b056667d511c5541"
-  integrity sha512-+XQXraDU1Kjb42kDZw/TWe40/uYLYP+f2jwITpR5YRVLMhbgC5q+CVz37g/Yfy1+uhuTeOCmCPn+pMSGw1PvVQ==
+"@spectrum-css/actiongroup@^1.0.25":
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-1.0.25.tgz#e9bfb9f98aacc5f0807bdec608a7a89de0354e24"
+  integrity sha512-cmLQylqtVFR4t2udXe30F8KykdIYb0NeYqXcrlxA1F9V6rlNRjUwdqbOn1SCK6cBe7ilCASuIx+FOXaU+OC2tg==
 
-"@spectrum-css/actionmenu@^3.0.26":
-  version "3.0.26"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-3.0.26.tgz#b9ee5288641671d57168b9a49aadb2dcf2c5fd84"
-  integrity sha512-Y3WB9chexG5bUnJ0YIKCCl/RPXCCEdaYpp6Lf/rgDTJgg/mbwll5OJCh5/aPWXx9M5iBhGIHF+/APHCTkKmemQ==
+"@spectrum-css/actionmenu@^3.0.27":
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-3.0.27.tgz#15c0d246eb1058fa95bbb8db88682a04dec8c7b5"
+  integrity sha512-aCMhDLh71aTzDDX0vFoksXeU/R/ogZc3j9iJT6yoBJZH/hYIeikY+My/0YNJB9q7lTp0ImB+u666yofVcK47nA==
 
 "@spectrum-css/asset@^3.0.20":
   version "3.0.20"
   resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.20.tgz#5f6a60ba062406637f8060bc620d0ef3fa0f2c9c"
   integrity sha512-CWxSDP//w7Gzs+BYCariU0hhvi7TjOQMdb0Pru6L7VzmXUVKLcJd4mQkFeNGulFFukkldZFThMJI088WmJhB5w==
 
-"@spectrum-css/avatar@^5.0.16":
-  version "5.0.16"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-5.0.16.tgz#0e44cfc2c928988c3c694b31b4ce2f0dfa689ad2"
-  integrity sha512-0YXLOc0o5TYVG5qywFufViKaq9TPFUpu19g2i/H4vEj8VxmBdx/uEzaMmAXtgIgWfSetmCORu4sXmcxTRN8vHQ==
+"@spectrum-css/avatar@^5.0.17":
+  version "5.0.17"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-5.0.17.tgz#162646bd1db509000c01e5e6ea9672e77954b9bc"
+  integrity sha512-E6mSCvnGF4far9aNEbKeRcgXDaa/zrrZtioHjYatfuBrKtO1cqz2zp1F+p0tsAXlGy6PrtzaPEHq+8Q4HuufoA==
 
 "@spectrum-css/badge@^1.0.18":
   version "1.0.18"
@@ -3841,37 +3841,37 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-3.0.0-beta.2.tgz#df448a3dcb8ac63448bd628843a2895cec305780"
   integrity sha512-NqrT03ItWzj+L0dtqjedhop6wKOspBmaowzp9IOY/2kL561kRqYTLKR9vTteZ3cEDVD3ajKA8y+bKIW0eN+X7A==
 
-"@spectrum-css/button@^6.0.10":
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-6.0.10.tgz#eabc2643cceec39a2314e3cb7be91cae7248019a"
-  integrity sha512-k3eBNBk4/FVfPJCVchMOgYOGE6gV4xdfsH+sl7G3eI5LqOaBeO1znW9ZyzB7eH3NJmLDIhImII+WSu4guY5S5w==
+"@spectrum-css/button@^6.0.11":
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-6.0.11.tgz#17c46275dce7cc4c503f17e310867062d7a6d74a"
+  integrity sha512-R3chsUyW36EkMQmbcIqVuJCmrCJAIL46nMqV3XliAx8+WCWs0N4Hz06kXb78Swnpn2cbGeftKjQxvRFjXFp8RQ==
 
-"@spectrum-css/buttongroup@^5.0.10":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-5.0.10.tgz#afdcb3dcb64696a5c614c837298ef9e99e5189d5"
-  integrity sha512-KJARALayC9ZDTqlejsBENpXRg8cYOLMm82Cp4jjgS0PFWXa2QlotpfeCwtK8aRSzpHEoufgRNvibE5acOJEqWg==
+"@spectrum-css/buttongroup@^5.0.11":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-5.0.11.tgz#8c0055a1d64448889ec5512c7d6022c67e172328"
+  integrity sha512-AwmQaC2BkrFQYbJ6gD1UezW4aFlDCRHgttXjG496zCUR2N87tQJs2UGpfIB4nTr5cjJN6iTQMFioULOhPBK5EQ==
 
-"@spectrum-css/card@^4.0.20":
-  version "4.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-4.0.20.tgz#8b9d1c7ec7a836abe1b28f0c9db6b31c0a9ebae7"
-  integrity sha512-Sxb3oLFtw/d35GK8q16OUYt09wgzf+kf3mokv//zW/4chZiMECeUBW5XDDDBmKpVKls6wcZeZVZtgmsfLBDDKg==
+"@spectrum-css/card@^4.0.21":
+  version "4.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-4.0.21.tgz#5e3ee33d7999a9c0ff9ee974a9c55a03de37f957"
+  integrity sha512-e9UA5DnsEkyNeeHRW9soxys76a3np3fc2rhbqSRiJ/quho/QaR51SLvtleWOOOkA9OK4Kh8mEjxl08+4v3QJ1Q==
 
 "@spectrum-css/checkbox@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-3.1.1.tgz#21fff2406e03a1066e426b3d8624d64fd594ef8f"
   integrity sha512-vu+2Si9shB2n8jyxCMpFJZOEMcdiBzP1Cj7miL7av1mUQyNP7uQJP+AAPS5umjIJh9Bm2SUAWL3RM76ZQUEstQ==
 
-"@spectrum-css/clearbutton@^1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.9.tgz#5966c30ebcb732a45ac6e1c71ad153589a06d524"
-  integrity sha512-911ZDLcTaor+ZklMMzJIchISewp5Uh6UWTGuqpsh/Pk9DnLbl/rZPwVVS11pyuMj9Xz+26r1GDDlUcG8OBKOVQ==
+"@spectrum-css/clearbutton@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.10.tgz#3ed03649bb258f3cdbffc27673fa5c1a26e7874e"
+  integrity sha512-pMB1mSf9ArcFu1JZl58pzpnzHkeDqPTeg+NtkcoFUaoqdEMzLuwpTzb2/Lt7ndRZEr47Pkn5y16WHGpISvfHVA==
 
-"@spectrum-css/closebutton@^1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-1.2.9.tgz#4411a7b958ad4a5c3729385f1930efd2a373ec4c"
-  integrity sha512-9o+DiFvdk00et95Ps+5leute0qTT8pzDgGL2BYgqOb3hrdHjdO95GfFXs/YxFdcgIONVvPypJEr5sbR+AP9m5w==
+"@spectrum-css/closebutton@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-1.2.10.tgz#49819d4cfb89c816170a236c44ef7a196895086e"
+  integrity sha512-RyrpayT6GUczXIBEKW/nKoK3uxb60UjK1AZkURoK6PcnJeo/Z1fAewW1eLV9syfV01JGSa0G6fBhDDYhDOCUxA==
 
-"@spectrum-css/coachmark@^5.0.10":
+"@spectrum-css/coachmark@^5.0.11":
   version "5.0.11"
   resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-5.0.11.tgz#be1bf26085cc48680fc30f68f03943e6de3145b8"
   integrity sha512-8DZLqXwT4PpQLVR5anCdnaWKzuULBg92SAZt0FAB0pVhbQ6eyoj4EFsDLTltVbZSfwb4P/azIaQgXgU51+xHtw==
@@ -3906,15 +3906,15 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-3.0.5.tgz#25b86c97402145a6aaaf58cbf1070e1c345d4f9b"
   integrity sha512-9YcJru496pHkcQMWP8y7Njk+ySMfdcap0hBAG/Fx+Vfmlcv9Mt1WCMuyLZusQ6a/0RVU/aKI4kLnDeunphBpNQ==
 
-"@spectrum-css/dialog@^6.0.10":
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.10.tgz#28da562cc994c583f3b901d43943426ce1834742"
-  integrity sha512-cmJewHxeKDELhDsjlnuXqcl7ewSX//sczLXohuvyJkpWMT/7NQdqVITcIP09JfyPIwUlzq6U/YP9H732/qp39w==
+"@spectrum-css/dialog@^6.0.11":
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.11.tgz#3d276ac14cc2eaeb2653558103f4f732f94e8654"
+  integrity sha512-yQyUwAVzIhuxSCTw4rdbj3116IqOFsE4CncgQxaifOitcoMDBQ7vD4WAYS6qwAW0Sy9CvzHZqwT9vDooIw2Syg==
 
-"@spectrum-css/divider@^1.0.24":
-  version "1.0.24"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-1.0.24.tgz#743ab3f02a4b44c8eb02f971394609f9034ae4d9"
-  integrity sha512-1di+RgsCNm+HsQl20lAwXh23RPMZxLInlz8A0w+r4s9WRrwInEbTC3xHmfN6rSfBPJKQSQ5J78ipOH8qDSB0Jg==
+"@spectrum-css/divider@^1.0.25":
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-1.0.25.tgz#7d541a14b403ff572ce62a03845d8ca47cfb3f9d"
+  integrity sha512-TQgvR32TTx2mCoA2JIODHCctcqL9hpJDene+RjbSRXbWNn0umk84NAgZ5/6Y9UZcexreAiM5uHDXO8Dv/M0eug==
   dependencies:
     "@spectrum-css/vars" "^8.0.0"
 
@@ -3928,12 +3928,12 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-2.0.0.tgz#462c1679df96d515780b3ee7fea2b8bccbd901bc"
   integrity sha512-K8hwoWOHcZTwLo6P3Itvl/ggZ+GChFyNoj5Rvlgj8R9/p62Eb9Vp9UDx2Mcg1zCJN2sBZAiqhYRQM+WawRtx5w==
 
-"@spectrum-css/fieldgroup@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.1.1.tgz#98156aa57727a05bb08d117b11f652ce3c178e66"
-  integrity sha512-6hD1b9OJFbBjq963rzMP5/sQ23eAVPNDDnrE03VePkBxYbNHvWdJrDsQH5O2dFQIT10S1WIlIPj3w7HQjrAWdA==
+"@spectrum-css/fieldgroup@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-3.1.2.tgz#dbe4c1de235e845caca18b0d2a30063ad2727bb1"
+  integrity sha512-bGzEfCGArX1dpgiMpS4Mwq9OIE1elENxS7fmSNz4Yhcdncsl0uBCU+J5J1IA/ThSXwMMfrYp1MF14oRdli6oRA==
 
-"@spectrum-css/fieldlabel@^4.0.23":
+"@spectrum-css/fieldlabel@^4.0.24":
   version "4.0.24"
   resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-4.0.24.tgz#42c9b826bace1c76ee65a40a684fcacc73748ee8"
   integrity sha512-ggx6gT61StwfCDWHuSncsM4eGBrphD8RtGo2WnWQdMCvF79VElBEIRPQQUYJFEWt+xqJAsoyK9wn8QhlRzRWAQ==
@@ -3958,130 +3958,130 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-3.1.21.tgz#41e815d9f15900c11e621d3992e37e04e2690178"
   integrity sha512-iTycfJRnW3WzyDDh9CrSMH6npuNI5yaZ7TDcCmOFinoSZ6ZQPaTnz6tI3jYAtg2minEmwF2lUa7k16MtwmoUTg==
 
-"@spectrum-css/menu@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.1.tgz#679760118c092d83c0c18a6ea5b4cfa54c585e69"
-  integrity sha512-GzZHSypWHn+HI0RmFh54QTp8GphqrbYf/B5mh3w/gAV9+4OZPTpSFKP7300UAgeNwIOsDpfV9brR4OXo5IlFVw==
+"@spectrum-css/menu@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.2.tgz#eab88b77ecdee87231a6eb0b2d72d2a00d256268"
+  integrity sha512-DioM3vwrh3Gbhb93Kzl1VmXFKmY60UxSkSx9Mt5yQjxyqGItXOsnb/K5HvTKfAbKy+lTgZYTS7MzjCTEoCf50g==
 
 "@spectrum-css/modal@^3.0.20":
   version "3.0.20"
   resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-3.0.20.tgz#351166199ecd45d6e0ef34ddced2668f6d24e53b"
   integrity sha512-+Lrs8ybpRaXtd8pfpOHgyWWO/Xd0H9cJnckWBN8wb0Q4kyMeHGchOYnAMP9OnLNkHRowA1CToJjuWUmK3thbUA==
 
-"@spectrum-css/picker@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-1.2.6.tgz#73cb853ab2bc955fb48ca9295184fb33c3a5637d"
-  integrity sha512-eSTqgT2AhVadVV2Suc9wmMLh5uPenBfAInW6dWkBzbuLW9aO63WR04VBNeNXgacXqRwwOYXQrPsdM1mo7qNKYw==
+"@spectrum-css/picker@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-1.2.7.tgz#ae6185f6e59ce19c75adeabfd3246d7d85d2621a"
+  integrity sha512-k+tNqRPZXu3ayYfk1r94VrOCPdNP9G6RTIgxiQphFjrYnoI1qDpThajcqIqQT7XsGFDcbzPoLjCV0BS04/9i8A==
 
-"@spectrum-css/popover@^5.0.13":
-  version "5.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-5.0.13.tgz#6ece4f39a1ca7e50ff1a46480803ecfed1e3d533"
-  integrity sha512-lzPpaOBvdTLtJMeR28qrqFuY+/u0UvFBZSmPl+0HYssPPgaN54IctHZApeKwf39+gT2xTIkQ9N95CZh22l7G+Q==
+"@spectrum-css/popover@^5.0.14":
+  version "5.0.14"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-5.0.14.tgz#a77ad18ad3535625d9ea9c4b7f380cf4ebfffb41"
+  integrity sha512-+/G+xrXTNGnYqYKVRJPtsYkfNBEPIyjW2VpC/5ZOPZrp3NWVLnNbASpqT0E7RVNzo0EJG5r1H7Gh3hxDRCTktA==
 
-"@spectrum-css/progressbar@^1.0.27":
-  version "1.0.27"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-1.0.27.tgz#28675590abe4dbf2fafbb010fd3823988c4b07cd"
-  integrity sha512-MeuZdObn6riqOetSsDx9uIGMLe+wrn8/veNJMBvfMQjuFKxrW26T7m8wB8OEIYeQP2xno2U97GkUv1XmeJp/zQ==
+"@spectrum-css/progressbar@^1.0.28":
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-1.0.28.tgz#831ea157b2457c6dee88cbd6b249818077a52396"
+  integrity sha512-l98LzqanA2EzE/8g/Om2Bvrw5gdbtyTq+PmtLLr8HbUVsVC+Ej4t4R9P5/hUavJzDJHcJYg3bdGY/K/Qo2Gq9A==
 
-"@spectrum-css/progresscircle@^1.0.20":
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-1.0.20.tgz#8a3f534d403c1a9d8a0f24d18597c58ab6c1e033"
-  integrity sha512-3IdCaZmbyytZLajkI2oXa620sGGTr6lK8Op79FQNBH/XQNyvmwFRdq/rCKdYJAtS/WVOyQzy9nn+rQba0iAoQg==
+"@spectrum-css/progresscircle@^1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-1.0.21.tgz#0db84f3e02922d46c12e338e77275b26f63224eb"
+  integrity sha512-p2FDwrCZwRNIiGD2xIiOEuk3BfvVGb6oEA9KM7npSp2fP4W8/1GrEqnYqGya2ii+lJKZ9qzuaqhaeLs97pcMGQ==
 
-"@spectrum-css/quickaction@^3.0.23":
-  version "3.0.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.23.tgz#778be186772128d8566d55dd6377a9f9acd535cf"
-  integrity sha512-XKGDfAyUSLl+TPelU+ksRU5avuEewYrIivIjG9I7fKaDw0KvrMKTM5Y+E+a8uvQkm7phldt8KjAepbzm0HTwng==
+"@spectrum-css/quickaction@^3.0.24":
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.24.tgz#eeb8b5212e818d29581ceb8a177f0dcd068fd0fe"
+  integrity sha512-MmJf5fqoChinOK5THTjU4D6bVp8lk6AUIe6JmSt9/N420ixfMysyYyKe1VGpqkZePFkPOiEKhh3vHT2utKFqBA==
 
-"@spectrum-css/radio@^3.0.21":
-  version "3.0.21"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.21.tgz#810cee978b54702ebc48b64011951c94ff6d45f6"
-  integrity sha512-qGV/7FAGfONI4V/ulev61BAxMbTu5KptN8W6aK3p3NBHuk+1540mNWiacpNvdZTgQaOr2cyOH5pngYgLqHLzHA==
+"@spectrum-css/radio@^3.0.22":
+  version "3.0.22"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-3.0.22.tgz#bf607b7020ef50c4b1e16beee44976418cac50b2"
+  integrity sha512-JZzfgLQn97p2A5+76KACDIORkWCUuGQ1rxtsG/TmoHQhJIQMBMnxBiqCg+q+16gQ/b0wnJftKThNqZW33LKs3Q==
 
-"@spectrum-css/search@^4.2.9":
-  version "4.2.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-4.2.9.tgz#b70109df3c5f6d2383822025a8581eb98ffa72c8"
-  integrity sha512-NUwQDBfx4xZtjkF9tD+JnwLg+fGfIY0nrxrZpTOcavoj8uiK7MA6+fweadezfQvkBo/uPy9buwPg7vTPKz4Bxg==
+"@spectrum-css/search@^4.2.10":
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-4.2.10.tgz#d6db95ce2be66f8e907bc8a8ebfe19f3e1f5c8b3"
+  integrity sha512-kbj7hc+fvTc+AppLJ+ogG813P3Le4A427kh7CT5LWF3iZggp7oT86t3BGaQ0MUUa3WnEiSttlTp3GqyKuAmK0g==
 
-"@spectrum-css/sidenav@^3.0.21":
-  version "3.0.21"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.21.tgz#350ffaf53441eb15783a734b3a9aba614ff8210d"
-  integrity sha512-A3x4m3tzRkgwLRxBaDyA9Oymp5EexcvgpMmhtfWjV1ZJN66vYN0nnjG/2usbF6LOgnoNoaAEhvoRKXQyHtsdUg==
+"@spectrum-css/sidenav@^3.0.22":
+  version "3.0.22"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.22.tgz#2bd81227807ec9fd42ac82f84268d1aaea3192ad"
+  integrity sha512-YvvR1pTjSEo+JgiD9pauNg2ho7B0V10IEPwLdC0TBexmvbWGZNxKPkdv5L9XExU7RMesOqD1/diGXG8n9/QP0A==
 
-"@spectrum-css/slider@^3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.1.4.tgz#454f623173c3d42df4c8d363f42cad0c2838f4b5"
-  integrity sha512-hjE/k+w78ttglfYhH/kxqyKmMWfO73rIe0ZCJFW6G4mREEKArwYMVqFEzjfkdc6/hjF/G65eu8yT3XMpYg5MPA==
+"@spectrum-css/slider@^3.1.5":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.1.5.tgz#ec95e7291cab7c2c11edb31ad87475f86c34193b"
+  integrity sha512-nFKjRA9ihHxnksvI9KA1wvcVeZEtwJqzgxo1wDt66FaSnkd/diXXVzhWJW1ryAUmyO429goKjEWzOdNUIEi/tQ==
 
-"@spectrum-css/splitbutton@^5.0.10":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.10.tgz#c77bf56fb87ed1b6abf16a7df36ae67720671c7f"
-  integrity sha512-Jb141oHrZjm61U8SQ+2LOy2LqEp3KXTTqG81pJOBdCupzwSOd01IY0S8do+bVbdI+8dCa5n7GyBUoyNliqxj/A==
+"@spectrum-css/splitbutton@^5.0.11":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.11.tgz#4f4e63f1e1bc38b51596a5cfed2c799597ee3032"
+  integrity sha512-QYbV6shmxZOfgYKt4nq4MCjOw0t9HpPCJdtAu2cE/d4itZuwjfGox4g51A0i7uDE3e78W+rAHZNSOSJ/u0xEqA==
 
 "@spectrum-css/splitview@^3.0.20":
   version "3.0.20"
   resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.20.tgz#981d69e775d6eb776f6d5ff1ed7c39977d4d33ed"
   integrity sha512-f2uEuenUo2aN9/5+KHiG2m7gB0U8TTHh1UqhrQjbn8hhN7v8vKJT9kj5qZRXDzmPwU+eVNL5PF8B+vz7C/IYtw==
 
-"@spectrum-css/statuslight@^4.0.11":
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-4.0.11.tgz#cced5092e9aa0f2e51888d5ce4a158f672327228"
-  integrity sha512-3j14ZKDAIgWhvET8lsimPwab0ZyKyooq/UarOPVCNvFLt5s8t3JETPUmQs4I2hMWpJi7VBjAXZDOdIY4qSEciA==
+"@spectrum-css/statuslight@^4.0.12":
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-4.0.12.tgz#a23545d40424dabe0f906ad04f837d5754059aea"
+  integrity sha512-YN9ArcWinh6vck597vWTtadxA0CD1W5cUJsfIjN8Ft4itYplfDEMoLIl8KXUc5BFefzRkwpkiv6XHQt0dIkHtg==
 
-"@spectrum-css/stepper@^3.0.23":
-  version "3.0.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.23.tgz#cd8ab3484c34242e1f069dc9897332fcab05c10f"
-  integrity sha512-M+q7A55wzJJDvZu/T1q9GhEmIoE/FZA2GMlSIgBtdTDF0RLD5WoSuuYOf1bhIPEMZNQi7x4EcDsLX63MI5y2UA==
+"@spectrum-css/stepper@^3.0.24":
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.24.tgz#8ba89f7bd38acf3041e22b5dfa11c3b4fc582de5"
+  integrity sha512-f+pHJ3LJbOt8AahldyIUOaG6+fiI4taPNKzPFilmEQAJv/8EwrjUNlJKEj2OmylOy5h8OxhMtSz7Uovr8nJ0GQ==
 
-"@spectrum-css/switch@^1.0.20":
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-1.0.20.tgz#c4fcbc6dd5f3230347614fbf41e190858a12f84e"
-  integrity sha512-6eTNZsLWGXa3HHUL0c2Uli1DGvA9riQs/wZWzLJZKdKstJCnM9NU/jDNCuKbDP4M6YtxAsKxyZFW6k0ddUNJ5g==
+"@spectrum-css/switch@^1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-1.0.21.tgz#6ebf92c9bccb8ad9eeecad69c903d4d819d4a274"
+  integrity sha512-qEXM8LU+DmzL4tHyXCQWO1K4556Js/b6mnW+nx+aq1mfqd95TCakK3WweNGdDX1Blueywep+baT/zD24C/feUA==
 
 "@spectrum-css/table@^4.0.17":
   version "4.0.17"
   resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.17.tgz#5a5eba1b66a620dc1e534a91d696b7b585b4a543"
   integrity sha512-H5iJE5iKqKAyacdbeRPPUfyJFtcK956bROdRSzWCmxNpIp7Y7tnxsgsrP9lcB/wGG80rl+ECVkZfe1YZ+PQwAA==
 
-"@spectrum-css/tabs@^3.2.13":
-  version "3.2.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.2.13.tgz#5d7be9f3d5cec018215d02694fa9778bd7c9732a"
-  integrity sha512-/DZrZNc27XTbZuEVCHMo7mQW/0tsUVGCxH/YocY2cubUQWbbSzcovwL0C46KtF1J8YhQhEnin/wt3N2E6o32qw==
+"@spectrum-css/tabs@^3.2.14":
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.2.14.tgz#43eba35a625f62317f08cd313acd89389ad4efc0"
+  integrity sha512-uZMJmramWEVC4y8litdIsZxGB8T9t8rbH1O/93WHQiFJQfPrCy+sGCYuHurxVHGQmHbAvi4eQ5ZuiyPQ11Q0QQ==
 
-"@spectrum-css/tag@^3.3.11":
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.11.tgz#66b5f91a845df2ad232fae702ae53b3fa46cf745"
-  integrity sha512-dyDUwG4fbsScMLaVOKQgKuUvYshGEIjTS9lVNhOHCz7klZ800UIMoCzDQXieHf+0nSdiR1Wy1oHBObHMMB8sxA==
+"@spectrum-css/tag@^3.3.12":
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-3.3.12.tgz#a1d908cac50cd0a8bd1fe7341bd6df221359dc69"
+  integrity sha512-SZMAkzdEYNPK2FLt7IgogNszkEzLLd8DQYCTlXeQRfNy3FxpHLsvrhnoXt0zTsYOrmfhJFNC0ixYhEMQS10auA==
 
-"@spectrum-css/taggroup@^3.3.11":
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-3.3.11.tgz#516484ddda331a82510c927a61a344aa4a04ed62"
-  integrity sha512-Xmz024i0LGaumTmhlIFZMaqxjjWUeu3cLRHnRalR1x5aWyz/tp8SK8iD5mJM7arEzx2kIP4UUVbCBHIjsO0wew==
+"@spectrum-css/taggroup@^3.3.12":
+  version "3.3.12"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-3.3.12.tgz#b942a83dcab6b56592517f0e98e4ef858b2c78e4"
+  integrity sha512-gYspJo5D7SMb7hzLADlEYnjwxo2Qi6aND5bqJ7lNg1TUWHvWUpaXFfu52poaV5U8745yPUd0L2PUo8S4GX/+Gg==
 
-"@spectrum-css/textfield@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.1.tgz#80f92cc5e2ba11840267388193d894e84eee64f9"
-  integrity sha512-g3oJc0QEskydrR5gQq5rYPFJfm7Y7FEI+ddjoaGPILrQhzGV/0+4s9/i+7qTUBHzSuVeSxml+5RIssNbo2DOZA==
+"@spectrum-css/textfield@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.2.tgz#007cd2216ab5c6c792ca758a7bb50ba07afdf5c2"
+  integrity sha512-1RDJ4hlxQAW2SGcRPNgOnr7XoJlfs5wsfRr0rAxuG09+i3IwOBNkcldncCQAC+hPDSz1fhaJxiskvX03tBmUqQ==
 
 "@spectrum-css/thumbnail@^2.0.15":
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-2.0.15.tgz#33833aca05037d053fd2315105352d7c70998a5e"
   integrity sha512-uZgyDQlr3BR3De+nO6X1sDzSDnFU/jF2IdqLC+EqVNMw9WeVSBqYkQVhDK6TTJUm+k4yqtDhON5YXBbUuaUzFw==
 
-"@spectrum-css/toast@^7.0.7":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-7.0.7.tgz#c449c62e287150949648ca909431bf53dca211fb"
-  integrity sha512-OjAIcmA/RmvmYU6m45OQD2eHhb/ivGY6Amh5W2j3ybn5oL12evQJvDni2DxL3jsUSQWNh+hZhY1pUOHLU7TvYA==
+"@spectrum-css/toast@^7.0.8":
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-7.0.8.tgz#e1277d1b7bd8eb846ddd4437eef7e7ed6352e51d"
+  integrity sha512-JoXECadMGrRlWy7aoRAHzKfHCgzsnW3L53SBcRWacGEb3yNRz4/BkUWTTEuweMYYDAcaGB028xX11waYjDHq8w==
 
-"@spectrum-css/tooltip@^3.1.15":
-  version "3.1.15"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.1.15.tgz#dff6e921c0bc4acb151641be1a1871b4ce30a3d4"
-  integrity sha512-7Xzfy1lWT6zJhgtqOakEMJALHRrArNYfvVW+/d4033fybNJXb6MQlNzVErc8QI1cjYwIIVncOFLzQH7FJP0j2A==
+"@spectrum-css/tooltip@^3.1.16":
+  version "3.1.16"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-3.1.16.tgz#46d3a7abe3329f9a290fa5177ea8364927c5002f"
+  integrity sha512-3lKzSgeBUDgs75ruxIFYpO7MlkkXkPMxiUySOr7PCrwdmsF0C+gb9Jwye0GXRIsAvOBPg3SQt/LxzACU2bYOZA==
 
-"@spectrum-css/tray@^1.0.25":
-  version "1.0.25"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-1.0.25.tgz#aaaf0ce66accbeccc112e6420fc65509d8e7e27c"
-  integrity sha512-oPd/oM3Og/ggS+Kyzpl6truSjxpKMpMgHkcvbiT+h3BeNJMqE5tpiPsO/34O8+9VsolLEI0MtVnnuQ7lENfDlA==
+"@spectrum-css/tray@^1.0.26":
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-1.0.26.tgz#045a23fd09fce526dd388eddbcabf52bd74ff2e8"
+  integrity sha512-hdQ5vI0H5MrCCrcJPLRUHUG2lkwrtazM73Zvy9zIXfCyypmT6SgTt9CsCQPRL40DixAtChCNkqMui/UHvQaS1g==
 
 "@spectrum-css/typography@^4.0.18":
   version "4.0.18"


### PR DESCRIPTION
## Description
- update Windows High Contrast Mode support across the library by taking on the most recent Spectrum CSS versions

## Related issue(s)

- fixes #2229

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/action-button-static-white-quiet--s)
    2. Also go [here](https://spectrum-css--spectrum-web-components.netlify.app/storybook/?path=/story/action-button-static-white-quiet--s)
    3. See which one did it better.
-   [ ] _Test case 2_
    1. Using Assistive Labs for Window High Contrast Mode
    2. Go [here](https://spectrum-css--spectrum-web-components.netlify.app/storybook/?path=/story/action-button-static-black-quiet--s) and all the other Action Button Stories
    3. See that they appear like: <img width="192" alt="image" src="https://user-images.githubusercontent.com/1156657/170152384-8dd5d104-7531-423a-bdfe-ea4e44ded403.png">
-   [ ] _Test case 3_
    1. Using Assistive Labs for Window High Contrast Mode
    2. Go [here](https://spectrum-css--spectrum-web-components.netlify.app/storybook/?path=/story/button-accent-fill--default) and all the other Button Stories w/ disabled buttons
    3. See that they appear like: <img width="298" alt="image" src="https://user-images.githubusercontent.com/1156657/170152513-8cb0c83e-7b06-4136-825c-c3e15326b172.png">

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)