### PR TITLE
docs: update release process to include steps for SWC React Wrappers

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -13,7 +13,14 @@ Users with permissions in the `@spectrum-web-components` organization on NPM can
     - Changes to the _major_ versions number are likely to point to undesired version numbers.
     - Changes to the _minor_ or _feature_ version number should be confirmed as correct against the changes that have been made since the last release.
 9. `Y` to confirm.
-10. Enter 2-factor authentication for npm.
+10. Enter one time password for npm.
+11. After the SWC packages are released, the React Wrapper packages will be generated. This multi-phase approach ensure that the wrapped packages share the same version as the standard packages.
+12. Scan the version summary for any unexpected changes.
+    - The versions _should_ be the same as those that just we applied to their matched SWC packages.
+    - Changes to the _major_ versions number are likely to point to undesired version numbers.
+    - Changes to the _minor_ or _feature_ version number should be confirmed as correct against the changes that have been made since the last release.
+13. `Y` to confirm.
+14. Enter a new one time password for npm.
 
 The docs site will publish automatically if the `#publish` string is included in the commit message and the check suite runs successfully.
 


### PR DESCRIPTION
Update release process documentation to support publishing the React Wrappers with the _SAME_ version string as their associated SWC packages.