### PR TITLE
fix(color-slider,color-wheel): fail to render focused style when first receiving focus #3278

### DIFF
--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -189,11 +189,11 @@ export class ColorSlider extends Focusable {
         this.input.focus();
     }
 
-    private handleFocusin(): void {
+    private handleFocus(): void {
         this.focused = true;
     }
 
-    private handleFocusout(): void {
+    private handleBlur(): void {
         if (this._pointerDown) {
             return;
         }
@@ -343,7 +343,7 @@ export class ColorSlider extends Focusable {
     protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.boundingClientRect = this.getBoundingClientRect();
-        this.addEventListener('focusin', this.handleFocusin);
-        this.addEventListener('focusout', this.handleFocusout);
+        this.addEventListener('focus', this.handleFocus);
+        this.addEventListener('blur', this.handleBlur);
     }
 }

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -131,12 +131,12 @@ describe('ColorSlider', () => {
 
         expect(el.focused).to.be.false;
 
-        el.dispatchEvent(new FocusEvent('focusin'));
+        el.dispatchEvent(new FocusEvent('focus'));
         await elementUpdated(el);
 
         expect(el.focused).to.be.true;
 
-        el.dispatchEvent(new FocusEvent('focusout'));
+        el.dispatchEvent(new FocusEvent('blur'));
         await elementUpdated(el);
 
         expect(el.focused).to.be.false;

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -119,6 +119,18 @@ describe('ColorSlider', () => {
 
         await elementUpdated(el);
 
+        expect(el.focused).to.be.false;
+
+        await sendKeys({ press: 'Tab' });
+        await elementUpdated(el);
+
+        expect(el.focused).to.be.true;
+
+        el.blur();
+        await elementUpdated(el);
+
+        expect(el.focused).to.be.false;
+
         el.dispatchEvent(new FocusEvent('focusin'));
         await elementUpdated(el);
 

--- a/packages/color-wheel/src/ColorWheel.ts
+++ b/packages/color-wheel/src/ColorWheel.ts
@@ -180,11 +180,11 @@ export class ColorWheel extends Focusable {
         this.input.focus();
     }
 
-    private handleFocusin(): void {
+    private handleFocus(): void {
         this.focused = true;
     }
 
-    private handleFocusout(): void {
+    private handleBlur(): void {
         if (this._pointerDown) {
             return;
         }
@@ -384,8 +384,8 @@ export class ColorWheel extends Focusable {
     protected override firstUpdated(changed: PropertyValues): void {
         super.firstUpdated(changed);
         this.boundingClientRect = this.getBoundingClientRect();
-        this.addEventListener('focusin', this.handleFocusin);
-        this.addEventListener('focusout', this.handleFocusout);
+        this.addEventListener('focus', this.handleFocus);
+        this.addEventListener('blur', this.handleBlur);
     }
 
     private observer?: WithSWCResizeObserver['ResizeObserver'];

--- a/packages/color-wheel/test/color-wheel.test.ts
+++ b/packages/color-wheel/test/color-wheel.test.ts
@@ -121,6 +121,18 @@ describe('ColorWheel', () => {
 
         await elementUpdated(el);
 
+        expect(el.focused).to.be.false;
+
+        await sendKeys({ press: 'Tab' });
+        await elementUpdated(el);
+
+        expect(el.focused).to.be.true;
+
+        el.blur();
+        await elementUpdated(el);
+
+        expect(el.focused).to.be.false;
+
         el.dispatchEvent(new FocusEvent('focusin'));
         await elementUpdated(el);
 

--- a/packages/color-wheel/test/color-wheel.test.ts
+++ b/packages/color-wheel/test/color-wheel.test.ts
@@ -133,12 +133,12 @@ describe('ColorWheel', () => {
 
         expect(el.focused).to.be.false;
 
-        el.dispatchEvent(new FocusEvent('focusin'));
+        el.dispatchEvent(new FocusEvent('focus'));
         await elementUpdated(el);
 
         expect(el.focused).to.be.true;
 
-        el.dispatchEvent(new FocusEvent('focusout'));
+        el.dispatchEvent(new FocusEvent('blur'));
         await elementUpdated(el);
 
         expect(el.focused).to.be.false;

--- a/tools/base/src/Base.ts
+++ b/tools/base/src/Base.ts
@@ -84,6 +84,10 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
             if (!activeElement) {
                 return false;
             }
+
+            const shadowRootActiveElement = activeElement.shadowRoot
+                ?.activeElement as HTMLElement;
+
             // Browsers without support for the `:focus-visible`
             // selector will throw on the following test (Safari, older things).
             // Some won't throw, but will be focusing item rather than the menu and
@@ -91,11 +95,16 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
             try {
                 return (
                     activeElement.matches(':focus-visible') ||
-                    activeElement.matches('.focus-visible')
+                    activeElement.matches('.focus-visible') ||
+                    shadowRootActiveElement?.matches(':focus-visible') ||
+                    shadowRootActiveElement?.matches('.focus-visible')
                 );
                 /* c8 ignore next 3 */
             } catch (error) {
-                return activeElement.matches('.focus-visible');
+                return (
+                    activeElement.matches('.focus-visible') ||
+                    shadowRootActiveElement?.matches('.focus-visible')
+                );
             }
         }
 

--- a/tools/base/src/Base.ts
+++ b/tools/base/src/Base.ts
@@ -90,24 +90,13 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
             // Some won't throw, but will be focusing item rather than the menu and
             // will rely on the polyfill to know whether focus is "visible" or not.
             try {
-                return !!(
+                return (
                     activeElement.matches(':focus-visible') ||
-                    activeElement.matches('.focus-visible') ||
-                    activeElement.shadowRoot?.activeElement?.matches(
-                        ':focus-visible'
-                    ) ||
-                    activeElement.shadowRoot?.activeElement?.matches(
-                        '.focus-visible'
-                    )
+                    activeElement.matches('.focus-visible')
                 );
                 /* c8 ignore next 3 */
             } catch (error) {
-                return !!(
-                    activeElement.matches('.focus-visible') ||
-                    activeElement.shadowRoot?.activeElement?.matches(
-                        '.focus-visible'
-                    )
-                );
+                return activeElement.matches('.focus-visible');
             }
         }
 

--- a/tools/base/src/Base.ts
+++ b/tools/base/src/Base.ts
@@ -85,25 +85,28 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
                 return false;
             }
 
-            const shadowRootActiveElement = activeElement.shadowRoot
-                ?.activeElement as HTMLElement;
-
             // Browsers without support for the `:focus-visible`
             // selector will throw on the following test (Safari, older things).
             // Some won't throw, but will be focusing item rather than the menu and
             // will rely on the polyfill to know whether focus is "visible" or not.
             try {
-                return (
+                return !!(
                     activeElement.matches(':focus-visible') ||
                     activeElement.matches('.focus-visible') ||
-                    shadowRootActiveElement?.matches(':focus-visible') ||
-                    shadowRootActiveElement?.matches('.focus-visible')
+                    activeElement.shadowRoot?.activeElement?.matches(
+                        ':focus-visible'
+                    ) ||
+                    activeElement.shadowRoot?.activeElement?.matches(
+                        '.focus-visible'
+                    )
                 );
                 /* c8 ignore next 3 */
             } catch (error) {
-                return (
+                return !!(
                     activeElement.matches('.focus-visible') ||
-                    shadowRootActiveElement?.matches('.focus-visible')
+                    activeElement.shadowRoot?.activeElement?.matches(
+                        '.focus-visible'
+                    )
                 );
             }
         }


### PR DESCRIPTION
## Description

`<sp-color-slider>` and `<sp-color-wheel>` should render the focused style when they first receive focus, tabbing into the document of iframe.

## Related issue(s)

#3278 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

For ColorSlider:

1. Open https://opensource.adobe.com/spectrum-web-components/components/color-slider/#default
2. Hover over and mouse click to set focus on the "#" sign next to the heading reading "Default."
3. Press Tab key once to set focus to the "#" link with href="#default".
4. Then press Tab a second time to move focus to the ColorSlider example rendered below.
5. Notice that the ColorSlider handle does not change, by growing in size, to display focus.
6. If you press Esc or an Arrow key to change the value, the focused style will render.

Repeat for ColorWheel:

1. Open https://opensource.adobe.com/spectrum-web-components/components/color-wheel/#example
2. Hover over and mouse click to set focus on the "#" sign next to the heading reading "Example."
3. Press Tab key once to set focus to the "#" link with href="#default".
4. Then press Tab a second time to move focus to the ColorWheel example rendered below.
5. Notice that the ColorWheel handle does not change, by growing in size, to display focus.
6. If you press Esc or an Arrow key to change the value, the focused style will render.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
