### PR TITLE
build: ensure CEM output features *.js files

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -10,6 +10,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { moduleFileExtensionsPlugin } from 'cem-plugin-module-file-extensions';
+
 export default {
     globs: ['**/sp-*.ts', '**/src/[A-Z]*.ts'],
     exclude: [
@@ -23,4 +25,5 @@ export default {
     outdir: '.',
     litelement: true,
     packagejson: false,
+    plugins: [moduleFileExtensionsPlugin()],
 };

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
         "@web/test-runner-visual-regression": "^0.6.5",
         "@webcomponents/webcomponentsjs": "^2.6.0",
         "alex": "^9.0.1",
+        "cem-plugin-module-file-extensions": "^0.0.5",
         "chalk": "^5.0.1",
         "chromedriver": "^103.0.0",
         "common-tags": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7135,6 +7135,11 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
+cem-plugin-module-file-extensions@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/cem-plugin-module-file-extensions/-/cem-plugin-module-file-extensions-0.0.5.tgz#6d6b8e45aac65cec7d27757d6ab58cd88ad6a7fe"
+  integrity sha512-Ky9tlWNnh9f6A/H3QbRqB0fu5sf9M6pbVwr2LMO6uqGkEn9A1+xF1fmq0SRJlUYPUszw6JEjaK7IByLOuAeAVg==
+
 chai-a11y-axe@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/chai-a11y-axe/-/chai-a11y-axe-1.3.2.tgz#77dc5f503901fed4f6097b5b0213ddb00cc891ea"


### PR DESCRIPTION
## Description
Leverage a Custom Elements Manifest Analyzer plugin to ensure that the `.ts` source is listed as its `.js` in the delivered manifests.

## Related issue(s)
- fixes #2104

## How has this been tested?
-   [ ] _Test case 1_
    1. run `yarn custom-element-json` locally
    2. see that the output manifest in the package directories does not have `.ts` listing.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.