### PR TITLE
docs(radio): remove label below

### DIFF
--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -151,22 +151,6 @@ Emphasized radio buttons are a secondary style for radio buttons. The blue color
 </div>
 ```
 
-### Label Below
-
-```html
-<sp-radio label-below>A label</sp-radio>
-```
-
-### Wrapping behavior
-
-```html
-<sp-radio label-below>
-    Radio with an extraordinarily long label please don't do this but if you did
-    it should wrap text when it gets longer than the container which contains
-    the radio which has an unacceptably long label
-</sp-radio>
-```
-
 ### Handling events
 
 Event handlers for clicks and other user actions can be registered on an `<sp-radio>` similar to a standard `<input type="radio">` element.

--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -27,7 +27,6 @@ import radioStyles from './radio.css.js';
  * @element sp-radio
  *
  * @slot - text label of the Radio button
- * @attr label-below - Moves the label below the radio button
  * @attr invalid - Uses the invalid style
  * @attr disabled - Uses the disabled style
  * @attr checked - Represents when the input is checked

--- a/packages/radio/src/spectrum-config.js
+++ b/packages/radio/src/spectrum-config.js
@@ -92,10 +92,6 @@ const config = {
                     hoist: true,
                 },
                 converter.classToHost(),
-                converter.classToAttribute(
-                    'spectrum-Radio--labelBelow',
-                    'label-below'
-                ),
                 converter.pseudoToAttribute('disabled', 'disabled'),
                 converter.pseudoToAttribute('checked', 'checked'),
                 converter.classToAttribute('is-invalid', 'invalid'),

--- a/packages/radio/stories/radio.stories.ts
+++ b/packages/radio/stories/radio.stories.ts
@@ -123,13 +123,6 @@ Disabled.args = {
     disabled: true,
 };
 
-export const labelBelow = (args: StoryArgs): TemplateResult => {
-    return html`
-        <sp-radio label-below ${spreadProps(args)}>Radio</sp-radio>
-    `;
-};
-labelBelow.storyName = 'Label below';
-
 const values = {
     first: 1,
     second: 2,
@@ -155,17 +148,6 @@ export const horizontalGroup = (): TemplateResult => {
             <sp-radio value="second">Option 2</sp-radio>
             <sp-radio value="third">Option 3</sp-radio>
             <sp-radio value="fourth">Option 4</sp-radio>
-        </sp-radio-group>
-    `;
-};
-
-export const horizontalLabelBelowGroup = (): TemplateResult => {
-    return html`
-        <sp-radio-group horizontal selected="first" name="group-example">
-            <sp-radio value="first" label-below>Option 1</sp-radio>
-            <sp-radio value="second" label-below>Option 2</sp-radio>
-            <sp-radio value="third" label-below>Option 3</sp-radio>
-            <sp-radio value="fourth" label-below>Option 4</sp-radio>
         </sp-radio-group>
     `;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Remove references to no longer supported 'label below' feature for radio component.

<!--- Describe your changes in detail -->

## Related issue(s)

Closes #2976.


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- [x] Validate reference to label below is no longer in storybook
- [x] Validate reference to label below is no longer on docs site 


## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)


