### PR TITLE
build(styles): update package export listing

### DIFF
--- a/tools/styles/exports.json
+++ b/tools/styles/exports.json
@@ -1,4 +1,5 @@
 {
+    ".": "./src/spectrum-base.css.js",
     "./all-large-dark.css": "./all-large-dark.css",
     "./all-large-darkest.css": "./all-large-darkest.css",
     "./all-large-light.css": "./all-large-light.css",

--- a/tools/styles/package.json
+++ b/tools/styles/package.json
@@ -20,10 +20,7 @@
     "module": "src/spectrum-base.css.js",
     "type": "module",
     "exports": {
-        ".": {
-            "development": "./src/index.dev.js",
-            "default": "./src/index.js"
-        },
+        ".": "./src/spectrum-base.css.js",
         "./package.json": "./package.json",
         "./all-large-dark.css": "./all-large-dark.css",
         "./all-large-darkest.css": "./all-large-darkest.css",


### PR DESCRIPTION
## Description
Still waiting for the publication to propagate at https://jspm.dev/npm:@spectrum-web-components/styles@0.22.1-style.28 and/or https://generator.jspm.io/#U2VhYGBkDM0rySzJSU1hcCguSE0uKSrN1S1PTdJNzs8tyM9LzSsp1i8uqcxJLXYw0DMy0jPUBfP0jCwAL2hwmD4A but this appears to revert the change in v0.15.1 of the `styles` package that caused it to stop building in JSPM. The publication has been stuck on v0.15.0 which has yet to introduce any of the Core Tokens work that we've released throughout the fall.

## Related issue(s)

- fixes #2802 (theoretically)

## How has this been tested?

-   [ ] _Test case 1_
    1. This is mainly to support the internal build process in JSPM, but when it's ready, we can review at https://jspm.dev/npm:@spectrum-web-components/styles@0.22.1-style.28 and/or https://generator.jspm.io/#U2VhYGBkDM0rySzJSU1hcCguSE0uKSrN1S1PTdJNzs8tyM9LzSsp1i8uqcxJLXYw0DMy0jPUBfP0jCwAL2hwmD4A

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.