### PR TITLE
fix: ensure that entering an ancestor Menu Item without a submenu closes related submenus

### DIFF
--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -767,6 +767,65 @@ describe('Submenu', () => {
         expect(activeOverlays.length).to.equal(0);
     });
 
+    it('closes decendent menus when Menu Item in ancestor without a submenu is pointerentered', async () => {
+        const el = await styledFixture<ActionMenu>(html`
+            <sp-action-menu>
+                <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
+                <sp-menu-group role="none">
+                    <span slot="header">New York</span>
+                    <sp-menu-item id="no-submenu">Bronx</sp-menu-item>
+                    <sp-menu-item id="submenu-item-1">
+                        Brooklyn
+                        <sp-menu slot="submenu">
+                            <sp-menu-item id="submenu-item-2">
+                                Ft. Greene
+                            </sp-menu-item>
+                            <sp-menu-item disabled>Park Slope</sp-menu-item>
+                            <sp-menu-item id="ancestor-item">
+                                Williamsburg
+                            </sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                    <sp-menu-item id="submenu-item-3">
+                        Manhattan
+                        <sp-menu slot="submenu">
+                            <sp-menu-item disabled>SoHo</sp-menu-item>
+                            <sp-menu-item>Union Square</sp-menu-item>
+                            <sp-menu-item>Upper East Side</sp-menu-item>
+                        </sp-menu>
+                    </sp-menu-item>
+                </sp-menu-group>
+            </sp-action-menu>
+        `);
+
+        const rootMenu = el.querySelector('#submenu-item-1') as MenuItem;
+        const noSubmenu = el.querySelector('#no-submenu') as MenuItem;
+
+        expect(el.open).to.be.false;
+        let opened = oneEvent(el, 'sp-opened');
+        el.click();
+        await opened;
+        expect(el.open).to.be.true;
+
+        let activeOverlays = document.querySelectorAll('active-overlay');
+        expect(activeOverlays.length).to.equal(1);
+        opened = oneEvent(rootMenu, 'sp-opened');
+        rootMenu.dispatchEvent(
+            new PointerEvent('pointerenter', { bubbles: true })
+        );
+        await opened;
+        activeOverlays = document.querySelectorAll('active-overlay');
+        expect(activeOverlays.length).to.equal(2);
+
+        const closed = oneEvent(rootMenu, 'sp-closed');
+        noSubmenu.dispatchEvent(
+            new PointerEvent('pointerenter', { bubbles: true })
+        );
+        await closed;
+        activeOverlays = document.querySelectorAll('active-overlay');
+        expect(activeOverlays.length).to.equal(1);
+    });
+
     it('closes decendent menus when Menu Item in ancestor is clicked', async () => {
         const el = await styledFixture<ActionMenu>(html`
             <sp-action-menu>

--- a/packages/overlay/src/overlay-events.ts
+++ b/packages/overlay/src/overlay-events.ts
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export class OverlayCloseEvent extends Event {
+    root?: HTMLElement;
+    constructor({ root }: { root?: HTMLElement }) {
+        super('sp-overlay-close', { bubbles: true, composed: true });
+        this.root = root;
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-overlay-close': CustomEvent<OverlayCloseEvent>;
+    }
+}

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -21,6 +21,7 @@ import {
     findOverlaysRootedInOverlay,
     parentOverlayOf,
 } from './overlay-utils.js';
+import { OverlayCloseEvent } from './overlay-events.js';
 
 function isLeftClick(event: MouseEvent): boolean {
     return event.button === 0;
@@ -223,8 +224,18 @@ export class OverlayStack {
         this.document.addEventListener('click', this.handleMouseCapture, true);
         this.document.addEventListener('click', this.handleMouse);
         this.document.addEventListener('keyup', this.handleKeyUp);
+        this.document.addEventListener(
+            'sp-overlay-close',
+            this.handleOverlayClose as EventListener
+        );
         window.addEventListener('resize', this.handleResize);
     }
+
+    handleOverlayClose = (event: OverlayCloseEvent): void => {
+        const { root } = event;
+        if (!root) return;
+        this.closeOverlaysForRoot(root);
+    };
 
     private isClickOverlayActiveForTrigger(trigger: HTMLElement): boolean {
         return this.overlays.some(


### PR DESCRIPTION
## Description
Submenus should be closed based off of any `pointerenter` event on Menu Items that are siblings to the root of the submenu regardless of whether that Menu Item has a submenu itself.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://close-overlays-by-root--spectrum-web-components.netlify.app/storybook/?path=/story/menu-submenu--submenu)
    2. Once all three menus have opened, move you mouse into the Menu Item that says "Williamsburg"
    3. See that the submenu related to the "Ft. Greene" Menu Item is closed.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)