### PR TITLE
chore(tooltip): update selfManaged story to be open by default

### DIFF
--- a/packages/tooltip/stories/tooltip.stories.ts
+++ b/packages/tooltip/stories/tooltip.stories.ts
@@ -304,6 +304,7 @@ export const overlaidLeft = (): TemplateResult => overlaid('left');
 
 export const selfManaged = ({
     placement,
+    open,
     offset,
     delayed,
 }: Properties): TemplateResult => html`
@@ -315,7 +316,7 @@ export const selfManaged = ({
             placement=${placement}
             offset=${offset}
             ?delayed=${delayed}
-            open
+            open=${open}
         >
             This is a tooltip.
         </sp-tooltip>
@@ -323,6 +324,7 @@ export const selfManaged = ({
 `;
 selfManaged.args = {
     placement: 'top',
+    open: true,
     offset: 6,
     delayed: false,
 };
@@ -337,6 +339,18 @@ selfManaged.argTypes = {
         type: { name: 'number', required: false },
         description:
             'The pixel distance from the parent element to place the tooltip',
+    },
+    open: {
+        name: 'open',
+        type: { name: 'boolean', required: false },
+        description: 'Whether the tooltip is open.',
+        table: {
+            type: { summary: 'boolean' },
+            defaultValue: { summary: false },
+        },
+        control: {
+            type: 'boolean',
+        },
     },
     placement: {
         name: 'placement',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Update the story so that it's open by default so we can compare the VRTs to the new updated tooltip. Also added a control for it in the story. 

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
For overlay v2 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   Ran tests locally
- Checked storybook

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
