### PR TITLE
docs: ensure that subpages for tools packages are included

### DIFF
--- a/projects/documentation/.eleventy.cjs
+++ b/projects/documentation/.eleventy.cjs
@@ -133,7 +133,21 @@ module.exports = function (eleventyConfig) {
             });
     });
 
-    eleventyConfig.addCollection('tool-examples', function (collection) {
+    eleventyConfig.addCollection('tool-root', function (collection) {
+        return collection
+            .getFilteredByTags('tool-examples', 'root')
+            .sort(function (a, b) {
+                if (a.data.displayName < b.data.displayName) {
+                    return -1;
+                }
+                if (b.data.displayName < a.data.displayName) {
+                    return 1;
+                }
+                return 0;
+            });
+    });
+
+    eleventyConfig.addCollection('tool-all', function (collection) {
         return collection
             .getFilteredByTag('tool-examples')
             .sort(function (a, b) {

--- a/projects/documentation/content/_includes/partials/sidenav.njk
+++ b/projects/documentation/content/_includes/partials/sidenav.njk
@@ -51,13 +51,25 @@
         multiLevel
     >
         <span slot="no-js">Tools</span>
-        {% for component in collections['tool-examples'] %}
+        {% for toolRoot in collections['tool-root'] %}
             <sp-sidenav-item
-                label="{{ component.data.displayName }}"
-                href="{{ component.url }}"
-                value="{{ component.data.componentName }}"
+                label="{{ toolRoot.data.displayName }}"
+                href="{{ toolRoot.url }}"
+                value="{{ toolRoot.data.componentName }}"
+                {% if componentPackage === toolRoot.data.componentName %}expanded{% endif %}
+                {% if value === toolRoot.data.componentName %}autofocus{% endif %}
             >
-                <a href="{{ component.url }}" slot="no-js">{{ component.data.displayName }}</a>
+                <a href="{{ toolRoot.url }}" slot="no-js">{{ toolRoot.data.displayName }}</a>
+                {% for componentChild in collections[toolRoot.data.componentName + '-children'] %}
+                    <sp-sidenav-item
+                        label="{{ componentChild.data.displayName }}"
+                        href="{{ componentChild.url }}"
+                        value="{{ componentChild.data.componentName }}"
+                        {% if value === componentChild.data.componentName %}autofocus{% endif %}
+                    >
+                        <a href="{{ componentChild.url }}" slot="no-js">{{ componentChild.data.displayName }}</a>
+                    </sp-sidenav-item>
+                {% endfor %}
             </sp-sidenav-item>
         {% endfor %}
     </sp-sidenav-item>


### PR DESCRIPTION
## Description
Ensure that subpages of the Tools documentation groups and displayed as such.

## Related issue(s)
- fixes #3054 

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://tools-docs--spectrum-web-components.netlify.app/tools/reactive-controllers/)
    2. See that `Element Resolution`, `Match Media` and `Roving Tab Index` are all accessible as sub pages in the navigation.

## Types of changes
-   [x] Docs

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.