### PR TITLE
docs(badge): typo in readme

### DIFF
--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -86,7 +86,7 @@ import { Badge } from '@spectrum-web-components/badge';
 
 ## Variants
 
-The `<sp-badge>` can the customized with either semantic or non-semantic variants.
+The `<sp-badge>` can be customized with either semantic or non-semantic variants.
 
 ### Semantic
 


### PR DESCRIPTION
Was tempted to commit directly to main (any thoughts around that @Westbrook?)