### PR TITLE
fix(textfield): minlength now accepted as minimum length for value.toString

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -314,7 +314,7 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
             }
             if (typeof this.minlength !== 'undefined') {
                 validity =
-                    validity && this.value.toString().length > this.minlength;
+                    validity && this.value.toString().length >= this.minlength;
             }
             this.valid = validity;
             this.invalid = !validity;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Textfield with the required property with value lengths === minlength are now correctly validated.

## Related issue(s)

https://github.com/adobe/spectrum-web-components/issues/3013

## Motivation and context

Fixes the bug described in the above-mentioned issue.

## How has this been tested?

No further testing.
I couldn't get repository to work. I tried on Linux, Windows and WSL. If an additional test is required, I currently cannot provide.

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
