### PR TITLE
fix(badge): ensure built assets as publish time

### DIFF
--- a/tsconfig-all.json
+++ b/tsconfig-all.json
@@ -24,6 +24,7 @@
         { "path": "packages/asset" },
         { "path": "packages/avatar" },
         { "path": "packages/banner" },
+        { "path": "packages/badge" },
         { "path": "packages/base" },
         { "path": "packages/bundle" },
         { "path": "packages/button" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17134,7 +17134,7 @@ playwright-core@1.22.2:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.22.2.tgz#ed2963d79d71c2a18d5a6fd25b60b9f0a344661a"
   integrity sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==
 
-playwright@1.22.2, playwright@^1.14.0, playwright@^1.22.2:
+playwright@^1.14.0, playwright@^1.22.2:
   version "1.22.2"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.22.2.tgz#353a7c29f89ca9600edc7a9a30aed790823c797d"
   integrity sha512-hUTpg7LytIl3/O4t0AQJS1V6hWsaSY5uZ7w1oCC8r3a1AQN5d6otIdCkiB3cbzgQkcMaRxisinjMFMVqZkybdQ==


### PR DESCRIPTION
## Description
Badge was left out of the paster `tsconfig.json` and didn't get built before publication last week. This fixes that so we can make a new release.

refs #2162 

## How has this been tested?
-   [ ] _Test case 1_
    1. checkout branch
    2. `rm -rf packages`
    3. `yarn`
    4. see that `packages/badge/sp-badge.js` exists.
 
## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
