### PR TITLE
table: allow resizing of table body

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: b6e034b28a383c32eb907260c30e419d02814c43
+        default: a6ae8ae1670bb58df91000503b5e716d172d14c6
 commands:
     downstream:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a6ae8ae1670bb58df91000503b5e716d172d14c6
+        default: 2b91f1c9e5d8bb6f0997b954a7d33a5e1da83984
 commands:
     downstream:
         steps:

--- a/packages/table/src/table-body.css
+++ b/packages/table/src/table-body.css
@@ -14,6 +14,7 @@ governing permissions and limitations under the License.
 
 :host {
     display: block;
+    flex-grow: 1;
 }
 
 :host(:not([tabindex])) {

--- a/packages/table/stories/table-elements.stories.ts
+++ b/packages/table/stories/table-elements.stories.ts
@@ -59,7 +59,7 @@ export const elements = (): TemplateResult => {
                 <sp-table-head-cell>Column Title</sp-table-head-cell>
                 <sp-table-head-cell>Column Title</sp-table-head-cell>
             </sp-table-head>
-            <sp-table-body style="height: 120px">
+            <sp-table-body style="height: 200px">
                 <sp-table-row value="row1" class="row1">
                     <sp-table-cell>Row Item Alpha</sp-table-cell>
                     <sp-table-cell>Row Item Alpha</sp-table-cell>

--- a/packages/table/stories/table-virtualized.stories.ts
+++ b/packages/table/stories/table-virtualized.stories.ts
@@ -241,7 +241,7 @@ export const virtualizedCustomValue = (args: Properties): TemplateResult => {
         <sp-table
             size="m"
             scroller="true"
-            style="height: 300px"
+            style="height: 200px"
             selects=${args.selects}
             .selected=${args.selected}
             @change=${args.onChange}

--- a/packages/table/stories/table-virtualized.stories.ts
+++ b/packages/table/stories/table-virtualized.stories.ts
@@ -241,7 +241,7 @@ export const virtualizedCustomValue = (args: Properties): TemplateResult => {
         <sp-table
             size="m"
             scroller="true"
-            style="height: 200px"
+            style="height: 300px"
             selects=${args.selects}
             .selected=${args.selected}
             @change=${args.onChange}

--- a/packages/table/stories/table-virtualized.stories.ts
+++ b/packages/table/stories/table-virtualized.stories.ts
@@ -162,7 +162,7 @@ export const virtualizedSingle = (args: Properties): TemplateResult => {
         <sp-table
             size="m"
             scroller="true"
-            style="height: 200px"
+            style="height: 300px"
             selects=${args.selects}
             .selected=${args.selected}
             @change=${({ target }: Event & { target: Table }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
There was a bug that didn't allow the table to be resized past 120px. Adding flex-grow to the CSS file now makes this possible. 

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes https://github.com/adobe/spectrum-web-components/issues/2864

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   Visually tested
- Passes all other tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
