### PR TITLE
updating paths to be package imports

### DIFF
--- a/packages/dialog/src/DialogBase.ts
+++ b/packages/dialog/src/DialogBase.ts
@@ -25,7 +25,7 @@ import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/dialog/sp-dialog.js'
 import modalWrapperStyles from '@spectrum-web-components/modal/src/modal-wrapper.css.js';
 import modalStyles from '@spectrum-web-components/modal/src/modal.css.js';
-import { Dialog } from  '@spectrum-web-components/dialog/src/Dialog.js'
+import { Dialog } from './Dialog.js';
 import { FocusVisiblePolyfillMixin } from '@spectrum-web-components/shared';
 import { firstFocusableIn } from '@spectrum-web-components/shared/src/first-focusable-in.js';
 

--- a/packages/dialog/src/DialogBase.ts
+++ b/packages/dialog/src/DialogBase.ts
@@ -22,10 +22,10 @@ import { property } from '@spectrum-web-components/base/src/decorators.js';
 import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
-import '../sp-dialog.js';
+import '@spectrum-web-components/dialog/sp-dialog.js'
 import modalWrapperStyles from '@spectrum-web-components/modal/src/modal-wrapper.css.js';
 import modalStyles from '@spectrum-web-components/modal/src/modal.css.js';
-import { Dialog } from './Dialog.js';
+import { Dialog } from  '@spectrum-web-components/dialog/src/Dialog.js'
 import { FocusVisiblePolyfillMixin } from '@spectrum-web-components/shared';
 import { firstFocusableIn } from '@spectrum-web-components/shared/src/first-focusable-in.js';
 

--- a/packages/dialog/src/DialogBase.ts
+++ b/packages/dialog/src/DialogBase.ts
@@ -22,6 +22,7 @@ import { property } from '@spectrum-web-components/base/src/decorators.js';
 import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
+// Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
 import '@spectrum-web-components/dialog/sp-dialog.js'
 import modalWrapperStyles from '@spectrum-web-components/modal/src/modal-wrapper.css.js';
 import modalStyles from '@spectrum-web-components/modal/src/modal.css.js';

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -21,6 +21,7 @@ import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
+// Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
 import '@spectrum-web-components/dialog/sp-dialog.js'
 import { DialogBase } from './DialogBase.js';
 import { Dialog } from './Dialog.js';

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -22,8 +22,8 @@ import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
 import '@spectrum-web-components/dialog/sp-dialog.js'
-import { DialogBase } from '@spectrum-web-components/dialog/src/DialogBase.js'
-import { Dialog} from '@spectrum-web-components/dialog/src/Dialog.js'
+import { DialogBase } from './DialogBase.js';
+import { Dialog } from './Dialog.js';
 
 /**
  * @element sp-dialog-wrapper

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -21,9 +21,9 @@ import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
-import '../sp-dialog.js';
-import { DialogBase } from './DialogBase.js';
-import { Dialog } from './Dialog.js';
+import '@spectrum-web-components/dialog/sp-dialog.js'
+import { DialogBase } from '@spectrum-web-components/dialog/src/DialogBase.js'
+import { Dialog} from '@spectrum-web-components/dialog/src/Dialog.js'
 
 /**
  * @element sp-dialog-wrapper

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -21,6 +21,7 @@ import {
 } from '@spectrum-web-components/base/src/decorators.js';
 
 import { Menu } from './Menu.js';
+// Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
 import "@spectrum-web-components/menu/sp-menu.js"
 import menuGroupStyles from './menu-group.css.js';
 

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -20,7 +20,7 @@ import {
     state,
 } from '@spectrum-web-components/base/src/decorators.js';
 
-import { Menu } from "@spectrum-web-components/menu/src/Menu.js"
+import { Menu } from './Menu.js';
 import "@spectrum-web-components/menu/sp-menu.js"
 import menuGroupStyles from './menu-group.css.js';
 

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -20,8 +20,8 @@ import {
     state,
 } from '@spectrum-web-components/base/src/decorators.js';
 
-import { Menu } from './Menu.js';
-import '../sp-menu.js';
+import { Menu } from "@spectrum-web-components/menu/src/Menu.js"
+import "@spectrum-web-components/menu/sp-menu.js"
 import menuGroupStyles from './menu-group.css.js';
 
 /**

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -19,9 +19,9 @@ import {
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import '../sp-table-row.js';
-import '../sp-table-checkbox-cell.js';
-import '../sp-table-body.js';
+import '@spectrum-web-components/table/sp-table-body.js';
+import '@spectrum-web-components/table/sp-table-row.js';
+import '@spectrum-web-components/table/sp-table-checkbox-cell.js';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import styles from './table.css.js';
 import { TableBody } from './TableBody.js';

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -19,6 +19,7 @@ import {
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
+// Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
 import '@spectrum-web-components/table/sp-table-body.js';
 import '@spectrum-web-components/table/sp-table-row.js';
 import '@spectrum-web-components/table/sp-table-checkbox-cell.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

We are from UXP team, We are working on [swc-wrappers ](https://git.corp.adobe.com/torq/swc-uxp-wrappers/, ) UXP.
We are facing issue while writing UXP wrapper for DialogBase, DialogWrapper, MenuGroup and Table.

Please find below findings for DialogBase Example.
```
import {
    CSSResultArray,
    html,
    PropertyValues,
    SpectrumElement,
    TemplateResult,
} from '@spectrum-web-components/base';
import { property } from '@spectrum-web-components/base/src/decorators.js';

import '@spectrum-web-components/underlay/sp-underlay.js';
import '@spectrum-web-components/button/sp-button.js';

import '../sp-dialog.js';  -> sp-dialog.js importing from local path
```

In DialogBase.ts code is importing sp-dialog.js from local path. This is causing reregistration sp-dialog us while implementing UXP Wrapper for DialogBase.
'CustomElementRegistry': the name "sp-dialog" has already been used with this registry
    at eval (webpack-internal:///../../node_modules/@swc-uxp-internal/dialog/sp-dialog.dev.js:5:16)
    at ../../node_modules/@swc-uxp-internal/dialog/sp-dialog.dev.js (file:///Users/asshukla/swc-wrappers/projects/swc-starter-webpack/dist/main.bundle.js:1629:1)
    at __webpack_require__ (file:///Users/asshukla/swc-wrappers/projects/swc-starter-webpack/dist/main.bundle.js:2673:42)
    at eval (webpack-internal:///../../node_modules/@swc-uxp-internal/dialog/src/DialogBase.dev.js:9:75)
    at ../../node_modules/@swc-uxp-internal/dialog/src/DialogBase.dev.js (file:///Users/asshukla/swc-wrappers/projects/swc-starter-webpack/dist/main.bundle.js:1649:1)
    at __webpack_require__ (file:///Users/asshukla/swc-wrappers/projects/swc-starter-webpack/dist/main.bundle.js:2673:42)
    at eval (webpack-internal:///../../packages/dialog/src/DialogBase.js:5:100)
    at ../../packages/dialog/src/DialogBase.js (file:///Users/asshukla/swc-wrappers/projects/swc-starter-webpack/dist/main.bundle.js:2439:1)
    at __webpack_require__ (file:///Users/asshukla/swc-wrappers/projects/swc-starter-webpack/dist/main.bundle.js:2673:42)
    at eval (webpack-internal:///../../packages/dialog/sp-dialog-base.js:2:76)

Instead of internal dependencies we tried in DialogBase.ts and rest of the component to make package imports, things are working fine.
import '@spectrum-web-components/dialog/sp-dialog.js'

