### PR TITLE
Make "sp-update-overlays" work from a clean render

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 9422a359e545049b1f0d8aa62a72f826182a41c3
+        default: c8f0b4b70a5556d5700716a779896174f83a970d
 commands:
     downstream:
         steps:

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -102,7 +102,7 @@
         "lit-html"
     ],
     "dependencies": {
-        "@floating-ui/dom": "^1.0.4",
+        "@floating-ui/dom": "^1.1.0",
         "@spectrum-web-components/action-button": "^0.10.9",
         "@spectrum-web-components/base": "^0.7.3",
         "@spectrum-web-components/shared": "^0.15.4",

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -427,8 +427,8 @@ export class ActiveOverlay extends SpectrumElement {
     };
 
     public resetOverlayPosition = (): void => {
-        this.style.setProperty('max-height', '');
-        this.style.setProperty('height', '');
+        this.style.removeProperty('max-height');
+        this.style.removeProperty('height');
         this.initialHeight = undefined;
         this.isConstrained = false;
         // force paint

--- a/packages/overlay/src/ActiveOverlay.ts
+++ b/packages/overlay/src/ActiveOverlay.ts
@@ -288,7 +288,7 @@ export class ActiveOverlay extends SpectrumElement {
             await this.updateOverlayPosition();
             document.addEventListener(
                 'sp-update-overlays',
-                this.setOverlayPosition
+                this.resetOverlayPosition
             );
         }
         if (this.placement && this.placement !== 'none') {
@@ -400,7 +400,7 @@ export class ActiveOverlay extends SpectrumElement {
         }
     }
 
-    private initialHeight!: number;
+    private initialHeight: number | undefined;
     private isConstrained = false;
 
     public async placeOverlay(): Promise<void> {
@@ -423,6 +423,16 @@ export class ActiveOverlay extends SpectrumElement {
             this.dispatchEvent(new Event('close'));
             return;
         }
+        this.setOverlayPosition();
+    };
+
+    public resetOverlayPosition = (): void => {
+        this.style.setProperty('max-height', '');
+        this.style.setProperty('height', '');
+        this.initialHeight = undefined;
+        this.isConstrained = false;
+        // force paint
+        this.offsetHeight;
         this.setOverlayPosition();
     };
 
@@ -651,7 +661,7 @@ export class ActiveOverlay extends SpectrumElement {
     override disconnectedCallback(): void {
         document.removeEventListener(
             'sp-update-overlays',
-            this.setOverlayPosition
+            this.resetOverlayPosition
         );
         super.disconnectedCallback();
     }

--- a/packages/overlay/src/active-overlay.css
+++ b/packages/overlay/src/active-overlay.css
@@ -41,6 +41,7 @@ governing permissions and limitations under the License.
     pointer-events: none;
     top: -9999em;
     left: -9999em;
+    max-height: 100%;
 }
 
 :host(:focus) {

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -1144,7 +1144,6 @@ updating.swc_vrt = {
 export const accordion = (): TemplateResult => {
     const handleToggle = (): void => {
         Overlay.update();
-        console.log('hi');
     };
     return html`
         <overlay-trigger type="modal" placement="right">

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -40,6 +40,8 @@ import '@spectrum-web-components/radio/sp-radio-group.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
+import '@spectrum-web-components/accordion/sp-accordion.js';
+import '@spectrum-web-components/accordion/sp-accordion-item.js';
 import '../../../projects/story-decorator/src/types.js';
 
 import './overlay-story-components.js';
@@ -1136,5 +1138,88 @@ export const updating = (): TemplateResult => {
 };
 
 updating.swc_vrt = {
+    skip: true,
+};
+
+export const accordion = (): TemplateResult => {
+    const handleToggle = (): void => {
+        Overlay.update();
+        console.log('hi');
+    };
+    return html`
+        <overlay-trigger type="modal" placement="right">
+            <sp-button variant="primary" slot="trigger">
+                Open overlay w/ accordion
+            </sp-button>
+            <div slot="click-content" style="max-height: 100%;display: flex;">
+                <sp-popover
+                    open
+                    dialog
+                    style="overflow-y: scroll;position: static;"
+                >
+                    <sp-accordion
+                        allow-multiple
+                        @sp-accordion-item-toggle=${handleToggle}
+                    >
+                        <sp-accordion-item label="Some things">
+                            <p>
+                                Thing
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                more things
+                            </p>
+                        </sp-accordion-item>
+                        <sp-accordion-item label="Other things">
+                            <p>
+                                Thing
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                more things
+                            </p>
+                        </sp-accordion-item>
+                        <sp-accordion-item label="More things">
+                            <p>
+                                Thing
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                more things
+                            </p>
+                        </sp-accordion-item>
+                        <sp-accordion-item label="Additional things">
+                            <p>
+                                Thing
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                <br />
+                                more things
+                            </p>
+                        </sp-accordion-item>
+                    </sp-accordion>
+                </sp-popover>
+            </div>
+        </overlay-trigger>
+    `;
+};
+
+accordion.swc_vrt = {
     skip: true,
 };

--- a/packages/overlay/test/overlay-update.test.ts
+++ b/packages/overlay/test/overlay-update.test.ts
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { elementUpdated, expect, fixture, oneEvent } from '@open-wc/testing';
+import { AccordionItem } from '@spectrum-web-components/accordion/src/AccordionItem.js';
+import { OverlayTrigger } from '../src/OverlayTrigger.js';
+import { accordion } from '../stories/overlay.stories.js';
+
+describe('sp-update-overlays event', () => {
+    it('updates overlay height', async () => {
+        const el = await fixture<OverlayTrigger>(accordion());
+        const container = el.querySelector('div') as HTMLElement;
+        const item = el.querySelector(
+            '[label="Other things"]'
+        ) as AccordionItem;
+
+        const height0 = container.getBoundingClientRect().height;
+        expect(height0).to.equal(0);
+
+        const opened = oneEvent(el, 'sp-opened');
+        el.open = 'click';
+        await opened;
+
+        const height1 = container.getBoundingClientRect().height;
+        expect(height1).to.not.equal(0);
+
+        item.click();
+        await elementUpdated(item);
+
+        const height2 = container.getBoundingClientRect().height;
+        expect(height2).to.not.equal(0);
+
+        expect(height1).to.be.lessThan(height2);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,17 +1996,17 @@
   dependencies:
     "@types/chai" "^4.2.12"
 
-"@floating-ui/core@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.3.tgz#eab273554bdd883fa2cb48d5218fedda3afbbc1f"
-  integrity sha512-27FDAEVHrAEQI1UV+7FIjZrFK862gBoAG0USoPMU7RoBCmaTDt6bnKVW/J2uPnOPI6TWqiWGtS7RFN+tN/k+vQ==
+"@floating-ui/core@^1.0.5":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.1.0.tgz#0a1dee4bbce87ff71602625d33f711cafd8afc08"
+  integrity sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ==
 
-"@floating-ui/dom@^1.0.4":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.8.tgz#207c6fdaf21a73166c877e99cc49c69f2e816c2d"
-  integrity sha512-uUm1xYQ0xdmFLhtetKgjK9AtF4INwDVwuJZvpK19ENHg1wYn7T0w9phYyCL5+HEpgJtX4ZYG6HJkDbtd2yP6cg==
+"@floating-ui/dom@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.1.0.tgz#29fea1344fdef15b6ba270a733d20b7134fee5c2"
+  integrity sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==
   dependencies:
-    "@floating-ui/core" "^1.0.3"
+    "@floating-ui/core" "^1.0.5"
 
 "@formatjs/ecma402-abstract@1.9.3":
   version "1.9.3"


### PR DESCRIPTION
## Description
When dispatching `sp-update-overlays` the expectation is the the size AND position of Overlays is updated. This change ensures that size rules applied as part of previous layout application passes is _removed_ before the update workflow is reentered.

## Related issue(s)
- fixes #2813

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://sp-update-overlays--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--accordion)
    2. Open the Overlay
    3. Toggle open Accordion Items until the overlay fills the vertical height of the viewport
    4. See that it is updated to fill the viewport but never overflows the viewport.
-  [ ] _Test case 2_
    1. Go [here](https://studio.webcomponents.dev/edit/1YZCcOq4PMMLIJVekDBk/src/index.ts?branch=overlay%40wfVpXdsTYhf9mY2slxW4t2Y2SjC3&p=stories)
    2. See how the size wasn't appropriately updated before.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.