### PR TITLE
test: update smoke test for new content

### DIFF
--- a/projects/documentation/e2e/published.spec.ts
+++ b/projects/documentation/e2e/published.spec.ts
@@ -47,7 +47,7 @@ test.describe('search and go', () => {
     });
 
     test('guide: getting-started', async ({ page }) => {
-        await searchFor('good luck', page);
+        await searchFor('getting started', page);
         await expect(page).toHaveURL(/getting-started/);
     });
 });


### PR DESCRIPTION
Prevent smoke test failures like: https://github.com/adobe/spectrum-web-components/actions/runs/3991273424

We should be able to Smoke Test the preview site to prevent this in the future, but keeping production and preview in sync in a productive way could be trouble.

Searching titles are more resilient, but are technically subject the same in production failures we're seeing right now.