### PR TITLE
fix: sets action-menu quiet to false by default, fixes #3040

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 2dbdd52d58095177457928aa96a394428c980acd
+        default: 46c860cf036161f43b5726702bd831fce66cbf74
 commands:
     downstream:
         steps:

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -62,7 +62,7 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
     protected override render(): TemplateResult {
         return html`
             <sp-action-button
-                quiet
+                ?quiet=${this.quiet}
                 ?selected=${this.open}
                 aria-haspopup="true"
                 aria-controls="popover"
@@ -85,7 +85,6 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
         if (changedProperties.has('invalid')) {
             this.invalid = false;
         }
-        this.quiet = true;
         super.update(changedProperties);
     }
 }

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -57,11 +57,24 @@ export default {
             },
             control: 'text',
         },
+        quiet: {
+            name: 'quiet',
+            type: { name: 'boolean', required: false },
+            description: 'Quiet rendering',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
     },
     args: {
         visibleLabel: 'More Actions',
         disabled: false,
         open: false,
+        quiet: false,
     },
 };
 
@@ -72,12 +85,18 @@ interface StoryArgs {
     customIcon?: string | TemplateResult;
     selects?: 'single';
     selected?: boolean;
+    quiet?: boolean;
 }
 
 const Template = (args: StoryArgs = {}): TemplateResult =>
     ActionMenuMarkup(args);
 
 export const Default = (args: StoryArgs = {}): TemplateResult => Template(args);
+
+export const quiet = (args: StoryArgs = {}): TemplateResult => Template(args);
+quiet.args = {
+    quiet: true,
+};
 
 export const selects = (args: StoryArgs = {}): TemplateResult =>
     Template({

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -21,6 +21,7 @@ export const ActionMenuMarkup = ({
     changeHandler = (() => undefined) as (event: Event) => void,
     disabled = false,
     open = false,
+    quiet = false,
     visibleLabel = '',
     customIcon = '' as string | TemplateResult,
     size = 'm' as 'm' | 's' | 'l' | 'xl' | 'xxl',
@@ -32,6 +33,7 @@ export const ActionMenuMarkup = ({
             label=${ariaLabel}
             ?disabled=${disabled}
             ?open=${open}
+            ?quiet=${quiet}
             size=${size}
             @change="${changeHandler}"
             .selects=${selects ? selects : undefined}

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -220,13 +220,13 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             expect(el.open).to.be.false;
             expect(changeSpy.callCount).to.equal(0);
         });
-        it('stays `quiet`', async () => {
+        it('can be `quiet`', async () => {
             const el = await actionMenuFixture();
             await elementUpdated(el);
 
-            expect(el.quiet).to.be.true;
+            expect(el.quiet).to.be.false;
 
-            el.quiet = false;
+            el.quiet = true;
             await elementUpdated(el);
 
             expect(el.quiet).to.be.true;

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -107,7 +107,7 @@ Cards can be supplied an `actions` via a names slot.
         alt="Demo Image"
     />
     <div slot="footer">Footer</div>
-    <sp-action-menu slot="actions" placement="bottom-end">
+    <sp-action-menu slot="actions" placement="bottom-end" quiet>
         <sp-menu-item>Deselect</sp-menu-item>
         <sp-menu-item>Select Inverse</sp-menu-item>
         <sp-menu-item>Feather...</sp-menu-item>
@@ -181,7 +181,7 @@ Quiet cards will also accept `actions` via a named slot.
     <sp-card variant="quiet" heading="Card Heading" subheading="JPG Photo">
         <img alt="" slot="preview" src="https://picsum.photos/200/300" />
         <div slot="description">10/15/18</div>
-        <sp-action-menu slot="actions" placement="bottom-end">
+        <sp-action-menu slot="actions" placement="bottom-end" quiet>
             <sp-menu-item>Deselect</sp-menu-item>
             <sp-menu-item>Select Inverse</sp-menu-item>
             <sp-menu-item>Feather...</sp-menu-item>
@@ -264,7 +264,7 @@ Or a `quiet` card:
     >
         <img src="https://picsum.photos/110" alt="Demo Image" slot="preview" />
         <div slot="footer">Footer</div>
-        <sp-action-menu slot="actions" placement="bottom-end">
+        <sp-action-menu slot="actions" placement="bottom-end" quiet>
             <sp-menu-item>Deselect</sp-menu-item>
             <sp-menu-item>Select Inverse</sp-menu-item>
             <sp-menu-item>Feather...</sp-menu-item>

--- a/packages/card/stories/card.stories.ts
+++ b/packages/card/stories/card.stories.ts
@@ -95,7 +95,7 @@ export const href = (args: StoryArgs): TemplateResult => {
                 Footer with a
                 <sp-link href="https://google.com">link to Google</sp-link>
             </div>
-            <sp-action-menu slot="actions" placement="bottom-end">
+            <sp-action-menu slot="actions" placement="bottom-end" quiet>
                 <sp-menu-item>Deselect</sp-menu-item>
                 <sp-menu-item>Select Inverse</sp-menu-item>
                 <sp-menu-item>Feather...</sp-menu-item>
@@ -122,7 +122,7 @@ export const actions = (args: StoryArgs): TemplateResult => {
         >
             <img slot="cover-photo" src=${portrait} alt="Demo Graphic" />
             <div slot="footer">Footer</div>
-            <sp-action-menu slot="actions" placement="bottom-end">
+            <sp-action-menu slot="actions" placement="bottom-end" quiet>
                 <sp-menu-item>Deselect</sp-menu-item>
                 <sp-menu-item>Select Inverse</sp-menu-item>
                 <sp-menu-item>Feather...</sp-menu-item>
@@ -233,7 +233,7 @@ export const quietActions = (args: StoryArgs): TemplateResult => {
             >
                 <img src=${portrait} alt="Demo Graphic" slot="preview" />
                 <div slot="description">10/15/18</div>
-                <sp-action-menu slot="actions" placement="bottom-end">
+                <sp-action-menu slot="actions" placement="bottom-end" quiet>
                     <sp-menu-item>Deselect</sp-menu-item>
                     <sp-menu-item>Select Inverse</sp-menu-item>
                     <sp-menu-item>Feather...</sp-menu-item>
@@ -326,7 +326,7 @@ export const smallQuiet = (args: StoryArgs): TemplateResult => {
             >
                 <img src=${portrait} alt="Demo Graphic" slot="preview" />
                 <div slot="footer">Footer</div>
-                <sp-action-menu slot="actions" placement="bottom-end">
+                <sp-action-menu slot="actions" placement="bottom-end" quiet>
                     <sp-menu-item>Deselect</sp-menu-item>
                     <sp-menu-item>Select Inverse</sp-menu-item>
                     <sp-menu-item>Feather...</sp-menu-item>
@@ -369,7 +369,7 @@ export const SlottedHeading = (args: StoryArgs): TemplateResult => {
                 quiet
             ></sp-textfield>
             <div slot="subheading">Last modified on 6/17/2020, 3:37 PM</div>
-            <sp-action-menu slot="actions" placement="bottom-end">
+            <sp-action-menu slot="actions" placement="bottom-end" quiet>
                 <sp-menu-item>Deselect</sp-menu-item>
                 <sp-menu-item>Select Inverse</sp-menu-item>
                 <sp-menu-item>Feather...</sp-menu-item>

--- a/packages/card/test/card.test.ts
+++ b/packages/card/test/card.test.ts
@@ -108,6 +108,7 @@ describe('card', () => {
                         slot="actions"
                         placement="bottom-end"
                         label="More Actions"
+                        quiet
                     >
                         <sp-menu>
                             <sp-menu-item>Deselect</sp-menu-item>

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -360,9 +360,6 @@ export class PickerBase extends SizedMixin(Focusable) {
             popover.style.setProperty('--swc-menu-width', `100%`);
             return;
         }
-        if (this.quiet) return;
-        // only use `this.offsetWidth` when Standard variant
-        popover.style.setProperty('min-width', `${this.offsetWidth}px`);
     }
 
     private async closeMenu(): Promise<void> {
@@ -635,6 +632,14 @@ export class PickerBase extends SizedMixin(Focusable) {
 export class Picker extends PickerBase {
     public static override get styles(): CSSResultArray {
         return [pickerStyles, chevronStyles];
+    }
+
+    protected override sizePopover(popover: HTMLElement): void {
+        super.sizePopover(popover);
+
+        if (this.quiet) return;
+        // only use `this.offsetWidth` when Standard variant
+        popover.style.setProperty('min-width', `${this.offsetWidth}px`);
     }
 
     protected override onKeydown = (event: KeyboardEvent): void => {

--- a/packages/top-nav/README.md
+++ b/packages/top-nav/README.md
@@ -40,6 +40,7 @@ import { TopNav, TopNavItem } from '@spectrum-web-components/top-nav';
         label="Account"
         placement="bottom-end"
         style="margin-inline-start: auto;"
+        quiet
     >
         <sp-menu-item>Account Settings</sp-menu-item>
         <sp-menu-item>My Profile</sp-menu-item>

--- a/packages/top-nav/stories/top-nav.stories.ts
+++ b/packages/top-nav/stories/top-nav.stories.ts
@@ -45,7 +45,11 @@ export const Default = (): TemplateResult => {
             <sp-top-nav-item href="#page-4">
                 Page with Really Long Name
             </sp-top-nav-item>
-            <sp-action-menu label="Account" style="margin-inline-start: auto;">
+            <sp-action-menu
+                label="Account"
+                style="margin-inline-start: auto;"
+                quiet
+            >
                 <sp-icon-settings slot="icon"></sp-icon-settings>
                 <sp-menu-item>Account Settings</sp-menu-item>
                 <sp-menu-item>My Profile</sp-menu-item>
@@ -77,7 +81,11 @@ export const Selected = (): TemplateResult => {
             <sp-top-nav-item href="#page-4">
                 Page with Really Long Name
             </sp-top-nav-item>
-            <sp-action-menu label="Account" style="margin-inline-start: auto;">
+            <sp-action-menu
+                label="Account"
+                style="margin-inline-start: auto;"
+                quiet
+            >
                 <sp-icon-settings slot="icon"></sp-icon-settings>
                 <sp-menu-item>Account Settings</sp-menu-item>
                 <sp-menu-item>My Profile</sp-menu-item>
@@ -108,7 +116,7 @@ class WrappedTopNav extends HTMLElement {
                 <sp-top-nav-item href="#page-4" autofocus>
                     Page with Really Long Name
                 </sp-top-nav-item>
-                <sp-action-menu label="Account" style="margin-inline-start: auto;">
+                <sp-action-menu label="Account" style="margin-inline-start: auto;" quiet>
                     <sp-icon-settings slot="icon"></sp-icon-settings>
                     <sp-menu-item>Account Settings</sp-menu-item>
                     <sp-menu-item>My Profile</sp-menu-item>
@@ -155,7 +163,7 @@ export const Modes = (): TemplateResult => {
                 <sp-action-button label="Link">
                     <sp-icon-link slot="icon"></sp-icon-link>
                 </sp-action-button>
-                <sp-action-menu label="User">
+                <sp-action-menu label="User" quiet>
                     <sp-avatar
                         slot="icon"
                         label="User avatar"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Modified `PickerBase` to no longer force divergent behavior on `quiet` attribute in `sizePopover`, moved this logic down into `Picker`.
* Modified `ActionMenu` to reflect its `quiet` property down onto the internal action-button, and no longer force its value to true.

NOTE: This is a breaking change, as the default behavior for `sp-action-menu` will now be noisy rathern than quiet.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

Fixes #3040 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
