### PR TITLE
refactor(help-text): use core tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 1be4d4d3555312e2c2c99363f75b591cff5dd812
+        default: 474603e79b9671773b053e27417136da1d079780
 commands:
     downstream:
         steps:

--- a/packages/help-text/package.json
+++ b/packages/help-text/package.json
@@ -53,7 +53,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/helptext": "^1.0.20"
+        "@spectrum-css/helptext": "^2.0.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/help-text/src/spectrum-help-text.css
+++ b/packages/help-text/src/spectrum-help-text.css
@@ -11,254 +11,246 @@ governing permissions and limitations under the License.
 */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-:host([size='s']) {
-    --spectrum-helptext-neutral-textonly-text-padding-bottom: var(
-        --spectrum-helptext-s-neutral-textonly-text-padding-bottom
-    ); /* .spectrum-HelpText--sizeS */
-    --spectrum-helptext-neutral-texticon-text-size: var(
-        --spectrum-helptext-s-neutral-texticon-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    --spectrum-helptext-neutral-texticon-icon-gap: var(
-        --spectrum-helptext-s-neutral-texticon-icon-gap,
-        var(--spectrum-global-dimension-size-85)
-    );
-    --spectrum-helptext-negative-texticon-icon-padding-top: var(
-        --spectrum-helptext-s-negative-texticon-icon-padding-top,
-        var(--spectrum-global-dimension-size-50)
-    );
-    --spectrum-helptext-negative-texticon-icon-padding-bottom: var(
-        --spectrum-helptext-s-negative-texticon-icon-padding-bottom,
-        var(--spectrum-global-dimension-size-50)
-    );
-    --spectrum-helptext-neutral-textonly-text-transform: var(
-        --spectrum-helptext-s-neutral-textonly-text-transform,
-        none
-    );
-    --spectrum-helptext-neutral-textonly-text-padding-top: var(
-        --spectrum-helptext-s-neutral-textonly-text-padding-top,
-        var(--spectrum-global-dimension-static-size-50)
-    );
-    --spectrum-helptext-neutral-textonly-text-line-height: var(
-        --spectrum-helptext-s-neutral-textonly-text-line-height,
-        var(--spectrum-alias-component-text-line-height)
-    );
-    --spectrum-helptext-neutral-textonly-text-letter-spacing: var(
-        --spectrum-helptext-s-neutral-textonly-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-}
-:host([size='m']) {
-    --spectrum-helptext-neutral-textonly-text-padding-bottom: var(
-        --spectrum-helptext-m-neutral-textonly-text-padding-bottom
-    ); /* .spectrum-HelpText--sizeM */
-    --spectrum-helptext-neutral-texticon-text-size: var(
-        --spectrum-helptext-m-neutral-texticon-text-size,
-        var(--spectrum-global-dimension-font-size-75)
-    );
-    --spectrum-helptext-neutral-texticon-icon-gap: var(
-        --spectrum-helptext-m-neutral-texticon-icon-gap,
-        var(--spectrum-global-dimension-size-100)
-    );
-    --spectrum-helptext-negative-texticon-icon-padding-top: var(
-        --spectrum-helptext-m-negative-texticon-icon-padding-top,
-        var(--spectrum-global-dimension-size-40)
-    );
-    --spectrum-helptext-negative-texticon-icon-padding-bottom: var(
-        --spectrum-helptext-m-negative-texticon-icon-padding-bottom,
-        var(--spectrum-global-dimension-size-40)
-    );
-    --spectrum-helptext-neutral-textonly-text-transform: var(
-        --spectrum-helptext-m-neutral-textonly-text-transform,
-        none
-    );
-    --spectrum-helptext-neutral-textonly-text-padding-top: var(
-        --spectrum-helptext-m-neutral-textonly-text-padding-top,
-        var(--spectrum-global-dimension-static-size-50)
-    );
-    --spectrum-helptext-neutral-textonly-text-line-height: var(
-        --spectrum-helptext-m-neutral-textonly-text-line-height,
-        var(--spectrum-alias-component-text-line-height)
-    );
-    --spectrum-helptext-neutral-textonly-text-letter-spacing: var(
-        --spectrum-helptext-m-neutral-textonly-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-}
-:host([size='l']) {
-    --spectrum-helptext-neutral-texticon-text-size: var(
-        --spectrum-helptext-l-neutral-texticon-text-size,
-        var(--spectrum-global-dimension-font-size-100)
-    ); /* .spectrum-HelpText--sizeL */
-    --spectrum-helptext-neutral-texticon-icon-gap: var(
-        --spectrum-helptext-l-neutral-texticon-icon-gap,
-        var(--spectrum-global-dimension-size-115)
-    );
-    --spectrum-helptext-negative-texticon-icon-padding-top: var(
-        --spectrum-helptext-l-negative-texticon-icon-padding-top,
-        var(--spectrum-global-dimension-size-75)
-    );
-    --spectrum-helptext-negative-texticon-icon-padding-bottom: var(
-        --spectrum-helptext-l-negative-texticon-icon-padding-bottom,
-        var(--spectrum-global-dimension-size-75)
-    );
-    --spectrum-helptext-neutral-textonly-text-transform: var(
-        --spectrum-helptext-l-neutral-textonly-text-transform,
-        none
-    );
-    --spectrum-helptext-neutral-textonly-text-padding-top: var(
-        --spectrum-helptext-l-neutral-textonly-text-padding-top,
-        var(--spectrum-global-dimension-size-75)
-    );
-    --spectrum-helptext-neutral-textonly-text-padding-bottom: var(
-        --spectrum-helptext-l-neutral-textonly-text-padding-bottom,
-        var(--spectrum-global-dimension-size-115)
-    );
-    --spectrum-helptext-neutral-textonly-text-line-height: var(
-        --spectrum-helptext-l-neutral-textonly-text-line-height,
-        var(--spectrum-alias-component-text-line-height)
-    );
-    --spectrum-helptext-neutral-textonly-text-letter-spacing: var(
-        --spectrum-helptext-l-neutral-textonly-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-}
-:host([size='xl']) {
-    --spectrum-helptext-neutral-textonly-text-padding-top: var(
-        --spectrum-helptext-xl-neutral-textonly-text-padding-top
-    ); /* .spectrum-HelpText--sizeXL */
-    --spectrum-helptext-neutral-texticon-text-size: var(
-        --spectrum-helptext-xl-neutral-texticon-text-size,
-        var(--spectrum-global-dimension-font-size-200)
-    );
-    --spectrum-helptext-neutral-texticon-icon-gap: var(
-        --spectrum-helptext-xl-neutral-texticon-icon-gap,
-        var(--spectrum-global-dimension-size-125)
-    );
-    --spectrum-helptext-negative-texticon-icon-padding-top: var(
-        --spectrum-helptext-xl-negative-texticon-icon-padding-top,
-        var(--spectrum-global-dimension-size-115)
-    );
-    --spectrum-helptext-negative-texticon-icon-padding-bottom: var(
-        --spectrum-helptext-xl-negative-texticon-icon-padding-bottom,
-        var(--spectrum-global-dimension-size-115)
-    );
-    --spectrum-helptext-neutral-textonly-text-transform: var(
-        --spectrum-helptext-xl-neutral-textonly-text-transform,
-        none
-    );
-    --spectrum-helptext-neutral-textonly-text-padding-bottom: var(
-        --spectrum-helptext-xl-neutral-textonly-text-padding-bottom,
-        var(--spectrum-global-dimension-size-130)
-    );
-    --spectrum-helptext-neutral-textonly-text-line-height: var(
-        --spectrum-helptext-xl-neutral-textonly-text-line-height,
-        var(--spectrum-alias-component-text-line-height)
-    );
-    --spectrum-helptext-neutral-textonly-text-letter-spacing: var(
-        --spectrum-helptext-xl-neutral-textonly-text-letter-spacing,
-        var(--spectrum-global-font-letter-spacing-none)
-    );
-}
 :host {
-    display: flex; /* .spectrum-HelpText */
-    font-size: var(--spectrum-helptext-neutral-texticon-text-size);
-}
-:host([dir='ltr']) .icon {
-    margin-right: var(
-        --spectrum-helptext-neutral-texticon-icon-gap
-    ); /* [dir=ltr] .spectrum-HelpText .spectrum-HelpText-validationIcon */
-}
-:host([dir='rtl']) .icon {
-    margin-left: var(
-        --spectrum-helptext-neutral-texticon-icon-gap
-    ); /* [dir=rtl] .spectrum-HelpText .spectrum-HelpText-validationIcon */
-}
-.icon {
-    flex-shrink: 0;
-    padding-bottom: var(
-        --spectrum-helptext-negative-texticon-icon-padding-bottom
+    --spectrum-helptext-line-height: var(
+        --spectrum-line-height-100
+    ); /* .spectrum-HelpText */
+    --spectrum-helptext-content-color-default: var(
+        --spectrum-neutral-subdued-content-color-default
     );
-    padding-top: var(
-        --spectrum-helptext-negative-texticon-icon-padding-top
-    ); /* .spectrum-HelpText .spectrum-HelpText-validationIcon */
-}
-:host([dir='ltr']) .text {
-    margin-right: var(
-        --spectrum-helptext-neutral-texticon-icon-gap
-    ); /* [dir=ltr] .spectrum-HelpText .spectrum-HelpText-text */
-}
-:host([dir='rtl']) .text {
-    margin-left: var(
-        --spectrum-helptext-neutral-texticon-icon-gap
-    ); /* [dir=rtl] .spectrum-HelpText .spectrum-HelpText-text */
-}
-.text {
-    letter-spacing: var(
-        --spectrum-helptext-neutral-textonly-text-letter-spacing
+    --spectrum-helptext-icon-color-default: var(
+        --spectrum-neutral-subdued-content-color-default
     );
-    line-height: var(--spectrum-helptext-neutral-textonly-text-line-height);
-    padding-bottom: var(
-        --spectrum-helptext-neutral-textonly-text-padding-bottom
+    --spectrum-helptext-disabled-content-color: var(
+        --spectrum-disabled-content-color
     );
-    padding-top: var(
-        --spectrum-helptext-neutral-textonly-text-padding-top
-    ); /* .spectrum-HelpText .spectrum-HelpText-text */
-    text-transform: var(--spectrum-helptext-neutral-textonly-text-transform);
 }
 :host([variant='neutral']) {
-    --spectrum-helptext-m-texticon-text-color-disabled: var(
-        --spectrum-helptext-m-neutral-texticon-text-color-disabled,
-        var(--spectrum-alias-text-color-disabled)
-    ); /* .spectrum-HelpText--neutral */
-    --spectrum-helptext-m-texticon-icon-color-disabled: var(
-        --spectrum-helptext-m-neutral-texticon-icon-color-disabled,
-        var(--spectrum-alias-icon-color-disabled)
-    );
-    --spectrum-helptext-m-texticon-text-color: var(
-        --spectrum-helptext-m-neutral-texticon-text-color,
-        var(--spectrum-alias-label-text-color)
-    );
-    --spectrum-helptext-m-texticon-icon-color: var(
-        --spectrum-helptext-m-neutral-texticon-icon-color,
-        var(--spectrum-alias-icon-color)
+    --spectrum-helptext-content-color-default: var(
+        --spectrum-neutral-subdued-content-color-default
+    ); /* .spectrum-HelpText.spectrum-HelpText--neutral */
+    --spectrum-helptext-icon-color-default: var(
+        --spectrum-neutral-subdued-content-color-default
     );
 }
 :host([variant='negative']) {
-    --spectrum-helptext-m-texticon-text-color-disabled: var(
-        --spectrum-helptext-m-negative-texticon-text-color-disabled,
-        var(--spectrum-alias-text-color-disabled)
-    ); /* .spectrum-HelpText--negative */
-    --spectrum-helptext-m-texticon-icon-color-disabled: var(
-        --spectrum-helptext-m-negative-texticon-icon-color-disabled,
-        var(--spectrum-alias-icon-color-disabled)
+    --spectrum-helptext-content-color-default: var(
+        --spectrum-negative-content-color
+    ); /* .spectrum-HelpText.spectrum-HelpText--negative */
+    --spectrum-helptext-icon-color-default: var(
+        --spectrum-negative-content-color
     );
-    --spectrum-helptext-m-texticon-text-color: var(
-        --spectrum-helptext-m-negative-texticon-text-color,
-        var(--spectrum-semantic-negative-text-color-small)
+}
+:host([disabled]) {
+    --spectrum-helptext-content-color-default: var(
+        --spectrum-helptext-disabled-content-color
+    ); /* .spectrum-HelpText.is-disabled */
+    --spectrum-helptext-icon-color-default: var(
+        --spectrum-helptext-disabled-content-color
     );
-    --spectrum-helptext-m-texticon-icon-color: var(
-        --spectrum-helptext-m-negative-texticon-icon-color,
-        var(--spectrum-semantic-negative-icon-color)
+}
+:host(:lang(ja)),
+:host(:lang(ko)),
+:host(:lang(zh)) {
+    --spectrum-helptext-cjk-line-height: var(
+        --spectrum-CJK-line-height-100
+    ); /* .spectrum-HelpText:lang(ja),
+   * .spectrum-HelpText:lang(zh),
+   * .spectrum-HelpText:lang(ko) */
+}
+:host([size='s']) {
+    --spectrum-helptext-min-height: var(
+        --spectrum-component-height-75
+    ); /* .spectrum-HelpText--sizeS */
+    --spectrum-helptext-icon-size: var(--spectrum-workflow-icon-size-75);
+    --spectrum-helptext-font-size: var(--spectrum-font-size-75);
+    --spectrum-helptext-text-to-visual: var(--spectrum-text-to-visual-75);
+    --spectrum-helptext-top-to-workflow-icon: var(
+        --spectrum-help-text-top-to-workflow-icon-small
+    );
+    --spectrum-helptext-bottom-to-workflow-icon: var(
+        --spectrum-helptext-top-to-workflow-icon
+    );
+    --spectrum-helptext-top-to-text: var(--spectrum-component-top-to-text-75);
+    --spectrum-helptext-bottom-to-text: var(
+        --spectrum-component-bottom-to-text-75
+    );
+}
+:host([size='m']) {
+    --spectrum-helptext-min-height: var(
+        --spectrum-component-height-75
+    ); /* .spectrum-HelpText--sizeM */
+    --spectrum-helptext-icon-size: var(--spectrum-workflow-icon-size-100);
+    --spectrum-helptext-font-size: var(--spectrum-font-size-75);
+    --spectrum-helptext-text-to-visual: var(--spectrum-text-to-visual-75);
+    --spectrum-helptext-top-to-workflow-icon: var(
+        --spectrum-help-text-top-to-workflow-icon-medium
+    );
+    --spectrum-helptext-bottom-to-workflow-icon: var(
+        --spectrum-helptext-top-to-workflow-icon
+    );
+    --spectrum-helptext-top-to-text: var(--spectrum-component-top-to-text-75);
+    --spectrum-helptext-bottom-to-text: var(
+        --spectrum-component-bottom-to-text-75
+    );
+}
+:host([size='l']) {
+    --spectrum-helptext-min-height: var(
+        --spectrum-component-height-100
+    ); /* .spectrum-HelpText--sizeL */
+    --spectrum-helptext-icon-size: var(--spectrum-workflow-icon-size-200);
+    --spectrum-helptext-font-size: var(--spectrum-font-size-100);
+    --spectrum-helptext-text-to-visual: var(--spectrum-text-to-visual-100);
+    --spectrum-helptext-top-to-workflow-icon: var(
+        --spectrum-help-text-top-to-workflow-icon-large
+    );
+    --spectrum-helptext-bottom-to-workflow-icon: var(
+        --spectrum-helptext-top-to-workflow-icon
+    );
+    --spectrum-helptext-top-to-text: var(--spectrum-component-top-to-text-100);
+    --spectrum-helptext-bottom-to-text: var(
+        --spectrum-component-bottom-to-text-100
+    );
+}
+:host([size='xl']) {
+    --spectrum-helptext-min-height: var(
+        --spectrum-component-height-200
+    ); /* .spectrum-HelpText--sizeXL */
+    --spectrum-helptext-icon-size: var(--spectrum-workflow-icon-size-300);
+    --spectrum-helptext-font-size: var(--spectrum-font-size-200);
+    --spectrum-helptext-text-to-visual: var(--spectrum-text-to-visual-200);
+    --spectrum-helptext-top-to-workflow-icon: var(
+        --spectrum-help-text-top-to-workflow-icon-extra-large
+    );
+    --spectrum-helptext-bottom-to-workflow-icon: var(
+        --spectrum-helptext-top-to-workflow-icon
+    );
+    --spectrum-helptext-top-to-text: var(--spectrum-component-top-to-text-200);
+    --spectrum-helptext-bottom-to-text: var(
+        --spectrum-component-bottom-to-text-200
+    );
+}
+@media (forced-colors: active) {
+    :host {
+        --highcontrast-helptext-content-color-default: CanvasText;
+        --highcontrast-helptext-icon-color-default: CanvasText;
+        forced-color-adjust: none;
+    }
+    .icon,
+    .text {
+        forced-color-adjust: none;
+    }
+}
+:host {
+    color: var(
+        --highcontrast-helptext-content-color-default,
+        var(
+            --mod-helptext-content-color-default,
+            var(--spectrum-helptext-content-color-default)
+        )
+    ); /* .spectrum-HelpText */
+    display: flex;
+    font-size: var(
+        --mod-helptext-font-size,
+        var(--spectrum-helptext-font-size)
+    );
+    min-height: var(
+        --mod-helptext-min-height,
+        var(--spectrum-helptext-min-height)
     );
 }
 .icon {
-    color: var(
-        --spectrum-helptext-m-texticon-icon-color
+    flex-shrink: 0;
+    height: var(--mod-helptext-icon-size, var(--spectrum-helptext-icon-size));
+    margin-inline-end: var(
+        --mod-helptext-text-to-visual,
+        var(--spectrum-helptext-text-to-visual)
     ); /* .spectrum-HelpText .spectrum-HelpText-validationIcon */
+    padding-block-end: var(
+        --mod-helptext-bottom-to-workflow-icon,
+        var(--spectrum-helptext-bottom-to-workflow-icon)
+    );
+    padding-block-start: var(
+        --mod-helptext-top-to-workflow-icon,
+        var(--spectrum-helptext-top-to-workflow-icon)
+    );
+    width: var(--mod-helptext-icon-size, var(--spectrum-helptext-icon-size));
 }
 .text {
-    color: var(
-        --spectrum-helptext-m-texticon-text-color
+    line-height: var(
+        --mod-helptext-line-height,
+        var(--spectrum-helptext-line-height)
+    );
+    padding-block-end: var(
+        --mod-helptext-bottom-to-text,
+        var(--spectrum-helptext-bottom-to-text)
+    );
+    padding-block-start: var(
+        --mod-helptext-top-to-text,
+        var(--spectrum-helptext-top-to-text)
     ); /* .spectrum-HelpText .spectrum-HelpText-text */
 }
-:host([disabled]) .icon {
+:host(:lang(ja)) .text,
+:host(:lang(ko)) .text,
+:host(:lang(zh)) .text {
+    line-height: var(
+        --mod-helptext-cjk-line-height,
+        var(--spectrum-helptext-cjk-line-height)
+    ); /* .spectrum-HelpText:lang(ja) .spectrum-HelpText-text,
+   * .spectrum-HelpText:lang(zh) .spectrum-HelpText-text,
+   * .spectrum-HelpText:lang(ko) .spectrum-HelpText-text */
+}
+:host([variant='neutral']) .text {
     color: var(
-        --spectrum-helptext-m-texticon-icon-color-disabled
-    ); /* .spectrum-HelpText.is-disabled .spectrum-HelpText-validationIcon */
+        --highcontrast-helptext-content-color-default,
+        var(
+            --mod-helptext-content-color-default,
+            var(--spectrum-helptext-content-color-default)
+        )
+    ); /* .spectrum-HelpText.spectrum-HelpText--neutral .spectrum-HelpText-text */
+}
+:host([variant='neutral']) .icon {
+    color: var(
+        --highcontrast-helptext-icon-color-default,
+        var(
+            --mod-helptext-icon-color-default,
+            var(--spectrum-helptext-icon-color-default)
+        )
+    ); /* .spectrum-HelpText.spectrum-HelpText--neutral .spectrum-HelpText-validationIcon */
+}
+:host([variant='negative']) .text {
+    color: var(
+        --highcontrast-helptext-content-color-default,
+        var(
+            --mod-helptext-content-color-default,
+            var(--spectrum-helptext-content-color-default)
+        )
+    ); /* .spectrum-HelpText.spectrum-HelpText--negative .spectrum-HelpText-text */
+}
+:host([variant='negative']) .icon {
+    color: var(
+        --highcontrast-helptext-icon-color-default,
+        var(
+            --mod-helptext-icon-color-default,
+            var(--spectrum-helptext-icon-color-default)
+        )
+    ); /* .spectrum-HelpText.spectrum-HelpText--negative .spectrum-HelpText-validationIcon */
 }
 :host([disabled]) .text {
     color: var(
-        --spectrum-helptext-m-texticon-text-color-disabled
+        --highcontrast-helptext-content-color-default,
+        var(
+            --mod-helptext-content-color-default,
+            var(--spectrum-helptext-content-color-default)
+        )
     ); /* .spectrum-HelpText.is-disabled .spectrum-HelpText-text */
+}
+:host([disabled]) .icon {
+    color: var(
+        --highcontrast-helptext-icon-color-default,
+        var(
+            --mod-helptext-icon-color-default,
+            var(--spectrum-helptext-icon-color-default)
+        )
+    ); /* .spectrum-HelpText.is-disabled .spectrum-HelpText-validationIcon */
 }

--- a/packages/styles/express/spectrum-scale-large.css
+++ b/packages/styles/express/spectrum-scale-large.css
@@ -307,15 +307,6 @@ governing permissions and limitations under the License.
     --spectrum-dialog-confirm-padding: var(
         --spectrum-global-dimension-static-size-300
     );
-    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
-        --spectrum-global-dimension-static-size-150
-    );
     --spectrum-listitem-m-texticon-padding-left: var(
         --spectrum-global-dimension-static-size-150
     );

--- a/packages/styles/express/spectrum-scale-medium.css
+++ b/packages/styles/express/spectrum-scale-medium.css
@@ -315,15 +315,6 @@ governing permissions and limitations under the License.
     --spectrum-dialog-confirm-padding: var(
         --spectrum-global-dimension-static-size-500
     );
-    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
-        --spectrum-global-dimension-size-115
-    );
     --spectrum-listitem-m-texticon-padding-left: var(
         --spectrum-global-dimension-size-125
     );

--- a/packages/styles/spectrum-scale-large.css
+++ b/packages/styles/spectrum-scale-large.css
@@ -318,15 +318,6 @@ governing permissions and limitations under the License.
     --spectrum-dialog-confirm-padding: var(
         --spectrum-global-dimension-static-size-300
     );
-    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
-        --spectrum-global-dimension-static-size-85
-    );
-    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
-        --spectrum-global-dimension-static-size-150
-    );
     --spectrum-listitem-m-texticon-padding-left: var(
         --spectrum-global-dimension-static-size-150
     );

--- a/packages/styles/spectrum-scale-medium.css
+++ b/packages/styles/spectrum-scale-medium.css
@@ -320,15 +320,6 @@ governing permissions and limitations under the License.
     --spectrum-dialog-confirm-padding: var(
         --spectrum-global-dimension-static-size-500
     );
-    --spectrum-helptext-s-neutral-textonly-text-padding-bottom: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-helptext-m-neutral-textonly-text-padding-bottom: var(
-        --spectrum-global-dimension-static-size-65
-    );
-    --spectrum-helptext-xl-neutral-textonly-text-padding-top: var(
-        --spectrum-global-dimension-size-115
-    );
     --spectrum-listitem-m-texticon-padding-left: var(
         --spectrum-global-dimension-size-125
     );

--- a/scripts/spectrum-tokens.js
+++ b/scripts/spectrum-tokens.js
@@ -29,7 +29,7 @@ const tokensRoot = path.join(
     '*.css'
 );
 
-const tokenPackages = ['actionbutton'];
+const tokenPackages = ['actionbutton', 'helptext'];
 
 const packagePaths = tokenPackages.map((packageName) => {
     return path.join(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3984,10 +3984,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-4.0.29.tgz#c09de2495b041a308b0cf110b1185cbb77c188fe"
   integrity sha512-MRputoPSSiIC0PoPOaX5zeDHyVcHdbfib7lCBk9di8R/eed3UzHvQeBwclAvCxkVHuyfIIzgaK3mlIt4flAvlw==
 
-"@spectrum-css/helptext@^1.0.20":
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-1.0.20.tgz#c0339735ebd2fee4caeba0aa9a2c39909720b6d8"
-  integrity sha512-qyqQ+1ffwvj31xxrKwfSH8jb0NFyIUroc5tBGsvFWQ8Dct8+OOkc5MCO0ZX6D5OxPXUyXMZOuwqNzlUQI067MA==
+"@spectrum-css/helptext@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-2.0.0.tgz#262cb489867e4f55e238c7a0c85c46fafda747a6"
+  integrity sha512-Yv2Ci5n28IY4cG5VU62FOMWtyS3JmQC2hrC4YyUdojP6mq4H9KHzEcXcHS/oDFQEaivp/lObxAXIbTfjT5P/+A==
 
 "@spectrum-css/icon@^3.0.23":
   version "3.0.23"


### PR DESCRIPTION
## Description
Leverage Core Tokens in the Help Text pattern.

Uses `beta` release, hold for full release.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://2ca598f7cc125086fc950534fe9be893--spectrum-web-components.netlify.app/review/)
    2. Review the changes.

## Types of changes
-   [x] refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.