### PR TITLE
fix: prevent longpress when interacting with context menu

### DIFF
--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -31,7 +31,7 @@ const holdAffordanceClass = {
     xl: 'spectrum-UIIcon-CornerTriangle300',
 };
 
-const LONGPRESS_DURATION = 300;
+export const LONGPRESS_DURATION = 300;
 let LONGPRESS_TIMEOUT: ReturnType<typeof setTimeout>;
 
 export type LongpressEvent = {
@@ -128,7 +128,8 @@ export class ActionButton extends SizedMixin(ButtonBase) {
         }
     };
 
-    private onPointerdown(): void {
+    private onPointerdown(event: PointerEvent): void {
+        if (event.button !== 0) return;
         this.addEventListener('pointerup', this.onPointerup);
         this.addEventListener('pointercancel', this.onPointerup);
         LONGPRESS_TIMEOUT = setTimeout(() => {

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -11,8 +11,12 @@ governing permissions and limitations under the License.
 */
 
 import '@spectrum-web-components/action-button/sp-action-button.js';
-import { ActionButton } from '@spectrum-web-components/action-button';
 import {
+    ActionButton,
+    LONGPRESS_DURATION,
+} from '@spectrum-web-components/action-button';
+import {
+    aTimeout,
     elementUpdated,
     expect,
     fixture,
@@ -96,10 +100,31 @@ describe('ActionButton', () => {
         });
 
         expect(longpressSpy.callCount).to.equal(2);
-        el.dispatchEvent(new Event('pointerdown'));
-        el.dispatchEvent(new Event('pointerup'));
-        el.dispatchEvent(new Event('pointerdown'));
+        el.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }));
+        el.dispatchEvent(new PointerEvent('pointerup'));
+        el.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }));
         await waitUntil(() => longpressSpy.callCount === 3);
+    });
+    it('does not dispatch `longpress` events when "right click"ed', async () => {
+        const longpressSpy = spy();
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button
+                    hold-affordance
+                    @longpress=${() => longpressSpy()}
+                >
+                    Button
+                </sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(longpressSpy.callCount).to.equal(0);
+
+        el.focus();
+        el.dispatchEvent(new PointerEvent('pointerdown', { button: 1 }));
+        await aTimeout(2 * LONGPRESS_DURATION);
+        expect(longpressSpy.callCount).to.equal(0);
     });
     it(':not([toggles])', async () => {
         const el = await fixture<ActionButton>(

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -104,7 +104,7 @@ describe('Overlay Trigger - Longpress', () => {
         await elementUpdated(el);
 
         open = oneEvent(el, 'sp-opened');
-        trigger.dispatchEvent(new Event('pointerdown'));
+        trigger.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }));
         await open;
         expect(content.open, 'opens for `pointerdown`').to.be.true;
         closed = oneEvent(el, 'sp-closed');


### PR DESCRIPTION
## Description
Context menu interaction no longer trigger the `longpress` event.

## Related issue(s)

- fixes #2517

## How has this been tested?

-   [ ] _Test case 1_
    1. Added new unit test
-   [ ] _Test case 2_
    1. Go [here](https://longpress-conextmenu--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--longpress)
    2. Right click the Action Button, see that it doesn't open the `longpress` menu.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.