### PR TITLE
fix(action-group): fixes action group click event which was not selecting action button when they are child elements of action group

### DIFF
--- a/packages/action-button/src/action-button.css
+++ b/packages/action-button/src/action-button.css
@@ -19,6 +19,7 @@ governing permissions and limitations under the License.
 #label {
     flex-grow: var(--spectrum-actionbutton-label-flex-grow);
     text-align: var(--spectrum-actionbutton-label-text-align);
+    pointer-events: none !important;
 }
 
 :host([size='xs']) {

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -171,8 +171,12 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
     }
 
     private handleClick(event: Event): void {
-        const target = event.target as ActionButton;
-        if (typeof target.value === 'undefined') {
+        const target = event.composedPath().find((el) => {
+            const btnTarget = el as ActionButton;
+            return this.buttons.includes(btnTarget);
+        }) as ActionButton;
+
+        if (typeof target?.value === 'undefined') {
             return;
         }
         switch (this.selects) {

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -172,7 +172,6 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
 
     private handleClick(event: Event): void {
         const target = event.target as ActionButton;
-
         if (typeof target.value === 'undefined') {
             return;
         }

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -171,10 +171,7 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
     }
 
     private handleClick(event: Event): void {
-        const target = event.composedPath().find((el) => {
-            const btnTarget = el as ActionButton;
-            return this.buttons.includes(btnTarget);
-        }) as ActionButton;
+        const target = event.target as ActionButton;
 
         if (typeof target?.value === 'undefined') {
             return;

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -173,7 +173,7 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
     private handleClick(event: Event): void {
         const target = event.target as ActionButton;
 
-        if (typeof target?.value === 'undefined') {
+        if (typeof target.value === 'undefined') {
             return;
         }
         switch (this.selects) {

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -684,6 +684,49 @@ describe('ActionGroup', () => {
         expect(secondButton.selected, 'second button selected').to.be.true;
     });
 
+    it('Clicking button event should bubble up from inner label to outer button element', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Multiple Group"
+                    selects="multiple"
+                    .selected=${['first', 'second']}
+                >
+                    <sp-action-button class="first" value="first">
+                        First
+                    </sp-action-button>
+                    <sp-action-button class="second" value="second">
+                        Second
+                    </sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el.selected.length).to.equal(2);
+
+        const firstButtonEl = el.querySelector('.first') as ActionButton;
+        const firstSpanEl = firstButtonEl.shadowRoot.querySelector(
+            '#label'
+        ) as HTMLSpanElement;
+        const secondButtonEl = el.querySelector('.second') as ActionButton;
+
+        expect(firstButtonEl.selected, 'first button selected').to.be.true;
+        expect(secondButtonEl.selected, 'second button selected').to.be.true;
+
+        firstSpanEl.click(); // clicking inner span bubbles up and fires outer button click
+        await elementUpdated(el);
+
+        expect(firstButtonEl.selected, 'first button selected').to.be.false;
+        expect(secondButtonEl.selected, 'second button selected').to.be.true;
+
+        firstButtonEl.click(); // clicking outer action-button element fires own click event
+        await elementUpdated(el);
+
+        expect(firstButtonEl.selected, 'first button selected').to.be.true;
+        expect(secondButtonEl.selected, 'second button selected').to.be.true;
+    });
+
     it('only selects user-passed buttons if present in action-group while [selects="multiple"]', async () => {
         const el = await multipleSelectedActionGroup(['second', 'fourth']);
 

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -684,57 +684,6 @@ describe('ActionGroup', () => {
         expect(secondButton.selected, 'second button selected').to.be.true;
     });
 
-    it('Clicking button event should bubble up', async () => {
-        const el = await fixture<ActionGroup>(
-            html`
-                <sp-action-group
-                    label="Selects Multiple Group"
-                    selects="multiple"
-                    .selected=${['first', 'second']}
-                >
-                    <sp-action-button class="first-btn" value="first">
-                        <span class="first-span">First</span>
-                    </sp-action-button>
-                    <sp-action-button class="second-btn" value="second">
-                        <span class="second-span">Second</span>
-                    </sp-action-button>
-                </sp-action-group>
-            `
-        );
-
-        await elementUpdated(el);
-        expect(el.selected.length).to.equal(2);
-
-        const firstButtonEl = el.querySelector('.first-btn') as ActionButton;
-        const firstSpanEl = el.querySelector('.first-span') as HTMLSpanElement;
-
-        const secondButtonEl = el.querySelector('.second-btn') as ActionButton;
-        const secondSpanEl = el.querySelector(
-            '.second-span'
-        ) as HTMLSpanElement;
-
-        expect(firstButtonEl.selected).to.be.true;
-        expect(secondButtonEl.selected).to.be.true;
-
-        firstSpanEl.click(); // clicking inner span element
-        await elementUpdated(el);
-
-        expect(firstButtonEl.selected).to.be.false;
-        expect(secondButtonEl.selected).to.be.true;
-
-        firstButtonEl.click(); // clicking outer action-button element
-        await elementUpdated(el);
-
-        expect(firstButtonEl.selected).to.be.true;
-        expect(secondButtonEl.selected).to.be.true;
-
-        secondSpanEl.click();
-        await elementUpdated(el);
-
-        expect(firstButtonEl.selected).to.be.true;
-        expect(secondButtonEl.selected).to.be.false;
-    });
-
     it('only selects user-passed buttons if present in action-group while [selects="multiple"]', async () => {
         const el = await multipleSelectedActionGroup(['second', 'fourth']);
 

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -684,6 +684,57 @@ describe('ActionGroup', () => {
         expect(secondButton.selected, 'second button selected').to.be.true;
     });
 
+    it('Clicking button event should bubble up', async () => {
+        const el = await fixture<ActionGroup>(
+            html`
+                <sp-action-group
+                    label="Selects Multiple Group"
+                    selects="multiple"
+                    .selected=${['first', 'second']}
+                >
+                    <sp-action-button class="first-btn" value="first">
+                        <span class="first-span">First</span>
+                    </sp-action-button>
+                    <sp-action-button class="second-btn" value="second">
+                        <span class="second-span">Second</span>
+                    </sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el.selected.length).to.equal(2);
+
+        const firstButtonEl = el.querySelector('.first-btn') as ActionButton;
+        const firstSpanEl = el.querySelector('.first-span') as HTMLSpanElement;
+
+        const secondButtonEl = el.querySelector('.second-btn') as ActionButton;
+        const secondSpanEl = el.querySelector(
+            '.second-span'
+        ) as HTMLSpanElement;
+
+        expect(firstButtonEl.selected).to.be.true;
+        expect(secondButtonEl.selected).to.be.true;
+
+        firstSpanEl.click(); // clicking inner span element
+        await elementUpdated(el);
+
+        expect(firstButtonEl.selected).to.be.false;
+        expect(secondButtonEl.selected).to.be.true;
+
+        firstButtonEl.click(); // clicking outer action-button element
+        await elementUpdated(el);
+
+        expect(firstButtonEl.selected).to.be.true;
+        expect(secondButtonEl.selected).to.be.true;
+
+        secondSpanEl.click();
+        await elementUpdated(el);
+
+        expect(firstButtonEl.selected).to.be.true;
+        expect(secondButtonEl.selected).to.be.false;
+    });
+
     it('only selects user-passed buttons if present in action-group while [selects="multiple"]', async () => {
         const el = await multipleSelectedActionGroup(['second', 'fourth']);
 


### PR DESCRIPTION

## Motivation and context

I’m trying to use `sp-action-group` component with `sp-action-button` as child components. When I try to select/click one of the `sp-action-button`, it calls [handleClick](https://github.com/adobe/spectrum-web-components/blob/main/packages/action-group/src/ActionGroup.ts#L171) event. Here, `event.target` is always `span` instead of parent `sp-action-button`. And, because of that `target.value` is always `undefined` and returns and does nothing. 

Technical detail: Retargeting is not occuring because the event occurs on a slotted element inside action button, that physically lives in the light DOM. And because of that event.target is always `span` instead of `sp-action-button`. To fix that, we used [event.composedPath()](https://javascript.info/shadow-dom-events#bubbling-event-composedpath) and compares if any html element in path is `action button` that is part of `this.buttons`.


## Related issue(s)

[#3048](https://github.com/adobe/spectrum-web-components/issues/3048)
[Slack discussion](https://creativecloud.slack.com/archives/CESK60MQD/p1678898210005339)


## How has this been tested?

ccx-commenting uses filter popover to filter comments where we have multiple action groups(as various filters) with action buttons as child elements. When we tried to use SWC (instead of RS2), clicking various filters (clicking action button) was not selecting action button(filter not being applied). I tested fix directly in commenting component.


## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
