### PR TITLE
fix modal blink draft

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 2d6944c9ffce3b991115861837ccd05e1b115cb5
+        default: 157d50398f96e74d40bfb0d8601e618283577cf6
 commands:
     downstream:
         steps:

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -62,6 +62,10 @@ export class OverlayStack {
     private overlayHolder!: HTMLElement;
     private _eventsAreBound = false;
 
+    constructor() {
+        this.initTabTrapping();
+    }
+
     private initTabTrapping(): void {
         if (this.trappingInited) return;
         this.trappingInited = true;
@@ -153,7 +157,6 @@ export class OverlayStack {
     }
 
     private startTabTrapping(): void {
-        this.initTabTrapping();
         /* c8 ignore next 3 */
         if (!this.canTabTrap) {
             return;

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -57,7 +57,6 @@ export class OverlayStack {
     private overlayTimer = new OverlayTimer();
 
     private canTabTrap = true;
-    private trappingInited = false;
     private tabTrapper!: HTMLElement;
     private overlayHolder!: HTMLElement;
     private _eventsAreBound = false;
@@ -67,8 +66,6 @@ export class OverlayStack {
     }
 
     private initTabTrapping(): void {
-        if (this.trappingInited) return;
-        this.trappingInited = true;
         /* c8 ignore next 4 */
         if (this.document.body.shadowRoot) {
             this.canTabTrap = false;
@@ -167,7 +164,7 @@ export class OverlayStack {
 
     private stopTabTrapping(): void {
         /* c8 ignore next 3 */
-        if (!this.canTabTrap || !this.trappingInited) {
+        if (!this.canTabTrap) {
             return;
         }
         this.tabTrapper.removeAttribute('tabindex');
@@ -179,7 +176,6 @@ export class OverlayStack {
     ): Promise<void> => {
         const topOverlay = this.overlays[this.overlays.length - 1];
         if (
-            !this.trappingInited ||
             topOverlay.interaction !== 'modal' ||
             event.target !== this.overlayHolder
         ) {

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -66,6 +66,16 @@ export class OverlayStack {
     }
 
     private initTabTrapping(): void {
+        /* c8 ignore next 5 */
+        if (document.readyState === 'loading') {
+            document.addEventListener(
+                'readystatechange',
+                () => {
+                    this.initTabTrapping();
+                },
+                { once: true }
+            );
+        }
         /* c8 ignore next 4 */
         if (this.document.body.shadowRoot) {
             this.canTabTrap = false;

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -927,3 +927,23 @@ export const definedOverlayElement = (): TemplateResult => {
 };
 
 definedOverlayElement.decorators = [definedOverlayDecorator];
+
+export const modalWithinNonModal = (): TemplateResult => {
+    return html`
+        <overlay-trigger type="click">
+            <sp-button variant="primary" slot="trigger">
+                Open "click" overlay
+            </sp-button>
+            <sp-popover slot="click-content" dialog>
+                <overlay-trigger type="modal">
+                    <sp-button variant="primary" slot="trigger">
+                        Open "modal" overlay
+                    </sp-button>
+                    <sp-popover slot="click-content" dialog>
+                        Modal overlay
+                    </sp-popover>
+                </overlay-trigger>
+            </sp-popover>
+        </overlay-trigger>
+    `;
+};

--- a/packages/overlay/test/overlay-trigger-hover.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover.test.ts
@@ -286,7 +286,7 @@ describe('Overlay Trigger - Hover', () => {
     });
     it('will not return focus to a "modal" parent', async () => {
         const el = await styledFixture<OverlayTrigger>(html`
-            <overlay-trigger type="modal" placement="none">
+            <overlay-trigger type="modal">
                 <sp-button slot="trigger">Toggle Dialog</sp-button>
                 <sp-dialog-wrapper
                     slot="click-content"

--- a/packages/overlay/test/overlay-trigger-hover.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover.test.ts
@@ -57,6 +57,63 @@ describe('Overlay Trigger - Hover', () => {
             await closed;
         }
     });
+    it('will not return focus to a "modal" parent', async () => {
+        const el = await styledFixture<OverlayTrigger>(html`
+            <overlay-trigger type="modal" placement="none">
+                <sp-button slot="trigger">Toggle Dialog</sp-button>
+                <sp-dialog-wrapper
+                    slot="click-content"
+                    headline="Dialog title"
+                    size="s"
+                >
+                    ${[1, 2, 3, 4].map(
+                        (index) => html`
+                            <overlay-trigger>
+                                <sp-button slot="trigger" id="button-${index}">
+                                    Button with Tooltip ${index}
+                                </sp-button>
+                                <sp-tooltip slot="hover-content">
+                                    Tooltip ${index}
+                                </sp-tooltip>
+                            </overlay-trigger>
+                        `
+                    )}
+                </sp-dialog-wrapper>
+            </overlay-trigger>
+        `);
+        await elementUpdated(el);
+
+        const button = el.querySelector('sp-button') as Button;
+        const dialog = el.querySelector('sp-dialog-wrapper') as HTMLElement;
+        await elementUpdated(button);
+        await elementUpdated(dialog);
+
+        let opened = oneEvent(button, 'sp-opened');
+        button.dispatchEvent(new Event('click', { bubbles: true }));
+        await opened;
+        const button1 = dialog.querySelector('#button-1') as Button;
+        const button2 = dialog.querySelector('#button-2') as Button;
+
+        opened = oneEvent(button1, 'sp-opened');
+        sendKeys({
+            press: 'Tab',
+        });
+        await opened;
+
+        await nextFrame();
+
+        expect(button1 === document.activeElement).to.be.true;
+
+        opened = oneEvent(button2, 'sp-opened');
+        sendKeys({
+            press: 'Tab',
+        });
+        await opened;
+
+        await nextFrame();
+
+        expect(button2 === document.activeElement).to.be.true;
+    });
     it('displays `hover` declaratively', async () => {
         const openedSpy = spy();
         const closedSpy = spy();
@@ -283,62 +340,5 @@ describe('Overlay Trigger - Hover', () => {
         await elementUpdated(el);
 
         expect(el.open).to.be.null;
-    });
-    it('will not return focus to a "modal" parent', async () => {
-        const el = await styledFixture<OverlayTrigger>(html`
-            <overlay-trigger type="modal">
-                <sp-button slot="trigger">Toggle Dialog</sp-button>
-                <sp-dialog-wrapper
-                    slot="click-content"
-                    headline="Dialog title"
-                    size="s"
-                >
-                    ${[1, 2, 3, 4].map(
-                        (index) => html`
-                            <overlay-trigger>
-                                <sp-button slot="trigger" id="button-${index}">
-                                    Button with Tooltip ${index}
-                                </sp-button>
-                                <sp-tooltip slot="hover-content">
-                                    Tooltip ${index}
-                                </sp-tooltip>
-                            </overlay-trigger>
-                        `
-                    )}
-                </sp-dialog-wrapper>
-            </overlay-trigger>
-        `);
-        await elementUpdated(el);
-
-        const button = el.querySelector('sp-button') as Button;
-        const dialog = el.querySelector('sp-dialog-wrapper') as HTMLElement;
-        await elementUpdated(button);
-        await elementUpdated(dialog);
-
-        let opened = oneEvent(button, 'sp-opened');
-        button.dispatchEvent(new Event('click', { bubbles: true }));
-        await opened;
-        const button1 = dialog.querySelector('#button-1') as Button;
-        const button2 = dialog.querySelector('#button-2') as Button;
-
-        opened = oneEvent(button1, 'sp-opened');
-        sendKeys({
-            press: 'Tab',
-        });
-        await opened;
-
-        await nextFrame();
-
-        expect(button1 === document.activeElement).to.be.true;
-
-        opened = oneEvent(button2, 'sp-opened');
-        sendKeys({
-            press: 'Tab',
-        });
-        await opened;
-
-        await nextFrame();
-
-        expect(button2 === document.activeElement).to.be.true;
     });
 });


### PR DESCRIPTION
## Description

Prevents janky blink that happens the first time a modal overlay is opened over a non-modal overlay

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/2599

## Motivation and context

Several consumers have situations where a modal opens over a non-modal, leading to a weird UX.

## How has this been tested?

1. All current tests pass
2. Open the [new story](https://hloftis-fix-modal-blink-draft--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--modal-within-non-modal) that reproduces the situation
3. Open both modals
4. Confirm that there is no blink/flicker

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
