### PR TITLE
fix(color-slider): [Bug][a11y] orientation is incorrect for RTL languages #3301

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: f7c5d7288d3853728f3feeb1cb41a0fcfd912c22
+        default: 272df076898ee35337c14698a17497e9ecc1644b
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -270,9 +270,8 @@ export class ColorSlider extends Focusable {
         const size = this.vertical ? rect.height : rect.width;
 
         const percent = Math.max(0, Math.min(1, (offset - minOffset) / size));
-        const sliderHandlePosition = this.vertical
-            ? 100 - 100 * percent
-            : 100 * percent;
+        const sliderHandlePosition =
+            this.vertical || !this.isLTR ? 100 - 100 * percent : 100 * percent;
 
         return sliderHandlePosition;
     }
@@ -288,7 +287,7 @@ export class ColorSlider extends Focusable {
     }
 
     private get handlePositionStyles(): string {
-        return `${this.vertical ? 'bottom' : 'left'}: ${
+        return `${this.vertical ? 'inset-block-end' : 'inset-inline-start'}: ${
             this.sliderHandlePosition
         }%`;
     }

--- a/packages/color-slider/src/color-slider.css
+++ b/packages/color-slider/src/color-slider.css
@@ -21,8 +21,8 @@ governing permissions and limitations under the License.
 }
 
 :host([vertical]) .handle {
-    top: unset;
-    bottom: 0;
+    inset-block-start: unset;
+    inset-block-end: 0;
 }
 
 :host(:focus) {
@@ -31,6 +31,10 @@ governing permissions and limitations under the License.
 
 .gradient {
     overflow: hidden;
+}
+
+:host([dir='rtl']) .gradient {
+    transform: scaleX(-1);
 }
 
 ::slotted(*) {

--- a/packages/color-slider/test/color-slider.test.ts
+++ b/packages/color-slider/test/color-slider.test.ts
@@ -631,7 +631,7 @@ describe('ColorSlider', () => {
 
         await elementUpdated(el);
 
-        expect(el.sliderHandlePosition).to.equal(52.083333333333336);
+        expect(el.sliderHandlePosition).to.equal(100 - 52.083333333333336);
 
         handle.dispatchEvent(
             new PointerEvent('pointermove', {
@@ -656,7 +656,7 @@ describe('ColorSlider', () => {
 
         await elementUpdated(el);
 
-        expect(el.sliderHandlePosition).to.equal(46.875);
+        expect(el.sliderHandlePosition).to.equal(100 - 46.875);
     });
     const colorFormats: {
         name: string;


### PR DESCRIPTION
## Description

Use `inset-block-*` and `inset-inline-*` and fix RTL orientation

## Related issue(s)

- #3301 

Also, see conversation here: https://github.com/adobe/spectrum-web-components/pull/3293#pullrequestreview-1470103325

## Motivation and context

ColorSlider should be oriented correctly for right to left languages and the behavior of arrow keys should be oriented right to left.

## How can we reproduce this issue?

1. Go to https://opensource.adobe.com/spectrum-web-components/components/color-slider/#default
2. Change the Direction to RTL
3. Tab or click to set focus to the first ColorSlider on the page.
4. Notice that the ColorSlider gradient remains oriented left to right
5. Use left or right arrow keys to change the value.
6. Notice that the handle moves in the opposite direction as one would expect.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
