### PR TITLE
Manage Swatch Group selection correction when "selects=single"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c8f0b4b70a5556d5700716a779896174f83a970d
+        default: b6e034b28a383c32eb907260c30e419d02814c43
 commands:
     downstream:
         steps:

--- a/packages/swatch/src/SwatchGroup.ts
+++ b/packages/swatch/src/SwatchGroup.ts
@@ -119,6 +119,10 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
         if (this.selects === 'single') {
             const { target } = event;
             target.tabIndex = 0;
+            target.selected = true;
+            if (this.selectedSet.has(target.value)) {
+                return;
+            }
             this.selectedSet.clear();
             this.selectedSet.add(target.value);
             this.rovingTabindexController.elements.forEach((child) => {

--- a/packages/swatch/stories/swatch-group.stories.ts
+++ b/packages/swatch/stories/swatch-group.stories.ts
@@ -98,7 +98,16 @@ export default {
         },
     },
     decorators: [
-        (story: () => TemplateResult): TemplateResult => html`
+        (
+            story: () => TemplateResult,
+            {
+                args: { selected = [] },
+            }: {
+                args: {
+                    selected: string[];
+                };
+            }
+        ): TemplateResult => html`
             <div
                 @change=${async (event: Event & { target: SwatchGroup }) => {
                     await 0;
@@ -111,7 +120,7 @@ export default {
                 }}
             >
                 ${story()}
-                <div>Selected: []</div>
+                <div>Selected: ${JSON.stringify(selected)}</div>
             </div>
         `,
     ],

--- a/packages/swatch/test/swatch-group.test.ts
+++ b/packages/swatch/test/swatch-group.test.ts
@@ -125,6 +125,12 @@ describe('Swatch Group', () => {
         expect(changeSpy.calledOnce).to.be.true;
         expect(el.selected).to.deep.equal([selectedChild.value]);
         expect(selectedChild.selected).to.be.true;
+
+        selectedChild.click();
+
+        expect(changeSpy.calledOnce).to.be.true;
+        expect(el.selected).to.deep.equal([selectedChild.value]);
+        expect(selectedChild.selected).to.be.true;
     });
     it('can have `change` events prevented', async () => {
         el.selects = 'single';

--- a/test/visual/test.ts
+++ b/test/visual/test.ts
@@ -88,9 +88,12 @@ export const test = (
                     `;
                 const decorate = (
                     story: () => TemplateResult,
-                    decorator: (story: () => TemplateResult) => TemplateResult
+                    decorator: (
+                        story: () => TemplateResult,
+                        { args }: { args: unknown }
+                    ) => TemplateResult
                 ) => {
-                    return () => decorator(story);
+                    return () => decorator(story, { args });
                 };
 
                 while (decorators.length) {


### PR DESCRIPTION
## Description
When `sp-swatch-group` has `selects="single"`, selected `sp-swatch` children no longer loose their selection when being clicked subsequent times.

## Related issue(s)

- fixes #2812

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://swatch-single--spectrum-web-components.netlify.app/storybook/?path=/story/swatch-group--selects-single)
    2. Click `yellow-500`, the selected Swatch
    3. See that the Swatch is not _deselected_ and the `selected` values

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.