### PR TITLE
Update focus return from overlays to modal parents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 834ff68ca4ba9da88a48be1044e9d9f797302f83
+        default: 1c2080150323a1989ad3af30e706a570ef280f23
 commands:
     downstream:
         steps:

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -109,9 +109,9 @@ export class DialogWrapper extends FocusVisiblePolyfillMixin(SpectrumElement) {
             const firstFocusable = firstFocusableIn(this.dialog);
             if (firstFocusable) {
                 if (firstFocusable.updateComplete) {
-                    firstFocusable.updateComplete.then(() =>
-                        firstFocusable.focus()
-                    );
+                    firstFocusable.updateComplete.then(() => {
+                        firstFocusable.focus();
+                    });
                     /* c8 ignore next 3 */
                 } else {
                     firstFocusable.focus();

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -17,6 +17,7 @@ import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/help-text/sp-help-text.js';
 import '@spectrum-web-components/textfield/sp-textfield.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 
 import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
@@ -516,3 +517,44 @@ export const wrapperFullscreen = (
         </sp-dialog-wrapper>
     `;
 };
+
+export const tooltips = (
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
+): TemplateResult => {
+    const open = context.viewMode === 'docs' ? undefined : 'click';
+    return html`
+        <overlay-trigger
+            type="modal"
+            placement="none"
+            @close=${handleClose(args)}
+            open=${ifDefined(open)}
+        >
+            <sp-button slot="trigger" variant="primary">
+                Toggle Dialog
+            </sp-button>
+            <sp-dialog-wrapper
+                slot="click-content"
+                headline="Dialog title"
+                dismissable
+                underlay
+                size="s"
+            >
+                ${[1, 2, 3, 4].map(
+                    (index) => html`
+                        <overlay-trigger>
+                            <sp-button slot="trigger">
+                                Button with Tooltip ${index}
+                            </sp-button>
+                            <sp-tooltip slot="hover-content">
+                                Tooltip ${index}
+                            </sp-tooltip>
+                        </overlay-trigger>
+                    `
+                )}
+            </sp-dialog-wrapper>
+        </overlay-trigger>
+    `;
+};
+
+tooltips.decorators = [overlayTriggerDecorator];

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -456,14 +456,15 @@ export class OverlayStack {
     }
 
     private async manageFocusAfterCloseWhenOverlaysRemain(
-        returnBeforeFocus?: boolean
+        returnBeforeFocus?: boolean,
+        previousTrigger?: HTMLElement
     ): Promise<void> {
         const topOverlay = this.overlays[this.overlays.length - 1];
         topOverlay.feature();
         // Push focus in the the next remaining overlay as needed when a `type="modal"` overlay exists.
         if (topOverlay.interaction === 'modal' || topOverlay.hasModalRoot) {
             if (returnBeforeFocus) return;
-            await topOverlay.focus();
+            await (previousTrigger || topOverlay).focus();
         } else {
             this.stopTabTrapping();
         }
@@ -543,7 +544,8 @@ export class OverlayStack {
 
         if (this.overlays.length) {
             await this.manageFocusAfterCloseWhenOverlaysRemain(
-                returnBeforeFocus
+                returnBeforeFocus || overlay.interaction === 'hover',
+                overlay.trigger
             );
         } else {
             this.manageFocusAfterCloseWhenLastOverlay(overlay);

--- a/packages/overlay/test/overlay-trigger-hover.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover.test.ts
@@ -191,7 +191,7 @@ describe('Overlay Trigger - Hover', () => {
 
         expect(el.open).to.be.null;
     });
-    it.only('will not return focus to a "modal" parent', async () => {
+    it('will not return focus to a "modal" parent', async () => {
         const el = await styledFixture<OverlayTrigger>(html`
             <overlay-trigger type="modal" placement="none">
                 <sp-button slot="trigger">Toggle Dialog</sp-button>

--- a/packages/overlay/test/overlay-trigger-sync.test.ts
+++ b/packages/overlay/test/overlay-trigger-sync.test.ts
@@ -413,7 +413,7 @@ describe('Overlay Trigger - sync', () => {
             );
 
             expect(
-                document.activeElement === outerClickContent,
+                document.activeElement === innerButton,
                 'outer popover recieved focus'
             ).to.be.true;
         });

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -413,7 +413,7 @@ describe('Overlay Trigger', () => {
             );
 
             expect(
-                document.activeElement === outerClickContent,
+                document.activeElement === innerButton,
                 'outer popover recieved focus'
             ).to.be.true;
         });


### PR DESCRIPTION
## Description
- "hover" content doesn't take focus, it shouldn't move focus when closing
- returned focus shouldn't go to the "root" of a parent modal but to the "trigger" of the recently closed modal

## Related issue(s)
- fixes #2483

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://returns-focus--spectrum-web-components.netlify.app/storybook/?path=/story/dialog-wrapped--tooltips)
    2. Tab through the modal
    3. See that the focus stays on the expected button

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
