### PR TITLE
fix(tabs): add "tablist" part to manage list styles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 474603e79b9671773b053e27417136da1d079780
+        default: 8778cd85ecd03399d5134d652cc64015d5bf8c53
 commands:
     downstream:
         steps:

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -38,6 +38,7 @@ const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
  * @slot tab-panel - Tab Panel elements related to the listed Tab elements
  * @attr {Boolean} quiet - The tabs border is a lot smaller
  * @attr {Boolean} compact - The collection of tabs take up less space
+ * @csspart tablist - Container element for the slotted sp-tab elements
  *
  * @fires change - The selected Tab child has changed.
  */
@@ -174,6 +175,7 @@ export class Tabs extends SizedMixin(Focusable) {
                 @sp-tab-contentchange=${this.updateSelectionIndicator}
                 id="list"
                 role="tablist"
+                part="tablist"
             >
                 <slot @slotchange=${this.onSlotChange}></slot>
                 <div
@@ -330,23 +332,15 @@ export class Tabs extends SizedMixin(Focusable) {
             document.fonts ? document.fonts.ready : Promise.resolve(),
         ]);
         const tabBoundingClientRect = selectedElement.getBoundingClientRect();
-        const parentBoundingClientRect = this.getBoundingClientRect();
 
         if (this.direction === 'horizontal') {
             const width = tabBoundingClientRect.width;
-            const offset =
-                this.dir === 'ltr'
-                    ? tabBoundingClientRect.left - parentBoundingClientRect.left
-                    : tabBoundingClientRect.right -
-                      parentBoundingClientRect.right;
+            const offset = selectedElement.offsetLeft;
 
-            this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${
-                this.dir === 'ltr' ? width : -1 * width
-            });`;
+            this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${width});`;
         } else {
             const height = tabBoundingClientRect.height;
-            const offset =
-                tabBoundingClientRect.top - parentBoundingClientRect.top;
+            const offset = selectedElement.offsetTop;
 
             this.selectionIndicatorStyle = `transform: translateY(${offset}px) scaleY(${height});`;
         }

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -14,12 +14,11 @@ governing permissions and limitations under the License.
 
 :host {
     display: grid;
+    grid-template-columns: 100%;
+}
 
-    --spectrum-tabs-emphasized-textonly-divider-background-color: transparent;
-    --spectrum-tabs-quiet-textonly-divider-background-color: transparent;
-    --spectrum-tabs-textonly-divider-background-color: transparent;
-    --spectrum-tabs-vertical-quiet-textonly-divider-background-color: transparent;
-    --spectrum-tabs-vertical-textonly-divider-background-color: transparent;
+:host(:not([direction^='vertical'])) {
+    grid-template-rows: auto 1fr;
 }
 
 :host([direction^='vertical']) {
@@ -33,6 +32,27 @@ governing permissions and limitations under the License.
 
 #selection-indicator {
     border-radius: 0;
+    z-index: 1;
+}
+
+:host([dir='rtl']) #selection-indicator {
+    left: 0;
+    right: auto;
+}
+
+:host(:not([direction^='vertical'])) #selection-indicator {
+    bottom: 0;
+}
+
+:host([dir='ltr'][direction='vertical']) #selection-indicator,
+:host([dir='rtl'][direction='vertical-right']) #selection-indicator {
+    left: 0;
+}
+
+:host([dir='ltr'][direction='vertical-right']) #selection-indicator,
+:host([dir='rtl'][direction='vertical']) #selection-indicator {
+    left: auto;
+    right: 0;
 }
 
 :host([disabled]) #selection-indicator {
@@ -51,6 +71,53 @@ governing permissions and limitations under the License.
 
 #list {
     justify-content: var(--swc-tabs-list-justify-content);
+    border: none !important;
+    background: linear-gradient(
+        to var(--sp-tabs-list-background-direction),
+        var(--sp-tabs-list-background-color) 0,
+        var(--sp-tabs-list-background-color)
+            var(--spectrum-tabs-quiet-textonly-divider-size),
+        transparent var(--spectrum-tabs-quiet-textonly-divider-size)
+    );
+
+    --sp-tabs-list-background-direction: top;
+    --sp-tabs-list-background-color: transparent;
+}
+
+:host(:not([direction^='vertical'])) #list {
+    padding-bottom: var(--spectrum-tabs-quiet-textonly-divider-size);
+}
+
+:host(:not([quiet])) #list {
+    --sp-tabs-list-background-color: var(
+        --spectrum-tabs-textonly-divider-background-color
+    );
+}
+
+:host([empasized]) #list {
+    --sp-tabs-list-background-color: var(
+        --spectrum-tabs-emphasized-textonly-divider-background-color
+    );
+}
+
+:host([direction^='vertical']) #list {
+    --sp-tabs-list-background-color: var(
+        --spectrum-tabs-vertical-textonly-divider-background-color
+    );
+}
+
+:host([dir='ltr'][direction='vertical']) #list,
+:host([dir='rtl'][direction='vertical-right']) #list {
+    padding-left: var(--spectrum-tabs-quiet-textonly-divider-size);
+
+    --sp-tabs-list-background-direction: right;
+}
+
+:host([dir='rtl'][direction='vertical']) #list,
+:host([dir='ltr'][direction='vertical-right']) #list {
+    padding-right: var(--spectrum-tabs-quiet-textonly-divider-size);
+
+    --sp-tabs-list-background-direction: left;
 }
 
 :host([disabled]) #list {
@@ -130,22 +197,26 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([dir='ltr'][direction='vertical-right']) #selection-indicator {
-    /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
-    left: auto;
-    right: calc(
-        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
-    );
-}
-
 :host([dir='rtl'][direction='vertical-right']) #selection-indicator {
     /* .spectrum-Tabs--vertical .spectrum-Tabs-selectionIndicator */
     right: auto;
-    left: calc(
-        -1 * var(--spectrum-tabs-vertical-rule-width, var(--spectrum-alias-border-size-thick))
-    );
+    left: 0;
 }
 
 #selection-indicator.first-position {
     transition: none;
+}
+
+:host([dir='ltr'][direction='vertical-right']) ::slotted(:not([slot])) {
+    margin-left: 0;
+    margin-right: calc(
+        var(--spectrum-tabs-vertical-textonly-tabitem-gap) / 2
+    ); /* [dir=ltr] .spectrum-Tabs--vertical .spectrum-Tabs-item */
+}
+
+:host([dir='rtl'][direction='vertical-right']) ::slotted(:not([slot])) {
+    margin-right: 0;
+    margin-left: calc(
+        var(--spectrum-tabs-vertical-textonly-tabitem-gap) / 2
+    ); /* [dir=rtl] .spectrum-Tabs--vertical .spectrum-Tabs-item */
 }

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -169,17 +169,11 @@ export class TopNav extends SizedMixin(SpectrumElement) {
             document.fonts ? document.fonts.ready : Promise.resolve(),
         ]);
         const itemBoundingClientRect = selectedItem.getBoundingClientRect();
-        const parentBoundingClientRect = this.getBoundingClientRect();
 
         const width = itemBoundingClientRect.width;
-        const offset =
-            this.dir === 'ltr'
-                ? itemBoundingClientRect.left - parentBoundingClientRect.left
-                : itemBoundingClientRect.right - parentBoundingClientRect.right;
+        const offset = selectedItem.offsetLeft;
 
-        this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${
-            this.dir === 'ltr' ? width : -1 * width
-        });`;
+        this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${width});`;
     };
 
     public override connectedCallback(): void {


### PR DESCRIPTION
## Description
Add a `tablist` part to the "tab list" container in the `<sp-tabs>` element.

Add this to the Custom Elements Manifest for future documentation and IED consumptions, but do not actively document this as we don't have a good path to documenting part _AND_ I'd like to keep parts sort of secret until they feel like a wholistic part of the library.

Comes with some slightly related updates to spacing, colors and WHCM delivery of the Tabs and Top Nav elements.

## Related issue(s)
- fixes #2460

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://tabs-list--spectrum-web-components.netlify.app/storybook/index.html?path=/story/tabs--vertical-right)
    2. Inspect the `<style>` tag in the story DOM
    3. Add `sp-tabs::part(tablist) { background: red; }` to see that the part is available.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)