### PR TITLE
Overlay fallbacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: de8ce09ade2a1ea8ad7058a84fa1a4b04998636c
+        default: 9586195fb1990d52099696881c1e0ae6a98762fc
 commands:
     downstream:
         steps:

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -740,7 +740,7 @@ customElements.define('start-end-contextmenu', StartEndContextmenu);
 export const virtualElement = (args: Properties): TemplateResult => {
     const contextMenuTemplate = (kind = ''): TemplateResult => html`
         <sp-popover
-            style="max-width: 33vw;"
+            style="width:300px;"
             @click=${(event: Event) =>
                 event.target?.dispatchEvent(
                     new Event('close', { bubbles: true })

--- a/packages/popover/src/popover.css
+++ b/packages/popover/src/popover.css
@@ -15,15 +15,7 @@ governing permissions and limitations under the License.
     --sp-popover-tip-size: 24px;
 
     min-width: min-content;
-}
-
-:host([placement*='top']),
-:host([placement*='bottom']) {
     max-height: 100%;
-}
-
-:host([placement*='left']),
-:host([placement*='right']) {
     max-width: 100%;
 }
 


### PR DESCRIPTION
## Description
Allow content opened from a "virtual trigger" to "flip" on both axises when looking for a place to position itself.
  - don't use `auto` because it's not predictable enough for closely related content like Pickers
  - update `size` usage to always fallback to the initial size when measuring
  - moves the Picker Menu location to above the Picker button in some Large VRTs due to their not being enough space below the picker for the content

## Related issue(s)

- fixes #2198

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://overlay-fallbacks--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--virtual-element)
    2. Squeeze the preview window down to 400px wide or so
    3. Try opening the "context menu" from various places on the screen.
      - top left
      - top right
      - bottom left
      - bottom right
    4. See they the "context menu" opens in a related position that DOES NOT flow outside of the viewport.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)