### PR TITLE
fix(meter,progress-bar): add i18n to progress delivery

### DIFF
--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -21,6 +21,7 @@ import {
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 
 import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
+import { LanguageResolutionController } from '@spectrum-web-components/reactive-controllers/src/LanguageResolution.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import styles from './meter.css.js';
 
@@ -52,6 +53,8 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
     @property({ type: String, reflect: true })
     public label = '';
 
+    private languageResolver = new LanguageResolutionController(this);
+
     @property({ type: Boolean, reflect: true, attribute: 'side-label' })
     // called sideLabel
     public sideLabel = false;
@@ -66,7 +69,10 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
                 <slot>${this.label}</slot>
             </sp-field-label>
             <sp-field-label size=${this.size} class="percentage">
-                ${this.progress}%
+                ${new Intl.NumberFormat(this.languageResolver.language, {
+                    style: 'percent',
+                    unitDisplay: 'narrow',
+                }).format(this.progress / 100)}
             </sp-field-label>
             <div class="track">
                 <div

--- a/packages/meter/test/meter.test.ts
+++ b/packages/meter/test/meter.test.ts
@@ -15,6 +15,7 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import '@spectrum-web-components/meter/sp-meter.js';
 import { Meter } from '@spectrum-web-components/meter';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
+import { createLanguageContext } from '../../../tools/reactive-controllers/test/helpers.js';
 
 describe('Meter', () => {
     testForLitDevWarnings(
@@ -86,5 +87,33 @@ describe('Meter', () => {
 
         expect(el.hasAttribute('aria-valuenow')).to.be.true;
         expect(el.getAttribute('aria-valuenow')).to.equal('100');
+    });
+
+    it('resolves a language (en-US)', async () => {
+        const [languageContext] = createLanguageContext('en-US');
+        const test = await fixture(html`
+            <div @sp-language-context=${languageContext}>
+                <sp-meter label="Changing Value" progress="45"></sp-meter>
+            </div>
+        `);
+        const el = test.querySelector('sp-meter') as Meter;
+        const percentage = el.shadowRoot.querySelector(
+            '.percentage'
+        ) as HTMLElement;
+        expect(percentage.textContent?.search('%')).to.not.equal(-1);
+    });
+
+    it('resolves a language (ar-sa)', async () => {
+        const [languageContext] = createLanguageContext('ar-sa');
+        const test = await fixture(html`
+            <div @sp-language-context=${languageContext}>
+                <sp-meter label="Changing Value" progress="45"></sp-meter>
+            </div>
+        `);
+        const el = test.querySelector('sp-meter') as Meter;
+        const percentage = el.shadowRoot.querySelector(
+            '.percentage'
+        ) as HTMLElement;
+        expect(percentage.textContent?.search('٪')).to.not.equal(-1);
     });
 });

--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -20,6 +20,7 @@ import {
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 
+import { LanguageResolutionController } from '@spectrum-web-components/reactive-controllers/src/LanguageResolution.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import styles from './progress-bar.css.js';
 
@@ -36,6 +37,8 @@ export class ProgressBar extends SizedMixin(SpectrumElement) {
 
     @property({ type: String })
     public label = '';
+
+    private languageResolver = new LanguageResolutionController(this);
 
     @property({ type: Boolean, reflect: true, attribute: 'over-background' })
     public overBackground = false;
@@ -63,7 +66,13 @@ export class ProgressBar extends SizedMixin(SpectrumElement) {
                                     size=${this.size}
                                     class="percentage"
                                 >
-                                    ${this.progress}%
+                                    ${new Intl.NumberFormat(
+                                        this.languageResolver.language,
+                                        {
+                                            style: 'percent',
+                                            unitDisplay: 'narrow',
+                                        }
+                                    ).format(this.progress / 100)}
                                 </sp-field-label>
                             `}
                   `

--- a/packages/progress-bar/test/progress-bar.test.ts
+++ b/packages/progress-bar/test/progress-bar.test.ts
@@ -16,6 +16,7 @@ import '@spectrum-web-components/progress-bar/sp-progress-bar.js';
 import { ProgressBar } from '@spectrum-web-components/progress-bar';
 import { stub } from 'sinon';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
+import { createLanguageContext } from '../../../tools/reactive-controllers/test/helpers.js';
 
 describe('ProgressBar', () => {
     testForLitDevWarnings(
@@ -126,5 +127,39 @@ describe('ProgressBar', () => {
             },
         });
         consoleWarnStub.restore();
+    });
+
+    it('resolves a language (en-US)', async () => {
+        const [languageContext] = createLanguageContext('en-US');
+        const test = await fixture(html`
+            <div @sp-language-context=${languageContext}>
+                <sp-progress-bar
+                    label="Changing Value"
+                    progress="45"
+                ></sp-progress-bar>
+            </div>
+        `);
+        const el = test.querySelector('sp-progress-bar') as ProgressBar;
+        const percentage = el.shadowRoot.querySelector(
+            '.percentage'
+        ) as HTMLElement;
+        expect(percentage.textContent?.search('%')).to.not.equal(-1);
+    });
+
+    it('resolves a language (ar-sa)', async () => {
+        const [languageContext] = createLanguageContext('ar-sa');
+        const test = await fixture(html`
+            <div @sp-language-context=${languageContext}>
+                <sp-progress-bar
+                    label="Changing Value"
+                    progress="45"
+                ></sp-progress-bar>
+            </div>
+        `);
+        const el = test.querySelector('sp-progress-bar') as ProgressBar;
+        const percentage = el.shadowRoot.querySelector(
+            '.percentage'
+        ) as HTMLElement;
+        expect(percentage.textContent?.search('٪')).to.not.equal(-1);
     });
 });


### PR DESCRIPTION
## Description
Update % delivery in `<sp-meter>` and `<sp-progress-bar>` to be internationalized.

cc: @tranjanessa  

## Related issue(s)
- fixes #3166

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://meter--spectrum-web-components.netlify.app/storybook/?path=/story/meter--side-label)
    2. Detach and reattach the `<sp-meter>` element from the DOM (this is required because the Storybook timing is faulty and the language resolution doesn't always attach). I usually do this by highlighting the element in the Elements tab of DevTools and pressing `Delete` then `Command + Z`.
    3. Find the `<sp-theme>` element.
    4. Apply the `lang` attribute with a value of `ar-sa`
    5. See that the % delivery is chagned
-   [ ] _Test case 2_
    1. Go [here](https://meter--spectrum-web-components.netlify.app/storybook/?path=/story/progress-bar--label)
    2. Detach and reattach the `<sp-progress-bar>` element from the DOM (this is required because the Storybook timing is faulty and the language resolution doesn't always attach). I usually do this by highlighting the element in the Elements tab of DevTools and pressing `Delete` then `Command + Z`.
    3. Find the `<sp-theme>` element.
    4. Apply the `lang` attribute with a value of `ar-sa`
    5. See that the % delivery is chagned

## Screenshots (if appropriate)
<img width="214" alt="image" src="https://user-images.githubusercontent.com/1156657/236725502-963f5ace-7e78-49d6-81c0-c80c9a53da0b.png">
<img width="211" alt="image" src="https://user-images.githubusercontent.com/1156657/236725568-8b504bd1-a57a-4713-82bd-830b956e9de9.png">

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x]  All new and existing tests passed.