### PR TITLE
Override errant `inset` rules on Button icons.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 4d06352734d3a46c31f6db27fc2c14bb6dfc2670
+        default: 7fad9526c9afb5acf75bf9ad9c49156475b2efca
 commands:
     downstream:
         steps:

--- a/packages/button/src/button.css
+++ b/packages/button/src/button.css
@@ -81,3 +81,7 @@ governing permissions and limitations under the License.
         border-color: highlight;
     }
 }
+
+::slotted([slot='icon']) {
+    inset: unset;
+}


### PR DESCRIPTION
## Description
Correct the icon position when the icon is a `position`ed element and is effected by `inset` rules.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://b4fb3e0be6d62dce954792067c78fe05--spectrum-web-components.netlify.app/review/)
    2. See diff.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.