### PR TITLE
fix(action-menu): stop stripping selected state from submenu items

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: fe47e28f552ccdb6a232d7908a3eebc261e10170
+        default: d960ed164f59dd28ce43f344492f73fd7478cc50
 commands:
     downstream:
         steps:

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -99,3 +99,20 @@ customIcon.args = {
     `,
     visibleLabel: '',
 };
+
+export const submenu = (): TemplateResult => {
+    return html`
+        <sp-action-menu label="More Actions">
+            <sp-menu-item>One</sp-menu-item>
+            <sp-menu-item>Two</sp-menu-item>
+            <sp-menu-item>
+                Select some items
+                <sp-menu slot="submenu" selects="multiple">
+                    <sp-menu-item>A</sp-menu-item>
+                    <sp-menu-item selected>B</sp-menu-item>
+                    <sp-menu-item>C</sp-menu-item>
+                </sp-menu>
+            </sp-menu-item>
+        </sp-action-menu>
+    `;
+};

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -540,7 +540,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             } else {
                 this.menuItems = [
                     ...this.querySelectorAll(
-                        ':scope > sp-menu-item, sp-menu:not([slot="submenu"]) sp-menu-item'
+                        'sp-menu-item:not([slot="submenu"] *)'
                     ),
                 ] as MenuItem[];
             }

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -539,7 +539,9 @@ export class PickerBase extends SizedMixin(Focusable) {
                 this.menuItems = this.optionsMenu.childItems;
             } else {
                 this.menuItems = [
-                    ...this.querySelectorAll('sp-menu-item'),
+                    ...this.querySelectorAll(
+                        ':scope > sp-menu-item, sp-menu:not([slot="submenu"]) sp-menu-item'
+                    ),
                 ] as MenuItem[];
             }
             this.manageSelection();

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -933,6 +933,43 @@ export function runPickerTests(): void {
             expect(getParentOffset(firstItem)).to.be.greaterThan(-1);
         });
     });
+    describe('grouped', async () => {
+        const groupedFixture = async (): Promise<Picker> => {
+            return fixture<Picker>(
+                html`
+                    <sp-picker
+                        quiet
+                        label="I would like to use Spectrum Web Components"
+                        value="0"
+                    >
+                        <sp-menu-group>
+                            <span slot="header">Timeline</span>
+                            <sp-menu-item value="0" id="should-be-selected">
+                                Immediately
+                            </sp-menu-item>
+                            <sp-menu-item value="1">
+                                I'm already using them
+                            </sp-menu-item>
+                            <sp-menu-divider></sp-menu-divider>
+                            <sp-menu-item value="2">Soon</sp-menu-item>
+                            <sp-menu-item value="3">
+                                As part of my next project
+                            </sp-menu-item>
+                            <sp-menu-item value="4">In the future</sp-menu-item>
+                        </sp-menu-group>
+                    </sp-picker>
+                `
+            );
+        };
+        beforeEach(async () => {
+            el = await groupedFixture();
+            await elementUpdated(el);
+        });
+        it('selects the item with a matching value in a group', async () => {
+            const item = el.querySelector('#should-be-selected') as MenuItem;
+            expect(item.selected).to.be.true;
+        });
+    });
     describe('slotted label', () => {
         const pickerFixture = async (): Promise<Picker> => {
             const test = await fixture<Picker>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

New behavior: Omit `submenu` items from the `menuItems` list managed by `PickerBase`.

## Related issue(s)

https://github.com/adobe/spectrum-web-components/issues/2480

## Motivation and context

A side-effect of the existing behavior (managing _all_ menu items) is that nested submenus have their selection states removed.

## How has this been tested?

1. Go to [Storybook](https://62ec14b045349f19bd39b6b0--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--submenu)
2. Toggle the selections in the submenu
---
1. Regression test added to suite 
2. All existing tests pass

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/364501/182928551-1308d015-f266-4d93-af78-c060b08fa755.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
