### PR TITLE
refactor(picker): extract state icon logic, so that it can be overwritten

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -386,6 +386,15 @@ export class PickerBase extends SizedMixin(Focusable) {
         `;
     }
 
+    protected renderStateIcon(): TemplateResult | typeof nothing {
+        if (!this.invalid) {
+            return nothing;
+        }
+        return html`
+            <sp-icon-alert class="validation-icon"></sp-icon-alert>
+        `;
+    }
+
     protected get buttonContent(): TemplateResult[] {
         const labelClasses = {
             'visually-hidden': this.icons === 'only' && !!this.value,
@@ -399,13 +408,7 @@ export class PickerBase extends SizedMixin(Focusable) {
                 <span id="label" class=${classMap(labelClasses)}>
                     ${this.renderLabelContent(this.selectedItemContent.content)}
                 </span>
-                ${this.invalid
-                    ? html`
-                          <sp-icon-alert
-                              class="validation-icon"
-                          ></sp-icon-alert>
-                      `
-                    : nothing}
+                ${this.renderStateIcon()}
                 <sp-icon-chevron100
                     class="picker ${chevronClass[
                         this.size as DefaultElementSize


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We need to add a loading spinner inside the picker's button, which is not supported right now. There is an invalid icon supported and we can extract that logic in a separate method, which can be overwritten from outside. This way, the component's API and DOM structure isn't changed, but the consumers gain more flexibility.

What we have now (in render):
```
${this.invalid
        ? html`
              <sp-icon-alert
                  class="validation-icon"
              ></sp-icon-alert>
          `
        : nothing}
```

The more flexible version:
```
protected renderStateIcon(): TemplateResult | typeof nothing {
    if (!this.invalid) {
        return nothing;
    }
    return html`
        <sp-icon-alert class="validation-icon"></sp-icon-alert>
    `;
}
```
In render:
`${this.renderStateIcon()}`

<!--- Describe your changes in detail -->

## Related issue(s)
<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/3076

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In one of Adobe's projects, we need to support the loading spinner inside the picker's button.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

It's just a refactor, the behavior should be the same and the tests should work as before.

## Screenshots (if appropriate)

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)
-   [x] Refactor (non-breaking change which changes the structure of the code)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
