### PR TITLE
feat: support non-flat "color" application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 262d30ff1a03288e249023672d704b0f232d6646
+        default: 10500edb351f4db403b24e1305a959910ef80e12
 commands:
     downstream:
         steps:

--- a/packages/swatch/src/swatch.css
+++ b/packages/swatch/src/swatch.css
@@ -11,3 +11,23 @@ governing permissions and limitations under the License.
 */
 
 @import './spectrum-swatch.css';
+
+/**
+ * Begin work around for https://github.com/adobe/spectrum-css/issues/1460
+ */
+
+.fill:before {
+    background: var(--spectrum-picked-color, transparent);
+}
+
+:host([border='none']) .fill:before {
+    background: var(--spectrum-picked-color, transparent);
+}
+
+:host .is-image .fill:before {
+    background: #0000;
+}
+
+/**
+ * End workaround for https://github.com/adobe/spectrum-css/issues/1460
+ */

--- a/packages/swatch/stories/swatch.stories.ts
+++ b/packages/swatch/stories/swatch.stories.ts
@@ -96,6 +96,10 @@ const template = ({
 };
 
 export const Default = (args: Properties): TemplateResult => template(args);
+export const gradient = (args: Properties): TemplateResult => template(args);
+gradient.args = {
+    color: 'linear-gradient(90deg, rgba(2,0,36,1) 0%, rgba(9,9,121,1) 35%, rgba(0,212,255,1) 100%)',
+};
 export const mixedValue = (args: Properties): TemplateResult => template(args);
 mixedValue.args = {
     mixedValue: true,


### PR DESCRIPTION
## Description
Update "color" application so that it can accept gradient information.

## Related issue(s)
- https://github.com/adobe/spectrum-css/issues/1460

-   [ ] _Test case 1_
    1. Go [here](https://swatch-gradient--spectrum-web-components.netlify.app/storybook/?path=/story/swatch--gradient)
    2. See that the Swatch displays with a gradient

## Screenshots (if appropriate)
<img width="53" alt="image" src="https://user-images.githubusercontent.com/1156657/230390295-7acc5ea1-f7dc-41d1-b63f-267a9b4aab7a.png">

## Types of changes
-   [x] feature

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.