### PR TITLE
chore: deprecate the "label" property

### DIFF
--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -371,6 +371,17 @@ export class ColorArea extends SpectrumElement {
     protected override render(): TemplateResult {
         const { width = 0, height = 0 } = this.boundingClientRect || {};
 
+        if (window.__swc.DEBUG) {
+            if (this.label) {
+                window.__swc.warn(
+                    this,
+                    `The "label" property in <${this.localName}> has been deprecated and will be removed in a future release. Please leverage "labelX" and "labelY" instead.`,
+                    'https://opensource.adobe.com/spectrum-web-components/components/color-area/#labels',
+                    { level: 'deprecation' }
+                );
+            }
+        }
+
         return html`
             <div
                 @pointerdown=${this.handleAreaPointerdown}


### PR DESCRIPTION
## Description
Announce deprecation of the `label` attribute/property in Color Area

## Related issue(s)
- refs #1802

## How has this been tested?

-   [ ] _Test case 1_
    1. Run Storybook locally
    2. Visit https://localhost:8000/?path=/story/color-area--default
    3. Inspect the `sp-color-area` element
    4. Give it a `label` attribute, e.g. `label="Special label"`
    5. See the Dev Mode warning.

## Screenshots (if appropriate)
<img width="405" alt="image" src="https://user-images.githubusercontent.com/1156657/198139385-34f9e2f7-9249-4064-a11e-ddf2fc3932aa.png">

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.