### PR TITLE
Address various warnings raised in Lit Dev Mode.

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -81,11 +81,11 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
         `;
     }
 
-    protected override updated(changedProperties: PropertyValues): void {
-        super.updated(changedProperties);
+    protected override update(changedProperties: PropertyValues<this>): void {
         if (changedProperties.has('invalid')) {
             this.invalid = false;
         }
         this.quiet = true;
+        super.update(changedProperties);
     }
 }

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -530,10 +530,10 @@ export class ColorArea extends SpectrumElement {
     protected override updated(changed: PropertyValues): void {
         super.updated(changed);
         if (this.x !== this.inputX.valueAsNumber) {
-            this.x = this.inputX.valueAsNumber;
+            this._x = this.inputX.valueAsNumber;
         }
         if (this.y !== this.inputY.valueAsNumber) {
-            this.y = this.inputY.valueAsNumber;
+            this._y = this.inputY.valueAsNumber;
         }
         if (changed.has('focused') && this.focused) {
             // Lazily bind the `input[type="range"]` elements in shadow roots

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -572,9 +572,12 @@ export class NumberField extends TextfieldBase {
         super.update(changes);
     }
 
+    public override willUpdate(): void {
+        this.multiline = false;
+    }
+
     protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
-        this.multiline = false;
         this.addEventListener('keydown', this.handleKeydown);
     }
 

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -13,7 +13,6 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
-    PropertyValues,
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -264,10 +263,8 @@ export class ActiveOverlay extends SpectrumElement {
         return undefined;
     }
 
-    public override async firstUpdated(
-        changedProperties: PropertyValues
-    ): Promise<void> {
-        super.firstUpdated(changedProperties);
+    public override async willUpdate(): Promise<void> {
+        if (this.hasUpdated) return;
 
         /* c8 ignore next */
         if (!this.overlayContent || !this.trigger) return;

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -438,6 +438,25 @@ export class PickerBase extends SizedMixin(Focusable) {
             // TODO: Add support functionally and visually for "multiple"
             this.selects = 'single';
         }
+        if (changes.has('disabled') && this.disabled) {
+            this.open = false;
+        }
+        if (
+            changes.has('open') &&
+            (this.open || typeof changes.get('open') !== 'undefined')
+        ) {
+            this.menuStatePromise = new Promise(
+                (res) => (this.menuStateResolver = res)
+            );
+            if (this.open) {
+                this.openMenu();
+            } else {
+                this.closeMenu();
+            }
+        }
+        if (changes.has('value') && !changes.has('selectedItem')) {
+            this.updateMenuItems();
+        }
         super.update(changes);
     }
 
@@ -527,32 +546,6 @@ export class PickerBase extends SizedMixin(Focusable) {
             resolve();
             this._willUpdateItems = false;
         });
-    }
-
-    protected override updated(changedProperties: PropertyValues): void {
-        super.updated(changedProperties);
-        if (changedProperties.has('disabled') && this.disabled) {
-            this.open = false;
-        }
-        if (
-            changedProperties.has('open') &&
-            (this.open || typeof changedProperties.get('open') !== 'undefined')
-        ) {
-            this.menuStatePromise = new Promise(
-                (res) => (this.menuStateResolver = res)
-            );
-            if (this.open) {
-                this.openMenu();
-            } else {
-                this.closeMenu();
-            }
-        }
-        if (
-            changedProperties.has('value') &&
-            !changedProperties.has('selectedItem')
-        ) {
-            this.updateMenuItems();
-        }
     }
 
     protected async manageSelection(): Promise<void> {

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -131,8 +131,7 @@ export class Search extends Textfield {
         this.inputElement.setAttribute('type', 'search');
     }
 
-    public override updated(changedProperties: PropertyValues): void {
-        super.updated(changedProperties);
+    public override willUpdate(): void {
         this.multiline = false;
     }
 }

--- a/packages/shared/src/observe-slot-presence.ts
+++ b/packages/shared/src/observe-slot-presence.ts
@@ -80,13 +80,18 @@ export function ObserveSlotPresence<T extends Constructor<ReactiveElement>>(
         }
 
         public managePresenceObservedSlot = (): void => {
+            let changes = false;
             lightDomSelectors.forEach((selector) => {
+                const nextValue = !!this.querySelector(selector);
+                const previousValue =
+                    this[slotContentIsPresent].get(selector) || false;
+                changes = changes || previousValue !== nextValue;
                 this[slotContentIsPresent].set(
                     selector,
                     !!this.querySelector(selector)
                 );
             });
-            this.requestUpdate();
+            if (changes) this.requestUpdate();
         };
     }
     return SlotPresenceObservingElement;

--- a/packages/shared/src/observe-slot-text.ts
+++ b/packages/shared/src/observe-slot-text.ts
@@ -82,7 +82,7 @@ export function ObserveSlotText<T extends Constructor<ReactiveElement>>(
                 const textNodes = [...childNodes].filter((node) => {
                     if ((node as HTMLElement).tagName) {
                         return slotName
-                            ? (node as HTMLElement).getAttribute('slot') !==
+                            ? (node as HTMLElement).getAttribute('slot') ===
                                   slotName
                             : !(node as HTMLElement).hasAttribute('slot');
                     }

--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -131,19 +131,16 @@ export class SliderHandle extends Focusable {
         if (changes.has('formatOptions') || changes.has('resolvedLanguage')) {
             delete this._numberFormatCache;
         }
-        super.update(changes);
-    }
-
-    protected override updated(changedProperties: PropertyValues<this>): void {
-        if (changedProperties.has('value')) {
-            const oldValue = changedProperties.get('value');
+        if (changes.has('value')) {
+            const oldValue = changes.get('value');
             if (oldValue != null) {
-                this.handleController /* c8 ignore next */
-                    ?.setValueFromHandle(this);
+                this.updateComplete.then(() => {
+                    this.handleController?.setValueFromHandle(this);
+                });
             }
         }
         this.handleController?.handleHasChanged(this);
-        super.updated(changedProperties);
+        super.update(changes);
     }
 
     protected override firstUpdated(

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -121,6 +121,9 @@ export class SplitButton extends SizedMixin(PickerBase) {
                 this.selects = 'single';
             }
         }
+        if (changes.has('value')) {
+            this.manageSplitButtonItems();
+        }
         super.update(changes);
     }
 
@@ -177,13 +180,6 @@ export class SplitButton extends SizedMixin(PickerBase) {
         return html`
             ${buttons}
         `;
-    }
-
-    protected override updated(changedProperties: PropertyValues): void {
-        super.updated(changedProperties);
-        if (changedProperties.has('value')) {
-            this.manageSplitButtonItems();
-        }
     }
 
     protected override async manageSelection(): Promise<void> {

--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -408,14 +408,8 @@ export class SplitView extends SpectrumElement {
         this.dispatchEvent(changeEvent);
     }
 
-    protected override firstUpdated(changed: PropertyValues): void {
-        super.firstUpdated(changed);
-        this.checkResize();
-    }
-
-    protected override updated(changed: PropertyValues): void {
-        super.updated(changed);
-        if (changed.has('primarySize')) {
+    protected override willUpdate(changed: PropertyValues): void {
+        if (!this.hasUpdated || changed.has('primarySize')) {
             this.splitterPos = undefined;
             this.checkResize();
         }

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -189,15 +189,16 @@ export class Tabs extends SizedMixin(Focusable) {
         `;
     }
 
-    protected override firstUpdated(changes: PropertyValues): void {
-        super.firstUpdated(changes);
-        const selectedChild = this.querySelector(':scope > [selected]') as Tab;
-        if (selectedChild) {
-            this.selectTarget(selectedChild);
+    protected override willUpdate(changes: PropertyValues): void {
+        if (!this.hasUpdated) {
+            const selectedChild = this.querySelector(
+                ':scope > [selected]'
+            ) as Tab;
+            if (selectedChild) {
+                this.selectTarget(selectedChild);
+            }
         }
-    }
 
-    protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
         if (changes.has('selected')) {
             if (changes.get('selected')) {

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -293,13 +293,16 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
         `;
     }
 
-    protected override updated(changedProperties: PropertyValues): void {
+    protected override update(changedProperties: PropertyValues): void {
         if (
             changedProperties.has('value') ||
             (changedProperties.has('required') && this.required)
         ) {
-            this.checkValidity();
+            this.updateComplete.then(() => {
+                this.checkValidity();
+            });
         }
+        super.update(changedProperties);
     }
 
     public checkValidity(): boolean {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13961,7 +13961,7 @@ lit-analyzer@^1.2.1:
     vscode-html-languageservice "3.1.0"
     web-component-analyzer "~1.1.1"
 
-lit-element@^3.2.0:
+lit-element@^3.1.0, lit-element@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.2.0.tgz#9c981c55dfd9a8f124dc863edb62cc529d434db7"
   integrity sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==
@@ -13969,14 +13969,14 @@ lit-element@^3.2.0:
     "@lit/reactive-element" "^1.3.0"
     lit-html "^2.2.0"
 
-lit-html@^2.0.0, lit-html@^2.2.0:
+lit-html@^2.0.0, lit-html@^2.1.0, lit-html@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.2.0.tgz#99345d944611e34543cd9f153d8cc3163b8bbab8"
   integrity sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit@^2.0.0, lit@^2.0.2, lit@^2.1.2:
+lit@2.2.6, lit@^2.0.0, lit@^2.0.2, lit@^2.1.2:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/lit/-/lit-2.2.6.tgz#4ef223e88517c000b0c01baf2e3535e61a75a5b5"
   integrity sha512-K2vkeGABfSJSfkhqHy86ujchJs3NR9nW1bEEiV+bXDkbiQ60Tv5GUausYN2mXigZn8lC1qXuc46ArQRKYmumZw==


### PR DESCRIPTION
## Description
- general: clean up multiple `lit-html` usage in local tooling
- shared: move initial Observer Slot Text work into `update`, as a mixin having it there will ensure calls to `super` as the same is required by `LitElement`
- color-area: use private properties when validating state from form elements in the UI so there's not additional render required
- use `willUpdate`
  - Tabs
  - Active Overlay
  - Split View
  - Radio Group
  - Number Field
  - Search
- Update Benchmarking to register perf only once there are no additional renders queued
- use `update`
  - Picker
  - Action Menu
  - Split Button
  - Slider Handle
  - Textfield
- Track changes in Observe Slot Presence

## Related issue(s)
- refs #2257 

## Motivation and context
Clearing out upstream warnings make room for #2308 

## How has this been tested?

-   [ ] _Test case 1_
    1. Everything works as it did before... 😏 

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)