### PR TITLE
fix: convert the langage resolution workflow to a Reactive Controller

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -20,7 +20,7 @@ import {
     property,
     query,
 } from '@spectrum-web-components/base/src/decorators.js';
-import { ProvideLang } from '@spectrum-web-components/theme';
+import { LanguageResolutionController } from '@spectrum-web-components/reactive-controllers/src/LanguageResolution.js';
 import { streamingListener } from '@spectrum-web-components/base/src/streaming-listener.js';
 import { NumberFormatter, NumberParser } from '@internationalized/number';
 
@@ -103,10 +103,6 @@ export class NumberField extends TextfieldBase {
     @property({ type: Number })
     public min?: number;
 
-    @property({ attribute: false })
-    private resolvedLanguage =
-        document.documentElement.lang || navigator.language;
-
     /**
      * The distance by which to alter the value of the element when taking a "step".
      *
@@ -183,6 +179,7 @@ export class NumberField extends TextfieldBase {
     private findChange!: (event: PointerEvent) => void;
     private change!: (event: PointerEvent) => void;
     private safty!: number;
+    private languageResolver = new LanguageResolutionController(this);
 
     private handlePointerdown(event: PointerEvent): void {
         if (event.button !== 0) {
@@ -440,12 +437,12 @@ export class NumberField extends TextfieldBase {
                 (formatOptionsNoUnit as Intl.NumberFormatOptions).style = style;
             }
             this._numberFormatterFocused = new NumberFormatter(
-                this.resolvedLanguage,
+                this.languageResolver.language,
                 formatOptionsNoUnit
             );
             try {
                 this._numberFormatter = new NumberFormatter(
-                    this.resolvedLanguage,
+                    this.languageResolver.language,
                     this.formatOptions
                 );
                 this._forcedUnit = '';
@@ -478,12 +475,12 @@ export class NumberField extends TextfieldBase {
                 (formatOptionsNoUnit as Intl.NumberFormatOptions).style = style;
             }
             this._numberParserFocused = new NumberParser(
-                this.resolvedLanguage,
+                this.languageResolver.language,
                 formatOptionsNoUnit
             );
             try {
                 this._numberParser = new NumberParser(
-                    this.resolvedLanguage,
+                    this.languageResolver.language,
                     this.formatOptions
                 );
                 this._forcedUnit = '';
@@ -617,32 +614,5 @@ export class NumberField extends TextfieldBase {
             }
             this.inputElement.inputMode = inputMode;
         }
-    }
-
-    public override connectedCallback(): void {
-        super.connectedCallback();
-        this.resolveLanguage();
-    }
-
-    public override disconnectedCallback(): void {
-        this.resolveLanguage();
-        super.disconnectedCallback();
-    }
-
-    private resolveLanguage(): void {
-        const queryThemeEvent = new CustomEvent<ProvideLang>(
-            'sp-language-context',
-            {
-                bubbles: true,
-                composed: true,
-                detail: {
-                    callback: (lang: string) => {
-                        this.resolvedLanguage = lang;
-                    },
-                },
-                cancelable: true,
-            }
-        );
-        this.dispatchEvent(queryThemeEvent);
     }
 }

--- a/packages/number-field/test/helpers.ts
+++ b/packages/number-field/test/helpers.ts
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import { html, TemplateResult } from '@spectrum-web-components/base';
 import { elementUpdated, fixture, nextFrame } from '@open-wc/testing';
-import { ProvideLang } from '@spectrum-web-components/theme';
 import { NumberField } from '@spectrum-web-components/number-field';
 import { sendMouse } from '../../../test/plugins/browser.js';
 
@@ -60,18 +59,4 @@ export async function clickBySelector(
         ],
     });
     await elementUpdated(el);
-}
-
-export function createLanguageContext(
-    lang: string
-): (event: CustomEvent<ProvideLang>) => void {
-    const langResolvers: ProvideLang['callback'][] = [];
-    const createLangResolver = (event: CustomEvent<ProvideLang>): void => {
-        langResolvers.push(event.detail.callback);
-        resolveLanguage();
-    };
-    const resolveLanguage = (): void => {
-        langResolvers.forEach((resolver) => resolver(lang));
-    };
-    return createLangResolver;
 }

--- a/packages/number-field/test/inputs.test.ts
+++ b/packages/number-field/test/inputs.test.ts
@@ -12,7 +12,8 @@ governing permissions and limitations under the License.
 
 import { html } from '@spectrum-web-components/base';
 import { elementUpdated, expect } from '@open-wc/testing';
-import { createLanguageContext, getElFrom } from './helpers.js';
+import { getElFrom } from './helpers.js';
+import { createLanguageContext } from '../../../tools/reactive-controllers/test/helpers.js';
 import polyfillCheck from '@formatjs/intl-numberformat/should-polyfill.js';
 
 import '@spectrum-web-components/number-field/sp-number-field.js';
@@ -309,7 +310,7 @@ describe('NumberField - inputs', () => {
     });
     describe('locale specific', () => {
         it('can determine the group symbol', async () => {
-            const languageContext = createLanguageContext('es-ES');
+            const [languageContext] = createLanguageContext('es-ES');
             const el = await getElFrom(html`
                 <div @sp-language-context=${languageContext}>${Default()}</div>
             `);

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -31,11 +31,8 @@ import {
 } from '@spectrum-web-components/number-field';
 import { sendKeys, setUserAgent } from '@web/test-runner-commands';
 import { spy } from 'sinon';
-import {
-    clickBySelector,
-    createLanguageContext,
-    getElFrom,
-} from './helpers.js';
+import { clickBySelector, getElFrom } from './helpers.js';
+import { createLanguageContext } from '../../../tools/reactive-controllers/test/helpers.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
@@ -74,7 +71,7 @@ describe('NumberField', () => {
             expect(el.value).to.equal(13377331);
         });
         it('with language context', async () => {
-            const languageContext = createLanguageContext('fr');
+            const [languageContext] = createLanguageContext('fr');
             const el = await getElFrom(html`
                 <div @sp-language-context=${languageContext}>
                     ${Default({ value: 1337 })}

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -24,9 +24,9 @@ import {
     waitUntil,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
-import { ProvideLang } from '@spectrum-web-components/theme';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import { stub } from 'sinon';
+import { createLanguageContext } from '../../../tools/reactive-controllers/test/helpers.js';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
 describe('Slider', () => {
@@ -832,15 +832,7 @@ describe('Slider', () => {
         expect(input.getAttribute('aria-valuetext')).to.equal('100%');
     });
     it('obeys language property', async () => {
-        let lang = 'de';
-        const langResolvers: ProvideLang['callback'][] = [];
-        const createLangResolver = (event: CustomEvent<ProvideLang>): void => {
-            langResolvers.push(event.detail.callback);
-            resolveLanguage();
-        };
-        const resolveLanguage = (): void => {
-            langResolvers.forEach((resolver) => resolver(lang));
-        };
+        const [languageContext, updateLanguage] = createLanguageContext('de');
         let el = await fixture<Slider>(
             html`
                 <sp-slider
@@ -848,7 +840,7 @@ describe('Slider', () => {
                     min="0"
                     max="10"
                     step="0.01"
-                    @sp-language-context=${createLangResolver}
+                    @sp-language-context=${languageContext}
                     .formatOptions=${{ maximumFractionDigits: 2 }}
                 ></sp-slider>
             `
@@ -862,8 +854,7 @@ describe('Slider', () => {
             'First German number'
         ).to.equal('2,44');
 
-        lang = 'en';
-        resolveLanguage();
+        updateLanguage('en');
         await elementUpdated(el);
 
         expect(
@@ -871,21 +862,20 @@ describe('Slider', () => {
             'First English number'
         ).to.equal('2.44');
 
-        lang = 'de';
-        resolveLanguage();
+        updateLanguage('de');
         el = await fixture<Slider>(
             html`
                 <sp-slider
                     min="0"
                     max="10"
-                    @sp-language-context=${createLangResolver}
+                    @sp-language-context=${languageContext}
                 >
                     <sp-slider-handle
                         slot="handle"
                         step="0.01"
                         value="2.44"
                         .formatOptions=${{ maximumFractionDigits: 2 }}
-                        @sp-language-context=${createLangResolver}
+                        @sp-language-context=${languageContext}
                     ></sp-slider-handle>
                 </sp-slider>
             `
@@ -899,8 +889,7 @@ describe('Slider', () => {
             'Second German number'
         ).to.equal('2,44');
 
-        lang = 'en';
-        resolveLanguage();
+        updateLanguage('en');
         await elementUpdated(el);
 
         expect(

--- a/tools/reactive-controllers/package.json
+++ b/tools/reactive-controllers/package.json
@@ -33,6 +33,10 @@
             "development": "./src/FocusGroup.dev.js",
             "default": "./src/FocusGroup.js"
         },
+        "./src/LanguageResolution.js": {
+            "development": "./src/LanguageResolution.dev.js",
+            "default": "./src/LanguageResolution.js"
+        },
         "./src/MatchMedia.js": {
             "development": "./src/MatchMedia.dev.js",
             "default": "./src/MatchMedia.js"

--- a/tools/reactive-controllers/src/LanguageResolution.ts
+++ b/tools/reactive-controllers/src/LanguageResolution.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import type { ReactiveController, ReactiveElement } from 'lit';
+import { ProvideLang } from '@spectrum-web-components/theme';
+
+export class LanguageResolutionController implements ReactiveController {
+    private host: ReactiveElement;
+    language = document.documentElement.lang || navigator.language;
+    private unsubscribe?: () => void;
+
+    constructor(host: ReactiveElement) {
+        this.host = host;
+        this.host.addController(this);
+    }
+
+    public hostConnected(): void {
+        this.resolveLanguage();
+    }
+
+    public hostDisconnected(): void {
+        this.unsubscribe?.();
+    }
+
+    private resolveLanguage(): void {
+        const queryThemeEvent = new CustomEvent<ProvideLang>(
+            'sp-language-context',
+            {
+                bubbles: true,
+                composed: true,
+                detail: {
+                    callback: (lang: string, unsubscribe: () => void) => {
+                        this.language = lang;
+                        this.unsubscribe = unsubscribe;
+                        this.host.requestUpdate();
+                    },
+                },
+                cancelable: true,
+            }
+        );
+        this.host.dispatchEvent(queryThemeEvent);
+    }
+}

--- a/tools/reactive-controllers/test/helpers.ts
+++ b/tools/reactive-controllers/test/helpers.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { ProvideLang } from '@spectrum-web-components/theme';
+
+export const createLanguageContext = (
+    lang: string
+): [(event: CustomEvent<ProvideLang>) => void, (lang: string) => void] => {
+    let language = lang;
+    const updateLanguage = (lang: string): void => {
+        language = lang;
+        resolveLanguage();
+    };
+    const langResolvers: [ProvideLang['callback'], () => void][] = [];
+    const createLangResolver = (event: CustomEvent<ProvideLang>): void => {
+        langResolvers.push([
+            event.detail.callback,
+            () => langResolvers.splice(langResolvers.length, 1),
+        ]);
+        resolveLanguage();
+    };
+    const resolveLanguage = (): void => {
+        langResolvers.forEach(([resolver, unsubscribe]) =>
+            resolver(language, unsubscribe)
+        );
+    };
+    return [createLangResolver, updateLanguage];
+};


### PR DESCRIPTION
## Description
- centralize language resolution tooling for reuse
- ensure the use of `unsubscribe` rather than event based contract nullification so that memory can be correctly released

## How has this been tested?

-   [ ] _Test case 1_
    1. The tests pass
-   [ ] _Test case 2_
    1. Go [here](https://resolved-language--spectrum-web-components.netlify.app/storybook/index.html?path=/story/slider--default)
    2. Duplicate the Slider in the story a bunch of times within the `<sp-story-decorator>` element
    3. Find the `<sp-theme>` element within the Decorator
    4. Check the value of `_contextConsumers.size` on the Theme element
    5. Delete some of the `<sp-slider>` elements. 
    6. See that `_contextConsumers.size` has decreased by the number of Slider you have deleted

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.