### PR TITLE
docs: make storybook themed

### DIFF
--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -1,7 +1,6 @@
 import { create } from '@web/storybook-prebuilt/theming/create.js';
 
 export default create({
-    base: 'light',
     brandTitle: 'Spectrum Web Components',
     brandUrl: 'https://opensource.adobe.com/spectrum-web-components',
     brandImage:

--- a/projects/story-decorator/package.json
+++ b/projects/story-decorator/package.json
@@ -71,6 +71,7 @@
         "@spectrum-web-components/menu": "^0.16.9",
         "@spectrum-web-components/overlay": "^0.18.9",
         "@spectrum-web-components/picker": "^0.13.9",
+        "@spectrum-web-components/reactive-controllers": "^0.3.4",
         "@spectrum-web-components/switch": "^0.11.5",
         "@spectrum-web-components/theme": "^0.14.8"
     },

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -23,6 +23,7 @@ import {
     queryAsync,
 } from '@spectrum-web-components/base/src/decorators.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import { DARK_MODE } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
 import '@spectrum-web-components/theme/src/express/themes.js';
@@ -49,7 +50,9 @@ export let dir: 'ltr' | 'rtl' =
     (urlParams.get('sp_dir') as 'ltr' | 'rtl') || 'ltr';
 export let theme: ThemeVariant =
     (urlParams.get('sp_theme') as ThemeVariant) || 'spectrum';
-export let color: Color = (urlParams.get('sp_color') as Color) || 'light';
+export let color: Color =
+    (urlParams.get('sp_color') as Color) ||
+    (matchMedia(DARK_MODE).matches ? 'dark' : 'light');
 export let scale: Scale = (urlParams.get('sp_scale') as Scale) || 'medium';
 export let reduceMotion = urlParams.get('sp_reduceMotion') === 'true';
 


### PR DESCRIPTION
## Description
Loosen theme application in Storybook so that by default the Manager UI and the Story UI can display the OS native color theme (e.g. dark mode).

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://themed-storybook--spectrum-web-components.netlify.app/storybook/?path=/story/accordion--default)
    2. See that the theme matches your OS settings
    3. Change your OS settings to not dark/light mode as appropriate
    4. Reload
    5. See that the theme matches the new OS settings

## Types of changes
-   [x] Something fun...?

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.