### PR TITLE
chore: use latest axe-core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 80a8f8e80ec5375753c239b5b96151079c6ed793
+        default: 12a0924e2cb935952dd29ba42145901d7269bc89
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -105,6 +105,11 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
         return [checkboxStyles, checkmarkSmallStyles, dashSmallStyles];
     }
 
+    public override handleChange(): void {
+        this.indeterminate = false;
+        super.handleChange();
+    }
+
     protected override render(): TemplateResult {
         return html`
             ${super.render()}
@@ -126,11 +131,7 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
             }
         }
         if (changes.has('indeterminate')) {
-            if (this.indeterminate) {
-                this.inputElement.setAttribute('aria-checked', 'mixed');
-            } else {
-                this.inputElement.removeAttribute('aria-checked');
-            }
+            this.inputElement.indeterminate = this.indeterminate;
         }
     }
 }

--- a/packages/checkbox/stories/checkbox.stories.ts
+++ b/packages/checkbox/stories/checkbox.stories.ts
@@ -32,7 +32,13 @@ export const readonly = (): TemplateResult => {
 
 export const Indeterminate = (): TemplateResult => {
     return html`
-        <sp-checkbox indeterminate>Checkbox</sp-checkbox>
+        <sp-checkbox indeterminate>
+            Checkbox, indeterminate, not checked
+        </sp-checkbox>
+        <br />
+        <sp-checkbox indeterminate checked>
+            Checkbox, indeterminate, checked
+        </sp-checkbox>
     `;
 };
 

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -204,4 +204,36 @@ describe('Checkbox', () => {
 
         expect(el.checked).to.be.true;
     });
+
+    it('`indeterminate, checked` becomes `not checked` on click', async () => {
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox checked .indeterminate=${true}>
+                indeterminate, checked
+            </sp-checkbox>
+        `);
+        expect(el.checked).to.be.true;
+        expect(el.indeterminate).to.be.true;
+
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.false;
+        expect(el.indeterminate).to.be.false;
+    });
+
+    it('`indeterminate, not checked` becomes `checked` on click', async () => {
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox .indeterminate=${true}>
+                indeterminate, checked
+            </sp-checkbox>
+        `);
+        expect(el.checked).to.be.false;
+        expect(el.indeterminate).to.be.true;
+
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.true;
+        expect(el.indeterminate).to.be.false;
+    });
 });

--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -22,7 +22,7 @@ import {
 
 import { Menu } from './Menu.js';
 // Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
-import "@spectrum-web-components/menu/sp-menu.js"
+import '@spectrum-web-components/menu/sp-menu.js';
 import menuGroupStyles from './menu-group.css.js';
 
 /**
@@ -89,14 +89,10 @@ export class MenuGroup extends Menu {
 
     public override render(): TemplateResult {
         return html`
-            <span
-                class="header"
-                aria-hidden="true"
-                ?hidden=${!this.headerElement}
-            >
+            <span class="header" ?hidden=${!this.headerElement}>
                 <slot name="header" @slotchange=${this.updateLabel}></slot>
             </span>
-            <sp-menu role="none">
+            <sp-menu ignore>
                 <slot></slot>
             </sp-menu>
         `;

--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -192,6 +192,10 @@ export class SplitView extends SpectrumElement {
                           class=${classMap(splitterClasses)}
                           role="separator"
                           aria-label=${ifDefined(this.label || undefined)}
+                          aria-valuenow=${Math.round(
+                              (parseFloat(this.firstPaneSize) / this.viewSize) *
+                                  100
+                          )}
                           tabindex=${ifDefined(
                               this.resizable ? '0' : undefined
                           )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7025,9 +7025,9 @@ avvio@^8.2.0:
     fastq "^1.6.1"
 
 axe-core@^4.3.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
-  integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
+  integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
 axios@^1.0.0:
   version "1.1.3"


### PR DESCRIPTION
## Description
- update axe-core version and respond to test failures
- correct `indeterminate` values for Checkboxes
- correct role/aria attribute application in Menu Groups
- apply `valuenow`, thought I'm not 100% sure why, to SplitView

## Related issue(s)
- fixes #3266

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/16000/workflows/27506cb2-99dc-49d9-9b54-22cf02164c6c/jobs/336229/tests#failed-test-0)
    2. See test failures
-   [ ] _Test case 2_
    1. Go [here](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/16002/workflows/8c63a347-64f5-4fc8-89c6-fc9ec94600a8/jobs/336327)
    2. See them not fail

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.