### PR TITLE
fix(number-field): explicitly setting NumberField wheel event handler as not passive

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -312,7 +312,7 @@ export class NumberField extends TextfieldBase {
         super.onFocus();
         this._trackingValue = this.inputValue;
         this.keyboardFocused = !this.readonly && true;
-        this.addEventListener('wheel', this.onScroll);
+        this.addEventListener('wheel', this.onScroll, { passive: false });
     }
 
     protected override onBlur(): void {

--- a/packages/number-field/stories/number-field.stories.ts
+++ b/packages/number-field/stories/number-field.stories.ts
@@ -422,3 +422,50 @@ readOnly.args = {
     readonly: true,
     value: '15',
 };
+
+export const ScrollingContainer = (args: StoryArgs = {}): TemplateResult => {
+    const onChange =
+        (args.onChange as (value: number) => void) ||
+        (() => {
+            return;
+        });
+    const onInput =
+        (args.onInput as (value: number) => void) ||
+        (() => {
+            return;
+        });
+    return html`
+        <style>
+            .scroller {
+                height: 140px;
+                width: 200px;
+                overflow-y: scroll;
+                padding: 10px;
+                background: var(--spectrum-global-color-gray-50);
+            }
+
+            .scroller > div {
+                height: 1000px;
+            }
+        </style>
+        <div class="scroller">
+            <div>
+                <sp-field-label for="default">Enter a number</sp-field-label>
+                <sp-number-field
+                    id="default"
+                    ...=${spreadProps(args)}
+                    @input=${(event: Event) =>
+                        onInput((event.target as NumberField).value)}
+                    @change=${(event: Event) =>
+                        onChange((event.target as NumberField).value)}
+                    style="width: 150px"
+                ></sp-number-field>
+                <p>
+                    This box should not scroll when the focus is inside the
+                    number field and field value is changed by using the mouse
+                    wheel.
+                </p>
+            </div>
+        </div>
+    `;
+};


### PR DESCRIPTION
## Description

This PR will explicitly set the focused NumberField `wheel` event handler as `passive`, since we do not want the browser to also scroll the page when changing the field value via mouse wheel.

## Related issue(s)

- fixes #2323

## Motivation and context

With this change, we mark the wheel event handler as being explicitly not passive, as we are preventing the default behavior of the browser when the NumberField is active.

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
