### PR TITLE
ci: create an empty cache by including extra key data when loading cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ parameters:
     current_golden_images_hash:
         type: string
         default: 3a3d3c96e67356a3bcc4c0eeb77076938c1bb31e
+    wireit_cache_name:
+        type: string
+        default: wireit
 commands:
     downstream:
         steps:
@@ -20,8 +23,8 @@ commands:
                       - v3b-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
             - restore_cache:
                   keys:
-                      - v3b-wireit-{{ arch }}-{{ checksum "package.json" }}-
-                      - v3b-wireit-{{ arch }}-
+                      - v3b-<< pipeline.parameters.wireit_cache_name >>-{{ arch }}-{{ checksum "package.json" }}-
+                      - v3b-<< pipeline.parameters.wireit_cache_name >>-{{ arch }}-
             - run:
                   name: Installing Dependencies
                   command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn


### PR DESCRIPTION
## Description
As per https://github.com/google/wireit/issues/71 the Wireit cache can grow... _forever_. This negates the caching benefits in CircleCI when you need to load/save many MB of data after a couple of weeks of leveraging the cache. This PR creates a parameter that can be passed the build so that when pointed to someting other than the default the cache will not get loaded and the install workflow will create a new cache from scratch. It is possible to inject a parameter as part of a chron based triggering of a CircleCI, so I've scheduled a weekly run that creates a new cache so that we can benefit from the speed of the caching _generally_ without allowing the cache to grow to large. If at some point the issue in question is addressed and there is a "wireit-native" cache management strategy, then we can remove this workaround.

## How has this been tested?
-   [ ] _Test case 1_
    1. I manually cleared the cache and runs returned to their previous performance metrics
-   [ ] _Test case 2_
    1. The job is scheduled to be triggered from this branch on Monday morning UTC.
    2. Confirm that the cache is once again created at the expected size.
    3. If so, update the trigger to run against `main` and merge this PR.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
