### PR TITLE
fix(radio): process :focus and :focus-visible

### DIFF
--- a/packages/radio/src/spectrum-config.js
+++ b/packages/radio/src/spectrum-config.js
@@ -29,6 +29,15 @@ const config = {
             fileName: 'radio',
             components: [
                 {
+                    find: [builder.pseudoClass('focus')],
+                    replace: [
+                        {
+                            replace: builder.pseudoClass('focus-visible'),
+                            hoist: true,
+                        },
+                    ],
+                },
+                {
                     // .spectrum-Radio-input:focus-visible+.spectrum-Radio-button:after
                     find: [
                         builder.class('spectrum-Radio-input'),

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -226,7 +226,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:focus) #button:before {
+:host(.focus-visible) #button:before {
     border-color: var(
         --highcontrast-radio-button-border-color-focus,
         var(
@@ -235,7 +235,16 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:focus) #button:after {
+:host(:focus-visible) #button:before {
+    border-color: var(
+        --highcontrast-radio-button-border-color-focus,
+        var(
+            --mod-radio-button-border-color-focus,
+            var(--spectrum-radio-button-border-color-focus)
+        )
+    );
+}
+:host(.focus-visible) #button:after {
     border-color: var(
         --highcontrast-radio-focus-indicator-color,
         var(
@@ -257,7 +266,29 @@ governing permissions and limitations under the License.
             var(--spectrum-radio-focus-indicator-gap) * 2
     );
 }
-:host([checked]:focus) #input + #button:before {
+:host(:focus-visible) #button:after {
+    border-color: var(
+        --highcontrast-radio-focus-indicator-color,
+        var(
+            --mod-radio-focus-indicator-color,
+            var(--spectrum-radio-focus-indicator-color)
+        )
+    );
+    border-style: solid;
+    border-width: var(
+        --mod-radio-focus-indicator-thickness,
+        var(--spectrum-radio-focus-indicator-thickness)
+    );
+    height: calc(
+        var(--spectrum-radio-button-control-size) +
+            var(--spectrum-radio-focus-indicator-gap) * 2
+    );
+    width: calc(
+        var(--spectrum-radio-button-control-size) +
+            var(--spectrum-radio-focus-indicator-gap) * 2
+    );
+}
+:host(.focus-visible[checked]) #input + #button:before {
     border-color: var(
         --highcontrast-radio-button-checked-border-color-focus,
         var(
@@ -266,7 +297,25 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:focus) #label {
+:host(:focus-visible[checked]) #input + #button:before {
+    border-color: var(
+        --highcontrast-radio-button-checked-border-color-focus,
+        var(
+            --mod-radio-button-checked-border-color-focus,
+            var(--spectrum-radio-button-checked-border-color-focus)
+        )
+    );
+}
+:host(.focus-visible) #label {
+    color: var(
+        --highcontrast-radio-neutral-content-color-focus,
+        var(
+            --mod-radio-neutral-content-color-focus,
+            var(--spectrum-radio-neutral-content-color-focus)
+        )
+    );
+}
+:host(:focus-visible) #label {
     color: var(
         --highcontrast-radio-neutral-content-color-focus,
         var(
@@ -328,7 +377,16 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([emphasized][checked]:focus) #input + #button:before {
+:host([emphasized].focus-visible[checked]) #input + #button:before {
+    border-color: var(
+        --highcontrast-radio-emphasized-accent-color-focus,
+        var(
+            --mod-radio-emphasized-accent-color-focus,
+            var(--spectrum-radio-emphasized-accent-color-focus)
+        )
+    );
+}
+:host([emphasized]:focus-visible[checked]) #input + #button:before {
     border-color: var(
         --highcontrast-radio-emphasized-accent-color-focus,
         var(


### PR DESCRIPTION
## Description
Ensure "focus" styles for Radio only display at `:focus-visible`

## Related issue(s)
- fixes #2998

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://radio-focus--spectrum-web-components.netlify.app/components/radio/#sizes)
    2. Click a Radio button
    3. See that _visible_ focus isn't given to the element
    4. Use an arrow key to focus another Radio button
    5. See that it is given visible focus

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.