### PR TITLE
chore: focus pre-commit cmds on staged assets

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,17 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+ALL_STAGED=$(git diff --name-only --cached --diff-filter=d)
 STAGED_FILES_TO_LINT=$(git diff --name-only --cached --diff-filter=d -- "*.ts" "*.js")
-yarn eslint -f pretty $STAGED_FILES_TO_LINT
+STAGED_CSS_TO_LINT=$(git diff --name-only --cached --diff-filter=d -- "*.css")
+
+[[ $STAGED_FILES_TO_LINT ]] && yarn eslint --fix -f pretty $STAGED_FILES_TO_LINT
+
 yarn analyze:quick
-yarn lint:css
-yarn pretty-quick --staged
+
+[[ $STAGED_CSS_TO_LINT ]] && yarn stylelint --fix $STAGED_CSS_TO_LINT
+
+# yarn analyze:quick
+yarn pretty-quick --staged --fix
+
+[[ $ALL_STAGED ]] && git add $ALL_STAGED

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,7 +11,6 @@ yarn analyze:quick
 
 [[ $STAGED_CSS_TO_LINT ]] && yarn stylelint --fix $STAGED_CSS_TO_LINT
 
-# yarn analyze:quick
 yarn pretty-quick --staged --fix
 
 [[ $ALL_STAGED ]] && git add $ALL_STAGED


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Capture more information on staged files & run linting commands on them in a more targeted way. Ensure commands are run only if files are present in stage.

## Motivation and context

- Prevent stray *.css linting errors from being included if the PR in-question didn't touch the file.
- Auto-fix where possible and commit that update

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Remove a copyright header from a *.js and *.css file_
    1. Commit to the branch 
    2. Check that auto-fix corrects the *.js and the *.css file in question

<img width="986" alt="Screen Shot 2022-06-27 at 2 35 49 PM" src="https://user-images.githubusercontent.com/1840295/176011979-91d5ca9b-a7df-43f0-8a47-62c3f21814e1.png">

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
