### PR TITLE
fix: prevent leaving multiple submenus open at a time

### DIFF
--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -47,11 +47,6 @@ function elementIsOrContains(
     return !!isOrContains && (el === isOrContains || el.contains(isOrContains));
 }
 
-/* c8 ignore next 3 */
-const noop = (): void => {
-    return;
-};
-
 /**
  * Spectrum Menu Component
  * @element sp-menu
@@ -70,43 +65,7 @@ export class Menu extends SpectrumElement {
         return [menuStyles];
     }
 
-    public get closeSelfAsSubmenu(): (leave?: boolean) => void {
-        this.isSubmenu = false;
-        return this._closeSelfAsSubmenu;
-    }
-
-    public setCloseSelfAsSubmenu(cb: (leave?: boolean) => void): void {
-        if (cb === this._closeSelfAsSubmenu) {
-            this.isSubmenu = false;
-            this._closeSelfAsSubmenu = noop;
-            return;
-        }
-        this.isSubmenu = true;
-        this._closeSelfAsSubmenu = cb;
-    }
-
-    _closeSelfAsSubmenu = noop;
-
     public isSubmenu = false;
-
-    public get closeOpenSubmenu(): (leave?: boolean) => void {
-        this.hasOpenSubmenu = false;
-        return this._closeOpenSubmenu;
-    }
-
-    public setCloseOpenSubmenu(cb: (leave?: boolean) => void): void {
-        if (cb === this._closeOpenSubmenu) {
-            this.hasOpenSubmenu = false;
-            this._closeOpenSubmenu = noop;
-            return;
-        }
-        this.hasOpenSubmenu = true;
-        this._closeOpenSubmenu = cb;
-    }
-
-    _closeOpenSubmenu = noop;
-
-    public hasOpenSubmenu = false;
 
     @property({ type: String, reflect: true })
     public label = '';
@@ -315,11 +274,6 @@ export class Menu extends SpectrumElement {
         }
     }
 
-    public submenuWillCloseOn(menuItem: MenuItem): void {
-        this.focusedItemIndex = this.childItems.indexOf(menuItem);
-        this.focusInItemIndex = this.focusedItemIndex;
-    }
-
     private onClick(event: Event): void {
         if (event.defaultPrevented) {
             return;
@@ -341,12 +295,6 @@ export class Menu extends SpectrumElement {
             event.preventDefault();
             if (target.hasSubmenu || target.open) {
                 return;
-            }
-            if (this.hasOpenSubmenu) {
-                this.closeOpenSubmenu();
-            }
-            if (this.isSubmenu) {
-                this.closeSelfAsSubmenu();
             }
             this.selectOrToggleItem(target);
         } else {
@@ -514,10 +462,10 @@ export class Menu extends SpectrumElement {
                 // Remove focus while opening overlay from keyboard or the visible focus
                 // will slip back to the first item in the menu.
                 this.blur();
-                lastFocusedItem.openOverlay({ immediate: true });
+                lastFocusedItem.openOverlay();
             }
-        } else if (this.isSubmenu && shouldCloseSelfAsSubmenu) {
-            this.closeSelfAsSubmenu(true);
+        } else if (shouldCloseSelfAsSubmenu && this.isSubmenu) {
+            this.dispatchEvent(new Event('close', { bubbles: true }));
         }
     }
 
@@ -533,7 +481,7 @@ export class Menu extends SpectrumElement {
                 // Remove focus while opening overlay from keyboard or the visible focus
                 // will slip back to the first item in the menu.
                 this.blur();
-                lastFocusedItem.openOverlay({ immediate: true });
+                lastFocusedItem.openOverlay();
                 return;
             }
         }

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -27,6 +27,7 @@ import type {
     ThemeVariant,
 } from '@spectrum-web-components/theme/src/Theme.js';
 import styles from './active-overlay.css.js';
+import { parentOverlayOf } from './overlay-utils.js';
 import {
     OverlayOpenCloseDetail,
     OverlayOpenDetail,
@@ -105,18 +106,6 @@ const stateTransition = (
     return stateMachine.states[state].on[event] || state;
 };
 
-const parentOverlayOf = (el: Element): ActiveOverlay | null => {
-    const closestOverlay = el.closest('active-overlay');
-    if (closestOverlay) {
-        return closestOverlay;
-    }
-    const rootNode = el.getRootNode() as ShadowRoot;
-    if (rootNode.host) {
-        return parentOverlayOf(rootNode.host);
-    }
-    return null;
-};
-
 const getFallbackPlacements = (
     placement: FloatingUIPlacement
 ): FloatingUIPlacement[] => {
@@ -146,6 +135,7 @@ export class ActiveOverlay extends SpectrumElement {
     public overlayContent!: HTMLElement;
     public overlayContentTip?: HTMLElement;
     public trigger!: HTMLElement;
+    public root?: HTMLElement;
     public virtualTrigger?: VirtualTrigger;
 
     protected childrenReady!: Promise<unknown[]>;
@@ -353,6 +343,7 @@ export class ActiveOverlay extends SpectrumElement {
         this.interaction = detail.interaction;
         this.theme = detail.theme;
         this.receivesFocus = detail.receivesFocus;
+        this.root = detail.root;
     }
 
     public dispose(): void {

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -33,6 +33,7 @@ export interface OverlayOpenDetail {
     receivesFocus?: 'auto';
     virtualTrigger?: VirtualTrigger;
     trigger: HTMLElement;
+    root?: HTMLElement;
     interaction: TriggerInteractions;
     theme: ThemeData;
     notImmediatelyClosable?: boolean;
@@ -61,6 +62,7 @@ export interface OverlayDisplayQueryDetail {
 export type Placement = FloatingUIPlacement | 'none';
 
 export type OverlayOptions = {
+    root?: HTMLElement;
     delayed?: boolean;
     placement?: Placement;
     offset?: number;

--- a/packages/overlay/src/overlay-utils.ts
+++ b/packages/overlay/src/overlay-utils.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import type { ActiveOverlay } from './ActiveOverlay';
+
+export const parentOverlayOf = (el?: Element): ActiveOverlay | null => {
+    if (!el) return null;
+    const closestOverlay = el.closest('active-overlay');
+    if (closestOverlay) {
+        return closestOverlay;
+    }
+    const rootNode = el.getRootNode() as ShadowRoot;
+    if (rootNode.host) {
+        return parentOverlayOf(rootNode.host);
+    }
+    return null;
+};
+
+export const findOverlaysRootedInOverlay = (
+    rootOverlay: ActiveOverlay | undefined,
+    activeOverlays: ActiveOverlay[]
+): ActiveOverlay[] => {
+    const overlays: ActiveOverlay[] = [];
+    if (!rootOverlay) return [];
+    for (const overlay of activeOverlays) {
+        if (!overlay.root) continue;
+        if (parentOverlayOf(overlay.root) === rootOverlay) {
+            overlays.push(overlay);
+            overlays.push(
+                ...findOverlaysRootedInOverlay(overlay, activeOverlays)
+            );
+        }
+    }
+    return overlays;
+};

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -97,6 +97,7 @@ export class Overlay {
         receivesFocus,
         notImmediatelyClosable,
         virtualTrigger,
+        root,
     }: OverlayOptions): Promise<boolean> {
         /* c8 ignore next */
         if (this.isOpen) return true;
@@ -140,6 +141,7 @@ export class Overlay {
             interaction: this.interaction,
             theme: queryThemeDetail,
             receivesFocus,
+            root,
             notImmediatelyClosable,
             virtualTrigger,
             ...overlayDetailQuery,


### PR DESCRIPTION
## Description
Rather than hack the Menu/Menu Item relationship to enforce open/close rules on a Menu with multiple submenus, add a `root` concept to the overlay stack that prevents multiple overlays from the same root, even if they have different triggers.
- prevent leaving things open
- prevent passing focus back to the "root"
- reduce code needed to manage submenus
- doesn't have a test for duplicate submenus being open because while I'm "certain ™️" that the issue comes from the way `setCloseSelfAsSubmenu` and `setCloseOpenSubmenu` were being used, I could never isolate a reproduction case to base a new test on
- [x] needs a test for closing super decedent submenus when changing two+ levels up

## Related issue(s)
- fixes #2197
- closes #2218 

## Motivation and context
Things should "just work" 😉 

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://submenu--spectrum-web-components.netlify.app/storybook/?path=/story/menu-submenu--submenu)
    2. Note: the menus open wonky by default.
    3. Mouse around in an attempt to break it and have a submenu not open or have more than one submenu for the same menu open or have sub-submenus not close, etc.
    4. Rejoice.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)