### PR TITLE
chore: take non-breaking Spectrum CSS updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 5ca9bd66b3f619f8124ee52b3681bafad31b864e
+        default: 6b2db3281823a5925a1d87c775198b49a5ef1a40
 commands:
     downstream:
         steps:

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -73,7 +73,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/accordion": "^3.0.31"
+        "@spectrum-css/accordion": "^3.0.39"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^3.0.20"
+        "@spectrum-css/actionbutton": "^3.0.29"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -63,7 +63,7 @@
         "@spectrum-web-components/reactive-controllers": "^0.3.5"
     },
     "devDependencies": {
-        "@spectrum-css/actiongroup": "^3.0.12"
+        "@spectrum-css/actiongroup": "^3.0.30"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -69,7 +69,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/actionmenu": "^4.0.8"
+        "@spectrum-css/actionmenu": "^4.0.17"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/asset": "^3.0.28"
+        "@spectrum-css/asset": "^3.0.35"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/avatar": "^6.0.0"
+        "@spectrum-css/avatar": "^6.0.15"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/badge": "^3.0.5"
+        "@spectrum-css/badge": "^3.0.17"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/button": "^0.20.4"
     },
     "devDependencies": {
-        "@spectrum-css/buttongroup": "^6.0.14"
+        "@spectrum-css/buttongroup": "^6.0.32"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -66,7 +66,7 @@
         "@spectrum-web-components/styles": "^0.23.3"
     },
     "devDependencies": {
-        "@spectrum-css/card": "^5.0.8"
+        "@spectrum-css/card": "^5.0.17"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -67,7 +67,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/checkbox": "^6.0.2"
+        "@spectrum-css/checkbox": "^6.0.17"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/clear-button/package.json
+++ b/packages/clear-button/package.json
@@ -45,7 +45,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/clearbutton": "^1.2.17"
+        "@spectrum-css/clearbutton": "^1.2.25"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -45,7 +45,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/closebutton": "^3.0.11"
+        "@spectrum-css/closebutton": "^3.0.29"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -18,11 +18,11 @@ governing permissions and limitations under the License.
     border-style: solid;
     box-sizing: border-box;
     cursor: pointer;
-    font-family: var(--mod-font-family-base, var(--spectrum-font-family-base));
-    line-height: var(
-        --mod-line-height-small,
-        var(--spectrum-line-height-small)
+    font-family: var(
+        --mod-sans-font-family-stack,
+        var(--spectrum-sans-font-family-stack)
     );
+    line-height: var(--mod-line-height-100, var(--spectrum-line-height-100));
     margin: 0;
     overflow: visible;
     text-decoration: none;

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/coachmark": "^5.0.21"
+        "@spectrum-css/coachmark": "^5.0.29"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-area/package.json
+++ b/packages/color-area/package.json
@@ -67,7 +67,7 @@
         "@spectrum-web-components/reactive-controllers": "^0.3.5"
     },
     "devDependencies": {
-        "@spectrum-css/colorarea": "^3.0.0"
+        "@spectrum-css/colorarea": "^3.0.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-slider/package.json
+++ b/packages/color-slider/package.json
@@ -68,7 +68,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/colorslider": "^2.0.13"
+        "@spectrum-css/colorslider": "^2.0.24"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-slider/src/spectrum-color-slider.css
+++ b/packages/color-slider/src/spectrum-color-slider.css
@@ -19,6 +19,15 @@ governing permissions and limitations under the License.
     --spectrum-colorslider-handle-hitarea-height: var(
         --spectrum-global-dimension-size-300
     );
+    --spectrum-colorslider-checkerboard-size: var(
+        --spectrum-opacity-checkerboard-square-size
+    );
+    --spectrum-colorslider-checkerboard-dark-color: var(
+        --spectrum-opacity-checkerboard-square-dark
+    );
+    --spectrum-colorslider-checkerboard-light-color: var(
+        --spectrum-opacity-checkerboard-square-light
+    );
 }
 :host([focused]) .handle {
     height: calc(
@@ -103,13 +112,12 @@ governing permissions and limitations under the License.
     width: var(--spectrum-colorslider-handle-hitarea-width);
 }
 .checkerboard {
-    background-position: 0 0,
-        0 var(--spectrum-global-dimension-static-size-100, 8px),
-        var(--spectrum-global-dimension-static-size-100, 8px)
-            calc(var(--spectrum-global-dimension-static-size-100, 8px) * -1),
-        calc(var(--spectrum-global-dimension-static-size-100, 8px) * -1) 0;
-    background-size: var(--spectrum-global-dimension-static-size-200, 16px)
-        var(--spectrum-global-dimension-static-size-200, 16px);
+    background: repeating-conic-gradient(
+            var(--spectrum-colorslider-checkerboard-light-color) 0 25%,
+            var(--spectrum-colorslider-checkerboard-dark-color) 0 50%
+        )
+        0 0 / calc(var(--spectrum-colorslider-checkerboard-size) * 2)
+        calc(var(--spectrum-colorslider-checkerboard-size) * 2);
 }
 .checkerboard:before {
     border-radius: var(
@@ -135,48 +143,6 @@ governing permissions and limitations under the License.
         --spectrum-colorarea-border-color,
         var(--spectrum-alias-border-color-translucent)
     );
-}
-.checkerboard {
-    background-color: var(
-        --spectrum-colorcontrol-checkerboard-light-color,
-        var(--spectrum-global-color-static-white)
-    );
-    background-image: linear-gradient(
-            -45deg,
-            transparent 75.5%,
-            var(
-                    --spectrum-colorcontrol-checkerboard-dark-color,
-                    var(--spectrum-global-color-static-gray-300)
-                )
-                75.5%
-        ),
-        linear-gradient(
-            45deg,
-            transparent 75.5%,
-            var(
-                    --spectrum-colorcontrol-checkerboard-dark-color,
-                    var(--spectrum-global-color-static-gray-300)
-                )
-                75.5%
-        ),
-        linear-gradient(
-            -45deg,
-            var(
-                    --spectrum-colorcontrol-checkerboard-dark-color,
-                    var(--spectrum-global-color-static-gray-300)
-                )
-                25.5%,
-            transparent 25.5%
-        ),
-        linear-gradient(
-            45deg,
-            var(
-                    --spectrum-colorcontrol-checkerboard-dark-color,
-                    var(--spectrum-global-color-static-gray-300)
-                )
-                25.5%,
-            transparent 25.5%
-        );
 }
 .checkerboard:before {
     box-shadow: inset 0 0 0

--- a/packages/color-wheel/package.json
+++ b/packages/color-wheel/package.json
@@ -68,7 +68,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/colorwheel": "^2.0.0"
+        "@spectrum-css/colorwheel": "^2.0.12"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -83,7 +83,7 @@
         "@spectrum-web-components/underlay": "^0.9.8"
     },
     "devDependencies": {
-        "@spectrum-css/dialog": "^6.0.25"
+        "@spectrum-css/dialog": "^6.0.34"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/divider": "^2.0.10"
+        "@spectrum-css/divider": "^2.0.28"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/dropzone": "^3.0.31"
+        "@spectrum-css/dropzone": "^3.0.40"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/help-text": "^0.2.13"
     },
     "devDependencies": {
-        "@spectrum-css/fieldgroup": "^4.0.13"
+        "@spectrum-css/fieldgroup": "^4.0.31"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -75,7 +75,7 @@
         "@spectrum-web-components/iconset": "^0.7.7"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^3.0.30"
+        "@spectrum-css/icon": "^3.0.38"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -49,7 +49,7 @@
         "@spectrum-web-components/iconset": "^0.7.7"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^3.0.30",
+        "@spectrum-css/icon": "^3.0.38",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fs": "^0.0.1-security",

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -49,7 +49,7 @@
     },
     "devDependencies": {
         "@adobe/spectrum-css-workflow-icons": "^1.5.4",
-        "@spectrum-css/icon": "^3.0.30",
+        "@spectrum-css/icon": "^3.0.38",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fs": "^0.0.1-security",

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/styles": "^0.23.3"
     },
     "devDependencies": {
-        "@spectrum-css/illustratedmessage": "^4.0.11"
+        "@spectrum-css/illustratedmessage": "^4.0.19"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/link": "^4.0.11"
+        "@spectrum-css/link": "^4.0.28"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -94,7 +94,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/menu": "^4.0.11"
+        "@spectrum-css/menu": "^4.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^3.0.1"
+        "@spectrum-css/progressbar": "^3.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -46,7 +46,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/modal": "^3.0.28"
+        "@spectrum-css/modal": "^3.0.36"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -68,7 +68,7 @@
     },
     "devDependencies": {
         "@formatjs/intl-numberformat": "7.1.4",
-        "@spectrum-css/stepper": "^3.0.34"
+        "@spectrum-css/stepper": "^3.0.39"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker-button/package.json
+++ b/packages/picker-button/package.json
@@ -48,7 +48,7 @@
         "@spectrum-web-components/icons-ui": "^0.9.11"
     },
     "devDependencies": {
-        "@spectrum-css/pickerbutton": "^2.0.7"
+        "@spectrum-css/pickerbutton": "^2.0.12"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -78,7 +78,7 @@
         "@spectrum-web-components/tray": "^0.5.2"
     },
     "devDependencies": {
-        "@spectrum-css/picker": "^2.0.5"
+        "@spectrum-css/picker": "^2.0.11"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/field-label": "^0.10.9"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^3.0.1"
+        "@spectrum-css/progressbar": "^3.0.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/progresscircle": "^2.0.10"
+        "@spectrum-css/progresscircle": "^2.0.28"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/quickaction": "^3.0.32"
+        "@spectrum-css/quickaction": "^3.0.41"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/textfield": "^0.13.14"
     },
     "devDependencies": {
-        "@spectrum-css/search": "^5.0.0"
+        "@spectrum-css/search": "^5.0.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -80,7 +80,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/sidenav": "^3.0.31"
+        "@spectrum-css/sidenav": "^3.0.39"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -31,7 +31,6 @@ governing permissions and limitations under the License.
     );
 }
 #item-link {
-    -ms-flex-pack: left;
     align-items: center;
     border-radius: var(
         --spectrum-sidenav-item-border-radius,
@@ -51,7 +50,7 @@ governing permissions and limitations under the License.
     );
     -webkit-hyphens: auto;
     hyphens: auto;
-    justify-content: left;
+    justify-content: start;
     min-height: var(
         --spectrum-sidenav-item-height,
         var(--spectrum-alias-single-line-height)

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -83,7 +83,7 @@
         "@spectrum-web-components/theme": "^0.14.14"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^3.1.12"
+        "@spectrum-css/slider": "^3.1.20"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -70,7 +70,7 @@
         "@spectrum-web-components/picker": "^0.15.1"
     },
     "devDependencies": {
-        "@spectrum-css/splitbutton": "^5.0.22"
+        "@spectrum-css/splitbutton": "^5.0.31"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/splitview": "^3.0.27"
+        "@spectrum-css/splitview": "^3.0.35"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/statuslight": "^6.0.2"
+        "@spectrum-css/statuslight": "^6.0.17"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/swatch/package.json
+++ b/packages/swatch/package.json
@@ -74,8 +74,8 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/swatch": "^3.0.9",
-        "@spectrum-css/swatchgroup": "^2.0.10"
+        "@spectrum-css/swatch": "^3.0.21",
+        "@spectrum-css/swatchgroup": "^2.0.29"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/swatch/src/spectrum-swatch.css
+++ b/packages/swatch/src/spectrum-swatch.css
@@ -285,74 +285,22 @@ governing permissions and limitations under the License.
     opacity: 1;
 }
 .fill {
-    --spectrum-swatch-checkerboard-size: 8px;
-    --spectrum-swatch-checkerboard-background-offset: 0px;
-    --spectrum-swatch-checkerboard-dark-color: #d9d9d9;
-    --spectrum-swatch-checkerboard-light-color: #fff;
+    --spectrum-swatch-checkerboard-size: var(
+        --spectrum-opacity-checkerboard-square-size
+    );
+    --spectrum-swatch-checkerboard-dark-color: var(
+        --spectrum-opacity-checkerboard-square-dark
+    );
+    --spectrum-swatch-checkerboard-light-color: var(
+        --spectrum-opacity-checkerboard-square-light
+    );
     align-items: center;
-    background-color: var(--spectrum-swatch-checkerboard-light-color);
-    background-image: linear-gradient(
-            -45deg,
-            transparent 75.5%,
-            var(--spectrum-swatch-checkerboard-dark-color) 75.5%
-        ),
-        linear-gradient(
-            45deg,
-            transparent 75.5%,
-            var(--spectrum-swatch-checkerboard-dark-color) 75.5%
-        ),
-        linear-gradient(
-            -45deg,
-            var(--spectrum-swatch-checkerboard-dark-color) 25.5%,
-            transparent 25.5%
-        ),
-        linear-gradient(
-            45deg,
-            var(--spectrum-swatch-checkerboard-dark-color) 25.5%,
-            transparent 25.5%
-        );
-    background-position: var(--spectrum-swatch-checkerboard-background-offset)
-            var(--spectrum-swatch-checkerboard-background-offset),
-        var(--spectrum-swatch-checkerboard-background-offset)
-            calc(
-                var(
-                        --mod-swatch-checkerboard-size,
-                        var(--spectrum-swatch-checkerboard-size)
-                    ) + var(--spectrum-swatch-checkerboard-background-offset)
-            ),
-        calc(
-                var(
-                        --mod-swatch-checkerboard-size,
-                        var(--spectrum-swatch-checkerboard-size)
-                    ) + var(--spectrum-swatch-checkerboard-background-offset)
-            )
-            calc(
-                var(
-                        --mod-swatch-checkerboard-size,
-                        var(--spectrum-swatch-checkerboard-size)
-                    ) * -1 +
-                    var(--spectrum-swatch-checkerboard-background-offset)
-            ),
-        calc(
-                var(
-                        --mod-swatch-checkerboard-size,
-                        var(--spectrum-swatch-checkerboard-size)
-                    ) * -1 +
-                    var(--spectrum-swatch-checkerboard-background-offset)
-            )
-            var(--spectrum-swatch-checkerboard-background-offset);
-    background-size: calc(
-            var(
-                    --mod-swatch-checkerboard-size,
-                    var(--spectrum-swatch-checkerboard-size)
-                ) * 2
+    background: repeating-conic-gradient(
+            var(--spectrum-swatch-checkerboard-light-color) 0 25%,
+            var(--spectrum-swatch-checkerboard-dark-color) 0 50%
         )
-        calc(
-            var(
-                    --mod-swatch-checkerboard-size,
-                    var(--spectrum-swatch-checkerboard-size)
-                ) * 2
-        );
+        0 0 / calc(var(--spectrum-swatch-checkerboard-size) * 2)
+        calc(var(--spectrum-swatch-checkerboard-size) * 2);
     border-radius: var(
         --mod-swatch-border-radius,
         var(--spectrum-swatch-border-radius)

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/checkbox": "^0.14.13"
     },
     "devDependencies": {
-        "@spectrum-css/switch": "^3.0.5"
+        "@spectrum-css/switch": "^3.0.22"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -122,7 +122,7 @@
         "@spectrum-web-components/icons-ui": "^0.9.11"
     },
     "devDependencies": {
-        "@spectrum-css/table": "^4.0.26"
+        "@spectrum-css/table": "^4.0.35"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -93,7 +93,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/tabs": "^3.2.27"
+        "@spectrum-css/tabs": "^3.2.37"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -72,8 +72,8 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/tag": "^5.0.9",
-        "@spectrum-css/taggroup": "^3.3.21"
+        "@spectrum-css/tag": "^5.0.17",
+        "@spectrum-css/taggroup": "^3.3.30"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -65,7 +65,7 @@
         "@spectrum-web-components/shared": "^0.15.6"
     },
     "devDependencies": {
-        "@spectrum-css/textfield": "^3.2.11"
+        "@spectrum-css/textfield": "^3.2.16"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/thumbnail/package.json
+++ b/packages/thumbnail/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/thumbnail": "^2.0.23"
+        "@spectrum-css/thumbnail": "^2.0.30"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/underlay": "^0.9.8"
     },
     "devDependencies": {
-        "@spectrum-css/tray": "^2.0.11"
+        "@spectrum-css/tray": "^2.0.29"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.7.5"
     },
     "devDependencies": {
-        "@spectrum-css/underlay": "^2.0.36"
+        "@spectrum-css/underlay": "^2.0.43"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/tools/styles/package.json
+++ b/tools/styles/package.json
@@ -108,10 +108,10 @@
     },
     "devDependencies": {
         "@spectrum-css/commons": "^4.0.2",
-        "@spectrum-css/expressvars": "^3.0.0",
-        "@spectrum-css/tokens": "^8.0.2",
+        "@spectrum-css/expressvars": "^3.0.2",
+        "@spectrum-css/tokens": "^8.1.0",
         "@spectrum-css/typography": "^5.0.1",
-        "@spectrum-css/vars": "^8.0.3"
+        "@spectrum-css/vars": "^8.0.5"
     },
     "customElements": "custom-elements.json",
     "sideEffects": [

--- a/tools/styles/tokens/global-vars.css
+++ b/tools/styles/tokens/global-vars.css
@@ -243,6 +243,7 @@
     --spectrum-popover-tip-height: 8px;
     --spectrum-menu-item-label-to-description: 1px;
     --spectrum-picker-minimum-width-multiplier: 2;
+    --spectrum-picker-end-edge-to-disclousure-icon-quiet: 0px;
     --spectrum-text-field-minimum-width-multiplier: 1.5;
     --spectrum-combo-box-minimum-width-multiplier: 2.5;
     --spectrum-combo-box-quiet-minimum-width-multiplier: 2;

--- a/tools/styles/tokens/large-vars.css
+++ b/tools/styles/tokens/large-vars.css
@@ -270,6 +270,14 @@
     --spectrum-field-edge-to-disclosure-icon-100: 13px;
     --spectrum-field-edge-to-disclosure-icon-200: 17px;
     --spectrum-field-edge-to-disclosure-icon-300: 22px;
+    --spectrum-field-end-edge-to-disclosure-icon-75: 9px;
+    --spectrum-field-end-edge-to-disclosure-icon-100: 13px;
+    --spectrum-field-end-edge-to-disclosure-icon-200: 17px;
+    --spectrum-field-end-edge-to-disclosure-icon-300: 22px;
+    --spectrum-field-top-to-disclosure-icon-75: 9px;
+    --spectrum-field-top-to-disclosure-icon-100: 13px;
+    --spectrum-field-top-to-disclosure-icon-200: 17px;
+    --spectrum-field-top-to-disclosure-icon-300: 22px;
     --spectrum-field-top-to-alert-icon-small: 5px;
     --spectrum-field-top-to-alert-icon-medium: 9px;
     --spectrum-field-top-to-alert-icon-large: 13px;

--- a/tools/styles/tokens/medium-vars.css
+++ b/tools/styles/tokens/medium-vars.css
@@ -267,6 +267,14 @@
     --spectrum-field-edge-to-disclosure-icon-100: 11px;
     --spectrum-field-edge-to-disclosure-icon-200: 14px;
     --spectrum-field-edge-to-disclosure-icon-300: 17px;
+    --spectrum-field-end-edge-to-disclosure-icon-75: 7px;
+    --spectrum-field-end-edge-to-disclosure-icon-100: 11px;
+    --spectrum-field-end-edge-to-disclosure-icon-200: 14px;
+    --spectrum-field-end-edge-to-disclosure-icon-300: 17px;
+    --spectrum-field-top-to-disclosure-icon-75: 7px;
+    --spectrum-field-top-to-disclosure-icon-100: 11px;
+    --spectrum-field-top-to-disclosure-icon-200: 14px;
+    --spectrum-field-top-to-disclosure-icon-300: 17px;
     --spectrum-field-top-to-alert-icon-small: 4px;
     --spectrum-field-top-to-alert-icon-medium: 7px;
     --spectrum-field-top-to-alert-icon-large: 10px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4199,45 +4199,45 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@spectrum-css/accordion@^3.0.31":
-  version "3.0.31"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-3.0.31.tgz#a0da7d7dd56e07ed94f39c0d9f6e2465ec3e98d6"
-  integrity sha512-/0kzKgpe5yTcjYHGEtJJt+pUiEkNFIaobSUsmDJKG6wsZMQhnLKpojaG6jAtVERKJqKcB6t7NZnvuxYp9jtIeA==
+"@spectrum-css/accordion@^3.0.39":
+  version "3.0.39"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-3.0.39.tgz#9e6a45f5598b2b6d22aecb18d81a9f0dd4799630"
+  integrity sha512-xAgvfysJzA3u3gC2sg+3y4hQ3fpsQp9LxZ3vSSjVR+EWu27PANGTNqyKQfF82Lkvez6CyVLL8l67KkJ2owFmIg==
 
 "@spectrum-css/actionbar@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-4.0.1.tgz#8742808a9334484896d7f47700a9544d444a41bc"
   integrity sha512-s97vdrYNN5LhilNeirs6Xox05VZazjTNSb+qrtItowdfHEw3XbzCs8n0AdHgMSZkezL9z6B/BojeOo7fIGWbdw==
 
-"@spectrum-css/actionbutton@^3.0.20":
-  version "3.0.20"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-3.0.20.tgz#bb84c5596854518b4148d51489827b85a95d78ee"
-  integrity sha512-gGy8tNVfRCSCY0yMePzxqlBIVT5/xiG624hkuxcqrT9b4PbPxkMmFeUovcNQyjusZxrBq/WtiLVpKPqqHUm58g==
+"@spectrum-css/actionbutton@^3.0.29":
+  version "3.0.29"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-3.0.29.tgz#07b896b6ea4dd0aad30992bfed7aa88ff6b8003d"
+  integrity sha512-Sik3Dyn13FgZmL7X85ShqVFJ9ArpiZIrBEgpmPL+58KCGAONh09D2Vcq7EthiUs82m8/JIFuYOKI71cYSl7oJQ==
 
-"@spectrum-css/actiongroup@^3.0.12":
-  version "3.0.12"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-3.0.12.tgz#21bc0747901ce22edeb54cfac4de0b12f46d5907"
-  integrity sha512-74AvsYaeVFGfMbHK7B4xcY/sbgf2iTcS09sWm861SUlDdbhm2pDmZoW7zVz1b7TMM0DqNh5eGmqUNtZgt5qH6Q==
+"@spectrum-css/actiongroup@^3.0.30":
+  version "3.0.30"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-3.0.30.tgz#1869040cdb7394ea74e71fd36411101d781cc5ee"
+  integrity sha512-azASgIu71iCgzdNWtcYGlL//J/3rDCD0KCLGu6rtI/DaGjYERnO1JOxo0a4zvqNIn5YbxVEyxruJUostLznpig==
 
-"@spectrum-css/actionmenu@^4.0.8":
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-4.0.8.tgz#31a691f396359f768515ecb3f4beb4e560fc9a8b"
-  integrity sha512-bJtAb3hSs4gjE7FVcwMdqVfpCeVQSQ7vWyRFfF39uGT4Oe0PxgdhbKQ5hs8YT3nmq98x6oF1+c2rtWYom8j95w==
+"@spectrum-css/actionmenu@^4.0.17":
+  version "4.0.17"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-4.0.17.tgz#c7d52c2d8787bdfa795b090741f55d97147da76e"
+  integrity sha512-RVxRiukwDoeNht+yC/gJrMVNRnt2VEgRwX0trrSPg5hN5VyUv8DaqM3ECne2qxht2WTK5B+4t+6mZfLWSOvSbw==
 
-"@spectrum-css/asset@^3.0.28":
-  version "3.0.28"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.28.tgz#288c04901ba844375b1cf911ffbdae6683b882c7"
-  integrity sha512-kQ4nv2QaXokVG2B0oGp+7gDKgUa/DlCu2hPQ6jAYM5DJSTsM1VY0PwNcBpJ/pvbKEF00lfV9KBfMOVobqhjjYQ==
+"@spectrum-css/asset@^3.0.35":
+  version "3.0.35"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.35.tgz#813e04dfb30e0f5b83171c2d2bb8bb77655165b3"
+  integrity sha512-zXzvtX7IVTS4YZEbcri4kYaNefyBd22zrqh2sxU25fiQf4rra7fhgponUhgdfqknvBx1Fi6GYDeZjL+IZcE9Mw==
 
-"@spectrum-css/avatar@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-6.0.0.tgz#9e8354e1c7f39c68236816608c82749614127d9c"
-  integrity sha512-3KmuULwc3bhViydMFn7kLxM8uTshC0600WV8yu1DqgKTHTO8bFuFAltzR22MCQ8HzVeWDqMqwUIYejZESROcbg==
+"@spectrum-css/avatar@^6.0.15":
+  version "6.0.15"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-6.0.15.tgz#2a76f1ff33ae393a8682124af9a3e362c0b80f9a"
+  integrity sha512-ZqNqp3mw5QZFTf3cNwB4QVEafB9P/CvdFzHA6YXEOvV/cj2uFhJS3qyOriL7K0GC48bBW/aVRTi2qtrEi/r0YA==
 
-"@spectrum-css/badge@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/badge/-/badge-3.0.5.tgz#6265201e45054c463d0c45d1ef6d5a36699b3719"
-  integrity sha512-TznSs+aGRmC2T4sW/CiLPP6MGZ6xqSY6FOBV8+uHO6eVXubw84pHffrbGIzQ64nlz8h3iZTAWesPtOl4DGRvOg==
+"@spectrum-css/badge@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/badge/-/badge-3.0.17.tgz#32c689b1af04431703229ff09a354a22bd745850"
+  integrity sha512-LeWgrawmE8Fz09Q+1gnq/Zcjdaqu6VQFMKMYsDVUGMZ5fh4XU3zxJiDNwtxsz7NhXk0mYUzOxfWivJcaC2vC3Q==
 
 "@spectrum-css/banner@3.0.0-beta.2":
   version "3.0.0-beta.2"
@@ -4249,40 +4249,40 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-9.0.8.tgz#f9ca097f978c4059c32e20264c0c1bfa49a68ca0"
   integrity sha512-lUTJTg5JzvOYLSHEGOpFK9DKojtc6hWpCrJX5PACgwvgkyJ5JOjxmpK10SSyFQtAwFnDHjlzwSBNGdNaxEW0ug==
 
-"@spectrum-css/buttongroup@^6.0.14":
-  version "6.0.14"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-6.0.14.tgz#0e6ae267e497104bfba7d4cedbd175112496ed40"
-  integrity sha512-CUmMN+rZbUgbqhOL5aLJ2iAZKDTi0JPvFaxveoNbavTdk37nD8FSGx/YLnxiyxFBTK5GaIUPXsLBQSC3IyBC8Q==
+"@spectrum-css/buttongroup@^6.0.32":
+  version "6.0.32"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-6.0.32.tgz#6d82c8a5ce3eba6a8d5037cc86e706a2a328d236"
+  integrity sha512-OuB/7e/d2rDrt1KRshf7+p39Gv5KX9t8TnzpNjIl5FI40rJW6vgZrrgEpysgovYM9dQOcwUroxxv0+qlbz+K6A==
 
-"@spectrum-css/card@^5.0.8":
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-5.0.8.tgz#e7ad83e53c70ab723f5309106b44bebec12e29bf"
-  integrity sha512-A+osla1zHIqeJ0IT6fusVvAesGVtjnYrwyMmYlnyy5mYrXzofwaCdFz/h0i/4ckN3GxZWzHh6kgqFvXbGGoADw==
+"@spectrum-css/card@^5.0.17":
+  version "5.0.17"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-5.0.17.tgz#07be2947995b425cd53f59bdc861497e48acb4ab"
+  integrity sha512-jrI1CRIjSOmdCB0j7ZQYrBYyDVnYpGAfaf4ssNbpARXYc3VtwrdohO8XkeqDdYv8vHI4oecgATnEYmP5UO47mw==
 
-"@spectrum-css/checkbox@^6.0.2":
-  version "6.0.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-6.0.8.tgz#796b3bb9270a89ab20bb1295e8e63156606958f1"
-  integrity sha512-4IZReb8A48Cf7cEkspt5zqCDh87j/JFCa31kZg1v6pcEwWxeTj/ELUi1NTQIZiBKqn636TqwRzCCjYZjqZ8HjQ==
+"@spectrum-css/checkbox@^6.0.17":
+  version "6.0.17"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-6.0.17.tgz#fc8d78765f793fbd813a1f8ae4c0d810d922cd81"
+  integrity sha512-y+c3a8eOl81Z1dwNLBGzyv/0Af7HmMhWZLWFbES1b/ADuxYcVMOTUzQaSUooayf0Pbh8hwTfOeeUYZdM44muYQ==
 
-"@spectrum-css/clearbutton@^1.2.17":
-  version "1.2.17"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.17.tgz#beda444a1b534c8d3c2129621361a22dd0b8d0aa"
-  integrity sha512-71f4qr8yLfdZjg48hFO1ny3/7odDc7xHaqbhyUuFpxrPvedz9KRt+SEAlpPsEOGJIC6sGQGaftUaReijsa2MVg==
+"@spectrum-css/clearbutton@^1.2.25":
+  version "1.2.25"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.25.tgz#fd853eedbbe7871115efb362b7edd670f8470b89"
+  integrity sha512-Cx6X3Npwhf4zrpgnwi+SIEZ1hhpIsGZ2ys4rTrYJvj4ZMVj5opDc6EfXIXENQWFZu3fH0jZcU+N0TTad1Zi9Qg==
 
-"@spectrum-css/closebutton@^3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-3.0.11.tgz#e0773734708e2127ec5c6024393b784a90cf9bbc"
-  integrity sha512-MyBY6Aoa7lXMXzN0OgjCxdQfFOxJGtgCGzs4+th9qBRUBDiV3gezlTQhAW2hGc3vTWXuEaOb9fRUKunFWOLNLw==
+"@spectrum-css/closebutton@^3.0.29":
+  version "3.0.29"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-3.0.29.tgz#fe2e019dfe8403787f433396390f278cc8b9627a"
+  integrity sha512-mN6gMauYX8r1xiG8h2watdlY7V26sjY2yuBVb/v4c4eE5xTqu5caDMormrc6unFmF9CZPzFCFeVwOX+TTM3mkA==
 
-"@spectrum-css/coachmark@^5.0.21":
-  version "5.0.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-5.0.23.tgz#e59f8a02ff3a3c28bb3580db14b6767569c29d14"
-  integrity sha512-UhuXSmefOE/9qKB1IkVWlNjX9V11Q1zOuyBefaQLPaiJHKx8E5NL9swI5PjswfFugfP15A/Rc+j4KFfTGy1QQw==
+"@spectrum-css/coachmark@^5.0.29":
+  version "5.0.29"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-5.0.29.tgz#f53a91ebb808104aae75f84959cb3d271276ba3e"
+  integrity sha512-+pLZ/g40pt0XfoZBIX5xQVYaxN/aOtY63kzlV7AZ1cSnAlJXVheFQaoX+sofP4EosZUdQBcAMP/4OoTDHWxLjw==
 
-"@spectrum-css/colorarea@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-3.0.0.tgz#817f0371b032c2c6b2e8d87d5f7b400854f5d434"
-  integrity sha512-4mUzpf6yU7W6WgmnNWGNXrzknz76HtRY2+1BwlijoclxyGID28QdfkfsSuaIm6f2fNWu6+XAQ4fSTImeZLa0jw==
+"@spectrum-css/colorarea@^3.0.10":
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-3.0.10.tgz#1c05a4ed4e9148047f1f585cd629fec76b9613f3"
+  integrity sha512-94veu17ZCWEX2H7M0AZcyJV+/TYvkELGwqA9LG6509yNNnNuk8h/lGCZ/bOcbyzqnrgt5pZ2pYlGdrhCq0tQDQ==
 
 "@spectrum-css/colorhandle@^4.0.0":
   version "4.0.0"
@@ -4294,45 +4294,45 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-3.0.0.tgz#e100c1baa2405fe4fa6a6e747dc3386530303b20"
   integrity sha512-bNeG8G9rDmVaIjZp0jHvEf2wmkemNPu54xEvWR6e0ZcYu9/j28dhODERPFX479g7RZsAvOqU2STVgxigt8AHYA==
 
-"@spectrum-css/colorslider@^2.0.13":
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-2.0.13.tgz#c5cb6aeb6e26c61e775e06e40c23e33742f8cbad"
-  integrity sha512-o3hHzO4LHDS/QRe42PJecgO7YLhK0buxBt9Ky1XZWXrhTzSTJezyF0PKaSOyPJa6OaS9YprWt+nnv1NIBzfg4Q==
+"@spectrum-css/colorslider@^2.0.24":
+  version "2.0.24"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-2.0.24.tgz#29585e076adad4ce42d2c22ddf98034d7460c6fd"
+  integrity sha512-8kyM7HzuV2TgN0DGABxNhWWOtC4IjYooiKxakzQnftYbjr9RrvXOMHSnl5U52Xj61Pos7N8Ep9rG51dF+9bmCQ==
 
-"@spectrum-css/colorwheel@^2.0.0":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-2.0.9.tgz#a802b7880e8bd7b127170c9b04f4351c60009a52"
-  integrity sha512-KErtnfSi7sj+sG2OvPZocE5CQJSuZXZWIhfB8N24eCbL4RPxLQv4H+6AbPLQFx9OlP1pY8Gk6Q1bQX57SDWVgA==
+"@spectrum-css/colorwheel@^2.0.12":
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-2.0.12.tgz#3dcf5590a2b54e28d9826e7cf056f03bfeb4378f"
+  integrity sha512-ZyocQGQvVBHVv79Ozv4koQOm9APKU7BmRsAgOndZtudQS3YAAFBTCjKdLL8NDRlW3w+XBL4ih8LsBwZtPySe4w==
 
 "@spectrum-css/commons@^4.0.2":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-4.0.2.tgz#4cb4c614c5e87927ecdf0d91582528f85e05a6e8"
   integrity sha512-suAr8H9b/ALlnGV+wTwvLOWTmHPYcekPHXtCPgUUok2p379suy86+M9Ps0u5t2J4HaZ8FIxMAH4EBewL5oqBMg==
 
-"@spectrum-css/dialog@^6.0.25":
-  version "6.0.25"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.25.tgz#d5ffaf4354b5feaeaa20b1eee39fdb8cbcdd4b00"
-  integrity sha512-6UJguaUFtZqfC/3BYxHS3FP8JcTplBINBb5E0ZG5FnU5VmxnzwU+1Me7E6wFSvH8Ruf8aXsacaza/gpIgut83Q==
+"@spectrum-css/dialog@^6.0.34":
+  version "6.0.34"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.34.tgz#519eb5d81dbcf0368f1e06db3830414700603231"
+  integrity sha512-ij0BvXiaB7q+2jRzWRmtTOg7RL4vIkp5S1EETUFyx1iCwv5u8DjlySH1fhzrtTPDjWkewL2uTSl546eWAs8eUQ==
 
-"@spectrum-css/divider@^2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-2.0.10.tgz#0f9f74db6aa9920fcc57e7f22e78b9cc4578d2c9"
-  integrity sha512-V48AGRvRvqZvWYbG07v7tXxjqCTEf/IQk3p716kPNs1UyJs7vIa0jlNr8ZtS49YDYJuvO1cebDR5hXyR8SWPvg==
+"@spectrum-css/divider@^2.0.28":
+  version "2.0.28"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-2.0.28.tgz#9602d059436e18114a44776a5f2e06b8c49b5c02"
+  integrity sha512-MQLaDNnVNfpQMmmxDCd7kZABhlsHcZpz3bvSgDKcgHGVI0ztqwkzncKwuoQZ0w+3Wifp0BPGgh6OGMU9cKnPsg==
 
-"@spectrum-css/dropzone@^3.0.31":
-  version "3.0.34"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-3.0.34.tgz#3ff928d4a8af95011d436adf90554aa3e7308dd6"
-  integrity sha512-ST+fs8VZsPpX9g/aiUWXahCINNIzjt+AMiK8Bjkgyz3vz5QGnhHhf2bALYaEWdODzY/ZfNZqEBxZdgLVe6PvFQ==
+"@spectrum-css/dropzone@^3.0.40":
+  version "3.0.40"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-3.0.40.tgz#784d42215718893f951ce99313d9fd1e451c5854"
+  integrity sha512-gSWrxCEibgYQ/gWV58oJsSGYUmUpaUY8lLbkSUwnTnvsJG8RyJr1Y5K2ElQeo2q89GaAnehX35B4TYrkciPT1A==
 
-"@spectrum-css/expressvars@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-3.0.0.tgz#ee670a826f0f60f54d77f78033e074ef9b3fd030"
-  integrity sha512-GApWglNogsRMHnYbK9EsU5kh1OgCNZgIv8DV3aiDib7OYq4jBWZSodwwsER2DrT4rErR72QfCJEO4Mu7JRFohg==
+"@spectrum-css/expressvars@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-3.0.2.tgz#eaf0ee036697d1f42d13f8d6d450fac8f9f4fd4a"
+  integrity sha512-+eMYiIteWGRXKG+qn12/mK7fXi4tKpRsjOrjcJX2/Nli3xhAc5vAi9pr9I7bvYeeAXQaloI8GRVZhtxvypWfbw==
 
-"@spectrum-css/fieldgroup@^4.0.13":
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-4.0.13.tgz#347fe0540c722e37d5c4bb1d2477c262cd8b4d0d"
-  integrity sha512-cPz2S/g9Pv5WS3UUWNnyy1+/DFJxAFsfUKv7W81QInPzZnPisvvlTQJzVKpNyeZVkvptUpcbjMbdFCoIj9ImaQ==
+"@spectrum-css/fieldgroup@^4.0.31":
+  version "4.0.31"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-4.0.31.tgz#035f27b841bcfda2597a79690859f5eea0138ac2"
+  integrity sha512-N+NYFFhHvw/pm3ChntRloUBRqbO80CmOd2otGcedRP22qWQ9FPSE0EEZuqdNemT5Zgi8pg/VUmma0zKQUR9mYw==
 
 "@spectrum-css/fieldlabel@^5.0.15":
   version "5.0.15"
@@ -4344,37 +4344,37 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-3.0.13.tgz#bb3ef6d2a66a528f9956fd2cef61d3e1ca844159"
   integrity sha512-DZesxo+DboeljfeSdMxylorfyPKisNiod4hPybHBqbYm0bs+CGuEOsXhayTzK34Xfsh19kkDQieM62rANkhUCQ==
 
-"@spectrum-css/icon@^3.0.30":
-  version "3.0.30"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.30.tgz#5e2c56318fd289948ce9d723919462510d646123"
-  integrity sha512-9oUpnzXOgamVGmR3SKvKJzUVZqodVN4iJg0KyUPRTPNtzbzLhRZhuWB9HlRmQlpvQDPZ3mvQX781UTFNwCw61A==
+"@spectrum-css/icon@^3.0.38":
+  version "3.0.38"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.38.tgz#8e573f2a2b377c3de39f299e4dea5f577c838855"
+  integrity sha512-/sckVetoKnU9YNcRogP2LNS48aQ71D2jzTSOUeOZPGlWfUu0gn49vSey9D/NZR3dAqqAfMfOj8g2A9rMw3pI5w==
 
-"@spectrum-css/illustratedmessage@^4.0.11":
-  version "4.0.16"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-4.0.16.tgz#35c8f0b50452b2d00d19a45733dad051bc9f5ac9"
-  integrity sha512-/Y2rIMH3PCX8kGGpT23yztC+um3w3VAA1C/jwSifn+SD2wDHJEfFqSkgJ096UTB0yVABLYBfnc6ndi6hQnYBvQ==
+"@spectrum-css/illustratedmessage@^4.0.19":
+  version "4.0.19"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-4.0.19.tgz#064bdb0413b55fec65347959598eb0b65fbd6750"
+  integrity sha512-Bx2jZ5m3vbYyc+6dDT9eY1FhyOtval2ilC4Unht7N2dRTCe/gVHG8/rThcx4FEaoVGIjZRNIovJFOGpCG3l/zQ==
 
-"@spectrum-css/link@^4.0.11":
-  version "4.0.16"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-4.0.16.tgz#0e011c095a13810956c23d9895e69b575de19125"
-  integrity sha512-lqD8y8PuOEBKoe/ocTsoIqQmF7Pt++/grSbDGcTjzSuL2OlU7XN8ZiemNVnlI/7FVFaWtpuexGszVM7oxi/jiw==
+"@spectrum-css/link@^4.0.28":
+  version "4.0.28"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-4.0.28.tgz#7dfe39d1f85337dd7b24f6ae67a37186c889a20a"
+  integrity sha512-qc56FlhdSvzqCGs5UMjRHa/EMgBfxMqMl938L3ububRNGmrJM3zvniGV4sAFzwQM+1yDeXSCh80KHIXwySsDYQ==
 
-"@spectrum-css/menu@^4.0.11":
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.11.tgz#36af824268f686df8998e4cf9693fc38f15bcd6a"
-  integrity sha512-LyqQ4PuW4Mhz5w/F+IjgT2WT2E48KfOV0TEHXOSIvtbsXL0DHnr1UwgAx3CZAuyQ6idD/CmOin+7bVnqPaEgUQ==
+"@spectrum-css/menu@^4.0.20":
+  version "4.0.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.20.tgz#8357e0103a98c67ed481332069b3d887a5f6cae4"
+  integrity sha512-6yW5GhfddG9doM0z9NUe69YQdMroGEo8wmjVwrkYsOfvg9sDBrRg+w0AU3qMDIg6FjRuPH4IrCa09sewCCEo8g==
 
-"@spectrum-css/modal@^3.0.28":
-  version "3.0.33"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-3.0.33.tgz#bdbae853310863db186e8471e7a25abc9daa933c"
-  integrity sha512-hs8uwe9bt3/gUV2R6ZTBHZdsUyP1DzqOOaj/rPtkATL7bNjrZ70+J+4N0Mzha2bZAE6VrOeg1gZx+LnJFF1gMg==
+"@spectrum-css/modal@^3.0.36":
+  version "3.0.36"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-3.0.36.tgz#6b80946f9698c0c63708248805617fa6c9f39de1"
+  integrity sha512-c2cVffBaiI0TZRLe+BbzbUOlUMy5kiRFe81TnYKvEITMqDwoSSnjL4HJweSaxI/1Ge05srCsZpyMwbaFzxeLrg==
 
-"@spectrum-css/picker@^2.0.5":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-2.0.9.tgz#9a42ef9908610e054597776297f30b2a0d7e9aa3"
-  integrity sha512-1js7vzLbH1tUQV7p3P27WQ6zHttI0tBGnIMu6lLnpRDbY9D9Rvep5V+SucZGkMbUARh0cCUpmj61+xY98n/f5g==
+"@spectrum-css/picker@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-2.0.11.tgz#4ddb96a3e474f2b45cb2ebff1d378ee7f35cac1d"
+  integrity sha512-9I1eNDK+D5mIwPD6ceaDaw2gwToYyaRC0vXCPy6egcSOcuRh6c7F33yslyFNmh6hatXrr904JkaowklDQgrFSg==
 
-"@spectrum-css/pickerbutton@^2.0.7":
+"@spectrum-css/pickerbutton@^2.0.12":
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/@spectrum-css/pickerbutton/-/pickerbutton-2.0.12.tgz#cba66576d6340c78f898fe163cb884593bbcbf43"
   integrity sha512-GUKSb5NnOmLe1r1V8oV28E+sZh98EDrtkzDnWrr5vHYgzeu6/W0HYFe/4d4FyyZsTyD3yh3tMRXOY9KgJ3rdzQ==
@@ -4384,140 +4384,140 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-5.0.18.tgz#4e8d1b15b0f96ff3c19a6642ebae7937e99723a4"
   integrity sha512-MpdlGjj6Y03l65UUiww8ulc6t6xImQFsIAqzDIuvtH+8BPEM4IbizJFGa6LEEvkMhHiwRF1s94LDg3d+q3ZmvA==
 
-"@spectrum-css/progressbar@^3.0.1":
+"@spectrum-css/progressbar@^3.0.20":
   version "3.0.20"
   resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-3.0.20.tgz#7acc02ddc53f0172c5cbdef4185c0f533b550d9e"
   integrity sha512-yNsZoBtw7n0KKzGHZKS4z+o6NDohTPCr2YT8wGAmTPHLJRkcgbSKMDJYj0be9Fgpaoe1EjZBm7P6JGLDAEs88w==
 
-"@spectrum-css/progresscircle@^2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-2.0.10.tgz#fa092fa611ddc3716e29bdbf172dd4cf4a715e45"
-  integrity sha512-sN0n3+tqRukj3hBe4QhkstQUKQswc6w9O1sOYPtjEVZls4IDqCuFh8QuqQ6VMtsj6qOs1/Mf5ynH8pfuAQBQZg==
+"@spectrum-css/progresscircle@^2.0.28":
+  version "2.0.28"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-2.0.28.tgz#ea38c8b3409313d50a332e187c2782d2d1e537ca"
+  integrity sha512-CgT7+OhjmSE3jvS7mixe41S65GIKqz5gbityLigziy451k51me9oSnL7LDWVI3iaC33d8Tta+eN5pajoqJo01Q==
 
-"@spectrum-css/quickaction@^3.0.32":
-  version "3.0.38"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.38.tgz#25b02c80e3f557ba78c5edf2025369ac4d413b4f"
-  integrity sha512-KYfJqBmDDEMK3zxXO0wfmX3O+MH5KMHeqMUwfjPWfibrpuWDy8NUWXJr1j+xnZETdbNp9tQrcovr9wra+vWvmQ==
+"@spectrum-css/quickaction@^3.0.41":
+  version "3.0.41"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.41.tgz#28a98d537942a05b64fa501482a8264c71a96fef"
+  integrity sha512-NOkcF0T8pJnfzT8jL4GDyiJchuSPOBmCOcMnre0DSERSijJxaCXts9GrVWrfwKOuQTRqYOLcGO0ZI53ms++5rA==
 
 "@spectrum-css/radio@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-5.0.1.tgz#4e2b896599ec9bad61cba389e59c6dcd4f002f10"
   integrity sha512-dJ1+YOaEmBiZl2dXSufn+M3akAWrLnuvVanHZTn//Xdq1vjmAK2IPtYAEuJpA6ckwLU5GXypQ4MjCFmxbhC9rQ==
 
-"@spectrum-css/search@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-5.0.0.tgz#0e8c548d7206c327dd854420476b558d373b9309"
-  integrity sha512-JAJ9QxtWJxnuXQU/CIf4vfy843XBMLZe8x+KnBgnzqGEkpYrheJ3E540GS/G7p889sfeKI4enZ5DHR/9tXEkBA==
+"@spectrum-css/search@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-5.0.3.tgz#c8187a4a5f3990e4d47f74cec8ae9a64f849dc97"
+  integrity sha512-aECgqu3xFQ80zq7qimYjttOHQ7kkhHm9fzt9+k5t7Z0yNFQgLzPCoPMLmZ+n7CQzNk23XAF0bFx68IUfQhMzlg==
 
-"@spectrum-css/sidenav@^3.0.31":
-  version "3.0.31"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.31.tgz#35ab4fec1c79d9e673c49457ed7b6a3fc35415c9"
-  integrity sha512-AndxBoHCUZU/gQ4Wkm0l33J37o0D8xI11QDK3vjCwX7AI8CG0179mrILha7t5EXOmnVyeUJY7bknbooZ+XWHfg==
+"@spectrum-css/sidenav@^3.0.39":
+  version "3.0.39"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.39.tgz#dcfcc3f9491fe87db66aa35431f541b834abc57b"
+  integrity sha512-sL9vnPWEl44wH12Q3OXH1Gpp52FDqBbEdzmAndqJ/eBqtUv7d0A85X2g0e1Xa28PrDJgBr673cF+Tm5tJh8uFQ==
 
-"@spectrum-css/slider@^3.1.12":
-  version "3.1.17"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.1.17.tgz#b6a437194339efe799eeb410f50411b18146a63c"
-  integrity sha512-iLngpUW0YRnjWEEkJbwm9FO01m51BsAzoB1FKFrYiqn0WntyVyvMHZlW89CZhpPoQVIrxyJ0JkkHn1af2i5ALA==
+"@spectrum-css/slider@^3.1.20":
+  version "3.1.20"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-3.1.20.tgz#741ef152e20c7c43356bf1ce56c0fa3a6b063558"
+  integrity sha512-Eak+WKS3FJoYCxVZt+TC4608f6KUZ4t1WjC3ovXMq3ku/nUZwMZwPZnPZ78ijjr14OP5FOH1DDdj8qaKvVkBEA==
 
-"@spectrum-css/splitbutton@^5.0.22":
-  version "5.0.22"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.22.tgz#a0172307e1a9cfe349ad3fc683189fb31d990f07"
-  integrity sha512-mT2Cj3sYMIerLOBZlc85hVZGnDh41Jlkfki6mGoassC4A46sYXPB4t3UEImEHleg0wkWN5Uacc5RXM7HRNwU4w==
+"@spectrum-css/splitbutton@^5.0.31":
+  version "5.0.31"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.31.tgz#0d2fae673a965462d71117ae94101cc470b4c08b"
+  integrity sha512-sCIvcGv2dNCGEKy+XrwZunXnVYh0UPk6PWeux2029JvUzff+k8BqY+96jJBNsM5zDkXmca6zg2gyd9Cm302xXg==
 
-"@spectrum-css/splitview@^3.0.27":
-  version "3.0.30"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.30.tgz#9440c2c98ab6c5d458672546d9d43868bb199455"
-  integrity sha512-fp7tisDcG3Z58lplO1SQTCQsYQCsuHhAp6CepairADvB1hxGcSUMvTHhyN130NMsbaRjjuYhfvKl54p/w1D2gQ==
+"@spectrum-css/splitview@^3.0.35":
+  version "3.0.35"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.35.tgz#f39e5f86d44159a6184f074e20d2518ab1e1b6e2"
+  integrity sha512-H/yQNHxxMmOVTSLgsTfovDNAItp7A3O8XgSNXe1HbXFteEGGsf+4eKD1E8CrGF5oAfBVuv64hWgHFOG4D1N2zg==
 
-"@spectrum-css/statuslight@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-6.0.2.tgz#9ec39bc550891e0dbb1ad55c1e1dcb3e7ab02e54"
-  integrity sha512-eP0w5rOSxF8JMO7ATiH4sXYRxIytfoKzfjJHcJ7Oj0OAFXcMsBC+l9YobMwXa9GudwVpRcL0SLShSZd5mobV1Q==
+"@spectrum-css/statuslight@^6.0.17":
+  version "6.0.17"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-6.0.17.tgz#2e72b9e72f606e90e386d03f948c3e7cde75d7f5"
+  integrity sha512-j7h79EogXsmP2bGb93a2qgBakqh7XioY+5qn9uSLfHYlmF1e06mQY1VHTawN/doWJmKFh345q8sT0/mqNZ1HuQ==
 
-"@spectrum-css/stepper@^3.0.34":
-  version "3.0.34"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.34.tgz#53623e7e444dc1c0a48b4cfefad915cf62471838"
-  integrity sha512-qvFtm6wFeTmTBeLkj7aGJbssYf6DR+Xo7Ee/3hcFYRf6XztafsaRiBeaOxsvEbfZxdg0Ari5GscT1s4N3Lplhg==
+"@spectrum-css/stepper@^3.0.39":
+  version "3.0.39"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-3.0.39.tgz#659f1a0fe34a672167214f58b359b22f3ac1d017"
+  integrity sha512-dvxWwhisutJmqijzWOQczVKcT0gPWHRc6HrSkPxmwYdQlJy/sweM2ZI2d6pjmwRL95gMgPGr2xugxQEDBRsb7g==
 
-"@spectrum-css/swatch@^3.0.9":
-  version "3.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/swatch/-/swatch-3.0.19.tgz#02ef65e5681b0983db9fce3554a7e0015f764367"
-  integrity sha512-aSiEEYRFIg10KvoI/rr1RyE1MTrcFuyA/6yGPbnhp1bDrV6PSfSKf3+jOqpQNLSTZ1m0bvBX5tih3XstK91zew==
+"@spectrum-css/swatch@^3.0.21":
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/swatch/-/swatch-3.0.21.tgz#99951a80dc24dfd2d41f6e272d2850cd091eb49d"
+  integrity sha512-YaOcRP1sH8c12NK/oI6tpJGcmUD0+p4aQxnc/Joz/bBmeOGSQMDjh9u+elxrIl6dEMbIK4edPky/K0Cgh8JYTA==
 
-"@spectrum-css/swatchgroup@^2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/swatchgroup/-/swatchgroup-2.0.10.tgz#61d5fc271343fd721eebd5c354378f903a3f05f0"
-  integrity sha512-mdyaG9oedbZF7TtznBXUdkrlpvnSKg9kriqZ8DmrTzvuW1wlzI34NOewF+BKlAEl8IQnSgUU5iSXj7deKyf/hg==
+"@spectrum-css/swatchgroup@^2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/swatchgroup/-/swatchgroup-2.0.29.tgz#d5dcf10838fa97646da28c0af8ae4c37760344ae"
+  integrity sha512-+F0OttqNF475ilISdkZ11PFNoCJ5nd+d3KJO6atYCMJyI2P9u6hInq1RlUz4CDnvVLsLiVlSF6FwMlXTgFQILw==
 
-"@spectrum-css/switch@^3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-3.0.5.tgz#e85f9c8612900490c28b3c22686a73c569985c94"
-  integrity sha512-Ul0ghnyPFlEWEc7BmuO/TullDpqSmQucD0f1/upYKzcagkvAvbXH8FbK+TiCBV1difwGoxGV1goAxnnnndvyGQ==
+"@spectrum-css/switch@^3.0.22":
+  version "3.0.22"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-3.0.22.tgz#f5e6cf80a677f0a180cc3d15154921b155768f9f"
+  integrity sha512-MxS8V9iI8C9VUC3a329GxpChE14slnmm9BHcSJT15oN6w9FKXiuVGCL1V8vZdlkZ/mHfF8MoMWPulm+4OP3ZLA==
 
-"@spectrum-css/table@^4.0.26":
-  version "4.0.26"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.26.tgz#ce266e21c7bc8889c635607fd58a72c8b82c2282"
-  integrity sha512-GIiaSptorhew1Gj7EUC355M7DIA4Jqqb6KdjBSXpa5Ju3oiKjPaOsM76aoKHSlzuVH7qZXRJOvyOxkxxBqux5Q==
+"@spectrum-css/table@^4.0.35":
+  version "4.0.35"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.35.tgz#f7eef8fc75a57bfa1d4083b5c20dc82d502827f2"
+  integrity sha512-SRo4OHZKls6dnKUqpnXgjAMfGh8XszCvkzKrkj+3YFLyRK5tNqwQ4/iZQryxd7cnO9zbjM3a094iEPNjf6Ycgw==
 
-"@spectrum-css/tabs@^3.2.27":
-  version "3.2.27"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.2.27.tgz#d428fc36932f597b0e053c8dc7eeb6f757e9a6f0"
-  integrity sha512-cjsFAv6y9/r9NH8+kEuZoRdF1XDifXMTnUHPCw1ADloN89pkv27Q56rgANzqEmzBuYrZd0IwBTVdd+NxGwFEaA==
+"@spectrum-css/tabs@^3.2.37":
+  version "3.2.37"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-3.2.37.tgz#e976c769971ee63e1c7851158d0b07c799f2380a"
+  integrity sha512-zf4/Hg9O2uYV3V220+cAk7dlBKLfE0rgd9nBmK3ucloF1A3DMNp8DJdF2YVlcVwV9AP9EN41vKeJfkzJ2w3/jA==
 
-"@spectrum-css/tag@^5.0.9":
-  version "5.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-5.0.13.tgz#05cb8bbc089c17a63774f8ab811409fef2febdbb"
-  integrity sha512-t6TJMOdFIMKbyooJkVTsEtX9Z/DpcfCa0NLXe9owrasUwvM/qTXjdgUyztRJ3emm9gTeObnJbergnoNBqWP9KQ==
+"@spectrum-css/tag@^5.0.17":
+  version "5.0.17"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-5.0.17.tgz#8e219283802cc46b887c8801043013ec2b158dd0"
+  integrity sha512-ac8YuXjDQdBmPV0JZhvmkOHf4qtj6Vk0OS8hNXSLUl3PYbgQ7d7EjVtAFcQW6P1l/95tCyvKYgpl3XUwHzC9yw==
 
-"@spectrum-css/taggroup@^3.3.21":
-  version "3.3.21"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-3.3.21.tgz#ab7df13999fdb0bc9f5ac919ac3b2fb2b15d705a"
-  integrity sha512-kh8HfGJEUycATBdUHZEpHUgSTGGA+TxQUysoqvboOYAGWCwoDFaPK3C2TtnUZhzWQ/g8J3glCzKb7ObH10XoXQ==
+"@spectrum-css/taggroup@^3.3.30":
+  version "3.3.30"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-3.3.30.tgz#2000f8f38cc73656851c16ca077aef321386569d"
+  integrity sha512-G3+E5fM4E1wWkV93NQEg0jdARVhUyqYPrrEzc+JbK9D4OSgb8aQozQqX+fysZ7j4r0+ysPtEcfhObv9KIdATEA==
 
-"@spectrum-css/textfield@^3.2.11":
-  version "3.2.14"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.14.tgz#1a4008667c8f1b664d805e22dcdbd8714b7e5908"
-  integrity sha512-2ZzeCf8WGR+HduVpk4op+91kTCW12gliuWbiMOB+9fUIYh9EpWj6Ac6CPyizwDYajPZ7b860imLZuQkfBpPUaA==
+"@spectrum-css/textfield@^3.2.16":
+  version "3.2.16"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-3.2.16.tgz#17cc6d41e6540ab3cc28b9ef9aa3dc2e0161264d"
+  integrity sha512-Ohiq+FIjzwxU/q5i8cgtJQn6Y24h7y1zvxA2L1v53ja40cJKzvAJSYjGVjyuOnLSftt//2xKza6AwPyJJmGEiA==
 
-"@spectrum-css/thumbnail@^2.0.23":
-  version "2.0.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-2.0.23.tgz#94eccf1b7e4f8d00753997aae480da93a144750f"
-  integrity sha512-lZJ5jrD1YtWobQwCaKnVS6al00hqxAAO05vw4vLqTNwqLZM4lFDUQG288EgI0Hj4/IB6k0CrU7xj4LK043EbqQ==
+"@spectrum-css/thumbnail@^2.0.30":
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-2.0.30.tgz#26349fbe2c7e39fc88e7ad9bbac22da7f5d4e972"
+  integrity sha512-GNP02/Z6UJYx0sv4+nKcJVzRT5P+gk4IsjA/6aFBRFuiZE8rrHcDlyC4KDAe42wXNSnkRiN8edGkGfONZG41aw==
 
 "@spectrum-css/toast@^8.0.15":
   version "8.0.15"
   resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-8.0.15.tgz#9a4a163aec1864caa295f68a955c01df08229dc0"
   integrity sha512-/ituADhERGfBLd9sd200J2NIjnj42muaYvjCa7+afb1hVH8IvKQlszBsfdd08k3tDgw3Q+VCiLFH6yEo3nYzQw==
 
-"@spectrum-css/tokens@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-8.0.2.tgz#9b8d78da2b02de944f475539493b3dc1ded7b22f"
-  integrity sha512-sncY3HFH8cePzTugliB/HVjoy1akpoTiDT8+gdGmlfkGP/U1cnwsYj8sLT5XHjRIojv9XIqvsz4pzkIj+z7DKg==
+"@spectrum-css/tokens@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-8.1.0.tgz#3b6358a4bc88f0442883edc0bc0fb076d8a0a377"
+  integrity sha512-AmSU1MPhE3UXRgWBITPtSw4kEHD/4lgHCk3WKT2iYGBSnuk16vrXWWYYtPIlt2Al4MMdgv5N56wTB9vVwprGdA==
 
 "@spectrum-css/tooltip@^4.0.10":
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-4.0.10.tgz#5bc64d2a1285a0f0771742a5c58e1f3c3601c0dd"
   integrity sha512-E1lo7TOzpUq/YLg8F8PyTPOaCVvR/CiHKdd5v34UG4dXFGRjJiliZZ9pZUzdmvjkYnAlF9GrYX3p6WEEIdDIZg==
 
-"@spectrum-css/tray@^2.0.11":
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-2.0.11.tgz#eca3b6c88273252221779862a3727f667fe841f2"
-  integrity sha512-gQNR+OC7eajCO+Q4G4siZDwdttMfX7jVYApHZB4iuPqYfiMZeG5WLRSU+r+AX48/E388JeAiDeozj/PGwdOceA==
+"@spectrum-css/tray@^2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-2.0.29.tgz#00a88cd4c953b7de939e9248aa17826593d94647"
+  integrity sha512-JK2oi/fxWD8hxytDWMKlSXz2BQoQnfNQk6qm28twZpJ6yBgQHmLYdvyb6A81nk4h9c+WggvGHCpdTlNs9Zsvtg==
 
 "@spectrum-css/typography@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-5.0.1.tgz#e2717836bd7d97f527b572d92f718edc6dffebf0"
   integrity sha512-sTmy3PprXzzmAV5itWXXSF23DSo4hUaF0yjNkuLpLW73Gpg32QY70gBKTaH8aRxtuG5lQQBBFX1nnN3fIQUa/Q==
 
-"@spectrum-css/underlay@^2.0.36":
-  version "2.0.40"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.40.tgz#47300072318e319fd5ed67b586c14ba5308f7218"
-  integrity sha512-csztERwnCpMGA1voFrqw+7hVoMkwXp3QlQznQSUaHS3fDebEI6i8ivVEw6AW1/PpAlda/nbszNjzfr8sWSLPOQ==
+"@spectrum-css/underlay@^2.0.43":
+  version "2.0.43"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-2.0.43.tgz#373ae95bcad12b268f02673a298ee78d68061bd6"
+  integrity sha512-0oeFjnk884FaZz0HEnWNb0SWdb+uAPNJy6zIWa73ZMcy6/iuDWWEQylLiTE93+GcRfCw9uhcZYvSQWsnmwiNYQ==
 
-"@spectrum-css/vars@^8.0.3":
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-8.0.4.tgz#dcf115551f240b25ba629a3b6c4d3eb1429bee15"
-  integrity sha512-3jYj5HYxbVfkR4jLV9l+L3g6jS4R09m0lV+gupqnXWpwcThlP0EOjkCkevu195imoS4pZ/i2iLpd98l4qcTc2Q==
+"@spectrum-css/vars@^8.0.5":
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-8.0.5.tgz#b7d5bf77b6fd05a3ba4d174cc094a7c1c86b0c0d"
+  integrity sha512-62FAqSmAj1LJd+TxEAh7dP6K+AF8gZtvgNiesUEg1ep/hyzefRD9gbtRlMH5O6DGeOlxOByRBaIbDFYPzwSfsw==
 
 "@spectrum-web-components/eslint-plugin@file:./linters/eslint":
   version "1.1.1"


### PR DESCRIPTION
## Description
Don't accept updates to `@spectrum-css/button` as it has some regressions in the visual delivery of the label that are still being worked out on the CSS side.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://73874bdaecee6ea6d7a506b37d5d256d--spectrum-web-components.netlify.app/review/#SwatchStories/roundingFull.png)
    2. See that VRTs point to minimal/expected changes.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.