### PR TITLE
fix(overlay): move "escape" listener to "keydown"

### DIFF
--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -223,7 +223,10 @@ export class ActiveOverlay extends SpectrumElement {
     }
 
     public feature(): void {
-        this.tabIndex = -1;
+        // eslint-disable-next-line spectrum-web-components/document-active-element
+        if (!this.contains(document.activeElement)) {
+            this.tabIndex = -1;
+        }
         const parentOverlay = parentOverlayOf(this.trigger);
         const parentIsModal = parentOverlay && parentOverlay.slot === 'open';
         if (parentIsModal) {

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -214,7 +214,7 @@ export class OverlayStack {
         this._eventsAreBound = true;
         this.document.addEventListener('click', this.handleMouseCapture, true);
         this.document.addEventListener('click', this.handleMouse);
-        this.document.addEventListener('keyup', this.handleKeyUp);
+        this.document.addEventListener('keydown', this.handleKeydown);
         this.document.addEventListener(
             'sp-overlay-close',
             this.handleOverlayClose as EventListener
@@ -600,7 +600,7 @@ export class OverlayStack {
         overlaysToClose.forEach((overlay) => this.hideAndCloseOverlay(overlay));
     };
 
-    private handleKeyUp = (event: KeyboardEvent): void => {
+    private handleKeydown = (event: KeyboardEvent): void => {
         if (event.code === 'Escape') {
             this.closeTopOverlay();
         }

--- a/packages/overlay/test/overlay-trigger-sync.test.ts
+++ b/packages/overlay/test/overlay-trigger-sync.test.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { isVisible } from '../../../test/testing-helpers.js';
+import { escapeEvent, isVisible } from '../../../test/testing-helpers.js';
 import {
     aTimeout,
     elementUpdated,
@@ -44,7 +44,10 @@ function pressKey(code: string): void {
     document.dispatchEvent(up);
 }
 
-const pressEscape = (): void => pressKey('Escape');
+const pressEscape = (): void => {
+    document.dispatchEvent(escapeEvent());
+};
+
 const pressSpace = (): void => pressKey('Space');
 
 describe('Overlay Trigger - sync', () => {

--- a/packages/overlay/test/overlay-trigger.test.ts
+++ b/packages/overlay/test/overlay-trigger.test.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { isVisible } from '../../../test/testing-helpers.js';
+import { escapeEvent, isVisible } from '../../../test/testing-helpers.js';
 import {
     aTimeout,
     elementUpdated,
@@ -44,7 +44,9 @@ function pressKey(code: string): void {
     document.dispatchEvent(up);
 }
 
-const pressEscape = (): void => pressKey('Escape');
+const pressEscape = (): void => {
+    document.dispatchEvent(escapeEvent());
+};
 const pressSpace = (): void => pressKey('Space');
 
 describe('Overlay Trigger', () => {

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -30,6 +30,7 @@ import {
     arrowLeftEvent,
     arrowRightEvent,
     arrowUpEvent,
+    escapeEvent,
     testForLitDevWarnings,
     tEvent,
 } from '../../../test/testing-helpers.js';
@@ -555,15 +556,7 @@ export function runPickerTests(): void {
                 'an active-overlay has been inserted on the page'
             );
 
-            button.dispatchEvent(
-                new KeyboardEvent('keyup', {
-                    bubbles: true,
-                    composed: true,
-                    cancelable: true,
-                    key: 'Escape',
-                    code: 'Escape',
-                })
-            );
+            button.dispatchEvent(escapeEvent());
             await elementUpdated(el);
             await waitUntil(() => el.open === false, 'closed by Escape');
             await waitUntil(


### PR DESCRIPTION
## Description
Move `Escape` listener to `keydown` to match native `<modal>` interaction.

## Related issue(s)

- fixes #1844

## How has this been tested?
-   [ ] _Test case 1_
    1. With updated unit tests.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.