### PR TITLE
fix(theme): stop language resolution propagation and demo using local languages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 94dfba954194a51d22abb150393ec0e5ac0a1a66
+        default: 262d30ff1a03288e249023672d704b0f232d6646
 commands:
     downstream:
         steps:

--- a/packages/number-field/stories/number-field.stories.ts
+++ b/packages/number-field/stories/number-field.stories.ts
@@ -255,6 +255,31 @@ decimals.args = {
     value: 19.274,
 };
 
+export const germanDecimals = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-field-label for="decimals">
+            Enter a number with visible decimals
+        </sp-field-label>
+        <sp-theme lang="de">
+            <sp-number-field
+                id="decimals"
+                style="width: 200px"
+                ...=${spreadProps(args)}
+                @change=${args.onChange}
+                .formatOptions=${{
+                    signDisplay: 'exceptZero',
+                    minimumFractionDigits: 1,
+                    maximumFractionDigits: 2,
+                } as unknown as Intl.NumberFormatOptions}
+            ></sp-number-field>
+        </sp-theme>
+    `;
+};
+
+germanDecimals.args = {
+    value: 19.274,
+};
+
 export const percents = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <sp-field-label for="percents">Enter a percentage</sp-field-label>

--- a/tools/theme/src/Theme.ts
+++ b/tools/theme/src/Theme.ts
@@ -523,6 +523,7 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
     }
 
     private _handleContextPresence(event: CustomEvent<ProvideLang>): void {
+        event.stopPropagation();
         const target = event.composedPath()[0] as HTMLElement;
         if (this._contextConsumers.has(target)) {
             return;


### PR DESCRIPTION
## Description
- `stopPropagation()` on language context events
- demo using local language data on individual components

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://local-custom-lang--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--german-decimals)
    2. See that the decimal is `,` because German
-   [ ] _Test case 2_
    1. Go [here](https://local-custom-lang--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--german-decimals)
    2. Find the `<sp-theme>` wrapping the `<sp-number-field>`
    3. Find the `lang` to `en-US`
    4. See that the decimal is `.` because English

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.