### PR TITLE
fix(overlay): removes use of px units in overlay stack

### DIFF
--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -102,9 +102,9 @@ export class OverlayStack {
             }
             #actual {
                 position: relative;
-                height: calc(100% - var(--swc-body-margins-block, 0px));
+                height: calc(100% - var(--swc-body-margins-block, 0));
                 z-index: 0;
-                min-height: calc(100vh - var(--swc-body-margins-block, 0px));
+                min-height: calc(100vh - var(--swc-body-margins-block, 0));
             }
             #holder {
                 display: none;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Switch to using unitless calculation for overlay stack margin offsets.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3187 

## Motivation and context

Units used in the calculation seem to force the use of px vs dynamic units. Changing to unitless zero value avoids unit changes by this calculation.

## How has this been tested?

Tested within app contexts.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
