### PR TITLE
docs: watch README while running docs site locally

### DIFF
--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -19,8 +19,9 @@
         "copy-docs": "node scripts/copy-component-docs.js",
         "prebuild": "rimraf _site && mkdir -p _site/src/components _site/src/tools && rimraf dist && mkdir dist && yarn copy-docs",
         "prewatch": "WATCH_MODE=true yarn build",
-        "watch": "WATCH_MODE=true run-p 'build:tsc -w' 'build:eleventy --watch' watch:move-css build:postcss 'build:postcss --watch' 'build:rollup --watch' watch:serve",
+        "watch": "WATCH_MODE=true run-p watch:readme 'build:tsc -w' 'build:eleventy --watch' watch:move-css build:postcss 'build:postcss --watch' 'build:rollup --watch' watch:serve",
         "watch:move-css": "yarn build:move-css && node scripts/watch-css.js",
+        "watch:readme": "node scripts/watch-readme.js",
         "watch:serve": "wds --root-dir=dist --watch"
     },
     "dependencies": {

--- a/projects/documentation/scripts/copy-component-docs.js
+++ b/projects/documentation/scripts/copy-component-docs.js
@@ -34,6 +34,16 @@ const partialPath = path.resolve(
     '../content/_includes/partials/components'
 );
 
+const extractFileNameRegExp = /([a-zA-Z-]+)\.md$/;
+const extractPackageNameRegExp = /([^/]+)\/([a-zA-Z-]+)\.md$/;
+
+const customElementJSONPath = path.resolve(
+    projectDir,
+    'projects/documentation/custom-elements.json'
+);
+let rawCustomElementsJSON = fs.readFileSync(customElementJSONPath);
+let customElements = JSON.parse(rawCustomElementsJSON);
+
 const findDeclaration = (customElements, test) => {
     let declaration;
     // Capture a specific declaration, inside of a module, not a specific module
@@ -46,115 +56,109 @@ const findDeclaration = (customElements, test) => {
     return declaration;
 };
 
+export async function processREADME(mdPath) {
+    const fileName = extractFileNameRegExp.exec(mdPath)[0];
+    if (fileName === 'CHANGELOG.md' || /node_modules/.test(mdPath)) {
+        return;
+    }
+    let componentName =
+        fileName !== 'README.md'
+            ? fileName.replace('.md', '')
+            : extractPackageNameRegExp.exec(mdPath)[1];
+    let componentHeading = componentName;
+    let tag = findDeclaration(
+        customElements,
+        (declaration) => declaration.tagName === 'sp-' + componentName
+    );
+    if (!tag) {
+        tag = findDeclaration(
+            customElements,
+            (declaration) => declaration.tagName === componentName
+        );
+    } else {
+        componentHeading = 'sp-' + componentHeading;
+    }
+    if (!tag && componentName.startsWith('icons-')) {
+        tag = findDeclaration(
+            customElements,
+            (declaration) => declaration.name === 'IconBase'
+        );
+    }
+    if (!tag && componentName.startsWith('textarea')) {
+        tag = findDeclaration(
+            customElements,
+            (declaration) => declaration.tagName === 'sp-textfield'
+        );
+    }
+    if (!tag && componentName.startsWith('help-text-mixin')) {
+        componentHeading = 'Help Text Mixin';
+        tag = findDeclaration(
+            customElements,
+            (declaration) => declaration.name === 'HelpTextManagedElement'
+        );
+    }
+    const isComponent = mdPath.includes('/packages/');
+    const destinationPath = isComponent
+        ? componentDestinationPath
+        : toolDestinationPath;
+    const componentPath = path.resolve(destinationPath, componentName);
+
+    fs.mkdirSync(componentPath, { recursive: true });
+    // Support the full page delivery of "Examples" and "API"
+    const exampleDestinationFile = path.resolve(
+        destinationPath,
+        componentName,
+        'index.md'
+    );
+    const apiDestinationFile = path.resolve(
+        destinationPath,
+        componentName,
+        'api.md'
+    );
+    // Create content only pages for each section of an individual elements docs
+    // The next two are not fully leveraged just yet.
+    const examplePartialFile = path.resolve(
+        destinationPath,
+        componentName,
+        'content.md'
+    );
+    const apiPartialFile = path.resolve(
+        destinationPath,
+        componentName,
+        'api-content.md'
+    );
+    if (tag) {
+        // Read the source markdown file.
+        fs.writeFileSync(
+            apiDestinationFile,
+            apiDestinationTemplate(componentName, componentHeading)
+        );
+        fs.writeFileSync(
+            apiPartialFile,
+            apiPartialTemplate(componentName, componentHeading, tag)
+        );
+    }
+    const tagType = isComponent ? 'component-examples' : 'tool-examples';
+    const body = fs.readFileSync(mdPath);
+    fs.writeFileSync(
+        exampleDestinationFile,
+        exampleDestinationTemplate(componentName, componentHeading, tagType)
+    );
+    fs.writeFileSync(
+        examplePartialFile,
+        examplePartialTemplate(componentName, componentHeading, body)
+    );
+}
+
 async function main() {
     fs.mkdirSync(componentDestinationPath, { recursive: true });
     fs.mkdirSync(toolDestinationPath, { recursive: true });
     fs.mkdirSync(partialPath, { recursive: true });
 
-    const customElementJSONPath = path.resolve(
-        projectDir,
-        'projects/documentation/custom-elements.json'
-    );
-    let rawCustomElementsJSON = fs.readFileSync(customElementJSONPath);
-    let customElements = JSON.parse(rawCustomElementsJSON);
-
-    const extractFileNameRegExp = /([a-zA-Z-]+)\.md$/;
-    const extractPackageNameRegExp = /([^/]+)\/([a-zA-Z-]+)\.md$/;
-
     for await (const mdPath of globby.stream(
         `${projectDir}/(packages|tools)/**/*.md`
     )) {
-        const fileName = extractFileNameRegExp.exec(mdPath)[0];
-        if (fileName === 'CHANGELOG.md' || /node_modules/.test(mdPath)) {
-            continue;
-        }
-        let componentName =
-            fileName !== 'README.md'
-                ? fileName.replace('.md', '')
-                : extractPackageNameRegExp.exec(mdPath)[1];
-        let componentHeading = componentName;
-        let tag = findDeclaration(
-            customElements,
-            (declaration) => declaration.tagName === 'sp-' + componentName
-        );
-        if (!tag) {
-            tag = findDeclaration(
-                customElements,
-                (declaration) => declaration.tagName === componentName
-            );
-        } else {
-            componentHeading = 'sp-' + componentHeading;
-        }
-        if (!tag && componentName.startsWith('icons-')) {
-            tag = findDeclaration(
-                customElements,
-                (declaration) => declaration.name === 'IconBase'
-            );
-        }
-        if (!tag && componentName.startsWith('textarea')) {
-            tag = findDeclaration(
-                customElements,
-                (declaration) => declaration.tagName === 'sp-textfield'
-            );
-        }
-        if (!tag && componentName.startsWith('help-text-mixin')) {
-            componentHeading = 'Help Text Mixin';
-            tag = findDeclaration(
-                customElements,
-                (declaration) => declaration.name === 'HelpTextManagedElement'
-            );
-        }
-        const isComponent = mdPath.includes('/packages/');
-        const destinationPath = isComponent
-            ? componentDestinationPath
-            : toolDestinationPath;
-        const componentPath = path.resolve(destinationPath, componentName);
-
-        fs.mkdirSync(componentPath, { recursive: true });
-        // Support the full page delivery of "Examples" and "API"
-        const exampleDestinationFile = path.resolve(
-            destinationPath,
-            componentName,
-            'index.md'
-        );
-        const apiDestinationFile = path.resolve(
-            destinationPath,
-            componentName,
-            'api.md'
-        );
-        // Create content only pages for each section of an individual elements docs
-        // The next two are not fully leveraged just yet.
-        const examplePartialFile = path.resolve(
-            destinationPath,
-            componentName,
-            'content.md'
-        );
-        const apiPartialFile = path.resolve(
-            destinationPath,
-            componentName,
-            'api-content.md'
-        );
-        if (tag) {
-            // Read the source markdown file.
-            fs.writeFileSync(
-                apiDestinationFile,
-                apiDestinationTemplate(componentName, componentHeading)
-            );
-            fs.writeFileSync(
-                apiPartialFile,
-                apiPartialTemplate(componentName, componentHeading, tag)
-            );
-        }
-        const tagType = isComponent ? 'component-examples' : 'tool-examples';
-        const body = fs.readFileSync(mdPath);
-        fs.writeFileSync(
-            exampleDestinationFile,
-            exampleDestinationTemplate(componentName, componentHeading, tagType)
-        );
-        fs.writeFileSync(
-            examplePartialFile,
-            examplePartialTemplate(componentName, componentHeading, body)
-        );
+        await processREADME(mdPath);
     }
 }
 


### PR DESCRIPTION
## Description
Rebuild docs site on README.md change while viewing docs site locally.

## Related issue(s)
- fixes #2730

## How has this been tested?

-   [ ] _Test case 1_
    1. Run the docs site locally
    2. Change some content in a README.md file
    3. See the changes happen live while the docs site is running.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.