### PR TITLE
fix(checkbox): add composed EventInit to CheckboxBase's change event

### DIFF
--- a/packages/checkbox/src/CheckboxBase.ts
+++ b/packages/checkbox/src/CheckboxBase.ts
@@ -46,6 +46,7 @@ export class CheckboxBase extends Focusable {
             },
             bubbles: event.bubbles,
             cancelable: event.cancelable,
+            composed: event.composed,
         });
         this.dispatchEvent(changeEvent);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The change event for checkboxes doesn't include the `composed` property. I included it as mentioned here in this comment: https://github.com/adobe/spectrum-web-components/pull/2365#discussion_r902022875

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Keeping things consistent across different components. 

## How has this been tested?

Ran existing test suite to make sure they behave the same. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
