### PR TITLE
Use Close Button in Dialog pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 0ac87af585f42cc90822a934834c0a51edf9645c
+        default: f1877d099d71f5e8dc74371cc43d88d86571262c
 commands:
     downstream:
         steps:

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -46,13 +46,10 @@
         "lit-html"
     ],
     "dependencies": {
-        "@spectrum-web-components/action-button": "^0.8.6",
         "@spectrum-web-components/base": "^0.5.7",
         "@spectrum-web-components/button": "^0.17.6",
         "@spectrum-web-components/button-group": "^0.8.9",
         "@spectrum-web-components/divider": "^0.4.9",
-        "@spectrum-web-components/icon": "^0.11.9",
-        "@spectrum-web-components/icons-ui": "^0.8.9",
         "@spectrum-web-components/icons-workflow": "^0.8.9",
         "@spectrum-web-components/modal": "^0.6.7",
         "@spectrum-web-components/shared": "^0.14.2",

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -25,10 +25,8 @@ import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import { conditionAttributeWithId } from '@spectrum-web-components/base/src/condition-attribute-with-id.js';
 
 import '@spectrum-web-components/divider/sp-divider.js';
-import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/button/sp-close-button.js';
 import '@spectrum-web-components/button-group/sp-button-group.js';
-import crossStyles from '@spectrum-web-components/icon/src/spectrum-icon-cross.css.js';
-import '@spectrum-web-components/icons-ui/icons/sp-icon-cross500.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import {
     FocusVisiblePolyfillMixin,
@@ -36,7 +34,7 @@ import {
 } from '@spectrum-web-components/shared';
 
 import styles from './dialog.css.js';
-import type { ActionButton } from '@spectrum-web-components/action-button';
+import type { CloseButton } from '@spectrum-web-components/button';
 
 function gatherAppliedIdsFromSlottedChildren(
     slot: HTMLSlotElement,
@@ -74,11 +72,11 @@ export class Dialog extends FocusVisiblePolyfillMixin(
     ])
 ) {
     public static override get styles(): CSSResultArray {
-        return [styles, crossStyles];
+        return [styles];
     }
 
     @query('.close-button')
-    closeButton?: ActionButton;
+    closeButton?: CloseButton;
 
     @query('.content')
     private contentElement!: HTMLDivElement;
@@ -162,18 +160,13 @@ export class Dialog extends FocusVisiblePolyfillMixin(
                     : html``}
                 ${this.dismissable
                     ? html`
-                          <sp-action-button
+                          <sp-close-button
                               class="close-button"
                               label="Close"
                               quiet
                               size="m"
                               @click=${this.close}
-                          >
-                              <sp-icon-cross500
-                                  class="spectrum-UIIcon-Cross500"
-                                  slot="icon"
-                              ></sp-icon-cross500>
-                          </sp-action-button>
+                          ></sp-close-button>
                       `
                     : html``}
             </div>


### PR DESCRIPTION
## Description
Update the close UI in `sp-dialog` to leverage am `sp-close-button` element instead of an `sp-action-button` with custom icon.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://42ba5b12c6c1ecbd84d280bc613b2aaa--spectrum-web-components.netlify.app/review/#DialogWrapperStories/wrapperDismissableUnderlayError.png)
    2. See how this changed the delivery.

## Types of changes
-   [x]  Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)