### PR TITLE
fix: prevent Dialog Wrapper from dispatching two "close" events

### DIFF
--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -177,8 +177,8 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
         );
     }
 
-    protected handleUnderlayTransitionend(): void {
-        if (!this.open) {
+    protected handleUnderlayTransitionend(event: TransitionEvent): void {
+        if (!this.open && event.propertyName === 'visibility') {
             this.dispatchClosed();
             this.resolveTransitionPromise();
         }

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -10,7 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { elementUpdated, expect, fixture, oneEvent } from '@open-wc/testing';
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    nextFrame,
+    oneEvent,
+} from '@open-wc/testing';
 import { spy } from 'sinon';
 
 import '@spectrum-web-components/theme/sp-theme.js';
@@ -74,8 +80,10 @@ describe('Dialog Wrapper', () => {
         await expect(el).to.be.accessible();
     });
     it('opens and closes', async () => {
+        const closeSpy = spy();
         const test = await styledFixture<OverlayTrigger>(longContent());
         const el = test.querySelector('sp-dialog-wrapper') as DialogWrapper;
+        el.addEventListener('close', () => closeSpy());
 
         await elementUpdated(el);
 
@@ -88,8 +96,10 @@ describe('Dialog Wrapper', () => {
         const closed = oneEvent(test, 'sp-closed');
         test.open = undefined;
         await closed;
+        await nextFrame();
 
         expect(el.open).to.be.false;
+        expect(closeSpy.callCount).to.equal(1);
     });
     it('dismisses via clicking the underlay when [dismissable]', async () => {
         const test = await styledFixture<DialogWrapper>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use a specific transition property to trigger the `close` event so that it doesn't trigger multiple times.

## Related issue(s)
- fixes #2346

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://dialog-close--spectrum-web-components.netlify.app/components/dialog-wrapper/#small)
    2. Open a dialog
    3. Bind an event lister to `close` with a console log
    4. Close the dialog
    5. See that it logs only once

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.