### PR TITLE
test: add "overlay-api" group to test suite

### DIFF
--- a/web-test-runner.config.ci.js
+++ b/web-test-runner.config.ci.js
@@ -30,4 +30,6 @@ standard.middleware.push(async (ctx, next) => {
     ctx.set('Cache-Control', 'public, max-age=604800, immutable');
 });
 
+standard.testFramework.config.retries = 1;
+
 export default standard;

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -16,6 +16,7 @@ import {
 import { sendMousePlugin } from './test/plugins/send-mouse-plugin.js';
 import {
     chromium,
+    chromiumWithFlags,
     configuredVisualRegressionPlugin,
     firefox,
     packages,
@@ -77,6 +78,12 @@ export default {
             'tools/shared/src/focus-visible.*',
             'tools/styles/**',
             '**/node_modules/**',
+            // The following are WIP removals for the Overlay API update
+            '**/ActiveOverlay.*',
+            '**/overlay-stack.*',
+            '**/overlay-utils.*',
+            '**/OverlayPopover.*',
+            '**/topLayerOverTransforms.*',
         ],
         threshold: {
             statements: 98.5,
@@ -88,7 +95,6 @@ export default {
     testFramework: {
         config: {
             timeout: 3000,
-            retries: 1,
         },
     },
     groups: [
@@ -113,6 +119,18 @@ export default {
             }
             return acc;
         }, []),
+        {
+            name: 'overlay-api',
+            files: [
+                'packages/action-menu/test/*.test.js',
+                'packages/dialog/test/*.test.js',
+                'packages/menu/test/*.test.js',
+                'packages/overlay/test/*.test.js',
+                'packages/picker/test/*.test.js',
+                'packages/split-button/test/*.test.js',
+            ],
+            browsers: [chromium, chromiumWithFlags, firefox, webkit],
+        },
     ],
     group: 'unit',
     browsers: [chromium, firefox, webkit],


### PR DESCRIPTION
## Description
- add a new test group for the `overlay-api`, so that all Overlay relative code can be tested as together
- move retries into CI, only

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.