### PR TITLE
fix(slider): add quiet and indeterminate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: da7e44df8d381dc28a2ed06ed799c467c00185c8
+        default: 204a28eef94b509e6ade326c2dcc1a503d9e1c57
 commands:
     downstream:
         steps:

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -128,7 +128,7 @@ An `<sp-slider>` element can be paired with an `<sp-number-field>` element via t
 
 #### Indeterminate
 
-The indeterminate attribute will be passed to the internal `<sp-number-field>` element and alter its visual delivery until a change has been made to the `<sp-slider>` element at which point the change event that is dispatched can be understood as always removing the indeterminate attribute from the `<sp-slider>`.
+The indeterminate attribute will be passed to the internal `<sp-number-field>` element and alter its visual delivery until a change has been made to the `<sp-slider>` element at which point the `change` event that is dispatched can be understood as always removing the indeterminate attribute from the `<sp-slider>`.
 
 ```html
 <sp-slider indeterminate editable></sp-slider>

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -119,6 +119,22 @@ An `<sp-slider>` element can be paired with an `<sp-number-field>` element via t
 ></sp-slider>
 ```
 
+#### Quiet
+
+```html
+<sp-slider quiet editable></sp-slider>
+<sp-slider quiet disabled editable></sp-slider>
+```
+
+#### Indeterminate
+
+The indeterminate attribute will be passed to the internal `<sp-number-field>` element and alter its visual delivery until a change has been made to the `<sp-slider>` element at which point the change event that is dispatched can be understood as always removing the indeterminate attribute from the `<sp-slider>`.
+
+```html
+<sp-slider indeterminate editable></sp-slider>
+<sp-slider indeterminate disabled editable></sp-slider>
+```
+
 ## Advanced normalization
 
 By default, `sp-slider` assumes a linear scale between the `min` and `max` values.

--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -379,6 +379,7 @@ export class HandleController implements Controller {
         event.stopPropagation();
         input.value = this.calculateHandlePosition(event, model).toString();
         model.handle.value = parseFloat(input.value);
+        this.host.indeterminate = false;
         this.requestUpdate();
     }
 

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -155,6 +155,18 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
     @property({ type: Boolean, reflect: true })
     public override disabled = false;
 
+    /**
+     * Applies `quiet` to the underlying `sp-number-field` when `editable === true`.
+     */
+    @property({ type: Boolean })
+    public quiet = false;
+
+    /**
+     * Applies `indeterminate` to the underlying `sp-number-field` when `editable === true`. Is removed on the next `change` event.
+     */
+    @property({ type: Boolean })
+    public indeterminate = false;
+
     @query('#label')
     public labelEl!: HTMLLabelElement;
 
@@ -193,6 +205,8 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                           value=${this.value}
                           ?hide-stepper=${this.hideStepper}
                           ?disabled=${this.disabled}
+                          ?quiet=${this.quiet}
+                          ?indeterminate=${this.indeterminate}
                           @input=${this.handleNumberInput}
                           @change=${this.handleNumberChange}
                       ></sp-number-field>
@@ -393,6 +407,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                 this.dispatchInputEvent();
             }
         }
+        this.indeterminate = false;
     }
 
     private trackSegmentStyles(start: number, end: number): StyleInfo {

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -416,6 +416,43 @@ export const Disabled = (args: StoryArgs = {}): TemplateResult => {
     `;
 };
 
+export const Quiet = (args: StoryArgs = {}): TemplateResult => {
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                editable
+                hide-stepper
+                quiet
+                value="5"
+                step="0.5"
+                min="0"
+                max="20"
+                label="Intensity"
+                ...=${spreadProps(args)}
+            ></sp-slider>
+        </div>
+    `;
+};
+
+export const Indeterminate = (args: StoryArgs = {}): TemplateResult => {
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                editable
+                indeterminate
+                value="5"
+                step="0.5"
+                min="0"
+                max="20"
+                label="Intensity"
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
+                ...=${spreadProps(args)}
+            ></sp-slider>
+        </div>
+    `;
+};
+
 export const ExplicitHandle = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">

--- a/packages/slider/test/slider-editable.test.ts
+++ b/packages/slider/test/slider-editable.test.ts
@@ -12,7 +12,12 @@ governing permissions and limitations under the License.
 
 import '../sp-slider.js';
 import { Slider } from '../';
-import { editable, hideStepper, StoryArgs } from '../stories/slider.stories.js';
+import {
+    editable,
+    hideStepper,
+    Indeterminate,
+    StoryArgs,
+} from '../stories/slider.stories.js';
 import { elementUpdated, expect, fixture } from '@open-wc/testing';
 import { TemplateResult } from '@spectrum-web-components/base';
 import { sendKeys } from '@web/test-runner-commands';
@@ -59,6 +64,29 @@ describe('Slider - editable', () => {
 
         await expect(el).to.be.accessible();
         el.remove();
+    });
+
+    it('toggles indeterminate when edited via the `<sp-number-field>`', async () => {
+        const el = await sliderFromFixture(Indeterminate);
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(5);
+        expect(el.indeterminate).to.be.true;
+
+        el.focus();
+
+        await elementUpdated(el);
+
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ type: '15' });
+        await sendKeys({ press: 'Enter' });
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal(15);
+        expect(el.indeterminate).to.be.false;
     });
 
     it('focuses `<sp-number-field>` directly', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `quiet` and `indeterminate` attributes, for slider edit mode.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes https://github.com/adobe/spectrum-web-components/issues/2399

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Expose more properties already available for the numeric input, used when slider can be edited by user input.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
