### PR TITLE
Group docs pages by package name, autofocus the current page in the Side Nav

### DIFF
--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -77,7 +77,8 @@ export class SideNavItem extends LikeAnchor(Focusable) {
         if (!this.href && event) {
             event.preventDefault();
         }
-        if (!this.disabled) {
+        // With an `href` this click will change the page contents, not toggle its children or become "selected".
+        if (!this.disabled && (!this.href || event?.defaultPrevented)) {
             if (this.hasChildren) {
                 this.expanded = !this.expanded;
             } else if (this.value) {

--- a/projects/documentation/.eleventy.cjs
+++ b/projects/documentation/.eleventy.cjs
@@ -105,7 +105,21 @@ module.exports = function (eleventyConfig) {
         return [...collection.getFilteredByGlob('./content/migrations/*.md')];
     });
 
-    eleventyConfig.addCollection('component-examples', function (collection) {
+    eleventyConfig.addCollection('component-root', function (collection) {
+        return collection
+            .getFilteredByTags('component-examples', 'root')
+            .sort(function (a, b) {
+                if (a.data.displayName < b.data.displayName) {
+                    return -1;
+                }
+                if (b.data.displayName < a.data.displayName) {
+                    return 1;
+                }
+                return 0;
+            });
+    });
+
+    eleventyConfig.addCollection('component-all', function (collection) {
         return collection
             .getFilteredByTag('component-examples')
             .sort(function (a, b) {

--- a/projects/documentation/content/_includes/partials/sidenav.njk
+++ b/projects/documentation/content/_includes/partials/sidenav.njk
@@ -23,13 +23,23 @@
         multiLevel
     >
         <span slot="no-js">Components</span>
-        {% for component in collections['component-examples'] %}
+        {% for componentRoot in collections['component-root'] %}
             <sp-sidenav-item
-                label="{{ component.data.displayName }}"
-                href="{{ component.url }}"
-                value="{{ component.data.componentName }}"
+                label="{{ componentRoot.data.displayName }}"
+                href="{{ componentRoot.url }}"
+                value="{{ componentRoot.data.componentName }}"
+                {% if componentPackage === componentRoot.data.componentName %}expanded{% endif %}
             >
-                <a href="{{ component.url }}" slot="no-js">{{ component.data.displayName }}</a>
+                <a href="{{ componentRoot.url }}" slot="no-js">{{ componentRoot.data.displayName }}</a>
+                {% for componentChild in collections[componentRoot.data.componentName + '-children'] %}
+                    <sp-sidenav-item
+                        label="{{ componentChild.data.displayName }}"
+                        href="{{ componentChild.url }}"
+                        value="{{ componentChild.data.componentName }}"
+                    >
+                        <a href="{{ componentChild.url }}" slot="no-js">{{ componentChild.data.displayName }}</a>
+                    </sp-sidenav-item>
+                {% endfor %}
             </sp-sidenav-item>
         {% endfor %}
     </sp-sidenav-item>

--- a/projects/documentation/content/_includes/partials/sidenav.njk
+++ b/projects/documentation/content/_includes/partials/sidenav.njk
@@ -29,6 +29,7 @@
                 href="{{ componentRoot.url }}"
                 value="{{ componentRoot.data.componentName }}"
                 {% if componentPackage === componentRoot.data.componentName %}expanded{% endif %}
+                {% if value === componentRoot.data.componentName %}autofocus{% endif %}
             >
                 <a href="{{ componentRoot.url }}" slot="no-js">{{ componentRoot.data.displayName }}</a>
                 {% for componentChild in collections[componentRoot.data.componentName + '-children'] %}
@@ -36,6 +37,7 @@
                         label="{{ componentChild.data.displayName }}"
                         href="{{ componentChild.url }}"
                         value="{{ componentChild.data.componentName }}"
+                        {% if value === componentChild.data.componentName %}autofocus{% endif %}
                     >
                         <a href="{{ componentChild.url }}" slot="no-js">{{ componentChild.data.displayName }}</a>
                     </sp-sidenav-item>

--- a/projects/documentation/scripts/component-template-parts.js
+++ b/projects/documentation/scripts/component-template-parts.js
@@ -207,7 +207,9 @@ ${
 export function exampleDestinationTemplate(
     componentName,
     componentHeading,
-    tagType
+    tagType,
+    parent,
+    packageName
 ) {
     return `---
 layout: examples.njk
@@ -215,8 +217,10 @@ title: '${nameToTitle(componentName)}: Spectrum Web Components'
 displayName: ${nameToTitle(componentName)}
 componentName: ${componentName}
 componentHeading: ${componentHeading}
+componentPackage: ${packageName}
 tags:
 - ${tagType}
+- ${parent}
 ---`;
 }
 

--- a/projects/documentation/scripts/copy-component-docs.js
+++ b/projects/documentation/scripts/copy-component-docs.js
@@ -61,10 +61,13 @@ export async function processREADME(mdPath) {
     if (fileName === 'CHANGELOG.md' || /node_modules/.test(mdPath)) {
         return;
     }
+    const packageName = extractPackageNameRegExp.exec(mdPath)[1];
     let componentName =
         fileName !== 'README.md'
             ? fileName.replace('.md', '')
             : extractPackageNameRegExp.exec(mdPath)[1];
+    const parent =
+        fileName === 'README.md' ? 'root' : packageName + '-children';
     let componentHeading = componentName;
     let tag = findDeclaration(
         customElements,
@@ -142,7 +145,9 @@ export async function processREADME(mdPath) {
     const body = fs.readFileSync(mdPath);
     fs.writeFileSync(
         exampleDestinationFile,
-        exampleDestinationTemplate(componentName, componentHeading, tagType)
+        exampleDestinationTemplate(componentName, componentHeading, tagType, 
+            parent,
+            packageName)
     );
     fs.writeFileSync(
         examplePartialFile,

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -367,6 +367,23 @@ sp-sidenav > sp-sidenav-item:not(:defined) > a {
     );
 }
 
+sp-sidenav-item[expanded] > sp-sidenav-item[expanded] > sp-sidenav-item:not(:defined) > a {
+    padding-left: calc(
+        var(
+                --spectrum-sidenav-multilevel-item-indentation-level2,
+                var(--spectrum-global-dimension-size-300)
+            ) +
+            var(
+                --spectrum-sidenav-item-padding-x,
+                var(--spectrum-global-dimension-size-150)
+            )
+    );
+}
+
+sp-sidenav-item:not([expanded], :defined) > sp-sidenav-item {
+    display: none;
+}
+
 sp-sidenav-item:not(:defined) a {
     padding-left: calc(
         var(


### PR DESCRIPTION
## Description
- group multiple docs pages for the same package under the package itself rather than as sibling pages
- autofocus the current page in the SideNav at page load

## Related issue(s)
- fixes #2411

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://docs-groups-autofocus--spectrum-web-components.netlify.app/components/tab/)
    2. See that the `Tab` navigation item is both visible on load and focused
-   [ ] _Test case 2_
    1. Go [here](https://docs-groups-autofocus--spectrum-web-components.netlify.app/components/slider-handle/)
    2. See that the `Slider Handle` navigation is both visible on load and focused

## Screenshots (if appropriate)
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/1156657/213556004-972c2c93-629d-4fd6-a41e-4769d7d61701.png">

## Types of changes
-   [x] Docs

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.