### PR TITLE
docs: make Theme API table more useful

### DIFF
--- a/packages/theme/src/Theme.ts
+++ b/packages/theme/src/Theme.ts
@@ -86,6 +86,7 @@ export interface ProvideLang {
 
 /**
  * @element sp-theme
+ * @attr {string} [lang=""] - The language of the content scoped to this `sp-theme` element, see: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang" target="_blank">MDN reference</a>.
  *
  * @slot - Content on which to apply the CSS Custom Properties defined by the current theme configuration
  */
@@ -111,6 +112,11 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
         });
     }
 
+    /**
+     * Reading direction of the content scoped to this `sp-theme` element.
+     * @type {"ltr" | "rtl" | ""}
+     * @attr
+     */
     override get dir(): 'ltr' | 'rtl' | '' {
         return this._dir;
     }
@@ -149,6 +155,13 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
 
     private _theme: ThemeVariant | '' = 'spectrum';
 
+    /**
+     * The Spectrum theme that is applied to the content scoped to this `sp-theme` element.
+     *
+     * A value is requried.
+     * @type {"spectrum" | "express" | ""}
+     * @attr
+     */
     get theme(): ThemeVariant | '' {
         const themeFragments = Theme.themeFragmentsByKind.get('theme');
         const { name } =
@@ -175,6 +188,13 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
 
     private _color: Color | '' = '';
 
+    /**
+     * The Spectrum color stops to apply to content scoped by this `sp-theme` element.
+     *
+     * A value is requried.
+     * @type {"lightest" | "light" | "dark" | "darkest" | ""}
+     * @attr
+     */
     get color(): Color | '' {
         const themeFragments = Theme.themeFragmentsByKind.get('color');
         const { name } =
@@ -201,6 +221,13 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
 
     private _scale: Scale | '' = '';
 
+    /**
+     * The Spectrum platform scale to apply to content scoped by this `sp-theme` element.
+     *
+     * A value is requried.
+     * @type {"medium" | "large" | ""}
+     * @attr
+     */
     get scale(): Scale | '' {
         const themeFragments = Theme.themeFragmentsByKind.get('scale');
         const { name } =

--- a/projects/documentation/scripts/component-template-parts.js
+++ b/projects/documentation/scripts/component-template-parts.js
@@ -121,7 +121,7 @@ ${
               tag.attributes,
               ['Property', 'Attribute', 'Type', 'Default', 'Description'],
               [
-                  (attribute) => `<code>${attribute.fieldName}</code>`,
+                  (attribute) => `<code>${attribute.fieldName || ''}</code>`,
                   (attribute) => `<code>${attribute.name || ''}</code>`,
                   (attribute) => `<code>${attribute.type?.text || ''}</code>`,
                   (attribute) => `<code>${attribute.default || ''}</code>`,


### PR DESCRIPTION
## Description
Expand JSDocs usage in `theme.ts` for better API table population in the docs site.

## Related issue(s)
- refs #2291

## Motivation and context
Easier to get started with the API.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://theme-docs--spectrum-web-components.netlify.app/components/theme/api/)
    2. See that there is more information than there way before.

## Screenshots (if appropriate)
Before:
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/1156657/176676906-5bc47ee0-ce68-451d-9770-6dabc24265fb.png">

After:
<img width="984" alt="image" src="https://user-images.githubusercontent.com/1156657/176676998-f7059124-1259-4f2a-b14f-a1eef3d2028e.png">

## Types of changes
-   [x] Documentation

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)