### PR TITLE
fix(slider): add less visually effectacious style to the slider output when editable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: fc8d3d58ca0f49baa3a19dea7945353f19f3f427
+        default: ff2245bf1c4b920769e991e468d7d119bf08f082
 commands:
     downstream:
         steps:

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -80,7 +80,16 @@ sp-field-label {
 }
 
 :host([editable]) output {
-    opacity: 0;
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: 0 -1px -1px 0;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    white-space: nowrap;
 }
 
 :host([disabled]) {

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -438,6 +438,24 @@ export const Quiet = (args: StoryArgs = {}): TemplateResult => {
     `;
 };
 
+export const inPopover = (args: StoryArgs = {}): TemplateResult => {
+    return html`
+        <sp-popover open dialog style="min-width: 0">
+            <sp-slider
+                editable
+                hide-stepper
+                quiet
+                value="5"
+                step="0.5"
+                min="0"
+                max="20"
+                label="Intensity"
+                ...=${spreadProps(args)}
+            ></sp-slider>
+        </sp-popover>
+    `;
+};
+
 export const Indeterminate = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">


### PR DESCRIPTION
## Description
Allows sliders not to change width when their label takes up their entire width and then have subsequent value changes.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://slider-editable--spectrum-web-components.netlify.app/storybook/?path=/story/slider--in-popover)
    2. Change the value of the slider
    3. See its width not change.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
