### PR TITLE
fix: correct the relationship between overlayWillCloseCallback and phased animations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 17deaa4bdbc7505adf80e6ed51a31695a36b52ed
+        default: 610d11a931eb6c531d450cce96b257ab211f79a5
 commands:
     downstream:
         steps:

--- a/packages/dialog/test/dialog-base.test.ts
+++ b/packages/dialog/test/dialog-base.test.ts
@@ -29,7 +29,6 @@ import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { alertDestructive } from '../stories/dialog.stories.js';
 import { Button } from '@spectrum-web-components/button/src/Button.js';
 import { DialogBase } from '@spectrum-web-components/dialog';
-import { sendMouse } from '../../../test/plugins/browser.js';
 
 async function styledFixture<T extends Element>(
     story: TemplateResult
@@ -50,18 +49,6 @@ const overlayTrigger = (story: () => TemplateResult): TemplateResult => html`
 `;
 
 describe('dialog base', () => {
-    beforeEach(async () => {
-        // Something about this prevents Chromium from swallowing the CSS transitions
-        // to "open" so that test timing can be properly acquired below.
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [0, 0],
-                },
-            ],
-        });
-    });
     it('does not close by default with interacting with buttons', async () => {
         const el = await styledFixture<OverlayTrigger>(
             overlayTrigger(
@@ -115,10 +102,6 @@ describe('dialog base', () => {
         expect(dialog.parentElement?.localName).to.equal('overlay-trigger');
     });
     it('does not close by default with interacting with buttons when recycled', async () => {
-        // There is an `sp-dialog-base` recyling issue in Firefox
-        if (/Firefox/.test(window.navigator.userAgent)) {
-            return;
-        }
         const el = await styledFixture<OverlayTrigger>(
             overlayTrigger(
                 () => html`

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -105,9 +105,7 @@ describe('Dialog Wrapper', () => {
         expect(el.open).to.be.false;
         expect(closeSpy.callCount).to.equal(1);
     });
-    xit('opens and closes when element is recycled', async () => {
-        // Skip while there is an `sp-dialog-base` recyling issue in Chromium and Firefox,
-        // this test passes outside of the testing context and in Safari...
+    it('opens and closes when element is recycled', async () => {
         const closeSpy = spy();
         const test = await styledFixture<OverlayTrigger>(longContent());
         const el = test.querySelector('sp-dialog-wrapper') as DialogWrapper;

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -48,6 +48,10 @@ interface ManagedOverlayContent {
     updateComplete?: Promise<boolean>;
 }
 
+function nextFrame(): Promise<void> {
+    return new Promise((res) => requestAnimationFrame(() => res()));
+}
+
 export class OverlayStack {
     public overlays: ActiveOverlay[] = [];
 
@@ -314,26 +318,26 @@ export class OverlayStack {
          * has to happen AFTER the current call stack completes in case there
          * is work there in to remove the previous "top" overlay.
          */
-        return new Promise((res) => requestAnimationFrame(res)).then(
-            async () => {
-                this.overlays.push(activeOverlay);
-                await activeOverlay.updateComplete;
-                this.addOverlayEventListeners(activeOverlay);
-                if (typeof contentWithLifecycle.open !== 'undefined') {
-                    contentWithLifecycle.open = true;
-                }
-                let cb: () => Promise<void> | void = () => {
-                    return;
-                };
-                if (contentWithLifecycle.overlayOpenCallback) {
-                    const { trigger } = activeOverlay;
-                    const { overlayOpenCallback } = contentWithLifecycle;
-                    cb = async () => await overlayOpenCallback({ trigger });
-                }
-                await activeOverlay.openCallback(cb);
-                return false;
-            }
-        );
+        await nextFrame();
+        this.overlays.push(activeOverlay);
+        await activeOverlay.updateComplete;
+        this.addOverlayEventListeners(activeOverlay);
+        if (typeof contentWithLifecycle.open !== 'undefined') {
+            await nextFrame();
+            // Without the rAF Firefox gets here to early
+            // and is not able trigger the animation.
+            contentWithLifecycle.open = true;
+        }
+        let cb: () => Promise<void> | void = () => {
+            return;
+        };
+        if (contentWithLifecycle.overlayOpenCallback) {
+            const { trigger } = activeOverlay;
+            const { overlayOpenCallback } = contentWithLifecycle;
+            cb = async () => await overlayOpenCallback({ trigger });
+        }
+        await activeOverlay.openCallback(cb);
+        return false;
     }
 
     public addOverlayEventListeners(activeOverlay: ActiveOverlay): void {
@@ -565,6 +569,7 @@ export class OverlayStack {
             this.manageFocusAfterCloseWhenLastOverlay(overlay);
         }
 
+        await overlay.updateComplete;
         overlay.remove();
         overlay.dispose();
 

--- a/packages/overlay/test/overlay-trigger-hover.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover.test.ts
@@ -36,7 +36,6 @@ import '@spectrum-web-components/theme/src/themes.js';
 import { TemplateResult } from '@spectrum-web-components/base';
 import { Theme } from '@spectrum-web-components/theme';
 import { Tooltip } from '@spectrum-web-components/tooltip';
-import { sendMouse } from '../../../test/plugins/browser.js';
 import { ignoreResizeObserverLoopError } from '../../../test/testing-helpers.js';
 
 ignoreResizeObserverLoopError(before, after);
@@ -53,32 +52,6 @@ async function styledFixture<T extends Element>(
 }
 
 describe('Overlay Trigger - Hover', () => {
-    afterEach(async () => {
-        const triggers = [
-            ...document.querySelectorAll('overlay-trigger'),
-        ] as OverlayTrigger[];
-        const promises = triggers.map((trigger) => {
-            if (trigger.open) {
-                const closed = oneEvent(trigger, 'sp-closed');
-                trigger.open = undefined;
-                return closed;
-            }
-            return Promise.resolve();
-        });
-        await Promise.all(promises);
-    });
-    beforeEach(async () => {
-        // Something about this prevents Chromium from swallowing the CSS transitions
-        // to "open" so that test timing can be properly acquired below.
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [0, 0],
-                },
-            ],
-        });
-    });
     it('displays `hover` declaratively', async () => {
         const openedSpy = spy();
         const closedSpy = spy();

--- a/packages/tray/src/Tray.ts
+++ b/packages/tray/src/Tray.ts
@@ -66,8 +66,10 @@ export class Tray extends SpectrumElement {
         }
     }
 
+    private animating = false;
+
     public overlayWillCloseCallback(): boolean {
-        if (!this.open) return false;
+        if (!this.open) return this.animating;
         this.close();
         return true;
     }
@@ -89,8 +91,8 @@ export class Tray extends SpectrumElement {
 
     protected handleUnderlayTransitionend(): void {
         if (!this.open) {
-            this.dispatchClosed();
             this.resolveTransitionPromise();
+            this.dispatchClosed();
         }
     }
 
@@ -106,9 +108,13 @@ export class Tray extends SpectrumElement {
             changes.get('open') !== undefined &&
             this.prefersMotion.matches
         ) {
-            this.transitionPromise = new Promise(
-                (res) => (this.resolveTransitionPromise = res)
-            );
+            this.animating = true;
+            this.transitionPromise = new Promise((res) => {
+                this.resolveTransitionPromise = () => {
+                    this.animating = false;
+                    res();
+                };
+            });
         }
         super.update(changes);
     }

--- a/test/visual/test.ts
+++ b/test/visual/test.ts
@@ -23,26 +23,9 @@ import { StoryDecorator } from '@spectrum-web-components/story-decorator/src/Sto
 import { html, TemplateResult } from '@spectrum-web-components/base';
 import { render } from 'lit';
 import { emulateMedia, sendKeys } from '@web/test-runner-commands';
-import { sendMouse } from '../plugins/browser.js';
+import { ignoreResizeObserverLoopError } from '../testing-helpers.js';
 
-let globalErrorHandler: undefined | OnErrorEventHandler = undefined;
-before(function () {
-    // Save Mocha's handler.
-    (
-        Mocha as unknown as { process: { removeListener(name: string): void } }
-    ).process.removeListener('uncaughtException');
-    globalErrorHandler = window.onerror;
-    addEventListener('error', (error) => {
-        if (error.message?.match?.(/ResizeObserver loop limit exceeded/)) {
-            return;
-        } else {
-            globalErrorHandler?.(error);
-        }
-    });
-});
-after(function () {
-    window.onerror = globalErrorHandler as OnErrorEventHandler;
-});
+ignoreResizeObserverLoopError(before, after);
 
 const wrap = () => html`
     <sp-story-decorator
@@ -207,17 +190,6 @@ export const regressVisuals = async (name: string, stories: TestsType) => {
                     colorScheme: 'no-preference',
                 });
             }
-        });
-        beforeEach(async () => {
-            // Something about this prevents Chromium from swallowing the CSS transitions in specific contexts.
-            await sendMouse({
-                steps: [
-                    {
-                        type: 'move',
-                        position: [0, 0],
-                    },
-                ],
-            });
         });
         afterEach(() => {
             const overlays = [


### PR DESCRIPTION
## Description
- prevent N number of `Escape` pressed or "close" button clicks from breaking the overlay that is being managed by those interactions
- ensure "open" animations are being run in Firefox
  - turn tests in this are back on for Firefox
- refactor work workflows for simplicity
- remove test time workaround for multiple overlay open/closes

## Related issue(s)
- fixes #2646

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://double-close--spectrum-web-components.netlify.app/storybook/?path=/story/dialog-base--slotted)
    2. Once the dialog is open, quickly press `Escape` N number of times.
    3. See that the dialog is closed
    4. Click the "Toggle Dialog" button
    5. See that the dialog is opened.
    6. Repeat 2-5 N number of times.
-   [ ] _Test case 2_
    1. Go [here](https://double-close--spectrum-web-components.netlify.app/storybook/?path=/story/dialog-base--slotted)
    2. Once the dialog is open, quickly click "Cancel" N number of times
    3. See that the dialog is closed
    4. Click the "Toggle Dialog" button
    5. See that the dialog is opened.
    6. Repeat 2-5 N number of times.
-   [ ] _Test case 3_
    1. Go [here](https://double-close--spectrum-web-components.netlify.app/storybook/?path=/story/dialog-base--slotted) in FireFox
    2. Open and close the dialog N number of times by which ever method you would like
    3. See that while _opening_ there is an animated transition between the closed and opened state

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)