### PR TITLE
fix(split-view): prevent touch-action on handle for delivery in mobile

### DIFF
--- a/packages/split-view/src/split-view.css
+++ b/packages/split-view/src/split-view.css
@@ -41,6 +41,10 @@ governing permissions and limitations under the License.
     display: none;
 }
 
+#gripper {
+    touch-action: none;
+}
+
 #splitter {
     order: 2;
     height: auto; /* for horizontal splitviews without proper outter height value */


### PR DESCRIPTION
## Description
Allow un-canceled touch interaction in mobile.

@pfulton I know this was a contribution to CSS, but this feels like an addition that could be made there to support more users of your output?

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://split-view--spectrum-web-components.netlify.app/storybook/?path=/story/split-view--horizontal-resizable) in a Chrome touch environment, can be emulated by Dev Tools
    2. Drag the split view handle
    3. See that the handle moves continuously

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
