### PR TITLE
perf: accept new Spectrum CSS featuring simpler DOM structure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 46c860cf036161f43b5726702bd831fce66cbf74
+        default: 2c1c1730876c03b12caf73edf03b9e45e70fff2e
 commands:
     downstream:
         steps:

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -60,10 +60,11 @@
         "@spectrum-web-components/base": "^0.7.4",
         "@spectrum-web-components/button": "^0.20.2",
         "@spectrum-web-components/icon": "^0.12.8",
-        "@spectrum-web-components/icons-ui": "^0.9.9"
+        "@spectrum-web-components/icons-ui": "^0.9.9",
+        "@spectrum-web-components/shared": "^0.15.5"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^3.0.11"
+        "@spectrum-css/actionbutton": "^3.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -53,7 +53,7 @@ export class ActionButton extends SizedMixin(ButtonBase, {
     validSizes: ['xs', 's', 'm', 'l', 'xl'],
 }) {
     public static override get styles(): CSSResultArray {
-        return [buttonStyles, cornerTriangleStyles];
+        return [...super.styles, buttonStyles, cornerTriangleStyles];
     }
 
     @property({ type: Boolean, reflect: true })

--- a/packages/action-button/src/action-button.css
+++ b/packages/action-button/src/action-button.css
@@ -12,31 +12,8 @@ governing permissions and limitations under the License.
 
 @import './spectrum-action-button.css';
 
-:host {
-    display: inline-flex;
-    flex-direction: row;
-}
-
-:host([disabled]) {
-    pointer-events: none;
-    cursor: auto;
-}
-
-:host([dir]) {
-    /* spectrum-css uses "-webkit-appearance: button" to workaround an
-     * iOS and Safari issue. However, it results in incorrect styling
-     * when applied in :host
-     */
-    -webkit-appearance: none; /* stylelint-disable-line */
-}
-
 ::slotted([slot='icon']) {
     flex-shrink: 0;
-}
-
-#button {
-    position: absolute;
-    inset: 0;
 }
 
 #label {
@@ -47,80 +24,6 @@ governing permissions and limitations under the License.
 :host([size='xs']) {
     /* Work around non-square icon only Action Buttons in Spectrum CSS */
     min-width: var(--spectrum-actionbutton-height, 0);
-
-    /* Pass t-shirt sizing to icons within the XS-sized Action Button */
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-xs
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-xs
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-75
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-75
-    );
-}
-
-:host([size='s']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-s
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-s
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-75
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-75
-    );
-}
-
-:host([size='m']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-m
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-m
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-100
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-100
-    );
-}
-
-:host([size='l']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-l
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-l
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-200
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-200
-    );
-}
-
-:host([size='xl']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-xl
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-xl
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-300
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-300
-    );
 }
 
 @media (forced-colors: active) {

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -20,12 +20,12 @@ governing permissions and limitations under the License.
     box-sizing: border-box;
     cursor: pointer;
     display: inline-flex;
-    font-family: var(--mod-font-family-base, var(--spectrum-font-family-base));
-    justify-content: center;
-    line-height: var(
-        --mod-line-height-small,
-        var(--spectrum-line-height-small)
+    font-family: var(
+        --mod-sans-font-family-stack,
+        var(--spectrum-sans-font-family-stack)
     );
+    justify-content: center;
+    line-height: var(--mod-line-height-100, var(--spectrum-line-height-100));
     margin: 0;
     overflow: visible;
     text-decoration: none;
@@ -280,16 +280,26 @@ governing permissions and limitations under the License.
             var(--spectrum-actionbutton-content-color-default)
         )
     );
+    gap: calc(
+        var(
+                --mod-actionbutton-text-to-visual,
+                var(--spectrum-actionbutton-text-to-visual)
+            ) +
+            var(
+                --mod-actionbutton-edge-to-text,
+                var(--spectrum-actionbutton-edge-to-text)
+            ) -
+            var(
+                --mod-actionbutton-edge-to-visual-only,
+                var(--spectrum-actionbutton-edge-to-visual-only)
+            )
+    );
     height: var(--mod-actionbutton-height, var(--spectrum-actionbutton-height));
     min-inline-size: var(
         --mod-actionbutton-min-width,
         var(--spectrum-actionbutton-min-width)
     );
-    padding-inline-end: var(
-        --mod-actionbutton-edge-to-text,
-        var(--spectrum-actionbutton-edge-to-text)
-    );
-    padding-inline-start: var(
+    padding-inline: var(
         --mod-actionbutton-edge-to-text,
         var(--spectrum-actionbutton-edge-to-text)
     );
@@ -416,67 +426,42 @@ governing permissions and limitations under the License.
         --mod-actionbutton-icon-size,
         var(--spectrum-actionbutton-icon-size)
     );
-    margin-inline-start: calc(
-        (
-                var(
-                        --mod-actionbutton-edge-to-text,
-                        var(--spectrum-actionbutton-edge-to-text)
-                    ) -
-                    var(
-                        --mod-actionbutton-edge-to-visual,
-                        var(--spectrum-actionbutton-edge-to-visual)
-                    )
-            ) * -1
+    margin-inline-end: calc(
+        var(
+                --mod-actionbutton-edge-to-visual-only,
+                var(--spectrum-actionbutton-edge-to-visual-only)
+            ) -
+            var(
+                --mod-actionbutton-edge-to-text,
+                var(--spectrum-actionbutton-edge-to-text)
+            )
     );
-    padding-inline-start: calc(
-        (
-                var(
-                        --mod-actionbutton-edge-to-text,
-                        var(--spectrum-actionbutton-edge-to-text)
-                    ) -
-                    var(
-                        --mod-actionbutton-edge-to-visual,
-                        var(--spectrum-actionbutton-edge-to-visual)
-                    )
-            ) * -1
+    margin-inline-start: calc(
+        var(
+                --mod-actionbutton-edge-to-visual,
+                var(--spectrum-actionbutton-edge-to-visual)
+            ) -
+            var(
+                --mod-actionbutton-edge-to-text,
+                var(--spectrum-actionbutton-edge-to-text)
+            )
     );
     width: var(
         --mod-actionbutton-icon-size,
         var(--spectrum-actionbutton-icon-size)
     );
 }
-[name='icon'] + #label {
-    padding-inline-end: 0;
-    padding-inline-start: var(
-        --mod-actionbutton-text-to-visual,
-        var(--spectrum-actionbutton-text-to-visual)
-    );
-}
 .hold-affordance + ::slotted([slot='icon']),
 [icon-only]::slotted([slot='icon']) {
-    margin-inline-end: calc(
-        (
-                var(
-                        --mod-actionbutton-edge-to-text,
-                        var(--spectrum-actionbutton-edge-to-text)
-                    ) -
-                    var(
-                        --mod-actionbutton-edge-to-visual-only,
-                        var(--spectrum-actionbutton-edge-to-visual-only)
-                    )
-            ) * -1
-    );
     margin-inline-start: calc(
-        (
-                var(
-                        --mod-actionbutton-edge-to-text,
-                        var(--spectrum-actionbutton-edge-to-text)
-                    ) -
-                    var(
-                        --mod-actionbutton-edge-to-visual-only,
-                        var(--spectrum-actionbutton-edge-to-visual-only)
-                    )
-            ) * -1
+        var(
+                --mod-actionbutton-edge-to-visual-only,
+                var(--spectrum-actionbutton-edge-to-visual-only)
+            ) -
+            var(
+                --mod-actionbutton-edge-to-text,
+                var(--spectrum-actionbutton-edge-to-text)
+            )
     );
 }
 #label {

--- a/packages/action-button/test/benchmark/basic-test.ts
+++ b/packages/action-button/test/benchmark/basic-test.ts
@@ -11,9 +11,20 @@ governing permissions and limitations under the License.
 */
 
 import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
 import { html } from 'lit';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
-    <sp-action-button open></sp-action-button>
+    <sp-action-button>Edit</sp-action-button>
+    <sp-action-button>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+        Edit
+    </sp-action-button>
+    <sp-action-button>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
+    <sp-action-button hold-affordance>
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
 `);

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -90,7 +90,7 @@
         "@spectrum-web-components/shared": "^0.15.5"
     },
     "devDependencies": {
-        "@spectrum-css/button": "^9.0.0"
+        "@spectrum-css/button": "^9.0.8"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -16,7 +16,7 @@ import {
     SizedMixin,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
-import { StyledButton } from './StyledButton.js';
+import { ButtonBase } from './ButtonBase.js';
 import buttonStyles from './button.css.js';
 
 export type DeprecatedButtonVariants = 'cta' | 'overBackground';
@@ -46,7 +46,7 @@ export type ButtonTreatments = 'fill' | 'outline';
  * @slot - text label of the Button
  * @slot icon - The icon to use for Button
  */
-export class Button extends SizedMixin(StyledButton) {
+export class Button extends SizedMixin(ButtonBase) {
     public static override get styles(): CSSResultArray {
         return [...super.styles, buttonStyles];
     }

--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import {
+    CSSResultArray,
     html,
     PropertyValues,
     TemplateResult,
@@ -21,20 +22,16 @@ import {
 } from '@spectrum-web-components/base/src/decorators.js';
 import { LikeAnchor } from '@spectrum-web-components/shared/src/like-anchor.js';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
-import {
-    ObserveSlotPresence,
-    ObserveSlotText,
-} from '@spectrum-web-components/shared';
+import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
+import buttonStyles from './button-base.css.js';
 
 /**
  * @slot - text content to be displayed in the Button element
  * @slot icon - icon element(s) to display at the start of the button
  */
-export class ButtonBase extends LikeAnchor(
-    ObserveSlotText(ObserveSlotPresence(Focusable, '[slot="icon"]'))
-) {
-    protected get hasIcon(): boolean {
-        return this.slotContentIsPresent;
+export class ButtonBase extends ObserveSlotText(LikeAnchor(Focusable)) {
+    public static override get styles(): CSSResultArray {
+        return [buttonStyles];
     }
 
     @property({ type: Boolean, reflect: true })
@@ -43,10 +40,6 @@ export class ButtonBase extends LikeAnchor(
     @property({ type: String })
     public type: 'button' | 'submit' | 'reset' = 'button';
 
-    protected get hasLabel(): boolean {
-        return this.slotHasContent;
-    }
-
     @query('.anchor')
     private anchorElement!: HTMLButtonElement;
 
@@ -54,19 +47,21 @@ export class ButtonBase extends LikeAnchor(
         return this;
     }
 
+    protected get hasLabel(): boolean {
+        return this.slotHasContent;
+    }
+
     protected get buttonContent(): TemplateResult[] {
         const content = [
             html`
-                <span id="label" ?hidden=${!this.hasLabel}>
+                <slot name="icon" ?icon-only=${!this.hasLabel}></slot>
+            `,
+            html`
+                <span id="label">
                     <slot @slotchange=${this.manageTextObservedSlot}></slot>
                 </span>
             `,
         ];
-        if (this.hasIcon) {
-            content.unshift(html`
-                <slot name="icon" ?icon-only=${!this.hasLabel}></slot>
-            `);
-        }
         return content;
     }
 

--- a/packages/button/src/StyledButton.ts
+++ b/packages/button/src/StyledButton.ts
@@ -10,12 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { CSSResultArray } from '@spectrum-web-components/base';
 import { ButtonBase } from './ButtonBase.js';
-import buttonStyles from './button-base.css.js';
 
-export class StyledButton extends ButtonBase {
-    public static override get styles(): CSSResultArray {
-        return [buttonStyles];
-    }
-}
+export class StyledButton extends ButtonBase {}

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -52,3 +52,67 @@ slot[name='icon']::slotted(img) {
         var(--spectrum-global-dimension-size-225)
     );
 }
+
+[icon-only] + #label {
+    display: none;
+}
+
+:host([size='s']) {
+    --spectrum-icon-tshirt-size-height: var(
+        --spectrum-alias-workflow-icon-size-s
+    );
+    --spectrum-icon-tshirt-size-width: var(
+        --spectrum-alias-workflow-icon-size-s
+    );
+    --spectrum-ui-icon-tshirt-size-height: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-75
+    );
+    --spectrum-ui-icon-tshirt-size-width: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-75
+    );
+}
+
+:host([size='m']) {
+    --spectrum-icon-tshirt-size-height: var(
+        --spectrum-alias-workflow-icon-size-m
+    );
+    --spectrum-icon-tshirt-size-width: var(
+        --spectrum-alias-workflow-icon-size-m
+    );
+    --spectrum-ui-icon-tshirt-size-height: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-100
+    );
+    --spectrum-ui-icon-tshirt-size-width: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-100
+    );
+}
+
+:host([size='l']) {
+    --spectrum-icon-tshirt-size-height: var(
+        --spectrum-alias-workflow-icon-size-l
+    );
+    --spectrum-icon-tshirt-size-width: var(
+        --spectrum-alias-workflow-icon-size-l
+    );
+    --spectrum-ui-icon-tshirt-size-height: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-200
+    );
+    --spectrum-ui-icon-tshirt-size-width: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-200
+    );
+}
+
+:host([size='xl']) {
+    --spectrum-icon-tshirt-size-height: var(
+        --spectrum-alias-workflow-icon-size-xl
+    );
+    --spectrum-icon-tshirt-size-width: var(
+        --spectrum-alias-workflow-icon-size-xl
+    );
+    --spectrum-ui-icon-tshirt-size-height: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-300
+    );
+    --spectrum-ui-icon-tshirt-size-width: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-300
+    );
+}

--- a/packages/button/src/button.css
+++ b/packages/button/src/button.css
@@ -12,66 +12,6 @@ governing permissions and limitations under the License.
 
 @import './spectrum-button.css';
 
-:host([size='s']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-s
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-s
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-75
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-75
-    );
-}
-
-:host([size='m']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-m
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-m
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-100
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-100
-    );
-}
-
-:host([size='l']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-l
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-l
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-200
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-200
-    );
-}
-
-:host([size='xl']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-xl
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-xl
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-300
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-300
-    );
-}
-
 @media (forced-colors: active) {
     :host([treatment][disabled]) {
         border-color: graytext;

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -221,7 +221,6 @@ governing permissions and limitations under the License.
     );
 }
 :host {
-    block-size: auto;
     border-radius: var(
         --mod-button-border-radius,
         var(--spectrum-button-border-radius)
@@ -234,28 +233,20 @@ governing permissions and limitations under the License.
     color: inherit;
     font-size: var(--mod-button-font-size, var(--spectrum-button-font-size));
     font-weight: var(--mod-bold-font-weight, var(--spectrum-bold-font-weight));
+    gap: var(
+        --mod-button-padding-label-to-icon,
+        var(--spectrum-button-padding-label-to-icon)
+    );
     height: var(--mod-button-height, var(--spectrum-button-height));
-    min-block-size: var(
-        --mod-button-min-width,
-        var(--spectrum-button-min-width)
-    );
-    min-block-size: var(
-        --mod-spectrum-button-height,
-        var(--spectrum-button-height)
-    );
+    min-block-size: var(--mod-button-height, var(--spectrum-button-height));
     min-inline-size: var(
         --mod-button-min-width,
         var(--spectrum-button-min-width)
     );
-    min-width: var(--mod-button-min-width, var(--spectrum-button-min-width));
     padding-block: 0;
-    padding-inline-end: var(
+    padding-inline: var(
         --mod-button-edge-to-text,
         var(--spectrum-button-edge-to-text)
-    );
-    padding-inline-start: var(
-        --mod-button-edge-to-visual,
-        var(--spectrum-button-edge-to-visual)
     );
     position: relative;
 }
@@ -265,26 +256,9 @@ governing permissions and limitations under the License.
 }
 ::slotted([slot='icon']) {
     color: inherit;
-    inset-block-end: calc(
-        var(
-                --mod-spectrum-button-edge-to-visual,
-                var(--spectrum-button-edge-to-visual)
-            ) -
-            var(--mod-button-border-width, var(--spectrum-button-border-width))
-    );
-    inset-inline-end: calc(
-        var(
-                --mod-spectrum-button-edge-to-visual,
-                var(--spectrum-button-edge-to-visual)
-            ) -
-            var(--mod-button-border-width, var(--spectrum-button-border-width))
-    );
-}
-[name='icon'] + #label {
-    padding-inline-end: 0;
-    padding-inline-start: var(
-        --mod-button-padding-label-to-icon,
-        var(--spectrum-button-padding-label-to-icon)
+    margin-inline-start: calc(
+        var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) -
+            var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text))
     );
 }
 :host:after {
@@ -294,14 +268,23 @@ governing permissions and limitations under the License.
     );
 }
 #label {
-    padding-block-end: var(
-        --mod-button-padding-label-bottom,
-        var(--spectrum-button-padding-label-bottom)
+    align-self: start;
+    line-height: var(--spectrum-line-height-100);
+    padding-block-end: calc(
+        var(
+                --mod-button-padding-label-bottom,
+                var(--spectrum-button-padding-label-bottom)
+            ) -
+            var(--mod-button-border-width, var(--spectrum-button-border-width))
     );
-    padding-block-start: var(
-        --mod-button-padding-label-top,
-        var(--spectrum-button-padding-label-top)
+    padding-block-start: calc(
+        var(
+                --mod-button-padding-label-top,
+                var(--spectrum-button-padding-label-top)
+            ) -
+            var(--mod-button-border-width, var(--spectrum-button-border-width))
     );
+    white-space: nowrap;
 }
 :host(.focus-visible):after,
 :host([focused]):after {
@@ -548,7 +531,7 @@ governing permissions and limitations under the License.
                 --mod-button-focus-ring-thickness,
                 var(--spectrum-button-focus-ring-thickness)
             )
-            ButtonTExt;
+            ButtonText;
         forced-color-adjust: none;
     }
     :host(:focus-visible):after {
@@ -557,7 +540,7 @@ governing permissions and limitations under the License.
                 --mod-button-focus-ring-thickness,
                 var(--spectrum-button-focus-ring-thickness)
             )
-            ButtonTExt;
+            ButtonText;
         forced-color-adjust: none;
     }
     :host([variant='accent'][treatment='fill']) {

--- a/packages/button/test/benchmark/test-basic.ts
+++ b/packages/button/test/benchmark/test-basic.ts
@@ -11,9 +11,15 @@ governing permissions and limitations under the License.
 */
 
 import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-help.js';
 import { html } from 'lit';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
-    <sp-button>Click me</sp-button>
+    <sp-button>Click Me</sp-button>
+    <sp-button disabled>Click Me</sp-button>
+    <sp-button>
+        <sp-icon-help slot="icon"></sp-icon-help>
+        Click Me
+    </sp-button>
 `);

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -166,10 +166,11 @@ export class SplitButton extends SizedMixin(PickerBase) {
                                   class="icon ${chevronClass[
                                       this.size as DefaultElementSize
                                   ]}"
+                                  slot="icon"
                               ></sp-icon-chevron100>
                           `
                         : html`
-                              <sp-icon-more class="icon"></sp-icon-more>
+                              <sp-icon-more></sp-icon-more>
                           `}
                 </sp-button>
             `,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4187,10 +4187,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-4.0.1.tgz#8742808a9334484896d7f47700a9544d444a41bc"
   integrity sha512-s97vdrYNN5LhilNeirs6Xox05VZazjTNSb+qrtItowdfHEw3XbzCs8n0AdHgMSZkezL9z6B/BojeOo7fIGWbdw==
 
-"@spectrum-css/actionbutton@^3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-3.0.11.tgz#acf083b8e1d54d249870bf275481126e0c21701c"
-  integrity sha512-oRWZcqtmq5A58xb+W4KWvQEhmW2aXlLwt3Qt5m9eSmO44E0o0oi7gGah4KgvZs6m929oZaEIrW7E4Y64nKFu5g==
+"@spectrum-css/actionbutton@^3.0.20":
+  version "3.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-3.0.20.tgz#bb84c5596854518b4148d51489827b85a95d78ee"
+  integrity sha512-gGy8tNVfRCSCY0yMePzxqlBIVT5/xiG624hkuxcqrT9b4PbPxkMmFeUovcNQyjusZxrBq/WtiLVpKPqqHUm58g==
 
 "@spectrum-css/actiongroup@^3.0.12":
   version "3.0.12"
@@ -4222,10 +4222,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-3.0.0-beta.2.tgz#df448a3dcb8ac63448bd628843a2895cec305780"
   integrity sha512-NqrT03ItWzj+L0dtqjedhop6wKOspBmaowzp9IOY/2kL561kRqYTLKR9vTteZ3cEDVD3ajKA8y+bKIW0eN+X7A==
 
-"@spectrum-css/button@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-9.0.0.tgz#bdbae6e3c7e478ab8509695b09786f9637be130e"
-  integrity sha512-8sbe+lCMkMBcJdKu1knIUme1rSU8u+RHyOUiiu921Jl69Gt3ydTk5mjQRuytWtU2FgVIAAkSRVaJ8x+JRHwCRg==
+"@spectrum-css/button@^9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-9.0.8.tgz#f9ca097f978c4059c32e20264c0c1bfa49a68ca0"
+  integrity sha512-lUTJTg5JzvOYLSHEGOpFK9DKojtc6hWpCrJX5PACgwvgkyJ5JOjxmpK10SSyFQtAwFnDHjlzwSBNGdNaxEW0ug==
 
 "@spectrum-css/buttongroup@^6.0.14":
   version "6.0.14"


### PR DESCRIPTION
## Description
Didn't actually need to be on the new processing, as no selectors were effected, but this update accepts a refactor of the Spectrum CSS output to allow for Button and Action Button to require less JS intervention in their layout increasing their render performance.

## Related issue(s)

- closes #2914 
- fixes #2975

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://lightning-buttons--spectrum-web-components.netlify.app/storybook/?path=/story/action-button-static-black-quiet--xl)
    2. See that Action Buttons display as before
-   [ ] _Test case 2_
    1. Go [here](https://lightning-buttons--spectrum-web-components.netlify.app/storybook/?path=/story/button-accent-fill--default)
    2. See that Buttons display as before

## Types of changes
-   [ ] Performance refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.