### PR TITLE
chore: wind example project back to 0-version for unified publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
     "packages": ["packages/*", "projects/*", "tools/*"],
-    "version": "0.30.0",
+    "version": "0.29.0",
     "granularPathspec": false,
     "npmClient": "yarn",
     "useWorkspaces": true,

--- a/projects/example-project-webpack/package.json
+++ b/projects/example-project-webpack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "example-project-webpack",
-    "version": "1.5.17",
+    "version": "0.1.6",
     "private": true,
     "description": "An example project that uses the web components and gives an example of how to bundle them minimally with webpack.",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Description

In order to publish all the packages at 0.x, none of the packages can be 1.x
