### PR TITLE
docs: fix overlay trigger static import statement

### DIFF
--- a/packages/overlay/overlay-trigger.md
+++ b/packages/overlay/overlay-trigger.md
@@ -29,7 +29,7 @@ import '@spectrum-web-components/overlay/overlay-trigger.js';
 The default of `<overlay-trigger>` will load dependencies in `@spectrum-web-components/overlay` asynchronously via a dynamic import. In the case that you would like to import those tranverse dependencies statically, import the side effectful registration of `<overlay-trigger>` as follows:
 
 ```
-import '@spectrum-web-components/overlay-trigger/sync/overlay-trigger.js';
+import '@spectrum-web-components/overlay/sync/overlay-trigger.js';
 ```
 
 When looking to leverage the `OverlayTrigger` base class as a type and/or for extension purposes, do so via:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a typo in the documentation for overlay-trigger, specifically the import statement provided for statically importing transitive dependencies.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- 

## Motivation and context

Fixes incorrect documentation

## How has this been tested?

Added the existing import statement to a project bundled with rollup: 

- the overaly did not work,
- saw the following error at build time
```bash
(!) Unresolved dependencies
@spectrum-web-components/overlay-trigger/sync/overlay-trigger.js 
```


Using the updated import statement, 
- the overlay trigger works 
- no complaints from rollup


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x]  I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
