### PR TITLE
fix: sp-split-button more button label

### DIFF
--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -158,7 +158,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
                     @click=${this.onButtonClick}
                     @focus=${this.onButtonFocus}
                     ?disabled=${this.disabled}
-                    aria-label="More"
+                    aria-labelledby="button"
                     variant=${this.variant}
                     treatment=${treatment}
                     size=${this.size}

--- a/packages/split-button/test/index.ts
+++ b/packages/split-button/test/index.ts
@@ -127,7 +127,7 @@ export function runSplitButtonTests(
             findAccessibilityNode<NamedRoledPopupNode>(
                 snapshot,
                 (node) =>
-                    node.role === 'button' &&
+                    (node.role === 'button' || node.role === 'buttonmenu') &&
                     node.name === 'Option 1' &&
                     node.haspopup
             ),
@@ -147,7 +147,7 @@ export function runSplitButtonTests(
             findAccessibilityNode<NamedRoledPopupNode>(
                 snapshot,
                 (node) =>
-                    node.role === 'button' &&
+                    (node.role === 'button' || node.role === 'buttonmenu') &&
                     node.name === 'Test' &&
                     node.haspopup
             ),


### PR DESCRIPTION
Fixes #3305

<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes the label for the more button from static text to a reference to the sibling button element

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->
#3305
-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Test case 1_
    1. Go to https://jnurthen-issue3305--spectrum-web-components.netlify.app/components/split-button/
    2. Inspect the more part of the split button and look at the Accessible Name in Dev tools
    3. Note that it should be the same as the accessible name of the button part of the split button


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

