### PR TITLE
docs: use code splitting in the JS output

### DIFF
--- a/projects/documentation/.eleventy.cjs
+++ b/projects/documentation/.eleventy.cjs
@@ -14,12 +14,12 @@ const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 module.exports = function (eleventyConfig) {
     eleventyConfig.addNunjucksGlobal('WATCH_MODE', process.env.WATCH_MODE);
     eleventyConfig.setUseGitIgnore(false);
-    eleventyConfig.addPassthroughCopy('content/favicon.ico');
-    eleventyConfig.addPassthroughCopy('content/favicon.svg');
-    eleventyConfig.addPassthroughCopy('content/404.html');
-    eleventyConfig.addPassthroughCopy('content/serviceWorker.js');
-    eleventyConfig.addPassthroughCopy('content/images/**/*');
-    eleventyConfig.addPassthroughCopy('content/manifest.webmanifest');
+    eleventyConfig.addPassthroughCopy('./content/favicon.ico');
+    eleventyConfig.addPassthroughCopy('./content/favicon.svg');
+    eleventyConfig.addPassthroughCopy('./content/404.html');
+    eleventyConfig.addPassthroughCopy('./content/serviceWorker.js');
+    eleventyConfig.addPassthroughCopy('./content/images/**/*');
+    eleventyConfig.addPassthroughCopy('./content/manifest.webmanifest');
     eleventyConfig.addPassthroughCopy('../src/**/*.css');
     eleventyConfig.addPlugin(syntaxHighlight, {
         init: function ({ Prism }) {

--- a/projects/documentation/scripts/build-ts.js
+++ b/projects/documentation/scripts/build-ts.js
@@ -27,6 +27,7 @@ async function main() {
         format: 'esm',
         target: ['es2020'],
         bundle: true,
+        splitting: true,
         outdir: './_site/src/',
         plugins: [
             litCssPlugin({


### PR DESCRIPTION
## Description
We missed the "code splitting" setting in our transition to `esbuild` and it bloated out first site load on mobile from 58kb to 99.5kb. This puts turns it back on and slims down our first load, again.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://docs-build--spectrum-web-components.netlify.app/)
    2. See the JS that loads when you run the site in Mobile with all _default_ theme options

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.