### PR TITLE
fix: correct theme calculation for triggering warnings

### DIFF
--- a/packages/theme/src/Theme.ts
+++ b/packages/theme/src/Theme.ts
@@ -311,7 +311,10 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
                 } else if (
                     !Theme.themeFragmentsByKind
                         .get(name)
-                        ?.get(resolvedValue + themeModifier)
+                        ?.get(
+                            resolvedValue +
+                                (name === 'theme' ? '' : themeModifier)
+                        )
                 ) {
                     issues.push(
                         `You have set "${name}='${resolvedValue}'" but the associated theme fragment has not been loaded.`
@@ -327,8 +330,8 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
                     'You are leveraging an <sp-theme> element and the following issues may disrupt your theme delivery:',
                     'https://opensource.adobe.com/spectrum-web-components/components/theme/#example',
                     {
-                        issues
-                    },
+                        issues,
+                    }
                 );
             }
         }


### PR DESCRIPTION
## Description
Don't let `theme="express"` express a Dev Mode warning incorrectly. Previously, we were looking for `express-express` instead of `express`.

## How has this been tested?

-   [ ] _Test case 1_
    1. Run `yarn storybook` locally
    2. Switch the the `express` theme
    3. See that Dev Mode doesn't warn you about missing Theme modules

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.