### PR TITLE
fix(tabs): correct indicator size by scaling from 100px

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "test:changed": "node ./tasks/test-changes.js",
         "test:ci": "yarn test:start",
         "test:create": "node test/visual/create.js",
+        "test:errors": "yarn test | grep -A 32 ❌",
         "test:focus": "yarn build && yarn test:ci --coverage --group",
         "test:start": "web-test-runner",
         "test:visual": "yarn test:visual:ci",

--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -110,7 +110,6 @@ governing permissions and limitations under the License.
 :host([direction='vertical-right']) #selection-indicator,
 :host([direction='vertical']) #selection-indicator {
     top: 0;
-    height: 1px;
 }
 
 /* 
@@ -141,13 +140,6 @@ governing permissions and limitations under the License.
         --spectrum-tabs-rule-color,
         var(--spectrum-global-color-gray-200)
     );
-}
-
-/*
- * Power scale based indicator transitions
- */
-:host([dir][direction='horizontal']) #selection-indicator {
-    width: 1px;
 }
 
 :host([dir='rtl'][direction='vertical-right']) #selection-indicator {

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -24,6 +24,7 @@ import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import { TopNavItem } from './TopNavItem.js';
 
 import tabStyles from '@spectrum-web-components/tabs/src/tabs.css.js';
+import { ScaledIndicator } from '@spectrum-web-components/tabs/src/Tabs.js';
 
 const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
 
@@ -37,7 +38,7 @@ const noSelectionStyle = 'transform: translateX(0px) scaleX(0) scaleY(0)';
 
 export class TopNav extends SizedMixin(SpectrumElement) {
     public static override get styles(): CSSResultArray {
-        return [tabStyles];
+        return [tabStyles, ScaledIndicator.baseStyles()];
     }
 
     @property()
@@ -172,12 +173,11 @@ export class TopNav extends SizedMixin(SpectrumElement) {
             selectedItem.updateComplete,
             document.fonts ? document.fonts.ready : Promise.resolve(),
         ]);
-        const itemBoundingClientRect = selectedItem.getBoundingClientRect();
-
-        const width = itemBoundingClientRect.width;
-        const offset = selectedItem.offsetLeft;
-
-        this.selectionIndicatorStyle = `transform: translateX(${offset}px) scaleX(${width});`;
+        const { width } = selectedItem.getBoundingClientRect();
+        this.selectionIndicatorStyle = ScaledIndicator.transformX(
+            selectedItem.offsetLeft,
+            width
+        );
     };
 
     public override connectedCallback(): void {


### PR DESCRIPTION
## Description

Scales tab indicators from a 100px base instead of a 1px base to avoid rounding & rendering errors.

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/2884

## Motivation and context

Fixes a rendering issue in horizontal tabs, vertical tabs, and TopNav.

## How has this been tested?

-   [ ] All automated tests pass
-   [ ] Vertical tabs
    1. Go to https://opensource.adobe.com/spectrum-web-components/components/tabs/#vertical-tabs
    2. Scale your viewport to 140%
    3. Select tabs & see the incorrect indicator sizes
    4. Go to https://hloftis-fix-2884--spectrum-web-components.netlify.app/components/tabs/#vertical-tabs
    5. Scale your viewport to 140%
    6. Select tabs & see the correct indicator sizes
-   [ ] TopNav
    1. Go to https://opensource.adobe.com/spectrum-web-components/storybook/iframe.html?id=top-nav--default&viewMode=story&args=#page-3
    2. Scale your viewport to 140%
    3. Select tabs and see incorrect indicator sizes
    4. Go to https://hloftis-fix-2884--spectrum-web-components.netlify.app/storybook/iframe.html?id=top-nav--default&viewMode=story&args=#page-3
    5. Scale your viewport to 140%
    6. Select tabs & see correct indicator sizes

## Screenshots (if appropriate)

Before:
![image](https://user-images.githubusercontent.com/364501/215576056-112fbc1c-4de8-4806-af74-1742c3a09fb2.png)

After:
![image](https://user-images.githubusercontent.com/364501/215576527-3fdaf475-1bea-4274-80c1-a0681c94640e.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
