### PR TITLE
fix(menu): ensure that Groups in Action Menus are rendered with the correct width

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 585d5f7ca26358064aaf41b2d4b4027137f21180
+        default: a8f503b7db4d5c9b28c2666a7ba9bbf71598932f
 commands:
     downstream:
         steps:

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -13,6 +13,8 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/menu/sp-menu-group.js';
+import '@spectrum-web-components/menu/sp-menu-divider.js';
 import { ActionMenuMarkup } from './';
 
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
@@ -179,3 +181,31 @@ export const controlled = (): TemplateResult => {
         <span id="state-json"></span>
     `;
 };
+
+export const groups = (): TemplateResult => html`
+    <sp-action-menu open>
+        <sp-menu-group id="cms">
+            <span slot="header">cms</span>
+            <sp-menu-item value="updateAllSiteContent">
+                Update All Content
+            </sp-menu-item>
+            <sp-menu-item value="refreshAllXDs">Refresh All XDs</sp-menu-item>
+        </sp-menu-group>
+        <sp-menu-group id="ssg">
+            <span slot="header">ssg</span>
+            <sp-menu-item value="clearCache">Clear Cache</sp-menu-item>
+        </sp-menu-group>
+        <sp-menu-group id="vrt">
+            <span slot="header">vrt</span>
+            <sp-menu-item value="vrt-contributions">Contributions</sp-menu-item>
+            <sp-menu-item value="vrt-internal">Internal</sp-menu-item>
+            <sp-menu-item value="vrt-public">Public</sp-menu-item>
+            <sp-menu-item value="vrt-patterns">Patterns</sp-menu-item>
+            <sp-menu-item value="vrt">All</sp-menu-item>
+        </sp-menu-group>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-group id="misc">
+            <sp-menu-item value="logout">Logout</sp-menu-item>
+        </sp-menu-group>
+    </sp-action-menu>
+`;

--- a/packages/menu/src/menu.css
+++ b/packages/menu/src/menu.css
@@ -14,6 +14,12 @@ governing permissions and limitations under the License.
 
 :host {
     /**
+     * Remove when Spectrum CSS supports this correctly
+     */
+    display: inline-flex;
+    flex-direction: column;
+
+    /**
      * TODO: remove the following when https://github.com/adobe/spectrum-css/issues/1130
      is correct
      */
@@ -34,5 +40,10 @@ governing permissions and limitations under the License.
 }
 
 ::slotted(*) {
+    /**
+     * Remove when Spectrum CSS supports this correctly
+     */
+    flex-shrink: 0;
+
     --swc-menu-width: 100%;
 }


### PR DESCRIPTION
## Description
Correct width application to `sp-menu` elements when opened within `sp-action-menu`s.

## Related issue(s)

- fixes #2555

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://7d851870bc1c12eade17f759b2dbb828--spectrum-web-components.netlify.app/review/#ActionMenuStories/groups.png)
    2. Review the VRT updates/additions

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.