### PR TITLE
fix: ensure streamingListener ends even if pointercancel not fired

### DIFF
--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -407,7 +407,10 @@ export class ColorArea extends SpectrumElement {
                 ${streamingListener({
                     start: ['pointerdown', this.handlePointerdown],
                     streamInside: ['pointermove', this.handlePointermove],
-                    end: [['pointerup', 'pointercancel'], this.handlePointerup],
+                    end: [
+                        ['pointerup', 'pointercancel', 'pointerleave'],
+                        this.handlePointerup,
+                    ],
                 })}
             ></sp-color-handle>
 

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -319,7 +319,10 @@ export class ColorSlider extends Focusable {
                 ${streamingListener({
                     start: ['pointerdown', this.handlePointerdown],
                     streamInside: ['pointermove', this.handlePointermove],
-                    end: [['pointerup', 'pointercancel'], this.handlePointerup],
+                    end: [
+                        ['pointerup', 'pointercancel', 'pointerleave'],
+                        this.handlePointerup,
+                    ],
                 })}
             ></sp-color-handle>
             <input

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -359,7 +359,10 @@ export class ColorWheel extends Focusable {
                 ${streamingListener({
                     start: ['pointerdown', this.handlePointerdown],
                     streamInside: ['pointermove', this.handlePointermove],
-                    end: [['pointerup', 'pointercancel'], this.handlePointerup],
+                    end: [
+                        ['pointerup', 'pointercancel', 'pointerleave'],
+                        this.handlePointerup,
+                    ],
                 })}
             ></sp-color-handle>
 

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -547,7 +547,11 @@ export class NumberField extends TextfieldBase {
                                   this.handlePointermove,
                               ],
                               end: [
-                                  ['pointerup', 'pointercancel'],
+                                  [
+                                      'pointerup',
+                                      'pointercancel',
+                                      'pointerleave',
+                                  ],
                                   this.handlePointerup,
                               ],
                           })}

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -357,7 +357,10 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                 ${streamingListener({
                     start: ['pointerdown', this.handlePointerdown],
                     streamInside: ['pointermove', this.handlePointermove],
-                    end: [['pointerup', 'pointercancel'], this.handlePointerup],
+                    end: [
+                        ['pointerup', 'pointercancel', 'pointerleave'],
+                        this.handlePointerup,
+                    ],
                 })}
             >
                 <div id="controls">


### PR DESCRIPTION
## Description
Add `pointerleave` to all `streamingListener` usage with pointer events to ensure that in cases where `pointercancel` is not fired the stream is broken.

It would be nice to have a test for this, but it's really a quirk of the browser and while I could manually fire the events that lead to this situation, I'm not sure that it would actually be guaranteeing anything that an actual consumer of the element would encounter.

## Related issue(s)
- fixes #3112 
- fixes #2103 (@hunterloftis I think I need a mouse to test whether this is "fixed" instead of "refs", can you support here?)
- fixes #3002 

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/slider--default) or [here](https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/color-slider--default)
    2. Resize content on the page so that the slider ends just before the right edge of the browser
    3. Move the slider value to almost 100%
    4. Grab the handle and quickly drag past the edge of the window
    5. Release the mouse off of the window
    6. Reenter the window
    7. See that without having the pointer down the slider value is still controlled
-   [ ] _Test case 2_
    1. Go [here](https://pointer-leave--spectrum-web-components.netlify.app/storybook/?path=/story/slider--default) or [here](https://pointer-leave--spectrum-web-components.netlify.app/storybook/?path=/story/color-slider--default)
    3. Move the slider value to almost 100%
    4. Grab the handle and quickly drag past the edge of the window
    5. Release the mouse off of the window
    6. Reenter the window
    7. See that the slider is no longer controlled by the pointer

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.