### PR TITLE
Fix Slider component scroll number-field to update the slider value

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -116,7 +116,7 @@ export class NumberField extends TextfieldBase {
     @property({ type: Number })
     public step?: number;
 
-    public stepperActive = false;
+    public managedInput = false;
 
     @property({ type: Number, reflect: true, attribute: 'step-modifier' })
     public stepModifier = 10;
@@ -189,7 +189,7 @@ export class NumberField extends TextfieldBase {
             event.preventDefault();
             return;
         }
-        this.stepperActive = true;
+        this.managedInput = true;
         this.buttons.setPointerCapture(event.pointerId);
         const stepUpRect = this.buttons.children[0].getBoundingClientRect();
         const stepDownRect = this.buttons.children[1].getBoundingClientRect();
@@ -239,7 +239,7 @@ export class NumberField extends TextfieldBase {
         this.dispatchEvent(
             new Event('change', { bubbles: true, composed: true })
         );
-        this.stepperActive = false;
+        this.managedInput = false;
     }
 
     private doNextChange(event: PointerEvent): number {
@@ -300,12 +300,14 @@ export class NumberField extends TextfieldBase {
 
     protected onScroll(event: WheelEvent): void {
         event.preventDefault();
+        this.managedInput = true;
         const direction = event.shiftKey
             ? event.deltaX / Math.abs(event.deltaX)
             : event.deltaY / Math.abs(event.deltaY);
         if (direction !== 0 && !isNaN(direction)) {
             this.stepBy(direction * (event.shiftKey ? this.stepModifier : 1));
         }
+        this.managedInput = false;
     }
 
     protected override onFocus(): void {

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -390,7 +390,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
             return;
         }
         // Do not apply uncommited values to the parent element unless interacting with the stepper UI.
-        // Stop uncommited input from being annouced to the parent application.
+        // Stop uncommitted input from being announced to the parent application.
         event.stopPropagation();
     }
 

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -385,12 +385,12 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
 
     private handleNumberInput(event: Event & { target: NumberField }): void {
         const { value } = event.target;
-        if (event.target?.stepperActive && !isNaN(value)) {
+        if (event.target?.managedInput && !isNaN(value)) {
             this.value = value;
             return;
         }
         // Do not apply uncommited values to the parent element unless interacting with the stepper UI.
-        // Stop uncommited input from being annoucned to the parent application.
+        // Stop uncommited input from being annouced to the parent application.
         event.stopPropagation();
     }
 
@@ -401,7 +401,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
             event.stopPropagation();
         } else {
             this.value = value;
-            if (!event.target?.stepperActive) {
+            if (!event.target?.managedInput) {
                 // When stepper is not active, sythesize an `input` event so that the
                 // `change` event isn't surprising.
                 this.dispatchInputEvent();

--- a/packages/slider/test/slider-editable.test.ts
+++ b/packages/slider/test/slider-editable.test.ts
@@ -141,6 +141,46 @@ describe('Slider - editable', () => {
         expect(el.value).to.equal(45);
         expect(inputSpy.callCount, 'still one input').to.equal(1);
         expect(changeSpy.callCount, 'still one change').to.equal(1);
+
+        el.shadowRoot.activeElement?.dispatchEvent(
+            new WheelEvent('wheel', { deltaY: 1 })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(46);
+        expect(inputSpy.callCount, 'still one input').to.equal(2);
+
+        el.shadowRoot.activeElement?.dispatchEvent(
+            new WheelEvent('wheel', { deltaY: -1 })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(45);
+        expect(inputSpy.callCount, 'still one input').to.equal(3);
+
+        el.shadowRoot.activeElement?.dispatchEvent(
+            new WheelEvent('wheel', { deltaX: 1, shiftKey: true })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(55);
+        expect(inputSpy.callCount, 'still one input').to.equal(4);
+
+        el.shadowRoot.activeElement?.dispatchEvent(
+            new WheelEvent('wheel', { deltaX: -1, shiftKey: true })
+        );
+
+        await elementUpdated(el);
+
+        expect(el.shadowRoot.activeElement).to.equal(el.numberField);
+        expect(el.value).to.equal(45);
+        expect(inputSpy.callCount, 'still one input').to.equal(5);
     });
 
     it('focuses `<input>` after pointer interactions', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related issue(s)

- fixes #2543

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to Storybook, to editable slider: https://opensource.adobe.com/spectrum-web-components/storybook/?path=/story/slider--editable
    2. Click the number input field, and mouse scroll to change the value
    3. Slider on the left of the number input is inert
-   [ ] _Test case 2_
    1. Go to Documentation site, to editable slider: https://chitiga-daniel-editable-slider-fix--spectrum-web-components.netlify.app/components/slider/
    2. Click the number input field, and mouse scroll to change the value
    3. Slider on the left of the number input is changing according to the value inside the number input

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
