### PR TITLE
refactor: prepare for the presence of the "popover" attribute/property in the platform

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -140,7 +140,7 @@ export class PickerBase extends SizedMixin(Focusable) {
 
     private closeOverlay?: Promise<() => void>;
 
-    private popover!: Popover;
+    private popoverEl!: Popover;
 
     protected listRole: 'listbox' | 'menu' = 'listbox';
     protected itemRole = 'option';
@@ -295,8 +295,8 @@ export class PickerBase extends SizedMixin(Focusable) {
             this.popoverFragment = document.createDocumentFragment();
         }
         render(this.renderPopover, this.popoverFragment, { host: this });
-        this.popover = this.popoverFragment.children[0] as Popover;
-        this.optionsMenu = this.popover.children[1] as Menu;
+        this.popoverEl = this.popoverFragment.children[0] as Popover;
+        this.optionsMenu = this.popoverEl.children[1] as Menu;
     }
 
     private async openMenu(): Promise<void> {
@@ -342,8 +342,8 @@ export class PickerBase extends SizedMixin(Focusable) {
             },
         });
 
-        this.sizePopover(this.popover);
-        this.closeOverlay = Picker.openOverlay(this, 'modal', this.popover, {
+        this.sizePopover(this.popoverEl);
+        this.closeOverlay = Picker.openOverlay(this, 'modal', this.popoverEl, {
             placement: this.isMobile.matches ? 'none' : this.placement,
             receivesFocus: 'auto',
         });

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -892,7 +892,7 @@ export function runPickerTests(): void {
             await (
                 el as unknown as { generatePopover(): void }
             ).generatePopover();
-            (el as unknown as { popover: Popover }).popover.style.height =
+            (el as unknown as { popoverEl: Popover }).popoverEl.style.height =
                 '40px';
 
             const firstItem = el.querySelector(

--- a/projects/documentation/src/components/side-nav-search.ts
+++ b/projects/documentation/src/components/side-nav-search.ts
@@ -38,7 +38,7 @@ export class SearchComponent extends LitElement {
     private searchResultsPopover: Popover | null = null;
 
     @query('sp-popover')
-    private popover?: Popover;
+    private popoverEl?: Popover;
 
     @query('sp-search')
     private searchField!: Search;
@@ -116,11 +116,11 @@ export class SearchComponent extends LitElement {
     }
 
     private async openPopover() {
-        if (!this.popover) return;
+        if (!this.popoverEl) return;
 
-        this.searchResultsPopover = this.popover;
+        this.searchResultsPopover = this.popoverEl;
 
-        const { popover } = this;
+        const { popoverEl: popover } = this;
         this.closeOverlay = await openOverlay(
             this.searchField,
             'click',


### PR DESCRIPTION
## Description
With the advent of the `popover` attribute, the `popover` property appears to reflect, so in preparation, let's rename some properties so that we don't accidentally create a popover when we don't need/want one.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://popover-prepare--spectrum-web-components.netlify.app/) in a browser with the "Experimental Web Platform features" flag turned on
    2. Open a Picker/the search nav in the docs site
    3. See that it opens as expected
    4. Previously this would attempt to open a popover

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.