### PR TITLE
feat(close-button): use core tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 8778cd85ecd03399d5134d652cc64015d5bf8c53
+        default: fe47e28f552ccdb6a232d7908a3eebc261e10170
 commands:
     downstream:
         steps:

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -46,7 +46,7 @@
         "tslib": "^2.0.0"
     },
     "devDependencies": {
-        "@spectrum-css/closebutton": "^1.2.13"
+        "@spectrum-css/closebutton": "^2.0.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -18,24 +18,16 @@ governing permissions and limitations under the License.
     border-style: solid;
     box-sizing: border-box; /* .spectrum-CloseButton */
     cursor: pointer;
-    font-family: var(
-        --spectrum-alias-body-text-font-family,
-        var(--spectrum-global-font-family-base)
-    );
-    line-height: var(
-        --spectrum-alias-component-text-line-height,
-        var(--spectrum-global-font-line-height-small)
-    );
+    font-family: var(--spectrum-font-family-base);
+    line-height: var(--spectrum-line-height-small);
     margin: 0;
     overflow: visible;
     text-decoration: none;
     text-transform: none;
-    transition: background var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        border-color var(--spectrum-global-animation-duration-100, 0.13s)
-            ease-out,
-        color var(--spectrum-global-animation-duration-100, 0.13s) ease-out,
-        box-shadow var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
+    transition: background var(--spectrum-animation-duration-100) ease-out,
+        border-color var(--spectrum-animation-duration-100) ease-out,
+        color var(--spectrum-animation-duration-100) ease-out,
+        box-shadow var(--spectrum-animation-duration-100) ease-out;
     user-select: none;
     -webkit-user-select: none;
     vertical-align: top;
@@ -46,51 +38,234 @@ governing permissions and limitations under the License.
 :host(::-moz-focus-inner) {
     border: 0; /* .spectrum-CloseButton::-moz-focus-inner */
     border-style: none;
-    margin-bottom: -2px;
-    margin-top: -2px;
+    margin-block-end: -2px;
+    margin-block-start: -2px;
     padding: 0;
 }
 :host(:disabled) {
     cursor: default; /* .spectrum-CloseButton:disabled */
 }
 :host {
-    --spectrum-global-color-static-black-rgb: 0, 0, 0;
-    --spectrum-global-color-static-white-rgb: 255, 255, 255;
-    border-color: transparent;
-    border-width: 0;
-    color: inherit;
-    position: relative; /* .spectrum-CloseButton */
+    --spectrum-closebutton-size-300: 24px; /* .spectrum-CloseButton */
+    --spectrum-closebutton-size-400: 32px;
+    --spectrum-closebutton-size-500: 40px;
+    --spectrum-closebutton-size-600: 48px;
+    --spectrum-closebutton-icon-color-default: var(
+        --spectrum-neutral-content-color-default
+    );
+    --spectrum-closebutton-icon-color-hover: var(
+        --spectrum-neutral-content-color-hover
+    );
+    --spectrum-closebutton-icon-color-down: var(
+        --spectrum-neutral-content-color-down
+    );
+    --spectrum-closebutton-icon-color-focus: var(
+        --spectrum-neutral-content-color-key-focus
+    );
+    --spectrum-closebutton-icon-color-disabled: var(
+        --spectrum-disabled-content-color
+    );
+    --spectrum-closebutton-focus-ring-thickness: var(
+        --spectrum-focus-ring-thickness
+    );
+    --spectrum-closebutton-focus-ring-gap: var(--spectrum-focus-ring-gap);
+    --spectrum-closebutton-focus-ring-color: var(--spectrum-focus-ring-color);
+    --spectrum-closebutton-height: var(--spectrum-component-height-100);
+    --spectrum-closebutton-width: var(--spectrum-closebutton-height);
+    --spectrum-closebutton-size: var(--spectrum-closebutton-size-400);
+    --spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-400);
+    --spectrum-closebutton-animation-duration: var(
+        --spectrum-animation-duration-100
+    );
 }
-:host {
-    --spectrum-closebutton-focus-ring-gap: var(
-        --spectrum-alias-component-focusring-gap-emphasized,
-        var(--spectrum-global-dimension-static-size-25)
-    ); /* .spectrum-CloseButton */
-    --spectrum-closebutton-focus-ring-size: var(
-        --spectrum-alias-component-focusring-size-emphasized,
-        var(--spectrum-global-dimension-static-size-25)
+:host([variant='white']) {
+    --spectrum-closebutton-static-background-color-default: transparent; /* .spectrum-CloseButton--staticWhite */
+    --spectrum-closebutton-static-background-color-hover: var(
+        --spectrum-transparent-white-300
+    );
+    --spectrum-closebutton-static-background-color-down: var(
+        --spectrum-transparent-white-400
+    );
+    --spectrum-closebutton-static-background-color-focus: var(
+        --spectrum-transparent-white-300
+    );
+    --spectrum-closebutton-icon-color-default: var(--spectrum-white);
+    --spectrum-closebutton-icon-color-disabled: var(
+        --spectrum-disabled-static-white-content-color
     );
     --spectrum-closebutton-focus-ring-color: var(
-        --spectrum-alias-focus-ring-color,
-        var(--spectrum-alias-focus-color)
+        --spectrum-static-white-focus-ring-color
     );
+}
+:host([variant='black']) {
+    --spectrum-closebutton-static-background-color-default: transparent; /* .spectrum-CloseButton--staticBlack */
+    --spectrum-closebutton-static-background-color-hover: var(
+        --spectrum-transparent-black-300
+    );
+    --spectrum-closebutton-static-background-color-down: var(
+        --spectrum-transparent-black-400
+    );
+    --spectrum-closebutton-static-background-color-focus: var(
+        --spectrum-transparent-black-300
+    );
+    --spectrum-closebutton-icon-color-default: var(--spectrum-black);
+    --spectrum-closebutton-icon-color-disabled: var(
+        --spectrum-disabled-static-black-content-color
+    );
+    --spectrum-closebutton-focus-ring-color: var(
+        --spectrum-static-black-focus-ring-color
+    );
+}
+@media (forced-colors: active) {
+    :host {
+        --highcontrast-closebutton-icon-color-disabled: GrayText;
+        --highcontrast-closebutton-icon-color-down: Highlight;
+        --highcontrast-closebutton-icon-color-hover: Highlight;
+        --highcontrast-closebutton-icon-color-focus: Highlight;
+        --highcontrast-closebutton-background-color-default: ButtonFace;
+        --highcontrast-closebutton-focus-ring-color: ButtonText;
+    }
+    :host(.focus-visible):after {
+        border-radius: 100%;
+        bottom: 0;
+        box-shadow: 0 0 0
+            var(
+                --mod-closebutton-focus-ring-thickness,
+                var(--spectrum-closebutton-focus-ring-thickness)
+            )
+            var(
+                --highcontrast-closebutton-focus-ring-color,
+                var(
+                    --mod-closebutton-focus-ring-color,
+                    var(--spectrum-closebutton-focus-ring-color)
+                )
+            );
+        content: '';
+        display: block;
+        forced-color-adjust: none;
+        left: 0;
+        margin: var(
+            --mod-closebutton-focus-ring-gap,
+            var(--spectrum-closebutton-focus-ring-gap)
+        );
+        position: absolute;
+        right: 0;
+        top: 0;
+        transition: opacity
+                var(
+                    --mod-closebutton-animation-duration,
+                    var(--spectrum-closebutton-animation-duration)
+                )
+                ease-out,
+            margin
+                var(
+                    --mod-closebutton-animation-duraction,
+                    var(--spectrum-closebutton-animation-duration)
+                )
+                ease-out;
+    }
+    :host(:focus-visible):after {
+        border-radius: 100%;
+        bottom: 0;
+        box-shadow: 0 0 0
+            var(
+                --mod-closebutton-focus-ring-thickness,
+                var(--spectrum-closebutton-focus-ring-thickness)
+            )
+            var(
+                --highcontrast-closebutton-focus-ring-color,
+                var(
+                    --mod-closebutton-focus-ring-color,
+                    var(--spectrum-closebutton-focus-ring-color)
+                )
+            );
+        content: '';
+        display: block;
+        forced-color-adjust: none;
+        left: 0;
+        margin: var(
+            --mod-closebutton-focus-ring-gap,
+            var(--spectrum-closebutton-focus-ring-gap)
+        );
+        position: absolute;
+        right: 0;
+        top: 0;
+        transition: opacity
+                var(
+                    --mod-closebutton-animation-duration,
+                    var(--spectrum-closebutton-animation-duration)
+                )
+                ease-out,
+            margin
+                var(
+                    --mod-closebutton-animation-duraction,
+                    var(--spectrum-closebutton-animation-duration)
+                )
+                ease-out;
+    }
+    :host([variant='black']) {
+        --highcontrast-closebutton-static-background-color-default: ButtonFace;
+        --highcontrast-closebutton-icon-color-default: Highlight;
+        --highcontrast-closebutton-icon-color-disabled: GrayText;
+    }
+    :host([variant='white']) {
+        --highcontrast-closebutton-static-background-color-default: ButtonFace;
+        --highcontrast-closebutton-icon-color-default: Highlight;
+        --highcontrast-closebutton-icon-color-disabled: Highlight;
+    }
+}
+:host {
+    align-items: center;
+    border-color: transparent;
+    border-radius: var(
+        --mod-closebutton-border-radius,
+        var(--spectrum-closebutton-border-radius)
+    );
+    border-width: 0;
+    color: inherit;
+    display: inline-flex;
+    flex-direction: row;
+    height: var(
+        --mod-closebutton-height,
+        var(--spectrum-closebutton-height)
+    ); /* .spectrum-CloseButton */
+    justify-content: center;
+    padding: 0;
+    position: relative;
     transition: border-color
-        var(--spectrum-global-animation-duration-100, 0.13s) ease-in-out;
+        var(
+            --mod-closebutton-animation-duration,
+            var(--spectrum-closebutton-animation-duration)
+        )
+        ease-in-out;
+    width: var(--mod-closebutton-width, var(--spectrum-closebutton-width));
 }
 :host:after {
     border-radius: calc(
-        var(--spectrum-CloseButton-size) +
-            var(--spectrum-closebutton-focus-ring-gap)
+        var(--mod-closebutton-size, var(--spectrum-closebutton-size)) +
+            var(
+                --mod-closebutton-focus-ring-gap,
+                var(--spectrum-closebutton-focus-ring-gap)
+            )
     );
     bottom: 0;
     content: '';
     left: 0;
-    margin: calc(var(--spectrum-closebutton-focus-ring-gap) * -1);
+    margin: calc(
+        var(
+                --mod-closebutton-focus-ring-gap,
+                var(--spectrum-closebutton-focus-ring-gap)
+            ) * -1
+    );
     pointer-events: none; /* .spectrum-CloseButton:after */
     position: absolute;
     right: 0;
     top: 0;
-    transition: box-shadow var(--spectrum-global-animation-duration-100, 0.13s)
+    transition: box-shadow
+        var(
+            --mod-closebutton-animation-duration,
+            var(--spectrum-closebutton-animation-duration)
+        )
         ease-in-out;
 }
 :host(.focus-visible) {
@@ -100,384 +275,305 @@ governing permissions and limitations under the License.
     box-shadow: none; /* .spectrum-CloseButton.focus-ring */
 }
 :host(.focus-visible):after {
-    box-shadow: 0 0 0 var(--spectrum-closebutton-focus-ring-size)
-        var(--spectrum-closebutton-focus-ring-color); /* .spectrum-CloseButton.focus-ring:after */
+    box-shadow: 0 0 0
+        var(
+            --mod-closebutton-focus-ring-thickness,
+            var(--spectrum-closebutton-focus-ring-thickness)
+        )
+        var(
+            --highcontrast-closebutton-focus-ring-color,
+            var(
+                --mod-closebutton-focus-ring-color,
+                var(--spectrum-closebutton-focus-ring-color)
+            )
+        ); /* .spectrum-CloseButton.focus-ring:after */
 }
 :host(:focus-visible):after {
-    box-shadow: 0 0 0 var(--spectrum-closebutton-focus-ring-size)
-        var(--spectrum-closebutton-focus-ring-color); /* .spectrum-CloseButton.focus-ring:after */
-}
-:host([variant='white']) {
-    --spectrum-closebutton-focus-ring-color: var(
-        --spectrum-global-color-static-white,
-        rgb(var(--spectrum-global-color-static-white-rgb))
-    ); /* .spectrum-CloseButton--staticWhite */
-}
-:host([variant='black']) {
-    --spectrum-closebutton-focus-ring-color: var(
-        --spectrum-global-color-static-black,
-        rgb(var(--spectrum-global-color-static-black-rgb))
-    ); /* .spectrum-CloseButton--staticBlack */
-}
-:host {
-    align-items: center;
-    border-radius: var(--spectrum-CloseButton-size); /* .spectrum-CloseButton */
-    display: inline-flex;
-    flex-direction: row;
-    justify-content: center;
-    padding: 0;
-}
-:host([size='s']) {
-    --spectrum-CloseButton-size: var(--spectrum-global-dimension-size-300);
-    border-radius: var(
-        --spectrum-global-dimension-size-300
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--sizeS */
-    height: var(--spectrum-global-dimension-size-300);
-    width: var(--spectrum-global-dimension-size-300);
-}
-:host([size='m']) {
-    --spectrum-CloseButton-size: var(--spectrum-global-dimension-size-400);
-    border-radius: var(
-        --spectrum-global-dimension-size-400
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--sizeM */
-    height: var(--spectrum-global-dimension-size-400);
-    width: var(--spectrum-global-dimension-size-400);
-}
-:host([size='l']) {
-    --spectrum-CloseButton-size: var(--spectrum-global-dimension-size-500);
-    border-radius: var(
-        --spectrum-global-dimension-size-500
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--sizeL */
-    height: var(--spectrum-global-dimension-size-500);
-    width: var(--spectrum-global-dimension-size-500);
-}
-:host([size='xl']) {
-    --spectrum-CloseButton-size: var(--spectrum-global-dimension-size-600);
-    border-radius: var(
-        --spectrum-global-dimension-size-600
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--sizeXL */
-    height: var(--spectrum-global-dimension-size-600);
-    width: var(--spectrum-global-dimension-size-600);
-}
-:host(:disabled) {
-    background-color: transparent; /* .spectrum-CloseButton:disabled */
-}
-:host(:disabled) .icon {
-    color: var(
-        --spectrum-alias-component-icon-color-disabled,
-        var(--spectrum-alias-icon-color-disabled)
-    ); /* .spectrum-CloseButton:disabled .spectrum-CloseButton-UIIcon */
+    box-shadow: 0 0 0
+        var(
+            --mod-closebutton-focus-ring-thickness,
+            var(--spectrum-closebutton-focus-ring-thickness)
+        )
+        var(
+            --highcontrast-closebutton-focus-ring-color,
+            var(
+                --mod-closebutton-focus-ring-color,
+                var(--spectrum-closebutton-focus-ring-color)
+            )
+        ); /* .spectrum-CloseButton.focus-ring:after */
 }
 :host(:not(:disabled)) {
-    background-color: transparent; /* .spectrum-CloseButton:not(:disabled) */
+    background-color: var(
+        --highcontrast-closebutton-background-color-default,
+        var(
+            --mod-closebutton-background-color-default,
+            var(--spectrum-closebutton-background-color-default)
+        )
+    ); /* .spectrum-CloseButton:not(:disabled) */
 }
 :host(:not(:disabled):hover) {
     background-color: var(
-        --spectrum-global-color-gray-200
+        --mod-closebutton-background-color-hover,
+        var(--spectrum-closebutton-background-color-hover)
     ); /* .spectrum-CloseButton:not(:disabled):hover */
 }
 :host(:not(:disabled):hover) .icon {
     color: var(
-        --spectrum-alias-component-icon-color-hover,
-        var(--spectrum-alias-icon-color-hover)
+        --highcontrast-closebutton-icon-color-hover,
+        var(
+            --mod-closebutton-icon-color-hover,
+            var(--spectrum-closebutton-icon-color-hover)
+        )
     ); /* .spectrum-CloseButton:not(:disabled):hover .spectrum-CloseButton-UIIcon */
 }
 :host(:not(:disabled)[active]) {
     background-color: var(
-        --spectrum-global-color-gray-300
+        --mod-closebutton-background-color-down,
+        var(--spectrum-closebutton-background-color-down)
     ); /* .spectrum-CloseButton:not(:disabled):active */
 }
 :host(:not(:disabled)[active]) .icon {
     color: var(
-        --spectrum-alias-component-icon-color-down,
-        var(--spectrum-alias-icon-color-down)
+        --highcontrast-closebutton-icon-color-down,
+        var(
+            --mod-closebutton-icon-color-down,
+            var(--spectrum-closebutton-icon-color-down)
+        )
     ); /* .spectrum-CloseButton:not(:disabled):active .spectrum-CloseButton-UIIcon */
 }
-:host(:not(:disabled).focus-visible) {
-    background-color: var(
-        --spectrum-global-color-gray-300
-    ); /* .spectrum-CloseButton:not(:disabled):focus-visible */
-}
-:host(:not(:disabled):focus-visible) {
-    background-color: var(
-        --spectrum-global-color-gray-300
-    ); /* .spectrum-CloseButton:not(:disabled):focus-visible */
-}
-:host(:not(:disabled).focus-visible) .icon {
-    color: var(
-        --spectrum-alias-component-icon-color-key-focus,
-        var(--spectrum-alias-icon-color-hover)
-    ); /* .spectrum-CloseButton:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon */
-}
-:host(:not(:disabled):focus-visible) .icon {
-    color: var(
-        --spectrum-alias-component-icon-color-key-focus,
-        var(--spectrum-alias-icon-color-hover)
-    ); /* .spectrum-CloseButton:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon */
-}
+:host(:not(:disabled).focus-visible),
 :host(:not(:disabled)[focused]) {
     background-color: var(
-        --spectrum-global-color-gray-300
-    ); /* .spectrum-CloseButton:not(:disabled).is-keyboardFocused */
+        --mod-closebutton-background-color-focus,
+        var(--spectrum-closebutton-background-color-focus)
+    ); /* .spectrum-CloseButton:not(:disabled):focus-visible,
+   * .spectrum-CloseButton:not(:disabled).is-keyboardFocused */
 }
+:host(:not(:disabled):focus-visible),
+:host(:not(:disabled)[focused]) {
+    background-color: var(
+        --mod-closebutton-background-color-focus,
+        var(--spectrum-closebutton-background-color-focus)
+    ); /* .spectrum-CloseButton:not(:disabled):focus-visible,
+   * .spectrum-CloseButton:not(:disabled).is-keyboardFocused */
+}
+:host(:not(:disabled).focus-visible) .icon,
 :host(:not(:disabled)[focused]) .icon {
     color: var(
-        --spectrum-alias-component-icon-color-key-focus,
-        var(--spectrum-alias-icon-color-hover)
-    ); /* .spectrum-CloseButton:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-color-focus,
+        var(
+            --mod-closebutton-icon-color-focus,
+            var(--spectrum-closebutton-icon-color-focus)
+        )
+    ); /* .spectrum-CloseButton:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon */
+}
+:host(:not(:disabled):focus-visible) .icon,
+:host(:not(:disabled)[focused]) .icon {
+    color: var(
+        --highcontrast-closebutton-icon-color-focus,
+        var(
+            --mod-closebutton-icon-color-focus,
+            var(--spectrum-closebutton-icon-color-focus)
+        )
+    ); /* .spectrum-CloseButton:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon */
 }
 :host(:not(:disabled)) .icon {
     color: var(
-        --spectrum-alias-component-icon-color-default,
-        var(--spectrum-alias-icon-color)
+        --mod-closebutton-icon-color-default,
+        var(--spectrum-closebutton-icon-color-default)
     ); /* .spectrum-CloseButton:not(:disabled) .spectrum-CloseButton-UIIcon */
 }
+:host(:not(:disabled).is-focused) .icon,
 :host(:not(:disabled):focus) .icon {
     color: var(
-        --spectrum-alias-component-icon-color-mouse-focus,
-        var(--spectrum-alias-icon-color-down)
-    ); /* .spectrum-CloseButton:not(:disabled):focus .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-color-focus,
+        var(
+            --mod-closebutton-icon-color-focus,
+            var(--spectrum-closebutton-icon-color-focus)
+        )
+    ); /* .spectrum-CloseButton:not(:disabled):focus .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton:not(:disabled).is-focused .spectrum-CloseButton-UIIcon */
 }
-:host(:not(:disabled).is-focused) .icon {
-    color: var(
-        --spectrum-alias-component-icon-color-mouse-focus,
-        var(--spectrum-alias-icon-color-down)
-    ); /* .spectrum-CloseButton:not(:disabled).is-focused .spectrum-CloseButton-UIIcon */
-}
-:host([variant='black']:not(:disabled)) {
-    background-color: transparent; /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled) */
-}
-:host([variant='black']:not(:disabled):hover) {
+:host(:disabled) {
     background-color: var(
-        --spectrum-closebutton-m-black-background-color-hover,
-        rgba(0, 0, 0, 0.25)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled):hover */
+        --mod-closebutton-background-color-default,
+        var(--spectrum-closebutton-background-color-default)
+    ); /* .spectrum-CloseButton:disabled */
 }
-:host([variant='black']:not(:disabled):hover) .icon {
+:host(:disabled) .icon {
     color: var(
-        --spectrum-closebutton-m-black-uiicon-color-hover,
-        var(--spectrum-global-color-static-black)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled):hover .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-color-disabled,
+        var(
+            --mod-closebutton-icon-color-disabled,
+            var(--spectrum-closebutton-icon-color-disabled)
+        )
+    ); /* .spectrum-CloseButton:disabled .spectrum-CloseButton-UIIcon */
 }
-:host([variant='black']:not(:disabled)[active]) {
-    background-color: var(
-        --spectrum-closebutton-m-black-background-color-down,
-        rgba(0, 0, 0, 0.4)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled):active */
-}
-:host([variant='black']:not(:disabled)[active]) .icon {
-    color: var(
-        --spectrum-closebutton-m-black-uiicon-color-down,
-        var(--spectrum-global-color-static-black)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled):active .spectrum-CloseButton-UIIcon */
-}
-:host([variant='black']:not(:disabled).focus-visible) {
-    background-color: var(
-        --spectrum-closebutton-m-black-background-color-mouse-focus,
-        transparent
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled):focus-visible */
-}
-:host([variant='black']:not(:disabled):focus-visible) {
-    background-color: var(
-        --spectrum-closebutton-m-black-background-color-mouse-focus,
-        transparent
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled):focus-visible */
-}
-:host([variant='black']:not(:disabled).focus-visible) .icon {
-    color: var(
-        --spectrum-closebutton-m-black-uiicon-color-mouse-focus,
-        var(--spectrum-global-color-static-black)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon */
-}
-:host([variant='black']:not(:disabled):focus-visible) .icon {
-    color: var(
-        --spectrum-closebutton-m-black-uiicon-color-mouse-focus,
-        var(--spectrum-global-color-static-black)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon */
-}
-:host([variant='black']:not(:disabled)[focused]) {
-    background-color: var(
-        --spectrum-closebutton-m-black-background-color-key-focus,
-        rgba(0, 0, 0, 0.25)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled).is-keyboardFocused */
-}
-:host([variant='black']:not(:disabled)[focused]) .icon {
-    color: var(
-        --spectrum-closebutton-m-black-uiicon-color-key-focus,
-        var(--spectrum-global-color-static-black)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon */
-}
-:host([variant='black']:not(:disabled)) .icon {
-    color: var(
-        --spectrum-closebutton-m-black-uiicon-color,
-        var(--spectrum-global-color-static-black)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:not(:disabled) .spectrum-CloseButton-UIIcon */
-}
-:host([variant='black']:disabled) .icon {
-    color: var(
-        --spectrum-closebutton-m-black-uiicon-color-disabled,
-        rgba(0, 0, 0, 0.4)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticBlack:disabled .spectrum-CloseButton-UIIcon */
-}
+:host([variant='black']:not(:disabled)),
 :host([variant='white']:not(:disabled)) {
-    background-color: transparent; /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled) */
+    background-color: var(
+        --highcontrast-closebutton-static-background-color-default,
+        var(
+            --mod-closebutton-static-background-color-default,
+            var(--spectrum-closebutton-static-background-color-default)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled),
+   * .spectrum-CloseButton--staticWhite:not(:disabled) */
 }
+:host([variant='black']:not(:disabled):hover),
 :host([variant='white']:not(:disabled):hover) {
     background-color: var(
-        --spectrum-closebutton-m-white-background-color-hover,
-        hsla(0, 0%, 100%, 0.25)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled):hover */
+        --highcontrast-closebutton-static-background-color-hover,
+        var(
+            --mod-closebutton-static-background-color-hover,
+            var(--spectrum-closebutton-static-background-color-hover)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):hover,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):hover */
 }
+:host([variant='black']:not(:disabled):hover) .icon,
 :host([variant='white']:not(:disabled):hover) .icon {
     color: var(
-        --spectrum-closebutton-m-white-uiicon-color-hover,
-        var(--spectrum-global-color-static-white)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled):hover .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-color-default,
+        var(
+            --mod-closebutton-icon-color-default,
+            var(--spectrum-closebutton-icon-color-default)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):hover .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):hover .spectrum-CloseButton-UIIcon */
 }
-:host([variant='white']:not(:disabled)[active]) {
+:host([variant='black'][active]:not(:disabled)),
+:host([variant='white'][active]:not(:disabled)) {
     background-color: var(
-        --spectrum-closebutton-m-white-background-color-down,
-        hsla(0, 0%, 100%, 0.4)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled):active */
+        --highcontrast-closebutton-static-background-color-down,
+        var(
+            --mod-closebutton-static-background-color-down,
+            var(--spectrum-closebutton-static-background-color-down)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):active,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):active */
 }
-:host([variant='white']:not(:disabled)[active]) .icon {
+:host([variant='black'][active]:not(:disabled)) .icon,
+:host([variant='white'][active]:not(:disabled)) .icon {
     color: var(
-        --spectrum-closebutton-m-white-uiicon-color-down,
-        var(--spectrum-global-color-static-white)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled):active .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-color-default,
+        var(
+            --mod-closebutton-icon-color-default,
+            var(--spectrum-closebutton-icon-color-default)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):active .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):active .spectrum-CloseButton-UIIcon */
 }
-:host([variant='white']:not(:disabled).focus-visible) {
+:host([variant='black']:not(:disabled).focus-visible),
+:host([variant='black'][focused]:not(:disabled)),
+:host([variant='white']:not(:disabled).focus-visible),
+:host([variant='white'][focused]:not(:disabled)) {
     background-color: var(
-        --spectrum-closebutton-m-white-background-color-mouse-focus,
-        transparent
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled):focus-visible */
+        --highcontrast-closebutton-static-background-color-focus,
+        var(
+            --mod-closebutton-static-background-color-focus,
+            var(--spectrum-closebutton-static-background-color-focus)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):focus-visible,
+   * .spectrum-CloseButton--staticBlack:not(:disabled).is-keyboardFocused,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):focus-visible,
+   * .spectrum-CloseButton--staticWhite:not(:disabled).is-keyboardFocused */
 }
-:host([variant='white']:not(:disabled):focus-visible) {
+:host([variant='black']:not(:disabled):focus-visible),
+:host([variant='black'][focused]:not(:disabled)),
+:host([variant='white']:not(:disabled):focus-visible),
+:host([variant='white'][focused]:not(:disabled)) {
     background-color: var(
-        --spectrum-closebutton-m-white-background-color-mouse-focus,
-        transparent
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled):focus-visible */
+        --highcontrast-closebutton-static-background-color-focus,
+        var(
+            --mod-closebutton-static-background-color-focus,
+            var(--spectrum-closebutton-static-background-color-focus)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):focus-visible,
+   * .spectrum-CloseButton--staticBlack:not(:disabled).is-keyboardFocused,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):focus-visible,
+   * .spectrum-CloseButton--staticWhite:not(:disabled).is-keyboardFocused */
 }
-:host([variant='white']:not(:disabled).focus-visible) .icon {
+:host([variant='black']:not(:disabled).focus-visible) .icon,
+:host([variant='black'][focused]:not(:disabled)) .icon,
+:host([variant='white']:not(:disabled).focus-visible) .icon,
+:host([variant='white'][focused]:not(:disabled)) .icon {
     color: var(
-        --spectrum-closebutton-m-white-uiicon-color-mouse-focus,
-        var(--spectrum-global-color-static-white)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-color-default,
+        var(
+            --mod-closebutton-icon-color-default,
+            var(--spectrum-closebutton-icon-color-default)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticBlack:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon */
 }
-:host([variant='white']:not(:disabled):focus-visible) .icon {
+:host([variant='black']:not(:disabled):focus-visible) .icon,
+:host([variant='black'][focused]:not(:disabled)) .icon,
+:host([variant='white']:not(:disabled):focus-visible) .icon,
+:host([variant='white'][focused]:not(:disabled)) .icon {
     color: var(
-        --spectrum-closebutton-m-white-uiicon-color-mouse-focus,
-        var(--spectrum-global-color-static-white)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-color-default,
+        var(
+            --mod-closebutton-icon-color-default,
+            var(--spectrum-closebutton-icon-color-default)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticBlack:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):focus-visible .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon */
 }
-:host([variant='white']:not(:disabled)[focused]) {
-    background-color: var(
-        --spectrum-closebutton-m-white-background-color-key-focus,
-        hsla(0, 0%, 100%, 0.25)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled).is-keyboardFocused */
-}
-:host([variant='white']:not(:disabled)[focused]) .icon {
+:host([variant='black']:not(:disabled)) .is-focused .icon,
+:host([variant='black']:not(:disabled):focus) .icon,
+:host([variant='white']:not(:disabled)) .is-focused .icon,
+:host([variant='white']:not(:disabled):focus) .icon {
     color: var(
-        --spectrum-closebutton-m-white-uiicon-color-key-focus,
-        var(--spectrum-global-color-static-white)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled).is-keyboardFocused .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-color-default,
+        var(
+            --mod-closebutton-icon-color-default,
+            var(--spectrum-closebutton-icon-color-default)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled):focus .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticBlack:not(:disabled).is-focused .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled):focus .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled).is-focused .spectrum-CloseButton-UIIcon */
 }
+:host([variant='black']:not(:disabled)) .icon,
 :host([variant='white']:not(:disabled)) .icon {
     color: var(
-        --spectrum-closebutton-m-white-uiicon-color,
-        var(--spectrum-global-color-static-white)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:not(:disabled) .spectrum-CloseButton-UIIcon */
+        --mod-closebutton-icon-color-default,
+        var(--spectrum-closebutton-icon-color-default)
+    ); /* .spectrum-CloseButton--staticBlack:not(:disabled) .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:not(:disabled) .spectrum-CloseButton-UIIcon */
 }
+:host([variant='black']:disabled) .icon,
 :host([variant='white']:disabled) .icon {
     color: var(
-        --spectrum-closebutton-m-white-uiicon-color-disabled,
-        hsla(0, 0%, 100%, 0.4)
-    ); /* .spectrum-CloseButton.spectrum-CloseButton--staticWhite:disabled .spectrum-CloseButton-UIIcon */
+        --highcontrast-closebutton-icon-disabled,
+        var(
+            --mod-closebutton-icon-color-disabled,
+            var(--spectrum-closebutton-icon-color-disabled)
+        )
+    ); /* .spectrum-CloseButton--staticBlack:disabled .spectrum-CloseButton-UIIcon,
+   * .spectrum-CloseButton--staticWhite:disabled .spectrum-CloseButton-UIIcon */
 }
 .icon {
     margin: 0; /* .spectrum-CloseButton-UIIcon */
 }
-@media (forced-colors: active) {
-    :host {
-        --spectrum-alias-component-icon-color-default: ButtonText;
-        --spectrum-alias-component-icon-color-disabled: GrayText;
-        --spectrum-alias-component-icon-color-down: Highlight;
-        --spectrum-alias-component-icon-color-hover: Highlight;
-        --spectrum-alias-component-icon-color-key-focus: Highlight;
-        --spectrum-alias-component-icon-color-mouse-focus: Highlight;
-        --spectrum-closebutton-m-black-background-color-down: ButtonFace;
-        --spectrum-closebutton-m-black-background-color-hover: ButtonFace;
-        --spectrum-closebutton-m-black-background-color-key-focus: ButtonFace;
-        --spectrum-closebutton-m-black-background-color-mouse-focus: ButtonFace;
-        --spectrum-closebutton-m-black-uiicon-color: ButtonText;
-        --spectrum-closebutton-m-black-uiicon-color-disabled: GrayText;
-        --spectrum-closebutton-m-black-uiicon-color-down: Highlight;
-        --spectrum-closebutton-m-black-uiicon-color-hover: Highlight;
-        --spectrum-closebutton-m-black-uiicon-color-key-focus: Highlight;
-        --spectrum-closebutton-m-black-uiicon-color-mouse-focus: Highlight;
-        --spectrum-closebutton-m-white-background-color-down: ButtonFace;
-        --spectrum-closebutton-m-white-background-color-hover: ButtonFace;
-        --spectrum-closebutton-m-white-background-color-key-focus: ButtonFace;
-        --spectrum-closebutton-m-white-background-color-mouse-focus: ButtonFace;
-        --spectrum-closebutton-m-white-uiicon-color: ButtonText;
-        --spectrum-closebutton-m-white-uiicon-color-disabled: GrayText;
-        --spectrum-closebutton-m-white-uiicon-color-down: Highlight;
-        --spectrum-closebutton-m-white-uiicon-color-hover: Highlight;
-        --spectrum-closebutton-m-white-uiicon-color-key-focus: Highlight;
-        --spectrum-closebutton-m-white-uiicon-color-mouse-focus: Highlight;
-    }
-    :host(.focus-visible):after {
-        border-radius: 100%;
-        bottom: 0;
-        box-shadow: 0 0 0
-            var(
-                --spectrum-alias-focus-ring-size,
-                var(--spectrum-global-dimension-static-size-25)
-            )
-            var(
-                --spectrum-alias-component-icon-color-default,
-                var(--spectrum-alias-icon-color)
-            );
-        content: '';
-        display: block;
-        forced-color-adjust: none;
-        left: 0;
-        margin: var(
-            --spectrum-alias-focus-ring-gap,
-            var(--spectrum-global-dimension-static-size-25)
-        );
-        position: absolute;
-        right: 0;
-        top: 0;
-        transition: opacity var(--spectrum-global-animation-duration-100, 0.13s)
-                ease-out,
-            margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
-    }
-    :host(:focus-visible):after {
-        border-radius: 100%;
-        bottom: 0;
-        box-shadow: 0 0 0
-            var(
-                --spectrum-alias-focus-ring-size,
-                var(--spectrum-global-dimension-static-size-25)
-            )
-            var(
-                --spectrum-alias-component-icon-color-default,
-                var(--spectrum-alias-icon-color)
-            );
-        content: '';
-        display: block;
-        forced-color-adjust: none;
-        left: 0;
-        margin: var(
-            --spectrum-alias-focus-ring-gap,
-            var(--spectrum-global-dimension-static-size-25)
-        );
-        position: absolute;
-        right: 0;
-        top: 0;
-        transition: opacity var(--spectrum-global-animation-duration-100, 0.13s)
-                ease-out,
-            margin var(--spectrum-global-animation-duration-100, 0.13s) ease-out;
-    }
+:host {
+    --spectrum-closebutton-background-color-default: var(
+        --system-spectrum-closebutton-background-color-default
+    ); /* .spectrum-CloseButton */
+    --spectrum-closebutton-background-color-hover: var(
+        --system-spectrum-closebutton-background-color-hover
+    );
+    --spectrum-closebutton-background-color-down: var(
+        --system-spectrum-closebutton-background-color-down
+    );
+    --spectrum-closebutton-background-color-focus: var(
+        --system-spectrum-closebutton-background-color-focus
+    );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3945,10 +3945,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.12.tgz#325b6625f53dcb6a699a5b9e5bca07eb80316eac"
   integrity sha512-GFrSv43d6nzXg/MqcN2YCZKG9lBS8amD2X7k6o9vKxUzK0nffWBlm380Fbjk0Q3FYojertgujAFoUSZuUqS3aQ==
 
-"@spectrum-css/closebutton@^1.2.13":
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-1.2.13.tgz#a02a33e211349138bcde0988cd4317749a7618e4"
-  integrity sha512-V/P/XVWPh/TR2Qo66vn6o+vi5/utDbrMIdNV+zuF1dbl1wxH5QMOdCQrQOtzHrzcwulJRu3+Sk759VRPojLYCA==
+"@spectrum-css/closebutton@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-2.0.0.tgz#5497082f80fa91a709b80122aaf78b61bb349636"
+  integrity sha512-4v6c8auOcPIXGtKkySABEmtVEyG+MoyhDqiUcrwgkY9wjvMjrzhMWNLPFli8PwinyBIrcjwb+duBAF6JzwF5Mw==
 
 "@spectrum-css/coachmark@^5.0.13":
   version "5.0.13"


### PR DESCRIPTION
## Description
Adopt Core Tokens based Spectrum CSS dependency for Close Button

## Motivation and context
Updated color delivery

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://0c9ba506034bd6de4cc37917dd49adb4--spectrum-web-components.netlify.app/review/)
    2. Review the diffs
-   [ ] _Test case 2_
    1. CI Passes

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.