### PR TITLE
fix(overlay): allow overlays to be positioned 0px from their targets

### DIFF
--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -433,6 +433,9 @@ export class ActiveOverlay extends SpectrumElement {
         await (document.fonts ? document.fonts.ready : Promise.resolve());
 
         function roundByDPR(num: number): number {
+            if (num === 0) {
+                return num;
+            }
             const dpr = window.devicePixelRatio || 1;
             return Math.round(num * dpr) / dpr || -10000;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While working on a project I was not able to open a popover if the computedPosition x position returned by floating-ui was 0 due to the way [we round numbers by device pixel ratio](https://github.com/adobe/spectrum-web-components/blob/main/packages/overlay/src/ActiveOverlay.ts#L437). It seems like this change was intentional #2121.

<img width="1737" alt="image" src="https://user-images.githubusercontent.com/4684894/207775914-888187f2-97a4-449b-8bae-1c8667d93923.png">



<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Allows popovers to be positioned correctly if their computed x position is 0.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
