### PR TITLE
refactor(number-field): use internal state rather than DOM values for validation

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -569,6 +569,12 @@ export class NumberField extends TextfieldBase {
         if (changes.has('formatOptions') || changes.has('resolvedLanguage')) {
             this.clearNumberFormatterCache();
         }
+        if (changes.has('value') || changes.has('max') || changes.has('min')) {
+            const value = this.numberParser.parse(
+                this.formattedValue.replace(this._forcedUnit, '')
+            );
+            this.value = value;
+        }
         super.update(changes);
     }
 
@@ -582,17 +588,6 @@ export class NumberField extends TextfieldBase {
     }
 
     protected override updated(changes: PropertyValues<this>): void {
-        if (
-            changes.has('value') ||
-            changes.has('max') ||
-            changes.has('min') ||
-            changes.has('min')
-        ) {
-            const value = this.numberParser.parse(
-                this.inputValue.replace(this._forcedUnit, '')
-            );
-            this.value = value;
-        }
         if (changes.has('min') || changes.has('formatOptions')) {
             let inputMode = 'numeric';
             const hasNegative = typeof this.min !== 'undefined' && this.min < 0;


### PR DESCRIPTION
## Description
Leverage internal state rather than DOM state so we can validate before the first render and prevent multiple renders when the value needs to change due to constraints.

## How has this been tested?

-   [ ] _Test case 1_
    1. See that tests pass
-   [ ] _Test case 2_
    1. Run tests
    2. See that no Lit Dev Mode warnings are generated for `sp-number-field`

## Types of changes
-   [x] refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)