### PR TITLE
fix(radio): initialize the radiogroup component correctly

### DIFF
--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -104,9 +104,7 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
                 const selectedRadio = this.querySelector(
                     `sp-radio[value="${this.selected}"]`
                 ) as Radio;
-                if (!selectedRadio) {
-                    this.selected = '';
-                } else {
+                if (selectedRadio) {
                     selectedRadio.checked = true;
                 }
             }

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -637,7 +637,7 @@ describe('Radio Group', () => {
 });
 
 describe('Radio Group - late children', () => {
-    it.only('accepts frame late children', async () => {
+    it('accepts frame late children', async () => {
         const test = await fixture(html`
             <div>
                 <sp-radio value="first">Bulbasaur</sp-radio>

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -638,6 +638,12 @@ describe('Radio Group', () => {
 
 describe('Radio Group - late children', () => {
     it('accepts frame late children', async () => {
+        /**
+         * In some cases (e.g. when wrapped in React components) will cause otherwise standard looking
+         * DOM structures to add `<sp-radio>` children to `<sp-radio-group>` parents in a non-syncronous manner.
+         * 
+         * This test emulates that render process to ensure that validation will still work as expect in that context.
+         */
         const test = await fixture(html`
             <div>
                 <sp-radio value="first">Bulbasaur</sp-radio>

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -13,7 +13,13 @@ governing permissions and limitations under the License.
 import '@spectrum-web-components/radio/sp-radio-group.js';
 import '@spectrum-web-components/radio/sp-radio.js';
 import { Radio, RadioGroup } from '@spectrum-web-components/radio';
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    html,
+    nextFrame,
+} from '@open-wc/testing';
 import {
     arrowDownEvent,
     arrowLeftEvent,
@@ -627,5 +633,31 @@ describe('Radio Group', () => {
         charmander.click();
 
         expect(changeSpy.calledWith(undefined)).to.be.false;
+    });
+});
+
+describe('Radio Group - late children', () => {
+    it.only('accepts frame late children', async () => {
+        const test = await fixture(html`
+            <div>
+                <sp-radio value="first">Bulbasaur</sp-radio>
+                <sp-radio value="second">Squirtle</sp-radio>
+                <sp-radio value="third">Charmander</sp-radio>
+                <sp-radio value="fourth">Other</sp-radio>
+            </div>
+        `);
+        const group = document.createElement('sp-radio-group');
+        const buttons = [...test.querySelectorAll('sp-radio')] as Radio[];
+
+        test.append(group);
+        group.selected = 'first';
+        Promise.resolve().then(function () {
+            group.append(...buttons);
+        });
+        await nextFrame();
+        await nextFrame();
+
+        expect(group.buttons.length).to.equal(4);
+        expect(group.selected).to.equal('first');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR proposes a fix for issue #3074, where the RadioGroup component's 'selected' property does not work correctly when used in a React application with a React wrapper.

After analyzing the code, it appears that the following lines can be removed, as the same logic is covered by the subsequent validateRadios() function call:
```
if (!selectedRadio) {
    this.selected = '';
} else {
```
Removing these lines should improve the accuracy of the DOM query within validateRadios(), as it ensures that updateComplete has occurred. This change aims to resolve the issue with the initial state of the default selected radio button when using the RadioGroup component with a React wrapper in a React application.
## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
