### PR TITLE
fix: don't close the top overlay on click if it's triggered by hover

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -284,8 +284,6 @@ export class OverlayTrigger extends SpectrumElement {
             case 'click':
                 if (this.clickContent) {
                     this.open = event.type;
-                } else if (this.closeHoverOverlay) {
-                    event.preventDefault();
                 }
                 return;
             case 'longpress':

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -432,9 +432,9 @@ export class OverlayStack {
         }
     };
 
-    private closeAllClickOverlays(): void {
+    private closeAllNonHoverOverlays(): void {
         for (const overlay of this.overlays) {
-            if (overlay.interaction === 'click') {
+            if (overlay.interaction != 'hover') {
                 this.hideAndCloseOverlay(overlay, false);
             }
         }
@@ -595,8 +595,8 @@ export class OverlayStack {
         }
         if (this.topOverlay?.interaction === 'hover') {
             // Don't close the top overlay on click if it comes from a hover, it will be closed when the mouse is moved out
-            // But do close everything that came from a click since we just clicked elsewhere!
-            this.closeAllClickOverlays();
+            // But do close all non-hover overlays since we just clicked elsewhere!
+            this.closeAllNonHoverOverlays();
         }
         else {
             this.closeTopOverlay();

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -593,7 +593,7 @@ export class OverlayStack {
         if (this.preventMouseRootClose || event.defaultPrevented) {
             return;
         }
-        if (this.topOverlay.interaction === 'hover') {
+        if (this.topOverlay?.interaction === 'hover') {
             // Don't close the top overlay on click if it comes from a hover, it will be closed when the mouse is moved out
             // But do close everything that came from a click since we just clicked elsewhere!
             this.closeAllClickOverlays();

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -573,6 +573,34 @@ export const longpress = (): TemplateResult => {
     `;
 };
 
+export const clickAndHoverTargets = (): TemplateResult => {
+    return html`
+        ${storyStyles}
+        <style>
+            .friendly-target {
+                padding: 4px;
+                margin: 6px;
+                border: 2px solid black;
+                border-radius: 6px;
+                cursor: default;
+            }
+       </style>
+        <overlay-trigger placement="right">
+            <div class="friendly-target" slot="trigger">Click me</div>
+            <sp-tooltip slot="click-content" tip="right">
+                Ok, now hover the other trigger
+            </sp-tooltip>
+        </overlay-trigger>
+        <overlay-trigger placement="left">
+            <div class="friendly-target" slot="trigger">Then hover me</div>
+            <sp-tooltip slot="hover-content" delayed tip="right">
+                Now click my trigger -- I should stay open, but the other overlay should close
+            </sp-tooltip>
+        </overlay-trigger>
+    `;
+};
+
+
 function nextFrame(): Promise<void> {
     return new Promise((res) => requestAnimationFrame(() => res()));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses the issue outlined in [CCEX-8559](https://jira.corp.adobe.com/browse/CCEX-8550) where clicking on an overlay trigger that has a hover element results in overlays shown by click not closing. 

## Related issue(s)

Fixes #2539 

## Motivation and context

This issue was found while addressing CCEX-8559.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to Storybook, select Overlay, select Click And Hover Targets
    2. Follow the instructions

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
