### PR TITLE
Table Phase 2 Additions

### DIFF
--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -14,6 +14,12 @@ yarn add @spectrum-web-components/table
 Import the side effectful registration of `<sp-table>`, `<sp-table-body>`, `<sp-table-cell>`, `<sp-table-checkbox-cell>`, `<sp-table-head>`, `<sp-table-head-cell>`. and `<sp-table-row>` via:
 
 ```
+import '@spectrum-web-components/table/elements.js';
+```
+
+Or individually via:
+
+```
 import '@spectrum-web-components/table/sp-table.js';
 import '@spectrum-web-components/table/sp-table-body.js';
 import '@spectrum-web-components/table/sp-table-cell.js';
@@ -82,44 +88,9 @@ To ensure that the table scrolls, make sure to add a `style` attribute to `<sp-t
 
 To manage selection on an `<sp-table>`, utilise the `selects` attribute on `<sp-table>`. Each `<sp-table-row>` has a `value` attribute which, by default, corresponds to its index in the table, and these `value`s tell `<sp-table>` which `<sp-table-row>`s are selected. The selected items can be manually fed in through the `.selected` attribute on the table.
 
-```html
-<sp-table size="m">
-    <sp-table-head>
-        <sp-table-head-cell sortable sort>Column Title</sp-table-head-cell>
-        <sp-table-head-cell>Column Title</sp-table-head-cell>
-        <sp-table-head-cell>Column Title</sp-table-head-cell>
-    </sp-table-head>
-    <sp-table-body>
-        <sp-table-row>
-            <sp-table-cell>Row Item Alpha</sp-table-cell>
-            <sp-table-cell>Row Item Alpha</sp-table-cell>
-            <sp-table-cell>Row Item Alpha</sp-table-cell>
-        </sp-table-row>
-        <sp-table-row>
-            <sp-table-cell>Row Item Bravo</sp-table-cell>
-            <sp-table-cell>Row Item Bravo</sp-table-cell>
-            <sp-table-cell>Row Item Bravo</sp-table-cell>
-        </sp-table-row>
-        <sp-table-row>
-            <sp-table-cell>Row Item Charlie</sp-table-cell>
-            <sp-table-cell>Row Item Charlie</sp-table-cell>
-            <sp-table-cell>Row Item Charlie</sp-table-cell>
-        </sp-table-row>
-        <sp-table-row>
-            <sp-table-cell>Row Item Delta</sp-table-cell>
-            <sp-table-cell>Row Item Delta</sp-table-cell>
-            <sp-table-cell>Row Item Delta</sp-table-cell>
-        </sp-table-row>
-        <sp-table-row>
-            <sp-table-cell>Row Item Echo</sp-table-cell>
-            <sp-table-cell>Row Item Echo</sp-table-cell>
-            <sp-table-cell>Row Item Echo</sp-table-cell>
-        </sp-table-row>
-    </sp-table-body>
-</sp-table>
-```
-
 ### `selects="single"`
+
+When `selects="single"` the `<sp-table>` will manage a _single_ selection in the array value of `selected`.
 
 ```html
 <sp-table
@@ -166,7 +137,7 @@ To manage selection on an `<sp-table>`, utilise the `selects` attribute on `<sp-
 
 ### `selects="multiple"`
 
-When `selects` is set to "multiple", the `<sp-table-checkbox-cell>` in `<sp-table-head>` acts as the select/deselect all button.
+When `selects="multiple"` the `<sp-table>` will manage a selection in the array value of `selected` in via a presence toggle. Further, an `<sp-table-checkbox-cell>` will be made available in the `<sp-table-head>` in order to select/deselect all items in the `<sp-table>`.
 
 ```html
 <sp-table
@@ -249,7 +220,7 @@ For large amounts of data, the `<sp-table>` can be virtualised to easily add tab
             const cell1 = document.createElement('sp-table-cell');
             const cell2 = document.createElement('sp-table-cell');
             const cell3 = document.createElement('sp-table-cell');
-            cell1.textContent = `Row Item Alpha ${item.value}`;
+            cell1.textContent = `Row Item Alpha ${item.name}`;
             cell2.textContent = `Row Item Alpha ${index}`;
             cell3.textContent = `Last Thing`;
             return [cell1, cell2, cell3];
@@ -283,7 +254,7 @@ For large amounts of data, the `<sp-table>` can be virtualised to easily add tab
             const cell1 = document.createElement('sp-table-cell');
             const cell2 = document.createElement('sp-table-cell');
             const cell3 = document.createElement('sp-table-cell');
-            cell1.textContent = `Row Item Alpha ${item.value}`;
+            cell1.textContent = `Row Item Alpha ${item.name}`;
             cell2.textContent = `Row Item Alpha ${index}`;
             cell3.textContent = `Last Thing`;
             return [cell1, cell2, cell3];
@@ -328,6 +299,207 @@ const renderItem = (item: Item, index: number): TemplateResult => {
 ```
 
 Please note that there is a bug when attempting to select all virtualised elements. The items are selected programatically, it's just not reflected visually.
+
+### Selection
+
+When making a selection on a virtualized table, it can sometimes be useful to track that selection as something other than an array of indexes. To make this possible the `itemValue` property will accept a method who argument is an item object, return a computed string value to track selection with this value rather than the item's index:
+
+```html-live
+<sp-table
+    size="m"
+    id="table-item-value-demo"
+    style="height: 200px"
+    scroller="true"
+    selects="multiple"
+>
+    <sp-table-head>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+    </sp-table-head>
+</sp-table>
+<div class="selection">Selected: [ ]</div>
+<script type="module">
+    const initItems = (count) => {
+        const total = count;
+        const items = [];
+        while (count) {
+            count--;
+            items.push({
+                id: crypto.randomUUID(),
+                name: String(total - count),
+                date: count,
+            });
+        }
+        return items;
+    };
+    const initTable = () => {
+        const table = document.querySelector('#table-item-value-demo');
+        table.items = initItems(50);
+
+        table.renderItem = (item, index) => {
+            const cell1 = document.createElement('sp-table-cell');
+            const cell2 = document.createElement('sp-table-cell');
+            const cell3 = document.createElement('sp-table-cell');
+            cell1.textContent = `Row Item Alpha ${item.name}`;
+            cell2.textContent = `Row Item Alpha ${index}`;
+            cell3.textContent = `Last Thing`;
+            return [cell1, cell2, cell3];
+        };
+
+        table.addEventListener('change', (event) => {
+            const selected = event.target.nextElementSibling;
+            selected.textContent = `Selected: ${JSON.stringify(event.target.selected, null, ' ')}`;
+        });
+    };
+    customElements.whenDefined('sp-table').then(() => {
+        initTable();
+    });
+</script>
+```
+
+<script type="module">
+    const initItems = (count) => {
+        const total = count;
+        const items = [];
+        while (count) {
+            count--;
+            items.push({
+                id: crypto.randomUUID(),
+                name: String(total - count),
+                date: count,
+            });
+        }
+        return items;
+    }
+
+    const initTable = () => {
+        const table = document.querySelector('#table-item-value-demo');
+        table.items = initItems(50);
+        table.itemValue = (item) => item.id;
+
+        table.renderItem = (item, index) => { 
+            const cell1 = document.createElement('sp-table-cell');
+            const cell2 = document.createElement('sp-table-cell');
+            const cell3 = document.createElement('sp-table-cell');
+            cell1.textContent = `Row Item Alpha ${item.name}`;
+            cell2.textContent = `Row Item Alpha ${index}`;
+            cell3.textContent = `Last Thing`;
+            return [cell1, cell2, cell3];
+        };
+
+        table.addEventListener('change', (event) => {
+            const selected = event.target.nextElementSibling;
+            selected.textContent = `Selected: ${JSON.stringify(event.target.selected, null, ' ')}`;
+        });
+    };
+    customElements.whenDefined('sp-table').then(() => {
+        initTable();
+    });
+</script>
+
+### Row Types
+
+All values in the item array are assumed to be homogenous by default. This means all of the rendered rows are either delivered as provided, or, in the case you are leveraging `selects`, rendered with an `<sp-table-checkbox-cell>`. However, when virtualizing a table with selection it can sometimes be useful to surface rows with additional interactions, e.g. "Load more data" links. To support that you can optionally include the `_$rowType$` brand in your item. The values for this are outlined by the `RowType` enum and include `ITEM` (0) and `INFORMATION` (1). When `_$rowType$: RowType.INFORMATION` is provided it informs the `<sp-table>` element not to deliver an `<sp-table-checkbox-cell>` with that row.
+
+```html-live
+<sp-table
+    size="m"
+    id="table-row-type-demo"
+    style="height: 200px"
+    scroller="true"
+    selects="single"
+>
+    <sp-table-head>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+    </sp-table-head>
+</sp-table>
+<script type="module">
+    const initItems = (count) => {
+        const total = count;
+        const items = [];
+        while (count) {
+            count--;
+            items.push({
+                name: String(total - count),
+                date: count,
+            });
+        }
+        return items;
+    };
+    const initTable = () => {
+        const table = document.querySelector('#table-row-type-demo');
+        const items = initItems(50);
+        items.splice(3, 0, {
+            _$rowType$: 1,
+        });
+        table.items = items;
+
+        table.renderItem = (item, index) => {
+            if (item._$rowType$ === 1) {
+                const infoCell = document.createElement('sp-table-cell');
+                infoCell.textContent = 'Use this row type for non-selectable content.';
+                return [infoCell];
+            }
+            const cell1 = document.createElement('sp-table-cell');
+            const cell2 = document.createElement('sp-table-cell');
+            const cell3 = document.createElement('sp-table-cell');
+            cell1.textContent = `Row Item Alpha ${item.name}`;
+            cell2.textContent = `Row Item Alpha ${index}`;
+            cell3.textContent = `Last Thing`;
+            return [cell1, cell2, cell3];
+        };
+    };
+    customElements.whenDefined('sp-table').then(() => {
+        initTable();
+    });
+</script>
+```
+
+<script type="module">
+    const initItems = (count) => {
+        const total = count;
+        const items = [];
+        while (count) {
+            count--;
+            items.push({
+                name: String(total - count),
+                date: count,
+            });
+        }
+        return items;
+    }
+
+    const initTable = () => {
+        const table = document.querySelector('#table-row-type-demo');
+        const items = initItems(50);
+        items.splice(3, 0, {
+            _$rowType$: 1,
+        });
+        table.items = items;
+
+
+        table.renderItem = (item, index) => { 
+            if (item._$rowType$ === 1) {
+                const infoCell = document.createElement('sp-table-cell');
+                infoCell.textContent = 'Use this row type for non-selectable content.';
+                return [infoCell];
+            }
+            const cell1 = document.createElement('sp-table-cell');
+            const cell2 = document.createElement('sp-table-cell');
+            const cell3 = document.createElement('sp-table-cell');
+            cell1.textContent = `Row Item Alpha ${item.name}`;
+            cell2.textContent = `Row Item Alpha ${index}`;
+            cell3.textContent = `Last Thing`;
+            return [cell1, cell2, cell3];
+        };
+    };
+    customElements.whenDefined('sp-table').then(() => {
+        initTable();
+    });
+</script>
 
 ### The `scroller` property
 

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -86,11 +86,11 @@ To ensure that the table scrolls, make sure to add a `style` attribute to `<sp-t
 
 ## Selection
 
-To manage selection on an `<sp-table>`, utilise the `selects` attribute on `<sp-table>`. Each `<sp-table-row>` has a `value` attribute which, by default, corresponds to its index in the table, and these `value`s tell `<sp-table>` which `<sp-table-row>`s are selected. The selected items can be manually fed in through the `.selected` attribute on the table.
+To manage selection on an `<sp-table>`, utilise the `selects` attribute on `<sp-table>`. Each `<sp-table-row>` has a `value` attribute which, by default, corresponds to its index in the table, and these `value`s tell `<sp-table>` which `<sp-table-row>`s are selected. The selected items can be manually applied via the `selected` property on the table.
 
 ### `selects="single"`
 
-When `selects="single"` the `<sp-table>` will manage a _single_ selection in the array value of `selected`.
+When `selects="single"`, the `<sp-table>` will manage a _single_ selection in the array value of `selected`.
 
 ```html
 <sp-table
@@ -137,7 +137,7 @@ When `selects="single"` the `<sp-table>` will manage a _single_ selection in the
 
 ### `selects="multiple"`
 
-When `selects="multiple"` the `<sp-table>` will manage a selection in the array value of `selected` in via a presence toggle. Further, an `<sp-table-checkbox-cell>` will be made available in the `<sp-table-head>` in order to select/deselect all items in the `<sp-table>`.
+When `selects="multiple"`, the `<sp-table>` will manage a selection in the array value of `selected` in via a presence toggle. Additionally, an `<sp-table-checkbox-cell>` will be made available in the `<sp-table-head>` in order to select/deselect all items in the `<sp-table>`.
 
 ```html
 <sp-table
@@ -302,7 +302,7 @@ Please note that there is a bug when attempting to select all virtualised elemen
 
 ### Selection
 
-When making a selection on a virtualized table, it can sometimes be useful to track that selection as something other than an array of indexes. To make this possible the `itemValue` property will accept a method who argument is an item object, return a computed string value to track selection with this value rather than the item's index:
+By default the `selected` property will surface an array of item indexes that are currently selected. However, when making a selection on a virtualized table, it can be useful to track selection as something other than indexes. To do so, set a custom method for the `itemValue` property. The `itemValue` method accepts an item and its index as arguments and should return the value you would like to track in the `selected` property.
 
 ```html-live
 <sp-table
@@ -400,7 +400,7 @@ When making a selection on a virtualized table, it can sometimes be useful to tr
 
 ### Row Types
 
-All values in the item array are assumed to be homogenous by default. This means all of the rendered rows are either delivered as provided, or, in the case you are leveraging `selects`, rendered with an `<sp-table-checkbox-cell>`. However, when virtualizing a table with selection it can sometimes be useful to surface rows with additional interactions, e.g. "Load more data" links. To support that you can optionally include the `_$rowType$` brand in your item. The values for this are outlined by the `RowType` enum and include `ITEM` (0) and `INFORMATION` (1). When `_$rowType$: RowType.INFORMATION` is provided it informs the `<sp-table>` element not to deliver an `<sp-table-checkbox-cell>` with that row.
+All values in the item array are assumed to be homogenous by default. This means all of the rendered rows are either delivered as provided, or, in the case you are leveraging `selects`, rendered with an `<sp-table-checkbox-cell>`. However, when virtualizing a table with selection, it can sometimes be useful to surface rows with additional interactions, e.g. "Load more data" links. To support that, you can optionally include the `_$rowType$` brand in your item. The values for this are outlined by the `RowType` enum and include `ITEM` (0) and `INFORMATION` (1). When `_$rowType$: RowType.INFORMATION` is provided, it instructs the `<sp-table>` not to deliver an `<sp-table-checkbox-cell>` in that row.
 
 ```html-live
 <sp-table

--- a/packages/table/elements.ts
+++ b/packages/table/elements.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import './sp-table-body.js';
+import './sp-table-cell.js';
+import './sp-table-checkbox-cell.js';
+import './sp-table-head-cell.js';
+import './sp-table-head.js';
+import './sp-table-row.js';
+import './sp-table-table.js';

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -125,6 +125,7 @@
     "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js",
+        "./elements.js",
         "./**/*.dev.js"
     ]
 }

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -443,6 +443,9 @@ export class Table extends SizedMixin(SpectrumElement, {
     }
 
     protected renderVirtualizedItems(index?: number): void {
+        // Rendering updates into the table while disconnected can
+        // cause runaway event binding in ancestor elements.
+        if (!this.isConnected) return;
         if (!this.tableBody) {
             this.tableBody = this.querySelector('sp-table-body') as TableBody;
             if (!this.tableBody) {
@@ -477,5 +480,12 @@ export class Table extends SizedMixin(SpectrumElement, {
             `,
             this.tableBody
         );
+    }
+
+    public override disconnectedCallback(): void {
+        if (this.tableBody) {
+            render(html``, this.tableBody);
+        }
+        super.disconnectedCallback();
     }
 }

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -41,7 +41,7 @@ interface Range {
 
 export enum RowType {
     ITEM = 0,
-    INFORMATION,
+    INFORMATION = 1,
 }
 
 export interface TableItem extends Record<string, unknown> {

--- a/packages/table/src/TableCheckboxCell.ts
+++ b/packages/table/src/TableCheckboxCell.ts
@@ -52,6 +52,10 @@ export class TableCheckboxCell extends SpectrumElement {
     @property({ type: Boolean, reflect: true, attribute: 'selects-single' })
     public selectsSingle = false;
 
+    public override click(): void {
+        this.checkbox.click();
+    }
+
     protected override render(): TemplateResult {
         return html`
             <sp-checkbox

--- a/packages/table/src/TableHeadCell.ts
+++ b/packages/table/src/TableHeadCell.ts
@@ -95,7 +95,7 @@ export class TableHeadCell extends SpectrumElement {
     }
 
     protected override update(changes: PropertyValues): void {
-        if (changes.has('sorted')) {
+        if (changes.has('sortDirection')) {
             this.setAttribute('aria-sort', ariaSortValue(this.sortDirection));
         }
         if (changes.has('sortable')) {

--- a/packages/table/src/TableRow.ts
+++ b/packages/table/src/TableRow.ts
@@ -58,7 +58,7 @@ export class TableRow extends SpectrumElement {
 
         await 0;
 
-        if (event?.defaultPrevented) {
+        if (event.defaultPrevented) {
             this.selected = !this.selected;
         }
     }
@@ -89,7 +89,7 @@ export class TableRow extends SpectrumElement {
             return;
         }
         const [checkboxCell] = this.checkboxCells;
-        if (!checkboxCell) return;
+        if (!checkboxCell) /* c8 ignore next */ return;
         checkboxCell.click();
     }
 

--- a/packages/table/test/table-selects.test.ts
+++ b/packages/table/test/table-selects.test.ts
@@ -170,6 +170,12 @@ describe('Table Selects', () => {
         expect(rowThreeCheckbox.checkbox.checked).to.be.true;
         expect(rowTwoCheckbox.checkbox.checked).to.be.false;
         expect(el.selected.length).to.equal(1);
+
+        rowTwo.click();
+        await elementUpdated(el);
+
+        expect(rowTwoCheckbox.checked).to.be.true;
+        expect(el.selected).to.deep.equal(['row2']);
     });
 
     it('surfaces [selects="multiple"] selection', async () => {

--- a/packages/table/test/table-selects.test.ts
+++ b/packages/table/test/table-selects.test.ts
@@ -206,7 +206,7 @@ describe('Table Selects', () => {
         expect(rowFourCheckbox.checked).to.be.true;
         expect(el.selected).to.deep.equal(['row1', 'row2', 'row4']);
 
-        tableHeadCheckboxCell.checkbox.click();
+        tableHeadCheckboxCell.click();
         await elementUpdated(el);
 
         expect(el.selected).to.deep.equal([

--- a/packages/table/test/virtualized-table-selects.test.ts
+++ b/packages/table/test/virtualized-table-selects.test.ts
@@ -209,6 +209,11 @@ describe('Virtualized Table Selects', () => {
         await elementUpdated(el);
 
         expect(el.selected).to.deep.equal(['2']);
+
+        rowTwo.click();
+        await elementUpdated(el);
+
+        expect(el.selected).to.deep.equal(['1']);
     });
 
     it('surfaces [selects="multiple"] selection on Virtualized Table', async () => {

--- a/packages/table/test/virtualized-table-selects.test.ts
+++ b/packages/table/test/virtualized-table-selects.test.ts
@@ -103,9 +103,14 @@ describe('Virtualized Table Selects', () => {
         expect(el.selected).to.deep.equal(['applied-47']);
 
         el.selected = ['0'];
+        await elementUpdated(el);
 
-        const rowOne = el.querySelector('[value="0"]') as TableRow;
-        expect(rowOne).to.be.null;
+        expect(el.selected).to.deep.equal([]);
+
+        el.selected = ['applied-1'];
+        await elementUpdated(el);
+
+        expect(el.selected).to.deep.equal(['applied-1']);
     });
 
     it('can prevent selection', async () => {
@@ -205,7 +210,7 @@ describe('Virtualized Table Selects', () => {
 
         expect(el.selected).to.deep.equal(['1']);
 
-        rowThreeCheckbox.checkbox.click();
+        rowThreeCheckbox.click();
         await elementUpdated(el);
 
         expect(el.selected).to.deep.equal(['2']);
@@ -383,6 +388,18 @@ describe('Virtualized Table Selects', () => {
         expect(rowOneCheckboxCell.checkbox.checked).to.be.true;
         expect(rowTwoCheckboxCell.checkbox.checked).to.be.true;
         expect(tableHeadCheckboxCell.indeterminate).to.be.true;
+
+        el.removeAttribute('selects');
+        await elementUpdated(el);
+
+        expect(el.selects).to.be.null;
+        expect(tableHeadCheckboxCell.indeterminate).to.be.true;
+
+        const checkboxes = el.querySelectorAll(
+            'sp-table-checkbox-cell'
+        ) as NodeListOf<TableCheckboxCell>;
+
+        expect(checkboxes.length).to.equal(0);
     });
 
     it('selects a user-passed value for .selected array with no [selects] specified on Virtualized `<sp-table>`, but does not allow interaction afterwards', async () => {


### PR DESCRIPTION
## Description
- toggle selection on row clicks
- expose `elements.js` as an export
- expand docs
- bind the virtualized list in a way that doesn't create run away listeners
- test coverage and clean up post refactor

## Related issue(s)
- refs #2456 

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://table--spectrum-web-components.netlify.app/components/table/)
    2. Read the docs
-   [ ] _Test case 2_
    1. Go [here](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/12737/workflows/635f986d-8cd1-47d5-b47a-d9d58b38ea41)
    2. See that the unit tests are passing
    3. VRTs will come later

## Types of changes\
-   [x] Feature work

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)