### PR TITLE
docs(overlay): document notImmediatelyClosable

### DIFF
--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -84,6 +84,7 @@ type OverlayOptions = {
     placement?: Placement;
     offset?: number;
     receivesFocus?: 'auto';
+    notImmediatelyClosable?: boolean;
 }
 ```
 
@@ -94,6 +95,8 @@ type OverlayOptions = {
 `offset` defines the distance of the overlay content from the trigger, measured in pixels.
 
 `receivesFocus` tells the overlay stack to throw focus into the overlay after it has opened.
+
+`notImmediatelyClosable` prevents immediate clicks from closing the ovleray. For example, since `focus` events are dispatched before `click` events, set `notImmediatelyClosable: true` when triggering an overlay via `focus` events.
 
 ### Events
 

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -96,7 +96,7 @@ type OverlayOptions = {
 
 `receivesFocus` tells the overlay stack to throw focus into the overlay after it has opened.
 
-`notImmediatelyClosable` prevents immediate clicks from closing the ovleray. For example, since `focus` events are dispatched before `click` events, set `notImmediatelyClosable: true` when triggering an overlay via `focus` events.
+`notImmediatelyClosable` prevents immediate clicks from closing the overlay. For example, since `focus` events are dispatched before `click` events, set `notImmediatelyClosable: true` when triggering an overlay via `focus`.
 
 ### Events
 

--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -96,7 +96,7 @@ type OverlayOptions = {
 
 `receivesFocus` tells the overlay stack to throw focus into the overlay after it has opened.
 
-`notImmediatelyClosable` prevents immediate clicks from closing the overlay. For example, since `focus` events are dispatched before `click` events, set `notImmediatelyClosable: true` when triggering an overlay via `focus`.
+`notImmediatelyClosable` prevents immediate clicks from closing the overlay. If you find that a trigger event is immediately overridden with a subsequent click (for instance, a `focus` trigger that should be closed on `click`), set `notImmediatelyClosable: true` to disregard clicks that coincide with the opening trigger.
 
 ### Events
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Document an undocumented option that's necessary for overlays like [this](https://studio.webcomponents.dev/edit/MgVf7AvrGMoL7z2aeNhj/src/index.ts?p=stories).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
