### PR TITLE
fix(checkbox): [a11y] use indeterminate property rather than aria-checked="mixed" #3266

### DIFF
--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -112,7 +112,7 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
                 ${checkmarkIcon[this.size as DefaultElementSize]}
                 ${dashIcon[this.size as DefaultElementSize]}
             </span>
-            <label id="label"><slot></slot></label>
+            <label id="label" for="input"><slot></slot></label>
         `;
     }
 
@@ -125,11 +125,12 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
                 this.inputElement.removeAttribute('aria-invalid');
             }
         }
-        if (changes.has('indeterminate')) {
+        if (changes.has('indeterminate') || this.indeterminate) {
+            this.inputElement.indeterminate = this.indeterminate;
             if (this.indeterminate) {
-                this.inputElement.setAttribute('aria-checked', 'mixed');
+                this.checked = false;
             } else {
-                this.inputElement.removeAttribute('aria-checked');
+                this.inputElement.checked = this.checked;
             }
         }
     }

--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -105,6 +105,11 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
         return [checkboxStyles, checkmarkSmallStyles, dashSmallStyles];
     }
 
+    public override handleChange(): void {
+        this.indeterminate = false;
+        super.handleChange();
+    }
+
     protected override render(): TemplateResult {
         return html`
             ${super.render()}
@@ -125,13 +130,8 @@ export class Checkbox extends SizedMixin(CheckboxBase) {
                 this.inputElement.removeAttribute('aria-invalid');
             }
         }
-        if (changes.has('indeterminate') || this.indeterminate) {
+        if (changes.has('indeterminate')) {
             this.inputElement.indeterminate = this.indeterminate;
-            if (this.indeterminate) {
-                this.checked = false;
-            } else {
-                this.inputElement.checked = this.checked;
-            }
         }
     }
 }

--- a/packages/checkbox/src/CheckboxBase.ts
+++ b/packages/checkbox/src/CheckboxBase.ts
@@ -55,7 +55,6 @@ export class CheckboxBase extends Focusable {
         return html`
             <input
                 id="input"
-                aria-labelledby="label"
                 type="checkbox"
                 .checked=${this.checked}
                 @change=${this.handleChange}

--- a/packages/checkbox/stories/checkbox.stories.ts
+++ b/packages/checkbox/stories/checkbox.stories.ts
@@ -32,7 +32,13 @@ export const readonly = (): TemplateResult => {
 
 export const Indeterminate = (): TemplateResult => {
     return html`
-        <sp-checkbox indeterminate>Checkbox</sp-checkbox>
+        <sp-checkbox indeterminate>
+            Checkbox, indeterminate, not checked
+        </sp-checkbox>
+        <br />
+        <sp-checkbox indeterminate checked>
+            Checkbox, indeterminate, checked
+        </sp-checkbox>
     `;
 };
 

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -145,61 +145,6 @@ describe('Checkbox', () => {
         expect(inputEl).to.have.attribute('aria-invalid', 'true');
     });
 
-    it.only('is `indeterminate` checkbox accessibly', async () => {
-        const el = await fixture<Checkbox>(
-            html`
-                <sp-checkbox indeterminate>Indeterminate Checked</sp-checkbox>
-            `
-        );
-
-        await elementUpdated(el);
-
-        await expect(el).to.be.accessible();
-
-        const labelEl = labelForCheckbox(el);
-        const inputEl = inputForCheckbox(el);
-
-        expect(labelEl.getAttribute('for')).to.equal(inputEl.id);
-        expect(inputEl.checked).to.be.false;
-        expect(inputEl.indeterminate).to.be.true;
-
-        inputEl.click();
-        await elementUpdated(el);
-
-        expect(el.checked).to.be.false;
-        expect(el.indeterminate).to.be.true;
-        expect(inputEl.indeterminate).to.be.true;
-
-        el.indeterminate = false;
-        await elementUpdated(el);
-
-        expect(inputEl.checked).to.be.false;
-        expect(inputEl.indeterminate).to.be.false;
-
-        inputEl.click();
-        await elementUpdated(el);
-
-        expect(el.checked).to.be.true;
-        expect(el.indeterminate).to.be.false;
-        expect(inputEl.indeterminate).to.be.false;
-        expect(inputEl.checked).to.be.true;
-
-        el.indeterminate = true;
-        await elementUpdated(el);
-
-        expect(el.checked).to.be.false;
-        expect(el.indeterminate).to.be.true;
-        expect(inputEl.indeterminate).to.be.true;
-        expect(inputEl.checked).to.be.false;
-
-        el.checked = true;
-        await elementUpdated(el);
-        expect(el.checked).to.be.false;
-        expect(el.indeterminate).to.be.true;
-        expect(inputEl.indeterminate).to.be.true;
-        expect(inputEl.checked).to.be.false;
-    });
-
     it('autofocuses', async () => {
         const autoElement = testFixture.querySelector(
             'sp-checkbox[autofocus]'
@@ -283,5 +228,37 @@ describe('Checkbox', () => {
         await elementUpdated(el);
 
         expect(el.checked).to.be.true;
+    });
+
+    it('`indeterminate, checked` becomes `not checked` on click', async () => {
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox checked .indeterminate=${true}>
+                indeterminate, checked
+            </sp-checkbox>
+        `);
+        expect(el.checked).to.be.true;
+        expect(el.indeterminate).to.be.true;
+
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.false;
+        expect(el.indeterminate).to.be.false;
+    });
+
+    it('`indeterminate, not checked` becomes `checked` on click', async () => {
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox .indeterminate=${true}>
+                indeterminate, checked
+            </sp-checkbox>
+        `);
+        expect(el.checked).to.be.false;
+        expect(el.indeterminate).to.be.true;
+
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.true;
+        expect(el.indeterminate).to.be.false;
     });
 });

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -28,6 +28,11 @@ function inputForCheckbox(checkbox: Checkbox): HTMLInputElement {
     return checkbox.shadowRoot.querySelector('#input') as HTMLInputElement;
 }
 
+function labelForCheckbox(checkbox: Checkbox): HTMLLabelElement {
+    if (!checkbox.shadowRoot) throw new Error('No shadowRoot');
+    return checkbox.shadowRoot.querySelector('#label') as HTMLLabelElement;
+}
+
 function labelNodeForCheckbox(checkbox: Checkbox): Node {
     if (!checkbox.shadowRoot) throw new Error('No shadowRoot');
     const slotEl = checkbox.shadowRoot.querySelector('slot');
@@ -94,6 +99,13 @@ describe('Checkbox', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+
+        const labelEl = labelForCheckbox(el);
+        const inputEl = inputForCheckbox(el);
+
+        expect(labelEl.getAttribute('for')).to.equal(inputEl.id);
+        expect(inputEl.checked).to.be.false;
+        expect(inputEl.indeterminate).to.be.false;
     });
 
     it('loads `checked` checkbox accessibly', async () => {
@@ -106,6 +118,13 @@ describe('Checkbox', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+
+        const labelEl = labelForCheckbox(el);
+        const inputEl = inputForCheckbox(el);
+
+        expect(labelEl.getAttribute('for')).to.equal(inputEl.id);
+        expect(inputEl.checked).to.be.true;
+        expect(inputEl.indeterminate).to.be.false;
     });
 
     it('is `invalid` checkbox accessibly', async () => {
@@ -118,6 +137,67 @@ describe('Checkbox', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+
+        const labelEl = labelForCheckbox(el);
+        const inputEl = inputForCheckbox(el);
+
+        expect(labelEl.getAttribute('for')).to.equal(inputEl.id);
+        expect(inputEl).to.have.attribute('aria-invalid', 'true');
+    });
+
+    it.only('is `indeterminate` checkbox accessibly', async () => {
+        const el = await fixture<Checkbox>(
+            html`
+                <sp-checkbox indeterminate>Indeterminate Checked</sp-checkbox>
+            `
+        );
+
+        await elementUpdated(el);
+
+        await expect(el).to.be.accessible();
+
+        const labelEl = labelForCheckbox(el);
+        const inputEl = inputForCheckbox(el);
+
+        expect(labelEl.getAttribute('for')).to.equal(inputEl.id);
+        expect(inputEl.checked).to.be.false;
+        expect(inputEl.indeterminate).to.be.true;
+
+        inputEl.click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.false;
+        expect(el.indeterminate).to.be.true;
+        expect(inputEl.indeterminate).to.be.true;
+
+        el.indeterminate = false;
+        await elementUpdated(el);
+
+        expect(inputEl.checked).to.be.false;
+        expect(inputEl.indeterminate).to.be.false;
+
+        inputEl.click();
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.true;
+        expect(el.indeterminate).to.be.false;
+        expect(inputEl.indeterminate).to.be.false;
+        expect(inputEl.checked).to.be.true;
+
+        el.indeterminate = true;
+        await elementUpdated(el);
+
+        expect(el.checked).to.be.false;
+        expect(el.indeterminate).to.be.true;
+        expect(inputEl.indeterminate).to.be.true;
+        expect(inputEl.checked).to.be.false;
+
+        el.checked = true;
+        await elementUpdated(el);
+        expect(el.checked).to.be.false;
+        expect(el.indeterminate).to.be.true;
+        expect(inputEl.indeterminate).to.be.true;
+        expect(inputEl.checked).to.be.false;
     });
 
     it('autofocuses', async () => {

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -30,7 +30,11 @@ function inputForCheckbox(checkbox: Checkbox): HTMLInputElement {
 
 function labelForCheckbox(checkbox: Checkbox): HTMLLabelElement {
     if (!checkbox.shadowRoot) throw new Error('No shadowRoot');
-    return checkbox.shadowRoot.querySelector('#label') as HTMLLabelElement;
+    const labelEl = checkbox.shadowRoot.querySelector('label');
+    if (!labelEl) {
+        throw new Error('Failed to find label in shadowRoot');
+    }
+    return labelEl;
 }
 
 function labelNodeForCheckbox(checkbox: Checkbox): Node {

--- a/packages/switch/test/switch.test.ts
+++ b/packages/switch/test/switch.test.ts
@@ -15,6 +15,20 @@ import { Switch } from '@spectrum-web-components/switch';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
+function inputForSwitch(checkbox: Switch): HTMLInputElement {
+    if (!checkbox.shadowRoot) throw new Error('No shadowRoot');
+    return checkbox.shadowRoot.querySelector('#input') as HTMLInputElement;
+}
+
+function labelForSwitch(checkbox: Switch): HTMLLabelElement {
+    if (!checkbox.shadowRoot) throw new Error('No shadowRoot');
+    const labelEl = checkbox.shadowRoot.querySelector('label');
+    if (!labelEl) {
+        throw new Error('Failed to find label in shadowRoot');
+    }
+    return labelEl;
+}
+
 describe('Switch', () => {
     testForLitDevWarnings(
         async () =>
@@ -34,6 +48,11 @@ describe('Switch', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+
+        const labelEl = labelForSwitch(el);
+        const inputEl = inputForSwitch(el);
+
+        expect(labelEl.getAttribute('for')).to.equal(inputEl.id);
     });
     it('loads `checked` switch accessibly', async () => {
         const el = await fixture<Switch>(
@@ -45,6 +64,11 @@ describe('Switch', () => {
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+
+        const labelEl = labelForSwitch(el);
+        const inputEl = inputForSwitch(el);
+
+        expect(labelEl.getAttribute('for')).to.equal(inputEl.id);
     });
 
     it('maintains its value when [readonly]', async () => {


### PR DESCRIPTION
## Description

Automated testing tools like aXe throw a conformance error when an aria-checked attribute is assigned to an HTMLInputElement element, because we should be using the native HTML checked attribute or the indeterminate property.

We should set the [HTMLInputElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement) object's indeterminate property via JavaScript (it cannot be set using an HTML attribute).

## Related issue(s)

#3266 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ x I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
