### PR TITLE
refactor: connect spectrum-tags.css to a source

### DIFF
--- a/packages/tags/src/spectrum-config.js
+++ b/packages/tags/src/spectrum-config.js
@@ -24,6 +24,26 @@ const converter = converterFor('spectrum-Tag');
 const config = {
     conversions: [
         {
+            inPackage: '@spectrum-css/taggroup',
+            outPackage: 'tags',
+            fileName: 'tags',
+            components: [
+                converter.classToHost('spectrum-TagGroup'),
+                {
+                    find: builder.class('spectrum-TagGroup-item'),
+                    replace: {
+                        type: 'pseudo-element',
+                        kind: 'slotted',
+                        selector: [
+                            {
+                                type: 'universal',
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+        {
             inPackage: '@spectrum-css/tag',
             outPackage: 'tags',
             fileName: 'tag',

--- a/packages/tags/src/spectrum-tags.css
+++ b/packages/tags/src/spectrum-tags.css
@@ -1,5 +1,5 @@
-/* stylelint-disable */ /* 
-Copyright 2020 Adobe. All rights reserved.
+/*
+Copyright 2023 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -8,40 +8,30 @@ Unless required by applicable law or agreed to in writing, software distributed 
 the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
+*/
 
-THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
+/* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-tag-border-size: var(
-        --spectrum-tag-s-border-size,
-        var(--spectrum-alias-border-size-thin)
-    ); /* .spectrum-Tags */
-    --spectrum-tag-icon-gap: var(
-        --spectrum-tag-s-icon-gap,
-        var(--spectrum-alias-item-workflow-icon-gap-s)
-    );
-    --spectrum-tag-text-size: var(
-        --spectrum-tag-s-text-size,
-        var(--spectrum-alias-item-text-size-s)
-    );
-    --spectrum-tag-height: var(
-        --spectrum-tag-s-height,
-        var(--spectrum-alias-item-height-s)
-    );
-    --spectrum-tag-padding-left: var(
-        --spectrum-tag-s-padding-left,
-        var(--spectrum-alias-item-workflow-padding-left-s)
-    );
-    --spectrum-tag-padding-right: var(
-        --spectrum-tag-s-padding-right,
-        var(--spectrum-alias-item-padding-s)
-    );
-    --spectrum-tag-avatar-padding-x: var(--spectrum-tag-icon-gap);
     --spectrum-taggroup-tag-gap-x: var(--spectrum-global-dimension-size-100);
     --spectrum-taggroup-tag-gap-y: var(--spectrum-global-dimension-size-100);
 }
 :host {
-    display: inline-block; /* .spectrum-Tags */
+    display: inline-flex;
     list-style: none;
     margin: 0;
     padding: 0;
+}
+::slotted(*) {
+    margin: calc(
+            var(
+                    --spectrum-taggroup-tag-gap-y,
+                    var(--spectrum-global-dimension-size-100)
+                ) / 2
+        )
+        calc(
+            var(
+                    --spectrum-taggroup-tag-gap-x,
+                    var(--spectrum-global-dimension-size-100)
+                ) / 2
+        );
 }


### PR DESCRIPTION
## Description
Ensure there is a source for the `spectrum-tags.css` output.

## Related issue(s)
- fixes #2977

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.