### PR TITLE
feat(picker): add loading state to the picker

### DIFF
--- a/packages/picker/README.md
+++ b/packages/picker/README.md
@@ -376,12 +376,50 @@ When the `value` of an `<sp-picker>` matches the `value` attribute or the trimme
 </sp-picker>
 <br />
 <br />
-<sp-field-label for="picker-disabled">Quiet:</sp-field-label>
+<sp-field-label for="picker-disabled-quiet">Quiet:</sp-field-label>
 <sp-picker
     label="Select a Country with a very long label, too long in fact"
     disabled
     quiet
     id="picker-disabled-quiet"
+>
+    <sp-menu-item>Deselect</sp-menu-item>
+    <sp-menu-item>Select inverse</sp-menu-item>
+    <sp-menu-item>Feather...</sp-menu-item>
+    <sp-menu-item>Select and mask...</sp-menu-item>
+    <sp-menu-divider></sp-menu-divider>
+    <sp-menu-item>Save selection</sp-menu-item>
+    <sp-menu-item disabled>Make work path</sp-menu-item>
+</sp-picker>
+```
+
+### Loading
+
+When given a `loading` attribute, an `<sp-picker>` will be delivered with an `<sp-progress-circle>` to visually outline that it is `loading` and it will not toggle open or display its `<sp-menu-item>` descendants until the attribute is removed.
+
+```html
+<sp-field-label for="picker-loading">Standard:</sp-field-label>
+<sp-picker
+    label="Select a Country with a very long label, too long in fact"
+    loading
+    id="picker-loading"
+>
+    <sp-menu-item>Deselect</sp-menu-item>
+    <sp-menu-item>Select inverse</sp-menu-item>
+    <sp-menu-item>Feather...</sp-menu-item>
+    <sp-menu-item>Select and mask...</sp-menu-item>
+    <sp-menu-divider></sp-menu-divider>
+    <sp-menu-item>Save selection</sp-menu-item>
+    <sp-menu-item disabled>Make work path</sp-menu-item>
+</sp-picker>
+<br />
+<br />
+<sp-field-label for="picker-loading-quiet">Quiet:</sp-field-label>
+<sp-picker
+    label="Select a Country with a very long label, too long in fact"
+    loading
+    quiet
+    id="picker-loading-quiet"
 >
     <sp-menu-item>Deselect</sp-menu-item>
     <sp-menu-item>Select inverse</sp-menu-item>

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -73,6 +73,7 @@
         "@spectrum-web-components/menu": "^0.16.15",
         "@spectrum-web-components/overlay": "^0.19.3",
         "@spectrum-web-components/popover": "^0.12.15",
+        "@spectrum-web-components/progress-circle": "^0.7.7",
         "@spectrum-web-components/reactive-controllers": "^0.3.5",
         "@spectrum-web-components/shared": "^0.15.5",
         "@spectrum-web-components/tray": "^0.5.1"

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -43,6 +43,8 @@ import type {
 } from '@spectrum-web-components/menu';
 import '@spectrum-web-components/tray/sp-tray.js';
 import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/progress-circle/sp-progress-circle.js';
+
 import type { Popover } from '@spectrum-web-components/popover';
 import {
     openOverlay,
@@ -104,6 +106,9 @@ export class PickerBase extends SizedMixin(Focusable) {
 
     @property({ type: Boolean, reflect: true })
     public invalid = false;
+
+    @property({ type: Boolean, reflect: true })
+    public loading = false;
 
     @property()
     public label?: string;
@@ -391,6 +396,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             'visually-hidden': this.icons === 'only' && !!this.value,
             placeholder: !this.value,
         };
+
         return [
             html`
                 <span id="icon" ?hidden=${this.icons === 'none'}>
@@ -404,6 +410,15 @@ export class PickerBase extends SizedMixin(Focusable) {
                           <sp-icon-alert
                               class="validation-icon"
                           ></sp-icon-alert>
+                      `
+                    : nothing}
+                ${this.loading
+                    ? html`
+                          <sp-progress-circle
+                              indeterminate
+                              aria-labelledby="label"
+                              aria-hidden="true"
+                          ></sp-progress-circle>
                       `
                     : nothing}
                 <sp-icon-chevron100
@@ -433,7 +448,7 @@ export class PickerBase extends SizedMixin(Focusable) {
                 @blur=${this.onButtonBlur}
                 @click=${this.onButtonClick}
                 @focus=${this.onButtonFocus}
-                ?disabled=${this.disabled}
+                ?disabled=${this.disabled || this.loading}
                 tabindex="-1"
             >
                 ${this.buttonContent}

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -35,6 +35,41 @@ governing permissions and limitations under the License.
     --spectrum-picker-width: var(--spectrum-global-dimension-size-2400);
 }
 
+:host([loading]) sp-progress-circle {
+    margin-inline-start: var(
+        --mod-picker-spacing-text-to-alert-icon-inline-start,
+        var(--spectrum-picker-spacing-text-to-alert-icon-inline-start)
+    );
+}
+
+:host([size='s']) sp-progress-circle {
+    --spectrum-progress-circle-size: var(--spectrum-workflow-icon-size-75);
+    --spectrum-progress-circle-thickness: var(
+        --spectrum-progress-circle-thickness-small
+    );
+}
+
+:host([size='m']) sp-progress-circle {
+    --spectrum-progress-circle-size: var(--spectrum-workflow-icon-size-100);
+    --spectrum-progress-circle-thickness: var(
+        --spectrum-progress-circle-thickness-small
+    );
+}
+
+:host([size='l']) sp-progress-circle {
+    --spectrum-progress-circle-size: var(--spectrum-workflow-icon-size-200);
+    --spectrum-progress-circle-thickness: var(
+        --spectrum-progress-circle-thickness-medium
+    );
+}
+
+:host([size='xl']) sp-progress-circle {
+    --spectrum-progress-circle-size: var(--spectrum-workflow-icon-size-300);
+    --spectrum-progress-circle-thickness: var(
+        --spectrum-progress-circle-thickness-large
+    );
+}
+
 #button {
     width: 100%;
     min-width: 100%;

--- a/packages/picker/stories/picker-sizes.stories.ts
+++ b/packages/picker/stories/picker-sizes.stories.ts
@@ -22,19 +22,47 @@ export default {
     component: 'sp-picker',
     argTypes: {
         onChange: { action: 'change' },
+        invalid: {
+            name: 'invalid',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        loading: {
+            name: 'loading',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
     },
 };
 
 type StoryArgs = {
     onChange: (val: string) => void;
+    invalid: boolean;
+    loading: boolean;
 };
 
 const picker = ({
     onChange,
     size,
+    loading,
+    invalid,
 }: {
     onChange: (val: string) => void;
     size: 's' | 'm' | 'l' | 'xl';
+    loading: boolean;
+    invalid: boolean;
 }): TemplateResult => {
     return html`
         <sp-field-label for="picker-${size}" size=${size}>
@@ -48,6 +76,8 @@ const picker = ({
                 onChange(picker.value);
             }}"
             label="Select a Country with a very long label, too long, in fact"
+            ?loading="${loading}"
+            ?invalid="${invalid}"
         >
             <sp-menu-item>Deselect</sp-menu-item>
             <sp-menu-item>Select Inverse</sp-menu-item>

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -58,6 +58,17 @@ export default {
                 type: 'boolean',
             },
         },
+        loading: {
+            name: 'loading',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
         open: {
             name: 'open',
             type: { name: 'boolean', required: false },
@@ -402,6 +413,29 @@ export const custom = (args: StoryArgs): TemplateResult => {
             <a href="#anchor">link</a>
             .
         </p>
+    `;
+};
+
+export const Loading = (args: StoryArgs): TemplateResult => {
+    return html`
+        <sp-field-label for="picker-loading">
+            Picker in loading state
+        </sp-field-label>
+        <sp-picker
+            id="picker-loading"
+            @change=${handleChange(args)}
+            ${spreadProps(args)}
+            loading
+        >
+            <span slot="label">Loading...</span>
+            <sp-menu-item value="item-1">Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-picker>
     `;
 };
 

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -286,6 +286,13 @@ export function runPickerTests(): void {
             expect(el.invalid).to.be.true;
             await expect(el).to.be.accessible();
         });
+        it('renders loading accessibly', async () => {
+            el.loading = true;
+            await elementUpdated(el);
+
+            expect(el.loading).to.be.true;
+            await expect(el).to.be.accessible();
+        });
         it('renders selection accessibly', async () => {
             el.value = 'option-2';
             await elementUpdated(el);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
We need to add a loading spinner inside the picker's button.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/3076

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In one of Adobe's projects, we need to support the loading spinner inside the picker's button.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Test case 1_
    1. Run `yarn storybook`
    2. Go to Picker -> Sizes stories: https://localhost:8001/?path=/story/picker-sizes--s 
    3. Change the sizes and from the controls, set the `loading` property on true. Also, change the scale.

## Screenshots (if appropriate)
Size S:
<img width="207" alt="Screenshot 2023-04-06 at 18 11 22" src="https://user-images.githubusercontent.com/40989335/230422430-24c08e7e-169e-4b55-b159-6679b94bebac.png">

Size M:
<img width="209" alt="Screenshot 2023-04-06 at 18 11 37" src="https://user-images.githubusercontent.com/40989335/230422485-f0921088-a0cd-4036-a05b-505a4b3f1be5.png">

Size L:
<img width="206" alt="Screenshot 2023-04-06 at 18 11 50" src="https://user-images.githubusercontent.com/40989335/230422508-4c433db3-178e-4b4d-bf83-9e4185f9a0bd.png">

Size XL:
<img width="208" alt="Screenshot 2023-04-06 at 18 12 01" src="https://user-images.githubusercontent.com/40989335/230422531-578be970-6711-403a-abb6-c08d9f012b6a.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
