### PR TITLE
fix(tabs): add "quiet", "compact", and "emphasized" "direction=vertical"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 013e85c7dad993cd1c2f8ae8a805af88e7bf01b6
+        default: 9e9efa22c4e85fa0f25496837ce2787657a10f34
 commands:
     downstream:
         steps:

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -103,58 +103,17 @@ import {
 </sp-tab-panel>
 </sp-tabs>
 
-### Disabled
+## Horizontal Tabs
 
-When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, `disabled`, and `quiet`, or with content like icons, etc.
 
-```html
-<sp-tabs selected="2" disabled>
-    <sp-tab label="Tab 1" value="1"></sp-tab>
-    <sp-tab label="Tab 2" value="2"></sp-tab>
-    <sp-tab label="Tab 3" value="3"></sp-tab>
-    <sp-tab label="Tab 4" value="4"></sp-tab>
-    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
-    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
-    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
-</sp-tabs>
-```
+<sp-tabs selected="compact" auto label="Horizontal Tabs variants">
+<sp-tab value="compact">Compact</sp-tab>
+<sp-tab-panel value="compact">
 
-### Vertical
+Compact tabs should never be used without the quiet variation. Please use Quiet + Compact Tabs instead.
 
-```html
-<sp-tabs selected="1" direction="vertical">
-    <sp-tab label="Tab 1" value="1"></sp-tab>
-    <sp-tab label="Tab 2" value="2"></sp-tab>
-    <sp-tab label="Tab 3" value="3"></sp-tab>
-    <sp-tab label="Tab 4" value="4"></sp-tab>
-    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
-    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
-    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
-    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
-</sp-tabs>
-```
-
-## Variants
-
-### Quiet
-
-```html
-<sp-tabs selected="1" quiet>
-    <sp-tab label="Tab 1" value="1"></sp-tab>
-    <sp-tab label="Tab 2" value="2"></sp-tab>
-    <sp-tab label="Tab 3" value="3"></sp-tab>
-    <sp-tab label="Tab 4" value="4"></sp-tab>
-    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
-    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
-    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
-    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
-</sp-tabs>
-```
-
-### Compact
-
-```html
+```html demo
 <sp-tabs selected="1" compact>
     <sp-tab label="Tab 1" value="1"></sp-tab>
     <sp-tab label="Tab 2" value="2"></sp-tab>
@@ -167,31 +126,190 @@ When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` chi
 </sp-tabs>
 ```
 
-## With icons
+</sp-tab-panel>
+<sp-tab value="disabled">Disabled</sp-tab>
+<sp-tab-panel value="disabled">
 
-```html
-<div>
-    <sp-icons-medium></sp-icons-medium>
-    <sp-tabs selected="1" direction="horizontal">
-        <sp-tab label="Tab 1" value="1">
-            <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
-        </sp-tab>
-        <sp-tab label="Tab 2" value="2">
-            <sp-icon-close slot="icon"></sp-icon-close>
-        </sp-tab>
-        <sp-tab label="Tab 3" value="3">
-            <sp-icon-chevron-down slot="icon"></sp-icon-chevron-down>
-        </sp-tab>
-        <sp-tab label="Tab 4" value="4">
-            <sp-icon-help slot="icon"></sp-icon-help>
-        </sp-tab>
-        <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
-        <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
-        <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
-        <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
-    </sp-tabs>
-</div>
+When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+
+```html demo
+<sp-tabs selected="2" disabled>
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
+</sp-tabs>
 ```
+
+</sp-tab-panel>
+<sp-tab value="icons">Icons</sp-tab>
+<sp-tab-panel value="icons">
+
+```html demo
+<sp-tabs selected="1">
+    <sp-tab label="Tab 1" value="1">
+        <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
+    </sp-tab>
+    <sp-tab label="Tab 2" value="2">
+        <sp-icon-close slot="icon"></sp-icon-close>
+    </sp-tab>
+    <sp-tab label="Tab 3" value="3">
+        <sp-icon-chevron-down slot="icon"></sp-icon-chevron-down>
+    </sp-tab>
+    <sp-tab label="Tab 4" value="4">
+        <sp-icon-help slot="icon"></sp-icon-help>
+    </sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
+<sp-tab value="quiet">Quiet</sp-tab>
+<sp-tab-panel value="quiet">
+
+```html demo
+<sp-tabs selected="1" quiet>
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
+<sp-tab value="quiet+compact">Quiet + Compact</sp-tab>
+<sp-tab-panel value="quiet+compact">
+
+```html demo
+<sp-tabs selected="1" quiet compact>
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
+## Vertical Tabs
+
+An `<sp-tabs>` element will display horizontally by default. It can be modified with states like `compact`, `disabled`, and `quiet`, or with content like icons, etc.
+
+<sp-tabs selected="compact" auto label="Horizontal Tabs variants">
+<sp-tab value="compact">Compact</sp-tab>
+<sp-tab-panel value="compact">
+
+Compact tabs should never be used without the quiet variation. Please use Quiet + Compact Tabs instead.
+
+```html demo
+<sp-tabs selected="1" compact direction="vertical">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
+<sp-tab value="disabled">Disabled</sp-tab>
+<sp-tab-panel value="disabled">
+
+When an `<sp-tabs>` element is given the `disabled` attribute its `<sp-tab>` children will be disabled as well, preventing a visitor from changing the selected tab. By default, `<sp-tab-panel>` children will not be addressed and the available content of the currently selected tab will be fully visible.
+
+```html demo
+<sp-tabs selected="2" disabled direction="vertical">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2 is selected</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3 is not selectable</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4 is not selectable</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
+<sp-tab value="icons">Icons</sp-tab>
+<sp-tab-panel value="icons">
+
+```html demo
+<sp-tabs selected="1" direction="vertical">
+    <sp-tab label="Tab 1" value="1">
+        <sp-icon-checkmark slot="icon"></sp-icon-checkmark>
+    </sp-tab>
+    <sp-tab label="Tab 2" value="2">
+        <sp-icon-close slot="icon"></sp-icon-close>
+    </sp-tab>
+    <sp-tab label="Tab 3" value="3">
+        <sp-icon-chevron-down slot="icon"></sp-icon-chevron-down>
+    </sp-tab>
+    <sp-tab label="Tab 4" value="4">
+        <sp-icon-help slot="icon"></sp-icon-help>
+    </sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
+<sp-tab value="quiet">Quiet</sp-tab>
+<sp-tab-panel value="quiet">
+
+```html demo
+<sp-tabs selected="1" quiet direction="vertical">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
+<sp-tab value="quiet+compact">Quiet + Compact</sp-tab>
+<sp-tab-panel value="quiet+compact">
+
+```html demo
+<sp-tabs selected="1" quiet compact direction="vertical">
+    <sp-tab label="Tab 1" value="1"></sp-tab>
+    <sp-tab label="Tab 2" value="2"></sp-tab>
+    <sp-tab label="Tab 3" value="3"></sp-tab>
+    <sp-tab label="Tab 4" value="4"></sp-tab>
+    <sp-tab-panel value="1">Content for Tab 1</sp-tab-panel>
+    <sp-tab-panel value="2">Content for Tab 2</sp-tab-panel>
+    <sp-tab-panel value="3">Content for Tab 3</sp-tab-panel>
+    <sp-tab-panel value="4">Content for Tab 4</sp-tab-panel>
+</sp-tabs>
+```
+
+</sp-tab-panel>
+</sp-tabs>
 
 ## Accessibility
 

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -75,6 +75,7 @@
         "lit-html"
     ],
     "dependencies": {
+        "@lit-labs/observers": "^1.0.1",
         "@spectrum-web-components/base": "^0.7.0",
         "@spectrum-web-components/reactive-controllers": "^0.3.0",
         "@spectrum-web-components/shared": "^0.15.0",

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -22,6 +22,7 @@ import {
     query,
 } from '@spectrum-web-components/base/src/decorators.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import { IntersectionController } from '@lit-labs/observers/intersection_controller.js';
 import { Tab } from './Tab.js';
 import { Focusable } from '@spectrum-web-components/shared';
 import { RovingTabindexController } from '@spectrum-web-components/reactive-controllers/src/RovingTabindex.js';
@@ -36,8 +37,6 @@ const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
  *
  * @slot - Tab elements to manage as a group
  * @slot tab-panel - Tab Panel elements related to the listed Tab elements
- * @attr {Boolean} quiet - The tabs border is a lot smaller
- * @attr {Boolean} compact - The collection of tabs take up less space
  * @csspart tablist - Container element for the slotted sp-tab elements
  *
  * @fires change - The selected Tab child has changed.
@@ -58,6 +57,12 @@ export class Tabs extends SizedMixin(Focusable) {
     @property({ type: Boolean })
     public auto = false;
 
+    /**
+     * The tab items are displayed closer together.
+     */
+    @property({ type: Boolean, reflect: true })
+    public compact = false;
+
     @property({ reflect: true })
     public direction: 'vertical' | 'vertical-right' | 'horizontal' =
         'horizontal';
@@ -67,6 +72,12 @@ export class Tabs extends SizedMixin(Focusable) {
 
     @property()
     public label = '';
+
+    /**
+     * The tab list is displayed without a border.
+     */
+    @property({ type: Boolean, reflect: true })
+    public quiet = false;
 
     @property({ attribute: false })
     public selectionIndicatorStyle = noSelectionStyle;
@@ -107,6 +118,20 @@ export class Tabs extends SizedMixin(Focusable) {
     }
 
     private _tabs: Tab[] = [];
+
+    constructor() {
+        super();
+        new IntersectionController(this, {
+            config: {
+                root: null,
+                rootMargin: "0px",
+                threshold: [0, 1]
+            },
+            callback: () => {
+                this.updateSelectionIndicator();
+            }
+        });
+    }
 
     rovingTabindexController = new RovingTabindexController<Tab>(this, {
         focusInIndex: (elements) => {

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -100,7 +100,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([direction^='vertical']) #list {
+:host(:not([quiet])[direction^='vertical']) #list {
     --sp-tabs-list-background-color: var(
         --spectrum-tabs-vertical-textonly-divider-background-color
     );

--- a/packages/tabs/stories/tabs.stories.ts
+++ b/packages/tabs/stories/tabs.stories.ts
@@ -49,7 +49,7 @@ export default {
 };
 
 interface Properties {
-    direction?: 'vertical' | 'vertical-right' | 'horizontal';
+    direction: 'vertical' | 'vertical-right' | 'horizontal';
     verticalTabs?: boolean;
     verticalTab?: boolean;
     auto?: boolean;
@@ -211,6 +211,92 @@ export const Vertical = (args: Properties): TemplateResult => {
     `;
 };
 Vertical.args = {
+    direction: 'vertical',
+};
+
+export const verticalQuiet = (args: Properties): TemplateResult => {
+    return html`
+        <sp-tabs
+            selected="1"
+            direction=${args.direction}
+            ?auto=${args.auto}
+            label="Demo Tabs"
+            quiet
+        >
+            <sp-tab label="Tab 1" value="1"></sp-tab>
+            <sp-tab label="Tab 2" value="2"></sp-tab>
+            <sp-tab label="Tab 3" value="3"></sp-tab>
+            <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
+        </sp-tabs>
+    `;
+};
+verticalQuiet.args = {
+    direction: 'vertical',
+};
+
+export const verticalEmphasizedQuiet = (args: Properties): TemplateResult => {
+    return html`
+        <sp-tabs
+            selected="1"
+            direction=${args.direction}
+            ?auto=${args.auto}
+            label="Demo Tabs"
+            quiet
+            emphasized
+        >
+            <sp-tab label="Tab 1" value="1"></sp-tab>
+            <sp-tab label="Tab 2" value="2"></sp-tab>
+            <sp-tab label="Tab 3" value="3"></sp-tab>
+            <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
+        </sp-tabs>
+    `;
+};
+verticalEmphasizedQuiet.args = {
+    direction: 'vertical',
+};
+
+export const verticalCompact = (args: Properties): TemplateResult => {
+    return html`
+        <sp-tabs
+            selected="1"
+            direction=${args.direction}
+            ?auto=${args.auto}
+            label="Demo Tabs"
+            compact
+        >
+            <sp-tab label="Tab 1" value="1"></sp-tab>
+            <sp-tab label="Tab 2" value="2"></sp-tab>
+            <sp-tab label="Tab 3" value="3"></sp-tab>
+            <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
+        </sp-tabs>
+    `;
+};
+verticalCompact.args = {
+    direction: 'vertical',
+};
+
+export const verticalQuietCompact = (args: Properties): TemplateResult => {
+    return html`
+        <sp-tabs
+            selected="1"
+            direction=${args.direction}
+            ?auto=${args.auto}
+            label="Demo Tabs"
+            quiet
+            compact
+        >
+            <sp-tab label="Tab 1" value="1"></sp-tab>
+            <sp-tab label="Tab 2" value="2"></sp-tab>
+            <sp-tab label="Tab 3" value="3"></sp-tab>
+            <sp-tab label="Tab 4" value="4"></sp-tab>
+            ${panels()}
+        </sp-tabs>
+    `;
+};
+verticalQuietCompact.args = {
     direction: 'vertical',
 };
 

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -698,6 +698,10 @@ sp-tabs::part(tablist) {
     overflow: auto visible;
 }
 
+.spectrum-Typography sp-tab-panel .spectrum-Body--sizeM:first-child {
+    margin-top: var(--spectrum-global-dimension-size-300);
+}
+
 main > sp-tabs > sp-tab:only-of-type {
     visibility: hidden;
     width: 0;


### PR DESCRIPTION
## Description
- add support for `quiet`, `compact`, and `emphasized` to the `direction="vertical|vertical-right"` variants
- update stories to include this
- update documentation to include this

## Related issue(s)
- fixes #2552

## How has this been tested?

-   [ ] _Test case 1_
    1. VRTs

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.