### PR TITLE
Allowing `title` attribute to cascade from `TextField` to `input`

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -68,6 +68,9 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
     @property({ attribute: 'type', reflect: true })
     private _type: TextfieldType = 'text';
 
+    @property({ type: String, reflect: true })
+    public override title = '';
+
     @state()
     get type(): TextfieldType {
         return textfieldTypes.find((t) => t === this._type) ?? 'text';
@@ -227,6 +230,7 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
                 aria-describedby=${this.helpTextId}
                 aria-label=${this.label || this.placeholder}
                 aria-invalid=${ifDefined(this.invalid || undefined)}
+                title=${ifDefined(this.title || undefined)}
                 class="input"
                 maxlength=${ifDefined(
                     this.maxlength > -1 ? this.maxlength : undefined
@@ -257,6 +261,7 @@ export class TextfieldBase extends ManageHelpText(Focusable) {
                 aria-describedby=${this.helpTextId}
                 aria-label=${this.label || this.placeholder}
                 aria-invalid=${ifDefined(this.invalid || undefined)}
+                title=${ifDefined(this.title || undefined)}
                 class="input"
                 maxlength=${ifDefined(
                     this.maxlength > -1 ? this.maxlength : undefined

--- a/packages/textfield/stories/textfield.stories.ts
+++ b/packages/textfield/stories/textfield.stories.ts
@@ -41,6 +41,7 @@ export const Default = (): TemplateResult => {
             placeholder="Enter your name"
             pattern="[\\d]*"
             value="Not a valid input"
+            title="Input must match the following pattern..."
         ></sp-textfield>
         <sp-textfield
             placeholder="Enter your name"

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -512,6 +512,51 @@ describe('Textfield', () => {
             : null;
         expect(input).to.not.be.null;
     });
+    it('invalid - boundary-type assertions and title', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    type="url"
+                    value="invalid-email"
+                    invalid="true"
+                    title="Input a valid email address"
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+        expect(el.shadowRoot.querySelector('input')).to.have.attribute('title');
+    });
+    it('invalid - multiline - boundary-type assertions and title', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    multiline
+                    placeholder="Enter your number"
+                    type="url"
+                    value="invalid-email"
+                    invalid="true"
+                    title="Input a valid email address"
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot
+            ? el.shadowRoot.querySelector('#invalid')
+            : null;
+        expect(input).to.not.be.null;
+        expect(el.shadowRoot.querySelector('textarea')).to.have.attribute(
+            'title'
+        );
+    });
     it('receives focus', async () => {
         let activeElement: HTMLInputElement | null = null;
         const onFocusIn = (event: Event): void => {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/3099

## Motivation and context

Fixes Adobe Express internal issue

## How has this been tested?

Changes were tested in the storybook environment


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
