### PR TITLE
chore: alias storybook command to 'start'

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "spectrum-css": "node ./scripts/process-spectrum-css.js",
         "spectrum-tokens": "node ./scripts/spectrum-tokens.js",
         "spectrum-vars": "node ./scripts/spectrum-vars.js",
+        "start": "yarn storybook",
         "storybook": "yarn build:ts && yarn build:css && run-p storybook:start watch:css build:watch",
         "storybook:build": "build-storybook -o projects/documentation/dist/storybook",
         "storybook:start": "web-dev-server --config wds-storybook.config.js",


### PR DESCRIPTION
## Description

Adding an alias for the `yarn storybook` command: `yarn start`

## Motivation and context

A `start` command is a nice feature because it describes what the developer is doing rather than the tool they are using.  We are using storybook for viewing development but the task we are performing is development. Just a personal preference but hoping it makes it easier to standardize commands across projects when different development tools might be in use.

## How has this been tested?

-   [x] _yarn start_
    1. Calls & runs `yarn storybook`

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [n/a] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [n/a] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
