### PR TITLE
Overlay body margin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 1f3f4e1b0f9b452c40671fded5e904460a79fed2
+        default: 37998589cbac604b55716671b61bc04c3b71f9f7
 commands:
     downstream:
         steps:

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -497,6 +497,7 @@ export class ActiveOverlay extends SpectrumElement {
             {
                 placement: this.placement,
                 middleware,
+                strategy: 'fixed',
             }
         );
 

--- a/packages/overlay/src/active-overlay.css
+++ b/packages/overlay/src/active-overlay.css
@@ -36,7 +36,7 @@ governing permissions and limitations under the License.
 
 :host {
     z-index: 1000;
-    position: absolute;
+    position: fixed;
     display: inline-block;
     pointer-events: none;
     top: -9999em;


### PR DESCRIPTION
## Description
Position overlays with `fixed` rather than `absolute`, which ensures that `margin` on the `body` doesn't interact negatively with the `roundByDPR` calculations.
- prepares for #2764 which also requires `fixed` positioning

## Related issue(s)

- fixes #2803

## How has this been tested?

-   [ ] _Test case 1_
    1. CI passes
-   [ ] _Test case 2_
    1. Go [here](https://overlay-body-margin--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--replace)
    2. Remove the `padding` from the `sp-theme` element.
    3. Remove the `margin: 0;` rule on the `body` element.
    4. Open the overlay in the story
    5. See that the overlay is visible and not displayed off screen.

## Types of changes
-   [x] refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.