### PR TITLE
fix: correct the origin on "maximumFractionDigits" when deciding "inputMode"

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -161,6 +161,9 @@ export class NumberField extends TextfieldBase {
     }
 
     private convertValueToNumber(value: string): number {
+        if (isIPhone() && this.inputElement.inputMode === 'decimal') {
+            value = value.replace(',', '.');
+        }
         return this.numberParser.parse(value);
     }
 
@@ -590,9 +593,9 @@ export class NumberField extends TextfieldBase {
         if (changes.has('min') || changes.has('formatOptions')) {
             let inputMode = 'numeric';
             const hasNegative = typeof this.min !== 'undefined' && this.min < 0;
-            const { maximumFractionDigits } = this.formatOptions;
-            const hasDecimals =
-                maximumFractionDigits && maximumFractionDigits > 0;
+            const { maximumFractionDigits } =
+                this.numberFormatter.resolvedOptions();
+            const hasDecimals = maximumFractionDigits > 0;
             /* c8 ignore next 18 */
             if (isIPhone()) {
                 // iPhone doesn't have a minus sign in either numeric or decimal.


### PR DESCRIPTION
## Description
Allow `.` button in iPhone virtual keyboard.

### Question
This leveraged the `resolvedOptions` of the Number Formatter, as seen in https://github.com/adobe/react-spectrum/blob/7cebb4eea31f383f1eec06cc53a7909f8736f66a/packages/%40react-aria/numberfield/src/useNumberField.ts#L148-L149, which seems to default to `3` if not set. Does this precipitate adding information around this to the documentation so that consumers know how to actively manage this keyboard input? cc: @wyanghz1

## Related issue(s)
- fixes #2674

## How has this been tested?
-   [ ] _Test case 1_
    1. On an iPhone
    2. Go [here](https://number-field-decimal--spectrum-web-components.netlify.app/components/slider/#editable)
    3. Attempt to edit the text of the slider input
    4. See that the `.` key is present

## Screenshots (if appropriate)
![Slider Spectrum Web Components](https://user-images.githubusercontent.com/1156657/198287003-3f3a7673-f916-42a8-b772-092daa913bc2.jpeg)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.