### PR TITLE
Stabilize HCM VRT passes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 9a12a736327f5b787dd2f0375bbc0d592b72b99b
+        default: 0ac87af585f42cc90822a934834c0a51edf9645c
 commands:
     downstream:
         steps:

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -40,7 +40,11 @@ textarea {
 
 .input {
     min-width: var(--spectrum-textfield-texticon-min-width);
+}
+
+:host([focused]) .input {
     caret-color: var(--swc-test-caret-color);
+    forced-color-adjust: var(--swc-test-forced-color-adjust);
 }
 
 :host([grows]) .input {

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -14,6 +14,7 @@ import {
     css,
     html,
     nothing,
+    PropertyValues,
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -131,7 +132,6 @@ export class StoryDecorator extends SpectrumElement {
                 }
                 :host([screenshot]) sp-theme {
                     padding: var(--spectrum-global-dimension-size-100);
-                    --swc-test-caret-color: transparent;
                 }
                 :host([reduce-motion]) sp-theme {
                     ${reduceMotionProperties}
@@ -384,5 +384,20 @@ export class StoryDecorator extends SpectrumElement {
                 Reduce Motion
             </sp-switch>
         `;
+    }
+
+    protected override willUpdate(changes: PropertyValues<this>): void {
+        if (changes.has('screenshot') && this.screenshot) {
+            Theme.registerThemeFragment(
+                'app',
+                'app',
+                css`
+                    :host {
+                        --swc-test-caret-color: transparent;
+                        --swc-test-forced-color-adjust: none;
+                    }
+                `
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description
HCM doesn't allow you to `caret-color: transparent`, which means that the blinking carat can cause issues in VRTs. This works around it by making all focused Text Fields appear without `forced-color-adjust` so that we can hide the caret as expected in that context. It's a bit of a hack, but it allows us to have stable VRTs in HCM and the values that go changed in that context are tested in non-focused Text Fields to balance it out.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://c2935d10de0a6e2731722869d4d51953--spectrum-web-components.netlify.app/review/#SearchStories/autofocus.png)
    2. Review the contexts where the delivery of the Text Field is updated in the VRT pass.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)