### PR TITLE
docs: differentiate between "components" and "tools" when generating search index

### DIFF
--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -150,7 +150,7 @@
             "files": [
                 "../../packages/*/*.md",
                 "../../tools/*/*.md",
-                "./**/scripts/build-search-index.js"
+                "./scripts/build-search-index.js"
             ],
             "output": [
                 "dist/searchIndex.json"
@@ -161,7 +161,7 @@
             "files": [
                 "../../packages/*/*.md",
                 "../../tools/*/*.md",
-                "scripts/build-search-index.js"
+                "./scripts/build-search-index.js"
             ],
             "output": [
                 "dist/searchIndex.json"

--- a/projects/documentation/scripts/build-search-index.js
+++ b/projects/documentation/scripts/build-search-index.js
@@ -36,12 +36,9 @@ async function main() {
     const documents = [];
 
     // Components
-    for await (const path of globby.stream(
-        `${projectDir}/(packages|tools)/**/*.md`,
-        {
-            ignore: ['**/node_modules/**'],
-        }
-    )) {
+    for await (const path of globby.stream(`${projectDir}/packages/**/*.md`, {
+        ignore: ['**/node_modules/**'],
+    })) {
         let componentName = /([^/]+)\/([a-zA-Z-]+)\.md$/.exec(path)[1];
         const fileName = /([a-zA-Z-]+)\.md$/.exec(path)[0];
         if (fileName === 'CHANGELOG.md') {
@@ -58,6 +55,29 @@ async function main() {
             url: `/${
                 process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''
             }components/${componentName}`,
+        });
+    }
+
+    // Tools
+    for await (const path of globby.stream(`${projectDir}/tools/**/*.md`, {
+        ignore: ['**/node_modules/**'],
+    })) {
+        let componentName = /([^/]+)\/([a-zA-Z-]+)\.md$/.exec(path)[1];
+        const fileName = /([a-zA-Z-]+)\.md$/.exec(path)[0];
+        if (fileName === 'CHANGELOG.md') {
+            continue;
+        }
+        if (fileName !== 'README.md') {
+            componentName = fileName.replace('.md', '');
+        }
+        const content = await fs.readFile(path, { encoding: 'utf8' });
+        const body = content.replace(/```((.|\s)*?)```/g, '');
+        documents.push({
+            title: nameToTitle(componentName),
+            body,
+            url: `/${
+                process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''
+            }tools/${componentName}`,
         });
     }
 

--- a/projects/documentation/scripts/build-search-index.js
+++ b/projects/documentation/scripts/build-search-index.js
@@ -18,14 +18,12 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const projectDir = path.resolve(__dirname, '..', '..', '..');
-const indexDir = path.resolve(
-    projectDir,
-    process.env.SWC_DIR
-        ? 'projects/documentation/dist'
-        : 'projects/documentation/_site/src/'
-);
-const indexPath = path.resolve(indexDir, 'searchIndex.json');
-fs.mkdirSync(indexDir, { recursive: true });
+const localDir = path.resolve(projectDir, 'projects/documentation/_site/src/');
+const buildDir = path.resolve(projectDir, 'projects/documentation/dist');
+const localIndexPath = path.resolve(localDir, 'searchIndex.json');
+const buildIndexPath = path.resolve(buildDir, 'searchIndex.json');
+fs.mkdirSync(localDir, { recursive: true });
+fs.mkdirSync(buildDir, { recursive: true });
 
 function nameToTitle(name) {
     return name.replace(/((^|\-)(\w))/gm, (match, p1, p2, p3) => {
@@ -99,14 +97,15 @@ async function main() {
         }
     )) {
         const guideName = /\/([^/]+).md$/.exec(path)[1];
+        const guideDir = path.split('/').at(-2);
         const content = await fs.readFile(path, { encoding: 'utf8' });
         const body = content.replace(/```((.|\s)*?)```/g, '');
         documents.push({
             title: nameToTitle(guideName),
             body,
-            url: `/${
-                process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''
-            }guides/${guideName}`,
+            url: `/${process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''}${
+                guideDir !== 'content' ? `${guideDir}/` : ''
+            }${guideName}`,
         });
     }
 
@@ -120,7 +119,8 @@ async function main() {
         }
     });
 
-    await fs.writeFile(indexPath, JSON.stringify(index));
+    await fs.writeFile(localIndexPath, JSON.stringify(index));
+    await fs.writeFile(buildIndexPath, JSON.stringify(index));
 }
 
 main();

--- a/projects/documentation/scripts/build-search-index.js
+++ b/projects/documentation/scripts/build-search-index.js
@@ -18,7 +18,12 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const projectDir = path.resolve(__dirname, '..', '..', '..');
-const indexDir = path.resolve(projectDir, 'projects/documentation/dist');
+const indexDir = path.resolve(
+    projectDir,
+    process.env.SWC_DIR
+        ? 'projects/documentation/dist'
+        : 'projects/documentation/_site/src/'
+);
 const indexPath = path.resolve(indexDir, 'searchIndex.json');
 fs.mkdirSync(indexDir, { recursive: true });
 
@@ -83,7 +88,12 @@ async function main() {
 
     // Guides
     for await (const path of globby.stream(
-        `${projectDir}/documentation/guides/*.md`,
+        [
+            `${projectDir}/projects/documentation/content/guides/*.md`,
+            `${projectDir}/projects/documentation/content/migrations/*.md`,
+            `${projectDir}/projects/documentation/content/getting-started.md`,
+            `${projectDir}/projects/documentation/content/dev-mode.md`,
+        ],
         {
             ignore: ['**/node_modules/**'],
         }

--- a/projects/documentation/scripts/build-search-index.js
+++ b/projects/documentation/scripts/build-search-index.js
@@ -52,12 +52,17 @@ async function main() {
         }
         const content = await fs.readFile(path, { encoding: 'utf8' });
         const body = content.replace(/```((.|\s)*?)```/g, '');
+        const title = nameToTitle(componentName);
         documents.push({
-            title: nameToTitle(componentName),
+            title,
             body,
-            url: `/${
-                process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''
-            }components/${componentName}`,
+            metadata: JSON.stringify({
+                category: 'Components',
+                name: title,
+                url: `/${
+                    process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''
+                }components/${componentName}`,
+            }),
         });
     }
 
@@ -75,12 +80,17 @@ async function main() {
         }
         const content = await fs.readFile(path, { encoding: 'utf8' });
         const body = content.replace(/```((.|\s)*?)```/g, '');
+        const title = nameToTitle(componentName);
         documents.push({
-            title: nameToTitle(componentName),
+            title,
             body,
-            url: `/${
-                process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''
-            }tools/${componentName}`,
+            metadata: JSON.stringify({
+                category: 'Tools',
+                name: title,
+                url: `/${
+                    process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''
+                }tools/${componentName}`,
+            }),
         });
     }
 
@@ -100,19 +110,25 @@ async function main() {
         const guideDir = path.split('/').at(-2);
         const content = await fs.readFile(path, { encoding: 'utf8' });
         const body = content.replace(/```((.|\s)*?)```/g, '');
+        const title = nameToTitle(guideName);
         documents.push({
-            title: nameToTitle(guideName),
+            title,
             body,
-            url: `/${process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''}${
-                guideDir !== 'content' ? `${guideDir}/` : ''
-            }${guideName}`,
+            metadata: JSON.stringify({
+                category: 'Guides',
+                name: title,
+                url: `/${process.env.SWC_DIR ? `${process.env.SWC_DIR}/` : ''}${
+                    guideDir !== 'content' ? `${guideDir}/` : ''
+                }${guideName}`,
+            }),
         });
     }
 
     const index = lunr(function () {
-        this.ref('url');
+        this.ref('metadata');
         this.field('title', { boost: 10 });
         this.field('body');
+        this.field('category');
 
         for (const document of documents) {
             this.add(document);

--- a/projects/documentation/src/components/search-index.ts
+++ b/projects/documentation/src/components/search-index.ts
@@ -55,14 +55,7 @@ export async function search(value: string): Promise<ResultGroup[]> {
 
     const search = index.search(value);
     for (const item of search) {
-        const parts = item.ref.split('/');
-        const name = parts.pop() as string;
-        let category = '';
-        if (parts.length < 3) {
-            category = 'Guides';
-        } else {
-            category = parts.pop() as string;
-        }
+        const { category, name, url } = JSON.parse(item.ref);
 
         if (!collatedResults.has(category)) {
             collatedResults.set(category, {
@@ -76,7 +69,7 @@ export async function search(value: string): Promise<ResultGroup[]> {
             catagoryData.results.push({
                 name,
                 label: label(name),
-                url: item.ref,
+                url,
             });
         }
     }

--- a/projects/documentation/src/components/search-index.ts
+++ b/projects/documentation/src/components/search-index.ts
@@ -56,10 +56,14 @@ export async function search(value: string): Promise<ResultGroup[]> {
     const search = index.search(value);
     for (const item of search) {
         const parts = item.ref.split('/');
-        if (parts.length < 3) continue;
-
         const name = parts.pop() as string;
-        const category = parts.pop() as string;
+        let category = '';
+        if (parts.length < 3) {
+            category = 'Guides';
+        } else {
+            category = parts.pop() as string;
+        }
+
         if (!collatedResults.has(category)) {
             collatedResults.set(category, {
                 maxScore: 0,


### PR DESCRIPTION
## Description
Allow for the search interface to work for all package types, guides, and help pages.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://search-tools--spectrum-web-components.netlify.app/)
    2. Search for `base`
    3. Choose the "Base" auto complete
    4. See that the correct docs page opens: https://search-tools--spectrum-web-components.netlify.app/tools/base/
-   [ ] _Test case 2_
    1. Go [here](https://search-tools--spectrum-web-components.netlify.app/)
    2. Search for `luck`
    3. Choose the "Getting Started" auto complete
    4. See that the correct docs page opens: https://search-tools--spectrum-web-components.netlify.app/getting-started/


## Types of changes=
-   [x] docs

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.