### PR TITLE
fix: process "defineElement()" to CEM files

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "@commitlint/cli": "^17.0.3",
         "@commitlint/config-conventional": "^17.0.0",
         "@commitlint/config-lerna-scopes": "^17.2.1",
-        "@custom-elements-manifest/analyzer": "^0.6.3",
+        "@custom-elements-manifest/analyzer": "^0.8.3",
         "@lit-labs/react": "^1.1.1",
         "@netlify/build": "^29.1.0",
         "@open-wc/dev-server-hmr": "^0.1.3",

--- a/projects/css-custom-vars-viewer/package.json
+++ b/projects/css-custom-vars-viewer/package.json
@@ -47,7 +47,7 @@
         "lit": "^2.5.0"
     },
     "devDependencies": {
-        "@custom-elements-manifest/analyzer": "^0.6.3",
+        "@custom-elements-manifest/analyzer": "^0.8.3",
         "@open-wc/eslint-config": "^10.0.0",
         "@open-wc/testing": "^3.1.7",
         "@typescript-eslint/eslint-plugin": "^5.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1911,12 +1911,13 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz#75b4c27948c81e88ccd3a8902047bcd797f38d32"
   integrity sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==
 
-"@custom-elements-manifest/analyzer@^0.6.3":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/analyzer/-/analyzer-0.6.3.tgz#47c10d167d4057030a5c5d5a34160907b954b386"
-  integrity sha512-Ao7nFsBodH+xJFpDO9Ducsil6fF9rHLye4CZCr5JgjItIgie8k3GO8Jb4SJAg2FAGR5exSDHPN1Sk2ElCW2D4g==
+"@custom-elements-manifest/analyzer@^0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@custom-elements-manifest/analyzer/-/analyzer-0.8.3.tgz#ac60acf4b3c4fffca90d7b7908c0826e5bb725fa"
+  integrity sha512-wT+t4JNVMj56bSCNxxjkDSKx2KJ6bzXQMjinXJe/2+9J7Abaw/9a4+EWYLWQ//KBXRvyNhWrkolFL6ICc/VATg==
   dependencies:
     "@custom-elements-manifest/find-dependencies" "^0.0.5"
+    "@github/catalyst" "^1.6.0"
     "@web/config-loader" "0.1.3"
     chokidar "3.5.2"
     command-line-args "5.1.2"
@@ -2189,6 +2190,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
+
+"@github/catalyst@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@github/catalyst/-/catalyst-1.6.0.tgz#378734d1d2b6a85af169d7e66c1a2a604bf1e82c"
+  integrity sha512-u8A+DameixqpeyHzvnJWTGj+wfiskQOYHzSiJscCWVfMkIT3rxnbHMtGh3lMthaRY21nbUOK71WcsCnCrXhBJQ==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"


### PR DESCRIPTION
## Description
Moving element registrations into `defineElement` altered the contents of our CEM output. This ensures element registering files in CEM look like:
```
    {
      "kind": "javascript-module",
      "path": "sp-button.js",
      "declarations": [],
      "exports": [
        {
          "kind": "custom-element-definition",
          "name": "sp-button",
          "declaration": {
            "name": "Button",
            "module": "/src/Button.js"
          }
        }
      ]
    },
```
and _NOT_ this:
```
    {
      "kind": "javascript-module",
      "path": "sp-button.js",
      "declarations": [],
      "exports": []
    },
```

## How has this been tested?
-   [ ] _Test case 1_
    1. Take the branch your local machine
    2. Run `yarn`
    3. Run `yarn custom-element-json`
    4. See that the contents of `packages/button/custom-elements-manifest.json` has the expanded listing outlined above.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
