### PR TITLE
docs: add labels to sp-number-field documentation

### DIFF
--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -27,7 +27,11 @@ import { NumberField } from '@spectrum-web-components/number-field';
 ## Example
 
 ```html
-<sp-number-field value="1024" style="width: 200px"></sp-number-field>
+<sp-number-field
+    label="Size"
+    value="1024"
+    style="width: 200px"
+></sp-number-field>
 ```
 
 ## Number formatting
@@ -79,6 +83,7 @@ If you need to allow the user to change the currency, you should include a separ
 ```html
 <sp-field-label for="currency">Transaction amount</sp-field-label>
 <sp-number-field
+    id="currency"
     style="width: 200px"
     value="45"
     format-options='{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Minor change to doc to pass axe-core.
Adds a label to an unlabeled field and an id to a field where it was missing

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

fixes #3275

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] Run Doc page
    1. Go to Doc Page for sp-number-field
    2. Run axe Dev tools
    3. ensure there are no unlabeled form field errors


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
