### PR TITLE
fix: match "pointerup" listeners with "pointercancel" for full coverage

### DIFF
--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -234,10 +234,15 @@ export class ButtonBase extends LikeAnchor(
             if (this.active) {
                 this.addEventListener('focusout', this.handleRemoveActive);
                 this.addEventListener('pointerup', this.handleRemoveActive);
+                this.addEventListener('pointercancel', this.handleRemoveActive);
                 this.addEventListener('pointerleave', this.handleRemoveActive);
             } else {
                 this.removeEventListener('focusout', this.handleRemoveActive);
                 this.removeEventListener('pointerup', this.handleRemoveActive);
+                this.removeEventListener(
+                    'pointercancel',
+                    this.handleRemoveActive
+                );
                 this.removeEventListener(
                     'pointerleave',
                     this.handleRemoveActive

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -198,8 +198,10 @@ export class Card extends LikeAnchor(
                 this.click();
             }
             this.removeEventListener('pointerup', handleEnd);
+            this.removeEventListener('pointercancel', handleEnd);
         };
         this.addEventListener('pointerup', handleEnd);
+        this.addEventListener('pointercancel', handleEnd);
     }
 
     protected get renderHeading(): TemplateResult {

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -467,10 +467,15 @@ export class MenuItem extends LikeAnchor(Focusable) {
             if (this.active) {
                 this.addEventListener('pointerup', this.handleRemoveActive);
                 this.addEventListener('pointerleave', this.handleRemoveActive);
+                this.addEventListener('pointercancel', this.handleRemoveActive);
             } else {
                 this.removeEventListener('pointerup', this.handleRemoveActive);
                 this.removeEventListener(
                     'pointerleave',
+                    this.handleRemoveActive
+                );
+                this.removeEventListener(
+                    'pointercancel',
                     this.handleRemoveActive
                 );
             }


### PR DESCRIPTION
## Description
Ensure all `pointerup` listeners are matched with a `pointercancel` listener in case the visitor proceeds to scroll while the pointer is down.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://pointercancel--spectrum-web-components.netlify.app/) on iOS
    2. Open one of the theme pickers
    3. Touch on of the Menu Items and "swipe"
    4. You'll see the page scroll (captured for fixing in #2536)
    5. Lift your finger on a part of the page that IS NOT the Menu Item you started on
    6. See that the "active" (looks a little like hover) state is removed.
    7. Compare to [production](https://opensource.adobe.com/spectrum-web-components/index.html)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)