### PR TITLE
chore: patch lru-cache for local testing on ARM based macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,13 @@ The build process compiles `.css` files using PostCSS and wraps them in the `lit
 # Contributing
 
 We'd be very grateful if you contributed to the project! Check out our [contribution guidelines](CONTRIBUTING.md) for more information.
+
+<a name="patches"></a>
+
+<details><summary><strong>Active patches</strong></summary>
+
+### lru-cache
+
+The `lru-cache` leveraged by `@web/dev-server` can interact negatively with ARM based macOS machines causing a critical hang in the cache of transpiled file responses. This only effects development time operations and specifically effects the local test passes. To avoid this `lru-cache@6.0` has been patched to make its `set` method a noop, avoiding the caching process all together.
+
+</details>

--- a/patches/lru-cache+6.0.0.patch
+++ b/patches/lru-cache+6.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/lru-cache/index.js b/node_modules/lru-cache/index.js
+index 573b6b8..6d47439 100644
+--- a/node_modules/lru-cache/index.js
++++ b/node_modules/lru-cache/index.js
+@@ -151,6 +151,8 @@ class LRUCache {
+   }
+ 
+   set (key, value, maxAge) {
++    return;
++    
+     maxAge = maxAge || this[MAX_AGE]
+ 
+     if (maxAge && typeof maxAge !== 'number')


### PR DESCRIPTION
## Description
Apply a noop patch to the `set` method of the `lru-cache` package so that `@web/dev-server` won't hang when `@web/test-runner` is leveraged on ARM based macOS.

## How has this been tested?
-   [ ] _Test case 1_
    1. Clone locally on an ARM based mac.
    2. Run tests
    3. See that they finish without hanging (failure in at least one Firefox test locally is not unexpected 😬)

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.