### PR TITLE
refactor(illustrated-message): core tokens update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 6b2db3281823a5925a1d87c775198b49a5ef1a40
+        default: 3a3d3c96e67356a3bcc4c0eeb77076938c1bb31e
 commands:
     downstream:
         steps:

--- a/packages/dropzone/src/dropzone.css
+++ b/packages/dropzone/src/dropzone.css
@@ -65,7 +65,7 @@ governing permissions and limitations under the License.
  */
 
 :host([dragged]) ::slotted(*) {
-    --spectrum-global-color-gray-500: var(
+    --mod-illustrated-message-illustration-color: var(
         --spectrum-dropzone-illustration-color
     );
 }

--- a/packages/illustrated-message/README.md
+++ b/packages/illustrated-message/README.md
@@ -29,33 +29,7 @@ import { IllustratedMessage } from '@spectrum-web-components/illustrated-message
 ```html
 <sp-illustrated-message
     heading="Drag and Drop Your File"
-    description="This message has italics"
->
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 150 103"
-        width="150"
-        height="103"
-        viewBox="0 0 150 103"
-    >
-        <path
-            d="M133.7,8.5h-118c-1.9,0-3.5,1.6-3.5,3.5v27c0,0.8,0.7,1.5,1.5,1.5s1.5-0.7,1.5-1.5V23.5h119V92c0,0.3-0.2,0.5-0.5,0.5h-118c-0.3,0-0.5-0.2-0.5-0.5V69c0-0.8-0.7-1.5-1.5-1.5s-1.5,0.7-1.5,1.5v23c0,1.9,1.6,3.5,3.5,3.5h118c1.9,0,3.5-1.6,3.5-3.5V12C137.2,10.1,135.6,8.5,133.7,8.5z M15.2,21.5V12c0-0.3,0.2-0.5,0.5-0.5h118c0.3,0,0.5,0.2,0.5,0.5v9.5H15.2z M32.6,16.5c0,0.6-0.4,1-1,1h-10c-0.6,0-1-0.4-1-1s0.4-1,1-1h10C32.2,15.5,32.6,15.9,32.6,16.5z M13.6,56.1l-8.6,8.5C4.8,65,4.4,65.1,4,65.1c-0.4,0-0.8-0.1-1.1-0.4c-0.6-0.6-0.6-1.5,0-2.1l8.6-8.5l-8.6-8.5c-0.6-0.6-0.6-1.5,0-2.1c0.6-0.6,1.5-0.6,2.1,0l8.6,8.5l8.6-8.5c0.6-0.6,1.5-0.6,2.1,0c0.6,0.6,0.6,1.5,0,2.1L15.8,54l8.6,8.5c0.6,0.6,0.6,1.5,0,2.1c-0.3,0.3-0.7,0.4-1.1,0.4c-0.4,0-0.8-0.1-1.1-0.4L13.6,56.1z"
-        ></path>
-    </svg>
-</sp-illustrated-message>
-```
-
-## Variants
-
-### CTA variant
-
-In this variant, the description text is not italisized.
-
-```html
-<sp-illustrated-message
-    heading="Drag and Drop Your File"
-    description="This message has no italics"
-    cta
+    description="Additional descriptive text"
 >
     <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -73,4 +47,4 @@ In this variant, the description text is not italisized.
 
 ## Content
 
-The popover accepts an svg into its default slot. This svg is displayed as an illustration above the heading and description
+The illustrated message accepts an `<svg>` into its default slot. This SVG is displayed as an illustration above the heading and description.

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/styles": "^0.23.3"
     },
     "devDependencies": {
-        "@spectrum-css/illustratedmessage": "^4.0.19"
+        "@spectrum-css/illustratedmessage": "^5.0.1"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/illustrated-message/src/spectrum-config.js
+++ b/packages/illustrated-message/src/spectrum-config.js
@@ -26,7 +26,6 @@ const config = {
             fileName: 'illustratedmessage',
             components: [
                 converter.classToHost(),
-                converter.classToAttribute('spectrum-IllustratedMessage--cta'),
                 converter.classToId('spectrum-IllustratedMessage-heading'),
                 converter.classToId('spectrum-IllustratedMessage-description'),
                 converter.classToId('spectrum-IllustratedMessage-illustration'),

--- a/packages/illustrated-message/src/spectrum-illustratedmessage.css
+++ b/packages/illustrated-message/src/spectrum-illustratedmessage.css
@@ -12,61 +12,169 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-illustratedmessage-description-max-width: 500px;
-    --spectrum-illustratedmessage-heading-max-width: 500px;
-    --spectrum-illustratedmessage-illustration-margin-bottom: 24px;
-    --spectrum-illustratedmessage-heading-margin: 0;
-    --spectrum-illustratedmessage-description-margin: 4px 0 0 0;
+    --spectrum-illustrated-message-description-max-inline-size: var(
+        --spectrum-illustrated-message-maximum-width
+    );
+    --spectrum-illustrated-message-heading-max-inline-size: var(
+        --spectrum-illustrated-message-maximum-width
+    );
+    --spectrum-illustrated-message-title-to-heading: var(
+        --spectrum-spacing-400
+    );
+    --spectrum-illustrated-message-heading-to-description: var(
+        --spectrum-spacing-75
+    );
+    --spectrum-illustrated-message-illustration-color: var(
+        --spectrum-neutral-visual-color
+    );
+    --spectrum-illustrated-message-illustration-accent-color: var(
+        --spectrum-accent-visual-color
+    );
+    --spectrum-illustrated-message-title-font-family: var(
+        --spectrum-sans-font-family-stack
+    );
+    --spectrum-illustrated-message-title-font-weight: var(
+        --spectrum-heading-sans-serif-font-weight
+    );
+    --spectrum-illustrated-message-title-font-style: var(
+        --spectrum-heading-sans-serif-font-style
+    );
+    --spectrum-illustrated-message-title-font-size: var(
+        --spectrum-illustrated-message-title-size
+    );
+    --spectrum-illustrated-message-title-line-height: var(
+        --spectrum-heading-line-height
+    );
+    --spectrum-illustrated-message-title-color: var(--spectrum-heading-color);
+    --spectrum-illustrated-message-description-font-family: var(
+        --spectrum-sans-font-family-stack
+    );
+    --spectrum-illustrated-message-description-font-weight: var(
+        --spectrum-body-sans-serif-font-weight
+    );
+    --spectrum-illustrated-message-description-font-style: var(
+        --spectrum-body-sans-serif-font-style
+    );
+    --spectrum-illustrated-message-description-font-size: var(
+        --spectrum-illustrated-message-body-size
+    );
+    --spectrum-illustrated-message-description-line-height: var(
+        --spectrum-body-line-height
+    );
+    --spectrum-illustrated-message-description-color: var(
+        --spectrum-body-color
+    );
+}
+:host:lang(ja),
+:host:lang(ko),
+:host:lang(zh) {
+    --spectrum-illustrated-message-title-font-size: var(
+        --spectrum-illustrated-message-cjk-title-size
+    );
+}
+@media (forced-colors: active) {
+    :host {
+        --highcontrast-illustrated-message-illustration-color: CanvasText;
+        --highcontrast-illustrated-message-illustration-accent-color: Highlight;
+    }
 }
 :host {
     align-items: center;
+    block-size: 100%;
     display: flex;
     flex-direction: column;
-    height: 100%;
     justify-content: center;
     text-align: center;
 }
 #illustration {
-    margin-bottom: var(
-        --spectrum-illustratedmessage-illustration-margin-bottom
+    fill: currentColor;
+    stroke: currentColor;
+    color: var(
+        --highcontrast-illustrated-message-illustration-color,
+        var(
+            --mod-illustrated-message-illustration-color,
+            var(--spectrum-illustrated-message-illustration-color)
+        )
+    );
+    margin-block-end: var(
+        --mod-illustrated-message-title-to-heading,
+        var(--spectrum-illustrated-message-title-to-heading)
+    );
+}
+.spectrum-IllustratedMessage-accent {
+    fill: currentColor;
+    stroke: currentColor;
+    color: var(
+        --highcontrast-illustrated-message-illustration-accent-color,
+        var(
+            --mod-illustrated-message-illustration-accent-color,
+            var(--spectrum-illustrated-message-illustration-accent-color)
+        )
     );
 }
 #heading {
     color: var(
-        --spectrum-illustratedmessage-heading-color,
-        var(--spectrum-global-color-gray-800)
+        --mod-illustrated-message-title-color,
+        var(--spectrum-illustrated-message-title-color)
+    );
+    font-family: var(
+        --mod-illustrated-message-title-font-family,
+        var(--spectrum-illustrated-message-title-font-family)
     );
     font-size: var(
-        --spectrum-illustratedmessage-heading-font-size,
-        var(--spectrum-alias-heading-m-text-size)
+        --mod-illustrated-message-title-font-size,
+        var(--spectrum-illustrated-message-title-font-size)
+    );
+    font-style: var(
+        --mod-illustrated-message-title-font-style,
+        var(--spectrum-illustrated-message-title-font-style)
     );
     font-weight: var(
-        --spectrum-illustratedmessage-heading-font-weight,
-        var(--spectrum-alias-heading-text-font-weight-regular)
+        --mod-illustrated-message-title-font-weight,
+        var(--spectrum-illustrated-message-title-font-weight)
     );
-    margin: var(--spectrum-illustratedmessage-heading-margin);
-    max-width: var(--spectrum-illustratedmessage-heading-max-width);
+    line-height: var(
+        --mod-illustrated-message-title-line-height,
+        var(--spectrum-illustrated-message-title-line-height)
+    );
+    margin-block: 0;
+    max-inline-size: var(
+        --mod-illustrated-message-heading-max-inline-size,
+        var(--spectrum-illustrated-message-heading-max-inline-size)
+    );
 }
 #description {
     color: var(
-        --spectrum-illustratedmessage-description-color,
-        var(--spectrum-global-color-gray-700)
+        --mod-illustrated-message-description-color,
+        var(--spectrum-illustrated-message-description-color)
+    );
+    font-family: var(
+        --mod-illustrated-message-description-font-family,
+        var(--spectrum-illustrated-message-description-font-family)
+    );
+    font-size: var(
+        --mod-illustrated-message-description-font-size,
+        var(--spectrum-illustrated-message-description-font-size)
     );
     font-style: var(
-        --spectrum-illustratedmessage-description-font-style,
-        var(--spectrum-global-font-style-regular)
+        --mod-illustrated-message-description-font-style,
+        var(--spectrum-illustrated-message-description-font-style)
     );
-    margin: var(--spectrum-illustratedmessage-description-margin);
-    max-width: var(--spectrum-illustratedmessage-description-max-width);
-}
-:host([cta]) #description {
-    font-style: var(
-        --spectrum-illustratedmessage-description-font-style,
-        var(--spectrum-global-font-style-regular)
+    font-weight: var(
+        --mod-illustrated-message-description-font-weight,
+        var(--spectrum-illustrated-message-description-font-weight)
     );
-}
-#illustration {
-    fill: currentColor;
-    stroke: currentColor;
-    color: var(--spectrum-global-color-gray-500);
+    line-height: var(
+        --mod-illustrated-message-description-line-height,
+        var(--spectrum-illustrated-message-description-line-height)
+    );
+    margin-block-end: 0;
+    margin-block-start: var(
+        --mod-illustrated-message-heading-to-description,
+        var(--spectrum-illustrated-message-heading-to-description)
+    );
+    max-inline-size: var(
+        --mod-illustrated-message-description-max-inline-size,
+        var(--spectrum-illustrated-message-description-max-inline-size)
+    );
 }

--- a/packages/illustrated-message/stories/illustrated-message.stories.ts
+++ b/packages/illustrated-message/stories/illustrated-message.stories.ts
@@ -23,19 +23,7 @@ export const Default = (): TemplateResult => {
     return html`
         <sp-illustrated-message
             heading="Drag and Drop Your File"
-            description="This message has italics"
-        >
-            ${illustration}
-        </sp-illustrated-message>
-    `;
-};
-
-export const CTA = (): TemplateResult => {
-    return html`
-        <sp-illustrated-message
-            heading="Drag and Drop Your File"
-            description="This message has no italics"
-            cta
+            description="Additional descriptive text"
         >
             ${illustration}
         </sp-illustrated-message>

--- a/packages/illustrated-message/test/benchmark/test-basic.ts
+++ b/packages/illustrated-message/test/benchmark/test-basic.ts
@@ -17,7 +17,7 @@ import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 measureFixtureCreation(html`
     <sp-illustrated-message
         heading="Drag and Drop Your File"
-        description="This message has italics"
+        description="Additional descriptive text"
     >
         <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/illustrated-message/test/illustrated-message.test.ts
+++ b/packages/illustrated-message/test/illustrated-message.test.ts
@@ -19,7 +19,7 @@ describe('Illustrated Message', () => {
             html`
                 <sp-illustrated-message
                     heading="Drag and Drop Your File"
-                    description="This message has italics"
+                    description="Additional descriptive text"
                 >
                     <svg
                         xmlns="http://www.w3.org/2000/svg"

--- a/scripts/spectrum-tokens.js
+++ b/scripts/spectrum-tokens.js
@@ -60,6 +60,7 @@ const tokenPackages = [
     'colorwheel',
     'colorhandle',
     'colorloupe',
+    'illustratedmessage',
 ];
 
 const packagePaths = tokenPackages.map((packageName) => {

--- a/tools/styles/express/spectrum-core-global.css
+++ b/tools/styles/express/spectrum-core-global.css
@@ -1845,9 +1845,6 @@ governing permissions and limitations under the License.
     --spectrum-alias-ui-icon-asterisk-size-100: var(
         --spectrum-global-dimension-size-100
     );
-    --spectrum-alias-component-text-color-selected-default: var(
-        --spectrum-global-color-gray-50
-    );
     --spectrum-alias-component-text-color-selected-hover: var(
         --spectrum-alias-component-text-color-selected-default
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4349,10 +4349,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.38.tgz#8e573f2a2b377c3de39f299e4dea5f577c838855"
   integrity sha512-/sckVetoKnU9YNcRogP2LNS48aQ71D2jzTSOUeOZPGlWfUu0gn49vSey9D/NZR3dAqqAfMfOj8g2A9rMw3pI5w==
 
-"@spectrum-css/illustratedmessage@^4.0.19":
-  version "4.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-4.0.19.tgz#064bdb0413b55fec65347959598eb0b65fbd6750"
-  integrity sha512-Bx2jZ5m3vbYyc+6dDT9eY1FhyOtval2ilC4Unht7N2dRTCe/gVHG8/rThcx4FEaoVGIjZRNIovJFOGpCG3l/zQ==
+"@spectrum-css/illustratedmessage@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-5.0.1.tgz#8d542dead78655944770899eecd4a849f802e7ad"
+  integrity sha512-uMaiSzQ5SUFfKQSlNr+kdGwsES8x+jaf7JMJ66LRcbm4hjcqJ8vIjBkz+kqDZ1FozspBis3ghosEn91NVuK7ug==
 
 "@spectrum-css/link@^4.0.28":
   version "4.0.28"


### PR DESCRIPTION
## Description

**Core token migration**

Updates version of spectrum CSS illustratedmessage to the latest v6 version that has the core token migration.

**Also: removes "cta" variant**

The CTA variant is no longer necessary, as it provides no unique styles. It has been removed in the spectrum CSS component. This variant was at a previous point in time differing only in whether the description text was italic or not. The more recent versions (including [current 0.9.14 illustrated-message SWC](https://opensource.adobe.com/spectrum-css/illustratedmessage.html)) as dictated by design and tokens, have a normal font-style by default.

## Related issue(s)

[spectrum-css PR 1699](https://github.com/adobe/spectrum-css/pull/1699)

## How has this been tested?

- Ran `yarn test` to make sure tests for `illustrated-message` still passed.
- Compared with VRTs. Notes in PR comments.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.