### PR TITLE
docs(dialog): fix story and add doc for responsive attribute

### DIFF
--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -86,6 +86,9 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
     @property()
     public headline = '';
 
+    /**
+     * When set to true, fills screens smaller than 350px high and 400px wide with the full dialog.
+     */
     @property({ type: Boolean })
     public responsive = false;
 

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -418,17 +418,6 @@ export const wrapperDismissableUnderlayError = (
     const open = context.viewMode === 'docs' ? false : true;
     return html`
         <div>
-            <sp-button
-                onClick="
-                    this.previousElementSibling.open = !this.previousElementSibling.open;
-                    if (this.previousElementSibling.open) {
-                        this.previousElementSibling.focus();
-                    }
-                "
-                variant="primary"
-            >
-                Toggle Dialog
-            </sp-button>
             <sp-dialog-wrapper
                 ?open=${open}
                 hero=${landscape}
@@ -441,6 +430,17 @@ export const wrapperDismissableUnderlayError = (
             >
                 Content of the dialog
             </sp-dialog-wrapper>
+            <sp-button
+                onClick="
+                    this.previousElementSibling.open = !this.previousElementSibling.open;
+                    if (this.previousElementSibling.open) {
+                        this.previousElementSibling.focus();
+                    }
+                "
+                variant="primary"
+            >
+                Toggle Dialog
+            </sp-button>
         </div>
     `;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

https://localhost:8000/?path=/story/dialog-wrapped--wrapper-dismissable-underlay-error This story would not reopen due to it having no previousElementSibling. Switched the order of the elements to fix. Also added JSDocs for `responsive` attribute.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Pointed out by SWC user in slack

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/dialog-wrapped--wrapper-dismissable-underlay-error
    2. Close the dialogue
    3. See that it does not reopen when clicking "Toggle Dialog" button. Note console error.
-   [ ] _Test case 2_
    1. Go here
    2. Close dialogue
    3. See that you can reopen dialogue with the button, unlike before.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
