### PR TITLE
refactor: abstract "getDeepElementFromPoint" into shared package

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -22,6 +22,7 @@ import {
     parentOverlayOf,
 } from './overlay-utils.js';
 import { OverlayCloseEvent } from './overlay-events.js';
+import { getDeepElementFromPoint } from '@spectrum-web-components/shared/src/get-deep-element-from-point.js';
 
 function isLeftClick(event: MouseEvent): boolean {
     return event.button === 0;
@@ -184,19 +185,9 @@ export class OverlayStack {
         event.stopPropagation();
         event.preventDefault();
         await this.closeTopOverlay();
-        let target = document.elementFromPoint(event.clientX, event.clientY);
-        while (target?.shadowRoot) {
-            const innerTarget = (
-                target.shadowRoot as unknown as {
-                    elementFromPoint: (x: number, y: number) => Element | null;
-                }
-            ).elementFromPoint(event.clientX, event.clientY);
-            if (!innerTarget || innerTarget === target) {
-                break;
-            }
-            target = innerTarget;
-        }
-        target?.dispatchEvent(new MouseEvent('contextmenu', event));
+        getDeepElementFromPoint(event.clientX, event.clientY)?.dispatchEvent(
+            new MouseEvent('contextmenu', event)
+        );
     };
 
     private get document(): Document {

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -23,6 +23,10 @@ import {
 } from '@spectrum-web-components/shared';
 ```
 
+### getDeepElementFromPoint
+
+The `getDeepElementFromPoint` method allows you to obtain the deepest possible element at a given coordinates on the current page. The method will step into any available `shadowRoot`s until it reaches the first element with no `shadowRoot` or no children available at the given coordinates.
+
 ### Focusable
 
 The `Focusable` subclass of `LitElement` adds some helpers method and lifecycle coverage in order to support passing focus to a container element inside of a custom element. The Focusable base class handles tabindex setting into shadowed elements automatically and is based heavily on the [aybolit delegate-focus-mixin](https://github.com/web-padawan/aybolit/blob/master/packages/core/src/mixins/delegate-focus-mixin.js).

--- a/packages/shared/src/get-deep-element-from-point.ts
+++ b/packages/shared/src/get-deep-element-from-point.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export const getDeepElementFromPoint = (
+    x: number,
+    y: number
+): Element | null => {
+    let target = document.elementFromPoint(x, y);
+    while (target?.shadowRoot) {
+        const innerTarget = (
+            target.shadowRoot as unknown as {
+                elementFromPoint: (x: number, y: number) => Element | null;
+            }
+        ).elementFromPoint(x, y);
+        if (!innerTarget || innerTarget === target) {
+            break;
+        }
+        target = innerTarget;
+    }
+    return target;
+};


### PR DESCRIPTION
## Description
Abstract `getDeepElementFromPoint` into `@spectrum-web-components/shared` so it can be used by other things when needed.

## Related issue(s)

- fixes #1798

## How has this been tested?
-   [ ] _Test case 1_
    1. Doesn't break anything. Works the same. Exported so other parts of the library can consume it as needed.\

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.