### PR TITLE
fix(shared): allow "disabled" first to return to "tabindex=0" in "focusable"

### DIFF
--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -208,7 +208,7 @@ export class ButtonBase extends ObserveSlotText(LikeAnchor(Focusable), '', [
     protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         if (!this.hasAttribute('tabindex')) {
-            this.tabIndex = 0;
+            this.setAttribute('tabindex', '0');
         }
         this.manageAnchor();
         this.addEventListener('keydown', this.handleKeydown);

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -226,6 +226,29 @@ describe('Button', () => {
         await elementUpdated(el);
         expect(clickSpy.calledOnce).to.be.true;
     });
+    it('`disabled` manages `tabindex`', async () => {
+        const el = await fixture<Button>(
+            html`
+                <sp-button disabled>Button</sp-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el.tabIndex).to.equal(-1);
+        expect(el.getAttribute('tabindex')).to.equal('-1');
+
+        el.disabled = false;
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(0);
+        expect(el.getAttribute('tabindex')).to.equal('0');
+
+        el.disabled = true;
+        await elementUpdated(el);
+
+        expect(el.tabIndex).to.equal(-1);
+        expect(el.getAttribute('tabindex')).to.equal('-1');
+    });
     it('manages `aria-disabled`', async () => {
         const el = await fixture<Button>(
             html`

--- a/packages/swatch/src/Swatch.ts
+++ b/packages/swatch/src/Swatch.ts
@@ -237,7 +237,7 @@ export class Swatch extends SizedMixin(Focusable, {
         this.addEventListener('keydown', this.handleKeydown);
         this.addEventListener('keypress', this.handleKeypress);
         if (!this.hasAttribute('tabindex')) {
-            this.tabIndex = 0;
+            this.setAttribute('tabindex', '0');
         }
     }
 }

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -137,12 +137,7 @@ export class Tag extends SizedMixin(SpectrumElement, {
             this.setAttribute('role', 'listitem');
         }
         if (this.deletable) {
-            this.setAttribute(
-                'tabindex',
-                !this.disabled && this.matches(':first-of-type:not([disabled])')
-                    ? '0'
-                    : '-1'
-            );
+            this.setAttribute('tabindex', '0');
         }
     }
 

--- a/tools/shared/src/focusable.ts
+++ b/tools/shared/src/focusable.ts
@@ -123,7 +123,7 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
         }
         this.manageFocusElementTabindex(tabIndex);
     }
-    private _tabIndex = -1;
+    private _tabIndex = 0;
 
     private onPointerdownManagementOfTabIndex(): void {
         if (this.tabIndex === -1) {


### PR DESCRIPTION
## Description
Ensure that `Focusable` extensions that start `disabled` will return to `tabindex=0` when `disabled` is removed.

## Related issue(s)

- fixes #3200 

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://focusable-tabindex--spectrum-web-components.netlify.app/storybook/?path=/story/button-black-outline--default)
    2. Inspect the Button in the middle that is disabled.
    3. See that it's `tabindex` is `-1`
    4. Set `$0.disabled = false`
    5. See that the `tabindex` updates to `0`.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.