### PR TITLE
test: add unit test pass to CI with --enable-experimental-web-platform-features flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,22 @@ jobs:
                   name: Are there changes?
                   command: git diff --exit-code
 
+    test-chromium-flags:
+        executor: node
+
+        steps:
+            - downstream
+            - run:
+                  name: Run tests
+                  command: yarn test:ci --config web-test-runner.config.ci-chromium-flags.js --group unit
+            - store_test_results:
+                  path: /root/project/results/
+            - store_artifacts:
+                  path: coverage
+            - run:
+                  name: Are there changes?
+                  command: git diff --exit-code
+
     test-firefox:
         executor: node
 
@@ -286,6 +302,7 @@ workflows:
     build:
         jobs:
             - test-chromium
+            - test-chromium-flags
             - test-firefox
             - test-webkit
             - hcm-visual:

--- a/web-test-runner.config.ci-chromium-flags.js
+++ b/web-test-runner.config.ci-chromium-flags.js
@@ -1,0 +1,17 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { chromiumWithFlags } from './web-test-runner.utils.js';
+import standard from './web-test-runner.config.ci.js';
+
+standard.browsers = [chromiumWithFlags];
+
+export default standard;

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -23,6 +23,17 @@ export const chromium = playwrightLauncher({
         }),
 });
 
+export const chromiumWithFlags = playwrightLauncher({
+    product: 'chromium',
+    launchOptions: {
+        args: ['--enable-experimental-web-platform-features'],
+    },
+    createBrowserContext: ({ browser }) =>
+        browser.newContext({
+            ignoreHTTPSErrors: true,
+        }),
+});
+
 export const firefox = playwrightLauncher({
     product: 'firefox',
     createBrowserContext: ({ browser }) =>


### PR DESCRIPTION
## Description
Add speculative unit testing to CI in advance of leveraging experimental features in the Overlay API rewrite.

## How has this been tested?
-   [ ] _Test case 1_
    1. It's tests: https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/14797/workflows/27d26608-26a0-4a51-bbf4-7f95c8929a48/jobs/287465
    2. They ran without failing

## Types of changes
-   [x] Tests

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.