### PR TITLE
fix: ensure "wheel" interactions lead to a "change" event

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -38,6 +38,8 @@ import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevr
 import styles from './number-field.css.js';
 
 export const FRAMES_PER_CHANGE = 5;
+// Debounce duration for inserting a `change` event after a batch of `wheel` originating `input` events.
+export const CHANGE_DEBOUNCE_MS = 100;
 export const indeterminatePlaceholder = '-';
 export const remapMultiByteCharacters: Record<string, string> = {
     '１': '1',
@@ -320,13 +322,12 @@ export class NumberField extends TextfieldBase {
             : event.deltaY / Math.abs(event.deltaY);
         if (direction !== 0 && !isNaN(direction)) {
             this.stepBy(direction * (event.shiftKey ? this.stepModifier : 1));
-            // Dispatch a change event after no new `input` events are queued by `wheel` interactions for 100ms.
             clearTimeout(this.queuedChangeEvent);
             this.queuedChangeEvent = setTimeout(() => {
                 this.dispatchEvent(
                     new Event('change', { bubbles: true, composed: true })
                 );
-            }, 100) as unknown as number;
+            }, CHANGE_DEBOUNCE_MS) as unknown as number;
         }
         this.managedInput = false;
     }

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -310,6 +310,8 @@ export class NumberField extends TextfieldBase {
         }
     }
 
+    private queuedChangeEvent!: number;
+
     protected onScroll(event: WheelEvent): void {
         event.preventDefault();
         this.managedInput = true;
@@ -318,6 +320,13 @@ export class NumberField extends TextfieldBase {
             : event.deltaY / Math.abs(event.deltaY);
         if (direction !== 0 && !isNaN(direction)) {
             this.stepBy(direction * (event.shiftKey ? this.stepModifier : 1));
+            // Dispatch a change event after no new `input` events are queued by `wheel` interactions for 100ms.
+            clearTimeout(this.queuedChangeEvent);
+            this.queuedChangeEvent = setTimeout(() => {
+                this.dispatchEvent(
+                    new Event('change', { bubbles: true, composed: true })
+                );
+            }, 100) as unknown as number;
         }
         this.managedInput = false;
     }

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -31,6 +31,7 @@ import {
 } from '../stories/number-field.stories.js';
 import '@spectrum-web-components/number-field/sp-number-field.js';
 import {
+    CHANGE_DEBOUNCE_MS,
     FRAMES_PER_CHANGE,
     indeterminatePlaceholder,
     NumberField,
@@ -362,7 +363,7 @@ describe('NumberField', () => {
             expect(el.value).to.equal(52);
             expect(inputSpy.callCount).to.equal(2);
             expect(changeSpy.callCount).to.equal(0);
-            await aTimeout(110);
+            await aTimeout(CHANGE_DEBOUNCE_MS + 10);
             expect(inputSpy.callCount).to.equal(2);
             expect(changeSpy.callCount).to.equal(1);
         });

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -11,7 +11,13 @@ governing permissions and limitations under the License.
 */
 
 import { html } from '@spectrum-web-components/base';
-import { elementUpdated, expect, nextFrame, oneEvent } from '@open-wc/testing';
+import {
+    aTimeout,
+    elementUpdated,
+    expect,
+    nextFrame,
+    oneEvent,
+} from '@open-wc/testing';
 import polyfillCheck from '@formatjs/intl-numberformat/should-polyfill.js';
 
 import {
@@ -337,6 +343,28 @@ describe('NumberField', () => {
             el.addEventListener('change', (event: Event) => {
                 changeSpy((event.target as NumberField)?.value);
             });
+        });
+        it('via scroll', async () => {
+            el.focus();
+            await elementUpdated(el);
+            expect(el.focused).to.be.true;
+            el.dispatchEvent(new WheelEvent('wheel', { deltaY: 1 }));
+            await elementUpdated(el);
+            expect(el.formattedValue).to.equal('51');
+            expect(el.valueAsString).to.equal('51');
+            expect(el.value).to.equal(51);
+            expect(inputSpy.callCount).to.equal(1);
+            expect(changeSpy.callCount).to.equal(0);
+            el.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
+            await elementUpdated(el);
+            expect(el.formattedValue).to.equal('52');
+            expect(el.valueAsString).to.equal('52');
+            expect(el.value).to.equal(52);
+            expect(inputSpy.callCount).to.equal(2);
+            expect(changeSpy.callCount).to.equal(0);
+            await aTimeout(110);
+            expect(inputSpy.callCount).to.equal(2);
+            expect(changeSpy.callCount).to.equal(1);
         });
         it('has a useful `value`', async () => {
             el.focus();


### PR DESCRIPTION
## Description
When interacting with a Number Field via the `wheel` event, ensure that a `change` event is dispatched, to ensure batched listening is successful. Do so by waiting 100ms after the last `input` event is fired to fire a `change` event. Timing here seems pretty flexible, and I could be convinced of a shorter debounce, but this feels like a good balance between firing the `change` and not firing it all the time, as the `wheel` event could be stop and start and allows for breaks in the interaction.

## Related issue(s)

- fixes #2867 

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://number-field-change--spectrum-web-components.netlify.app/storybook/index.html?path=/story/number-field--default)
    2. Interact with the Number Field with the `wheel` event
    3. Check the "Actions" Tab in the Storybook interface
    4. See that a large number of `onInput` events are being handled and a smaller number of `onChange` events are being handled.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.