### PR TITLE
docs: begin Iconset deprecation process

### DIFF
--- a/packages/iconset/README.md
+++ b/packages/iconset/README.md
@@ -28,3 +28,7 @@ export class IconsLarge extends IconsetSVG {
     }
 }
 ```
+
+### Deprecated
+
+Iconsets have been deprecated and will be removed from the project in an upcoming version. Using a technique that ensures only the icons actually leveraged in your application are present in your build, like UI Icons (../icons-ui/) or Workflow Icons (../icons-workflow/), will ensure smaller bundles and higher performance for you visitor. For non-Spectrum icons, you can still slot SVG and image content into an [`sp-icon` element](../icon/) or sanitize the SVG to a template literal so that it can be returned from the `render()` method in an extension of `IconBase` to create your own named icon element.

--- a/packages/iconset/src/iconset.ts
+++ b/packages/iconset/src/iconset.ts
@@ -22,6 +22,14 @@ export abstract class Iconset extends LitElement {
     protected override firstUpdated(): void {
         // force no display for all iconsets
         this.style.display = 'none';
+        if (window.__swc.DEBUG) {
+            window.__swc.warn(
+                this,
+                'Iconsets have been deprecated and will be removed from the project in an upcoming version. For default Spectrum Icons, learn more about leveraging UI Icons (https://opensource.adobe.com/spectrum-web-components/components/icons-ui/) or Workflow Icons (https://opensource.adobe.com/spectrum-web-components/components/icons-workflow/) as an alternative.',
+                'https://opensource.adobe.com/spectrum-web-components/components/iconset/#deprecated',
+                { level: 'deprecation' }
+            );
+        }
     }
 
     /**

--- a/packages/iconset/test/iconset.test.ts
+++ b/packages/iconset/test/iconset.test.ts
@@ -17,11 +17,34 @@ import { IconsMedium } from '@spectrum-web-components/icons';
 import { Icon } from '@spectrum-web-components/icon';
 import { IconsetRegistry } from '@spectrum-web-components/iconset/src/iconset-registry.js';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { stub } from 'sinon';
 
 describe('Iconset', () => {
     after(() => {
         const sets = [...document.querySelectorAll('sp-icons-medium')];
         sets.map((set) => set.remove());
+    });
+    it('warns in Dev Mode of deprecation', async () => {
+        const consoleWarnStub = stub(console, 'warn');
+        const el = document.createElement('sp-icons-medium');
+        document.body.append(el);
+
+        await elementUpdated(el);
+
+        expect(consoleWarnStub.called).to.be.true;
+        const spyCall = consoleWarnStub.getCall(0);
+        expect(
+            spyCall.args.at(0).includes('deprecated'),
+            'confirm deprecation message'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-icons-medium',
+                type: 'api',
+                level: 'deprecation',
+            },
+        });
+        consoleWarnStub.restore();
     });
 
     it('will re-register with new name', async () => {


### PR DESCRIPTION
## Description
Begin deprecating Iconsets:
- https://opensource.adobe.com/spectrum-web-components/components/iconset/
- https://opensource.adobe.com/spectrum-web-components/components/icons/

This will post deprecation notices to Dev Mode and the docs site in advance of removing these packages in favor of UI Icons and Workflow Icons. This also points to a longer term need to productionize the work going into #2407 or similar so that it is more clear how downstream projects can make/manage/deliver their own icon content.

## Motivation and context
Begin removal of contradictory packages/documentation to ease consumption of the library. cc: @e111077

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.