### PR TITLE
fix: special case the possibility of leaving an overlay trigger by entering its overlay content

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -98,6 +98,7 @@ export class OverlayTrigger extends SpectrumElement {
     private longpressContent?: HTMLElement;
     private hoverContent?: HTMLElement;
     private targetContent?: HTMLElement;
+    private overlaidContent?: HTMLElement;
 
     private _longpressId = `longpress-describedby-descriptor`;
 
@@ -209,6 +210,7 @@ export class OverlayTrigger extends SpectrumElement {
             delete this[name];
             (await canClose)();
         });
+        this.overlaidContent = undefined;
     }
 
     private manageOpen(): void {
@@ -237,6 +239,7 @@ export class OverlayTrigger extends SpectrumElement {
             },
             { once: true }
         );
+        this.overlaidContent = content;
         return OverlayTrigger.openOverlay(
             target,
             interaction,
@@ -266,6 +269,26 @@ export class OverlayTrigger extends SpectrumElement {
     }
 
     private onTrigger(event: CustomEvent<LongpressEvent>): void {
+        if (
+            event.type === 'mouseleave' &&
+            this.open === 'hover' &&
+            (event as unknown as MouseEvent).relatedTarget ===
+                this.overlaidContent
+        ) {
+            this.overlaidContent.addEventListener(
+                'mouseleave',
+                (event: MouseEvent) => {
+                    if (event.relatedTarget === this.targetContent) {
+                        return;
+                    }
+                    this.onTrigger(
+                        event as unknown as CustomEvent<LongpressEvent>
+                    );
+                },
+                { once: true }
+            );
+            return;
+        }
         if (this.disabled) return;
 
         switch (event.type) {

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -269,16 +269,18 @@ export class OverlayTrigger extends SpectrumElement {
     }
 
     private onTrigger(event: CustomEvent<LongpressEvent>): void {
-        if (
+        const mouseIsEnteringHoverContent =
             event.type === 'mouseleave' &&
             this.open === 'hover' &&
             (event as unknown as MouseEvent).relatedTarget ===
-                this.overlaidContent
-        ) {
+                this.overlaidContent;
+        if (mouseIsEnteringHoverContent && this.overlaidContent) {
             this.overlaidContent.addEventListener(
                 'mouseleave',
                 (event: MouseEvent) => {
-                    if (event.relatedTarget === this.targetContent) {
+                    const mouseIsEnteringTrigger =
+                        event.relatedTarget === this.targetContent;
+                    if (mouseIsEnteringTrigger) {
                         return;
                     }
                     this.onTrigger(

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -202,15 +202,17 @@ export class Tooltip extends SpectrumElement {
     private closeOverlay = async (
         event?: PointerEvent | FocusEvent | Event
     ): Promise<void> => {
-        if (
+        const pointerIsEnteringTooltip =
             event &&
             event.type === 'pointerleave' &&
-            (event as PointerEvent).relatedTarget === this
-        ) {
+            (event as PointerEvent).relatedTarget === this;
+        if (pointerIsEnteringTooltip) {
             this.addEventListener(
                 'pointerleave',
                 (event: PointerEvent) => {
-                    if (event.relatedTarget === this.parentElement) {
+                    const pointerIsEnteringParnet =
+                        event.relatedTarget === this.parentElement;
+                    if (pointerIsEnteringParnet) {
                         return;
                     }
                     this.closeOverlay(event);

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -199,7 +199,26 @@ export class Tooltip extends SpectrumElement {
         });
     };
 
-    private closeOverlay = async (): Promise<void> => {
+    private closeOverlay = async (
+        event?: PointerEvent | FocusEvent | Event
+    ): Promise<void> => {
+        if (
+            event &&
+            event.type === 'pointerleave' &&
+            (event as PointerEvent).relatedTarget === this
+        ) {
+            this.addEventListener(
+                'pointerleave',
+                (event: PointerEvent) => {
+                    if (event.relatedTarget === this.parentElement) {
+                        return;
+                    }
+                    this.closeOverlay(event);
+                },
+                { once: true }
+            );
+            return;
+        }
         if (this.abortOverlay) this.abortOverlay(true);
         if (!this.closeOverlayCallback) return;
         (await this.closeOverlayCallback)();

--- a/packages/tooltip/test/tooltip.test.ts
+++ b/packages/tooltip/test/tooltip.test.ts
@@ -74,6 +74,62 @@ describe('Tooltip', () => {
 
         expect(el.open).to.be.false;
     });
+    it('allows pointer to enter the "tooltip" without closing the "tooltip"', async () => {
+        const button = await fixture<Button>(
+            html`
+                <sp-button>
+                    This is a button.
+                    <sp-tooltip self-managed placement="bottom">
+                        Help text.
+                    </sp-tooltip>
+                </sp-button>
+            `
+        );
+
+        const el = button.querySelector('sp-tooltip') as Tooltip;
+
+        await elementUpdated(el);
+        await expect(button).to.be.accessible();
+        let opened = oneEvent(button, 'sp-opened');
+        button.dispatchEvent(new PointerEvent('pointerenter'));
+        button.dispatchEvent(
+            new PointerEvent('pointerleave', {
+                relatedTarget: el,
+            })
+        );
+        el.dispatchEvent(
+            new PointerEvent('pointerleave', {
+                relatedTarget: button,
+            })
+        );
+        await opened;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.true;
+        await expect(button).to.be.accessible();
+
+        let closed = oneEvent(button, 'sp-closed');
+        button.dispatchEvent(new PointerEvent('pointerleave'));
+        await closed;
+        await elementUpdated(el);
+
+        expect(el.open).to.be.false;
+
+        opened = oneEvent(button, 'sp-opened');
+        button.dispatchEvent(new PointerEvent('pointerenter'));
+        button.dispatchEvent(
+            new PointerEvent('pointerleave', {
+                relatedTarget: el,
+            })
+        );
+        await opened;
+        await elementUpdated(el);
+
+        closed = oneEvent(button, 'sp-closed');
+        el.dispatchEvent(new PointerEvent('pointerleave'));
+        await closed;
+        await elementUpdated(el);
+    });
     it('cleans up when self manages', async () => {
         const button = await fixture<Button>(
             html`


### PR DESCRIPTION
## Description
Due to https://bugs.chromium.org/p/chromium/issues/detail?id=1363632 we need to use JS to manage pointer events and their interaction between the trigger and the content of an overlay, particularly when that content is a tooltip.

TODO:
- [ ] confirm with reporter
- [ ] devise a test for this interaction

## Related issue(s)

- fixes #2573

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://tooltip-enter--spectrum-web-components.netlify.app/storybook/index.html?path=/story/overlay--default)
    2. Slowly enter the button with your pointer device from the bottom center, see that the tooltip is opened correctly.
-   [ ] _Test case 2_
    1. Go [here](https://tooltip-enter--spectrum-web-components.netlify.app/storybook/index.html?path=/story/tooltip--self-managed&args=placement:bottom;offset:0)
    2. Close the tooltip
    3. Slowly enter the button with your pointer device from the bottom center, see that the tooltip is opened correctly.
  
## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.