### PR TITLE
docs: use correct Button settings within the toast docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 35c7beec74e7ade1972b4a01e18243a09314b386
+        default: 13b4b5eabf22ceb4b58dcefc733b3403e1963966
 commands:
     downstream:
         steps:

--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -37,7 +37,12 @@ import { Toast } from '@spectrum-web-components/toast';
 ```html
 <sp-toast open>
     This is important information that you should read, soon.
-    <sp-button slot="action" variant="overBackground" quiet>
+    <sp-button
+        slot="action"
+        static="white"
+        variant="secondary"
+        treatment="outline"
+    >
         Do something
     </sp-button>
 </sp-toast>
@@ -48,7 +53,12 @@ import { Toast } from '@spectrum-web-components/toast';
 ```html
 <sp-toast open style="width: 300px">
     This is important information that you should read, soon.
-    <sp-button slot="action" variant="overBackground" quiet>
+    <sp-button
+        slot="action"
+        static="white"
+        variant="secondary"
+        treatment="outline"
+    >
         Do something
     </sp-button>
 </sp-toast>

--- a/packages/toast/stories/toast.stories.ts
+++ b/packages/toast/stories/toast.stories.ts
@@ -30,7 +30,14 @@ const toast = ({
         ?open=${open}
     >
         ${content}
-        <sp-button slot="action" variant="overBackground" quiet>Undo</sp-button>
+        <sp-button
+            slot="action"
+            static="white"
+            variant="secondary"
+            treatment="outline"
+        >
+            Undo
+        </sp-button>
     </sp-toast>
 `;
 


### PR DESCRIPTION
## Description
The Core Tokens update moved the `white/black` values out of `variant` and into `static` and this allows for consumption of the Toast pattern to better follow the Spectrum guidelines outlined in https://opensource.adobe.com/spectrum-css/toast.html

## Related issue(s)
- fix #2289

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://toast-buttons--spectrum-web-components.netlify.app/components/toast/#with-actions)
    2. See that the outline of the button is more subdued rather than solid white.

## Screenshots (if appropriate)
<img width="557" alt="image" src="https://user-images.githubusercontent.com/1156657/216187233-6bbdfdaa-f8b4-4149-9cd8-a8b75d51ac67.png">

## Types of changes
-   [ ] Docs

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.