### PR TITLE
docs: add a11y information

### DIFF
--- a/projects/documentation/content/index.md
+++ b/projects/documentation/content/index.md
@@ -22,15 +22,13 @@ title: Spectrum Web Components
 </section>
 <section id="features">
     <div class="feature">
-        <h2 id="standards-based" class="spectrum-Heading spectrum-Heading--sizeS">
-            Standards based&nbsp;<sp-link class="header-anchor" href="index.html#standards-based" aria-label="§" data-js-focus-visible="" tabindex="0">#</sp-link>
+        <h2 id="accessible" class="spectrum-Heading spectrum-Heading--sizeS">
+            Accessible by default&nbsp;<sp-link class="header-anchor" href="index.html#accessible" aria-label="§" data-js-focus-visible="" tabindex="0">#</sp-link>
         </h2>
         <p class="spectrum-Body spectrum-Body--sizeM">
-        <sp-link
-            href="https://developer.mozilla.org/en-US/docs/Web/Web_Components"
-        >Web Components</sp-link> are a set of technologies that work together, letting
-        you create custom elements that work just like the
-        standard HTML elements built into your browser.
+            Developed with existing and emerging browser specifications in mind,
+	        our components deliver a high quality experience whether using a screen
+            reader, keyboard navigation, and/or customized contrast.
         </p>
     </div>
     <div class="feature">
@@ -43,6 +41,18 @@ title: Spectrum Web Components
                 href="https://lit-element.polymer-project.org/"
             >LitElement</sp-link> base class. LitElement is designed for creating web
             components with a minimum amount of overhead.
+        </p>
+    </div>
+    <div class="feature">
+        <h2 id="standards-based" class="spectrum-Heading spectrum-Heading--sizeS">
+            Standards based&nbsp;<sp-link class="header-anchor" href="index.html#standards-based" aria-label="§" data-js-focus-visible="" tabindex="0">#</sp-link>
+        </h2>
+        <p class="spectrum-Body spectrum-Body--sizeM">
+        <sp-link
+            href="https://developer.mozilla.org/en-US/docs/Web/Web_Components"
+        >Web Components</sp-link> are a set of technologies that work together, letting
+        you create custom elements that work just like the
+        standard HTML elements built into your browser.
         </p>
     </div>
     <div class="feature">

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -24,11 +24,11 @@ governing permissions and limitations under the License.
 @import '@spectrum-web-components/styles/tokens/medium-vars.css' screen and
         (min-width: 701px) and (min-height: 701px),
     (hover: hover), (pointer: fine);
-@import '@spectrum-web-components/styles/tokens/spectrum/custom-medium-vars.css' screen and
-        (min-width: 701px) and (min-height: 701px),
+@import '@spectrum-web-components/styles/tokens/spectrum/custom-medium-vars.css'
+        screen and (min-width: 701px) and (min-height: 701px),
     (hover: hover), (pointer: fine);
-@import '@spectrum-web-components/styles/tokens/spectrum/medium-vars.css' screen and
-        (min-width: 701px) and (min-height: 701px),
+@import '@spectrum-web-components/styles/tokens/spectrum/medium-vars.css' screen
+        and (min-width: 701px) and (min-height: 701px),
     (hover: hover), (pointer: fine);
 @import '@spectrum-web-components/styles/scale-large.css' screen and
         (max-width: 700px) and (hover: none) and (pointer: coarse),
@@ -36,11 +36,11 @@ governing permissions and limitations under the License.
 @import '@spectrum-web-components/styles/tokens/large-vars.css' screen and
         (max-width: 700px) and (hover: none) and (pointer: coarse),
     (max-height: 700px) and (hover: none) and (pointer: coarse);
-@import '@spectrum-web-components/styles/tokens/spectrum/custom-large-vars.css' screen and
-        (max-width: 700px) and (hover: none) and (pointer: coarse),
+@import '@spectrum-web-components/styles/tokens/spectrum/custom-large-vars.css'
+        screen and (max-width: 700px) and (hover: none) and (pointer: coarse),
     (max-height: 700px) and (hover: none) and (pointer: coarse);
-@import '@spectrum-web-components/styles/tokens/spectrum/large-vars.css' screen and
-        (max-width: 700px) and (hover: none) and (pointer: coarse),
+@import '@spectrum-web-components/styles/tokens/spectrum/large-vars.css' screen
+        and (max-width: 700px) and (hover: none) and (pointer: coarse),
     (max-height: 700px) and (hover: none) and (pointer: coarse);
 
 @import '@spectrum-web-components/styles/theme-dark.css' screen and
@@ -421,39 +421,9 @@ sp-divider[size='s']:not(:defined) {
 }
 
 .feature {
-    flex: 0 1 calc(33.33% - 30px);
+    flex: 0 1 calc(50% - 30px);
     padding: 0 0 20px;
     box-sizing: border-box;
-}
-
-@media screen and (max-width: 1100px) {
-    .feature {
-        flex: 0 1 calc(50% - 30px);
-    }
-
-    .feature:first-of-type {
-        flex-basis: 100%;
-    }
-}
-
-@media screen and (max-width: 960px) {
-    .feature {
-        flex: 0 1 calc(33.33% - 30px);
-    }
-
-    .feature:first-of-type {
-        flex: 0 1 calc(33.33% - 30px);
-    }
-}
-
-@media screen and (max-width: 725px) {
-    .feature {
-        flex: 0 1 calc(50% - 30px);
-    }
-
-    .feature:first-of-type {
-        flex-basis: 100%;
-    }
 }
 
 @media screen and (max-width: 525px) {


### PR DESCRIPTION
## Description
Add accessibility content to the home page of the documentation site:
> **Accessible by default**
> Developed with existing and emerging browser specifications in mind to deliver/maintain a quality experience whether using a screen reader, keyboard navigation, and/or high contrast colors.

## Related issue(s)
- fixes #2615 

## Types of changes
-   [ ] Documentation

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.