### PR TITLE
docs: deliver mobile docs as "large" scale by default

### DIFF
--- a/projects/documentation/content/_data/site.cjs
+++ b/projects/documentation/content/_data/site.cjs
@@ -30,5 +30,5 @@ module.exports = {
     shortDesc:
         'Spectrum Web Components provide interface components as custom elements to help teams work more efficiently and to make applications more consistent.',
     url,
-    WATCH_MODE: process.env.WATCH_MODE === 'true',
+    WATCH_MODE: process.env.WATCH_MODE,
 };

--- a/projects/documentation/content/_includes/layout.njk
+++ b/projects/documentation/content/_includes/layout.njk
@@ -13,7 +13,7 @@
     {% block content %}
       {{ content | safe }}
     {% endblock %}
-    {% if site.WATCH_MODE !== true %}
+    {% if site.WATCH_MODE !== 'true' %}
     <script async defer>
         if ('serviceWorker' in navigator) {
           window.addEventListener('load', () => {

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -47,15 +47,17 @@ import { copyText } from './copy-to-clipboard.js';
 
 import layoutStyles from './layout.css';
 import { nothing } from 'lit-html';
+import {
+    DARK_MODE,
+    IS_MOBILE,
+} from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
 
 const SWC_THEME_COLOR_KEY = 'swc-docs:theme:color';
 const SWC_THEME_SCALE_KEY = 'swc-docs:theme:scale';
 const SWC_THEME_THEME_KEY = 'swc-docs:theme:theme';
 const SWC_THEME_DIR_KEY = 'swc-docs:theme:dir';
-const COLOR_FALLBACK = matchMedia('(prefers-color-scheme: dark)').matches
-    ? 'dark'
-    : 'light';
-const SCALE_FALLBACK = 'medium';
+const COLOR_FALLBACK = matchMedia(DARK_MODE).matches ? 'dark' : 'light';
+const SCALE_FALLBACK = matchMedia(IS_MOBILE).matches ? 'large' : 'medium';
 const THEME_FALLBACK = 'spectrum';
 const DIR_FALLBACK = 'ltr';
 const DEFAULT_COLOR = (
@@ -311,10 +313,9 @@ export class LayoutElement extends LitElement {
         return html`
             <div class="manage-theme">
                 <div class="theme-control">
-                    <sp-field-label for="theme-color">Theme</sp-field-label>
+                    <sp-field-label for="theme-theme">Theme</sp-field-label>
                     <sp-picker
-                        id="theme-color"
-                        placement="bottom"
+                        id="theme-theme"
                         quiet
                         value=${this.theme}
                         @change=${this.updateTheme}
@@ -334,7 +335,6 @@ export class LayoutElement extends LitElement {
                     </sp-field-label>
                     <sp-picker
                         id="theme-color"
-                        placement="bottom"
                         quiet
                         value=${this.color}
                         @change=${this.updateColor}
@@ -353,7 +353,6 @@ export class LayoutElement extends LitElement {
                     <sp-picker
                         id="theme-scale"
                         label="Scale"
-                        placement="bottom"
                         quiet
                         value=${this.scale}
                         @change=${this.updateScale}
@@ -370,7 +369,6 @@ export class LayoutElement extends LitElement {
                     <sp-picker
                         id="theme-direction"
                         label="Direction"
-                        placement="bottom"
                         quiet
                         value=${this.dir}
                         @change=${this.updateDirection}

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -11,10 +11,16 @@ governing permissions and limitations under the License.
 */
 
 @import '@spectrum-web-components/styles/core-global.css';
-@import '@spectrum-web-components/styles/scale-medium.css';
 @import '@spectrum-web-components/styles/fonts.css';
 @import '@spectrum-web-components/styles/typography.css';
 @import '@spectrum-css/table/dist/index-vars.css';
+
+@import '@spectrum-web-components/styles/scale-medium.css' screen and
+        (min-width: 701px) and (min-height: 701px),
+    not (hover: none), not (pointer: coarse);
+@import '@spectrum-web-components/styles/scale-large.css' screen and
+        (max-width: 700px) and (hover: none) and (pointer: coarse),
+    (max-height: 700px) and (hover: none) and (pointer: coarse);
 
 @import '@spectrum-web-components/styles/theme-dark.css' screen and
     (prefers-color-scheme: dark);
@@ -135,7 +141,7 @@ body {
 
 @media screen and (max-width: 458px) {
     docs-page:not(:defined) {
-        padding: 170px var(--spectrum-global-dimension-size-300) 24px;
+        padding: 212px var(--spectrum-global-dimension-size-300) 24px;
     }
 }
 


### PR DESCRIPTION
## Description
Load the docs site at the "large" scale by default in "mobile" contexts.
- align more appropriately with Spectrum standards
- really remove the Service Worker during development
- correct a duplicated ID
- ensure reduced Cumulative Layout Shift in the updated delivery

## Screenshots (if appropriate)
<img width="361" alt="image" src="https://user-images.githubusercontent.com/1156657/175520141-ab6628bf-c364-4480-a91f-5650b884eebf.png">

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)