### PR TITLE
fix: tab indicator positioning

### DIFF
--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -124,12 +124,12 @@ export class Tabs extends SizedMixin(Focusable) {
         new IntersectionController(this, {
             config: {
                 root: null,
-                rootMargin: "0px",
-                threshold: [0, 1]
+                rootMargin: '0px',
+                threshold: [0, 1],
             },
             callback: () => {
                 this.updateSelectionIndicator();
-            }
+            },
         });
     }
 
@@ -357,15 +357,16 @@ export class Tabs extends SizedMixin(Focusable) {
             document.fonts ? document.fonts.ready : Promise.resolve(),
         ]);
         const tabBoundingClientRect = selectedElement.getBoundingClientRect();
+        const tabPanelClientRect = this.getBoundingClientRect();
 
         if (this.direction === 'horizontal') {
             const width = tabBoundingClientRect.width;
-            const offset = selectedElement.offsetLeft;
+            const offset = tabBoundingClientRect.left - tabPanelClientRect.left;
 
             this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${width});`;
         } else {
             const height = tabBoundingClientRect.height;
-            const offset = selectedElement.offsetTop;
+            const offset = tabBoundingClientRect.top - tabPanelClientRect.top;
 
             this.selectionIndicatorStyle = `transform: translateY(${offset}px) scaleY(${height});`;
         }

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -357,16 +357,15 @@ export class Tabs extends SizedMixin(Focusable) {
             document.fonts ? document.fonts.ready : Promise.resolve(),
         ]);
         const tabBoundingClientRect = selectedElement.getBoundingClientRect();
-        const tabPanelClientRect = this.getBoundingClientRect();
 
         if (this.direction === 'horizontal') {
             const width = tabBoundingClientRect.width;
-            const offset = tabBoundingClientRect.left - tabPanelClientRect.left;
+            const offset = selectedElement.offsetLeft;
 
             this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${width});`;
         } else {
             const height = tabBoundingClientRect.height;
-            const offset = tabBoundingClientRect.top - tabPanelClientRect.top;
+            const offset = selectedElement.offsetTop;
 
             this.selectionIndicatorStyle = `transform: translateY(${offset}px) scaleY(${height});`;
         }

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -15,6 +15,7 @@ governing permissions and limitations under the License.
 :host {
     display: grid;
     grid-template-columns: 100%;
+    position: relative;
 }
 
 :host(:not([direction^='vertical'])) {


### PR DESCRIPTION
## Description

On Safari, the tab offsetLeft and offsetTop were not working properly. This fix instead calculates the tab indicator position based off its location relative to the `sp-tabs` wrapping component.

## Related issue(s)

#2629

-

## Motivation and context

Tab indicators were not behaving properly on Safari.

## How has this been tested?

Verified my changes by opening the storybook on both Safari and Chrome. Ran unit tests.

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
