### PR TITLE
fix: prevent Grid clicks from throwing focus unexpectedly

### DIFF
--- a/tools/grid/src/Grid.ts
+++ b/tools/grid/src/Grid.ts
@@ -11,8 +11,12 @@ governing permissions and limitations under the License.
 */
 
 import {
+    adoptStyles,
     CSSResultArray,
+    html,
     PropertyValues,
+    ReactiveElement,
+    render,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
@@ -95,6 +99,25 @@ export class Grid extends LitVirtualizer {
         this.selected = selected;
     }
 
+    public override createRenderRoot(): this {
+        const renderRoot =
+            this.shadowRoot ??
+            this.attachShadow(
+                (this.constructor as typeof ReactiveElement).shadowRootOptions
+            );
+        adoptStyles(
+            renderRoot,
+            (this.constructor as typeof ReactiveElement).elementStyles
+        );
+        return renderRoot as unknown as this;
+    }
+
+    public override render(): TemplateResult {
+        return html`
+            <slot></slot>
+        `;
+    }
+
     protected override update(changes: PropertyValues<this>): void {
         if (
             changes.has('itemSize') ||
@@ -122,6 +145,9 @@ export class Grid extends LitVirtualizer {
             });
         }
 
+        if (this.isConnected) {
+            render(super.render(), this);
+        }
         super.update(changes);
     }
 

--- a/tools/grid/src/GridController.ts
+++ b/tools/grid/src/GridController.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import type { ReactiveController, ReactiveElement } from 'lit';
+import type { ReactiveController } from 'lit';
 
 import { ResizeController } from '@lit-labs/observers/resize_controller.js';
 import { RovingTabindexController } from '@spectrum-web-components/reactive-controllers/src/RovingTabindex.js';
@@ -17,6 +17,7 @@ import {
     RangeChangedEvent,
     VisibilityChangedEvent,
 } from '@lit-labs/virtualizer/Virtualizer.js';
+import { Grid } from './Grid.js';
 
 interface ItemSize {
     width: number;
@@ -26,7 +27,7 @@ interface ItemSize {
 export class GridController<T extends HTMLElement>
     implements ReactiveController
 {
-    host!: ReactiveElement;
+    host!: Grid;
 
     resizeController!: ResizeController;
 
@@ -60,7 +61,7 @@ export class GridController<T extends HTMLElement>
     _last = 0;
 
     constructor(
-        host: ReactiveElement,
+        host: Grid,
         {
             elements,
             itemSize,
@@ -150,7 +151,7 @@ export class GridController<T extends HTMLElement>
                 });
             });
         };
-        const scrollToFirst = (): void => (this.host as any).scrollToIndex(0);
+        const scrollToFirst = (): void => this.host.scrollToIndex(0);
         const focusIntoGrid = (): void => {
             this.focus();
             this.host.tabIndex = -1;
@@ -169,7 +170,7 @@ export class GridController<T extends HTMLElement>
 
     protected handleFocusout = (event: FocusEvent): void => {
         if (
-            event.relatedTarget &&
+            !event.relatedTarget ||
             !this.host.contains(event.relatedTarget as HTMLElement)
         ) {
             this.host.tabIndex = 0;

--- a/tools/grid/src/grid.css
+++ b/tools/grid/src/grid.css
@@ -14,4 +14,9 @@ governing permissions and limitations under the License.
     display: block;
     position: relative;
     contain: strict;
+    pointer-events: none;
+}
+
+::slotted(*) {
+    pointer-events: all;
 }

--- a/tools/grid/test/grid.test.ts
+++ b/tools/grid/test/grid.test.ts
@@ -14,10 +14,13 @@ import { elementUpdated, expect, fixture, nextFrame } from '@open-wc/testing';
 import { html } from '@spectrum-web-components/base';
 import { Card } from '@spectrum-web-components/card';
 
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/scale-medium.js';
+import '@spectrum-web-components/theme/theme-light.js';
 import '@spectrum-web-components/grid/sp-grid.js';
 import { Grid } from '@spectrum-web-components/grid';
 import { Default } from '../stories/grid.stories.js';
-import { sendKeys } from '@web/test-runner-commands';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
 describe('Grid', () => {
@@ -61,6 +64,44 @@ describe('Grid', () => {
         expect(
             el.querySelector(el.focusableSelector) === document.activeElement
         ).to.be.true;
+    });
+    it('does not focus when clicking grid', async () => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <sp-theme color="light" scale="medium">${Default()}</sp-theme>
+            `
+        );
+        const el = test.querySelector('sp-grid') as Grid;
+
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(0);
+
+        el.focus();
+
+        await nextFrame();
+        await nextFrame();
+
+        const firstItem = el.querySelector(el.focusableSelector) as HTMLElement;
+
+        expect(firstItem === document.activeElement).to.be.true;
+
+        const firstRect = firstItem?.getBoundingClientRect();
+        const position = [
+            Math.round(firstRect.x + firstRect.width + 2),
+            Math.round(firstRect.y + 2),
+        ] as [number, number];
+        await sendMouse({
+            type: 'click',
+            position,
+        });
+
+        await nextFrame();
+        await nextFrame();
+
+        expect(
+            el.querySelector(el.focusableSelector) === document.activeElement
+        ).to.be.false;
     });
     it('allows to tab in and out', async () => {
         const test = await fixture<HTMLDivElement>(


### PR DESCRIPTION
## Description
While the Grid element needs to manage the Roving Tab Index of its children during Tab presses and `focus()` calls it shouldn't steal focus (particularly when scrolled to some degree) when clicked. Remove `touch-events` to prevent this. Force the Grid to be a shadow DOM rendering custom element so that it can accept style rules in an encapsulated manner.

## Related issue(s)

- fixes #2501

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://grid-pointer-focus--spectrum-web-components.netlify.app/storybook/?path=/story/grid--sized)
    2. Scroll down a good amount
    3. Click BETWEEN the card elements
    4. See that focus IS NOT thrown to the first Card element

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.