### PR TITLE
refactor: move update request to after active update

### DIFF
--- a/packages/shared/src/observe-slot-presence.ts
+++ b/packages/shared/src/observe-slot-presence.ts
@@ -91,7 +91,11 @@ export function ObserveSlotPresence<T extends Constructor<ReactiveElement>>(
                     !!this.querySelector(selector)
                 );
             });
-            if (changes) this.requestUpdate();
+            if (changes) {
+                this.updateComplete.then(() => {
+                    this.requestUpdate();
+                });
+            }
         };
     }
     return SlotPresenceObservingElement;

--- a/packages/shared/src/observe-slot-text.ts
+++ b/packages/shared/src/observe-slot-text.ts
@@ -97,7 +97,9 @@ export function ObserveSlotText<T extends Constructor<ReactiveElement>>(
             changedProperties: PropertyValues
         ): void {
             super.firstUpdated(changedProperties);
-            this.manageTextObservedSlot();
+            this.updateComplete.then(() => {
+                this.manageTextObservedSlot();
+            });
         }
     }
     return SlotTextObservingElement;


### PR DESCRIPTION
## Description
Reduces multiple render passes in patterns leveraging the ObserverSlotPresence mixin, specifically `sp-dialog`.

Reduce multiple render passes in patterns leveraging the ObserveSlotText mixin, e.g. Action Button, Tab, Meter.

## How has this been tested?

-   [ ] _Test case 1_
    1. Run the test
    2. See that the Lit Dev Mode warnings for these components are not triggered.

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.