### PR TITLE
fix: add support for "padding" attribute

### DIFF
--- a/tools/grid/src/Grid.ts
+++ b/tools/grid/src/Grid.ts
@@ -41,6 +41,9 @@ export class Grid extends LitVirtualizer {
     @property({ type: String })
     public gap: `${'0' | `${number}px`}` = '0';
 
+    @property({ type: String })
+    public padding: `${'0' | `${number}px`}` | undefined;
+
     @property({ type: Array })
     public override items: Record<string, unknown>[] = [];
 
@@ -78,8 +81,9 @@ export class Grid extends LitVirtualizer {
     gridController = new GridController<HTMLElement>(this, {
         elements: () => [],
         itemSize: () => this.itemSize,
-        /* c8 ignore next 1 */
+        /* c8 ignore next 2 */
         gap: () => this.gap,
+        padding: () => this.padding || this.gap,
     });
 
     protected handleChange(event: Event): void {
@@ -122,6 +126,7 @@ export class Grid extends LitVirtualizer {
         if (
             changes.has('itemSize') ||
             changes.has('gap') ||
+            changes.has('padding') ||
             changes.has('focusableSelector')
         ) {
             this.updateComplete.then(() => {
@@ -133,6 +138,7 @@ export class Grid extends LitVirtualizer {
                     ],
                     itemSize: () => this.itemSize,
                     gap: () => this.gap,
+                    padding: () => this.padding || this.gap,
                 });
             });
 
@@ -142,6 +148,7 @@ export class Grid extends LitVirtualizer {
                     height: `${this.itemSize.height}px`,
                 },
                 gap: this.gap,
+                padding: this.padding || this.gap,
             });
         }
 

--- a/tools/grid/stories/grid.stories.ts
+++ b/tools/grid/stories/grid.stories.ts
@@ -123,7 +123,9 @@ export const Default = (): TemplateResult => {
     `;
 };
 
-export const sized = (): TemplateResult => {
+export const sized = (
+    { gap, padding } = { gap: 10, padding: 10 }
+): TemplateResult => {
     const items = generateItems(1000);
 
     const renderItem = (
@@ -188,7 +190,8 @@ export const sized = (): TemplateResult => {
                 width: 200,
                 height: 300,
             }}
-            .gap=${'10px'}
+            .gap=${`${gap}px`}
+            .padding=${`${padding}px`}
         ></sp-grid>
         <sp-action-bar variant="fixed" style="display: none">
             <sp-checkbox @click=${handleActionBarChange} checked>
@@ -208,4 +211,34 @@ export const sized = (): TemplateResult => {
         <h2>Random after content that is focusable</h2>
         <input id="last-input" />
     `;
+};
+
+sized.args = {
+    gap: 10,
+    padding: 10,
+};
+
+sized.argTypes = {
+    gap: {
+        name: 'gap',
+        type: { name: 'number', required: false },
+        description: 'Spacing between items.',
+        table: {
+            type: { summary: 'number' },
+        },
+        control: {
+            type: 'number',
+        },
+    },
+    padding: {
+        name: 'padding',
+        type: { name: 'number', required: false },
+        description: 'Spacing around all items.',
+        table: {
+            type: { summary: 'number' },
+        },
+        control: {
+            type: 'number',
+        },
+    },
 };


### PR DESCRIPTION
## Description
Support customization of `padding` in the Grid

Note:
The Storybook won't responsively update when the `padding` is changed in the UI due to https://github.com/lit/lit/issues/3285, but update `gap` and previously send `padding` updates will take.

## Related issue(s)

- fixes #2554

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://grid-padding--spectrum-web-components.netlify.app/storybook/?path=/story/grid--sized)
    2. Update `gap` and `padding` in the Story UI
    3. See above note about responsivity...

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.