### PR TITLE
fix: ensure Overlay.update bypasses the auto close mechanism

### DIFF
--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -288,7 +288,7 @@ export class ActiveOverlay extends SpectrumElement {
             await this.updateOverlayPosition();
             document.addEventListener(
                 'sp-update-overlays',
-                this.updateOverlayPosition
+                this.setOverlayPosition
             );
         }
         if (this.placement && this.placement !== 'none') {
@@ -418,12 +418,16 @@ export class ActiveOverlay extends SpectrumElement {
         );
     }
 
-    public updateOverlayPosition = async (): Promise<void> => {
-        if (!this.placement || this.placement === 'none') {
-            return;
-        }
+    public updateOverlayPosition = (): void => {
         if (this.interaction !== 'modal' && this.cleanup) {
             this.dispatchEvent(new Event('close'));
+            return;
+        }
+        this.setOverlayPosition();
+    };
+
+    public setOverlayPosition = async (): Promise<void> => {
+        if (!this.placement || this.placement === 'none') {
             return;
         }
         await (document.fonts ? document.fonts.ready : Promise.resolve());
@@ -646,7 +650,7 @@ export class ActiveOverlay extends SpectrumElement {
     override disconnectedCallback(): void {
         document.removeEventListener(
             'sp-update-overlays',
-            this.updateOverlayPosition
+            this.setOverlayPosition
         );
         super.disconnectedCallback();
     }

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -45,6 +45,7 @@ import '../../../projects/story-decorator/src/types.js';
 import './overlay-story-components.js';
 import { render } from 'lit-html';
 import { Popover } from '@spectrum-web-components/popover';
+import { Button } from '@spectrum-web-components/button';
 
 const storyStyles = html`
     <style>
@@ -1108,4 +1109,30 @@ export const modalWithinNonModal = (): TemplateResult => {
             </sp-popover>
         </overlay-trigger>
     `;
+};
+
+export const updating = (): TemplateResult => {
+    const update = (): void => {
+        const button = document.querySelector('[slot="trigger"]') as Button;
+        button.style.left = `${Math.floor(Math.random() * 200)}px`;
+        button.style.top = `${Math.floor(Math.random() * 200)}px`;
+        button.style.position = 'fixed';
+        Overlay.update();
+    };
+    return html`
+        <overlay-trigger type="click">
+            <sp-button variant="primary" slot="trigger">
+                Open inline overlay
+            </sp-button>
+            <sp-popover slot="click-content" dialog>
+                <sp-button variant="primary" @click=${update}>
+                    Update trigger location.
+                </sp-button>
+            </sp-popover>
+        </overlay-trigger>
+    `;
+};
+
+updating.swc_vrt = {
+    skip: true,
 };


### PR DESCRIPTION
## Description
Allow `Overlay.update` to be reacted to without closing the overlay.

## Related issue(s)
- fixes #2766

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://overlay-update--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--updating)
    2. Open the overlay
    3. Update the trigger location
    4. See that across multiple moves that overlay is NOT closed

## Types of changes
-   [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.