### PR TITLE
chore: create site-build UI in GitHub Actions; remove from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,33 +278,6 @@ jobs:
                   regression_scale: << parameters.scale >>
                   regression_dir: << parameters.dir >>
 
-    site-build:
-        executor: node
-
-        steps:
-            - downstream
-            - run:
-                  name: Generate Docs
-                  command: yarn docs:ci
-            - run: touch projects/documentation/dist/.nojekyll
-            - save_cache:
-                  name: Cache docs site
-                  paths:
-                      - projects/documentation/dist
-                  key: v1-docs-site-{{ .Revision }}
-
-    site-publish:
-        executor: node
-
-        steps:
-            - checkout
-            - restore_cache:
-                  name: Restore docs site cache
-                  keys:
-                      - v1-docs-site-{{ .Revision }}
-            - run: git config --global user.email "circleci@adobe.com" && git config --global user.name "CircleCI"
-            - run: npx gh-pages -d projects/documentation/dist -m "[skip ci] update demonstration site" -t
-
 workflows:
     version: 2
     commitlint:
@@ -337,15 +310,3 @@ workflows:
                       branches:
                           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                           ignore: /pull\/[0-9]+/
-            - site-build:
-                  filters:
-                      branches:
-                          only:
-                              - main
-            - site-approve:
-                  type: approval
-                  requires:
-                      - site-build
-            - site-publish:
-                  requires:
-                      - site-approve

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Site publish
+
+on:
+    check_suite:
+        types: [completed]
+    workflow_dispatch:
+jobs:
+    site-build:
+        name: Build & publish site
+        runs-on: ubuntu-latest
+        # Run the job if manually triggered or if the commit message includes '#publish' & the check suite has passed
+        if: github.event_name == "workflow_dispatch" || (contains(github.event.head_commit.message, '#publish') && github.event.check_suite.conclusion == "success")
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: '16'
+                  cache: 'yarn'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Install dependencies
+              run: yarn --frozen-lockfile
+
+            - name: Generate Docs
+              run: yarn docs:ci
+
+            - name: Deploy to GitHub Pages
+              run: |
+                  git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+                  touch projects/documentation/dist/.nojekyll
+                  npx gh-pages -d projects/documentation/dist -m "[skip ci] update demonstration site" -t -u "github-actions-bot <support+actions@github.com>"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,22 +1,28 @@
-# Releasing a new version of SWC
+# Releasing a new version of Spectrum Web Components
 
-Users with permissions against the `@spectrum-web-components` organization on NPM can follow the following steps to create and publish a new version of the SWC library.
+Users with permissions in the `@spectrum-web-components` organization on NPM can follow the following steps to create and publish a new version.
 
-1. merge outstanding PRs and wait for `main` show that it has completed the required CI jobs
-2. `git checkout main`
-3. `git pull`
-4. `rm -rf node_modules packages projects tools`
-5. `git checkout packages`
-6. `git checkout projects`
-7. `git checkout tools`
-8. `yarn`
-9. `npm whoami` ensure that you are logged in with the user account for the public NPM registry
-10. `yarn lerna-publish`
-11. scan the version summary for any unexpected changes
+1. Merge all pull requests to be included in the release and wait for the `main` branch to show that it has completed the required CI jobs.
+2. `git checkout main && git fetch && git pull && git clean -dfX`
+3. `rm -rf node_modules packages projects tools`
+4. `git checkout packages projects tools`
+5. `yarn install`
+6. `npm whoami` ensure that you are logged in with the user account for the public NPM registry
+7. `yarn lerna-publish`
+8. Scan the version summary for any unexpected changes.
+    - Changes to the _major_ versions number are likely to point to undesired version numbers.
+    - Changes to the _minor_ or _feature_ version number should be confirmed as correct against the changes that have been made since the last release.
+9. `Y` to confirm.
+10. Enter 2-factor authentication for npm.
 
--   changes to the _major_ versions number are likely to point to undesired version numbers
--   changes to the _minor_ or _feature_ version number should be confirmed as correct against the changes that have been made since the last release
+The docs site will publish automatically if the `#publish` string is included in the commit message and the check suite runs successfully.
 
-12. `Y` to confirm
-13. enter npm’s 2-factor auth
-14. Go to [CircleCI](https://app.circleci.com/pipelines/github/adobe) and once the commit to `main` with the new versions is ready, press the 👍🏼 button on the "site-approve" job to publish a new version of the documentation site
+## Publishing the docs site manually
+
+Navigate to SWC's [Actions](https://github.com/adobe/spectrum-web-components/actions) and click the `Build & publish site` link under the _Workflows_ heading.
+
+At the top of the table you will see a `Run workflow` dropdown; click that and run it from the `main` branch.
+
+[Running manual workflows](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow), GitHub documentation
+
+If you have the [GitHub CLI](https://cli.github.com) installed, you can alternatively run `gh workflow run publish.yml --ref main` from the command line.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "icons": "node ./scripts/process-icons.js && pretty-quick --pattern \"packages/**/*.svg.ts\" && eslint -f pretty --fix \"packages/**/*.svg.ts\"",
         "icons:ui": "yarn workspace @spectrum-web-components/icons-ui build",
         "icons:workflow": "yarn workspace @spectrum-web-components/icons-workflow build",
-        "lerna-publish": "lerna publish --message \"chore: release new versions\"",
+        "lerna-publish": "lerna publish --message \"chore: release new versions #publish\"",
         "lint": "run-p lint:js lint:docs lint:ts lint:css lint:packagejson",
         "lint:css": "stylelint \"packages/**/*.css\"",
         "lint:docs": "eslint -f pretty \"projects/documentation/**/*.ts\"",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR creates a workflow_dispatch trigger for the site deploy commands. This allows the site to be deployed manually via the GitHub Actions UI.

## Motivation and context

CircleCI shows a failed status on most builds on the main branch because the approval to build the site is only "passed" on release branches.  This approach will clean up the status reporting for the main branch, making it easier to identify true failures.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _gh workflow run publish.yml --ref chore-ci-build-site-on-release_
    - [docs](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-using-github-cli)

Note: Cannot be run from the UI until the workflow exists on main.  Once on main you can use the UI or use gh cli or trigger it using a REST API call.

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
