### PR TITLE
fix(overlay): ensure CSS calcs resolve to the expected measurement value

### DIFF
--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -72,6 +72,13 @@ export const wrapperLabeledHero = (
 ): TemplateResult => {
     const open = context.viewMode === 'docs' ? false : true;
     return html`
+        <style>
+            sp-story-decorator {
+                inset: 0;
+                position: absolute;
+                overflow: hidden;
+            }
+        </style>
         <sp-dialog-wrapper
             ?open=${open}
             hero=${landscape}

--- a/packages/overlay/src/overlay-stack.ts
+++ b/packages/overlay/src/overlay-stack.ts
@@ -102,9 +102,10 @@ export class OverlayStack {
             }
             #actual {
                 position: relative;
-                height: calc(100% - var(--swc-body-margins-block, 0));
+                height: calc(100% - var(--swc-body-margins-block, 0px));
                 z-index: 0;
-                min-height: calc(100vh - var(--swc-body-margins-block, 0));
+                min-height: calc(100vh - var(--swc-body-margins-block, 0px));
+                min-height: calc(100dvh - var(--swc-body-margins-block, 0px));
             }
             #holder {
                 display: none;


### PR DESCRIPTION
## Description
Reverts the work in https://github.com/adobe/spectrum-web-components/pull/3188 and sets a VRT that will alert us to further regression in the future.

When @benjamind is able to provide an update repro for #3187 then we can look at another approach to address his situation using this test as a guide.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://regression--spectrum-web-components.netlify.app/storybook/?path=/story/dialog-wrapped--wrapper-labeled-hero)
    2. See that the `<sp-button>` in the top left, behind the dialog is visible.
    3. If you inspect the `#shadow-root` on the `<body>` element, you can inspect `<div id="actual">` and revert the CSS calc for `min-height: calc(100dvh - var(--swc-body-margins-block, 0px));` to be `min-height: calc(100dvh - var(--swc-body-margins-block, 0));` to retriger the issue

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.