### PR TITLE
fix(search): prevent overflow content from going behind clear button

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 0272c0954bcca37a0a48daa736d881172ac244b3
+        default: 2d6944c9ffce3b991115861837ccd05e1b115cb5
 commands:
     downstream:
         steps:

--- a/packages/search/src/search.css
+++ b/packages/search/src/search.css
@@ -12,6 +12,18 @@ governing permissions and limitations under the License.
 
 @import './spectrum-search.css';
 
+:host([dir='ltr']) {
+    --spectrum-textfield-texticon-padding-right: var(
+        --spectrum-alias-infieldbutton-full-height-m
+    );
+}
+
+:host([dir='rtl']) {
+    --spectrum-textfield-texticon-padding-left: var(
+        --spectrum-alias-infieldbutton-full-height-m
+    );
+}
+
 input::-webkit-search-cancel-button {
     display: none;
 }

--- a/packages/search/stories/search.stories.ts
+++ b/packages/search/stories/search.stories.ts
@@ -26,6 +26,12 @@ export const autofocus = (): TemplateResult => html`
     <sp-search autofocus></sp-search>
 `;
 
+export const focusedOverflowing = (): TemplateResult => html`
+    <sp-search
+        value="this is a really long search term that overflows the available space"
+    ></sp-search>
+`;
+
 export const Quiet = (): TemplateResult => html`
     <sp-search quiet></sp-search>
     <sp-search quiet disabled></sp-search>


### PR DESCRIPTION
## Description
Update the end of line padding to prevent the text from falling behind the clear button when typing a long search term.

## Related issue(s)

- fixes #2574

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://206c63a096c098a7218cbf9156aae66f--spectrum-web-components.netlify.app/review/)
    2. Review the addition across themes.

## Screenshots (if appropriate)
<img width="201" alt="image" src="https://user-images.githubusercontent.com/1156657/190709545-f76d4254-cb1a-4f9b-ae03-6abc2040ceee.png">

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
