### PR TITLE
chore: manage deps for build stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
         "@typescript-eslint/eslint-plugin": "^5.35.0",
         "@typescript-eslint/parser": "^5.35.0",
         "@web/dev-server": "^0.1.35",
-        "@web/dev-server-rollup": "^0.3.19",
-        "@web/dev-server-storybook": "^0.5.4",
+        "@web/dev-server-rollup": "^0.3.21",
+        "@web/dev-server-storybook": "^0.6.0",
         "@web/rollup-plugin-copy": "^0.3.0",
         "@web/rollup-plugin-html": "^1.11.0",
         "@web/test-runner": "^0.15.0",
@@ -185,7 +185,7 @@
         "yargs": "^17.2.1"
     },
     "resolutions": {
-        "playwright": "1.30.0"
+        "@web/polyfills-loader": "1.4.1"
     },
     "workspaces": [
         "packages/*",

--- a/projects/example-project-rollup/package.json
+++ b/projects/example-project-rollup/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^18.11.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
-    "@web/dev-server": "^0.1.34",
+    "@web/dev-server": "^0.1.35",
     "concurrently": "^7.0.0",
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5620,10 +5620,22 @@
     rollup "^2.67.0"
     whatwg-url "^11.0.0"
 
-"@web/dev-server-storybook@^0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-storybook/-/dev-server-storybook-0.5.4.tgz#a8baf715d397b1775e4cca15a2eaac61f486db61"
-  integrity sha512-zZg2cRrE9HjObL2rtD+P6OvV0qDcxOkSeY13iLxv938/01vAsNUS8eTvdGi2Hzz+EzxvuM6QitKKlxFGG3rKZw==
+"@web/dev-server-rollup@^0.3.21":
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-rollup/-/dev-server-rollup-0.3.21.tgz#edeecc599970fcc03f6a53fd7c5fdaf01178e88a"
+  integrity sha512-138t+vMFkegRip6Rtlz68Bo5rl984C9c2rLg3dWl9JEEJSQcWgA3iEwXYh4xTc52WjXnM3/LpboAjTYQOMyfrA==
+  dependencies:
+    "@rollup/plugin-node-resolve" "^13.0.4"
+    "@web/dev-server-core" "^0.3.19"
+    nanocolors "^0.2.1"
+    parse5 "^6.0.1"
+    rollup "^2.67.0"
+    whatwg-url "^11.0.0"
+
+"@web/dev-server-storybook@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-storybook/-/dev-server-storybook-0.6.0.tgz#15d9dd58ea27f73a7818e664e362616f531b0ab9"
+  integrity sha512-DiVDO43FbQzib4YfhG3OizWpP4eHql9gzlWRWj8u0ry9o5qf7STom52Q4ETo47jcyIz2FooICaA6oxILUfl5bg==
   dependencies:
     "@babel/core" "^7.16.0"
     "@babel/preset-env" "^7.16.4"
@@ -5644,7 +5656,7 @@
     rollup-plugin-terser "^7.0.2"
     storybook-addon-markdown-docs "^1.0.4"
 
-"@web/dev-server@^0.1.34", "@web/dev-server@^0.1.35":
+"@web/dev-server@^0.1.35":
   version "0.1.35"
   resolved "https://registry.yarnpkg.com/@web/dev-server/-/dev-server-0.1.35.tgz#d845822d7c3c7749adf03f7abac4a69e2a4490cc"
   integrity sha512-E7TSTSFdGPzhkiE3kIVt8i49gsiAYpJIZHzs1vJmVfdt8U4rsmhE+5roezxZo0hkEw4mNsqj9zCc4Dzqy/IFHg==
@@ -5664,7 +5676,7 @@
     open "^8.0.2"
     portfinder "^1.0.32"
 
-"@web/parse5-utils@^1.1.2", "@web/parse5-utils@^1.2.0", "@web/parse5-utils@^1.3.0":
+"@web/parse5-utils@^1.2.0", "@web/parse5-utils@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@web/parse5-utils/-/parse5-utils-1.3.0.tgz#e2e9e98b31a4ca948309f74891bda8d77399f6bd"
   integrity sha512-Pgkx3ECc8EgXSlS5EyrgzSOoUbM6P8OKS471HLAyvOBcP1NCBn0to4RN/OaKASGq8qa3j+lPX9H14uA5AHEnQg==
@@ -5672,23 +5684,28 @@
     "@types/parse5" "^6.0.1"
     parse5 "^6.0.1"
 
-"@web/polyfills-loader@^1.1.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@web/polyfills-loader/-/polyfills-loader-1.1.1.tgz#78aeda1dd4a68316d4c82e45d591fee704e56e03"
-  integrity sha512-FYztGhE0+JdAi7esRMdqzLZ4Q4bnZnkBHWcoqml3F2nJMAupJHuJBVc0Tpc0BgjG/crnF1yf5OtJ0+LroJ0DTw==
+"@web/polyfills-loader@1.4.1", "@web/polyfills-loader@^1.1.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@web/polyfills-loader/-/polyfills-loader-1.4.1.tgz#1e74cc481b1853b3cd1d0ec9d560d8511bd2a145"
+  integrity sha512-3dGhkctHgMJpWQFWpS++ksiEA6F8kiKrY5Ia6F3Vu+oh5UlN+c7QG8WPKIcFR8M7Ec6EofO25JfBybiVUTZ+CQ==
   dependencies:
     "@babel/core" "^7.12.10"
-    "@web/parse5-utils" "^1.1.2"
+    "@web/parse5-utils" "^1.3.0"
+    "@webcomponents/shadycss" "^1.11.0"
     "@webcomponents/webcomponentsjs" "^2.5.0"
     abortcontroller-polyfill "^1.5.0"
+    construct-style-sheets-polyfill "^3.0.5"
     core-js-bundle "^3.8.1"
     dynamic-import-polyfill "^0.1.1"
+    es-module-shims "^1.4.1"
     intersection-observer "^0.12.0"
     parse5 "^6.0.1"
     regenerator-runtime "^0.13.7"
     resize-observer-polyfill "^1.5.1"
+    shady-css-scoped-element "^0.0.2"
     systemjs "^6.8.1"
-    terser "^5.5.1"
+    terser "^5.14.2"
+    urlpattern-polyfill "^6.0.2"
     whatwg-fetch "^3.5.0"
 
 "@web/rollup-plugin-copy@^0.3.0":
@@ -5992,6 +6009,11 @@
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.10.2.tgz#40e03cab6dc5e12f199949ba2b79e02f183d1e7b"
   integrity sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A==
+
+"@webcomponents/shadycss@^1.11.0":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.11.1.tgz#add19d5e0db4a014e143d2278921347dcd8f0a55"
+  integrity sha512-qSok/oMynEgS99wFY5fKT6cR1y64i01RkHGYOspkh2JQsLSM8pjciER+gu3fqTx589y/7LoSuyB5G9Rh7dyXaQ==
 
 "@webcomponents/webcomponentsjs@^2.5.0":
   version "2.5.0"
@@ -8315,6 +8337,11 @@ constantinople@^4.0.1:
   dependencies:
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.1"
+
+construct-style-sheets-polyfill@^3.0.5:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/construct-style-sheets-polyfill/-/construct-style-sheets-polyfill-3.1.0.tgz#c490abd79efdb359fafa62ec14ea55232be0eecf"
+  integrity sha512-HBLKP0chz8BAY6rBdzda11c3wAZeCZ+kIG4weVC2NM3AXzxx09nhe8t0SQNdloAvg5GLuHwq/0SPOOSPvtCcKw==
 
 content-disposition@0.5.4, content-disposition@^0.5.2, content-disposition@^0.5.3, content-disposition@~0.5.2:
   version "0.5.4"
@@ -18111,7 +18138,7 @@ playwright-core@1.30.0:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.30.0.tgz#de987cea2e86669e3b85732d230c277771873285"
   integrity sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==
 
-playwright@1.30.0, playwright@^1.22.2, playwright@^1.30.0:
+playwright@^1.22.2, playwright@^1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.30.0.tgz#b1d7be2d45d97fbb59f829f36f521f12010fe072"
   integrity sha512-ENbW5o75HYB3YhnMTKJLTErIBExrSlX2ZZ1C/FzmHjUYIfxj/UnI+DWpQr992m+OQVSg0rCExAOlRwB+x+yyIg==
@@ -21724,15 +21751,10 @@ systeminformation@^5.3.3:
   resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.9.13.tgz#90aef7cc534027870d2d10fec63580a7a916aff9"
   integrity sha512-AGL34jWboB7bjmNYIcJ5hbYEVYXQuLPbIq7bJg3rJJNHYZvZkQC9hH15KpH9CPg9ZxCsTqAfUNyGMv1jmv78Tw==
 
-systemjs@^6.8.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.10.1.tgz#4a42a9f4ee8dc740c29dc9af631da819ae736c69"
-  integrity sha512-i2HiBOTIsm4GpjpiDHqTscZ/78htyTtdhpcbY2XPbIpsaNDIBA9vtxwIl8kSSnIRO0Zn7SHqvvILu3cMoXQuYw==
-
-systemjs@^6.8.3:
-  version "6.8.3"
-  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.8.3.tgz#67e27f49242e9d81c2b652b204ae54e8bfcc75a3"
-  integrity sha512-UcTY+FEA1B7e+bpJk1TI+a9Na6LG7wFEqW7ED16cLqLuQfI/9Ri0rsXm3tKlIgNoHyLHZycjdAOijzNbzelgwA==
+systemjs@^6.8.1, systemjs@^6.8.3:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/systemjs/-/systemjs-6.13.0.tgz#7b28e74b44352e1650e8652499f42de724c3fc7f"
+  integrity sha512-P3cgh2bpaPvAO2NE3uRp/n6hmk4xPX4DQf+UzTlCAycssKdqhp6hjw+ENWe+aUS7TogKRFtptMosTSFeC6R55g==
 
 table-layout@^1.0.1:
   version "1.0.2"
@@ -21934,10 +21956,20 @@ terser@^4.6.3, terser@^4.8.1:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.0.0, terser@^5.5.1, terser@^5.7.2:
+terser@^5.0.0, terser@^5.7.2:
   version "5.15.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.15.1.tgz#8561af6e0fd6d839669c73b92bdd5777d870ed6c"
   integrity sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.2"
+    acorn "^8.5.0"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
+terser@^5.14.2:
+  version "5.16.4"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.4.tgz#51284b440b93242291a98f2a9903c024cfb70e6e"
+  integrity sha512-5yEGuZ3DZradbogeYQ1NaGz7rXVBDWujWlx1PT8efXO6Txn+eWbfKqB2bTDVmFXmePFkoLU6XI8UektMIEA0ug==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
@@ -22990,6 +23022,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urlpattern-polyfill@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-6.0.2.tgz#a193fe773459865a2a5c93b246bb794b13d07256"
+  integrity sha512-5vZjFlH9ofROmuWmXM9yj2wljYKgWstGwe8YTyiqM7hVum/g9LyCizPZtb3UqsuppVwety9QJmfc42VggLpTgg==
+  dependencies:
+    braces "^3.0.2"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Fix the CI build failure plaguing all of our branches after the Playwright docker image updated its version of Node.