### PR TITLE
fix(number-field): simplify width management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: d90341f72a429e122c7332f3ef62b6deccf7cfe1
+        default: 14137deade3fdf0d4adfbdc6de91f7c7edf56184
     wireit_cache_name:
         type: string
         default: wireit

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         "alex": "^10.0.0",
         "cem-plugin-module-file-extensions": "^0.0.5",
         "chalk": "^5.0.1",
-        "chromedriver": "^112.0.0",
+        "chromedriver": "^114.0.1",
         "common-tags": "^1.8.2",
         "cssnano": "^5.0.15",
         "custom-elements-manifest": "^2.0.0",

--- a/packages/number-field/src/number-field.css
+++ b/packages/number-field/src/number-field.css
@@ -12,13 +12,12 @@ governing permissions and limitations under the License.
 
 @import './spectrum-number-field.css';
 
-:host([quiet]) {
-    width: var(--spectrum-stepper-quiet-width);
+:host {
+    inline-size: var(--mod-stepper-width, var(--spectrum-stepper-width));
 }
 
-#textfield,
-:host([quiet]) #textfield {
-    width: 100%;
+#textfield {
+    inline-size: 100%;
 }
 
 sp-field-button {

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -47,14 +47,14 @@ sp-field-label {
 :host([editable]) sp-number-field {
     grid-area: number;
 
-    --spectrum-stepper-width: var(
+    --mod-stepper-width: var(
         --spectrum-slider-editable-number-field-width,
         var(--spectrum-global-dimension-size-1000)
     );
 }
 
 :host([hide-stepper]) sp-number-field {
-    --spectrum-stepper-width: var(
+    --mod-stepper-width: var(
         --spectrum-slider-editable-number-field-width,
         var(--spectrum-global-dimension-size-900)
     );

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -15,10 +15,7 @@ governing permissions and limitations under the License.
 :host {
     display: inline-flex;
     flex-direction: column;
-    width: var(
-        --spectrum-alias-single-line-width,
-        var(--spectrum-global-dimension-size-2400)
-    );
+    inline-size: var(--mod-textfield-width, var(--spectrum-textfield-width));
 }
 
 :host([multiline]) {
@@ -30,7 +27,7 @@ governing permissions and limitations under the License.
 }
 
 #textfield {
-    width: 100%;
+    inline-size: 100%;
 }
 
 #textfield,
@@ -39,7 +36,7 @@ textarea {
 }
 
 .input {
-    min-width: var(--spectrum-textfield-texticon-min-width);
+    min-inline-size: var(--spectrum-textfield-min-width);
 }
 
 :host([focused]) .input {
@@ -112,7 +109,7 @@ textarea {
             )
     );
     text-indent: 0;
-    width: 100%;
+    inline-size: 100%;
     vertical-align: top;
     margin: 0;
     overflow: visible;

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -127,13 +127,15 @@ describe('Textfield', () => {
                 ></sp-textfield>
             `
         );
-        const startBounds = el.getBoundingClientRect();
-
+        // Resizing only effects the block size of the host rect, so measure the `focusElement` when resizing.
+        const sizedElement = (el as HTMLElement & { focusElement: HTMLElement })
+            .focusElement;
+        const startBounds = sizedElement.getBoundingClientRect();
         await sendMouse({
             steps: [
                 {
                     type: 'move',
-                    position: [startBounds.right - 2, startBounds.bottom - 2],
+                    position: [startBounds.right - 6, startBounds.bottom - 6],
                 },
                 {
                     type: 'down',
@@ -148,9 +150,9 @@ describe('Textfield', () => {
             ],
         });
 
-        const endBounds = el.getBoundingClientRect();
-        expect(endBounds.width).to.be.greaterThan(startBounds.width);
+        const endBounds = sizedElement.getBoundingClientRect();
         expect(endBounds.height).to.be.greaterThan(startBounds.height);
+        expect(endBounds.width).to.be.greaterThan(startBounds.width);
     });
     it('accepts resize styling', async () => {
         const el = await litFixture<Textfield>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8069,10 +8069,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^112.0.0:
-  version "112.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-112.0.0.tgz#34c86f6cfc8f5e208100088dbb9563439243f8b2"
-  integrity sha512-fEw1tI05dmK1KK8MGh99LAppP7zCOPEXUxxbYX5wpIBCCmKasyrwZhk/qsdnxJYKd/h0TfiHvGEj7ReDQXW1AA==
+chromedriver@^114.0.1:
+  version "114.0.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-114.0.1.tgz#6b781922e74e2f6520cbd3e363dfabc41c4347f5"
+  integrity sha512-Srkyt7xv+RL9aSNVkmARm0tAfw84fIBKge9c1MCTiHfW0tjuNFdhKVlgD0TmPmwSKOeFJrTdd1Flf2hGWWKsUw==
   dependencies:
     "@testim/chrome-version" "^1.1.3"
     axios "^1.2.1"


### PR DESCRIPTION
## Description
Resolve a couple of incongruities between Spectrum CSS and SWC width application in Number Field, Text Field, and editable Slider elements.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://number-field-width--spectrum-web-components.netlify.app/storybook/?path=/story/slider--editable)
    2. Compare to [here](https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/slider--editable)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.