### PR TITLE
chore: enable noImplicitOverride

### DIFF
--- a/packages/accordion/src/Accordion.ts
+++ b/packages/accordion/src/Accordion.ts
@@ -31,7 +31,7 @@ import styles from './accordion.css.js';
  * @slot - The sp-accordion-item children to display.
  */
 export class Accordion extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -56,7 +56,7 @@ export class Accordion extends SpectrumElement {
         isFocusableElement: (el: AccordionItem) => !el.disabled,
     });
 
-    public focus(): void {
+    public override focus(): void {
         this.focusGroupController.focus();
     }
 
@@ -87,7 +87,7 @@ export class Accordion extends SpectrumElement {
         this.focusGroupController.clearElementCache();
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot
                 @slotchange=${this.handleSlotchange}

--- a/packages/accordion/src/AccordionItem.ts
+++ b/packages/accordion/src/AccordionItem.ts
@@ -29,7 +29,7 @@ import styles from './accordion-item.css.js';
  * @fires sp-accordion-item-toggle - Announce that an accordion item has been toggled while allowing the event to be cancelled.
  */
 export class AccordionItem extends Focusable {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles, chevronIconStyles];
     }
 
@@ -40,9 +40,9 @@ export class AccordionItem extends Focusable {
     public label = '';
 
     @property({ type: Boolean, reflect: true })
-    public disabled = false;
+    public override disabled = false;
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         return this.shadowRoot.querySelector('#header') as HTMLElement;
     }
 
@@ -68,7 +68,7 @@ export class AccordionItem extends Focusable {
         }
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <h3 id="heading">
                 <button
@@ -90,7 +90,7 @@ export class AccordionItem extends Focusable {
         `;
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('disabled')) {
             if (this.disabled) {

--- a/packages/action-bar/src/ActionBar.ts
+++ b/packages/action-bar/src/ActionBar.ts
@@ -26,7 +26,7 @@ export const actionBarVariants = ['sticky', 'fixed'];
  * @slot - Content to display with the Action Bar
  */
 export class ActionBar extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [actionBarStyles];
     }
 
@@ -68,7 +68,7 @@ export class ActionBar extends SpectrumElement {
 
     private _variant = '';
 
-    public render(): TemplateResult {
+    public override render(): TemplateResult {
         return html`
             <sp-popover ?open=${this.open} id="popover">
                 <slot></slot>

--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -49,7 +49,7 @@ export type LongpressEvent = {
  * while `altKey===true`.
  */
 export class ActionButton extends SizedMixin(ButtonBase) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [buttonStyles, cornerTriangleStyles];
     }
 
@@ -153,7 +153,7 @@ export class ActionButton extends SizedMixin(ButtonBase) {
     /**
      * @private
      */
-    protected handleKeydown(event: KeyboardEvent): void {
+    protected override handleKeydown(event: KeyboardEvent): void {
         if (!this.holdAffordance) {
             return super.handleKeydown(event);
         }
@@ -169,7 +169,7 @@ export class ActionButton extends SizedMixin(ButtonBase) {
         }
     }
 
-    protected handleKeyup(event: KeyboardEvent): void {
+    protected override handleKeyup(event: KeyboardEvent): void {
         if (!this.holdAffordance) {
             return super.handleKeyup(event);
         }
@@ -189,7 +189,7 @@ export class ActionButton extends SizedMixin(ButtonBase) {
         }
     }
 
-    protected get buttonContent(): TemplateResult[] {
+    protected override get buttonContent(): TemplateResult[] {
         const buttonContent = super.buttonContent;
         if (this.holdAffordance) {
             buttonContent.unshift(html`
@@ -203,7 +203,7 @@ export class ActionButton extends SizedMixin(ButtonBase) {
         return buttonContent;
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         const isButton = this.role === 'button';
         const canBePressed = isButton && (this.selected || this.toggles);

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -32,7 +32,7 @@ const EMPTY_SELECTION: string[] = [];
  * @fires change - Announces that selection state has been changed by user
  */
 export class ActionGroup extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -134,7 +134,7 @@ export class ActionGroup extends SpectrumElement {
         this.dispatchChange(old);
     }
 
-    public focus(options?: FocusOptions): void {
+    public override focus(options?: FocusOptions): void {
         this.rovingTabindexController.focus(options);
     }
 
@@ -283,18 +283,18 @@ export class ActionGroup extends SpectrumElement {
         }
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot role="presentation" @slotchange=${this.manageButtons}></slot>
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.addEventListener('click', this.handleClick);
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('selects')) {
             this.manageSelects();
@@ -355,7 +355,7 @@ export class ActionGroup extends SpectrumElement {
         this.manageSelects();
     };
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         if (!this.observer) {
             this.observer = new MutationObserver(this.manageButtons);
@@ -364,7 +364,7 @@ export class ActionGroup extends SpectrumElement {
         this.observer.observe(this, { childList: true, subtree: true });
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.observer.disconnect();
         super.disconnectedCallback();
     }

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -36,7 +36,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import '../sp-action-group.js';
 
 class QuietActionGroup extends LitElement {
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <sp-action-group quiet>
                 <slot name="first"></slot>
@@ -48,7 +48,7 @@ class QuietActionGroup extends LitElement {
 customElements.define('quiet-action-group', QuietActionGroup);
 
 class EmphasizedActionGroup extends LitElement {
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <sp-action-group emphasized>
                 <slot name="first"></slot>

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -35,20 +35,20 @@ import actionMenuStyles from './action-menu.css.js';
  *   its overlay, use `selects="single" to activate this functionality.
  */
 export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [actionMenuStyles];
     }
 
     @property({ type: String })
-    public selects: undefined | 'single' = undefined;
+    public override selects: undefined | 'single' = undefined;
 
-    protected listRole: 'listbox' | 'menu' = 'menu';
-    protected itemRole = 'menuitem';
+    protected override listRole: 'listbox' | 'menu' = 'menu';
+    protected override itemRole = 'menuitem';
     private get hasLabel(): boolean {
         return this.slotHasContent;
     }
 
-    protected get buttonContent(): TemplateResult[] {
+    protected override get buttonContent(): TemplateResult[] {
         return [
             html`
                 <slot name="icon" slot="icon" ?icon-only=${!this.hasLabel}>
@@ -59,7 +59,7 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
         ];
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <sp-action-button
                 quiet
@@ -81,7 +81,7 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
         `;
     }
 
-    protected updated(changedProperties: PropertyValues): void {
+    protected override updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
         if (changedProperties.has('invalid')) {
             this.invalid = false;

--- a/packages/asset/src/Asset.ts
+++ b/packages/asset/src/Asset.ts
@@ -61,7 +61,7 @@ const folder = (label: string): TemplateResult => html`
  * @slot - content to be displayed in the asset when an acceptable value for `file` is not present
  */
 export class Asset extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -71,7 +71,7 @@ export class Asset extends SpectrumElement {
     @property()
     public label = '';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         if (this.variant === 'file') {
             return file(this.label);
         } else if (this.variant === 'folder') {

--- a/packages/avatar/src/Avatar.ts
+++ b/packages/avatar/src/Avatar.ts
@@ -30,7 +30,7 @@ const defaultSize = validSizes[2];
  * @element sp-avatar
  */
 export class Avatar extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [avatarStyles];
     }
 
@@ -63,7 +63,7 @@ export class Avatar extends SpectrumElement {
 
     private _size = defaultSize;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <img
                 class="image"
@@ -73,7 +73,7 @@ export class Avatar extends SpectrumElement {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         if (!this.hasAttribute('size')) {
             this.setAttribute('size', `${this.size}`);

--- a/packages/badge/src/Badge.ts
+++ b/packages/badge/src/Badge.ts
@@ -43,14 +43,14 @@ export type BadgeVariant = typeof BADGE_VARIANTS[number];
  * @slot icon - Optional icon that appears to the left of the label
  */
 export class Badge extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
     @property({ type: String, reflect: true })
     public variant: BadgeVariant = 'informative';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot name="icon" ?icon-only=${!this.slotHasContent}></slot>
             <div id="label">

--- a/packages/banner/src/Banner.ts
+++ b/packages/banner/src/Banner.ts
@@ -36,11 +36,11 @@ export class Banner extends SpectrumElement {
     @property({ reflect: true, type: Boolean })
     public corner = false;
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [bannerStyles];
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div id="header"><slot name="header"></slot></div>
             <div id="content"><slot name="content"></slot></div>

--- a/packages/base/src/Base.ts
+++ b/packages/base/src/Base.ts
@@ -64,14 +64,14 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
         /**
          * @private
          */
-        public shadowRoot!: ShadowRoot;
+        public override shadowRoot!: ShadowRoot;
         private _dirParent?: HTMLElement;
 
         /**
          * @private
          */
         @property({ reflect: true })
-        public dir: 'ltr' | 'rtl' = 'ltr';
+        public override dir: 'ltr' | 'rtl' = 'ltr';
 
         /**
          * @private
@@ -100,7 +100,7 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
             }
         }
 
-        public connectedCallback(): void {
+        public override connectedCallback(): void {
             if (!this.hasAttribute('dir')) {
                 let dirParent = ((this as HTMLElement).assignedSlot ||
                     this.parentNode) as HTMLElement;
@@ -145,7 +145,7 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
             super.connectedCallback();
         }
 
-        public disconnectedCallback(): void {
+        public override disconnectedCallback(): void {
             super.disconnectedCallback();
             if (this._dirParent) {
                 if (this._dirParent === document.documentElement) {

--- a/packages/base/src/sizedMixin.ts
+++ b/packages/base/src/sizedMixin.ts
@@ -73,7 +73,7 @@ export function SizedMixin<T extends Constructor<ReactiveElement>>(
 
         private _size: ElementSize | null = defaultSize;
 
-        protected update(changes: PropertyValues): void {
+        protected override update(changes: PropertyValues): void {
             if (!this.hasAttribute('size') && !noDefaultSize) {
                 this.setAttribute('size', this.size);
             }

--- a/packages/base/src/streaming-listener.ts
+++ b/packages/base/src/streaming-listener.ts
@@ -54,7 +54,7 @@ class StreamingListenerDirective extends AsyncDirective {
         return nothing;
     }
 
-    update(
+    override update(
         part: Part,
         [
             {
@@ -150,11 +150,11 @@ class StreamingListenerDirective extends AsyncDirective {
         this.removeListener(this.streamOutside[0], this.handleBetween);
     }
 
-    disconnected(): void {
+    override disconnected(): void {
         this.removeListeners();
     }
 
-    reconnected(): void {
+    override reconnected(): void {
         this.addListeners();
     }
 }

--- a/packages/button-group/src/ButtonGroup.ts
+++ b/packages/button-group/src/ButtonGroup.ts
@@ -25,14 +25,14 @@ import styles from './button-group.css.js';
  * @slot - the sp-button elements that make up the group
  */
 export class ButtonGroup extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
     @property({ type: Boolean, reflect: true })
     public vertical = false;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot></slot>
         `;

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -46,7 +46,7 @@ export type ButtonTreatments = 'fill' | 'outline';
  * @slot icon - The icon to use for Button
  */
 export class Button extends SizedMixin(StyledButton) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [...super.styles, buttonStyles];
     }
 
@@ -95,7 +95,7 @@ export class Button extends SizedMixin(StyledButton) {
         this.treatment = quiet ? 'outline' : 'fill';
     }
 
-    protected firstUpdated(changes: PropertyValues<this>): void {
+    protected override firstUpdated(changes: PropertyValues<this>): void {
         super.firstUpdated(changes);
         if (!this.hasAttribute('variant')) {
             this.setAttribute('variant', this.variant);

--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -50,7 +50,7 @@ export class ButtonBase extends LikeAnchor(
     @query('.anchor')
     private anchorElement!: HTMLButtonElement;
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         return this;
     }
 
@@ -82,7 +82,7 @@ export class ButtonBase extends LikeAnchor(
         });
     }
 
-    public click(): void {
+    public override click(): void {
         if (this.disabled) {
             return;
         }
@@ -123,7 +123,7 @@ export class ButtonBase extends LikeAnchor(
         return handled;
     }
 
-    public renderAnchor(): TemplateResult {
+    public override renderAnchor(): TemplateResult {
         return html`
             ${this.buttonContent}
             ${super.renderAnchor({
@@ -140,7 +140,7 @@ export class ButtonBase extends LikeAnchor(
         `;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return this.href && this.href.length > 0
             ? this.renderAnchor()
             : this.renderButton();
@@ -211,7 +211,7 @@ export class ButtonBase extends LikeAnchor(
         }
     }
 
-    protected firstUpdated(changed: PropertyValues): void {
+    protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         if (!this.hasAttribute('tabindex')) {
             this.tabIndex = 0;
@@ -222,7 +222,7 @@ export class ButtonBase extends LikeAnchor(
         this.addEventListener('pointerdown', this.handlePointerdown);
     }
 
-    protected updated(changed: PropertyValues): void {
+    protected override updated(changed: PropertyValues): void {
         super.updated(changed);
         if (changed.has('href')) {
             this.manageAnchor();

--- a/packages/button/src/ClearButton.ts
+++ b/packages/button/src/ClearButton.ts
@@ -59,7 +59,7 @@ const crossIcon: Record<string, () => TemplateResult> = {
  * @slot icon - The icon to use for Clear Button
  */
 export class ClearButton extends SizedMixin(StyledButton) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [...super.styles, buttonStyles, crossMediumStyles];
     }
 
@@ -69,11 +69,11 @@ export class ClearButton extends SizedMixin(StyledButton) {
     @property({ reflect: true })
     public variant: 'overBackground' | '' = '';
 
-    protected get buttonContent(): TemplateResult[] {
+    protected override get buttonContent(): TemplateResult[] {
         return [crossIcon[this.size]()];
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div class="fill">${super.render()}</div>
         `;

--- a/packages/button/src/CloseButton.ts
+++ b/packages/button/src/CloseButton.ts
@@ -60,7 +60,7 @@ const crossIcon: Record<string, () => TemplateResult> = {
  * @slot icon - The icon to use for Close Button
  */
 export class CloseButton extends SizedMixin(StyledButton) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [...super.styles, buttonStyles, crossMediumStyles];
     }
 
@@ -70,7 +70,7 @@ export class CloseButton extends SizedMixin(StyledButton) {
     @property({ reflect: true })
     public variant: ButtonStatics | '' = '';
 
-    protected get buttonContent(): TemplateResult[] {
+    protected override get buttonContent(): TemplateResult[] {
         return [crossIcon[this.size]()];
     }
 }

--- a/packages/button/src/StyledButton.ts
+++ b/packages/button/src/StyledButton.ts
@@ -15,7 +15,7 @@ import { ButtonBase } from './ButtonBase.js';
 import buttonStyles from './button-base.css.js';
 
 export class StyledButton extends ButtonBase {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [buttonStyles];
     }
 }

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -58,7 +58,7 @@ export class Card extends LikeAnchor(
         }
     )
 ) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [headingStyles, detailStyles, cardStyles];
     }
 
@@ -109,7 +109,7 @@ export class Card extends LikeAnchor(
         return this.getSlotContentPresence('[slot="preview"]');
     }
 
-    public click(): void {
+    public override click(): void {
         this.likeAnchor?.click();
     }
 
@@ -256,7 +256,7 @@ export class Card extends LikeAnchor(
         `;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div class="body">
                 <div class="header">
@@ -323,7 +323,7 @@ export class Card extends LikeAnchor(
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.addEventListener('pointerdown', this.handlePointerdown);
         this.addEventListener('focusin', this.handleFocusin);

--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -100,11 +100,11 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
     @property({ type: Boolean, reflect: true })
     public emphasized = false;
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [checkboxStyles, checkmarkSmallStyles, dashSmallStyles];
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${super.render()}
             <span id="box">
@@ -115,7 +115,7 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
         `;
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('invalid')) {
             if (this.invalid) {

--- a/packages/checkbox/src/CheckboxBase.ts
+++ b/packages/checkbox/src/CheckboxBase.ts
@@ -27,7 +27,7 @@ export class CheckboxBase extends Focusable {
     @query('#input')
     protected inputElement!: HTMLInputElement;
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         return this.inputElement;
     }
 
@@ -50,7 +50,7 @@ export class CheckboxBase extends Focusable {
         this.dispatchEvent(changeEvent);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <input
                 id="input"

--- a/packages/coachmark/src/Coachmark.ts
+++ b/packages/coachmark/src/Coachmark.ts
@@ -24,7 +24,7 @@ import styles from './coachmark.css.js';
  * @element sp-coachmark
  */
 export class Coachmark extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -34,7 +34,7 @@ export class Coachmark extends SpectrumElement {
     @property({ reflect: true })
     public variant: 'dark' | 'light' | '' = '';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div class="ring"></div>
             <div class="ring"></div>

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -42,7 +42,7 @@ import styles from './color-area.css.js';
  * @fires change - An alteration to the value of the Color Area has been committed by the user.
  */
 export class ColorArea extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -241,7 +241,7 @@ export class ColorArea extends SpectrumElement {
 
     private activeKeys = new Set();
 
-    public focus(focusOptions: FocusOptions = {}): void {
+    public override focus(focusOptions: FocusOptions = {}): void {
         super.focus(focusOptions);
         this.forwardFocus();
     }
@@ -452,7 +452,7 @@ export class ColorArea extends SpectrumElement {
         this.handlePointermove(event);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         const { width = 0, height = 0 } = this.boundingClientRect || {};
 
         return html`
@@ -517,7 +517,7 @@ export class ColorArea extends SpectrumElement {
         `;
     }
 
-    protected firstUpdated(changed: PropertyValues): void {
+    protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.boundingClientRect = this.getBoundingClientRect();
 
@@ -527,7 +527,7 @@ export class ColorArea extends SpectrumElement {
         this.addEventListener('keydown', this.handleKeydown);
     }
 
-    protected updated(changed: PropertyValues): void {
+    protected override updated(changed: PropertyValues): void {
         super.updated(changed);
         if (this.x !== this.inputX.valueAsNumber) {
             this.x = this.inputX.valueAsNumber;
@@ -553,7 +553,7 @@ export class ColorArea extends SpectrumElement {
 
     private observer?: WithSWCResizeObserver['ResizeObserver'];
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         if (
             !this.observer &&
@@ -571,7 +571,7 @@ export class ColorArea extends SpectrumElement {
         this.observer?.observe(this);
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.observer?.unobserve(this);
         super.disconnectedCallback();
     }

--- a/packages/color-handle/src/ColorHandle.ts
+++ b/packages/color-handle/src/ColorHandle.ts
@@ -44,7 +44,7 @@ export const replaceHueRegExp = /(^hs[v|l]a?\()\d{1,3}/;
  * @element sp-color-handle
  */
 export class ColorHandle extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -72,7 +72,7 @@ export class ColorHandle extends SpectrumElement {
         this.releasePointerCapture(event.pointerId);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div class="color" style="background-color: ${this.color}"></div>
             <sp-color-loupe
@@ -82,7 +82,7 @@ export class ColorHandle extends SpectrumElement {
         `;
     }
 
-    protected firstUpdated(changed: PropertyValues): void {
+    protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.addEventListener('pointerdown', this.handlePointerdown);
         this.addEventListener('pointerup', this.handlePointerup);

--- a/packages/color-loupe/src/ColorLoupe.ts
+++ b/packages/color-loupe/src/ColorLoupe.ts
@@ -24,7 +24,7 @@ import styles from './color-loupe.css.js';
  * @element sp-color-loupe
  */
 export class ColorLoupe extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -34,7 +34,7 @@ export class ColorLoupe extends SpectrumElement {
     @property({ type: String })
     public color = 'rgba(255, 0, 0, 0.5)';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <svg style="--spectrum-picked-color: ${this.color};">
                 <defs>

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -40,12 +40,12 @@ import { TinyColor } from '@ctrl/tinycolor';
  * @fires change - An alteration to the value of the Color Slider has been committed by the user.
  */
 export class ColorSlider extends Focusable {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
     @property({ type: Boolean, reflect: true })
-    public disabled = false;
+    public override disabled = false;
 
     @property({ type: Boolean, reflect: true })
     public focused = false;
@@ -203,7 +203,7 @@ export class ColorSlider extends Focusable {
     @query('input')
     public input!: HTMLInputElement;
 
-    public get focusElement(): HTMLInputElement {
+    public override get focusElement(): HTMLInputElement {
         return this.input;
     }
 
@@ -273,7 +273,7 @@ export class ColorSlider extends Focusable {
         );
     }
 
-    public focus(focusOptions: FocusOptions = {}): void {
+    public override focus(focusOptions: FocusOptions = {}): void {
         super.focus(focusOptions);
         this.forwardFocus();
     }
@@ -385,7 +385,7 @@ export class ColorSlider extends Focusable {
         }%`;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div
                 class="checkerboard"
@@ -431,7 +431,7 @@ export class ColorSlider extends Focusable {
         `;
     }
 
-    protected firstUpdated(changed: PropertyValues): void {
+    protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.boundingClientRect = this.getBoundingClientRect();
         this.addEventListener('focusin', this.handleFocusin);

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -41,12 +41,12 @@ import { TinyColor } from '@ctrl/tinycolor';
  * @fires change - An alteration to the value of the Color Wheel has been committed by the user.
  */
 export class ColorWheel extends Focusable {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
     @property({ type: Boolean, reflect: true })
-    public disabled = false;
+    public override disabled = false;
 
     @property({ type: Boolean, reflect: true })
     public focused = false;
@@ -192,7 +192,7 @@ export class ColorWheel extends Focusable {
     @query('input')
     public input!: HTMLInputElement;
 
-    public get focusElement(): HTMLInputElement {
+    public override get focusElement(): HTMLInputElement {
         return this.input;
     }
 
@@ -258,7 +258,7 @@ export class ColorWheel extends Focusable {
         );
     }
 
-    public focus(focusOptions: FocusOptions = {}): void {
+    public override focus(focusOptions: FocusOptions = {}): void {
         super.focus(focusOptions);
         this.forwardFocus();
     }
@@ -365,7 +365,7 @@ export class ColorWheel extends Focusable {
         this.handlePointermove(event);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         const { width: diameter = 160 } = this.boundingClientRect || {};
 
         const radius = diameter / 2;
@@ -414,7 +414,7 @@ export class ColorWheel extends Focusable {
         `;
     }
 
-    protected firstUpdated(changed: PropertyValues): void {
+    protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.boundingClientRect = this.getBoundingClientRect();
         this.addEventListener('focusin', this.handleFocusin);
@@ -423,7 +423,7 @@ export class ColorWheel extends Focusable {
 
     private observer?: WithSWCResizeObserver['ResizeObserver'];
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         if (
             !this.observer &&
@@ -441,7 +441,7 @@ export class ColorWheel extends Focusable {
         this.observer?.observe(this);
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.observer?.unobserve(this);
         super.disconnectedCallback();
     }

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -73,7 +73,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
         '[slot="button"]',
     ])
 ) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles, crossStyles];
     }
 
@@ -120,7 +120,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
         );
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div class="grid">
                 <slot name="hero"></slot>
@@ -189,7 +189,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
         }
     };
 
-    protected shouldUpdate(changes: PropertyValues): boolean {
+    protected override shouldUpdate(changes: PropertyValues): boolean {
         if (changes.has('mode') && !!this.mode) {
             this.dismissable = false;
         }
@@ -199,7 +199,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
         return super.shouldUpdate(changes);
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.setAttribute('role', 'dialog');
     }
@@ -265,7 +265,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
         }
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.tabIndex = 0;
         window.addEventListener(
@@ -274,7 +274,7 @@ export class Dialog extends FocusVisiblePolyfillMixin(
         );
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         window.removeEventListener(
             'resize',
             this.shouldManageTabOrderForScrolling

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -43,7 +43,7 @@ import { firstFocusableIn } from '@spectrum-web-components/shared/src/first-focu
  * @fires close - Announces that the dialog has been closed.
  */
 export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [modalWrapperStyles, modalStyles];
     }
 
@@ -99,7 +99,7 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
     @query('sp-dialog')
     private dialog!: Dialog;
 
-    public focus(): void {
+    public override focus(): void {
         if (this.shadowRoot) {
             const firstFocusable = firstFocusableIn(this.dialog);
             if (firstFocusable) {
@@ -191,7 +191,7 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    protected update(changes: PropertyValues<this>): void {
+    protected override update(changes: PropertyValues<this>): void {
         if (changes.has('open') && changes.get('open') !== undefined) {
             this.transitionPromise = new Promise(
                 (res) => (this.resolveTransitionPromise = res)
@@ -200,7 +200,7 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
         super.update(changes);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${this.underlay
                 ? html`
@@ -290,7 +290,7 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
         `;
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         if (changes.has('open')) {
             if (this.open) {
                 this.dialog.updateComplete.then(() => {
@@ -310,7 +310,7 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
      * while opening the Tray when focusable content is included: e.g. Menu
      * elements whose selected Menu Item is not the first Menu Item.
      */
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         await this.transitionPromise;
         return complete;

--- a/packages/divider/src/Divider.ts
+++ b/packages/divider/src/Divider.ts
@@ -28,21 +28,21 @@ import styles from './divider.css.js';
 export class Divider extends SizedMixin(SpectrumElement, {
     validSizes: ['s', 'm', 'l'],
 }) {
-    public static styles: CSSResultArray = [styles];
+    public static override styles: CSSResultArray = [styles];
 
     @property({ type: Boolean, reflect: true })
     public vertical = false;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html``;
     }
 
-    protected firstUpdated(changed: PropertyValues<this>): void {
+    protected override firstUpdated(changed: PropertyValues<this>): void {
         super.firstUpdated(changed);
         this.setAttribute('role', 'separator');
     }
 
-    protected updated(changed: PropertyValues<this>): void {
+    protected override updated(changed: PropertyValues<this>): void {
         super.updated(changed);
         if (changed.has('vertical')) {
             if (this.vertical) {

--- a/packages/divider/stories/typography-decorator.ts
+++ b/packages/divider/stories/typography-decorator.ts
@@ -27,12 +27,12 @@ import styles from '@spectrum-web-components/theme/src/typography.css.js';
  */
 @customElement('typography-decorator')
 export class Typography extends LitElement {
-    static styles: CSSResultArray = [styles];
+    static override styles: CSSResultArray = [styles];
 
     @property({ attribute: false })
     public story?: TemplateResult;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         if (!this.story) return html``;
         return html`
             <div class="spectrum-Typography">${this.story}</div>

--- a/packages/dropzone/src/Dropzone.ts
+++ b/packages/dropzone/src/Dropzone.ts
@@ -39,7 +39,7 @@ export type DropEffects = 'copy' | 'move' | 'link' | 'none';
  * @fires sp-dropzone-drop - Announces when dragged files have been dropped on the UI.
  */
 export class Dropzone extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [dropzoneStyles];
     }
 
@@ -63,7 +63,7 @@ export class Dropzone extends SpectrumElement {
 
     private debouncedDragLeave: number | null = null;
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
 
         this.addEventListener('drop', this.onDrop);
@@ -71,7 +71,7 @@ export class Dropzone extends SpectrumElement {
         this.addEventListener('dragleave', this.onDragLeave);
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         super.disconnectedCallback();
 
         this.removeEventListener('drop', this.onDrop);
@@ -139,7 +139,7 @@ export class Dropzone extends SpectrumElement {
         this.dispatchEvent(dropEvent);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot></slot>
         `;

--- a/packages/field-group/src/FieldGroup.ts
+++ b/packages/field-group/src/FieldGroup.ts
@@ -31,7 +31,7 @@ import styles from './field-group.css.js';
 export class FieldGroup extends ManageHelpText(SpectrumElement, {
     mode: 'external',
 }) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -52,7 +52,7 @@ export class FieldGroup extends ManageHelpText(SpectrumElement, {
         return;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div class="group" role="presentation">
                 <slot @slotchange=${this.handleSlotchange}></slot>
@@ -61,7 +61,7 @@ export class FieldGroup extends ManageHelpText(SpectrumElement, {
         `;
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
         if (changes.has('label')) {
             if (this.label) {

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -36,7 +36,7 @@ type AcceptsFocusVisisble = HTMLElement & { forceFocusVisible?(): void };
  * @slot - text content of the label
  */
 export class FieldLabel extends SizedMixin(SpectrumElement) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles, asteriskIconStyles];
     }
 
@@ -49,7 +49,7 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
     public disabled = false;
 
     @property({ type: String })
-    public id = '';
+    public override id = '';
 
     @property({ type: String })
     public for = '';
@@ -117,7 +117,7 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
         return labelText.join(' ');
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <label>
                 <slot @slotchange=${this.manageFor}></slot>
@@ -132,12 +132,12 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.addEventListener('click', this.handleClick);
     }
 
-    protected willUpdate(changes: PropertyValues): void {
+    protected override willUpdate(changes: PropertyValues): void {
         if (!this.hasAttribute('id')) {
             this.setAttribute(
                 'id',

--- a/packages/help-text/src/HelpText.ts
+++ b/packages/help-text/src/HelpText.ts
@@ -29,7 +29,7 @@ type HelpTextVariants = 'neutral' | 'negative';
  * @element sp-help-text
  */
 export class HelpText extends SizedMixin(SpectrumElement) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -42,7 +42,7 @@ export class HelpText extends SizedMixin(SpectrumElement) {
     @property({ reflect: true })
     public variant: HelpTextVariants = 'neutral';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${this.variant === 'negative' && this.icon
                 ? html`

--- a/packages/icon/src/Icon.ts
+++ b/packages/icon/src/Icon.ts
@@ -36,21 +36,21 @@ export class Icon extends IconBase {
 
     private updateIconPromise?: Promise<void>;
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         window.addEventListener('sp-iconset-added', this.iconsetListener);
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         super.disconnectedCallback();
         window.removeEventListener('sp-iconset-added', this.iconsetListener);
     }
 
-    public firstUpdated(): void {
+    public override firstUpdated(): void {
         this.updateIconPromise = this.updateIcon();
     }
 
-    public attributeChangedCallback(
+    public override attributeChangedCallback(
         name: string,
         old: string,
         value: string
@@ -70,7 +70,7 @@ export class Icon extends IconBase {
         }
     };
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         if (this.name) {
             return html`
                 <div id="container"></div>
@@ -121,7 +121,7 @@ export class Icon extends IconBase {
         return { iconset: iconsetName, icon: iconName };
     }
 
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         await this.updateIconPromise;
         return complete;

--- a/packages/icon/src/IconBase.ts
+++ b/packages/icon/src/IconBase.ts
@@ -21,7 +21,7 @@ import { property } from '@spectrum-web-components/base/src/decorators.js';
 import iconStyles from './icon.css.js';
 
 export class IconBase extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [iconStyles];
     }
 
@@ -31,7 +31,7 @@ export class IconBase extends SpectrumElement {
     @property({ reflect: true })
     public size?: 's' | 'm' | 'l' | 'xl' | 'xxl';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot></slot>
         `;

--- a/packages/icons-ui/README.md
+++ b/packages/icons-ui/README.md
@@ -78,7 +78,7 @@ import '@spectrum-web-components/icon';
 import { Arrow75Icon } from '@spectrum-web-components/icons-ui';
 
 class ElementWithIcon extends LitElement {
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <sp-icon>
                 ${Arrow75Icon()}

--- a/packages/icons-ui/bin/build.js
+++ b/packages/icons-ui/bin/build.js
@@ -171,7 +171,7 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (error, icons) => {
          * @element ${iconElementName}
          */
         export class Icon${ComponentName} extends IconBase {
-            protected render(): TemplateResult {
+            protected override render(): TemplateResult {
                 setCustomTemplateLiteralTag(html);
                 return ${ComponentName}Icon() as TemplateResult;
             }

--- a/packages/icons-workflow/README.md
+++ b/packages/icons-workflow/README.md
@@ -78,7 +78,7 @@ import '@spectrum-web-components/icon';
 import { AbcIcon } from '@spectrum-web-components/icons-workflow';
 
 class ElementWithIcon extends LitElement {
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <sp-icon>
                 ${AbcIcon()}

--- a/packages/icons-workflow/bin/build.js
+++ b/packages/icons-workflow/bin/build.js
@@ -193,7 +193,7 @@ glob(`${rootDir}/node_modules/${iconsPath}/**.svg`, (error, icons) => {
          * @element ${iconElementName}
          */
         export class Icon${ComponentName} extends IconBase {
-            protected render(): TemplateResult {
+            protected override render(): TemplateResult {
                 setCustomTemplateLiteralTag(html);
                 return ${ComponentName}Icon({hidden: !this.label, title: this.label}) as TemplateResult;
             }

--- a/packages/icons/src/IconsLarge.ts
+++ b/packages/icons/src/IconsLarge.ts
@@ -25,7 +25,7 @@ export class IconsLarge extends IconsetSVG {
         this.name = 'ui'; // default iconset name for these icons
     }
 
-    protected renderDefaultContent(): TemplateResult {
+    protected override renderDefaultContent(): TemplateResult {
         return iconsSVG;
     }
     /**
@@ -33,10 +33,10 @@ export class IconsLarge extends IconsetSVG {
      * @param icon
      * @param size
      */
-    protected getSVGIconName(icon: string): string {
+    protected override getSVGIconName(icon: string): string {
         return `spectrum-icon-${icon}`;
     }
-    protected getSanitizedIconName(icon: string): string {
+    protected override getSanitizedIconName(icon: string): string {
         return icon.replace('spectrum-icon-', '');
     }
 }

--- a/packages/icons/src/IconsMedium.ts
+++ b/packages/icons/src/IconsMedium.ts
@@ -25,7 +25,7 @@ export class IconsMedium extends IconsetSVG {
         this.name = 'ui'; // default iconset name for these icons
     }
 
-    protected renderDefaultContent(): TemplateResult {
+    protected override renderDefaultContent(): TemplateResult {
         return iconsSVG;
     }
     /**
@@ -33,10 +33,10 @@ export class IconsMedium extends IconsetSVG {
      * @param icon
      * @param size
      */
-    protected getSVGIconName(icon: string): string {
+    protected override getSVGIconName(icon: string): string {
         return `spectrum-icon-${icon}`;
     }
-    protected getSanitizedIconName(icon: string): string {
+    protected override getSanitizedIconName(icon: string): string {
         return icon.replace('spectrum-icon-', '');
     }
 }

--- a/packages/iconset/src/iconset-svg.ts
+++ b/packages/iconset/src/iconset-svg.ts
@@ -28,7 +28,7 @@ export abstract class IconsetSVG extends Iconset {
     /**
      * First updated handler just ensures we've processed any slotted symbols
      */
-    public updated(changedProperties: PropertyValues): void {
+    public override updated(changedProperties: PropertyValues): void {
         if (!this.slotContainer) {
             return;
         }
@@ -110,7 +110,7 @@ export abstract class IconsetSVG extends Iconset {
         return html``;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot @slotchange=${this.onSlotChange}>
                 ${this.renderDefaultContent()}

--- a/packages/iconset/src/iconset.ts
+++ b/packages/iconset/src/iconset.ts
@@ -19,7 +19,7 @@ export abstract class Iconset extends LitElement {
 
     private _name!: string;
 
-    protected firstUpdated(): void {
+    protected override firstUpdated(): void {
         // force no display for all iconsets
         this.style.display = 'none';
     }
@@ -78,7 +78,7 @@ export abstract class Iconset extends LitElement {
     /**
      * On updated we register the iconset if we're not already registered
      */
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.addIconset();
         window.addEventListener('sp-iconset-removed', this.handleRemoved);
@@ -86,7 +86,7 @@ export abstract class Iconset extends LitElement {
     /**
      * On disconnected we remove the iconset
      */
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         super.disconnectedCallback();
         window.removeEventListener('sp-iconset-removed', this.handleRemoved);
         this.removeIconset();

--- a/packages/iconset/stories/icons-demo.ts
+++ b/packages/iconset/stories/icons-demo.ts
@@ -34,19 +34,19 @@ export class DelayedReady extends SpectrumElement {
     _delayedReady!: Promise<void>;
     _resolveDelayedReady!: () => void;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot @slotchange=${this.handleSlotchange}></slot>
         `;
     }
 
-    protected firstUpdated(): void {
+    protected override firstUpdated(): void {
         this._delayedReady = new Promise(
             (res) => (this._resolveDelayedReady = res)
         );
     }
 
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         await this._delayedReady;
         return complete;
@@ -90,11 +90,11 @@ export class IconsDemo extends SpectrumElement {
         this.iconset = [];
         this.handleIconSetAdded = this.handleIconSetAdded.bind(this);
     }
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         window.addEventListener('sp-iconset-added', this.handleIconSetAdded);
     }
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         window.removeEventListener('sp-iconset-added', this.handleIconSetAdded);
         super.disconnectedCallback();
     }
@@ -103,7 +103,7 @@ export class IconsDemo extends SpectrumElement {
         this.iconset = iconset.getIconList();
         this.requestUpdate();
     }
-    public static get styles(): CSSResultGroup {
+    public static override get styles(): CSSResultGroup {
         return [
             ...bodyStyles,
             css`
@@ -223,7 +223,7 @@ export class IconsDemo extends SpectrumElement {
             })}
         `;
     }
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${this.icons.length
                 ? this.renderSearch()

--- a/packages/illustrated-message/src/IllustratedMessage.ts
+++ b/packages/illustrated-message/src/IllustratedMessage.ts
@@ -32,7 +32,7 @@ import bodyStyles from '@spectrum-web-components/styles/body.js';
 export class IllustratedMessage extends SpectrumElement {
     public static readonly is = 'sp-illustrated-message';
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [headingStyles, bodyStyles, messageStyles];
     }
 
@@ -42,7 +42,7 @@ export class IllustratedMessage extends SpectrumElement {
     @property()
     public description = '';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div id="illustration"><slot></slot></div>
             <h2

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -33,7 +33,7 @@ import linkStyles from './link.css.js';
 export class Link extends SizedMixin(LikeAnchor(Focusable), {
     noDefaultSize: true,
 }) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [linkStyles];
     }
 
@@ -43,11 +43,11 @@ export class Link extends SizedMixin(LikeAnchor(Focusable), {
     @property({ type: String, reflect: true })
     public variant: 'secondary' | undefined;
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         return this.anchorElement;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return this.renderAnchor({ id: 'anchor' });
     }
 }

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -66,7 +66,7 @@ const noop = (): void => {
  *   Item children of this Menu will not have their `selected` state managed.
  */
 export class Menu extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [menuStyles];
     }
 
@@ -292,7 +292,7 @@ export class Menu extends SpectrumElement {
         this.addEventListener('focusin', this.handleFocusin);
     }
 
-    public focus({ preventScroll }: FocusOptions = {}): void {
+    public override focus({ preventScroll }: FocusOptions = {}): void {
         if (
             !this.childItems.length ||
             this.childItems.every((childItem) => childItem.disabled)
@@ -677,7 +677,7 @@ export class Menu extends SpectrumElement {
         }
     }
 
-    public render(): TemplateResult {
+    public override render(): TemplateResult {
         return html`
             <slot></slot>
         `;
@@ -685,7 +685,7 @@ export class Menu extends SpectrumElement {
 
     private _notFirstUpdated = false;
 
-    protected firstUpdated(changed: PropertyValues): void {
+    protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         if (!this.hasAttribute('tabindex')) {
             const role = this.getAttribute('role');
@@ -706,7 +706,7 @@ export class Menu extends SpectrumElement {
         this.childItemsUpdated = Promise.all(updates);
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
         if (changes.has('selects') && this._notFirstUpdated) {
             this.selectsChanged();
@@ -731,7 +731,7 @@ export class Menu extends SpectrumElement {
         this.childItemsUpdated = Promise.all(updates);
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', this.ownRole);
@@ -742,7 +742,7 @@ export class Menu extends SpectrumElement {
     protected childItemsUpdated!: Promise<unknown[]>;
     protected cacheUpdated = Promise.resolve();
 
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         await this.childItemsUpdated;
         await this.cacheUpdated;

--- a/packages/menu/src/MenuDivider.ts
+++ b/packages/menu/src/MenuDivider.ts
@@ -19,11 +19,11 @@ import dividerStyles from '@spectrum-web-components/divider/src/divider.css.js';
  * @element sp-menu-divider
  */
 export class MenuDivider extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [dividerStyles, menuDividerStyles];
     }
 
-    protected firstUpdated(): void {
+    protected override firstUpdated(): void {
         this.setAttribute('role', 'separator');
         this.setAttribute('size', 'm');
     }

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -31,7 +31,7 @@ import menuGroupStyles from './menu-group.css.js';
  * @slot - menu items to be listed in the group
  */
 export class MenuGroup extends Menu {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [...super.styles, menuGroupStyles];
     }
 
@@ -51,7 +51,7 @@ export class MenuGroup extends Menu {
     @state()
     private headerElement?: HTMLElement;
 
-    protected get ownRole(): string {
+    protected override get ownRole(): string {
         switch (this.selects) {
             case 'multiple':
             case 'single':
@@ -83,7 +83,7 @@ export class MenuGroup extends Menu {
         this.headerElement = headerElement;
     }
 
-    public render(): TemplateResult {
+    public override render(): TemplateResult {
         return html`
             <span
                 class="header"

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -107,7 +107,7 @@ const removeEvent = new MenuItemRemovedEvent();
  * @fires sp-menu-item-removed - announces when removed from the DOM so the parent menu can remove ownership and update selected state
  */
 export class MenuItem extends LikeAnchor(Focusable) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [menuItemStyles, checkmarkStyles, chevronStyles];
     }
 
@@ -169,7 +169,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
     @query('.anchor')
     private anchorElement!: HTMLAnchorElement;
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         return this;
     }
 
@@ -214,7 +214,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
     @property({ type: Boolean })
     public open = false;
 
-    public click(): void {
+    public override click(): void {
         if (this.disabled) {
             return;
         }
@@ -253,7 +253,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
         this.triggerUpdate();
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot name="icon" @slotchange=${this.breakItemChildrenCache}></slot>
             <div id="label">
@@ -315,7 +315,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
         this.active = true;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.setAttribute('tabindex', '-1');
         this.addEventListener('pointerdown', this.handlePointerdown);
@@ -466,7 +466,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
         this.updateAriaSelected();
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
         if (changes.has('label')) {
             this.setAttribute('aria-label', this.label || '');
@@ -509,7 +509,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
         }
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.isInSubmenu = !!this.closest('[slot="submenu"]');
         if (this.isInSubmenu) {
@@ -522,7 +522,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
 
     _parentElement!: HTMLElement;
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         removeEvent.reset(this);
         if (!this.isInSubmenu) {
             this._parentElement?.dispatchEvent(removeEvent);

--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -30,7 +30,7 @@ import styles from './meter.css.js';
  * @slot - text labeling the Meter
  */
 export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -56,7 +56,7 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
     // called sideLabel
     public sideLabel = false;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <sp-field-label size=${this.size} class="label">
                 ${this.slotHasContent ? html`` : this.label}
@@ -74,12 +74,12 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.setAttribute('role', 'progressbar');
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('progress')) {
             this.setAttribute('aria-valuenow', '' + this.progress);

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -62,7 +62,7 @@ export const remapMultiByteCharacters: Record<string, string> = {
  * @slot negative-help-text - negative help text to associate to your form element when `invalid`
  */
 export class NumberField extends TextfieldBase {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [...super.styles, styles, chevronStyles];
     }
 
@@ -70,7 +70,7 @@ export class NumberField extends TextfieldBase {
     private buttons!: HTMLDivElement;
 
     @property({ type: Boolean, reflect: true })
-    public focused = false;
+    public override focused = false;
 
     _forcedUnit = '';
 
@@ -122,7 +122,7 @@ export class NumberField extends TextfieldBase {
     public stepModifier = 10;
 
     @property({ type: Number })
-    public set value(rawValue: number) {
+    public override set value(rawValue: number) {
         const value = this.validateInput(rawValue);
         if (value === this.value) {
             return;
@@ -132,7 +132,7 @@ export class NumberField extends TextfieldBase {
         this.requestUpdate('value', oldValue);
     }
 
-    public get value(): number {
+    public override get value(): number {
         return this._value;
     }
 
@@ -142,7 +142,7 @@ export class NumberField extends TextfieldBase {
             : this.inputElement.value;
     }
 
-    public _value = NaN;
+    public override _value = NaN;
     private _trackingValue = '';
 
     /**
@@ -308,14 +308,14 @@ export class NumberField extends TextfieldBase {
         }
     }
 
-    protected onFocus(): void {
+    protected override onFocus(): void {
         super.onFocus();
         this._trackingValue = this.inputValue;
         this.keyboardFocused = !this.readonly && true;
         this.addEventListener('wheel', this.onScroll);
     }
 
-    protected onBlur(): void {
+    protected override onBlur(): void {
         super.onBlur();
         this.keyboardFocused = !this.readonly && false;
         this.removeEventListener('wheel', this.onScroll);
@@ -334,7 +334,7 @@ export class NumberField extends TextfieldBase {
     private wasIndeterminate = false;
     private indeterminateValue?: number;
 
-    protected handleChange(): void {
+    protected override handleChange(): void {
         const value = this.convertValueToNumber(this.inputValue);
         if (this.wasIndeterminate) {
             this.wasIndeterminate = false;
@@ -348,7 +348,7 @@ export class NumberField extends TextfieldBase {
         super.handleChange();
     }
 
-    protected handleInput(): void {
+    protected override handleInput(): void {
         if (this.indeterminate) {
             this.wasIndeterminate = true;
             this.indeterminateValue = this.value;
@@ -415,7 +415,7 @@ export class NumberField extends TextfieldBase {
         return value;
     }
 
-    protected get displayValue(): string {
+    protected override get displayValue(): string {
         const indeterminateValue = this.focused ? '' : indeterminatePlaceholder;
         return this.indeterminate ? indeterminateValue : this.formattedValue;
     }
@@ -499,7 +499,7 @@ export class NumberField extends TextfieldBase {
     private _numberParser?: NumberParser;
     private _numberParserFocused?: NumberParser;
 
-    protected renderField(): TemplateResult {
+    protected override renderField(): TemplateResult {
         this.autocomplete = 'off';
         return html`
             ${super.renderField()}
@@ -565,20 +565,20 @@ export class NumberField extends TextfieldBase {
         `;
     }
 
-    protected update(changes: PropertyValues): void {
+    protected override update(changes: PropertyValues): void {
         if (changes.has('formatOptions') || changes.has('resolvedLanguage')) {
             this.clearNumberFormatterCache();
         }
         super.update(changes);
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.multiline = false;
         this.addEventListener('keydown', this.handleKeydown);
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         if (
             changes.has('value') ||
             changes.has('max') ||
@@ -619,12 +619,12 @@ export class NumberField extends TextfieldBase {
         }
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.resolveLanguage();
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.resolveLanguage();
         super.disconnectedCallback();
     }

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -187,7 +187,7 @@ export class ActiveOverlay extends SpectrumElement {
     private originalPlacement?: Placement;
     private restoreContent?: () => Element[];
 
-    public async focus(): Promise<void> {
+    public override async focus(): Promise<void> {
         const firstFocusable = firstFocusableIn(this);
         if (firstFocusable) {
             if ((firstFocusable as SpectrumElement).updateComplete) {
@@ -216,7 +216,7 @@ export class ActiveOverlay extends SpectrumElement {
 
     private timeout?: number;
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -274,7 +274,7 @@ export class ActiveOverlay extends SpectrumElement {
         return undefined;
     }
 
-    public async firstUpdated(
+    public override async firstUpdated(
         changedProperties: PropertyValues
     ): Promise<void> {
         super.firstUpdated(changedProperties);
@@ -585,7 +585,7 @@ export class ActiveOverlay extends SpectrumElement {
         `;
     }
 
-    public render(): TemplateResult {
+    public override render(): TemplateResult {
         const content = html`
             <div id="contents">
                 <slot @slotchange=${this.onSlotChange}></slot>
@@ -607,7 +607,7 @@ export class ActiveOverlay extends SpectrumElement {
     private stealOverlayContentPromise = Promise.resolve();
     private stealOverlayContentResolver!: () => void;
 
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const actions: Promise<unknown>[] = [
             super.getUpdateComplete(),
             this.stealOverlayContentPromise,
@@ -619,7 +619,7 @@ export class ActiveOverlay extends SpectrumElement {
         return complete as boolean;
     }
 
-    disconnectedCallback(): void {
+    override disconnectedCallback(): void {
         document.removeEventListener(
             'sp-update-overlays',
             this.updateOverlayPosition

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -65,7 +65,7 @@ export class OverlayTrigger extends SpectrumElement {
     private closeLongpressOverlay?: Promise<() => void>;
     private closeHoverOverlay?: Promise<() => void>;
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [overlayTriggerStyles];
     }
 
@@ -110,7 +110,7 @@ export class OverlayTrigger extends SpectrumElement {
         this.removeAttribute('open');
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         // Keyboard event availability documented in README.md
         /* eslint-disable lit-a11y/click-events-have-key-events */
         return html`
@@ -145,7 +145,7 @@ export class OverlayTrigger extends SpectrumElement {
         /* eslint-enable lit-a11y/click-events-have-key-events */
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
         if (this.disabled && changes.has('disabled')) {
             this.closeAllOverlays();
@@ -417,13 +417,13 @@ export class OverlayTrigger extends SpectrumElement {
     private openStatePromise = Promise.resolve();
     private openStateResolver!: () => void;
 
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         await this.openStatePromise;
         return complete;
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.closeAllOverlays();
         super.disconnectedCallback();
     }

--- a/packages/overlay/stories/overlay-story-components.ts
+++ b/packages/overlay/stories/overlay-story-components.ts
@@ -34,7 +34,7 @@ import '@spectrum-web-components/overlay/overlay-trigger.js';
 const MAX_DEPTH = 7;
 
 class OverlayTargetIcon extends LitElement {
-    static get styles(): CSSResultGroup {
+    static override get styles(): CSSResultGroup {
         return css`
             :host {
                 position: absolute;
@@ -48,7 +48,7 @@ class OverlayTargetIcon extends LitElement {
         `;
     }
 
-    public render(): TemplateResult {
+    public override render(): TemplateResult {
         return html`
             <svg
                 aria-hidden="true"
@@ -77,7 +77,7 @@ class OverlayDrag extends LitElement {
 
     private targetElement: HTMLElement | undefined | null;
 
-    static get styles(): CSSResultGroup {
+    static override get styles(): CSSResultGroup {
         return css`
             :host {
                 display: block;
@@ -167,13 +167,13 @@ class OverlayDrag extends LitElement {
         this.top = (parent.offsetHeight - target.offsetHeight) / 2;
     }
 
-    public updated(): void {
+    public override updated(): void {
         if (this.targetElement) {
             this.targetElement.style.transform = `translate(${this.left}px, ${this.top}px)`;
         }
     }
 
-    public render(): TemplateResult {
+    public override render(): TemplateResult {
         return html`
             <slot @slotchange=${this.onSlotChange}></slot>
         `;
@@ -193,9 +193,9 @@ class RecursivePopover extends LitElement {
 
     protected isShiftTabbing = false;
 
-    public shadowRoot!: ShadowRoot;
+    public override shadowRoot!: ShadowRoot;
 
-    public static get styles(): CSSResultGroup {
+    public static override get styles(): CSSResultGroup {
         return [
             css`
                 :host {
@@ -228,7 +228,7 @@ class RecursivePopover extends LitElement {
         this.focus();
     }
 
-    public focus(): void {
+    public override focus(): void {
         if (this.shadowRoot.activeElement !== null) {
             return;
         }
@@ -260,7 +260,7 @@ class RecursivePopover extends LitElement {
         }
     }
 
-    public render(): TemplateResult {
+    public override render(): TemplateResult {
         return html`
             <sp-radio-group
                 horizontal
@@ -313,7 +313,7 @@ export class PopoverContent extends LitElement {
     @query('overlay-trigger')
     public trigger!: OverlayTrigger;
 
-    render(): TemplateResult {
+    override render(): TemplateResult {
         return html`
             <overlay-trigger>
                 <sp-button slot="trigger">Open me</sp-button>

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -728,7 +728,7 @@ export const superComplexModal = (): TemplateResult => {
 };
 
 class StartEndContextmenu extends HTMLElement {
-    shadowRoot!: ShadowRoot;
+    override shadowRoot!: ShadowRoot;
     constructor() {
         super();
         this.attachShadow({ mode: 'open' });

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -94,7 +94,7 @@ export class PickerBase extends SizedMixin(Focusable) {
     }
 
     @property({ type: Boolean, reflect: true })
-    public disabled = false;
+    public override disabled = false;
 
     @property({ type: Boolean, reflect: true })
     public focused = false;
@@ -150,7 +150,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         this.onKeydown = this.onKeydown.bind(this);
     }
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         if (this.open) {
             return this.optionsMenu;
         }
@@ -173,7 +173,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         this.toggle();
     }
 
-    public focus(options?: FocusOptions): void {
+    public override focus(options?: FocusOptions): void {
         super.focus(options);
 
         if (!this.disabled && this.focusElement) {
@@ -408,7 +408,7 @@ export class PickerBase extends SizedMixin(Focusable) {
 
     // a helper to throw focus to the button is needed because Safari
     // won't include buttons in the tab order even with tabindex="0"
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <span
                 id="focus-helper"
@@ -432,7 +432,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         `;
     }
 
-    protected update(changes: PropertyValues<this>): void {
+    protected override update(changes: PropertyValues<this>): void {
         if (this.selects) {
             // Always force `selects` to "single" when set.
             // TODO: Add support functionally and visually for "multiple"
@@ -529,7 +529,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         });
     }
 
-    protected updated(changedProperties: PropertyValues): void {
+    protected override updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
         if (changedProperties.has('disabled') && this.disabled) {
             this.open = false;
@@ -587,7 +587,7 @@ export class PickerBase extends SizedMixin(Focusable) {
     private selectionPromise = Promise.resolve();
     private selectionResolver!: () => void;
 
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         await this.menuStatePromise;
         await this.itemsUpdated;
@@ -595,7 +595,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         return complete;
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         this.updateMenuItems();
         this.addEventListener(
             'sp-menu-item-added-or-updated',
@@ -605,7 +605,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         super.connectedCallback();
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.close();
 
         super.disconnectedCallback();
@@ -613,11 +613,11 @@ export class PickerBase extends SizedMixin(Focusable) {
 }
 
 export class Picker extends PickerBase {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [pickerStyles, chevronStyles];
     }
 
-    protected onKeydown = (event: KeyboardEvent): void => {
+    protected override onKeydown = (event: KeyboardEvent): void => {
         const { code } = event;
         this.focused = true;
         if (!code.startsWith('Arrow') || this.readonly) {

--- a/packages/popover/src/Popover.ts
+++ b/packages/popover/src/Popover.ts
@@ -30,7 +30,7 @@ import popoverStyles from './popover.css.js';
  * @slot - content to display within the Popover
  */
 export class Popover extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [popoverStyles];
     }
 
@@ -74,7 +74,7 @@ export class Popover extends SpectrumElement {
         `;
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.addEventListener(
             'sp-overlay-query',
@@ -82,7 +82,7 @@ export class Popover extends SpectrumElement {
         );
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         super.disconnectedCallback();
         this.removeEventListener(
             'sp-overlay-query',
@@ -104,7 +104,7 @@ export class Popover extends SpectrumElement {
         }
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot></slot>
             ${this.tip ? this.renderTip() : nothing}

--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -27,7 +27,7 @@ import styles from './progress-bar.css.js';
  * @element sp-progress-bar
  */
 export class ProgressBar extends SizedMixin(SpectrumElement) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -46,7 +46,7 @@ export class ProgressBar extends SizedMixin(SpectrumElement) {
     @property({ type: Number })
     public progress = 0;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${this.label
                 ? html`
@@ -74,14 +74,14 @@ export class ProgressBar extends SizedMixin(SpectrumElement) {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'progressbar');
         }
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('indeterminate')) {
             if (this.indeterminate) {

--- a/packages/progress-circle/src/ProgressCircle.ts
+++ b/packages/progress-circle/src/ProgressCircle.ts
@@ -29,7 +29,7 @@ import progressCircleStyles from './progress-circle.css.js';
 export class ProgressCircle extends SizedMixin(SpectrumElement, {
     validSizes: ['s', 'm', 'l'],
 }) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [progressCircleStyles];
     }
 
@@ -51,7 +51,7 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
             : `transform: rotate(${rotation}deg);`;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         const styles = [
             this.makeRotation(-180 + (180 / 50) * Math.min(this.progress, 50)),
             this.makeRotation(
@@ -78,14 +78,14 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'progressbar');
         }
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (!this.indeterminate && changes.has('progress')) {
             this.setAttribute('aria-valuenow', '' + this.progress);

--- a/packages/quick-actions/src/QuickActions.ts
+++ b/packages/quick-actions/src/QuickActions.ts
@@ -26,7 +26,7 @@ import styles from './quick-actions.css.js';
  * @slot - Action Buttons to displayed for quick use
  */
 export class QuickActions extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -42,7 +42,7 @@ export class QuickActions extends SpectrumElement {
     })
     public textOnly = false;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot></slot>
         `;

--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -35,7 +35,7 @@ import radioStyles from './radio.css.js';
  * @fires change - When the input is interacted with and its state is changed
  */
 export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [radioStyles];
     }
 
@@ -44,7 +44,7 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
      * @private
      */
     @property({ type: Boolean })
-    public autofocus = false;
+    public override autofocus = false;
 
     @property({ type: String, reflect: true })
     public value = '';
@@ -64,7 +64,7 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
     @property({ type: Boolean, reflect: true })
     public readonly = false;
 
-    public click(): void {
+    public override click(): void {
         if (this.disabled) {
             return;
         }
@@ -106,7 +106,7 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div id="input"></div>
             <span id="button"></span>
@@ -114,7 +114,7 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.setAttribute('role', 'radio');
         if (!this.hasAttribute('tabindex')) {
@@ -125,7 +125,7 @@ export class Radio extends FocusVisiblePolyfillMixin(SpectrumElement) {
         this.addEventListener('keyup', this.handleKeyup);
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('invalid')) {
             if (this.invalid) {

--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -58,7 +58,7 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
         isFocusableElement: (el: Radio) => !el.disabled,
     });
 
-    public focus(): void {
+    public override focus(): void {
         this.rovingTabindexController.focus();
     }
 
@@ -90,7 +90,7 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
     @property({ reflect: true })
     public selected = '';
 
-    protected firstUpdated(changes: PropertyValues<this>): void {
+    protected override firstUpdated(changes: PropertyValues<this>): void {
         super.firstUpdated(changes);
         this.setAttribute('role', 'radiogroup');
         const checkedRadio = this.querySelector('sp-radio[checked]') as Radio;
@@ -116,7 +116,7 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
         });
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
         if (changes.has('selected')) {
             this.validateRadios();
@@ -134,7 +134,7 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
         }
     }
 
-    protected handleSlotchange(): void {
+    protected override handleSlotchange(): void {
         this.rovingTabindexController.clearElementCache();
     }
 }

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -38,7 +38,7 @@ const stopPropagation = (event: Event): void => event.stopPropagation();
  * @fires submit - The search form has been submitted.
  */
 export class Search extends Textfield {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [...super.styles, searchStyles];
     }
 
@@ -46,13 +46,13 @@ export class Search extends Textfield {
     public action = '';
 
     @property()
-    public label = 'Search';
+    public override label = 'Search';
 
     @property()
     public method?: 'GET' | 'POST' | 'dialog';
 
     @property()
-    public placeholder = 'Search';
+    public override placeholder = 'Search';
 
     @query('#form')
     public form!: HTMLFormElement;
@@ -97,7 +97,7 @@ export class Search extends Textfield {
         );
     }
 
-    protected renderField(): TemplateResult {
+    protected override renderField(): TemplateResult {
         return html`
             <form
                 action=${this.action}
@@ -126,12 +126,12 @@ export class Search extends Textfield {
         `;
     }
 
-    public firstUpdated(changedProperties: PropertyValues): void {
+    public override firstUpdated(changedProperties: PropertyValues): void {
         super.firstUpdated(changedProperties);
         this.inputElement.setAttribute('type', 'search');
     }
 
-    public updated(changedProperties: PropertyValues): void {
+    public override updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
         this.multiline = false;
     }

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -32,14 +32,14 @@ import { Focusable } from '@spectrum-web-components/shared';
 import { html } from 'lit-element';
 
 class FocusableButton extends Focusable {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [...super.styles];
     }
     public get focusElement(): HTMLElement {
         return this.shadowRoot.querySelector('#button') as HTMLElement;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <button
                 id="button"
@@ -75,7 +75,7 @@ class ObserveSlotPresenceElement extends ObserveSlotPresence(LitElement, '[slot=
     protected get hasConditionalSlotContent() {
         return this.slotContentIsPresent;
     }
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <button
                 id="button"
@@ -107,7 +107,7 @@ import { ObserveSlotText } from '@spectrum-web-components/shared';
 import { LitElement, html } from 'lit-element';
 
 class ObserveSlotTextElement extends ObserveSlotText(LitElement, '#observing-slot') {
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <button
                 id="button"

--- a/packages/shared/src/focus-visible.ts
+++ b/packages/shared/src/focus-visible.ts
@@ -125,7 +125,7 @@ export const FocusVisiblePolyfillMixin = <
 
         // Attempt to coordinate with the polyfill when connected to the
         // document:
-        connectedCallback(): void {
+        override connectedCallback(): void {
             super.connectedCallback && super.connectedCallback();
             if (!hasFocusVisible) {
                 requestAnimationFrame(() => {
@@ -137,7 +137,7 @@ export const FocusVisiblePolyfillMixin = <
             }
         }
 
-        disconnectedCallback(): void {
+        override disconnectedCallback(): void {
             super.disconnectedCallback && super.disconnectedCallback();
             // It's important to remove the polyfill event listener when we
             // disconnect, otherwise we will leak the whole element via window:

--- a/packages/shared/src/focusable.ts
+++ b/packages/shared/src/focusable.ts
@@ -34,7 +34,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
      * @private
      */
     @property({ type: Boolean })
-    public autofocus = false;
+    public override autofocus = false;
 
     /**
      * The tab index to apply to this control. See general documentation about
@@ -43,7 +43,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
      * @private
      */
     @property({ type: Number })
-    public get tabIndex(): number {
+    public override get tabIndex(): number {
         if (this.focusElement === this) {
             const tabindex = this.hasAttribute('tabindex')
                 ? Number(this.getAttribute('tabindex'))
@@ -69,7 +69,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         // as the cache for this value.
         return this.focusElement.tabIndex;
     }
-    public set tabIndex(tabIndex: number) {
+    public override set tabIndex(tabIndex: number) {
         // Flipping `manipulatingTabindex` to true before a change
         // allows for that change NOT to effect the cached value of tabindex
         if (this.manipulatingTabindex) {
@@ -148,7 +148,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         throw new Error('Must implement focusElement getter!');
     }
 
-    public focus(options?: FocusOptions): void {
+    public override focus(options?: FocusOptions): void {
         if (this.disabled || !this.focusElement) {
             return;
         }
@@ -160,7 +160,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    public blur(): void {
+    public override blur(): void {
         const focusElement = this.focusElement || this;
         if (focusElement !== this) {
             focusElement.blur();
@@ -169,7 +169,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    public click(): void {
+    public override click(): void {
         if (this.disabled) {
             return;
         }
@@ -198,7 +198,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         if (
             !this.hasAttribute('tabindex') ||
@@ -208,7 +208,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    protected update(changedProperties: PropertyValues): void {
+    protected override update(changedProperties: PropertyValues): void {
         if (changedProperties.has('disabled')) {
             this.handleDisabledChanged(
                 this.disabled,
@@ -219,7 +219,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         super.update(changedProperties);
     }
 
-    protected updated(changedProperties: PropertyValues): void {
+    protected override updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
 
         if (changedProperties.has('disabled') && this.disabled) {
@@ -259,7 +259,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.updateComplete.then(() => {
             requestAnimationFrame(() => {

--- a/packages/shared/src/observe-slot-presence.ts
+++ b/packages/shared/src/observe-slot-presence.ts
@@ -35,7 +35,8 @@ export function ObserveSlotPresence<T extends Constructor<ReactiveElement>>(
         : [lightDomSelector];
     class SlotPresenceObservingElement
         extends constructor
-        implements SlotPresenceObservingInterface {
+        implements SlotPresenceObservingInterface
+    {
         private [slotElementObserver]!: MutationObserver;
 
         /**
@@ -85,12 +86,12 @@ export function ObserveSlotPresence<T extends Constructor<ReactiveElement>>(
             this.managePresenceObservedSlot();
         }
 
-        public connectedCallback(): void {
+        public override connectedCallback(): void {
             super.connectedCallback();
             this[startObserving]();
         }
 
-        public disconnectedCallback(): void {
+        public override disconnectedCallback(): void {
             this[slotElementObserver].disconnect();
             super.disconnectedCallback();
         }

--- a/packages/shared/src/observe-slot-text.ts
+++ b/packages/shared/src/observe-slot-text.ts
@@ -60,7 +60,9 @@ export function ObserveSlotText<T extends Constructor<ReactiveElement>>(
             this.slotHasContent = assignedNodes.length > 0;
         }
 
-        protected firstUpdated(changedProperties: PropertyValues): void {
+        protected override firstUpdated(
+            changedProperties: PropertyValues
+        ): void {
             super.firstUpdated(changedProperties);
             this.manageTextObservedSlot();
         }
@@ -82,12 +84,12 @@ export function ObserveSlotText<T extends Constructor<ReactiveElement>>(
             this[slotElementObserver].observe(this, config);
         }
 
-        public connectedCallback(): void {
+        public override connectedCallback(): void {
             super.connectedCallback();
             this[startObserving]();
         }
 
-        public disconnectedCallback(): void {
+        public override disconnectedCallback(): void {
             if (this[slotElementObserver]) {
                 this[slotElementObserver].disconnect();
             }

--- a/packages/shared/test/observe-slot-presence.test.ts
+++ b/packages/shared/test/observe-slot-presence.test.ts
@@ -17,7 +17,7 @@ class ObserverTest extends ObserveSlotPresence(
     LitElement,
     '[slot="test-slot"]'
 ) {
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             Test Element
         `;

--- a/packages/shared/test/observe-slot-text.test.ts
+++ b/packages/shared/test/observe-slot-text.test.ts
@@ -15,7 +15,7 @@ import { LitElement, TemplateResult } from '@spectrum-web-components/base';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 
 class ObserverTest extends ObserveSlotText(LitElement) {
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot @slotchange=${this.manageTextObservedSlot}></slot>
         `;

--- a/packages/sidenav/src/Sidenav.ts
+++ b/packages/sidenav/src/Sidenav.ts
@@ -36,7 +36,7 @@ export interface SidenavSelectDetail {
  * This change can be "canceled" via `event.preventDefault()`.
  */
 export class SideNav extends Focusable {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [sidenavStyles];
     }
 
@@ -99,11 +99,11 @@ export class SideNav extends Focusable {
         }
     }
 
-    public focus(): void {
+    public override focus(): void {
         this.rovingTabindexController.focus();
     }
 
-    public blur(): void {
+    public override blur(): void {
         if (this.focusElement === this) {
             return;
         }
@@ -111,7 +111,7 @@ export class SideNav extends Focusable {
         super.blur();
     }
 
-    public click(): void {
+    public override click(): void {
         if (this.focusElement === this) {
             return;
         }
@@ -119,7 +119,7 @@ export class SideNav extends Focusable {
         super.click();
     }
 
-    public get focusElement(): SideNavItem | SideNav {
+    public override get focusElement(): SideNavItem | SideNav {
         return this.rovingTabindexController.focusInElement || this;
     }
 
@@ -153,7 +153,7 @@ export class SideNav extends Focusable {
         }
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <nav @sidenav-select=${this.handleSelect}>
                 <slot
@@ -164,7 +164,7 @@ export class SideNav extends Focusable {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         const selectedChild = this.querySelector('[selected]') as SideNavItem;
         if (selectedChild) {
@@ -172,7 +172,7 @@ export class SideNav extends Focusable {
         }
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('manageTabIndex')) {
             if (this.manageTabIndex) {

--- a/packages/sidenav/src/SidenavHeading.ts
+++ b/packages/sidenav/src/SidenavHeading.ts
@@ -31,18 +31,18 @@ export class SideNavHeading extends SpectrumElement {
     @property({ reflect: true })
     public label = '';
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [sidenavItemStyles, sidenavHeadingStyles];
     }
 
-    protected update(changes: PropertyValues): void {
+    protected override update(changes: PropertyValues): void {
         if (!this.hasAttribute('slot')) {
             this.slot = 'descendant';
         }
         super.update(changes);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <h2 id="heading">${this.label}</h2>
             <div id="list" aria-labelledby="heading">

--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -31,7 +31,7 @@ import sidenavItemStyles from './sidenav-item.css.js';
  * @slot - the Sidenav Items to display as children of this item
  */
 export class SideNavItem extends LikeAnchor(Focusable) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [sidenavItemStyles];
     }
 
@@ -100,22 +100,22 @@ export class SideNavItem extends LikeAnchor(Focusable) {
         this.dispatchEvent(selectionEvent);
     }
 
-    public click(): void {
+    public override click(): void {
         this.handleClick();
     }
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         return this.shadowRoot.querySelector('#item-link') as HTMLElement;
     }
 
-    protected update(changes: PropertyValues): void {
+    protected override update(changes: PropertyValues): void {
         if (!this.hasAttribute('slot')) {
             this.slot = 'descendant';
         }
         super.update(changes);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <a
                 href=${this.href || '#'}
@@ -141,19 +141,19 @@ export class SideNavItem extends LikeAnchor(Focusable) {
         `;
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         if (this.hasChildren && this.expanded && !this.selected) {
             this.focusElement.tabIndex = -1;
         }
         super.updated(changes);
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.startTrackingSelection();
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.stopTrackingSelection();
         super.disconnectedCallback();
     }

--- a/packages/sidenav/test/sidenav.test.ts
+++ b/packages/sidenav/test/sidenav.test.ts
@@ -399,7 +399,7 @@ describe('Sidenav', () => {
     });
     it('manage tab index through shadow DOM', async () => {
         class SideNavTestEl extends LitElement {
-            protected render(): TemplateResult {
+            protected override render(): TemplateResult {
                 return manageTabIndex();
             }
         }

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -45,11 +45,13 @@ export const variants = ['filled', 'ramp', 'range', 'tick'];
  * @slot handle - optionally accepts two or more sp-slider-handle elements
  */
 export class Slider extends ObserveSlotText(SliderHandle, '') {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [sliderStyles];
     }
 
-    public handleController: HandleController = new HandleController(this);
+    public override handleController: HandleController = new HandleController(
+        this
+    );
 
     /**
      * Whether to display a Number Field along side the slider UI
@@ -108,7 +110,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
         return this.handleController.values;
     }
 
-    public get handleName(): string {
+    public override get handleName(): string {
         return 'value';
     }
 
@@ -125,7 +127,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
         return valueArray.join(`${this._forcedUnit}, `) + this._forcedUnit;
     };
 
-    public get ariaValueText(): string {
+    public override get ariaValueText(): string {
         if (!this.getAriaValueText) {
             return `${this.value}${this._forcedUnit}`;
         }
@@ -136,13 +138,13 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
     public labelVisibility?: 'text' | 'value' | 'none';
 
     @property({ type: Number, reflect: true })
-    public min = 0;
+    public override min = 0;
 
     @property({ type: Number, reflect: true })
-    public max = 100;
+    public override max = 100;
 
     @property({ type: Number })
-    public step = 1;
+    public override step = 1;
 
     @property({ type: Number, attribute: 'tick-step' })
     public tickStep = 0;
@@ -151,7 +153,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
     public tickLabels = false;
 
     @property({ type: Boolean, reflect: true })
-    public disabled = false;
+    public override disabled = false;
 
     @query('#label')
     public labelEl!: HTMLLabelElement;
@@ -162,11 +164,11 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
     @query('#track')
     public track!: HTMLDivElement;
 
-    public get numberFormat(): NumberFormatter {
+    public override get numberFormat(): NumberFormatter {
         return this.getNumberFormat();
     }
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         return this.handleController.focusElement;
     }
 
@@ -177,7 +179,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
         }
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${this.renderLabel()} ${this.renderTrack()}
             ${this.editable
@@ -199,17 +201,17 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
         `;
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.handleController.hostConnected();
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         super.disconnectedCallback();
         this.handleController.hostDisconnected();
     }
 
-    public update(changedProperties: Map<string, boolean>): void {
+    public override update(changedProperties: Map<string, boolean>): void {
         this.handleController.hostUpdate();
         if (changedProperties.has('disabled') && this.disabled) {
             this.handleController.cancelDrag();
@@ -405,7 +407,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
 
     private _numberFieldInput: Promise<unknown> = Promise.resolve();
 
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         if (this.editable) {
             await this._numberFieldInput;

--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -81,7 +81,7 @@ export class SliderHandle extends Focusable {
         return this.name;
     }
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         /* c8 ignore next */
         return this.handleController?.inputForHandle(this) ?? this;
     }
@@ -127,14 +127,14 @@ export class SliderHandle extends Focusable {
         return numberFormat.format(value);
     };
 
-    protected update(changes: PropertyValues): void {
+    protected override update(changes: PropertyValues): void {
         if (changes.has('formatOptions') || changes.has('resolvedLanguage')) {
             delete this._numberFormatCache;
         }
         super.update(changes);
     }
 
-    protected updated(changedProperties: PropertyValues<this>): void {
+    protected override updated(changedProperties: PropertyValues<this>): void {
         if (changedProperties.has('value')) {
             const oldValue = changedProperties.get('value');
             if (oldValue != null) {
@@ -146,7 +146,9 @@ export class SliderHandle extends Focusable {
         super.updated(changedProperties);
     }
 
-    protected firstUpdated(changedProperties: PropertyValues<this>): void {
+    protected override firstUpdated(
+        changedProperties: PropertyValues<this>
+    ): void {
         super.firstUpdated(changedProperties);
         this.dispatchEvent(new CustomEvent('sp-slider-handle-ready'));
     }
@@ -210,12 +212,12 @@ export class SliderHandle extends Focusable {
         return this.getNumberFormat();
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.resolveLanguage();
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.resolveLanguage();
         super.disconnectedCallback();
     }

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -49,7 +49,7 @@ export type SplitButtonTypes = 'field' | 'more';
  * @slot - menu items to be listed in the Button
  **/
 export class SplitButton extends SizedMixin(PickerBase) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles, chevronStyles];
     }
 
@@ -62,7 +62,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
     @property({ reflect: true })
     public variant: ButtonVariants = 'accent';
 
-    public get target(): HTMLButtonElement | this {
+    public override get target(): HTMLButtonElement | this {
         return this;
     }
 
@@ -72,10 +72,10 @@ export class SplitButton extends SizedMixin(PickerBase) {
     @query('.trigger')
     private trigger!: HTMLButtonElement;
 
-    protected listRole: 'listbox' | 'menu' = 'menu';
-    protected itemRole = 'menuitem';
+    protected override listRole: 'listbox' | 'menu' = 'menu';
+    protected override itemRole = 'menuitem';
 
-    public get focusElement(): HTMLElement {
+    public override get focusElement(): HTMLElement {
         if (this.open) {
             return this.optionsMenu;
         }
@@ -85,7 +85,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
         return this.button;
     }
 
-    protected sizePopover(popover: HTMLElement): void {
+    protected override sizePopover(popover: HTMLElement): void {
         popover.style.setProperty('min-width', `${this.offsetWidth}px`);
     }
 
@@ -99,7 +99,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
         }
     }
 
-    protected get buttonContent(): TemplateResult[] {
+    protected override get buttonContent(): TemplateResult[] {
         return [
             html`
                 <div
@@ -113,7 +113,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
         ];
     }
 
-    protected update(changes: PropertyValues<this>): void {
+    protected override update(changes: PropertyValues<this>): void {
         if (changes.has('type')) {
             if (this.type === 'more') {
                 this.selects = undefined;
@@ -124,7 +124,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
         super.update(changes);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         const treatment = ['cta', 'accent'].includes(this.variant)
             ? 'fill'
             : 'outline';
@@ -179,14 +179,14 @@ export class SplitButton extends SizedMixin(PickerBase) {
         `;
     }
 
-    protected updated(changedProperties: PropertyValues): void {
+    protected override updated(changedProperties: PropertyValues): void {
         super.updated(changedProperties);
         if (changedProperties.has('value')) {
             this.manageSplitButtonItems();
         }
     }
 
-    protected async manageSelection(): Promise<void> {
+    protected override async manageSelection(): Promise<void> {
         await this.manageSplitButtonItems();
         await super.manageSelection();
     }

--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -49,7 +49,7 @@ const COLLAPSE_THREASHOLD = 50;
  * @slot Two sibling elements to be sized by the element attritubes
  */
 export class SplitView extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -133,12 +133,12 @@ export class SplitView extends SpectrumElement {
         }
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         this.observer?.observe(this);
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         this.observer?.unobserve(this);
         super.disconnectedCallback();
     }
@@ -164,7 +164,7 @@ export class SplitView extends SpectrumElement {
         return this._splitterSize;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         const splitterClasses = {
             'is-resized-start': this.splitterPos === this.minPos,
             'is-resized-end': (this.splitterPos &&
@@ -408,12 +408,12 @@ export class SplitView extends SpectrumElement {
         this.dispatchEvent(changeEvent);
     }
 
-    protected firstUpdated(changed: PropertyValues): void {
+    protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.checkResize();
     }
 
-    protected updated(changed: PropertyValues): void {
+    protected override updated(changed: PropertyValues): void {
         super.updated(changed);
         if (changed.has('primarySize')) {
             this.splitterPos = undefined;

--- a/packages/status-light/src/StatusLight.ts
+++ b/packages/status-light/src/StatusLight.ts
@@ -27,7 +27,7 @@ import statusLightStyles from './status-light.css.js';
  * @slot - text label of the Status Light
  */
 export class StatusLight extends SizedMixin(SpectrumElement) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [statusLightStyles];
     }
 
@@ -56,13 +56,13 @@ export class StatusLight extends SizedMixin(SpectrumElement) {
         | 'celery'
         | 'purple' = 'info';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot></slot>
         `;
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('disabled')) {
             if (this.disabled) {

--- a/packages/switch/src/Switch.ts
+++ b/packages/switch/src/Switch.ts
@@ -27,7 +27,7 @@ import legacyStyles from './switch-legacy.css.js';
  * @slot - text label of the Switch
  */
 export class Switch extends CheckboxBase {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         /* c8 ignore next 4 */
         if (window.hasOwnProperty('ShadyDOM')) {
             // Override some styles if we are using the web component polyfill
@@ -39,7 +39,7 @@ export class Switch extends CheckboxBase {
     @property({ type: Boolean, reflect: true })
     public emphasized = false;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${super.render()}
             <span id="switch"></span>
@@ -47,12 +47,12 @@ export class Switch extends CheckboxBase {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.inputElement.setAttribute('role', 'switch');
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         if (changes.has('checked')) {
             this.inputElement.setAttribute(
                 'aria-checked',

--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -35,7 +35,7 @@ import tabItemStyles from './tab.css.js';
 export class Tab extends FocusVisiblePolyfillMixin(
     ObserveSlotText(ObserveSlotPresence(SpectrumElement, '[slot="icon"]'), '')
 ) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [tabItemStyles];
     }
 
@@ -79,7 +79,7 @@ export class Tab extends FocusVisiblePolyfillMixin(
         );
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${this.hasIcon
                 ? html`
@@ -93,7 +93,7 @@ export class Tab extends FocusVisiblePolyfillMixin(
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.setAttribute('role', 'tab');
         if (!this.hasAttribute('id')) {
@@ -107,7 +107,7 @@ export class Tab extends FocusVisiblePolyfillMixin(
         );
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (
             changes.has('label') &&

--- a/packages/tabs/src/TabPanel.ts
+++ b/packages/tabs/src/TabPanel.ts
@@ -26,7 +26,7 @@ import panelStyles from './tab-panel.css.js';
  * @slot - content of the Tab Panel
  */
 export class TabPanel extends SpectrumElement {
-    static styles = [panelStyles];
+    static override styles = [panelStyles];
 
     /**
      * @private
@@ -39,13 +39,13 @@ export class TabPanel extends SpectrumElement {
     @property({ type: String, reflect: true })
     public value = '';
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot></slot>
         `;
     }
 
-    protected firstUpdated(): void {
+    protected override firstUpdated(): void {
         this.slot = 'tab-panel';
         this.setAttribute('role', 'tabpanel');
         this.tabIndex = 0;
@@ -54,7 +54,7 @@ export class TabPanel extends SpectrumElement {
         }
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         if (changes.has('selected')) {
             if (this.selected) {
                 this.removeAttribute('aria-hidden');

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -42,7 +42,7 @@ const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
  * @fires change - The selected Tab child has changed.
  */
 export class Tabs extends SizedMixin(Focusable) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [tabStyles];
     }
 
@@ -135,11 +135,11 @@ export class Tabs extends SizedMixin(Focusable) {
     /**
      * @private
      */
-    public get focusElement(): Tab | this {
+    public override get focusElement(): Tab | this {
         return this.rovingTabindexController.focusInElement || this;
     }
 
-    protected manageAutoFocus(): void {
+    protected override manageAutoFocus(): void {
         const tabs = [...this.children] as Tab[];
         const tabUpdateCompletes = tabs.map((tab) => {
             if (typeof tab.updateComplete !== 'undefined') {
@@ -165,7 +165,7 @@ export class Tabs extends SizedMixin(Focusable) {
         });
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div
                 aria-label=${ifDefined(this.label ? this.label : undefined)}
@@ -189,7 +189,7 @@ export class Tabs extends SizedMixin(Focusable) {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         const selectedChild = this.querySelector(':scope > [selected]') as Tab;
         if (selectedChild) {
@@ -197,7 +197,7 @@ export class Tabs extends SizedMixin(Focusable) {
         }
     }
 
-    protected updated(changes: PropertyValues<this>): void {
+    protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
         if (changes.has('selected')) {
             if (changes.get('selected')) {
@@ -356,13 +356,13 @@ export class Tabs extends SizedMixin(Focusable) {
         return;
     };
 
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         await this.tabChangePromise;
         return complete;
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         window.addEventListener('resize', this.updateSelectionIndicator);
         if ('fonts' in document) {
@@ -382,7 +382,7 @@ export class Tabs extends SizedMixin(Focusable) {
         }
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         window.removeEventListener('resize', this.updateSelectionIndicator);
         if ('fonts' in document) {
             (

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -444,7 +444,7 @@ describe('Tabs', () => {
 
     it('accepts keyboard based selection through shadow DOM', async () => {
         class TabTestEl extends LitElement {
-            protected render(): TemplateResult {
+            protected override render(): TemplateResult {
                 return html`
                     <sp-tabs selected="Unknown">
                         <sp-tab label="Tab 1" value="first">

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -34,7 +34,7 @@ import styles from './tag.css.js';
 export class Tag extends SizedMixin(SpectrumElement, {
     validSizes: ['s', 'm', 'l'],
 }) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -97,7 +97,7 @@ export class Tag extends SizedMixin(SpectrumElement, {
         );
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         const slots: TemplateResult[] = [];
         if (this.hasAvatar) {
             slots.push(
@@ -131,7 +131,7 @@ export class Tag extends SizedMixin(SpectrumElement, {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'listitem');
@@ -146,7 +146,7 @@ export class Tag extends SizedMixin(SpectrumElement, {
         }
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('disabled')) {
             if (this.disabled) {

--- a/packages/tags/src/Tags.ts
+++ b/packages/tags/src/Tags.ts
@@ -30,7 +30,7 @@ import styles from './tags.css.js';
  * @slot - Tag elements to manage as a group
  */
 export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -58,7 +58,7 @@ export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
         this.addEventListener('focusin', this.handleFocusin);
     }
 
-    public focus(): void {
+    public override focus(): void {
         this.rovingTabindexController.focus();
     }
 
@@ -104,13 +104,13 @@ export class Tags extends FocusVisiblePolyfillMixin(SpectrumElement) {
         this.rovingTabindexController.clearElementCache();
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <slot @slotchange=${this.handleSlotchange}></slot>
         `;
     }
 
-    protected firstUpdated(): void {
+    protected override firstUpdated(): void {
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'list');
         }

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -43,7 +43,7 @@ export type TextfieldType = typeof textfieldTypes[number];
  * @fires change - An alteration to the value of the element has been committed by the user.
  */
 export class TextfieldBase extends ManageHelpText(Focusable) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [textfieldStyles, checkmarkStyles];
     }
 
@@ -127,7 +127,7 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
         | HTMLInputElement['autocomplete']
         | HTMLTextAreaElement['autocomplete'];
 
-    public get focusElement(): HTMLInputElement | HTMLTextAreaElement {
+    public override get focusElement(): HTMLInputElement | HTMLTextAreaElement {
         return this.inputElement;
     }
 
@@ -286,14 +286,14 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
         `;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div id="textfield">${this.renderField()}</div>
             ${this.renderHelpText(this.invalid)}
         `;
     }
 
-    protected updated(changedProperties: PropertyValues): void {
+    protected override updated(changedProperties: PropertyValues): void {
         if (
             changedProperties.has('value') ||
             (changedProperties.has('required') && this.required)
@@ -327,7 +327,7 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
  */
 export class Textfield extends TextfieldBase {
     @property({ type: String })
-    public set value(value: string) {
+    public override set value(value: string) {
         if (value === this.value) {
             return;
         }
@@ -336,9 +336,9 @@ export class Textfield extends TextfieldBase {
         this.requestUpdate('value', oldValue);
     }
 
-    public get value(): string {
+    public override get value(): string {
         return this._value;
     }
 
-    protected _value = '';
+    protected override _value = '';
 }

--- a/packages/theme/src/Theme.ts
+++ b/packages/theme/src/Theme.ts
@@ -127,7 +127,7 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
         }
     }
 
-    public shadowRoot!: ShadowRootWithAdoptedStyleSheets;
+    public override shadowRoot!: ShadowRootWithAdoptedStyleSheets;
 
     private _theme: ThemeVariant | '' = 'spectrum';
 

--- a/packages/thumbnail/src/Thumbnail.ts
+++ b/packages/thumbnail/src/Thumbnail.ts
@@ -30,7 +30,7 @@ export class Thumbnail extends SizedMixin(SpectrumElement, {
     validSizes: ['xxs', 'xs', 's', 'm', 'l'],
     defaultSize: 's',
 }) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -40,7 +40,7 @@ export class Thumbnail extends SizedMixin(SpectrumElement, {
     @property({ type: Boolean, reflect: true })
     public cover = false;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${this.background
                 ? html`

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -51,7 +51,7 @@ export type ToastVariants =
  */
 
 export class Toast extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [toastStyles];
     }
 
@@ -202,7 +202,7 @@ export class Toast extends SpectrumElement {
         this.open = false;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             ${this.renderIcon(this.variant)}
             <div class="body" role="alert">
@@ -221,7 +221,7 @@ export class Toast extends SpectrumElement {
         `;
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('open')) {
             if (this.open) {

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -45,7 +45,7 @@ customElements.define('tooltip-proxy', TooltipProxy);
  */
 
 export class Tooltip extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [tooltipStyles];
     }
 
@@ -235,7 +235,7 @@ export class Tooltip extends SpectrumElement {
         }
     }
 
-    render(): TemplateResult {
+    override render(): TemplateResult {
         return html`
             <slot name="icon"></slot>
             <span id="label"><slot></slot></span>
@@ -243,7 +243,9 @@ export class Tooltip extends SpectrumElement {
         `;
     }
 
-    protected async update(changed: PropertyValues<this>): Promise<void> {
+    protected override async update(
+        changed: PropertyValues<this>
+    ): Promise<void> {
         if (changed.has('open') && this.selfManaged) {
             if (this.open) {
                 this.openOverlay();
@@ -255,7 +257,7 @@ export class Tooltip extends SpectrumElement {
         super.update(changed);
     }
 
-    protected updated(changed: PropertyValues<this>): void {
+    protected override updated(changed: PropertyValues<this>): void {
         super.updated(changed);
         if (changed.has('selfManaged')) {
             this.manageTooltip();

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -36,7 +36,7 @@ const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
  */
 
 export class TopNav extends SizedMixin(SpectrumElement) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [tabStyles];
     }
 
@@ -85,7 +85,7 @@ export class TopNav extends SizedMixin(SpectrumElement) {
         }
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <div @click=${this.onClick} id="list">
                 <slot @slotchange=${this.onSlotChange}></slot>
@@ -100,13 +100,13 @@ export class TopNav extends SizedMixin(SpectrumElement) {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.setAttribute('direction', 'horizontal');
         this.manageItems();
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         if (changes.has('dir')) {
             this.updateSelectionIndicator();
@@ -182,7 +182,7 @@ export class TopNav extends SizedMixin(SpectrumElement) {
         });`;
     };
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         window.addEventListener('resize', this.updateSelectionIndicator);
         if ('fonts' in document) {
@@ -193,7 +193,7 @@ export class TopNav extends SizedMixin(SpectrumElement) {
         }
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         window.removeEventListener('resize', this.updateSelectionIndicator);
         if ('fonts' in document) {
             (

--- a/packages/top-nav/src/TopNavItem.ts
+++ b/packages/top-nav/src/TopNavItem.ts
@@ -33,7 +33,7 @@ import topNavItemStyles from './top-nav-item.css.js';
  */
 
 export class TopNavItem extends LikeAnchor(Focusable) {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [itemStyles, topNavItemStyles];
     }
 
@@ -45,15 +45,15 @@ export class TopNavItem extends LikeAnchor(Focusable) {
 
     public value = '';
 
-    public get focusElement(): HTMLAnchorElement {
+    public override get focusElement(): HTMLAnchorElement {
         return this.anchor;
     }
 
-    public click(): void {
+    public override click(): void {
         this.anchor.click();
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <a
                 id="item-label"
@@ -71,11 +71,11 @@ export class TopNavItem extends LikeAnchor(Focusable) {
         `;
     }
 
-    protected firstUpdated(changes: PropertyValues): void {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
     }
 
-    protected updated(changes: PropertyValues): void {
+    protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         this.value = this.anchor.href;
     }

--- a/packages/top-nav/stories/top-nav.stories.ts
+++ b/packages/top-nav/stories/top-nav.stories.ts
@@ -87,7 +87,7 @@ export const Selected = (): TemplateResult => {
 };
 
 class WrappedTopNav extends HTMLElement {
-    shadowRoot!: ShadowRoot;
+    override shadowRoot!: ShadowRoot;
 
     constructor() {
         super();

--- a/packages/tray/src/Tray.ts
+++ b/packages/tray/src/Tray.ts
@@ -36,7 +36,7 @@ import styles from './tray.css.js';
  * @fires close - Announces that the Tray has been closed.
  */
 export class Tray extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [modalStyles, styles];
     }
 
@@ -55,7 +55,7 @@ export class Tray extends SpectrumElement {
     @query('.tray')
     private tray!: HTMLDivElement;
 
-    public focus(): void {
+    public override focus(): void {
         const firstFocusable = firstFocusableIn(this);
         if (firstFocusable) {
             firstFocusable.focus();
@@ -100,7 +100,7 @@ export class Tray extends SpectrumElement {
         }
     }
 
-    protected update(changes: PropertyValues<this>): void {
+    protected override update(changes: PropertyValues<this>): void {
         if (
             changes.has('open') &&
             changes.get('open') !== undefined &&
@@ -113,7 +113,7 @@ export class Tray extends SpectrumElement {
         super.update(changes);
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <sp-underlay
                 ?open=${this.open}
@@ -138,7 +138,7 @@ export class Tray extends SpectrumElement {
      * while opening the Tray when focusable content is included: e.g. Menu
      * elements whose selected Menu Item is not the first Menu Item.
      */
-    protected async getUpdateComplete(): Promise<boolean> {
+    protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
         await this.transitionPromise;
         return complete;

--- a/packages/underlay/src/Underlay.ts
+++ b/packages/underlay/src/Underlay.ts
@@ -24,14 +24,14 @@ import styles from './underlay.css.js';
  * @element sp-underlay
  */
 export class Underlay extends SpectrumElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
     @property({ type: Boolean, reflect: true })
     public open = false;
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html``;
     }
 }

--- a/projects/documentation/src/components/adobe-logo.ts
+++ b/projects/documentation/src/components/adobe-logo.ts
@@ -26,11 +26,11 @@ export class SpectrumLogo extends LitElement {
     @property({ type: String })
     public size: string = '36px';
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [logoStyles];
     }
 
-    render() {
+    override render() {
         return html`
             <svg
                 version="1.1"

--- a/projects/documentation/src/components/code-example.ts
+++ b/projects/documentation/src/components/code-example.ts
@@ -51,7 +51,7 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
 
     private prismjsLoaded = false;
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [Styles, StylesLight, StylesDark];
     }
 
@@ -117,7 +117,7 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
         return toHtmlTemplateString(this.liveHTML);
     }
 
-    protected shouldUpdate(): boolean {
+    protected override shouldUpdate(): boolean {
         if (this.preprocessed || this.prismjsLoaded) {
             return true;
         }
@@ -130,7 +130,7 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
         return false;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         // highlighedCode needs to happen first in case the HTML is live and
         // needs to be placed into the light DOM
         const { highlightedCode, renderedCode } = this;
@@ -174,7 +174,7 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
         });
     };
 
-    protected updated(): void {
+    protected override updated(): void {
         setTimeout(this.shouldManageTabOrderForScrolling);
     }
 
@@ -194,7 +194,7 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
         this.dispatchEvent(queryThemeEvent);
     }
 
-    public connectedCallback(): void {
+    public override connectedCallback(): void {
         super.connectedCallback();
         window.addEventListener(
             'resize',
@@ -203,7 +203,7 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
         this.trackTheme();
     }
 
-    public disconnectedCallback(): void {
+    public override disconnectedCallback(): void {
         window.removeEventListener(
             'resize',
             this.shouldManageTabOrderForScrolling

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -140,7 +140,7 @@ export interface TrackTheme {
 
 // @customElement('docs-page')
 export class LayoutElement extends LitElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [layoutStyles];
     }
 
@@ -158,7 +158,7 @@ export class LayoutElement extends LitElement {
     public color: Color = DEFAULT_COLOR;
 
     @property({ reflect: true })
-    public dir: 'ltr' | 'rtl' = DEFAULT_DIR;
+    public override dir: 'ltr' | 'rtl' = DEFAULT_DIR;
 
     @property({ type: Boolean })
     public open = false;
@@ -270,7 +270,7 @@ export class LayoutElement extends LitElement {
         this.requestUpdate();
     }
 
-    public focus() {
+    public override focus() {
         (this.shadowRoot!.querySelector('docs-side-nav')! as SideNav).focus();
     }
 
@@ -384,7 +384,7 @@ export class LayoutElement extends LitElement {
         `;
     }
 
-    render() {
+    override render() {
         return html`
             <sp-theme
                 .color=${this.color}
@@ -434,7 +434,7 @@ export class LayoutElement extends LitElement {
         `;
     }
 
-    protected firstUpdated(): void {
+    protected override firstUpdated(): void {
         loadDefaults();
         isNarrowMediaQuery.addEventListener(
             'change',
@@ -442,7 +442,7 @@ export class LayoutElement extends LitElement {
         );
     }
 
-    updated(changes: PropertyValues) {
+    override updated(changes: PropertyValues) {
         let loadStyleFragments = false;
         if (changes.has('color')) {
             if (window.localStorage) {

--- a/projects/documentation/src/components/side-nav-search.ts
+++ b/projects/documentation/src/components/side-nav-search.ts
@@ -46,14 +46,14 @@ export class SearchComponent extends LitElement {
     @query('#focus-return')
     private focusReturn!: HTMLSpanElement;
 
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [sideNavSearchMenuStyles];
     }
 
     @property({ type: Array })
     public results: ResultGroup[] = [];
 
-    public focus(): void {
+    public override focus(): void {
         this.searchField.focus();
     }
 
@@ -215,7 +215,7 @@ export class SearchComponent extends LitElement {
         }
     }
 
-    render(): TemplateResult {
+    override render(): TemplateResult {
         return html`
             <div id="search-container" @focusout=${this.onFocusout}>
                 <sp-search

--- a/projects/documentation/src/components/side-nav.ts
+++ b/projects/documentation/src/components/side-nav.ts
@@ -29,7 +29,7 @@ import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
 @customElement('docs-side-nav')
 export class SideNav extends LitElement {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [sideNavStyles];
     }
 
@@ -40,7 +40,7 @@ export class SideNav extends LitElement {
         this.open = !this.open;
     }
 
-    public focus() {
+    public override focus() {
         const target = document.querySelector(
             '[slot="logo"]'
         ) as HTMLAnchorElement;
@@ -53,7 +53,7 @@ export class SideNav extends LitElement {
         target.focus();
     }
 
-    render(): TemplateResult {
+    override render(): TemplateResult {
         return html`
             <sp-underlay
                 class="scrim"
@@ -81,7 +81,7 @@ export class SideNav extends LitElement {
         `;
     }
 
-    updated(changes: PropertyValues) {
+    override updated(changes: PropertyValues) {
         if (changes.has('open') && !this.open && changes.get('open')) {
             this.dispatchEvent(new Event('close'));
         }

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -104,7 +104,7 @@ ActiveOverlay.prototype.renderTheme = function (
 };
 
 export class StoryDecorator extends SpectrumElement {
-    static get styles() {
+    static override get styles() {
         return [
             css`
                 :host(:focus) {
@@ -259,7 +259,7 @@ export class StoryDecorator extends SpectrumElement {
         }
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         return html`
             <sp-theme
                 theme=${this.theme}

--- a/projects/vrt-compare/src/OnionSkinner.ts
+++ b/projects/vrt-compare/src/OnionSkinner.ts
@@ -58,7 +58,7 @@ export class OnionSkinner extends SpectrumElement {
         this.onionLevel = 1;
     }
 
-    render() {
+    override render() {
         return html`
             <slot
                 @slotchange=${this.handleSlotchange}
@@ -101,7 +101,7 @@ export class OnionSkinner extends SpectrumElement {
         `;
     }
 
-    static styles = [
+    static override styles = [
         css`
             :host {
                 display: grid;

--- a/projects/vrt-compare/src/VrtCompare.ts
+++ b/projects/vrt-compare/src/VrtCompare.ts
@@ -211,7 +211,7 @@ export class VrtCompare extends ObserveSlotPresence(SpectrumElement, [
         this._loadingImages = false;
     }
 
-    protected shouldUpdate() {
+    protected override shouldUpdate() {
         if (
             this.view === 'error' ||
             (this.view === 'actual' && !this.hasActual) ||
@@ -227,7 +227,7 @@ export class VrtCompare extends ObserveSlotPresence(SpectrumElement, [
         return true;
     }
 
-    protected render(): TemplateResult {
+    protected override render(): TemplateResult {
         if (this._loadingImages) {
             return html`
                 <sp-progress-circle indeterminate></sp-progress-circle>
@@ -350,7 +350,7 @@ export class VrtCompare extends ObserveSlotPresence(SpectrumElement, [
         `;
     }
 
-    protected updated(changes: PropertyValues) {
+    protected override updated(changes: PropertyValues) {
         if (changes.has('zoom')) {
             let zoom = Math.min(this.zoom, 2);
             zoom = Math.min(zoom, 0.5);
@@ -358,7 +358,7 @@ export class VrtCompare extends ObserveSlotPresence(SpectrumElement, [
         }
     }
 
-    static styles = [
+    static override styles = [
         css`
             :host {
                 display: grid;

--- a/test/benchmark/helpers.ts
+++ b/test/benchmark/helpers.ts
@@ -31,7 +31,7 @@ export class TestFixture extends LitElement {
     @property({ type: Object })
     template: TemplateResult = html``;
 
-    remove(): boolean {
+    override remove(): boolean {
         const parent = this.parentNode;
         if (parent) {
             parent.removeChild(this);
@@ -73,7 +73,7 @@ export class TestFixture extends LitElement {
         }
     }
 
-    render() {
+    override render() {
         return html`
             ${this.shouldAttachContents ? this.template : ''}
         `;

--- a/test/lit-helpers.ts
+++ b/test/lit-helpers.ts
@@ -45,7 +45,7 @@ class SpreadDirective extends AsyncDirective {
     render(_spreadData: { [key: string]: unknown }) {
         return nothing;
     }
-    update(part: Part, [spreadData]: Parameters<this['render']>) {
+    override update(part: Part, [spreadData]: Parameters<this['render']>) {
         if (this.element !== (part as ElementPart).element) {
             this.element = (part as ElementPart).element;
         }
@@ -144,7 +144,7 @@ class SpreadDirective extends AsyncDirective {
         }
     }
 
-    disconnected() {
+    override disconnected() {
         const { prevData, element } = this;
         for (const key in prevData) {
             if (key[0] !== '@') continue;
@@ -158,7 +158,7 @@ class SpreadDirective extends AsyncDirective {
         }
     }
 
-    reconnected() {
+    override reconnected() {
         const { prevData, element } = this;
         for (const key in prevData) {
             if (key[0] !== '@') continue;
@@ -183,7 +183,7 @@ class SpreadPropsDirective extends AsyncDirective {
     render(_spreadData: { [key: string]: unknown }) {
         return nothing;
     }
-    update(part: Part, [spreadData]: Parameters<this['render']>) {
+    override update(part: Part, [spreadData]: Parameters<this['render']>) {
         if (this.element !== (part as ElementPart).element) {
             this.element = (part as ElementPart).element;
         }

--- a/tools/grid/src/Grid.ts
+++ b/tools/grid/src/Grid.ts
@@ -27,7 +27,7 @@ import { GridController } from './GridController.js';
  * @fires change - Announces that the value of `selected` has changed
  */
 export class Grid extends LitVirtualizer {
-    public static get styles(): CSSResultArray {
+    public static override get styles(): CSSResultArray {
         return [styles];
     }
 
@@ -38,7 +38,7 @@ export class Grid extends LitVirtualizer {
     public gap: `${'0' | `${number}px`}` = '0';
 
     @property({ type: Array })
-    public items: Record<string, unknown>[] = [];
+    public override items: Record<string, unknown>[] = [];
 
     @property({ type: Object })
     public itemSize: {
@@ -50,11 +50,14 @@ export class Grid extends LitVirtualizer {
     };
 
     /* c8 ignore next 3 */
-    get renderItem(): (item: unknown, index: number) => TemplateResult {
+    override get renderItem(): (
+        item: unknown,
+        index: number
+    ) => TemplateResult {
         return super.renderItem;
     }
 
-    set renderItem(
+    override set renderItem(
         fn: (item: unknown, index: number, selected: boolean) => TemplateResult
     ) {
         super.renderItem = (
@@ -93,7 +96,7 @@ export class Grid extends LitVirtualizer {
         this.selected = selected;
     }
 
-    protected update(changes: PropertyValues<this>): void {
+    protected override update(changes: PropertyValues<this>): void {
         if (
             changes.has('itemSize') ||
             changes.has('gap') ||
@@ -123,12 +126,12 @@ export class Grid extends LitVirtualizer {
         super.update(changes);
     }
 
-    connectedCallback(): void {
+    override connectedCallback(): void {
         super.connectedCallback();
         this.addEventListener('change', this.handleChange, { capture: true });
     }
 
-    disconnectedCallback(): void {
+    override disconnectedCallback(): void {
         this.removeEventListener('change', this.handleChange, {
             capture: true,
         });

--- a/tools/reactive-controllers/src/RovingTabindex.ts
+++ b/tools/reactive-controllers/src/RovingTabindex.ts
@@ -20,13 +20,13 @@ interface UpdateTabIndexes {
 export class RovingTabindexController<
     T extends HTMLElement
 > extends FocusGroupController<T> {
-    protected set focused(focused: boolean) {
+    protected override set focused(focused: boolean) {
         if (focused === this.focused) return;
         super.focused = focused;
         this.manageTabindexes();
     }
 
-    protected get focused(): boolean {
+    protected override get focused(): boolean {
         return super.focused;
     }
 
@@ -34,7 +34,7 @@ export class RovingTabindexController<
 
     private manageIndexesAnimationFrame = 0;
 
-    clearElementCache(offset = 0): void {
+    override clearElementCache(offset = 0): void {
         cancelAnimationFrame(this.manageIndexesAnimationFrame);
         super.clearElementCache(offset);
         if (!this.managed) return;
@@ -74,13 +74,13 @@ export class RovingTabindexController<
         });
     }
 
-    manage(): void {
+    override manage(): void {
         this.managed = true;
         this.manageTabindexes();
         super.manage();
     }
 
-    unmanage(): void {
+    override unmanage(): void {
         this.managed = false;
         this.updateTabindexes(() => ({ tabIndex: 0 }));
         super.unmanage();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "lib": ["es2017", "dom", "dom.iterable"],
         "module": "esNext",
         "moduleResolution": "node",
+        "noImplicitOverride": true,
         "noImplicitReturns": true,
         "noUnusedParameters": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
## Description

Require overrides to be specified via `override`.

## Related issue(s)

https://github.com/adobe/spectrum-web-components/pull/2326

## Motivation and context

This mitigates breaking dependency chains while refactoring.

## How has this been tested?

- Test suite should pass

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
