### PR TITLE
add semver resolution to update-spectrum-css script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ In the case that you'd like to serve and test a static build of the documentatio
 yarn docs:build
 ```
 
+# Updating Spectrum CSS
+
+There are two mechanisms for broadly updating SWC's Spectrum CSS dependencies:
+
+-   `yarn update:spectrum-css` brings all Spectrum CSS dependencies to 'latest'
+-   `yarn update:spectrum-css:nonbreaking` brings them to the latest minor or patch version
+
+We aim to keep Spectrum CSS as current as possible, to track the Spectrum design system closely.
+The `:nonbreaking` variant lets us release patch updates quickly in cases where more work is required to be compatible with 'latest.'
+
 # Advanced development
 
 There are several commands that can be useful in specific scenarios:
@@ -79,7 +89,6 @@ There are several commands that can be useful in specific scenarios:
 -   `yarn spectrum-vars` to ensure that theme files are up-to-date.
 -   `yarn process-icons` to make sure that the most recent icons are included.
 -   `yarn process-spectrum` to process the spectrum CSS style sources into the individual packages.
--   `yarn update:spectrum-css` to ensure that the `latest` version of `@spectrum-css` dependencies are being used across the project.
 -   `yarn build` to make sure the available JS has been built from the current TS source.
 
 ## Linting

--- a/package.json
+++ b/package.json
@@ -82,8 +82,9 @@
         "test:visual:clean:current": "rimraf test/visual/screenshots-current",
         "test:watch": "yarn test:watch:focus unit",
         "test:watch:focus": "yarn build && run-p watch:css build:watch \"test:start --watch --group {1}\" --",
-        "update:spectrum-css": "node ./scripts/update-spectrum-css.js || yarn update:spectrum-css:cleanup",
+        "update:spectrum-css": "node ./scripts/update-spectrum-css.js --latest || yarn update:spectrum-css:cleanup",
         "update:spectrum-css:cleanup": "yarn lint:packagejson && yarn --ignore-scripts && yarn process-spectrum",
+        "update:spectrum-css:nonbreaking": "node ./scripts/update-spectrum-css.js || yarn update:spectrum-css:cleanup",
         "vrt:quick-link": "yarn netlify deploy --alias=vrt --dir=projects/vrt-quick-link",
         "watch:css": "node ./tasks/watch-css.js"
     },

--- a/scripts/update-spectrum-css.js
+++ b/scripts/update-spectrum-css.js
@@ -16,6 +16,8 @@ import { readFileSync, writeFileSync } from 'fs';
 import latestVersion from 'latest-version';
 import fg from 'fast-glob';
 
+const useLatest = process.argv[2] === '--latest';
+
 async function update() {
     let updated = false;
     try {
@@ -28,12 +30,16 @@ async function update() {
             );
             async function updateDependency(packageName, depType) {
                 if (packageName.startsWith('@spectrum-css')) {
-                    const targetVersion = await latestVersion(packageName);
-                    const currentVersion = packageJSON[depType][
-                        packageName
-                    ].replace('^', '');
-                    if (currentVersion !== targetVersion) {
-                        packageJSON[depType][packageName] = `^${targetVersion}`;
+                    const currentVersion = packageJSON[depType][packageName];
+                    const targetVersion = await latestVersion(packageName, {
+                        version: useLatest ? 'latest' : currentVersion,
+                    });
+                    const targetRange = `^${targetVersion}`;
+                    if (currentVersion.replace('^', '') !== targetVersion) {
+                        console.log(
+                            `updating ${packageName} from ${currentVersion} to ${targetRange}`
+                        );
+                        packageJSON[depType][packageName] = targetRange;
                         shouldUpdate = true;
                     }
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

By default, use semver to upgrade spectrum-css (^5.0.0 -> 5.0.1, but ^5.0.0 !-> 6.0.0).

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/pull/2643

## Motivation and context

Non-breaking changes can be done regularly & perhaps even automated, whereas human intervention is normally required for breaking changes.

## How has this been tested?

- Run `yarn update:spectrum-css` on main
- See that it provides breaking updates to many components
- Run `yarn update:spectrum-css:nonbreaking` on this branch
- See that it only updates 'card' and 'tabs', which are the only non-breaking css changes
- Run `yarn update:spectrum-css` on this branch
- See that it has the same behavior as main (update everything to latest)

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
