### PR TITLE
Table Testing Updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 6dc6af331a25eb51bf40892702e95ea3e84eb3fe
+        default: 6fdb9a517f43b792128ff75e11ff1cc92a1a5bd2
 commands:
     downstream:
         steps:
@@ -92,7 +92,7 @@ commands:
                       echo $(cat count_end.txt)
                       if [[ $(cat count_start.txt) -eq $(cat count_end.txt) ]]; then exit 0; else exit 1; fi
             - save_cache:
-                  when: on_fail
+                  when: always
                   name: Build Golden Images Revision Cache
                   paths:
                       - test/visual/screenshots-baseline
@@ -248,7 +248,7 @@ jobs:
                       echo $(cat count_end.txt)
                       if [[ $(cat count_start.txt) -eq $(cat count_end.txt) ]]; then exit 0; else exit 1; fi
             - save_cache:
-                  when: on_fail
+                  when: always
                   name: Build Golden Images Revision Cache
                   paths:
                       - test/visual/screenshots-baseline

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -486,9 +486,6 @@ export class Table extends SizedMixin(SpectrumElement, {
     }
 
     public override disconnectedCallback(): void {
-        if (this.tableBody) {
-            render(html``, this.tableBody);
-        }
         super.disconnectedCallback();
     }
 }

--- a/packages/table/src/TableBody.ts
+++ b/packages/table/src/TableBody.ts
@@ -17,7 +17,7 @@ import {
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import styles from './table-body.css.js';
-import { ResizeController } from '@lit-labs/observers/resize_controller.js';
+import { MutationController } from '@lit-labs/observers/mutation_controller.js';
 
 /**
  * @element sp-table
@@ -29,10 +29,13 @@ export class TableBody extends SpectrumElement {
 
     constructor() {
         super();
-        new ResizeController(this, {
-            callback: (entries) => {
-                if (!entries.length) return;
-                if (entries[0].contentRect.height < this.scrollHeight) {
+        new MutationController(this, {
+            config: {
+                childList: true,
+                subtree: true,
+            },
+            callback: () => {
+                if (this.offsetHeight < this.scrollHeight) {
                     this.tabIndex = 0;
                 } else {
                     this.removeAttribute('tabindex');

--- a/packages/table/src/table-body.css
+++ b/packages/table/src/table-body.css
@@ -16,8 +16,6 @@ governing permissions and limitations under the License.
     display: block;
 }
 
-:host:not([scroller]) {
+:host(:not([tabindex])) {
     overflow: visible;
-    flex-grow: 1;
-    box-sizing: border-box;
 }

--- a/packages/table/src/table.css
+++ b/packages/table/src/table.css
@@ -16,8 +16,3 @@ governing permissions and limitations under the License.
     display: flex;
     flex-direction: column;
 }
-
-:host([scroller]) sp-table-body {
-    overflow: visible;
-    min-height: max-content;
-}

--- a/packages/table/test/table.test.ts
+++ b/packages/table/test/table.test.ts
@@ -17,6 +17,10 @@ import {
     nextFrame,
 } from '@open-wc/testing';
 
+import { TemplateResult } from '@spectrum-web-components/base';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/src/themes.js';
+import type { Theme } from '@spectrum-web-components/theme';
 import '@spectrum-web-components/table/sp-table.js';
 import '@spectrum-web-components/table/sp-table-head.js';
 import '@spectrum-web-components/table/sp-table-head-cell.js';
@@ -45,9 +49,24 @@ before(function () {
 after(function () {
     window.onerror = globalErrorHandler as OnErrorEventHandler;
 });
+
+async function styledFixture<T extends Element>(
+    story: TemplateResult
+): Promise<T> {
+    const test = await fixture<Theme>(html`
+        <sp-theme theme="classic" scale="medium" color="light">
+            ${story}
+        </sp-theme>
+    `);
+    return test.children[0] as T;
+}
+
 describe('Table', () => {
     it('loads default table accessibly', async () => {
-        const el = await fixture<Table>(elements());
+        const el = await styledFixture<Table>(elements());
+        await nextFrame();
+        await nextFrame();
+        await nextFrame();
         await nextFrame();
         await nextFrame();
         await nextFrame();

--- a/packages/table/test/virtualized-table.test.ts
+++ b/packages/table/test/virtualized-table.test.ts
@@ -18,6 +18,10 @@ import {
     oneEvent,
 } from '@open-wc/testing';
 
+import { TemplateResult } from '@spectrum-web-components/base';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/src/themes.js';
+import type { Theme } from '@spectrum-web-components/theme';
 import '@spectrum-web-components/table/sp-table.js';
 import '@spectrum-web-components/table/sp-table-head.js';
 import '@spectrum-web-components/table/sp-table-head-cell.js';
@@ -54,11 +58,25 @@ after(function () {
     window.onerror = globalErrorHandler as OnErrorEventHandler;
 });
 
+async function styledFixture<T extends Element>(
+    story: TemplateResult
+): Promise<T> {
+    const test = await fixture<Theme>(html`
+        <sp-theme theme="classic" scale="medium" color="light">
+            ${story}
+        </sp-theme>
+    `);
+    return test.children[0] as T;
+}
+
 describe('Virtualized Table', () => {
     const virtualItems = makeItems(50);
 
     it('loads virtualized table accessibly', async () => {
-        const el = await fixture<Table>(virtualized());
+        const el = await styledFixture<Table>(virtualized());
+        await nextFrame();
+        await nextFrame();
+        await nextFrame();
         await nextFrame();
         await nextFrame();
         await nextFrame();


### PR DESCRIPTION
## Description
- use Mutation Observer over Resize Observer as most Tables don't actually resize
- add extra delay to the tests to ensure we test the after render context
- test styled Tables
- remove the default `overlay: auto` when not measuring in such a way as the scroll
- update VRT cache
- store a VRT cache against the revision number ALWAYS (help establish a cache on flaky subjects)
- remove the Table Body clearing code, it spun up an error in the tests
  - [ ] do some extra tests to confirm this doesn't make event listener add infinitely

## Related issue(s)
- refs #290

## How has this been tested?

-   [ ] _Test case 1_
    1. It's tests, mainly

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.