### PR TITLE
fix(avatar): ensure there is ALWAYS a focusElement

### DIFF
--- a/packages/avatar/src/Avatar.ts
+++ b/packages/avatar/src/Avatar.ts
@@ -42,7 +42,7 @@ export class Avatar extends LikeAnchor(Focusable) {
     anchorElement!: HTMLAnchorElement;
 
     public override get focusElement(): HTMLElement {
-        return this.anchorElement;
+        return this.anchorElement || this;
     }
 
     @property()

--- a/packages/avatar/test/avatar.test.ts
+++ b/packages/avatar/test/avatar.test.ts
@@ -91,4 +91,24 @@ describe('Avatar', () => {
             : (el.querySelector('img') as HTMLImageElement);
         expect(imageEl.hasAttribute('alt')).to.be.false;
     });
+    it('can receive a `tabindex` without an `href`', async () => {
+        try {
+            const el = await fixture<Avatar>(
+                html`
+                    <sp-avatar
+                        label="Shantanu Narayen"
+                        src="https://place.dog/500/500"
+                        tabindex="0"
+                    ></sp-avatar>
+                `
+            );
+            await elementUpdated(el);
+            const focusEl = el.focusElement;
+            expect(focusEl).to.exist;
+        } catch (error) {
+            expect(() => {
+                throw error;
+            }).to.throw('There should be no error.');
+        }
+    });
 });


### PR DESCRIPTION
## Description
Ensure the "focusable" Avatars resolve a `focusElement` so that they don't throw an error when provided a `tabindex`.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://avatar-error--spectrum-web-components.netlify.app/storybook/?path=/story/avatar--size-100)
    2. Inspect the Avatar
    3. Give it a `tabindex` attribute or `tabIndex` property
    4. See that no errors are thrown.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.