### PR TITLE
fix: style icons in Picker correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: ff012765d2965286bdcc120883c7d8eace5469ec
+        default: c9deb3a150c2e8b1fbd58518f8c7423c8a250750
 commands:
     downstream:
         steps:

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -41,6 +41,10 @@ governing permissions and limitations under the License.
     max-width: 100%;
 }
 
+#icon:not([hidden]) {
+    display: inline-flex;
+}
+
 :host([readonly]) #button {
     user-select: inherit;
 }


### PR DESCRIPTION
## Description
Prevent icons in the Picker trigger from appearing too high vertically.

## Related issue(s)
- fixes #2649

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://icon-picker--spectrum-web-components.netlify.app/storybook/?path=/story/picker--icons)
    2. See the icon is vertically centered
-   [ ] _Test case 2_
    1. Go [here](https://icon-picker--spectrum-web-components.netlify.app/storybook/?path=/story/picker--icons-only)
    2. See the icon is vertically centered
-   [ ] _Test case 3_
    1. Go [here](https://icon-picker--spectrum-web-components.netlify.app/storybook/?path=/story/picker--icons-none)
    2. See there is no icon

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.