### PR TITLE
fix: ensure reactivity of resolved language

### DIFF
--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -13,7 +13,10 @@ governing permissions and limitations under the License.
 import { PropertyValues } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
-import { LanguageResolutionController } from '@spectrum-web-components/reactive-controllers/src/LanguageResolution.js';
+import {
+    LanguageResolutionController,
+    languageResolverUpdatedSymbol,
+} from '@spectrum-web-components/reactive-controllers/src/LanguageResolution.js';
 import {
     NumberFormatOptions,
     NumberFormatter,
@@ -138,8 +141,11 @@ export class SliderHandle extends Focusable {
                 }
             }
         }
-        
-        if (changes.has('formatOptions') || changes.has('resolvedLanguage')) {
+
+        if (
+            changes.has('formatOptions') ||
+            changes.has(languageResolverUpdatedSymbol)
+        ) {
             delete this._numberFormatCache;
         }
         if (changes.has('value')) {
@@ -154,7 +160,9 @@ export class SliderHandle extends Focusable {
         super.update(changes);
     }
 
-    protected override firstUpdated(changedProperties: PropertyValues<this>): void {
+    protected override firstUpdated(
+        changedProperties: PropertyValues<this>
+    ): void {
         super.firstUpdated(changedProperties);
         this.dispatchEvent(new CustomEvent('sp-slider-handle-ready'));
     }

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -244,6 +244,28 @@ const editableDecorator = (story: () => TemplateResult): TemplateResult => {
     `;
 };
 
+export const max20 = (args: StoryArgs = {}): TemplateResult => {
+    return html`
+        <div style="width: 200px; margin: 12px 20px;">
+            <sp-slider
+                editable
+                max="20"
+                min="0"
+                value="5"
+                step="1"
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
+                ...=${spreadProps(args)}
+            >
+                Max 20
+            </sp-slider>
+        </div>
+    `;
+};
+max20.swc_vrt = {
+    skip: true,
+};
+
 export const editable = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">

--- a/tools/reactive-controllers/src/LanguageResolution.ts
+++ b/tools/reactive-controllers/src/LanguageResolution.ts
@@ -13,6 +13,10 @@ governing permissions and limitations under the License.
 import type { ReactiveController, ReactiveElement } from 'lit';
 import { ProvideLang } from '@spectrum-web-components/theme';
 
+export const languageResolverUpdatedSymbol = Symbol(
+    'language resolver updated'
+);
+
 export class LanguageResolutionController implements ReactiveController {
     private host: ReactiveElement;
     language = document.documentElement.lang || navigator.language;
@@ -39,9 +43,13 @@ export class LanguageResolutionController implements ReactiveController {
                 composed: true,
                 detail: {
                     callback: (lang: string, unsubscribe: () => void) => {
+                        const previous = this.language;
                         this.language = lang;
                         this.unsubscribe = unsubscribe;
-                        this.host.requestUpdate();
+                        this.host.requestUpdate(
+                            languageResolverUpdatedSymbol,
+                            previous
+                        );
                     },
                 },
                 cancelable: true,


### PR DESCRIPTION
## Description
- Language Resolver: ensure language resolution updates are responsive to the element owning the language resolver
- Number Field: normalize device specific input to page specific language when using the iOS `decimal` keyboard
- Add a demo

## Related issue(s)
- fixes #2709 

## Motivation and context
International usage

## How has this been tested?

*Docs Site*:
1. using iOS
2. region set to `Romania`
3. Go to https://language-resolution-fix--spectrum-web-components.netlify.app/components/number-field/
4. Open dev tools and change lang attribute in `<html>` to `ro-RO`
  - We do not current bind to non-custom element sources of language reactively, so this will not change the language of the SWC content in the page. We could take a separate feature request to do so in an opt in manner. For now, I'll list the expected behavior based no today's feature set, and then list an alternate path where the language is resolved below.
5. Click on the input
6. The keyboard will show up with `,` input `1,024`
7. Press "Done"
8. EXPECTED OUTPUT: `1.024`
  - as the language of the SWC element on the site had not been appropriately managed, they will still be in the initial `en-US` language. That means that the Romanian input will be translated for display in English.

*Docs Site ALT*:
1. using iOS
2. region set to `Romania`
3. Go to https://language-resolution-fix--spectrum-web-components.netlify.app/components/number-field/
4. Open dev tools and change lang attribute on `<sp-theme>` to `ro-RO`
5. Success here will be marked by the visible value of the input being udpated from `1,024` to `1.024`
6. Click on the input
7. The keyboard will show up with `,` input `1,024`
8. Press "Done"
9. EXPECTED OUTPUT: `1,024`
  - Romanian input in a site set to the Romanian language should accept and display values in the same format

*Storybook*:
1. using iOS
2. region set to `Romania`
3. Go to https://language-resolution-fix--spectrum-web-components.netlify.app/storybook/index.html?path=/story/number-field--decimals
4. Storybook doesn't load in the expected order, so language reactivity is not available by default:
  - Inspect the `<sp-number-field>` element.
  - Call `<sp-number-field>.languageResolver.resolveLanguage()`
  - Find the `<sp-theme>` ancestor, it's within the `<sp-story-decorator>` shadow root
  - Set the `lang` attribute/property to `ro-RO`
  - Correctly updated language should display `+19,27` in the Number Field
5. The keyboard should feature the `,` key
6. Edit the value to be `19,27`
7. Press "Done"
8. EXPECTED OUTPUT: `+19,27`

*Example 1*: `<sp-number-field>` is prepared to accept decimal input, e.g. step is less and 1 and `maximumFractionDigits` is greater than 0.
1. using iOS
10. region set to `Romania`
11. the site language is set to `en-US`
12. the keyboard features `,` as a separator
13. insert `1,5`
14. EXPECTED OUTPUT: `1.5`
  - as the site language is set to `en-US` the output should always be formatted to `en-US` regardless of the input language or mode of the visiting device

*Example 1 INVERTED*: `<sp-number-field>` is prepared to accept decimal input, e.g. step is less and 1 and `maximumFractionDigits` is greater than 0.
1. using iOS
9. region set to `America`
10. the site language is set to `ro-RO`
11. the keyboard features `.` as a separator
12. insert `1.5`
13. EXPECTED OUTPUT: `1,5`
  - as the site language is set to `ro-RO` the output should always be formatted to `ro-RO` regardless of the input language or mode of the visiting device

*Example 2*: `<sp-number-field>` is NOT prepared to accept decimal input, e.g. step is set to 1
1. using iOS
2. region set to `Romania`
7. the site language is set to `en-US`
8. the keyboard features `,` as a separator
9. insert `1,5`
10. EXPECTED OUTPUT: `2`
  - The above value is interpreted at `1.5` due to the site language being `en-US`, the lack of support for decimal values rounds this value

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.