### PR TITLE
fix: prepare for future core token consumption that leverages component names

### DIFF
--- a/scripts/spectrum-tokens.js
+++ b/scripts/spectrum-tokens.js
@@ -119,7 +119,10 @@ const processPackages = async (srcPath, index) => {
         `\\s*--spectrum-alias-${packageName}[^;]*;`,
         'g'
     );
-    for (const varsPath of await fg([varsPaths])) {
+    const varsWithoutTokens = await fg([varsPaths], {
+        ignore: ['**/tokens/**/*.css'],
+    });
+    for (const varsPath of varsWithoutTokens) {
         let css = fs.readFileSync(varsPath, 'utf8');
         css = css.replaceAll(varsRegExp, '');
         css = css.replaceAll(aliasRegExp, '');


### PR DESCRIPTION
## Description
The Action Button usage of core tokens implied that there would be no longer a need for CSS Custom Properties with component names in them. The Radio Button usage disproved that. This prepares for Radio Button (which is on hold) and other patterns that may do this as well to apply Custom Properties with component names in the `tokens` directory.

## How has this been tested?

-   [ ] _Test case 1_
    1. See #2458

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.