### PR TITLE
fix(dialog): don't show DialogWrapper divider when there's no headline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 4ac955bf17512db5e816ae29a47605ad83f0fdc9
+        default: 3cbbe0af3aa421ad794dc0ce87a7df95b1210ba9
 commands:
     downstream:
         steps:

--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -118,3 +118,7 @@ import { DialogWrapper } from '@spectrum-web-components/dialog';
     </sp-button>
 </overlay-trigger>
 ```
+
+## Accessibility
+
+An `sp-dialog-wrapper` element leverages the `headline` attribute/property to label the dialog content for screen readers. The `headline-visibility` attribute will accept a value of `"none"` to suppress the headline visually.

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -69,6 +69,9 @@ export class DialogWrapper extends DialogBase {
     @property()
     public headline = '';
 
+    @property({ type: String, attribute: 'headline-visibility' })
+    public headlineVisibility: 'none' | undefined;
+
     protected override get dialog(): Dialog {
         return this.shadowRoot.querySelector('sp-dialog') as Dialog;
     }
@@ -98,10 +101,14 @@ export class DialogWrapper extends DialogBase {
     }
 
     protected override renderDialog(): TemplateResult {
+        const hideDivider =
+            this.noDivider ||
+            !this.headline ||
+            this.headlineVisibility === 'none';
         return html`
             <sp-dialog
                 ?dismissable=${this.dismissable}
-                ?no-divider=${this.noDivider || !this.headline}
+                ?no-divider=${hideDivider}
                 ?error=${this.error}
                 mode=${ifDefined(this.mode)}
                 size=${ifDefined(this.size)}
@@ -122,7 +129,12 @@ export class DialogWrapper extends DialogBase {
                     : html``}
                 ${this.headline
                     ? html`
-                          <h2 slot="heading">${this.headline}</h2>
+                          <h2
+                              slot="heading"
+                              ?hidden=${this.headlineVisibility === 'none'}
+                          >
+                              ${this.headline}
+                          </h2>
                       `
                     : html``}
                 <slot></slot>

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -105,6 +105,20 @@ export class DialogWrapper extends DialogBase {
             this.noDivider ||
             !this.headline ||
             this.headlineVisibility === 'none';
+
+        if (window.__swc.DEBUG) {
+            if (!this.headline) {
+                window.__swc.warn(
+                    this,
+                    `<${this.localName}> elements will not be accessible to screen readers without a "headline" attribute or property.`,
+                    'https://opensource.adobe.com/spectrum-web-components/components/dialog-wrapper/#accessibility',
+                    {
+                        type: 'accessibility',
+                    }
+                );
+            }
+        }
+
         return html`
             <sp-dialog
                 ?dismissable=${this.dismissable}

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -101,7 +101,7 @@ export class DialogWrapper extends DialogBase {
         return html`
             <sp-dialog
                 ?dismissable=${this.dismissable}
-                ?no-divider=${this.noDivider}
+                ?no-divider=${this.noDivider || !this.headline}
                 ?error=${this.error}
                 mode=${ifDefined(this.mode)}
                 size=${ifDefined(this.size)}

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -473,6 +473,51 @@ export const wrapperFullscreen = (
     `;
 };
 
+export const wrapperWithHeadline = (
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
+): TemplateResult => {
+    const open = context.viewMode === 'docs' ? false : true;
+    return html`
+        <sp-dialog-wrapper
+            ?open=${open}
+            headline="Headline for dialog"
+            @close=${handleClose(args)}
+        >
+            Content of the dialog
+        </sp-dialog-wrapper>
+    `;
+};
+
+export const wrapperWithHeadlineNoDivider = (
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
+): TemplateResult => {
+    const open = context.viewMode === 'docs' ? false : true;
+    return html`
+        <sp-dialog-wrapper
+            ?open=${open}
+            headline="Headline for dialog"
+            no-divider=${true}
+            @close=${handleClose(args)}
+        >
+            Content of the dialog
+        </sp-dialog-wrapper>
+    `;
+};
+
+export const wrapperNoHeadline = (
+    args: StoryArgs = {},
+    context: { viewMode?: string } = {}
+): TemplateResult => {
+    const open = context.viewMode === 'docs' ? false : true;
+    return html`
+        <sp-dialog-wrapper ?open=${open} @close=${handleClose(args)}>
+            Content of the dialog
+        </sp-dialog-wrapper>
+    `;
+};
+
 export const tooltips = (
     args: StoryArgs = {},
     context: { viewMode?: string } = {}

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -506,13 +506,18 @@ export const wrapperWithHeadlineNoDivider = (
     `;
 };
 
-export const wrapperNoHeadline = (
+export const wrapperHeadlineVisibilityNone = (
     args: StoryArgs = {},
     context: { viewMode?: string } = {}
 ): TemplateResult => {
     const open = context.viewMode === 'docs' ? false : true;
     return html`
-        <sp-dialog-wrapper ?open=${open} @close=${handleClose(args)}>
+        <sp-dialog-wrapper
+            headline="Accessible headline"
+            .headlineVisibility=${'none'}
+            ?open=${open}
+            @close=${handleClose(args)}
+        >
             Content of the dialog
         </sp-dialog-wrapper>
     `;

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -33,8 +33,8 @@ import {
     wrapperDismissable,
     wrapperDismissableUnderlayError,
     wrapperFullscreen,
+    wrapperHeadlineVisibilityNone,
     wrapperLabeledHero,
-    wrapperNoHeadline,
     wrapperWithHeadline,
     wrapperWithHeadlineNoDivider,
 } from '../stories/dialog-wrapper.stories.js';
@@ -150,6 +150,8 @@ describe('Dialog Wrapper', () => {
         );
         await elementUpdated(wrapper);
 
+        await expect(wrapper).to.be.accessible();
+
         const dialog = wrapper.shadowRoot.querySelector('sp-dialog') as Dialog;
         const divider = dialog.shadowRoot.querySelector(
             'sp-divider.divider'
@@ -158,8 +160,12 @@ describe('Dialog Wrapper', () => {
         expect(divider).to.be.null;
     });
     it("hides header divider when there's no header", async () => {
-        const wrapper = await styledFixture<DialogWrapper>(wrapperNoHeadline());
+        const wrapper = await styledFixture<DialogWrapper>(
+            wrapperHeadlineVisibilityNone()
+        );
         await elementUpdated(wrapper);
+
+        await expect(wrapper).to.be.accessible();
 
         const dialog = wrapper.shadowRoot.querySelector('sp-dialog') as Dialog;
         const divider = dialog.shadowRoot.querySelector(

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -34,11 +34,15 @@ import {
     wrapperDismissableUnderlayError,
     wrapperFullscreen,
     wrapperLabeledHero,
+    wrapperNoHeadline,
+    wrapperWithHeadline,
+    wrapperWithHeadlineNoDivider,
 } from '../stories/dialog-wrapper.stories.js';
 import { OverlayTrigger } from '@spectrum-web-components/overlay';
 import { html, TemplateResult } from '@spectrum-web-components/base';
 import { Theme } from '@spectrum-web-components/theme';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
+import { Divider } from '@spectrum-web-components/divider/src/Divider.js';
 
 async function styledFixture<T extends Element>(
     story: TemplateResult
@@ -126,6 +130,43 @@ describe('Dialog Wrapper', () => {
 
         expect(el.open).to.be.false;
         expect(closeSpy.callCount).to.equal(1);
+    });
+    it("shows header divider when there's a header", async () => {
+        const wrapper = await styledFixture<DialogWrapper>(
+            wrapperWithHeadline()
+        );
+        await elementUpdated(wrapper);
+
+        const dialog = wrapper.shadowRoot.querySelector('sp-dialog') as Dialog;
+        const divider = dialog.shadowRoot.querySelector(
+            'sp-divider.divider'
+        ) as Divider;
+
+        expect(divider).to.be.not.null;
+    });
+    it('hides header divider when there\'s a header but "no-divider"', async () => {
+        const wrapper = await styledFixture<DialogWrapper>(
+            wrapperWithHeadlineNoDivider()
+        );
+        await elementUpdated(wrapper);
+
+        const dialog = wrapper.shadowRoot.querySelector('sp-dialog') as Dialog;
+        const divider = dialog.shadowRoot.querySelector(
+            'sp-divider.divider'
+        ) as Divider;
+
+        expect(divider).to.be.null;
+    });
+    it("hides header divider when there's no header", async () => {
+        const wrapper = await styledFixture<DialogWrapper>(wrapperNoHeadline());
+        await elementUpdated(wrapper);
+
+        const dialog = wrapper.shadowRoot.querySelector('sp-dialog') as Dialog;
+        const divider = dialog.shadowRoot.querySelector(
+            'sp-divider.divider'
+        ) as Divider;
+
+        expect(divider).to.be.null;
     });
     it('dismisses via clicking the underlay when [dismissable]', async () => {
         const test = await styledFixture<DialogWrapper>(

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -17,7 +17,7 @@ import {
     nextFrame,
     oneEvent,
 } from '@open-wc/testing';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
@@ -313,5 +313,29 @@ describe('Dialog Wrapper', () => {
         expect(confirmSpy.callCount).to.equal(1);
         expect(secondarySpy.callCount).to.equal(1);
         expect(cancelSpy.called, 'dispatched `secondary`').to.be.true;
+    });
+
+    it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
+        const consoleWarnStub = stub(console, 'warn');
+        const el = await fixture<DialogWrapper>(html`
+            <sp-dialog-wrapper></sp-dialog-wrapper>
+        `);
+
+        await elementUpdated(el);
+
+        expect(consoleWarnStub.called).to.be.true;
+        const spyCall = consoleWarnStub.getCall(0);
+        expect(
+            spyCall.args.at(0).includes('accessible'),
+            'confirm accessibility-centric message'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-dialog-wrapper',
+                type: 'accessibility',
+                level: 'default',
+            },
+        });
+        consoleWarnStub.restore();
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

DialogWrapper shouldn't show a divider if there's no headline

<!--- Describe your changes in detail -->

## Related issue(s)

fixes #2699


## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

3 new unit tests. visual confirmation of expected behavior using storybook.


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

See Storybook cases:
DialogWrapper:Wrapper With Headline
DialogWrapper:Wrapper With Headline No Divider
DialogWrapper:Wrapper No Headline


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
