### PR TITLE
chore: repair quotes on publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,15 @@
 name: Site publish
 
 on:
+    workflow_dispatch:
     check_suite:
         types: [completed]
-    workflow_dispatch:
 jobs:
     site-build:
         name: Build & publish site
         runs-on: ubuntu-latest
         # Run the job if manually triggered or if the commit message includes '#publish' & the check suite has passed
-        if: github.event_name == "workflow_dispatch" || (contains(github.event.head_commit.message, '#publish') && github.event.check_suite.conclusion == "success")
+        if: github.event_name == 'workflow_dispatch' || (contains(github.event.head_commit.message, '#publish') && github.event.check_suite.conclusion == 'success')
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2


### PR DESCRIPTION
## Description

Syntax error being thrown on the new publish workflow.

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
