### PR TITLE
fix(dialog): swap secondary and cancel button order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 37ef2ae112e90181dfdecccc9eff308de5d90c83
+        default: 834ff68ca4ba9da88a48be1044e9d9f797302f83
 commands:
     downstream:
         steps:

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -255,18 +255,6 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
                               <div slot="footer">${this.footer}</div>
                           `
                         : html``}
-                    ${this.secondaryLabel
-                        ? html`
-                              <sp-button
-                                  variant="primary"
-                                  treatment="outline"
-                                  slot="button"
-                                  @click=${this.clickSecondary}
-                              >
-                                  ${this.secondaryLabel}
-                              </sp-button>
-                          `
-                        : html``}
                     ${this.cancelLabel
                         ? html`
                               <sp-button
@@ -276,6 +264,18 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
                                   @click=${this.clickCancel}
                               >
                                   ${this.cancelLabel}
+                              </sp-button>
+                          `
+                        : html``}
+                    ${this.secondaryLabel
+                        ? html`
+                              <sp-button
+                                  variant="primary"
+                                  treatment="outline"
+                                  slot="button"
+                                  @click=${this.clickSecondary}
+                              >
+                                  ${this.secondaryLabel}
                               </sp-button>
                           `
                         : html``}


### PR DESCRIPTION
The order of secondary and cancel button is wrong according to Spectrum spec.

## Description

Change the order of secondary and cancel button inside the render method.

## Related issue(s)

fixes #2344


## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

Manually tested.

## Screenshots (if appropriate)

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
