### PR TITLE
HOT FIX! Revert faulty button variant management.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 7fad9526c9afb5acf75bf9ad9c49156475b2efca
+        default: 853ba71d77c122a902772153c412861af409aa4c
 commands:
     downstream:
         steps:

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -10,7 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { CSSResultArray, SizedMixin } from '@spectrum-web-components/base';
+import {
+    CSSResultArray,
+    PropertyValues,
+    SizedMixin,
+} from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { StyledButton } from './StyledButton.js';
 import buttonStyles from './button.css.js';
@@ -122,5 +126,12 @@ export class Button extends SizedMixin(StyledButton) {
     @property({ type: Boolean })
     public set quiet(quiet: boolean) {
         this.treatment = quiet ? 'outline' : 'fill';
+    }
+
+    protected override firstUpdated(changes: PropertyValues<this>): void {
+        super.firstUpdated(changes);
+        if (!this.hasAttribute('variant')) {
+            this.setAttribute('variant', this.variant);
+        }
     }
 }

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -130,6 +130,8 @@ export class Button extends SizedMixin(StyledButton) {
 
     protected override firstUpdated(changes: PropertyValues<this>): void {
         super.firstUpdated(changes);
+        // There is no Spectrum design context for an `<sp-button>` without a variant
+        // apply one manually when a consumer has not applied one themselves.
         if (!this.hasAttribute('variant')) {
             this.setAttribute('variant', this.variant);
         }

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -49,6 +49,10 @@ describe('Button', () => {
         expect(el).to.not.be.undefined;
         expect(el.textContent).to.include('Button');
         await expect(el).to.be.accessible();
+
+        // Applies a default variant as an stylable attribute
+        expect(el.variant).to.equal('accent');
+        expect(el.getAttribute('variant')).to.equal('accent');
     });
     it('loads default w/ element content', async () => {
         const el = await fixture<Button>(

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -543,7 +543,7 @@ describe('Button', () => {
             );
 
             await elementUpdated(el);
-            expect(el.hasAttribute('variant')).to.be.false;
+            expect(el.hasAttribute('variant')).to.not.equal('overBackground');
             expect(el.treatment).to.equal('outline');
             expect(el.static).to.equal('white');
         });


### PR DESCRIPTION
## Description
Accidentally removed this functionality as part of last weeks Core Tokens updates for Button 🙈 


## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://2e3cd5a9d50bafd54620be656239428d--spectrum-web-components.netlify.app/review/)
    2. See that all the Buttons go back to `variant="accent"` by default.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.