### PR TITLE
chore: enable dev mode warnings for external consumption of the overlay API

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -341,12 +341,18 @@ export class OverlayTrigger extends SpectrumElement {
         const { targetContent, clickContent } = this;
         this.closeAllOverlays();
         this.prepareToFocusOverlayContent(clickContent);
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = true;
+        }
         this.closeClickOverlay = this.openOverlay(
             targetContent,
             this.type ? this.type : 'click',
             clickContent,
             this.overlayOptions
         );
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = false;
+        }
     }
 
     private _longpressEvent?: CustomEvent<LongpressEvent>;
@@ -364,6 +370,9 @@ export class OverlayTrigger extends SpectrumElement {
         this.prepareToFocusOverlayContent(longpressContent);
         const notImmediatelyClosable =
             this._longpressEvent?.detail?.source !== 'keyboard';
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = true;
+        }
         this.closeLongpressOverlay = this.openOverlay(
             targetContent,
             this.type ? this.type : 'longpress',
@@ -374,6 +383,9 @@ export class OverlayTrigger extends SpectrumElement {
                 notImmediatelyClosable,
             }
         );
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = false;
+        }
         this._longpressEvent = undefined;
     }
 
@@ -393,6 +405,9 @@ export class OverlayTrigger extends SpectrumElement {
             this.abortOverlay = res;
         });
         const { targetContent, hoverContent } = this;
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = true;
+        }
         this.closeHoverOverlay = this.openOverlay(
             targetContent,
             'hover',
@@ -402,6 +417,9 @@ export class OverlayTrigger extends SpectrumElement {
                 ...this.overlayOptions,
             }
         );
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = false;
+        }
     }
 
     private onClickSlotChange(

--- a/packages/overlay/src/loader.ts
+++ b/packages/overlay/src/loader.ts
@@ -18,8 +18,27 @@ export const openOverlay = async (
     content: HTMLElement,
     options: OverlayOptions
 ): Promise<() => void> => {
+    if (window.__swc.DEBUG) {
+        // eslint-disable-next-line no-var
+        var ignoreDeprecations = window.__swc.ignoreWarningLevels.deprecation;
+    }
     const { Overlay } = await import(
         '@spectrum-web-components/overlay/src/overlay.js'
     );
+    if (window.__swc.DEBUG) {
+        if (
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            ignoreDeprecations &&
+            !window.__swc.ignoreWarningLevels.deprecation
+        ) {
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            window.__swc.ignoreWarningLevels.deprecation = ignoreDeprecations;
+            requestAnimationFrame(() => {
+                window.__swc.ignoreWarningLevels.deprecation = false;
+            });
+        }
+    }
     return Overlay.open(target, interaction, content, options);
 };

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -65,6 +65,17 @@ export class Overlay {
         options: OverlayOptions
     ): Promise<() => void> {
         const overlay = new Overlay(owner, interaction, overlayElement);
+        if (window.__swc.DEBUG) {
+            window.__swc.warn(
+                undefined,
+                'The Overlay API is currently being refactored and there are likely to be breaking changes, deprecations and/or removals in a future release. The SWC team wants feedback from direct Overlay API consumers like you - please share your thoughts on the future of overlays here:',
+                'https://github.com/adobe/spectrum-web-components/discussions/2764',
+                {
+                    type: 'default',
+                    level: 'deprecation',
+                }
+            );
+        }
         await overlay.open(options);
         return (): void => {
             overlay.close();

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -343,10 +343,16 @@ export class PickerBase extends SizedMixin(Focusable) {
         });
 
         this.sizePopover(this.popoverEl);
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = true;
+        }
         this.closeOverlay = Picker.openOverlay(this, 'modal', this.popoverEl, {
             placement: this.isMobile.matches ? 'none' : this.placement,
             receivesFocus: 'auto',
         });
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = false;
+        }
     }
 
     protected sizePopover(popover: HTMLElement): void {

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -192,11 +192,17 @@ export class Tooltip extends SpectrumElement {
         const abortPromise: Promise<boolean> = new Promise((res) => {
             this.abortOverlay = res;
         });
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = true;
+        }
         this.closeOverlayCallback = openOverlay(parentElement, 'hover', this, {
             abortPromise,
             offset: this.offset,
             placement: this.placement,
         });
+        if (window.__swc.DEBUG) {
+            window.__swc.ignoreWarningLevels.deprecation = false;
+        }
     };
 
     private closeOverlay = async (

--- a/tools/base/src/Base.ts
+++ b/tools/base/src/Base.ts
@@ -166,8 +166,31 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
 export class SpectrumElement extends SpectrumMixin(LitElement) {}
 
 if (window.__swc.DEBUG) {
+    const ignoreWarningTypes = {
+        default: false,
+        accessibility: false,
+        api: false,
+    };
+    const ignoreWarningLevels = {
+        default: false,
+        low: false,
+        medium: false,
+        high: false,
+        deprecation: false,
+    };
     window.__swc = {
         ...window.__swc,
+        ignoreWarningLocalNames: {
+            ...(window.__swc?.ignoreWarningLocalNames || {}),
+        },
+        ignoreWarningTypes: {
+            ...ignoreWarningTypes,
+            ...(window.__swc?.ignoreWarningTypes || {}),
+        },
+        ignoreWarningLevels: {
+            ...ignoreWarningLevels,
+            ...(window.__swc?.ignoreWarningLevels || {}),
+        },
         issuedWarnings: new Set(),
         warn: (
             element,
@@ -179,11 +202,11 @@ if (window.__swc.DEBUG) {
             const id = `${localName}:${type}:${level}` as BrandedSWCWarningID;
             if (!window.__swc.verbose && window.__swc.issuedWarnings.has(id))
                 return;
-            window.__swc.issuedWarnings.add(id);
             /* c8 ignore next 3 */
-            if (window.__swc.ignoreWarningLocalNames?.[localName]) return;
-            if (window.__swc.ignoreWarningTypes?.[type]) return;
-            if (window.__swc.ignoreWarningLevels?.[level]) return;
+            if (window.__swc.ignoreWarningLocalNames[localName]) return;
+            if (window.__swc.ignoreWarningTypes[type]) return;
+            if (window.__swc.ignoreWarningLevels[level]) return;
+            window.__swc.issuedWarnings.add(id);
             let listedIssues = '';
             if (issues && issues.length) {
                 issues.unshift('');


### PR DESCRIPTION
## Description
This _should_ send a dev mode warning to any consumer of the Overlay API that IS NOT a SWC component. Hopefully, this will get a larger amount of custom Overlay API usage linked back to the team for us to focus on while testing the v2 API.

TO DO:
- [ ] ship canary to confirm this work as expected

## Related issue(s)
- refs #2764 

## How has this been tested?
-   [ ] _Test case 1_
    1. Run Storybook locally
    2. Visit https://localhost:8000/?path=/story/overlay--defined-overlay-element directly
    3. See that no `DEPRECATION NOTICE` is dispatched in the console
    4. Visit https://localhost:8000/?path=/story/overlay--detached-element
    5. See that a `DEPRECATION NOTICE` is dispatched in the console

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.