### PR TITLE
Correct Split Button delivery based on new Button tokens.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 13b4b5eabf22ceb4b58dcefc733b3403e1963966
+        default: 4d06352734d3a46c31f6db27fc2c14bb6dfc2670
 commands:
     downstream:
         steps:

--- a/packages/split-button/src/split-button.css
+++ b/packages/split-button/src/split-button.css
@@ -12,18 +12,61 @@ governing permissions and limitations under the License.
 
 @import './spectrum-split-button.css';
 
+#button {
+    --spectrum-splitbutton-flat-edge-padding: calc(
+        var(--spectrum-button-edge-to-text) -
+            var(
+                --spectrum-button-border-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * 2
+    );
+    --spectrum-splitbutton-round-edge-padding: var(
+        --spectrum-button-edge-to-visual,
+        var(--spectrum-global-dimension-size-200)
+    );
+    --spectrum-splitbutton-cta-flat-edge-padding: calc(
+        var(--spectrum-button-edge-to-text) -
+            var(
+                --spectrum-button-border-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * 3
+    );
+}
+
+.trigger {
+    --spectrum-splitbutton-trigger-flat-edge-padding: calc(
+        var(--spectrum-button-edge-to-text) -
+            var(
+                --spectrum-button-border-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * 2
+    );
+    --spectrum-splitbutton-trigger-round-edge-padding: var(
+        --spectrum-button-edge-to-visual,
+        var(--spectrum-global-dimension-size-200)
+    );
+    --spectrum-splitbutton-cta-trigger-flat-edge-padding: calc(
+        var(--spectrum-button-edge-to-text) -
+            var(
+                --spectrum-button-border-width,
+                var(--spectrum-alias-border-size-thick)
+            ) * 3
+    );
+}
+
+:host([dir='ltr']) #button[variant='accent'] {
+    margin-right: var(
+        --spectrum-button-border-width,
+        var(--spectrum-alias-border-size-thick)
+    );
+}
+
 /**
  * Begin workaround for SplitButton not natively supporting t-shirt sizes.
  */
 sp-button {
-    --spectrum-button-m-primary-outline-texticon-border-radius: calc(
-        (
-                var(--spectrum-button-primary-fill-texticon-text-size) *
-                    var(
-                        --spectrum-button-primary-fill-texticon-text-line-height
-                    )
-            ) + var(--spectrum-icon-tshirt-size-height) / 2 +
-            var(--spectrum-alias-border-size-thick)
+    --spectrum-button-m-primary-outline-texticon-border-radius: var(
+        --spectrum-button-border-radius
     );
 }
 


### PR DESCRIPTION
## Description
Split Button relied on some tokens that are no longer available. This updates to the new Button API.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://531befeff6cfbc69aa81fc962fb04b1a--spectrum-web-components.netlify.app/review/#SplitButtonAccentFieldStories/s.png)
    2. See the changes.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.