### PR TITLE
docs[styles]: correct typos and update import statement

### DIFF
--- a/tools/styles/README.md
+++ b/tools/styles/README.md
@@ -1,8 +1,8 @@
 ## Description
 
-Spectrum Web Components are a [`LitElement`](https://lit-element.polymer-project.org) powered web component library of patterns built ontop of the [Spectrum CSS](https://opensource.adobe.com/spectrum-css) specification. Styles for these components are made available (and in some cases customizable) via CSS Custom Properties, e.g. `var(--spectrum-global-color-static-black)`. In this package you will find the various CSS Custom Properties that power the various color and size themese defined by Spectrum CSS.
+Spectrum Web Components are a [`LitElement`](https://lit-element.polymer-project.org)-powered web component library of patterns built on top of the [Spectrum CSS](https://opensource.adobe.com/spectrum-css) specification. Styles for these components are made available (and, in some cases, customizable) via CSS Custom Properties, e.g. `var(--spectrum-global-color-static-black)`. In this package, you will find the CSS Custom Properties that power the various color and size themes defined by Spectrum CSS.
 
-The easiest way to consume these values is via the `<sp-theme>` element, however in some case it can be useful to have direct access to the files outlining the CSS Custom Properties ontop of which the rest of the component system is built.
+The easiest way to consume these values is via the `<sp-theme>` element. However, in some cases, it can be useful to have direct access to the files outlining the CSS Custom Properties, on top of which the rest of the component system is built.
 
 ### Usage
 
@@ -10,7 +10,7 @@ The easiest way to consume these values is via the `<sp-theme>` element, however
 [![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/styles?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/styles)
 
 ```
-npm install @spectrum-web-components/styles
+yarn add @spectrum-web-components/styles
 ```
 
 ## Theme packages
@@ -19,49 +19,49 @@ npm install @spectrum-web-components/styles
 @import '@spectrum-web-components/styles/all-medium-darkest.css';
 ```
 
-This file brings together the globals variables and font settings with the "Darkest" color set and "Medium" scale system specification.
+This file brings together the global variables and font settings with the "Darkest" color set and "Medium" scale system specification.
 
 ```
 @import '@spectrum-web-components/styles/all-medium-dark.css';
 ```
 
-This file brings together the globals variables and font settings with the "Dark" color set and "Medium" scale system specification.
+This file brings together the global variables and font settings with the "Dark" color set and "Medium" scale system specification.
 
 ```
 @import '@spectrum-web-components/styles/all-medium-light.css';
 ```
 
-This file brings together the globals variables and font settings with the "Light" color set and "Medium" scale system specification.
+This file brings together the global variables and font settings with the "Light" color set and "Medium" scale system specification.
 
 ```
 @import '@spectrum-web-components/styles/all-medium-lightest.css';
 ```
 
-This file brings together the globals variables and font settings with the "Lightest" color set and "Medium" scale system specification.
+This file brings together the global variables and font settings with the "Lightest" color set and "Medium" scale system specification.
 
 ```
 @import '@spectrum-web-components/styles/all-large-darkest.css';
 ```
 
-This file brings together the globals variables and font settings with the "Darkest" color set and "Large" scale system specification.
+This file brings together the global variables and font settings with the "Darkest" color set and "Large" scale system specification.
 
 ```
 @import '@spectrum-web-components/styles/all-large-dark.css';
 ```
 
-This file brings together the globals variables and font settings with the "Dark" color set and "Large" scale system specification.
+This file brings together the global variables and font settings with the "Dark" color set and "Large" scale system specification.
 
 ```
 @import '@spectrum-web-components/styles/all-large-light.css';
 ```
 
-This file brings together the globals variables and font settings with the "Light" color set and "Large" scale system specification.
+This file brings together the global variables and font settings with the "Light" color set and "Large" scale system specification.
 
 ```
 @import '@spectrum-web-components/styles/all-large-lightest.css';
 ```
 
-This file brings together the globals variables and font settings with the "Lightest" color set and "Large" scale system specification.
+This file brings together the global variables and font settings with the "Lightest" color set and "Large" scale system specification.
 
 ## Color sets
 
@@ -71,7 +71,7 @@ This file brings together the globals variables and font settings with the "Ligh
 @import '@spectrum-web-components/styles/theme-darkest.css';
 ```
 
-This file provides only the variables needed to power a color pallet featuring colors found in the "Darkest" theme.
+This file provides only the variables needed to power a color palette featuring colors found in the "Darkest" theme.
 
 ### Dark
 
@@ -79,7 +79,7 @@ This file provides only the variables needed to power a color pallet featuring c
 @import '@spectrum-web-components/styles/theme-dark.css';
 ```
 
-This file provides only the variables needed to power a color pallet featuring colors found in the "Dark" theme.
+This file provides only the variables needed to power a color palette featuring colors found in the "Dark" theme.
 
 ### Light
 
@@ -87,7 +87,7 @@ This file provides only the variables needed to power a color pallet featuring c
 @import '@spectrum-web-components/styles/theme-light.css';
 ```
 
-This file provides only the variables needed to power a color pallet featuring colors found in the "Light" theme.
+This file provides only the variables needed to power a color palette featuring colors found in the "Light" theme.
 
 ### Lightest
 
@@ -95,7 +95,7 @@ This file provides only the variables needed to power a color pallet featuring c
 @import '@spectrum-web-components/styles/theme-lightest.css';
 ```
 
-This file provides only the variables needed to power a color pallet featuring colors found in the "Lightest" theme.
+This file provides only the variables needed to power a color palette featuring colors found in the "Lightest" theme.
 
 ## Scale
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While working on another issue, I noticed that the import statement for the package was for npm instead of yarn, and I noticed a few typos that I wanted to fix. I also added commas because I love them. 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
