### PR TITLE
chore: clean up folders leftover during post-checkout

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,18 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+# If this is a file checkout (== 0) exit.
+if [ "$3" == "0" ]; then exit; fi
+
+# If this is a branch checkout (== 1) continue...
+
+# For each element, check for a node_modules dir without a corresponding
+# package.json.  That indicates the element does not exist in this branch.
+for e in {packages,projects,tools}/*; do
+  if [[ -d $e/node_modules && !( -f $e/package.json ) ]]; then
+    # Safe to delete this folder
+    rm -rf $e
+  fi
+done
+
+exit 0


### PR DESCRIPTION
## Description

When a new component is created and then the developer moves on to a new branch, sometimes a `leftover` component folder remains behind due to the untracked node_modules folder which prevents git from fully cleaning up after the branch change.

## Motivation and context

Prevents ghost folders from staying behind as you develop across multiple branches.

## How has this been tested?

-   [x] _Validate identification & clean-up of leftover folders_
    1. (from root) `mkdir packages/foo/node_modules`
    2. `sh .husky/post-checkout` - should remove the `packages/foo` folder

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://git.corp.adobe.com/DIWI/unified-experience-components/blob/main/CONTRIBUTING.md)>)**
        document.
-   [x] All new and existing tests passed.
