### PR TITLE
fix(overlay): fixes slotted content on first render in overlay triggers

### DIFF
--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -162,6 +162,23 @@ export class OverlayTrigger extends SpectrumElement {
         }
     }
 
+    protected override firstUpdated(changes: PropertyValues<this>): void {
+        super.firstUpdated(changes);
+        this.clickContent = this.extractSlotContentFromSlot(
+            this.shadowRoot.querySelector('slot[name="click-content"]')
+        );
+        this.hoverContent = this.extractSlotContentFromSlot(
+            this.shadowRoot.querySelector('slot[name="hover-content"]')
+        );
+        this.longpressContent = this.extractSlotContentFromSlot(
+            this.shadowRoot.querySelector('slot[name="longpress-content"]')
+        );
+        this.targetContent = this.extractSlotContentFromSlot(
+            this.shadowRoot.querySelector('slot[name="trigger"]')
+        );
+        this.manageOpen();
+    }
+
     protected manageLongpressDescriptor(): void {
         const trigger = this.querySelector(
             '[slot="trigger"]'
@@ -451,10 +468,19 @@ export class OverlayTrigger extends SpectrumElement {
         this.targetContent = this.extractSlotContentFromEvent(event);
     }
 
-    private extractSlotContentFromEvent(event: Event): HTMLElement | undefined {
-        const slot = event.target as HTMLSlotElement;
+    private extractSlotContentFromSlot(
+        slot: HTMLSlotElement | null
+    ): HTMLElement | undefined {
+        if (!slot) {
+            return undefined;
+        }
         const nodes = slot.assignedNodes({ flatten: true });
         return nodes.find((node) => node instanceof HTMLElement) as HTMLElement;
+    }
+
+    private extractSlotContentFromEvent(event: Event): HTMLElement | undefined {
+        const slot = event.target as HTMLSlotElement;
+        return this.extractSlotContentFromSlot(slot);
     }
 
     private openStatePromise = Promise.resolve();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a `firstUpdated` handler to OverlayTrigger to ensure that slotted content is properly assigned to the intent content slot variables. This ensures that any slotted content is properly tracked by the overlay trigger component and will avoid a timing issue in the slotted content distribution.

## Related issue(s)

#3144 

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
