### PR TITLE
fix(link): add the missing quiet property to Link component

### DIFF
--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -23,7 +23,6 @@ import linkStyles from './link.css.js';
 /**
  * @element sp-link
  *
- * @attr quiet - uses quiet styles or not
  * @attr over-background - uses over background styles or not
  */
 export class Link extends LikeAnchor(Focusable) {
@@ -39,6 +38,12 @@ export class Link extends LikeAnchor(Focusable) {
 
     @property({ type: String, reflect: true })
     public static: 'black' | 'white' | undefined;
+
+    /**
+     * Uses quiet styles or not
+     */
+    @property({ type: Boolean, reflect: true, attribute: 'quiet' })
+    public quiet = false;
 
     public override get focusElement(): HTMLElement {
         return this.anchorElement;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Missing type definition for `quiet` property in Link component cause typescript compile error

## Related issue(s)

N/A

## Motivation and context

User need type definition to use `quiet` property of Link component in a typescript project.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)
Current API:
<img width="961" alt="image" src="https://user-images.githubusercontent.com/1207520/222799277-6852ecf8-f3fc-4766-a975-45dbf926d6b9.png">

API doc change after this PR:
 
<img width="962" alt="image" src="https://user-images.githubusercontent.com/1207520/222799433-3b61b902-0cb0-4061-a9cf-2a2af847c63f.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
