### PR TITLE
ci: update golden image cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: d960ed164f59dd28ce43f344492f73fd7478cc50
+        default: 37ef2ae112e90181dfdecccc9eff308de5d90c83
 commands:
     downstream:
         steps:


### PR DESCRIPTION
Correct being on the wrong side of a rendering flake in the VRT system.