### PR TITLE
docs: correct application of themed code styling

### DIFF
--- a/projects/documentation/src/components/code-example.ts
+++ b/projects/documentation/src/components/code-example.ts
@@ -52,7 +52,7 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
     private prismjsLoaded = false;
 
     public static override get styles(): CSSResultArray {
-        return [Styles, StylesLight, StylesDark];
+        return [Styles];
     }
 
     private get codeSlot(): Element | this {
@@ -142,7 +142,7 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
                       </div>
                   `
                 : undefined}
-            <bdo class="markup ${this.codeTheme}" dir="ltr">
+            <bdo class="markup" dir="ltr">
                 ${highlightedCode}
                 <div class="copy-holder">
                     <sp-action-button
@@ -155,6 +155,11 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
                     </sp-action-button>
                 </div>
             </bdo>
+            <style>
+                ${this.codeTheme === 'light'
+                    ? StylesLight.toString()
+                    : StylesDark.toString()}
+            </style>
         `;
     }
 


### PR DESCRIPTION
## Description
Ensure theme specific style application in code samples.

## Related issue(s)
- fixes #2793

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://docs-code-themes--spectrum-web-components.netlify.app/)
    2. See the code sample highlighting
    3. Switch the theme color
    4. See the code sample highlighting
    5. Experience being able to read the code in all themes.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.