### PR TITLE
fix: prevent "hover" overlays from receiving focus

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -257,7 +257,9 @@ export class OverlayTrigger extends SpectrumElement {
             offset: this.offset,
             placement: this.placement,
             receivesFocus:
-                this.type && this.type !== 'inline' ? 'auto' : undefined,
+                !this.type || this.type === 'inline' || this.open === 'hover'
+                    ? undefined
+                    : 'auto',
         };
     }
 

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -16,6 +16,7 @@ import {
     OverlayContentTypes,
     OverlayTrigger,
     Placement,
+    TriggerInteractions,
     VirtualTrigger,
 } from '../';
 import '@spectrum-web-components/action-button/sp-action-button.js';
@@ -109,6 +110,12 @@ export default {
                 ],
             },
         },
+        type: {
+            control: {
+                type: 'inline-radio',
+                options: ['modal', 'replace', 'inline'],
+            },
+        },
         colorStop: {
             control: {
                 type: 'inline-radio',
@@ -127,9 +134,15 @@ interface Properties {
     placement: Placement;
     offset: number;
     open?: OverlayContentTypes;
+    type?: Extract<TriggerInteractions, 'inline' | 'modal' | 'replace'>;
 }
 
-const template = ({ placement, offset, open }: Properties): TemplateResult => {
+const template = ({
+    placement,
+    offset,
+    open,
+    type,
+}: Properties): TemplateResult => {
     return html`
         ${storyStyles}
         <overlay-trigger
@@ -137,6 +150,7 @@ const template = ({ placement, offset, open }: Properties): TemplateResult => {
             placement="${placement}"
             offset="${offset}"
             open=${ifDefined(open)}
+            type=${ifDefined(type)}
         >
             <sp-button variant="primary" slot="trigger">Show Popover</sp-button>
             <sp-popover

--- a/packages/overlay/test/overlay-trigger-hover.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover.test.ts
@@ -10,10 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import {
+    aTimeout,
     elementUpdated,
     expect,
     fixture,
     html,
+    oneEvent,
     waitUntil,
 } from '@open-wc/testing';
 import '@spectrum-web-components/popover/sp-popover.js';
@@ -143,21 +145,18 @@ describe('Overlay Trigger - Hover', () => {
         expect(el.open).to.be.undefined;
 
         const trigger = el.querySelector('[slot="trigger"]') as ActionButton;
-        trigger.dispatchEvent(
-            new Event('mouseenter', {
-                bubbles: true,
-            })
-        );
+        const opened = oneEvent(el, 'sp-opened');
+        trigger.focus();
+        await opened;
 
         await elementUpdated(el);
+        await aTimeout(500);
 
         expect(el.open).to.equal('hover');
 
-        trigger.dispatchEvent(
-            new Event('mouseleave', {
-                bubbles: true,
-            })
-        );
+        const closed = oneEvent(el, 'sp-closed');
+        trigger.blur();
+        await closed;
 
         await elementUpdated(el);
 


### PR DESCRIPTION
## Description
Prevent `<overlay-trigger type="modal">` from attempting to throw focus into `hover-content` children.

## Related issue(s)

- refs #2317

## Motivation and context
An `<overlay-trigger>` should be able to have dialog and tooltip content.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://no-tooltip-focus--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--default&args=type:modal)
    2. `Tab` to focus the button so that the Tooltip is triggered
    3. Press `Space` to open the Dialog and see that it is triggered while retracting the Tooltip
    4. Press `Escape` to retract the Dialog and see that the Tooltip is not triggered again.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)