### PR TITLE
build: ensure icons before running types

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,6 +253,7 @@
         "build:types": {
             "command": "tsc --build tsconfig-all.json",
             "dependencies": [
+                "process-icons",
                 "test:create",
                 "build:css"
             ],


### PR DESCRIPTION
Clean up race condition that could initiate the types build before all of the TS files are present.