### PR TITLE
docs: cleanup usage of <sp-button variant="cta">

### DIFF
--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -514,7 +514,7 @@ describe('Button', () => {
             await elementUpdated(el);
             expect(el.treatment).to.equal('fill');
         });
-        it('upgrades [variant="cta"]', async () => {
+        it('upgrades [variant="cta"] to [variant="accent"]', async () => {
             const el = await fixture<Button>(
                 html`
                     <sp-button variant="cta">Button</sp-button>

--- a/packages/split-button/src/spectrum-config.js
+++ b/packages/split-button/src/spectrum-config.js
@@ -24,11 +24,6 @@ const config = {
                     selector: '.spectrum-SplitButton--left',
                     name: 'left',
                 },
-                {
-                    type: 'boolean',
-                    selector: '.spectrum-Button--cta',
-                    name: 'variant="cta"',
-                },
             ],
             ids: [
                 {

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -207,7 +207,7 @@ The large scale of `<sp-theme>` will switch to using Spectrum's larger mobile [P
         <div><sp-switch>Overdrive</sp-switch></div>
         <sp-button-group id="buttons">
             <sp-button variant="primary">Cancel</sp-button>
-            <sp-button variant="cta">Continue</sp-button>
+            <sp-button variant="accent">Continue</sp-button>
         </sp-button-group>
     </div>
 </sp-theme>
@@ -254,7 +254,7 @@ previewing or editing content that will be displayed in a light theme with a rig
         <div><sp-switch>Overdrive</sp-switch></div>
         <sp-button-group id="buttons">
             <sp-button variant="primary">Cancel</sp-button>
-            <sp-button variant="cta">Continue</sp-button>
+            <sp-button variant="accent">Continue</sp-button>
         </sp-button-group>
         <sp-theme color="light" dir="rtl">
             <div id="inner">
@@ -271,7 +271,7 @@ previewing or editing content that will be displayed in a light theme with a rig
                 <div><sp-switch>Overdrive</sp-switch></div>
                 <sp-button-group id="buttons">
                     <sp-button variant="primary">Cancel</sp-button>
-                    <sp-button variant="cta">Continue</sp-button>
+                    <sp-button variant="accent">Continue</sp-button>
                 </sp-button-group>
             </div>
         </sp-theme>

--- a/projects/documentation/content/guides/adding-component.md
+++ b/projects/documentation/content/guides/adding-component.md
@@ -126,7 +126,7 @@ If you look at an `sp-button` in the Chrome developer tools, you will see a DOM
 structure that looks like this.
 
 ```bash
-▼<sp-button tabindex="0" variant="cta">
+▼<sp-button tabindex="0" variant="accent">
     ▼ #shadow-root (open)
         ▼ <button id="button" tabindex="0">
             ▼ <div id="label>
@@ -266,7 +266,7 @@ attributes/properties on the component. For example, here is a call-to-action
 style button.
 
 ```html
-<sp-button variant="cta">CTA</sp-button>
+<sp-button variant="accent">CTA</sp-button>
 ```
 
 We could conditionally add CSS classes to the elements of the shadow DOM during

--- a/projects/documentation/content/guides/spectrum-config.md
+++ b/projects/documentation/content/guides/spectrum-config.md
@@ -70,12 +70,12 @@ module.exports = {
                     // as it is defined in the implementation of the component
                     name: 'variant',
                     // This is a list of possible values for the attribute. If
-                    // the option is of the form ".spectrum-Button--cta" where
+                    // the option is of the form ".spectrum-Button--accent" where
                     // ".spectrum-Button" is the root CSS class, then we can extract
                     // the enum value name automatically
                     values: [
-                        // This related the enum value <sp-button variant="cta">
-                        '.spectrum-Button--cta',
+                        // This related the enum value <sp-button variant="accent">
+                        '.spectrum-Button--accent',
                         '.spectrum-Button--primary',
                         '.spectrum-Button--secondary',
                         // If for some reason, we need to override the enum

--- a/projects/documentation/content/index.md
+++ b/projects/documentation/content/index.md
@@ -60,7 +60,7 @@ title: Spectrum Web Components
 ## Sample element usage
 
 ```html
-<sp-button variant="cta" href="components/button">
+<sp-button variant="accent" href="components/button">
     Use Spectrum Web Component buttons
 </sp-button>
 ```

--- a/scripts/process-spectrum-postcss-plugin.js
+++ b/scripts/process-spectrum-postcss-plugin.js
@@ -267,7 +267,7 @@ class SpectrumProcessor {
         });
 
         // Map classes to attributes
-        // e.g. ".spectrum-Button--cta" -> ":host([variant='cta'])"
+        // e.g. ".spectrum-Button--accent" -> ":host([variant='accent'])"
         astTransforms.push((selector, rule) => {
             const result = selector.clone();
             let attributeFound = false;
@@ -394,7 +394,7 @@ class SpectrumProcessor {
         });
 
         // Map classes to descendent attributes
-        // e.g. ".spectrum-Dialog .spectrum-Button--cta" -> "[variant='cta']"
+        // e.g. ".spectrum-Dialog .spectrum-Button--accent" -> "[variant='accent']"
         astTransforms.push((selector, rule) => {
             const result = selector.clone();
             let attributeFound = false;
@@ -751,8 +751,8 @@ class SpectrumProcessor {
      * Make sure that the first component of the selector is wrapped in
      * a ":host()" declaration
      *
-     * @param {string} selector - Selector to modify (e.g. "[variant='cta'] #button:focus")
-     * @return {string} The modified selector (e.g. ":host([variant='cta']) #button:focus")
+     * @param {string} selector - Selector to modify (e.g. "[variant='accent'] #button:focus")
+     * @return {string} The modified selector (e.g. ":host([variant='accent']) #button:focus")
      */
     addHostToSelector(selector) {
         // We made a replacement, which means that this expression


### PR DESCRIPTION
## Description
Remove usage of `cta` variant in favor of `accent` across docs and comments.

## Related issue(s)

- fixes #2290

## Motivation and context
Clearer documentation.

## Types of changes
-   [x] Documentation

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.