### PR TITLE
fix(picker): #3240 [Bug][a11y]: Picker "Dismiss" button has invalid aria-label attribute name

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -476,7 +476,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             <div class="visually-hidden">
                 <button
                     tabindex="-1"
-                    arial-label="Dismiss"
+                    aria-label="Dismiss"
                     @click=${this.close}
                 ></button>
             </div>

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -96,6 +96,9 @@ export function runPickerTests(): void {
             await expect(el).to.be.accessible();
         });
         it('closes accessibly', async () => {
+            el.focus();
+            await elementUpdated(el);
+            expect(el.shadowRoot?.activeElement).to.equal(el.button);
             const opened = oneEvent(el, 'sp-opened');
             el.open = true;
             await opened;
@@ -104,12 +107,20 @@ export function runPickerTests(): void {
             const accessibleCloseButton = document.querySelector(
                 '.visually-hidden button'
             ) as HTMLButtonElement;
+            expect(accessibleCloseButton).to.have.attribute(
+                'aria-label',
+                'Dismiss'
+            );
 
             const closed = oneEvent(el, 'sp-closed');
             accessibleCloseButton.click();
             await closed;
 
+            await elementUpdated(el);
+
             expect(el.open).to.be.false;
+            expect(el.shadowRoot?.activeElement).to.equal(el.button);
+            expect(document.activeElement).to.eq(el);
         });
         it('accepts new selected item content', async () => {
             const option2 = el.querySelector('[value="option-2"') as MenuItem;

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -98,7 +98,7 @@ export function runPickerTests(): void {
         it('closes accessibly', async () => {
             el.focus();
             await elementUpdated(el);
-            expect(el.shadowRoot?.activeElement).to.equal(el.button);
+            expect(el.shadowRoot.activeElement).to.equal(el.button);
             const opened = oneEvent(el, 'sp-opened');
             el.open = true;
             await opened;
@@ -119,7 +119,7 @@ export function runPickerTests(): void {
             await elementUpdated(el);
 
             expect(el.open).to.be.false;
-            expect(el.shadowRoot?.activeElement).to.equal(el.button);
+            expect(el.shadowRoot.activeElement).to.equal(el.button);
             expect(document.activeElement).to.eq(el);
         });
         it('accepts new selected item content', async () => {


### PR DESCRIPTION
## Description

Fixes spelling error in `aria-label` attribute for the Picker's "Dismiss" button and updates tests.

## Related issue(s)

#3240 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
