### PR TITLE
refactor: remove local work around for Slider positioning

### DIFF
--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -167,22 +167,6 @@ sp-field-label {
     ) !important;
 }
 
-/**
- * Begin workaround for https://github.com/adobe/spectrum-css/issues/1205
- */
-
-:host([dir='ltr'][variant='range']) .track,
-:host([dir='rtl'][variant='range']) .track {
-    /* [dir=ltr] .spectrum-Slider--range .spectrum-Slider-track,
-   * [dir=rtl] .spectrum-Slider--range .spectrum-Slider-track */
-    margin: var(--spectrum-slider-range-track-reset);
-    margin-top: calc(var(--spectrum-slider-track-height) / -2);
-}
-
-/**
- * End workaround for https://github.com/adobe/spectrum-css/issues/1205
- */
-
 :host([dir='ltr']) .track:not(:first-of-type):not(:last-of-type) {
     left: var(--spectrum-slider-track-segment-position);
 }


### PR DESCRIPTION
## Description
Remove local CSS overrides.

## Related issue(s)

- fixes #1527

## How has this been tested?
-   [x] _Test case 1_
    1. VRTs exhibited no change in visual delivery.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.