### PR TITLE
chore: use latest icon assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: d5225d21d1d688a563804b73fc758b4615851fa1
+        default: eefb588a24fb2655c5768c12929565911b3ef39c
 commands:
     downstream:
         steps:

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -50,7 +50,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^3.0.21",
+        "@spectrum-css/icon": "^3.0.23",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fs": "^0.0.1-security",

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -49,7 +49,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@adobe/spectrum-css-workflow-icons": "^1.2.1",
+        "@adobe/spectrum-css-workflow-icons": "^1.5.4",
         "@spectrum-css/icon": "^3.0.21",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,10 +53,10 @@
     semver "^7.3.5"
     slugify "^1.6.5"
 
-"@adobe/spectrum-css-workflow-icons@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.2.1.tgz#7e2cb3fcfb5c8b12d7275afafbb6ec44913551b4"
-  integrity sha512-uVgekyBXnOVkxp+CUssjN/gefARtudZC8duEn1vm0lBQFwGRZFlDEzU1QC+aIRWCrD1Z8OgRpmBYlSZ7QS003w==
+"@adobe/spectrum-css-workflow-icons@^1.5.4":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@adobe/spectrum-css-workflow-icons/-/spectrum-css-workflow-icons-1.5.4.tgz#0e09ff519c36139176c3ba3ce617a995c9032f67"
+  integrity sha512-sZ19YOLGw5xTZzCEkVXPjf53lXVzo063KmDTJjpSjy/XLVsF+RaX0b436SfSM4hsIUZ7n27+UsbOvzFaFjcYXw==
 
 "@ampproject/remapping@^2.1.0":
   version "2.1.2"
@@ -3945,6 +3945,11 @@
   version "3.0.21"
   resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.21.tgz#086d30fd659975bc932e847140531dcae9a57ffd"
   integrity sha512-GlpqVotZ2c6nsMfQOBzBb855aZ6L1mtbAcgcwhKzACJhJxw0MKUD5euA8mUzMtCnlLZ0XCgoJbU+PLNrx/yz0A==
+
+"@spectrum-css/icon@^3.0.23":
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.23.tgz#95a5e1aa7fa0eace579449b3aaa7ec87c8c77f7f"
+  integrity sha512-HtH8M1+b2KxcOJjdaqqemp/Yx7TUBosHhlzuZcDxoG2OpSrg7LtkJfDyv+0qFELzB934k9JbiE4xVlHRzTcrZA==
 
 "@spectrum-css/illustratedmessage@^4.0.4":
   version "4.0.4"


### PR DESCRIPTION
## Description
Make sure the latest versions of icons like "Invite" are available in the library:
<img width="113" alt="image" src="https://user-images.githubusercontent.com/1156657/175401659-3257788c-8d50-4ca9-9e6a-c925f301a16e.png">

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://icons--spectrum-web-components.netlify.app/storybook/?path=/story/icons-workflow--elements)
    2. See that the "Invite" icon is available.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.