### PR TITLE
docs: prune release process

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -4,23 +4,22 @@ Users with permissions in the `@spectrum-web-components` organization on NPM can
 
 1. Merge all pull requests to be included in the release and wait for the `main` branch to show that it has completed the required CI jobs.
 2. `git checkout main && git fetch && git pull && git clean -dfX`
-3. `rm -rf node_modules packages projects tools`
-4. `git checkout packages projects tools`
-5. `yarn install`
-6. `npm whoami` ensure that you are logged in with the user account for the public NPM registry
-7. `yarn lerna-publish`
-8. Scan the version summary for any unexpected changes.
+3. Run `nvm use` assumes a Node Version Manager install, and confirm your on an operable version of Node.
+4. `yarn install` 
+5. `npm whoami` ensure that you are logged in with the user account for the public NPM registry
+6. `yarn lerna-publish`
+7. Scan the version summary for any unexpected changes.
     - Changes to the _major_ versions number are likely to point to undesired version numbers.
     - Changes to the _minor_ or _feature_ version number should be confirmed as correct against the changes that have been made since the last release.
-9. `Y` to confirm.
-10. Enter one time password for npm.
-11. After the SWC packages are released, the React Wrapper packages will be generated. This multi-phase approach ensure that the wrapped packages share the same version as the standard packages.
-12. Scan the version summary for any unexpected changes.
+8. `Y` to confirm.
+9. Enter one time password for npm.
+10. After the SWC packages are released, the React Wrapper packages will be generated. This multi-phase approach ensure that the wrapped packages share the same version as the standard packages.
+11. Scan the version summary for any unexpected changes.
     - The versions _should_ be the same as those that just we applied to their matched SWC packages.
     - Changes to the _major_ versions number are likely to point to undesired version numbers.
     - Changes to the _minor_ or _feature_ version number should be confirmed as correct against the changes that have been made since the last release.
-13. `Y` to confirm.
-14. Enter a new one time password for npm.
+12. `Y` to confirm.
+13. Enter a new one time password for npm.
 
 The docs site will publish automatically if the `#publish` string is included in the commit message and the check suite runs successfully.
 


### PR DESCRIPTION
## Description
- `git clean -dfx` removes the need to `rm -rf` anything.
- most actions work even outside of the Node version requirements, but make sure you're on something expected before running the release.
