### PR TITLE
fix(menu): #3164 plug memory leak with gobal events

### DIFF
--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -43,11 +43,12 @@ import { MutationController } from '@lit-labs/observers/mutation-controller.js';
 const POINTERLEAVE_TIMEOUT = 100;
 
 export class MenuItemRemovedEvent extends Event {
-    constructor() {
+    constructor(item: MenuItem) {
         super('sp-menu-item-removed', {
             bubbles: true,
             composed: true,
         });
+        this.reset(item);
     }
     get item(): MenuItem {
         return this._item;
@@ -60,11 +61,12 @@ export class MenuItemRemovedEvent extends Event {
 }
 
 export class MenuItemAddedOrUpdatedEvent extends Event {
-    constructor() {
+    constructor(item: MenuItem) {
         super('sp-menu-item-added-or-updated', {
             bubbles: true,
             composed: true,
         });
+        this.reset(item);
     }
     set focusRoot(root: Menu | undefined) {
         this.item.menuData.focusRoot = this.item.menuData.focusRoot || root;
@@ -95,9 +97,6 @@ export class MenuItemAddedOrUpdatedEvent extends Event {
 }
 
 export type MenuItemChildren = { icon: Element[]; content: Node[] };
-
-const addOrUpdateEvent = new MenuItemAddedOrUpdatedEvent();
-const removeEvent = new MenuItemRemovedEvent();
 
 /**
  * @element sp-menu-item
@@ -512,17 +511,15 @@ export class MenuItem extends LikeAnchor(Focusable) {
         if (this.isInSubmenu) {
             return;
         }
-        addOrUpdateEvent.reset(this);
-        this.dispatchEvent(addOrUpdateEvent);
+        this.dispatchEvent(new MenuItemAddedOrUpdatedEvent(this));
         this._parentElement = this.parentElement as HTMLElement;
     }
 
     _parentElement!: HTMLElement;
 
     public override disconnectedCallback(): void {
-        removeEvent.reset(this);
         if (!this.isInSubmenu) {
-            this._parentElement?.dispatchEvent(removeEvent);
+            this._parentElement?.dispatchEvent(new MenuItemRemovedEvent(this));
         }
         this.isInSubmenu = false;
         super.disconnectedCallback();
@@ -533,8 +530,7 @@ export class MenuItem extends LikeAnchor(Focusable) {
             return;
         }
         await new Promise((ready) => requestAnimationFrame(ready));
-        addOrUpdateEvent.reset(this);
-        this.dispatchEvent(addOrUpdateEvent);
+        this.dispatchEvent(new MenuItemAddedOrUpdatedEvent(this));
     }
 
     public menuData: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Global Events were holding onto DOM trees and showing up in chromes DetachedElement retainer chains. Use per instance events instead of reusing the 

<!--- Describe your changes in detail -->


<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Fixes #3164 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested the fix locally in a project using SWC.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
