### PR TITLE
Ensure the Picker label is managed by its Menu Item children

### DIFF
--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -44,6 +44,7 @@
         "lit-html"
     ],
     "dependencies": {
+        "@lit-labs/observers": "^1.0.1",
         "@spectrum-web-components/action-button": "^0.8.6",
         "@spectrum-web-components/base": "^0.5.7",
         "@spectrum-web-components/reactive-controllers": "^0.2.4",

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -61,7 +61,6 @@ export class ActionGroup extends SpectrumElement {
             },
             callback: () => {
                 this.manageButtons();
-                return true;
             },
         });
     }

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -20,6 +20,7 @@ import {
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import type { ActionButton } from '@spectrum-web-components/action-button';
 import { RovingTabindexController } from '@spectrum-web-components/reactive-controllers/src/RovingTabindex.js';
+import { MutationController } from '@lit-labs/observers/mutation_controller.js';
 
 import styles from './action-group.css.js';
 
@@ -49,6 +50,21 @@ export class ActionGroup extends SpectrumElement {
     public _buttons: ActionButton[] = [];
 
     protected _buttonSelector = 'sp-action-button';
+
+    constructor() {
+        super();
+
+        new MutationController(this, {
+            config: {
+                childList: true,
+                subtree: true,
+            },
+            callback: () => {
+                this.manageButtons();
+                return true;
+            },
+        });
+    }
 
     rovingTabindexController = new RovingTabindexController<ActionButton>(
         this,
@@ -354,20 +370,4 @@ export class ActionGroup extends SpectrumElement {
         this.manageChildren();
         this.manageSelects();
     };
-
-    public override connectedCallback(): void {
-        super.connectedCallback();
-        if (!this.observer) {
-            this.observer = new MutationObserver(this.manageButtons);
-            this.manageButtons();
-        }
-        this.observer.observe(this, { childList: true, subtree: true });
-    }
-
-    public override disconnectedCallback(): void {
-        this.observer.disconnect();
-        super.disconnectedCallback();
-    }
-
-    private observer!: MutationObserver;
 }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -50,6 +50,7 @@
         "lit-html"
     ],
     "dependencies": {
+        "@lit-labs/observers": "^1.0.1",
         "@spectrum-web-components/action-button": "^0.8.6",
         "@spectrum-web-components/base": "^0.5.7",
         "@spectrum-web-components/divider": "^0.4.9",

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -217,9 +217,8 @@ export class MenuItem extends LikeAnchor(Focusable) {
                 childList: true,
                 subtree: true,
             },
-            callback: (): boolean => {
+            callback: () => {
                 this.breakItemChildrenCache();
-                return true;
             },
         });
     }

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -33,6 +33,7 @@ import checkmarkStyles from '@spectrum-web-components/icon/src/spectrum-icon-che
 import type { Menu } from './Menu.js';
 import type { OverlayOpenCloseDetail } from '@spectrum-web-components/overlay';
 import { reparentChildren } from '@spectrum-web-components/shared/src/reparent-children.js';
+import { MutationController } from '@lit-labs/observers/mutation_controller.js';
 
 /**
  * Duration during which a pointing device can leave an `<sp-menu-item>` element
@@ -209,6 +210,18 @@ export class MenuItem extends LikeAnchor(Focusable) {
         this.addEventListener('click', this.handleClickCapture, {
             capture: true,
         });
+
+        new MutationController(this, {
+            config: {
+                characterData: true,
+                childList: true,
+                subtree: true,
+            },
+            callback: (): boolean => {
+                this.breakItemChildrenCache();
+                return true;
+            },
+        });
     }
 
     @property({ type: Boolean })
@@ -255,12 +268,9 @@ export class MenuItem extends LikeAnchor(Focusable) {
 
     protected override render(): TemplateResult {
         return html`
-            <slot name="icon" @slotchange=${this.breakItemChildrenCache}></slot>
+            <slot name="icon"></slot>
             <div id="label">
-                <slot
-                    id="slot"
-                    @slotchange=${this.breakItemChildrenCache}
-                ></slot>
+                <slot id="slot"></slot>
             </div>
             <slot name="value"></slot>
             ${this.selected

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -114,14 +114,20 @@ export function runPickerTests(): void {
             expect((el.button.textContent || '').trim()).to.equal(
                 'Select Inverse'
             );
-            const itemUpdated = oneEvent(el, 'sp-menu-item-added-or-updated');
-            option2.innerHTML = 'Invert Selection';
+            let itemUpdated = oneEvent(el, 'sp-menu-item-added-or-updated');
+            const newLabel1 = 'Invert Selection';
+            option2.innerHTML = newLabel1;
             await itemUpdated;
             await elementUpdated(el);
             expect(el.value).to.equal('option-2');
-            expect((el.button.textContent || '').trim()).to.equal(
-                'Invert Selection'
-            );
+            expect((el.button.textContent || '').trim()).to.equal(newLabel1);
+            itemUpdated = oneEvent(el, 'sp-menu-item-added-or-updated');
+            const newLabel2 = 'Other option';
+            option2.childNodes[0].textContent = newLabel2;
+            await itemUpdated;
+            await elementUpdated(el);
+            expect(el.value).to.equal('option-2');
+            expect((el.button.textContent || '').trim()).to.equal(newLabel2);
         });
         it('accepts new selected item content when open', async () => {
             const option2 = el.querySelector('[value="option-2"') as MenuItem;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,6 +42,7 @@
         "lit-html"
     ],
     "dependencies": {
+        "@lit-labs/observers": "^1.0.1",
         "@spectrum-web-components/base": "^0.5.7",
         "focus-visible": "^5.1.0",
         "tslib": "^2.0.0"

--- a/packages/shared/src/observe-slot-presence.ts
+++ b/packages/shared/src/observe-slot-presence.ts
@@ -47,7 +47,6 @@ export function ObserveSlotPresence<T extends Constructor<ReactiveElement>>(
                 },
                 callback: () => {
                     this.managePresenceObservedSlot();
-                    return true;
                 },
             });
 

--- a/packages/shared/src/observe-slot-text.ts
+++ b/packages/shared/src/observe-slot-text.ts
@@ -14,11 +14,9 @@ import {
     property,
     queryAssignedNodes,
 } from '@spectrum-web-components/base/src/decorators.js';
+import { MutationController } from '@lit-labs/observers/mutation_controller.js';
 
-const slotElementObserver = Symbol('slotElementObserver');
-// Fix needed for: https://github.com/lit/lit/issues/1789
 const assignedNodesList = Symbol('assignedNodes');
-const startObserving = Symbol('startObserving');
 
 type Constructor<T = Record<string, unknown>> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,7 +37,25 @@ export function ObserveSlotText<T extends Constructor<ReactiveElement>>(
         extends constructor
         implements SlotTextObservingInterface
     {
-        private [slotElementObserver]!: MutationObserver;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(args);
+
+            new MutationController(this, {
+                config: {
+                    characterData: true,
+                    subtree: true,
+                },
+                callback: (mutationsList: Array<MutationRecord>): boolean => {
+                    for (const mutation of mutationsList) {
+                        if (mutation.type === 'characterData') {
+                            this.manageTextObservedSlot();
+                        }
+                    }
+                    return true;
+                },
+            });
+        }
 
         @property({ type: Boolean, attribute: false })
         public slotHasContent = false;
@@ -65,35 +81,6 @@ export function ObserveSlotText<T extends Constructor<ReactiveElement>>(
         ): void {
             super.firstUpdated(changedProperties);
             this.manageTextObservedSlot();
-        }
-
-        private [startObserving](): void {
-            const config = { characterData: true, subtree: true };
-            if (!this[slotElementObserver]) {
-                const callback = (
-                    mutationsList: Array<MutationRecord>
-                ): void => {
-                    for (const mutation of mutationsList) {
-                        if (mutation.type === 'characterData') {
-                            this.manageTextObservedSlot();
-                        }
-                    }
-                };
-                this[slotElementObserver] = new MutationObserver(callback);
-            }
-            this[slotElementObserver].observe(this, config);
-        }
-
-        public override connectedCallback(): void {
-            super.connectedCallback();
-            this[startObserving]();
-        }
-
-        public override disconnectedCallback(): void {
-            if (this[slotElementObserver]) {
-                this[slotElementObserver].disconnect();
-            }
-            super.disconnectedCallback();
         }
     }
     return SlotTextObservingElement;

--- a/packages/shared/src/observe-slot-text.ts
+++ b/packages/shared/src/observe-slot-text.ts
@@ -46,13 +46,13 @@ export function ObserveSlotText<T extends Constructor<ReactiveElement>>(
                     characterData: true,
                     subtree: true,
                 },
-                callback: (mutationsList: Array<MutationRecord>): boolean => {
+                callback: (mutationsList: Array<MutationRecord>) => {
                     for (const mutation of mutationsList) {
                         if (mutation.type === 'characterData') {
                             this.manageTextObservedSlot();
+                            return;
                         }
                     }
-                    return true;
                 },
             });
         }

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -49,6 +49,7 @@
     ],
     "dependencies": {
         "@internationalized/number": "^3.1.0",
+        "@lit-labs/observers": "^1.0.1",
         "@spectrum-web-components/base": "^0.5.7",
         "@spectrum-web-components/field-label": "^0.7.11",
         "@spectrum-web-components/number-field": "^0.3.12",

--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -79,7 +79,6 @@ export class HandleController implements Controller {
             },
             callback: () => {
                 this.extractModelFromLightDom();
-                return true;
             },
         });
 

--- a/packages/theme/src/Theme.ts
+++ b/packages/theme/src/Theme.ts
@@ -105,8 +105,9 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
         if (dir === this.dir) return;
         this.setAttribute('dir', dir);
         this._dir = dir;
+        const targetDir = dir === 'rtl' ? dir : 'ltr';
         this.trackedChildren.forEach((el) => {
-            el.setAttribute('dir', dir === 'rtl' ? dir : 'ltr');
+            el.setAttribute('dir', targetDir);
         });
     }
 


### PR DESCRIPTION
## Description
Update Menu Item to leverage a Mutation Observer as opposed to `slotchange` events when updating its content to work around https://github.com/lit/lit/issues/2629
- apply Mutation Observe with mutation controller
- update other usages of Mutation Observer to leverage mutation controller

## Related issue(s)

- fixes #2158

## Motivation and context
Components should "just work ™️" regardless of the tools you leverage them in.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://picker-label--spectrum-web-components.netlify.app/components/picker/#matching-value)
    2. Find the `sp-menu-item` element in the inspector with "Select inverse" as its text content
    3. Select the *Text Node* that represents that content
    4. In the console use `$0.textContent = 'Something else'` to update the active label of the Picker
    5. See that the "label" is updated
    6. Open the Picker and do the above using another text value
    7. See that the "label" is updated

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.