### PR TITLE
feat(icon): image src invalid error api

### DIFF
--- a/packages/icon/src/Icon.ts
+++ b/packages/icon/src/Icon.ts
@@ -73,9 +73,9 @@ export class Icon extends IconBase {
     private announceIconImageSrcError(): void {
         this.dispatchEvent(
             new Event('error', {
-                cancelable: true,
-                bubbles: true,
-                composed: true,
+                cancelable: false,
+                bubbles: false,
+                composed: false,
             })
         );
     }

--- a/packages/icon/src/Icon.ts
+++ b/packages/icon/src/Icon.ts
@@ -70,6 +70,16 @@ export class Icon extends IconBase {
         }
     };
 
+    private announceIconImageSrcError(): void {
+        this.dispatchEvent(
+            new Event('error', {
+                cancelable: true,
+                bubbles: true,
+                composed: true,
+            })
+        );
+    }
+
     protected override render(): TemplateResult {
         if (this.name) {
             return html`
@@ -77,7 +87,11 @@ export class Icon extends IconBase {
             `;
         } else if (this.src) {
             return html`
-                <img src="${this.src}" alt=${ifDefined(this.label)} />
+                <img
+                    src="${this.src}"
+                    alt=${ifDefined(this.label)}
+                    @error=${this.announceIconImageSrcError}
+                />
             `;
         }
         return super.render();

--- a/packages/icon/stories/icon.stories.ts
+++ b/packages/icon/stories/icon.stories.ts
@@ -57,6 +57,27 @@ export const imageIcon = (): TemplateResult => {
 
 imageIcon.storyName = 'Image Icon';
 
+export const imageIconSrcError = (): TemplateResult => {
+    const error = (): void => {
+        console.error('Invalid sp-icon src provided');
+    };
+
+    return html`
+        ${sizes.map(
+            (size) => html`
+                <sp-icon
+                    label="Back"
+                    size=${size}
+                    src=${back}
+                    @error=${error}
+                ></sp-icon>
+            `
+        )}
+    `;
+};
+
+imageIcon.storyName = 'Image Icon src invalid error';
+
 export const svgIcon = (): TemplateResult => {
     return html`
         ${sizes.map(

--- a/packages/icon/stories/icon.stories.ts
+++ b/packages/icon/stories/icon.stories.ts
@@ -77,7 +77,11 @@ export const imageIconSrcError = (): TemplateResult => {
     `;
 };
 
-imageIcon.storyName = 'Image Icon src invalid error';
+imageIconSrcError.storyName = 'Image Icon src invalid error';
+
+imageIconSrcError.swc_vrt = {
+    skip: true,
+};
 
 export const svgIcon = (): TemplateResult => {
     return html`

--- a/packages/icon/stories/icon.stories.ts
+++ b/packages/icon/stories/icon.stories.ts
@@ -58,6 +58,7 @@ export const imageIcon = (): TemplateResult => {
 imageIcon.storyName = 'Image Icon';
 
 export const imageIconSrcError = (): TemplateResult => {
+    const invalidImgSrc = 'invalid-image-src';
     const error = (): void => {
         console.error('Invalid sp-icon src provided');
     };
@@ -68,7 +69,7 @@ export const imageIconSrcError = (): TemplateResult => {
                 <sp-icon
                     label="Back"
                     size=${size}
-                    src=${back}
+                    src=${invalidImgSrc}
                     @error=${error}
                 ></sp-icon>
             `

--- a/packages/icon/test/icon.test.ts
+++ b/packages/icon/test/icon.test.ts
@@ -10,12 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import Sinon from 'sinon';
+import { isWebKit } from '@spectrum-web-components/shared';
 import '@spectrum-web-components/icon/sp-icon.js';
 import { Icon } from '@spectrum-web-components/icon';
 import '@spectrum-web-components/icons/sp-icons-medium.js';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
-import Sinon from 'sinon';
 
 describe('Icon', () => {
     before(async () => {
@@ -86,7 +87,10 @@ describe('Icon', () => {
 
         await expect(el).to.be.accessible();
 
-        expect(error).to.be.calledOnce;
+        // Skipping the test case expectation for webkit because of error event not dispatching bug for the same, https://github.com/microsoft/playwright/issues/22332
+        if (!isWebKit()) {
+            expect(error).to.be.calledOnce;
+        }
     });
 
     it('loads w/ label', async () => {

--- a/packages/icon/test/icon.test.ts
+++ b/packages/icon/test/icon.test.ts
@@ -15,6 +15,7 @@ import { Icon } from '@spectrum-web-components/icon';
 import '@spectrum-web-components/icons/sp-icons-medium.js';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
+import Sinon from 'sinon';
 
 describe('Icon', () => {
     before(async () => {
@@ -67,6 +68,25 @@ describe('Icon', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+    });
+
+    it('loads w/ invalid src, error dispatching', async () => {
+        const error = Sinon.spy();
+        const el = await fixture<Icon>(
+            html`
+                <sp-icon
+                    label="Image Icon"
+                    src="invalid-image-src"
+                    @error=${error}
+                ></sp-icon>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+
+        expect(error).to.be.calledWithExactly(new Event('error'));
     });
 
     it('loads w/ label', async () => {

--- a/packages/icon/test/icon.test.ts
+++ b/packages/icon/test/icon.test.ts
@@ -89,7 +89,7 @@ describe('Icon', () => {
 
         // Skipping the test case expectation for webkit because of error event not dispatching bug for the same, https://github.com/microsoft/playwright/issues/22332
         if (!isWebKit()) {
-            expect(error).to.be.calledOnce;
+            await waitUntil(() => error.calledOnce, 'The error was thrown.');
         }
     });
 

--- a/packages/icon/test/icon.test.ts
+++ b/packages/icon/test/icon.test.ts
@@ -15,7 +15,13 @@ import { isWebKit } from '@spectrum-web-components/shared';
 import '@spectrum-web-components/icon/sp-icon.js';
 import { Icon } from '@spectrum-web-components/icon';
 import '@spectrum-web-components/icons/sp-icons-medium.js';
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    html,
+    waitUntil,
+} from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
 describe('Icon', () => {

--- a/packages/icon/test/icon.test.ts
+++ b/packages/icon/test/icon.test.ts
@@ -86,7 +86,7 @@ describe('Icon', () => {
 
         await expect(el).to.be.accessible();
 
-        expect(error).to.be.calledWithExactly(new Event('error'));
+        expect(error).to.be.calledOnce;
     });
 
     it('loads w/ label', async () => {


### PR DESCRIPTION
Adding support for error API within the icon component

## Description

Added error API support for icon component having invalid src passed, in such case the component will announce an `Event("error")` which can be handled by parent component

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Test case 1_
    Added a test case

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
