### PR TITLE
docs: use sp-table in docs site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 2d6b428b63f1fba174f51beb71263062c1c344a8
+        default: d2746808ec5d8b4bb93c07288caced6a356f1b1b
 commands:
     downstream:
         steps:

--- a/packages/table/src/table-row.css
+++ b/packages/table/src/table-row.css
@@ -16,3 +16,7 @@ governing permissions and limitations under the License.
     display: flex;
     width: 100%;
 }
+
+:host(:last-of-type) {
+    border-bottom: none;
+}

--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -22,7 +22,6 @@
         "watch": "yarn serve --watch"
     },
     "dependencies": {
-        "@spectrum-css/table": "^4.0.26",
         "@spectrum-web-components/bundle": "^0.29.2",
         "@spectrum-web-components/custom-vars-viewer": "^0.0.1"
     },
@@ -195,7 +194,8 @@
             "files": [
                 "../../packages/**/*.md",
                 "../../tools/**/*.md",
-                "scripts/copy-component-docs.js"
+                "scripts/copy-component-docs.js",
+                "scripts/component-template-parts.js"
             ],
             "clean": "if-file-deleted",
             "output": [

--- a/projects/documentation/scripts/component-template-parts.js
+++ b/projects/documentation/scripts/component-template-parts.js
@@ -48,45 +48,49 @@ function buildTable(title, rowData, headings, cells, copyData) {
 ### ${title}
 
 <div class="table-container">
-<table class="spectrum-Table spectrum-Table--sizeM">
-<thead class="spectrum-Table-head">
-<tr>
+<sp-table size="m" class="${title.toLowerCase()}">
+<sp-table-head>
 ${headings
     .map(
         (heading) => `
-<th class="spectrum-Table-headCell">
+${
+    heading === 'Description'
+        ? `<sp-table-head-cell class="${title} description">`
+        : `<sp-table-head-cell>`
+}
 ${heading}
-</th>
+</sp-table-head-cell>
 `
     )
     .join('')}
-</tr>
-</thead>
-<tbody class="spectrum-Table-body">
+</sp-table-head>
+<sp-table-body>
 ${rowData
     .sort(sortByName)
     .map(
         (property) => `
-<tr class="spectrum-Table-row" id="${title.toLowerCase()}_${
-            property.name
-        }" data-name="${copyData.name}" data-value="${copyData.value(
-            property
-        )}">
+<sp-table-row id="${title.toLowerCase()}_${property.name}" data-name="${
+            copyData.name
+        }" data-value="${copyData.value(property)}">
 ${cells
     .map(
-        (cell) => `
-<td class="spectrum-Table-cell">
+        (cell, index) => `
+${
+    headings[index] === 'Description'
+        ? `<sp-table-cell class="${title} description">`
+        : `<sp-table-cell>`
+}
 ${encodeCodeWrappedHTML(cell(property))}
-</td>
+</sp-table-cell>
 `
     )
     .join('')}
-</tr>
+</sp-table-row>
 `
     )
     .join('')}
-</tbody>
-</table>
+</sp-table-body>
+</sp-table>
 </div>
     `;
 }

--- a/projects/documentation/src/components.ts
+++ b/projects/documentation/src/components.ts
@@ -34,6 +34,13 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-save-floppy.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-stopwatch.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-user-activity.js';
+import '@spectrum-web-components/table/sp-table.js';
+import '@spectrum-web-components/table/sp-table-body.js';
+import '@spectrum-web-components/table/sp-table-cell.js';
+import '@spectrum-web-components/table/sp-table-checkbox-cell.js';
+import '@spectrum-web-components/table/sp-table-head.js';
+import '@spectrum-web-components/table/sp-table-head-cell.js';
+import '@spectrum-web-components/table/sp-table-row.js';
 
 if ('requestIdleCallback' in window) {
     requestIdleCallback(() => {
@@ -81,7 +88,9 @@ document
     ?.addEventListener('click', (event: Event) => {
         const path = event.composedPath();
         const row = path.find(
-            (el) => (el as Element).localName === 'tr' && (el as Element).id
+            (el) =>
+                (el as Element).localName === 'sp-table-row' &&
+                (el as Element).id
         ) as HTMLElement;
         if (row) {
             location.hash = row.id;

--- a/projects/documentation/src/components/layout.css
+++ b/projects/documentation/src/components/layout.css
@@ -12,11 +12,15 @@ governing permissions and limitations under the License.
 
 :host {
     display: block;
+    min-height: 100vh;
+    min-height: 100dvh;
 }
 
 #app {
     width: 100%;
     height: 100%;
+    min-height: 100vh;
+    min-height: 100dvh;
     display: flex;
     flex-direction: column;
 }

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -16,7 +16,6 @@ governing permissions and limitations under the License.
 @import '@spectrum-web-components/styles/tokens/spectrum/custom-vars.css';
 @import '@spectrum-web-components/styles/fonts.css';
 @import '@spectrum-web-components/styles/typography.css';
-@import '@spectrum-css/table/dist/index-vars.css';
 
 @import '@spectrum-web-components/styles/scale-medium.css' screen and
         (min-width: 701px) and (min-height: 701px),
@@ -445,6 +444,36 @@ sp-divider[size='s']:not(:defined) {
     box-sizing: border-box;
 }
 
+@media screen and (max-width: 1100px) {
+    .feature {
+        flex: 0 1 calc(50% - 30px);
+    }
+
+    .feature:first-of-type {
+        flex-basis: 100%;
+    }
+}
+
+@media screen and (max-width: 960px) {
+    .feature {
+        flex: 0 1 calc(33.33% - 30px);
+    }
+
+    .feature:first-of-type {
+        flex: 0 1 calc(33.33% - 30px);
+    }
+}
+
+@media screen and (max-width: 725px) {
+    .feature {
+        flex: 0 1 calc(50% - 30px);
+    }
+
+    .feature:first-of-type {
+        flex-basis: 100%;
+    }
+}
+
 @media screen and (max-width: 525px) {
     .feature {
         flex: 0 1 100%;
@@ -492,11 +521,13 @@ article {
     margin-bottom: 3em;
 }
 
-.spectrum-Table {
-    width: 100%;
+.table-container > sp-table-body,
+.table-container > sp-table-header {
+    overflow: visible;
+    min-width: max-content;
 }
 
-.spectrum-Table-body {
+.table-container > sp-table-body {
     --spectrum-table-row-background-color: var(--spectrum-global-color-gray-75);
 }
 
@@ -505,13 +536,42 @@ article {
     margin: 0 calc(-1 * var(--spectrum-global-dimension-size-700));
 }
 
-.table-container > table {
-    padding: 0 var(--spectrum-global-dimension-size-700);
+.table-container > sp-table {
     max-width: 1080px;
+    width: min-content;
+    padding: 0 var(--spectrum-global-dimension-size-700);
+    box-sizing: border-box;
+    align-items: stretch;
+    min-width: 100%;
 }
 
-.spectrum-Table {
-    min-width: 100%;
+.table-container sp-table-cell,
+.table-container sp-table-head-cell {
+    box-sizing: border-box;
+    word-break: break-word;
+    min-width: var(--spectrum-global-dimension-size-1250);
+}
+
+sp-table.attributes sp-table-cell,
+sp-table.attributes sp-table-head-cell {
+    flex: 0 0 17%;
+}
+
+sp-table .description {
+    min-width: var(--spectrum-global-dimension-size-1600);
+}
+
+sp-table.attributes .description {
+    flex: 1 1 25%;
+}
+
+sp-table.slots .description,
+sp-table.custom .description {
+    flex: 0 1 65%;
+}
+
+sp-table.events .description {
+    flex: 0 1 40%;
 }
 
 @media screen and (max-width: 960px) {
@@ -520,7 +580,7 @@ article {
         margin: 0 -16px;
     }
 
-    .table-container > table {
+    .table-container > sp-table {
         padding: 0 16px;
     }
 }


### PR DESCRIPTION
## Description
Dog food the `<sp-table>` elements in the API tables for the docs site.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://docs-api-2--spectrum-web-components.netlify.app/)
    2. Visit your favorite component
    3. Checkout it's API table
    4. Scale the width of the browser up and down.
    5. See that content can always be viewed, whether by default or by horizontal scroll.
    6. Confirm that forced line breaks are not overly distracting from API communication

## Types of changes
-   [x] Docs and self component usage

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.