### PR TITLE
feat(slider): update "value" default to match browser native range input

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 67c26c795235a9696725d05a025ddba23f1f2ea2
+        default: b7380bc16e38864fdd1cbd45b929b801db117a9d
 commands:
     downstream:
         steps:

--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -88,8 +88,12 @@ export class SliderHandle extends Focusable {
 
     _forcedUnit = '';
 
+    /**
+     * By default, the value of a Slider Handle will be halfway between its
+     * `min` and `max` values, or the `min` value when `max` is less than `min`.
+     */
     @property({ type: Number })
-    value = 10;
+    value!: number;
 
     @property({ type: Boolean, reflect: true })
     public dragging = false;
@@ -126,6 +130,15 @@ export class SliderHandle extends Focusable {
     private languageResolver = new LanguageResolutionController(this);
 
     protected override update(changes: PropertyValues): void {
+        if (!this.hasUpdated) {
+            const { max, min } = this as { max: number; min: number };
+            if (this.value == null) {
+                if (!isNaN(max) && !isNaN(min)) {
+                    this.value = max < min ? min : min + (max - min) / 2;
+                }
+            }
+        }
+        
         if (changes.has('formatOptions') || changes.has('resolvedLanguage')) {
             delete this._numberFormatCache;
         }
@@ -141,9 +154,7 @@ export class SliderHandle extends Focusable {
         super.update(changes);
     }
 
-    protected override firstUpdated(
-        changedProperties: PropertyValues<this>
-    ): void {
+    protected override firstUpdated(changedProperties: PropertyValues<this>): void {
         super.firstUpdated(changedProperties);
         this.dispatchEvent(new CustomEvent('sp-slider-handle-ready'));
     }

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -109,7 +109,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(46);
         expect(el.highlight).to.be.false;
 
         el.focus();
@@ -118,14 +118,14 @@ describe('Slider', () => {
         });
         await elementUpdated(el);
 
-        expect(el.value).to.equal(9);
+        expect(el.value).to.equal(45);
         expect(el.highlight).to.be.true;
         await sendKeys({
             press: 'ArrowUp',
         });
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(46);
         expect(el.highlight).to.be.true;
     });
     it('accepts pointer events', async () => {
@@ -224,7 +224,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(35);
 
         const controls = el.shadowRoot.querySelector(
             '#controls'
@@ -246,7 +246,7 @@ describe('Slider', () => {
         await elementUpdated(el);
 
         expect(pointerId).to.equal(-1);
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(35);
         expect(el.dragging, 'handle is not yet being dragged').to.be.false;
 
         controls.dispatchEvent(
@@ -308,7 +308,7 @@ describe('Slider', () => {
 
         expect(el.dragging).to.be.false;
         expect(pointerId).to.equal(-1);
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         handle.setPointerCapture = (id: number) => (pointerId = id);
@@ -340,7 +340,7 @@ describe('Slider', () => {
         await elementUpdated(el);
 
         expect(pointerId).to.equal(-1);
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
     });
     it('accepts pointermove events', async () => {
         const el = await fixture<Slider>(
@@ -350,7 +350,7 @@ describe('Slider', () => {
         );
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         await sendMouse({
@@ -390,7 +390,7 @@ describe('Slider', () => {
         );
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(6);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         await sendMouse({
@@ -430,7 +430,7 @@ describe('Slider', () => {
         );
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         const handleBoundingRect = handle.getBoundingClientRect();
@@ -452,7 +452,7 @@ describe('Slider', () => {
 
         expect(el.dragging, 'is dragging').to.be.true;
         expect(el.highlight, 'not highlighted').to.be.false;
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         const inputEvent = oneEvent(el, 'input');
         await sendMouse({
@@ -501,7 +501,7 @@ describe('Slider', () => {
         );
         await elementUpdated(el);
 
-        expect(el.value, 'initial').to.equal(10);
+        expect(el.value, 'initial').to.equal(50);
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
         el.track.setPointerCapture = (id: number) => (pointerId = id);
@@ -682,7 +682,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
         expect(el.dragging).to.be.false;
 
         const handle = el.shadowRoot.querySelector('.handle') as HTMLDivElement;
@@ -695,7 +695,7 @@ describe('Slider', () => {
         );
         await nextFrame();
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
     });
     it('responds to input events on the <input/> element', async () => {
         const el = await fixture<Slider>(
@@ -706,7 +706,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         const input = el.shadowRoot.querySelector('.input') as HTMLInputElement;
 
@@ -925,7 +925,7 @@ describe('Slider', () => {
 
         await elementUpdated(el);
 
-        expect(el.value).to.equal(10);
+        expect(el.value).to.equal(50);
 
         el.min = 0;
         el.max = 200;


### PR DESCRIPTION
## Description
When not supplied, value will now be set to halfway between min and max as opposed to `10` as it has been previously.

## Related issue(s)
- fixes #1788

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://slider-default--spectrum-web-components.netlify.app/components/slider/#standard)
    2. See the default value of the documented sliders is `50` and not `10`.

## Types of changes
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.