### PR TITLE
fix: keep parent overlays open when not closing child hover overlays

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -605,16 +605,28 @@ export class OverlayStack {
             return;
         }
         const overlaysToClose = [];
-        // Find the top most overlay that is not triggered by an
-        // element on the path of the current click event.
+        /**
+         * Find the first overlay that should be closed by this and include it in the
+         * array of overlays for closure.
+         *
+         * Event path dictates closure while the click event:
+         * - did not occur within the overlay content of the overlay
+         * AND was
+         * - not triggered by something in the click event's composed path
+         * OR
+         * - not a "hover" overlay
+         * Select the overlay for closure
+         */
         let index = this.overlays.length;
         while (index && overlaysToClose.length === 0) {
             index -= 1;
             const overlay = this.overlays[index];
-            if (
-                !event.composedPath().includes(overlay.trigger) ||
-                overlay.interaction !== 'hover'
-            ) {
+            const path = event.composedPath();
+            const eventPathDictatesClosure =
+                (!path.includes(overlay.trigger) ||
+                    overlay.interaction !== 'hover') &&
+                !path.includes(overlay.overlayContent);
+            if (eventPathDictatesClosure) {
                 overlaysToClose.push(overlay);
             }
         }

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -353,6 +353,41 @@ export const replace = (): TemplateResult => {
     `;
 };
 
+export const deep = (): TemplateResult => html`
+    <overlay-trigger>
+        <sp-button variant="primary" slot="trigger">
+            Open popover 1 with buttons + selfmanaged Tooltips
+        </sp-button>
+        <sp-popover dialog slot="click-content" direction="bottom" tip open>
+            <sp-action-button>
+                <sp-tooltip self-managed placement="bottom" offset="0">
+                    My Tooltip 1
+                </sp-tooltip>
+                A
+            </sp-action-button>
+            <sp-action-button>
+                <sp-tooltip self-managed placement="bottom" offset="0">
+                    My Tooltip 1
+                </sp-tooltip>
+                B
+            </sp-action-button>
+        </sp-popover>
+    </overlay-trigger>
+
+    <overlay-trigger>
+        <sp-button variant="primary" slot="trigger">
+            Open popover 2 with buttons without ToolTips
+        </sp-button>
+        <sp-popover dialog slot="click-content" direction="bottom" tip open>
+            <sp-action-button>X</sp-action-button>
+            <sp-action-button>Y</sp-action-button>
+        </sp-popover>
+    </overlay-trigger>
+`;
+deep.swc_vrt = {
+    skip: true,
+};
+
 export const modalLoose = (): TemplateResult => {
     const closeEvent = new Event('close', { bubbles: true, composed: true });
     return html`


### PR DESCRIPTION
## Description
Prevent clicks within ancestor overlays from closing those ancestor overlays.

## Related issue(s)
- fixes #2693

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://overlay-stack-mangement--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--deep)
    2. Click the first buttons to open the Popover
    3. Hover the first button in the Popover to open the Tooltip
    4. Click the button associated to the Tooltip
    5. See that the Popover is still open

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.