### PR TITLE
docs: ensure that sp-dialog is given a valid "size" attribute

### DIFF
--- a/packages/overlay/overlay-trigger.md
+++ b/packages/overlay/overlay-trigger.md
@@ -98,7 +98,7 @@ This example only delivers content via the "click" interaction and leverages bot
 <overlay-trigger placement="top" type="replace">
     <sp-button slot="trigger">Overlay Trigger</sp-button>
     <sp-popover slot="click-content" open>
-        <sp-dialog size="small">
+        <sp-dialog size="s">
             <h2 slot="heading">Click content</h2>
             An &lt;overlay-trigger&gt; can be used to manage either or both of
             the "click" and "hover" content slots that are made available. Here,

--- a/packages/tray/README.md
+++ b/packages/tray/README.md
@@ -29,7 +29,7 @@ import { Tray } from '@spectrum-web-components/tray';
 <overlay-trigger type="modal" placement="none">
     <sp-button slot="trigger" variant="secondary">Toggle tray</sp-button>
     <sp-tray slot="click-content">
-        <sp-dialog size="small" dismissable>
+        <sp-dialog size="s" dismissable>
             <h2 slot="heading">New Messages</h2>
             You have 5 new messages.
         </sp-dialog>

--- a/packages/tray/test/benchmark/basic-test.ts
+++ b/packages/tray/test/benchmark/basic-test.ts
@@ -17,7 +17,7 @@ import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
     <sp-tray open>
-        <sp-dialog size="small">
+        <sp-dialog size="s">
             <h2 slot="heading">New Messages</h2>
             You have 5 new messages.
         </sp-dialog>

--- a/packages/underlay/README.md
+++ b/packages/underlay/README.md
@@ -55,7 +55,7 @@ When leveraging an `<sp-underlay>` in conjunction with overlay content, place it
 </sp-button>
 
 <sp-underlay></sp-underlay>
-<sp-dialog size="small">
+<sp-dialog size="s">
     <h1 slot="heading">Hello, I'm an overlay!</h1>
     <p>Enjoy your day...</p>
     <sp-button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Correct consumption of `<sp-dialog>` across documentation site.

## Related issue(s)

- fixes #2303

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://tray-docs--spectrum-web-components.netlify.app/components/tray/#dialog)
    2. Click "toggle tray"
    3. See that the dialog fills the width of the tray.

## Types of changes
-   [x] Docs update

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.