### PR TITLE
fix: prevent reuse of applied IDs when associating Dialogs to their content

### DIFF
--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -37,17 +37,19 @@ import {
 import styles from './dialog.css.js';
 import type { CloseButton } from '@spectrum-web-components/button';
 
+let appliedIds = 0;
+
 function gatherAppliedIdsFromSlottedChildren(
     slot: HTMLSlotElement,
     idBase: string
 ): string[] {
     const assignedElements = slot.assignedElements();
     const ids: string[] = [];
-    assignedElements.forEach((el, i) => {
+    assignedElements.forEach((el) => {
         if (el.id) {
             ids.push(el.id);
         } else {
-            const id = idBase + `-${i}`;
+            const id = idBase + `-${appliedIds++}`;
             el.id = id;
             ids.push(id);
         }

--- a/packages/dialog/test/dialog.test.ts
+++ b/packages/dialog/test/dialog.test.ts
@@ -10,7 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    html,
+    nextFrame,
+} from '@open-wc/testing';
 import { TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/dialog/sp-dialog.js';
@@ -56,6 +62,31 @@ describe('Dialog', () => {
     });
     it('loads dialog without footer accessibly', async () => {
         const el = await fixture<Dialog>(small());
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+    });
+    it('does not recycle applied content ids', async () => {
+        const el = await fixture<Dialog>(html`
+            <sp-dialog size="s">
+                <h2 slot="heading">Disclaimer</h2>
+                <p>Initial paragraph.</p>
+            </sp-dialog>
+        `);
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+
+        const paragraph = document.createElement('p');
+        paragraph.textContent = 'Added paragraph.';
+
+        const target = el.querySelector('p') as HTMLParagraphElement;
+        target.insertAdjacentElement('beforebegin', paragraph);
+
+        // Slotchange time exists outside of the standard update lifecycle
+        await nextFrame();
 
         await elementUpdated(el);
 


### PR DESCRIPTION
## Description
Ensure that late added content does not accidentally receive already applied IDs when associating it to its parent `sp-dialog` element.

## Related issue(s)

- fixes #2486

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/12976/workflows/25d21100-1c1d-41bb-aa2f-85f6a9f4ad6d)
    2. See that the new test passes

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)