### PR TITLE
chore: use latest CSS dependency for dialog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 736cd95e39a2b4879e7cd3af7183d7f79f453b9a
+        default: 5f6b12fd7bdee7ee08c4c8bb4e79153aa7beedc3
 commands:
     downstream:
         steps:

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -83,7 +83,7 @@
         "@spectrum-web-components/underlay": "^0.9.5"
     },
     "devDependencies": {
-        "@spectrum-css/dialog": "^6.0.21"
+        "@spectrum-css/dialog": "^6.0.24"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dialog/src/spectrum-dialog.css
+++ b/packages/dialog/src/spectrum-dialog.css
@@ -158,6 +158,14 @@ governing permissions and limitations under the License.
     );
     width: 100%;
 }
+:host([mode='fullscreen']) slot[name='heading'] + .divider {
+    margin-bottom: calc(
+        var(
+                --spectrum-dialog-confirm-divider-margin-bottom,
+                var(--spectrum-global-dimension-static-size-200)
+            ) - var(--spectrum-dialog-confirm-description-padding) * 2
+    ); /* .spectrum-Dialog--fullscreen .spectrum-Dialog-heading+.spectrum-Dialog-divider */
+}
 :host([no-divider]) .divider {
     display: none; /* .spectrum-Dialog--noDivider .spectrum-Dialog-divider */
 }
@@ -192,7 +200,7 @@ governing permissions and limitations under the License.
     );
     margin: 0 var(--spectrum-dialog-confirm-description-margin);
     overflow-y: auto;
-    padding: 0 var(--spectrum-dialog-confirm-description-padding);
+    padding: calc(var(--spectrum-dialog-confirm-description-padding) * 2);
 }
 .content,
 .footer {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4496,10 +4496,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-4.0.2.tgz#4cb4c614c5e87927ecdf0d91582528f85e05a6e8"
   integrity sha512-suAr8H9b/ALlnGV+wTwvLOWTmHPYcekPHXtCPgUUok2p379suy86+M9Ps0u5t2J4HaZ8FIxMAH4EBewL5oqBMg==
 
-"@spectrum-css/dialog@^6.0.21":
-  version "6.0.21"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.21.tgz#c39b99783cd8959fa2da7e2a56a59905a070bfc3"
-  integrity sha512-40Mb4Z3dW0eXf39qBSQlsJzhMa/ieDfwwthySDKtOe5Fd1nR7SpkhbJfYgf1a7NKu+gVUVMeygLzX3g6o2tYHw==
+"@spectrum-css/dialog@^6.0.24":
+  version "6.0.24"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.24.tgz#7cbe808a16e44d39e7f3cb49e9694be59b0db0f4"
+  integrity sha512-9RL4Qvwqq59OyvRqGBXMqL2vMhphiVMoxUA38+yKHfMIF/44s0rHb5zLzFx+8bK/6+r5Md64XQXPJhIywcB2aA==
 
 "@spectrum-css/divider@^2.0.7":
   version "2.0.7"


### PR DESCRIPTION
## Description
Take latest Spectrum CSS Dialog package. Changes some padding and sizing to allow for content in the dialog to not be clipped.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://dialog-update--spectrum-web-components.netlify.app/storybook/?path=/story/dialog-wrapped--tooltips)
    2. Tab focus the first Button in the Dialog
    3. See that its Focus Ring is not clipped on the top or left edge

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.