### PR TITLE
fix(slider): slider input aria-valuetext omits formatOptions for unit #3340

### DIFF
--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -145,7 +145,13 @@ export class HandleController implements Controller {
     public formattedValueForHandle(model: ModelValue): string {
         const { handle } = model;
         const numberFormat = handle.numberFormat ?? this.host.numberFormat;
-        return handle.getAriaHandleText(model.value, numberFormat);
+        const _forcedUnit =
+            handle._forcedUnit === ''
+                ? this.host._forcedUnit
+                : handle._forcedUnit;
+        return (
+            handle.getAriaHandleText(model.value, numberFormat) + _forcedUnit
+        );
     }
 
     public get formattedValues(): Map<string, string> {

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -123,8 +123,8 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
     ) => {
         const valueArray = [...values.values()];
         if (valueArray.length === 2)
-            return `${valueArray[0]}${this._forcedUnit} - ${valueArray[1]}${this._forcedUnit}`;
-        return valueArray.join(`${this._forcedUnit}, `) + this._forcedUnit;
+            return `${valueArray[0]} – ${valueArray[1]}`;
+        return valueArray.join(', ');
     };
 
     public override get ariaValueText(): string {

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -123,7 +123,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
     ) => {
         const valueArray = [...values.values()];
         if (valueArray.length === 2)
-            return `${valueArray[0]} – ${valueArray[1]}`;
+            return `${valueArray[0]} - ${valueArray[1]}`;
         return valueArray.join(', ');
     };
 

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -537,11 +537,13 @@ export const TwoHandles = (args: StoryArgs = {}): TemplateResult => {
                 <sp-slider-handle
                     slot="handle"
                     name="min"
+                    label="Minimum"
                     value="5"
                 ></sp-slider-handle>
                 <sp-slider-handle
                     slot="handle"
                     name="max"
+                    label="Maximum"
                     value="250"
                 ></sp-slider-handle>
             </sp-slider>
@@ -573,11 +575,13 @@ export const TwoHandlesPt = (args: StoryArgs = {}): TemplateResult => {
                 <sp-slider-handle
                     slot="handle"
                     name="min"
+                    label="Minimum"
                     value="5"
                 ></sp-slider-handle>
                 <sp-slider-handle
                     slot="handle"
                     name="max"
+                    label="Maximum"
                     value="250"
                 ></sp-slider-handle>
             </sp-slider>
@@ -599,16 +603,25 @@ export const ThreeHandlesPc = (args: StoryArgs = {}): TemplateResult => {
                 max="255"
                 @input=${handleHandleEvent(args)}
                 @change=${handleHandleEvent(args)}
-                .formatOptions=${{
-                    style: 'unit',
-                    unit: 'pc',
-                }}
+                .formatOptions=${{ style: 'unit', unit: 'pc' }}
                 ...=${spreadProps(args)}
             >
                 Output Levels
-                <sp-slider-handle slot="handle" value="5"></sp-slider-handle>
-                <sp-slider-handle slot="handle" value="133"></sp-slider-handle>
-                <sp-slider-handle slot="handle" value="250"></sp-slider-handle>
+                <sp-slider-handle
+                    slot="handle"
+                    value="5"
+                    label="Low"
+                ></sp-slider-handle>
+                <sp-slider-handle
+                    slot="handle"
+                    value="133"
+                    label="Mid"
+                ></sp-slider-handle>
+                <sp-slider-handle
+                    slot="handle"
+                    value="250"
+                    label="High"
+                ></sp-slider-handle>
             </sp-slider>
         </div>
     `;
@@ -632,12 +645,14 @@ export const ThreeHandlesOrdered = (args: StoryArgs = {}): TemplateResult => {
                 <sp-slider-handle
                     slot="handle"
                     name="low"
+                    label="Low"
                     value="5"
                     max="next"
                 ></sp-slider-handle>
                 <sp-slider-handle
                     slot="handle"
                     name="mid"
+                    label="Mid"
                     value="100"
                     min="previous"
                     max="next"
@@ -645,6 +660,7 @@ export const ThreeHandlesOrdered = (args: StoryArgs = {}): TemplateResult => {
                 <sp-slider-handle
                     slot="handle"
                     name="high"
+                    label="High"
                     value="250"
                     min="previous"
                 ></sp-slider-handle>
@@ -785,12 +801,14 @@ export const ThreeHandlesComplex = (args: StoryArgs = {}): TemplateResult => {
                 <sp-slider-handle
                     slot="handle"
                     name="black"
+                    label="Black"
                     value=${values.black}
                     .normalization=${blackNormalization}
                 ></sp-slider-handle>
                 <sp-slider-handle
                     slot="handle"
                     name="gray"
+                    label="Gray"
                     value="0.215"
                     min="0"
                     max="1"
@@ -801,6 +819,7 @@ export const ThreeHandlesComplex = (args: StoryArgs = {}): TemplateResult => {
                 <sp-slider-handle
                     slot="handle"
                     name="white"
+                    label="White"
                     value=${values.white}
                     .normalization=${whiteNormalization}
                 ></sp-slider-handle>

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -977,6 +977,84 @@ describe('Slider', () => {
 
         expect(input.getAttribute('aria-valuetext')).to.equal('50');
     });
+    it('supports units not included in Intl.NumberFormatOptions', async () => {
+        let el = await fixture<Slider>(
+            html`
+                <sp-slider value="50" min="0" max="100" format-options="{"style": "unit", "unit": "px"}"></sp-slider>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const input = el.focusElement as HTMLInputElement;
+        await elementUpdated(el);
+
+        expect(input.getAttribute('aria-valuetext')).to.equal('50');
+
+        el = await fixture<Slider>(
+            html`
+                <sp-slider
+                    value="5"
+                    step="1"
+                    min="0"
+                    max="255"
+                    format-options='{"style": "unit", "unit": "px"}'
+                >
+                    <sp-slider-handle
+                        slot="handle"
+                        name="min"
+                        label="Minimum"
+                        value="5"
+                    ></sp-slider-handle>
+                    <sp-slider-handle
+                        slot="handle"
+                        name="max"
+                        label="Maximum"
+                        value="250"
+                    ></sp-slider-handle>
+                </sp-slider>
+            `
+        );
+
+        await elementUpdated(el);
+
+        let shadowRoot = el.shadowRoot as ShadowRoot;
+        expect(shadowRoot.querySelector('input#input-0[aria-valuetext="5px"]'))
+            .to.exist;
+        expect(
+            shadowRoot.querySelector('input#input-1[aria-valuetext="250px"]')
+        ).to.exist;
+
+        el = await fixture<Slider>(
+            html`
+                <sp-slider value="5" step="1" min="0" max="255">
+                    <sp-slider-handle
+                        slot="handle"
+                        name="min"
+                        label="Minimum"
+                        value="5"
+                        format-options='{"style": "unit", "unit": "px"}'
+                    ></sp-slider-handle>
+                    <sp-slider-handle
+                        slot="handle"
+                        name="max"
+                        label="Maximum"
+                        value="250"
+                        format-options='{"style": "unit", "unit": "px"}'
+                    ></sp-slider-handle>
+                </sp-slider>
+            `
+        );
+
+        await elementUpdated(el);
+
+        shadowRoot = el.shadowRoot as ShadowRoot;
+        expect(shadowRoot.querySelector('input#input-0[aria-valuetext="5px"]'))
+            .to.exist;
+        expect(
+            shadowRoot.querySelector('input#input-1[aria-valuetext="250px"]')
+        ).to.exist;
+    });
     it('accepts min/max/value in the same timing', async () => {
         const el = await fixture<Slider>(
             html`


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Related issue(s)

- #3340 

## Motivation and context

The aria-valuetext attribute on the input[type="range"] element within the SliderHandle in the Slider shadowDom should include the _forcedUnit for units not included in Intl.NumberFormatOptions, like px or pc.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
