### PR TITLE
fix(action-menu): [Bug][a11y]: ActionMenu implementation includes incorrect aria-* attributes #3259

### DIFF
--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -210,7 +210,13 @@ export class ActionButton extends SizedMixin(ButtonBase, {
     protected override updated(changes: PropertyValues): void {
         super.updated(changes);
         const isButton = this.role === 'button';
-        const canBePressed = isButton && (this.selected || this.toggles);
+        const canBePressed =
+            isButton &&
+            (this.selected || this.toggles) &&
+            !(
+                this.hasAttribute('aria-haspopup') &&
+                this.hasAttribute('aria-expanded')
+            );
         if (changes.has('selected') || changes.has('role')) {
             // When role !== 'button' then the Action Button is within
             // an Action Group that manages selects which means the

--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -230,6 +230,16 @@ export class ActionButton extends SizedMixin(ButtonBase, {
             } else {
                 // When !this.toggles the lack of "aria-pressed" is inconsequential.
                 this.removeAttribute('aria-pressed');
+                if (
+                    isButton &&
+                    this.toggles &&
+                    this.hasAttribute('aria-expanded')
+                ) {
+                    this.setAttribute(
+                        'aria-expanded',
+                        this.selected ? 'true' : 'false'
+                    );
+                }
             }
         }
     }

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -235,4 +235,48 @@ describe('ActionButton', () => {
         expect(el.selected).to.be.true;
         expect(button.getAttribute('aria-pressed')).to.equal('true');
     });
+    it('toggles [aria-haspopup][aria-expanded]', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button
+                    toggles
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                >
+                    Button
+                </sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        const button = el.focusElement;
+
+        expect(el.toggles).to.be.true;
+        expect(el.selected).to.be.false;
+        expect(button).not.to.have.attribute('aria-pressed');
+        expect(button).to.have.attribute('aria-haspopup', 'true');
+        expect(button).to.have.attribute('aria-expanded', 'false');
+
+        el.focus();
+        await sendKeys({
+            press: 'Space',
+        });
+        await elementUpdated(el);
+
+        expect(el.toggles).to.be.true;
+        expect(el.selected).to.be.true;
+        expect(button).not.to.have.attribute('aria-pressed');
+        expect(button).to.have.attribute('aria-haspopup', 'true');
+        expect(button).to.have.attribute('aria-expanded', 'true');
+
+        el.addEventListener('change', (event: Event) => event.preventDefault());
+        el.click();
+        await elementUpdated(el);
+
+        expect(el.toggles).to.be.true;
+        expect(el.selected).to.be.true;
+        expect(button).not.to.have.attribute('aria-pressed');
+        expect(button).to.have.attribute('aria-haspopup', 'true');
+        expect(button).to.have.attribute('aria-expanded', 'true');
+    });
 });

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -65,7 +65,7 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
                 ?quiet=${this.quiet}
                 ?selected=${this.open}
                 aria-haspopup="true"
-                aria-controls="popover"
+                aria-controls=${ifDefined(this.open ? 'menu' : undefined)}
                 aria-expanded=${this.open ? 'true' : 'false'}
                 aria-label=${ifDefined(this.label || undefined)}
                 id="button"

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -275,6 +275,9 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             button.click();
             await elementUpdated(el);
             expect(el.open).to.be.true;
+            expect(button).to.have.attribute('aria-haspopup', 'true');
+            expect(button).to.have.attribute('aria-expanded', 'true');
+            expect(button).to.have.attribute('aria-controls', 'menu');
         });
         it('opens unmeasured with deprecated syntax', async () => {
             const el = await deprecatedActionMenuFixture();
@@ -290,6 +293,12 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             const el = await actionMenuFixture();
 
             await elementUpdated(el);
+
+            const button = el.button as HTMLButtonElement;
+            expect(button).to.have.attribute('aria-haspopup', 'true');
+            expect(button).to.have.attribute('aria-expanded', 'false');
+            expect(button).not.to.have.attribute('aria-controls');
+
             let items = el.querySelectorAll('sp-menu-item');
             const count = items.length;
             expect(items.length).to.equal(count);
@@ -299,6 +308,8 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             await opened;
 
             expect(el.open).to.be.true;
+            expect(button).to.have.attribute('aria-expanded', 'true');
+            expect(button).to.have.attribute('aria-controls', 'menu');
             items = el.querySelectorAll('sp-menu-item');
             expect(items.length).to.equal(0);
 
@@ -307,6 +318,8 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             await closed;
 
             expect(el.open).to.be.false;
+            expect(button).to.have.attribute('aria-expanded', 'false');
+            expect(button).not.to.have.attribute('aria-controls');
             items = el.querySelectorAll('sp-menu-item');
             expect(items.length).to.equal(count);
 
@@ -315,6 +328,8 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             await opened;
 
             expect(el.open).to.be.true;
+            expect(button).to.have.attribute('aria-expanded', 'true');
+            expect(button).to.have.attribute('aria-controls', 'menu');
             items = el.querySelectorAll('sp-menu-item');
             expect(items.length).to.equal(0);
 
@@ -323,6 +338,8 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             await closed;
 
             expect(el.open).to.be.false;
+            expect(button).to.have.attribute('aria-expanded', 'false');
+            expect(button).not.to.have.attribute('aria-controls');
             items = el.querySelectorAll('sp-menu-item');
             expect(items.length).to.equal(count);
         });

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -458,6 +458,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             ></span>
             <button
                 aria-haspopup="true"
+                aria-controls=${ifDefined(this.open ? 'menu' : undefined)}
                 aria-expanded=${this.open ? 'true' : 'false'}
                 aria-labelledby="icon label applied-label"
                 id="button"
@@ -539,7 +540,7 @@ export class PickerBase extends SizedMixin(Focusable) {
             return html`
                 <sp-tray
                     id="popover"
-                    role="dialog"
+                    role="presentation"
                     @sp-menu-item-added-or-updated=${this.updateMenuItems}
                     .overlayOpenCallback=${this.overlayOpenCallback}
                     .overlayCloseCallback=${this.overlayCloseCallback}
@@ -551,7 +552,7 @@ export class PickerBase extends SizedMixin(Focusable) {
         return html`
             <sp-popover
                 id="popover"
-                role="dialog"
+                role="presentation"
                 @sp-menu-item-added-or-updated=${this.updateMenuItems}
                 .overlayOpenCallback=${this.overlayOpenCallback}
                 .overlayCloseCallback=${this.overlayCloseCallback}

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -150,6 +150,9 @@ export class SplitButton extends SizedMixin(PickerBase) {
                 <sp-button
                     aria-haspopup="true"
                     aria-expanded=${this.open ? 'true' : 'false'}
+                    aria-controls=${ifDefined(
+                        this.open ? this.optionsMenu.id : undefined
+                    )}
                     class="button trigger ${this.variant}"
                     @blur=${this.onButtonBlur}
                     @click=${this.onButtonClick}

--- a/packages/split-button/test/index.ts
+++ b/packages/split-button/test/index.ts
@@ -109,6 +109,13 @@ export function runSplitButtonTests(
         const el = test.querySelector('sp-split-button') as SplitButton;
 
         await elementUpdated(el);
+
+        const trigger = el.shadowRoot?.querySelector(
+            '[aria-haspopup][aria-expanded]'
+        );
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+        expect(trigger).not.to.have.attribute('aria-controls');
+
         let items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(3);
 
@@ -117,6 +124,8 @@ export function runSplitButtonTests(
         await opened;
 
         expect(el.open).to.be.true;
+        expect(trigger).to.have.attribute('aria-expanded', 'true');
+        expect(trigger).to.have.attribute('aria-controls', 'menu');
         items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(0);
 
@@ -125,6 +134,8 @@ export function runSplitButtonTests(
         await closed;
 
         expect(el.open).to.be.false;
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+        expect(trigger).not.to.have.attribute('aria-controls');
         items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(3);
 
@@ -133,6 +144,8 @@ export function runSplitButtonTests(
         await opened;
 
         expect(el.open).to.be.true;
+        expect(trigger).to.have.attribute('aria-expanded', 'true');
+        expect(trigger).to.have.attribute('aria-controls', 'menu');
         items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(0);
 
@@ -141,6 +154,8 @@ export function runSplitButtonTests(
         await closed;
 
         expect(el.open).to.be.false;
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+        expect(trigger).not.to.have.attribute('aria-controls');
         items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(3);
     });
@@ -151,6 +166,13 @@ export function runSplitButtonTests(
         const el = test.querySelector('sp-split-button') as SplitButton;
 
         await elementUpdated(el);
+
+        const trigger = el.shadowRoot?.querySelector(
+            '[aria-haspopup][aria-expanded]'
+        );
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+        expect(trigger).not.to.have.attribute('aria-controls');
+
         let items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(3);
 
@@ -159,6 +181,8 @@ export function runSplitButtonTests(
         await opened;
 
         expect(el.open).to.be.true;
+        expect(trigger).to.have.attribute('aria-expanded', 'true');
+        expect(trigger).to.have.attribute('aria-controls', 'menu');
         items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(0);
 
@@ -167,6 +191,8 @@ export function runSplitButtonTests(
         await closed;
 
         expect(el.open).to.be.false;
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+        expect(trigger).not.to.have.attribute('aria-controls');
         items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(3);
 
@@ -175,6 +201,8 @@ export function runSplitButtonTests(
         await opened;
 
         expect(el.open).to.be.true;
+        expect(trigger).to.have.attribute('aria-expanded', 'true');
+        expect(trigger).to.have.attribute('aria-controls', 'menu');
         items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(0);
 
@@ -183,6 +211,8 @@ export function runSplitButtonTests(
         await closed;
 
         expect(el.open).to.be.false;
+        expect(trigger).to.have.attribute('aria-expanded', 'false');
+        expect(trigger).not.to.have.attribute('aria-controls');
         items = el.querySelectorAll('sp-menu-item');
         expect(items.length).to.equal(3);
     });

--- a/packages/split-button/test/index.ts
+++ b/packages/split-button/test/index.ts
@@ -110,9 +110,7 @@ export function runSplitButtonTests(
 
         await elementUpdated(el);
 
-        const trigger = el.shadowRoot?.querySelector(
-            '[aria-haspopup][aria-expanded]'
-        );
+        const trigger = el.shadowRoot?.querySelector('.trigger');
         expect(trigger).to.have.attribute('aria-expanded', 'false');
         expect(trigger).not.to.have.attribute('aria-controls');
 
@@ -167,9 +165,7 @@ export function runSplitButtonTests(
 
         await elementUpdated(el);
 
-        const trigger = el.shadowRoot?.querySelector(
-            '[aria-haspopup][aria-expanded]'
-        );
+        const trigger = el.shadowRoot?.querySelector('.trigger');
         expect(trigger).to.have.attribute('aria-expanded', 'false');
         expect(trigger).not.to.have.attribute('aria-controls');
 


### PR DESCRIPTION
## Description

There are several small issues with ActionMenu accessibility implementation that require changes to ActionButton and Picker as well.

1. `sp-action-button` within shadowDOM for  `sp-action-menu` includes `aria-pressed` in addition to `aria-expanded` state, which is overkill.

Possible solution would be to change:
https://github.com/adobe/spectrum-web-components/blob/c820757885bf4b000cacd84b54a0df618df72bd4/packages/action-button/src/ActionButton.ts#L213

to 

```ts
        const canBePressed = 
            isButton && 
            (this.selected || this.toggles) && 
            !(this.hasAttribute('aria-haspopup') && this.hasAttribute('aria-expanded'));
```

So that we don't add `aria-pressed` to popup buttons that have `aria-expanded` state.

2. `sp-action-button` within shadowDOM for  `sp-action-menu` should only include `aria-controls` conditionally when the menu is `open`, and `aria-controls` should control the `menu` rather than the `popover`.

Possible solution would be to change:
https://github.com/adobe/spectrum-web-components/blob/c820757885bf4b000cacd84b54a0df618df72bd4/packages/action-menu/src/ActionMenu.ts#L68

to

```ts
                aria-controls=${ifDefined(this.open ? 'menu' : undefined)}
```


2a. Similarly within `sp-picker` add the following to the button within the shadowDOM at 
https://github.com/adobe/spectrum-web-components/blob/c820757885bf4b000cacd84b54a0df618df72bd4/packages/picker/src/Picker.ts#L420

```ts
               aria-controls=${ifDefined(this.open ? 'menu' : undefined)}
               aria-expanded=${this.open ? 'true' : 'false'} 
```

You'll need to `import {ifDefined} from '@spectrum-web-components/base/src/directives.js'`;

3. Remove `role="dialog"` from the `sp-tray` and `sp-popover` within `sp-picker` by changing 
https://github.com/adobe/spectrum-web-components/blob/c820757885bf4b000cacd84b54a0df618df72bd4/packages/picker/src/Picker.ts#L501
to
```ts
                    role="presentation"
```
and
https://github.com/adobe/spectrum-web-components/blob/c820757885bf4b000cacd84b54a0df618df72bd4/packages/picker/src/Picker.ts#L513
to
```ts
                    role="presentation"
```

## Related issue(s)

#3259 

Supercedes #3265 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
