### PR TITLE
docs: exclude non-project readmes from docs search

### DIFF
--- a/projects/documentation/scripts/build-search-index.js
+++ b/projects/documentation/scripts/build-search-index.js
@@ -37,7 +37,9 @@ async function main() {
     const documents = [];
 
     // Components
-    for await (const path of globby.stream(`${projectDir}/packages/**/*.md`)) {
+    for await (const path of globby.stream(`${projectDir}/packages/**/*.md`, {
+        ignore: ['**/node_modules/**'],
+    })) {
         let componentName = /([^/]+)\/([a-zA-Z-]+)\.md$/.exec(path)[1];
         const fileName = /([a-zA-Z-]+)\.md$/.exec(path)[0];
         if (fileName === 'CHANGELOG.md') {
@@ -59,7 +61,10 @@ async function main() {
 
     // Guides
     for await (const path of globby.stream(
-        `${projectDir}/documentation/guides/*.md`
+        `${projectDir}/documentation/guides/*.md`,
+        {
+            ignore: ['**/node_modules/**'],
+        }
     )) {
         const guideName = /\/([^/]+).md$/.exec(path)[1];
         const content = await fs.readFile(path, { encoding: 'utf8' });


### PR DESCRIPTION
## Description
Prevent non-project package inclusion in the autocomplete list for search.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://docs-search--spectrum-web-components.netlify.app/)
    2. Type "doc" into the search interface
    3. See that "Prettier" and "Glob" are not offered as options in the auto complete.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.