### PR TITLE
Hloftis/fix 2510 v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 40ccd8ea6dc00253cdbe8bf98b9a9aeef853530a
+        default: 5ae06cffc6f04da1e1a85f10b668a0073b8dbe90
 commands:
     downstream:
         steps:

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -16,6 +16,7 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 import { ActionMenuMarkup } from './';
 
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
+import { MenuItem } from '@spectrum-web-components/menu/src/MenuItem.js';
 
 export default {
     component: 'sp-action-menu',
@@ -114,5 +115,54 @@ export const submenu = (): TemplateResult => {
                 </sp-menu>
             </sp-menu-item>
         </sp-action-menu>
+    `;
+};
+
+export const controlled = (): TemplateResult => {
+    const state = {
+        snap: true,
+        grid: false,
+        guides: true,
+    };
+    function toggle(prop: keyof typeof state) {
+        return (event: Event): void => {
+            const item = event.target as MenuItem;
+            state[prop] = !state[prop];
+            // in Lit-based usage, this would be handled via render():
+            // <sp-menu-item ?selected=${this.isSomethingSelected}>
+            item.selected = state[prop];
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            document.getElementById(
+                'state-json'
+            )!.textContent = `application state: ${JSON.stringify(state)}`;
+        };
+    }
+    return html`
+        <sp-action-menu label="View">
+            <sp-menu-item @click=${() => alert('action')}>
+                Non-selectable action
+            </sp-menu-item>
+            <sp-menu-item ?selected=${state.snap} @click=${toggle('snap')}>
+                Snap
+            </sp-menu-item>
+            <sp-menu-item>
+                Show
+                <sp-menu slot="submenu">
+                    <sp-menu-item
+                        ?selected=${state.grid}
+                        @click=${toggle('grid')}
+                    >
+                        Grid
+                    </sp-menu-item>
+                    <sp-menu-item
+                        ?selected=${state.guides}
+                        @click=${toggle('guides')}
+                    >
+                        Guides
+                    </sp-menu-item>
+                </sp-menu>
+            </sp-menu-item>
+        </sp-action-menu>
+        <span id="state-json"></span>
     `;
 };

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -16,7 +16,7 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 import { ActionMenuMarkup } from './';
 
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
-import { MenuItem } from '@spectrum-web-components/menu/src/MenuItem.js';
+import type { MenuItem } from '@spectrum-web-components/menu/src/MenuItem.js';
 
 export default {
     component: 'sp-action-menu',
@@ -123,38 +123,51 @@ export const controlled = (): TemplateResult => {
         snap: true,
         grid: false,
         guides: true,
+        latestChange: '',
     };
-    function toggle(prop: keyof typeof state) {
+    function toggle(prop: 'snap' | 'grid' | 'guides') {
         return (event: Event): void => {
             const item = event.target as MenuItem;
             state[prop] = !state[prop];
             // in Lit-based usage, this would be handled via render():
             // <sp-menu-item ?selected=${this.isSomethingSelected}>
             item.selected = state[prop];
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            document.getElementById(
-                'state-json'
-            )!.textContent = `application state: ${JSON.stringify(state)}`;
         };
     }
+    function onChange(event: Event): void {
+        state.latestChange = (event.target as MenuItem).value;
+        logState();
+    }
+    function logState(): void {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        document.getElementById(
+            'state-json'
+        )!.textContent = `application state: ${JSON.stringify(state)}`;
+    }
     return html`
-        <sp-action-menu label="View">
-            <sp-menu-item @click=${() => alert('action')}>
+        <sp-action-menu label="View" @change=${onChange}>
+            <sp-menu-item value="action" @click=${() => alert('action')}>
                 Non-selectable action
             </sp-menu-item>
-            <sp-menu-item ?selected=${state.snap} @click=${toggle('snap')}>
+            <sp-menu-item
+                value="snap"
+                ?selected=${state.snap}
+                @click=${toggle('snap')}
+            >
                 Snap
             </sp-menu-item>
             <sp-menu-item>
                 Show
                 <sp-menu slot="submenu">
                     <sp-menu-item
+                        value="grid"
                         ?selected=${state.grid}
                         @click=${toggle('grid')}
                     >
                         Grid
                     </sp-menu-item>
                     <sp-menu-item
+                        value="guides"
                         ?selected=${state.guides}
                         @click=${toggle('guides')}
                     >

--- a/packages/action-menu/test/action-menu.test.ts
+++ b/packages/action-menu/test/action-menu.test.ts
@@ -64,12 +64,12 @@ const actionSubmenuFixture = async (): Promise<ActionMenu> =>
         html`
             <sp-action-menu label="More Actions">
                 <sp-menu-item>One</sp-menu-item>
-                <sp-menu-item>Two</sp-menu-item>
+                <sp-menu-item selected class="selected-item">Two</sp-menu-item>
                 <sp-menu-item id="item-with-submenu">
                     B should be selected
                     <sp-menu slot="submenu">
                         <sp-menu-item>A</sp-menu-item>
-                        <sp-menu-item selected id="selected-item">
+                        <sp-menu-item selected class="selected-item">
                             B
                         </sp-menu-item>
                         <sp-menu-item>C</sp-menu-item>
@@ -242,10 +242,10 @@ describe('Action menu', () => {
             'sp-menu[slot="submenu"]'
         ) as Menu;
         const selectedItem = submenu.querySelector(
-            '#selected-item'
+            '.selected-item'
         ) as MenuItem;
 
-        expect(selectedItem.selected, 'item is not initially selected').to.be
+        expect(selectedItem.selected, 'item should be initially selected').to.be
             .true;
 
         let opened = oneEvent(root, 'sp-opened');
@@ -264,7 +264,50 @@ describe('Action menu', () => {
         await elementUpdated(submenu);
         expect(
             selectedItem.selected,
-            'initially selected item is no longer selected'
+            'initially selected item should maintain selection'
         ).to.be.true;
+    });
+    it.only('allows top-level selection state to change', async () => {
+        const root = await actionSubmenuFixture();
+        const unselectedItem = root.querySelector('sp-menu-item') as MenuItem;
+        const selectedItem = root.querySelector('.selected-item') as MenuItem;
+
+        selectedItem.addEventListener('click', () => {
+            selectedItem.selected = false;
+        });
+
+        expect(unselectedItem.innerHTML).to.equal('One');
+        expect(unselectedItem.selected).to.be.false;
+        expect(selectedItem.innerHTML).to.equal('Two');
+        expect(selectedItem.selected).to.be.true;
+
+        let opened = oneEvent(root, 'sp-opened');
+        root.click();
+        await opened;
+
+        // close by clicking selected
+        // (with event listener: should set selected = false)
+        let closed = oneEvent(root, 'sp-closed');
+        selectedItem.click();
+        await closed;
+
+        opened = oneEvent(root, 'sp-opened');
+        root.click();
+        await opened;
+
+        // close by clicking unselected
+        // (no event listener: should remain selected = false)
+        closed = oneEvent(root, 'sp-closed');
+        unselectedItem.click();
+        await closed;
+
+        opened = oneEvent(root, 'sp-opened');
+        root.click();
+        await opened;
+
+        expect(unselectedItem.innerHTML).to.equal('One');
+        expect(unselectedItem.selected).to.be.false;
+        expect(selectedItem.innerHTML).to.equal('Two');
+        expect(selectedItem.selected).to.be.false;
     });
 });

--- a/packages/action-menu/test/action-menu.test.ts
+++ b/packages/action-menu/test/action-menu.test.ts
@@ -267,7 +267,7 @@ describe('Action menu', () => {
             'initially selected item should maintain selection'
         ).to.be.true;
     });
-    it.only('allows top-level selection state to change', async () => {
+    it('allows top-level selection state to change', async () => {
         const root = await actionSubmenuFixture();
         const unselectedItem = root.querySelector('sp-menu-item') as MenuItem;
         const selectedItem = root.querySelector('.selected-item') as MenuItem;

--- a/packages/action-menu/test/action-menu.test.ts
+++ b/packages/action-menu/test/action-menu.test.ts
@@ -271,9 +271,11 @@ describe('Action menu', () => {
         const root = await actionSubmenuFixture();
         const unselectedItem = root.querySelector('sp-menu-item') as MenuItem;
         const selectedItem = root.querySelector('.selected-item') as MenuItem;
+        let selected = true;
 
         selectedItem.addEventListener('click', () => {
-            selectedItem.selected = false;
+            selected = !selected;
+            selectedItem.selected = selected;
         });
 
         expect(unselectedItem.innerHTML).to.equal('One');
@@ -309,5 +311,20 @@ describe('Action menu', () => {
         expect(unselectedItem.selected).to.be.false;
         expect(selectedItem.innerHTML).to.equal('Two');
         expect(selectedItem.selected).to.be.false;
+
+        // close by clicking selected
+        // (with event listener: should set selected = false)
+        closed = oneEvent(root, 'sp-closed');
+        selectedItem.click();
+        await closed;
+
+        opened = oneEvent(root, 'sp-opened');
+        root.click();
+        await opened;
+
+        expect(unselectedItem.innerHTML).to.equal('One');
+        expect(unselectedItem.selected).to.be.false;
+        expect(selectedItem.innerHTML).to.equal('Two');
+        expect(selectedItem.selected).to.be.true;
     });
 });

--- a/packages/action-menu/test/action-menu.test.ts
+++ b/packages/action-menu/test/action-menu.test.ts
@@ -64,12 +64,14 @@ const actionSubmenuFixture = async (): Promise<ActionMenu> =>
         html`
             <sp-action-menu label="More Actions">
                 <sp-menu-item>One</sp-menu-item>
-                <sp-menu-item selected class="selected-item">Two</sp-menu-item>
+                <sp-menu-item selected id="root-selected-item">
+                    Two
+                </sp-menu-item>
                 <sp-menu-item id="item-with-submenu">
                     B should be selected
                     <sp-menu slot="submenu">
                         <sp-menu-item>A</sp-menu-item>
-                        <sp-menu-item selected class="selected-item">
+                        <sp-menu-item selected id="sub-selected-item">
                             B
                         </sp-menu-item>
                         <sp-menu-item>C</sp-menu-item>
@@ -242,7 +244,7 @@ describe('Action menu', () => {
             'sp-menu[slot="submenu"]'
         ) as Menu;
         const selectedItem = submenu.querySelector(
-            '.selected-item'
+            '#sub-selected-item'
         ) as MenuItem;
 
         expect(selectedItem.selected, 'item should be initially selected').to.be
@@ -270,7 +272,9 @@ describe('Action menu', () => {
     it('allows top-level selection state to change', async () => {
         const root = await actionSubmenuFixture();
         const unselectedItem = root.querySelector('sp-menu-item') as MenuItem;
-        const selectedItem = root.querySelector('.selected-item') as MenuItem;
+        const selectedItem = root.querySelector(
+            '#root-selected-item'
+        ) as MenuItem;
         let selected = true;
 
         selectedItem.addEventListener('click', () => {
@@ -278,9 +282,9 @@ describe('Action menu', () => {
             selectedItem.selected = selected;
         });
 
-        expect(unselectedItem.innerHTML).to.equal('One');
+        expect(unselectedItem.textContent).to.include('One');
         expect(unselectedItem.selected).to.be.false;
-        expect(selectedItem.innerHTML).to.equal('Two');
+        expect(selectedItem.textContent).to.include('Two');
         expect(selectedItem.selected).to.be.true;
 
         let opened = oneEvent(root, 'sp-opened');
@@ -307,9 +311,9 @@ describe('Action menu', () => {
         root.click();
         await opened;
 
-        expect(unselectedItem.innerHTML).to.equal('One');
+        expect(unselectedItem.textContent).to.include('One');
         expect(unselectedItem.selected).to.be.false;
-        expect(selectedItem.innerHTML).to.equal('Two');
+        expect(selectedItem.textContent).to.include('Two');
         expect(selectedItem.selected).to.be.false;
 
         // close by clicking selected
@@ -322,9 +326,9 @@ describe('Action menu', () => {
         root.click();
         await opened;
 
-        expect(unselectedItem.innerHTML).to.equal('One');
+        expect(unselectedItem.textContent).to.include('One');
         expect(unselectedItem.selected).to.be.false;
-        expect(selectedItem.innerHTML).to.equal('Two');
+        expect(selectedItem.textContent).to.include('Two');
         expect(selectedItem.selected).to.be.true;
     });
 });

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -231,9 +231,9 @@ export class PickerBase extends SizedMixin(Focusable) {
             if (menuChangeEvent) {
                 menuChangeEvent.preventDefault();
             }
-            this.setSelected(this.selectedItem, false);
+            this.setMenuItemSelected(this.selectedItem, false);
             if (oldSelectedItem) {
-                this.setSelected(oldSelectedItem, true);
+                this.setMenuItemSelected(oldSelectedItem, true);
             }
             this.selectedItem = oldSelectedItem;
             this.value = oldValue;
@@ -241,12 +241,12 @@ export class PickerBase extends SizedMixin(Focusable) {
             return;
         }
         if (oldSelectedItem) {
-            this.setSelected(oldSelectedItem, false);
+            this.setMenuItemSelected(oldSelectedItem, false);
         }
-        this.setSelected(item, !!this.selects);
+        this.setMenuItemSelected(item, !!this.selects);
     }
 
-    protected setSelected(item: MenuItem, value: boolean): void {
+    protected setMenuItemSelected(item: MenuItem, value: boolean): void {
         // matches null | undefined
         if (this.selects == null) return;
         item.selected = value;
@@ -326,7 +326,7 @@ export class PickerBase extends SizedMixin(Focusable) {
                 }
             ) => {
                 if (this.value === el.value) {
-                    this.setSelected(el as MenuItem, true);
+                    this.setMenuItemSelected(el as MenuItem, true);
                 }
                 return (el) => {
                     if (typeof el.focused !== 'undefined') {

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -319,7 +319,7 @@ export class PickerBase extends SizedMixin(Focusable) {
                     selected?: boolean;
                 }
             ) => {
-                if (this.value === el.value) {
+                if (this.selects != null && this.value === el.value) {
                     el.selected = true;
                 }
                 return (el) => {
@@ -458,7 +458,7 @@ export class PickerBase extends SizedMixin(Focusable) {
                     this,
                     `You no longer need to provide an <sp-menu> child to ${localName}. Any styling or attributes on the <sp-menu> will be ignored.`,
                     'https://opensource.adobe.com/spectrum-web-components/components/picker/#sizes',
-                    { level: 'deprecation' },
+                    { level: 'deprecation' }
                 );
             }
         }
@@ -556,6 +556,8 @@ export class PickerBase extends SizedMixin(Focusable) {
     }
 
     protected async manageSelection(): Promise<void> {
+        if (this.selects == null) return;
+
         await this.menuStatePromise;
         this.selectionPromise = new Promise(
             (res) => (this.selectionResolver = res)

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -231,9 +231,9 @@ export class PickerBase extends SizedMixin(Focusable) {
             if (menuChangeEvent) {
                 menuChangeEvent.preventDefault();
             }
-            this.selectedItem.selected = false;
+            this.setSelected(this.selectedItem, false);
             if (oldSelectedItem) {
-                oldSelectedItem.selected = true;
+                this.setSelected(oldSelectedItem, true);
             }
             this.selectedItem = oldSelectedItem;
             this.value = oldValue;
@@ -241,9 +241,15 @@ export class PickerBase extends SizedMixin(Focusable) {
             return;
         }
         if (oldSelectedItem) {
-            oldSelectedItem.selected = false;
+            this.setSelected(oldSelectedItem, false);
         }
-        item.selected = !!this.selects;
+        this.setSelected(item, !!this.selects);
+    }
+
+    protected setSelected(item: MenuItem, value: boolean): void {
+        // matches null | undefined
+        if (this.selects == null) return;
+        item.selected = value;
     }
 
     public toggle(target?: boolean): void {
@@ -319,8 +325,8 @@ export class PickerBase extends SizedMixin(Focusable) {
                     selected?: boolean;
                 }
             ) => {
-                if (this.selects != null && this.value === el.value) {
-                    el.selected = true;
+                if (this.value === el.value) {
+                    this.setSelected(el as MenuItem, true);
                 }
                 return (el) => {
                     if (typeof el.focused !== 'undefined') {

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -84,7 +84,7 @@ export default {
     protocol: 'https:',
     concurrency: 4,
     concurrentBrowsers: 1,
-    testsFinishTimeout: 30000,
+    testsFinishTimeout: 60000,
     coverageConfig: {
         report: true,
         reportDir: 'coverage',
@@ -109,7 +109,7 @@ export default {
     },
     testFramework: {
         config: {
-            timeout: 5000,
+            timeout: 3000,
             retries: 1,
         },
     },


### PR DESCRIPTION
## Description

`ActionMenu` inherits from `PickerBase`, which currently manages selections in two places even when `selects` is undefined:

- `restoreChildren` (via `openMenu`)
- `manageSelection`

This change guards against managing child `selected` states when `selects` is undefined.

I also found that the action-menu tests were frequently timing out during development, so I increased the timeout limit from 30s to 60s.

## Related issue(s)

Resolves https://github.com/adobe/spectrum-web-components/issues/2510

## Motivation and context

Consumers should be able to control top-level menu-item selection states.

## How has this been tested?

1. Added an automated regression test in the action-menu suite
2. Added an [interactive story](https://hloftis-fix-2510-v2--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--controlled) where you can test that:
3. "Snap" and "Guides" are selected by default
4. All selectable items can be toggled on/off by the user
5. The selection state is accurately reflected into the logged application state object
6. The non-selectable action triggers an alert, but never is selected

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/364501/190240798-59566f9b-b372-40dc-ab21-2d8cd3322e49.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
