### PR TITLE
docs: sequester themeing from main UI in mobile

### DIFF
--- a/projects/documentation/src/components/layout.css
+++ b/projects/documentation/src/components/layout.css
@@ -88,6 +88,7 @@ docs-side-nav:not(:defined) {
     display: grid;
     grid-template-columns: auto auto;
     justify-content: flex-end;
+    min-height: 52px;
 }
 
 .theme-control {
@@ -124,11 +125,12 @@ header {
     display: flex;
     flex-direction: row;
     align-items: center;
+    justify-content: space-between;
     background-color: var(--spectrum-global-color-gray-50);
     top: 0px;
     right: 0px;
     left: 0px;
-    padding-left: 8px;
+    padding-inline: 8px;
     z-index: 1;
 
     --spectrum-actionbutton-height: var(--spectrum-global-dimension-size-500);
@@ -143,12 +145,8 @@ header svg {
     height: 100%;
 }
 
-:host([dir='ltr']) .theme-control {
-    margin-left: var(--spectrum-global-dimension-size-400);
-}
-
-:host([dir='rtl']) .theme-control {
-    margin-right: var(--spectrum-global-dimension-size-400);
+.theme-control {
+    margin-inline-start: var(--spectrum-global-dimension-size-400);
 }
 
 sp-field-label:not(:defined) {
@@ -238,4 +236,51 @@ sp-picker:not(:defined) sp-menu-item {
 
 #logo span {
     white-space: nowrap;
+}
+
+aside {
+    display: flex;
+    flex-direction: column;
+    max-height: 100vh;
+    height: 100vh;
+    overflow: auto;
+    position: fixed;
+    z-index: 10;
+    top: 0;
+    right: 0;
+    background-color: var(--spectrum-global-color-gray-75);
+    width: var(--spectrum-global-dimension-size-2400);
+    transition: transform
+        var(
+            --spectrum-dialog-confirm-background-entry-animation-duration,
+            var(--spectrum-global-animation-duration-600)
+        )
+        cubic-bezier(0, 0, 0.4, 1);
+}
+
+aside .manage-theme {
+    flex-direction: column;
+    display: flex;
+    padding: 0px 24px 24px;
+}
+
+.scrim {
+    z-index: 10;
+    touch-action: none;
+    position: fixed;
+}
+
+aside header {
+    background: none;
+    border-color: transparent;
+    padding-inline: 8px;
+    justify-content: end;
+}
+
+aside .theme-control {
+    margin: 0 0 var(--spectrum-spacing-300);
+}
+
+aside:not(.show) {
+    transform: translateX(100%);
 }

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -28,16 +28,15 @@ import type {
     Theme,
     ThemeVariant,
 } from '@spectrum-web-components/theme';
-import '@spectrum-web-components/picker/sp-picker.js';
 import type { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
-import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/link/sp-link.js';
 import '@spectrum-web-components/divider/sp-divider.js';
 import '@spectrum-web-components/toast/sp-toast.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 
 import type { SideNav } from './side-nav.js';
 import './adobe-logo.js';
@@ -165,6 +164,9 @@ export class LayoutElement extends LitElement {
     @property({ type: Boolean })
     public open = false;
 
+    @property({ type: Boolean })
+    public settings = false;
+
     @property({ type: Boolean, attribute: false })
     private isNarrow = isNarrowMediaQuery.matches;
 
@@ -193,6 +195,10 @@ export class LayoutElement extends LitElement {
 
     toggleNav() {
         this.open = !this.open;
+    }
+
+    toggleSettings() {
+        this.settings = !this.settings;
     }
 
     private updateColor(event: Event) {
@@ -309,6 +315,32 @@ export class LayoutElement extends LitElement {
         `;
     }
 
+    private get settingsContent(): TemplateResult {
+        if (this.settings || !this.isNarrow) {
+            import('./settings.js');
+        }
+        return html`
+            <sp-underlay
+                class="scrim"
+                ?open=${this.settings}
+                @click=${this.toggleSettings}
+                ?hidden=${!this.isNarrow}
+            ></sp-underlay>
+            <aside class=${this.settings ? 'show' : ''}>
+                <header>
+                    <sp-action-button
+                        quiet
+                        label="Cloase Navigation"
+                        @click=${this.toggleSettings}
+                    >
+                        <sp-icon-close slot="icon"></sp-icon-close>
+                    </sp-action-button>
+                </header>
+                ${this.manageTheme}
+            </aside>
+        `;
+    }
+
     private get manageTheme(): TemplateResult {
         return html`
             <div class="manage-theme">
@@ -400,18 +432,28 @@ export class LayoutElement extends LitElement {
                                       slot="icon"
                                   ></sp-icon-show-menu>
                               </sp-action-button>
+
+                              <sp-action-button
+                                  quiet
+                                  label="Open Settings"
+                                  @click=${this.toggleSettings}
+                              >
+                                  <sp-icon-settings
+                                      slot="icon"
+                                  ></sp-icon-settings>
+                              </sp-action-button>
                           </header>
                       `
                     : html``}
                 <div id="body">
-                    ${this.sideNav}
+                    ${this.sideNav} ${this.settingsContent}
                     <div
                         id="page"
                         ?inert=${this.isNarrow && this.open}
                         @alert=${this.addAlert}
                         @copy-text=${this.copyText}
                     >
-                        ${this.manageTheme}
+                        ${!this.isNarrow ? this.manageTheme : ''}
                         <slot></slot>
                     </div>
                 </div>

--- a/projects/documentation/src/components/settings.ts
+++ b/projects/documentation/src/components/settings.ts
@@ -1,0 +1,16 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/field-label/sp-field-label.js';
+import '@spectrum-web-components/picker/sp-picker.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
+import '@spectrum-web-components/underlay/sp-underlay.js';

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -68,7 +68,7 @@ body {
         right: 0;
         min-height: 100vh;
         box-sizing: border-box;
-        padding: 96px 0 24px
+        padding: 92px 0 24px
             calc(var(--spectrum-global-dimension-size-2400) + 48px);
         background: linear-gradient(
             to right,
@@ -120,7 +120,7 @@ body {
 @media screen and (max-width: 960px) {
     docs-page:not(:defined) {
         display: block;
-        padding: 114px var(--spectrum-global-dimension-size-300) 24px;
+        padding: 71px var(--spectrum-global-dimension-size-300) 24px;
         overflow: hidden;
     }
 
@@ -128,7 +128,7 @@ body {
         content: '';
         position: absolute;
         width: 100%;
-        top: 48px;
+        top: 60px;
         border-bottom: 1px solid var(--spectrum-global-color-gray-200);
         left: 0;
     }
@@ -159,12 +159,6 @@ body {
 @media screen and (max-width: 500px) {
     sp-sidenav:not(:defined) {
         column-count: 2;
-    }
-}
-
-@media screen and (max-width: 458px) {
-    docs-page:not(:defined) {
-        padding: 212px var(--spectrum-global-dimension-size-300) 24px;
     }
 }
 


### PR DESCRIPTION
## Description
Require even less JS over the wire for the initial page load/render by moving theme options into a right side nav.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://docs-mobile--spectrum-web-components.netlify.app/)
    2. Size the browser from large to small and see that the layout works in a predictable way at all width.
    3. Visit in an incognito window with the dev tools set to "mobile" so you get the default mobile view on a clean cache
    4. Open the options panel on the left and see that you can change the theme settings.

<img src="https://user-images.githubusercontent.com/1156657/223857711-76fab928-6899-4d86-b4e7-7c0ccda6856c.png" alt="SWC home page on mobile" width="40%" /><img src="https://user-images.githubusercontent.com/1156657/223857751-d2568158-9c25-4c25-ad01-0ecb70cfc05b.png" alt="SWC home page with settings pane open on mobile" width="40%" />


## Types of changes
-   [x] Docs

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.