### PR TITLE
refactor: prepare label/tooltip styles for Overlay refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 9e8dccaa14302cd46dc10df9a8478b71c828b018
+        default: 9d40e1befb96d184dbe3a73f0b2bb0c20df88f18
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -29,7 +29,9 @@ import buttonStyles from './button-base.css.js';
  * @slot - text content to be displayed in the Button element
  * @slot icon - icon element(s) to display at the start of the button
  */
-export class ButtonBase extends ObserveSlotText(LikeAnchor(Focusable)) {
+export class ButtonBase extends ObserveSlotText(LikeAnchor(Focusable), '', [
+    'sp-tooltip',
+]) {
     public static override get styles(): CSSResultArray {
         return [buttonStyles];
     }

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -35,6 +35,10 @@ governing permissions and limitations under the License.
     inset: 0;
 }
 
+::slotted(sp-tooltip) {
+    position: absolute;
+}
+
 :host:after {
     pointer-events: none;
 }
@@ -54,7 +58,7 @@ slot[name='icon']::slotted(img) {
 }
 
 [icon-only] + #label {
-    display: none;
+    display: contents;
 }
 
 :host([size='s']) {

--- a/packages/button/src/button.css
+++ b/packages/button/src/button.css
@@ -21,7 +21,3 @@ governing permissions and limitations under the License.
         border-color: highlight;
     }
 }
-
-::slotted([slot='icon']) {
-    inset: unset;
-}

--- a/packages/tooltip/stories/tooltip.stories.ts
+++ b/packages/tooltip/stories/tooltip.stories.ts
@@ -15,6 +15,7 @@ import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
 import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import { Placement } from '@spectrum-web-components/overlay';
@@ -383,3 +384,16 @@ selfManaged.argTypes = {
         },
     },
 };
+
+export const selfManagedIconOnly = (): TemplateResult => html`
+    ${overlayStyles}
+    <sp-action-button class="self-managed">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+        <sp-tooltip self-managed>This is a tooltip.</sp-tooltip>
+    </sp-action-button>
+    <hr />
+
+    <sp-action-button class="self-managed">
+        <sp-icon-edit slot="icon"></sp-icon-edit>
+    </sp-action-button>
+`;


### PR DESCRIPTION
## Description
Can we make buttons smarter about consuming Tooltips in advance of the new Overlay API?

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://button-slots--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--self-managed-icon-only)
    2. Ensure the top button (with Tooltip) and bottom button (without Tooltip) display the same visually
-   [ ] _Test case 2_
    1. Go [here](https://3f739bdefe5cf6e781e59c351b81bef0--spectrum-web-components.netlify.app/review/)
    2. See that the VRTs only fail on the addition of a new story.

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.