### PR TITLE
refactor(slider): prefent requesting another update until after the first update has been made

### DIFF
--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -107,7 +107,9 @@ export class HandleController implements Controller {
     }
 
     public requestUpdate(): void {
-        this.host.requestUpdate();
+        if (this.host.hasUpdated) {
+            this.host.requestUpdate();
+        }
     }
 
     /**
@@ -129,7 +131,6 @@ export class HandleController implements Controller {
             }
         } else {
             input.valueAsNumber = handle.value;
-            handle.value = input.valueAsNumber;
             this.requestUpdate();
         }
         handle.value = input.valueAsNumber;


### PR DESCRIPTION
## Description
Prevent requesting an update before the first update. Prevent Lit Dev Mode warnings.

## How has this been tested?

-   [ ] _Test case 1_
    1. Run the tests
    2. See that the `sp-slider` doesn't generate warning from LIt.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)