### PR TITLE
docs: try lazy loading the non-page content

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
         "typescript": "^4.7.2",
         "yargs": "^17.2.1"
     },
-    "customElements": ".storybook/custom-elements.json",
+    "customElements": "projects/documentation/custom-elements.json",
     "workspaces": [
         "packages/*",
         "projects/*",

--- a/projects/documentation/src/components.ts
+++ b/projects/documentation/src/components.ts
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import './router.js';
 import { Overlay } from '@spectrum-web-components/overlay';
-import '@spectrum-web-components/bundle/elements.js';
 import '@spectrum-web-components/tabs/sp-tab-panel.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
 import '@spectrum-web-components/tabs/sp-tabs.js';
@@ -34,6 +33,16 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-save-floppy.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-stopwatch.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-user-activity.js';
+
+if ('requestIdleCallback' in window) {
+    requestIdleCallback(
+        () => import('@spectrum-web-components/bundle/elements.js')
+    );
+} else {
+    requestAnimationFrame(
+        () => import('@spectrum-web-components/bundle/elements.js')
+    );
+}
 
 declare global {
     interface Window {


### PR DESCRIPTION
## Description
Lazily load the bundle package on component pages. Reduce blocking time by up to 50%:

Before: https://www.webpagetest.org/result/220601_AiDcCE_R4/
After: https://www.webpagetest.org/result/220601_AiDc98_R3/

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://lazy-docs--spectrum-web-components.netlify.app/components/action-button/)
    2. Confirm the pages loads the same as [this one](https://opensource.adobe.com/spectrum-web-components/components/action-button/) but faster...

## Types of changes
-   [x] Optimization

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
