### PR TITLE
fix: manage "tabindex" when toggling "disabled"

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     },
     "wireit": {
         "build:css:watch": {
-            "command": "yarn build:css --watch",
+            "command": "node ./tasks/watch-css.js",
             "service": true
         },
         "build:css": {
@@ -210,7 +210,7 @@
             "clean": "if-file-deleted"
         },
         "build:ts:watch": {
-            "command": "yarn build:ts --watch",
+            "command": "node ./tasks/watch-packages.js",
             "service": true
         },
         "build:ts": {

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
         "build:component-inventory": "node ./tasks/build-component-inventory.js",
         "build:confirm": "lerna exec --ignore \"{@spectrum-web-components/{base,bundle,close-button,clear-button,iconset,modal,shared,styles,custom-vars-viewer},documentation,example-project-rollup,example-project-webpack,swc-templates,@types/swc}\" -- test -f src/index.js",
         "build:css": "wireit",
-        "build:css:watch": "node ./tasks/watch-css.js",
+        "build:css:watch": "wireit",
         "build:react": "yarn gen-react-wrapper && node ./tasks/build-react.js && yarn tsc --build tsconfig-react-wrapper.json",
         "build:tests": "tsc --build test/tsconfig.json && tsc --build test/tsconfig-node.json",
         "build:ts": "wireit",
-        "build:ts:watch": "node ./tasks/watch-packages.js",
+        "build:ts:watch": "wireit",
         "build:types": "wireit",
-        "build:watch": "run-p build:css:watch build:ts:watch",
+        "build:watch": "wireit",
         "custom-element-json": "lerna exec --ignore \"{@spectrum-web-components/{base,bundle,modal,iconset,shared,styles,custom-vars-viewer},documentation,example-project-rollup,example-project-webpack,swc-templates,@types/swc}\" -- cem analyze --config ../../custom-elements-manifest.config.js --packagejson",
         "docs:analyze": "cem analyze --globs \"packages/**/*.ts\" --exclude \"**/*.d.ts\" --exclude \"**/stories/**\" --exclude \"**/icons/**\" --exclude \"**/elements/**\" --outdir projects/documentation --litelement",
         "docs:build": "yarn workspace documentation build",
@@ -190,6 +190,10 @@
         "yargs": "^17.2.1"
     },
     "wireit": {
+        "build:css:watch": {
+            "command": "yarn build:css --watch",
+            "service": true
+        },
         "build:css": {
             "command": "node ./tasks/build-css.js",
             "dependencies": [
@@ -204,6 +208,10 @@
                 "tools/**/*.css.ts"
             ],
             "clean": "if-file-deleted"
+        },
+        "build:ts:watch": {
+            "command": "yarn build:ts --watch",
+            "service": true
         },
         "build:ts": {
             "command": "node ./tasks/esbuild-packages.js",
@@ -258,6 +266,12 @@
                 "!**/local.d.ts"
             ],
             "clean": "if-file-deleted"
+        },
+        "build:watch": {
+            "dependencies": [
+                "build:css:watch",
+                "build:ts:watch"
+            ]
         },
         "build": {
             "dependencies": [
@@ -351,7 +365,7 @@
                 "wds-storybook.config.js"
             ],
             "dependencies": [
-                "build",
+                "build:watch",
                 "prestorybook"
             ]
         },

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -59,6 +59,34 @@ describe('ActionButton', () => {
         expect(el.textContent).to.include('Button');
         await expect(el).to.be.accessible();
     });
+    it('manages a `tabindex`', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button>Button</sp-action-button>
+            `
+        );
+
+        expect(el.tabIndex).to.equal(0);
+        expect(el.disabled).to.be.false;
+
+        el.setAttribute('tabindex', '-1');
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(-1);
+        expect(el.disabled).to.be.false;
+
+        el.disabled = true;
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(-1);
+        expect(el.disabled).to.be.true;
+
+        el.disabled = false;
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(-1);
+        expect(el.disabled).to.be.false;
+    });
     it('maintains a `size` attribute', async () => {
         const el = await fixture<ActionButton>(
             html`

--- a/tools/shared/src/focusable.ts
+++ b/tools/shared/src/focusable.ts
@@ -81,9 +81,10 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
             return;
         }
         if (this.focusElement === this) {
-            if (tabIndex !== this.tabIndex) {
+            if (tabIndex !== this._tabIndex) {
                 this._tabIndex = tabIndex;
                 const tabindex = this.disabled ? '-1' : '' + tabIndex;
+                this.manipulatingTabindex = true;
                 this.setAttribute('tabindex', tabindex);
             }
             return;
@@ -122,7 +123,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
         this.manageFocusElementTabindex(tabIndex);
     }
-    private _tabIndex = 0;
+    private _tabIndex = -1;
 
     private onPointerdownManagementOfTabIndex(): void {
         if (this.tabIndex === -1) {


### PR DESCRIPTION
## Description
Ensure the toggling `disabled` OFF will return the `tabindex` to its previous value. Specifically, make sure that `-1` is returned to `-1`.

*To do:*
- [x] Broader testing, specifically focusing on contexts where parent elements (like `sp-action-group` might otherwise be managing the `tabindex` of the element).
- [x] Ensure other elements that leverage the `focusable` base class are not effected in a negative way: see [failing test](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/15269/workflows/c192187e-f230-4b40-8173-e9f2309e0504/jobs/307769/tests#failed-test-0) 🙈 

## Related issue(s)
- TK

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://focusable-tabindex--spectrum-web-components.netlify.app/storybook/index.html?path=/story/action-button--icon-size-overridden)
    2. Inspect the Action Button
    3. Set its `tabindex` to `-1` in the HTML
    4. Apply the `disabled` attribute
    5. See that its `tabindex` stays `-1`
    6. Remove the `disabled` attribute
    7. See that its `tabindex` stays `-1`
-   [ ] _Test case 2_
    1. Go to other elements that leverage the `focusable` base class
    2. Do similar testing.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.