### PR TITLE
fix: leverage "dvh" rather than measured screen height

### DIFF
--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -283,18 +283,8 @@ export class ActiveOverlay extends SpectrumElement {
 
         this.state = 'active';
 
-        // force paint
-        // this prevents a timing issue that can show up in tests as
-        // 'Error: Timeout: Wait for decorator to become ready...'
-        this.offsetWidth;
-
         this.feature();
-        if (this.placement === 'none') {
-            this.style.setProperty(
-                '--swc-visual-viewport-height',
-                `${window.innerHeight}px`
-            );
-        } else if (this.placement) {
+        if (this.placement && this.placement !== 'none') {
             await this.updateOverlayPosition();
             document.addEventListener(
                 'sp-update-overlays',

--- a/packages/overlay/src/active-overlay.css
+++ b/packages/overlay/src/active-overlay.css
@@ -50,8 +50,8 @@ governing permissions and limitations under the License.
 :host([placement='none']) {
     position: fixed;
     height: 100vh;
+    height: 100dvh;
     height: fill-available;
-    max-height: var(--swc-visual-viewport-height);
     top: 0;
     left: 0;
 }

--- a/packages/tray/src/tray.css
+++ b/packages/tray/src/tray.css
@@ -16,7 +16,8 @@ governing permissions and limitations under the License.
 :host {
     align-items: flex-end;
     position: fixed !important;
-    max-height: var(--swc-visual-viewport-height);
+    max-height: 100vh;
+    max-height: 100dvh;
 }
 
 sp-underlay {


### PR DESCRIPTION
## Description
Reduce manual measurement of the layout by leveraging `dvh` with a fallback to `vh`.

## Related issue(s)
- fixes #2772

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://overlay-container--spectrum-web-components.netlify.app/components/dialog-wrapper/)
    2. Make the browser very short
    3. Open the overlay in the docs content
    4. Expand the hight of the browser
    5. See that the overlay remains centered, vertically
-   [ ] _Test case 2_
    1. Go [here](https://overlay-container--spectrum-web-components.netlify.app/), in iOS
    2. Play with the Pickers and the Dialogs to make sure they display correctly

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.