### PR TITLE
fix(dialog): use default value for "resolveTransitionPromise" for ope…

### DIFF
--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -91,7 +91,9 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
 
     private transitionPromise = Promise.resolve();
 
-    private resolveTransitionPromise!: () => void;
+    private resolveTransitionPromise = (): void => {
+        return;
+    };
 
     @property({ type: Boolean })
     public underlay = false;


### PR DESCRIPTION
…n by default dialogs

<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow Dialog Wrapper to be `open` by default.

## Related issue(s)
- fixes #2316 

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://open-by-default-dialog--spectrum-web-components.netlify.app/storybook/?path=/story/dialog-wrapped--wrapper-buttons)
    2. Refresh, click buttons in the dialog, etc.
    3. See now errors in the dev console

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
