### PR TITLE
fix(base): ensure streaming listener "streams" on the animation frame

### DIFF
--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -25,7 +25,7 @@ import {
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { sendMouse } from '../../../test/plugins/browser.js';
-import { stub } from 'sinon';
+import { spy, stub } from 'sinon';
 import { createLanguageContext } from '../../../tools/reactive-controllers/test/helpers.js';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
@@ -382,6 +382,61 @@ describe('Slider', () => {
         expect(el.value).to.equal(0);
     });
 
+    it('dispatches `input` of the animation frame', async () => {
+        const inputSpy = spy();
+        const el = await fixture<Slider>(
+            html`
+                <sp-slider
+                    value="50"
+                    style="width: 100px"
+                    @input=${({ target }: Event & { target: Slider }) =>
+                        inputSpy(target.value)}
+                ></sp-slider>
+            `
+        );
+        await elementUpdated(el);
+
+        let frames = 0;
+        let shouldCountFrames = true;
+        const countFrames = (): void => {
+            if (!shouldCountFrames) return;
+            frames += 1;
+            requestAnimationFrame(countFrames);
+        };
+        countFrames();
+        type Steps = {
+            type: 'move';
+            position: [number, number];
+        }[];
+        const toRight: Steps = [...Array(51).keys()].map((i) => ({
+            type: 'move',
+            position: [9 + i, 30],
+        }));
+        const toLeft: Steps = toRight.slice(0, -1).reverse();
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [9, 30],
+                },
+                {
+                    type: 'down',
+                },
+                ...toRight,
+                ...toLeft,
+                {
+                    type: 'up',
+                },
+            ],
+        });
+        shouldCountFrames = false;
+
+        expect(
+            inputSpy.callCount,
+            'should not have more "input"s than frames'
+        ).to.lte(frames);
+    });
+
     it('manages RTL when min != 0', async () => {
         const el = await fixture<Slider>(
             html`
@@ -517,6 +572,7 @@ describe('Slider', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         handle.dispatchEvent(
             new PointerEvent('pointermove', {
                 clientX: 58,
@@ -526,6 +582,7 @@ describe('Slider', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
 
         expect(el.value, 'first pointerdown').to.equal(50);
         expect(el.dragging, 'is dragging').to.be.true;
@@ -542,6 +599,7 @@ describe('Slider', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
 
         expect(el.value, 'first pointermove').to.equal(0);
 
@@ -576,6 +634,7 @@ describe('Slider', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
 
         expect(el.value, 'second pointerdown').to.equal(50);
         expect(el.dragging, 'is dragging').to.be.true;
@@ -591,6 +650,7 @@ describe('Slider', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
 
         expect(el.value, 'second pointermove').to.equal(0);
 
@@ -639,7 +699,7 @@ describe('Slider', () => {
             ],
         });
 
-        await nextFrame();
+        await elementUpdated(el);
 
         expect(el.highlight, 'with no highlight').to.be.false;
         expect(el.dragging, 'dragging').to.be.true;
@@ -657,6 +717,7 @@ describe('Slider', () => {
             ],
         });
         await inputEvent;
+        await nextFrame();
 
         expect(el.value).to.equal(8);
 

--- a/packages/split-view/test/split-view.test.ts
+++ b/packages/split-view/test/split-view.test.ts
@@ -10,7 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    html,
+    nextFrame,
+} from '@open-wc/testing';
 
 import '@spectrum-web-components/split-view/sp-split-view.js';
 import { SplitView } from '@spectrum-web-components/split-view';
@@ -228,6 +234,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(Math.round(el.splitterPos)).to.equal(
             pos - el.getBoundingClientRect().left
         );
@@ -239,6 +246,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(el.splitterPos).to.equal(el.primaryMin);
         expect(getComputedStyle(splitter).cursor).to.equal('e-resize');
 
@@ -311,6 +319,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(Math.round(el.splitterPos || 0)).to.equal(
             el.getBoundingClientRect().right - pos
         );
@@ -321,6 +330,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(el.splitterPos || 0).to.equal(splitTotalWidth - el.secondaryMin);
         expect(getComputedStyle(splitter).cursor).to.equal('e-resize');
 
@@ -547,6 +557,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(el.splitterPos || 0).to.equal(50);
         expect(splitter.classList.contains('is-collapsed-start')).to.be.false;
         expect(getComputedStyle(splitter).cursor).to.equal('ew-resize');
@@ -557,6 +568,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(el.splitterPos || 0).to.equal(0);
 
         expect(splitter.classList.contains('is-collapsed-start')).to.be.true;
@@ -568,6 +580,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(el.splitterPos || 0).to.equal(350);
         expect(splitter.classList.contains('is-collapsed-end')).to.be.false;
         expect(getComputedStyle(splitter).cursor).to.equal('ew-resize');
@@ -623,6 +636,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(el.splitterPos || 0).to.equal(50);
         expect(splitter.classList.contains('is-collapsed-start')).to.be.false;
         expect(getComputedStyle(splitter).cursor).to.equal('ns-resize');
@@ -633,6 +647,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(el.splitterPos || 0).to.equal(0);
 
         expect(splitter.classList.contains('is-collapsed-start')).to.be.true;
@@ -644,6 +659,7 @@ describe('SplitView', () => {
             })
         );
         await elementUpdated(el);
+        await nextFrame();
         expect(el.splitterPos || 0).to.equal(splitTotalHeight - 50);
         expect(splitter.classList.contains('is-collapsed-end')).to.be.false;
         expect(getComputedStyle(splitter).cursor).to.equal('ns-resize');


### PR DESCRIPTION
## Description
Use `requestAnimationFrame` based limiting to dispatch "streamed" events in a more performance manner

## Related issue(s)
- fixes #3226
- refs #3186

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://slider-input--spectrum-web-components.netlify.app/storybook/index.html?path=/story/slider--default)
    2. Reduce your CPU and parallel hardware usage your browser's dev tools
    3. Interact with the slider a lot at once, very quickly
    4. See that the handle sticks pretty close to your mouse
    5. Compare to [production](https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/slider--default) with the same browser settings

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.