### PR TITLE
test: allow Stories to be skipped at VRT time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a8f503b7db4d5c9b28c2666a7ba9bbf71598932f
+        default: ff012765d2965286bdcc120883c7d8eace5469ec
 commands:
     downstream:
         steps:

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -606,6 +606,9 @@ export const clickAndHoverTargets = (): TemplateResult => {
         </div>
     `;
 };
+clickAndHoverTargets.swc_vrt = {
+    skip: true,
+};
 
 function nextFrame(): Promise<void> {
     return new Promise((res) => requestAnimationFrame(() => res()));

--- a/test/visual/create.js
+++ b/test/visual/create.js
@@ -42,8 +42,9 @@ governing permissions and limitations under the License.
 
 import * as stories from '../stories/${stories}.stories.js';
 import { regressVisuals } from '../../../test/visual/test.js';
+import type { TestsType } from '../../../test/visual/test.js';
 
-regressVisuals('${name}', stories);
+regressVisuals('${name}', stories as unknown as TestsType);
 `;
         const directory = path.join('packages', packageName, 'test');
         fs.mkdirSync(directory, { recursive: true });

--- a/test/visual/test.ts
+++ b/test/visual/test.ts
@@ -52,25 +52,38 @@ const wrap = () => html`
     ></sp-story-decorator>
 `;
 
+interface Story<T> {
+    (args: T): TemplateResult;
+    args?: Partial<T>;
+    argTypes?: Record<string, unknown>;
+    decorators?: (() => TemplateResult)[];
+    swc_vrt?: {
+        skip: Boolean;
+    };
+}
+
 type StoriesType = {
+    [name: string]: Story<{}>;
+};
+
+export type TestsType = StoriesType & {
     default: {
         title: string;
         swc_vrt?: {
             preload?: () => void;
         };
     };
-    [name: string]: (() => TemplateResult) | any;
 };
 
 export const test = (
-    tests: StoriesType,
+    tests: TestsType,
     name: string,
     color: Color,
     scale: Scale,
     dir: 'ltr' | 'rtl'
 ) => {
     Object.keys(tests).map((story) => {
-        if (story !== 'default') {
+        if (story !== 'default' && !tests[story].swc_vrt?.skip) {
             it(story, async () => {
                 let test = await fixture<StoryDecorator>(wrap());
                 await elementUpdated(test);
@@ -168,7 +181,7 @@ export const test = (
     });
 };
 
-export const regressVisuals = async (name: string, stories: StoriesType) => {
+export const regressVisuals = async (name: string, stories: TestsType) => {
     describe(`${name} Visual Regressions`, () => {
         const {
             defaultColor: color,


### PR DESCRIPTION
## Description
Adds new configuration to a story that allows it to be skipped at VRT time:

```
export const story = () => html`...`;
story.swc_vrt = {
    skip: true,
};
```

### To do:
- [x] Need updated golden image cache, waiting on some other PRs to lang to generate it.

## Related issue(s)

- fixes #2611

## Motivation and context
Not all stories are exciting enough to capture as VRTs.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/13303/workflows/850b9511-fbd8-421d-947e-db95ec783ec9/jobs/228666)
    2. See that the VRT output is one less image than previously.

## Types of changes
-   [x] Tooling

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
