### PR TITLE
docs(tooltip): document self-managed API

### DIFF
--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -41,6 +41,24 @@ Tooltips can be top, bottom, left, or right.
 <sp-tooltip open placement="right">Label</sp-tooltip>
 ```
 
+### Self-managed overlays
+
+By default, Tooltip provides styling without behavior.
+You must combine it with an [Overlay Trigger](https://opensource.adobe.com/spectrum-web-components/components/overlay-trigger/#%22hover%22-content-only) in order to manage its overlay behavior.
+
+You can instead apply the `self-managed` attribute for this common case,
+which automaticaly binds to the parent element's hover interaction:
+
+```html
+<sp-action-button>
+    Trigger
+    <sp-tooltip self-managed>Content</sp-tooltip>
+</sp-action-button>
+```
+
+This is especially useful when inserting an intermediate `<overlay-trigger>` would interfere with
+parent/child relationships, such as between `<sp-action-group>` and `<sp-action-button>`.
+
 ## Variants
 
 ### Informative

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -57,6 +57,9 @@ export class Tooltip extends SpectrumElement {
 
     private _tooltipId = `sp-tooltip-describedby-helper-${Tooltip.instanceCount++}`;
 
+    /**
+     * Automatically bind to the parent element's hover interaction. Without this, you must provide your own `overlay-trigger`.
+     */
     @property({ type: Boolean, attribute: 'self-managed' })
     public selfManaged = false;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provide a brief explanation of a currently-undocumented API that we recommend as a best practice.

<!--- Describe your changes in detail -->

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/1436
- resolves https://github.com/adobe/spectrum-web-components/issues/2924

## Motivation and context

User questions

## How has this been tested?

- [ ] Check the [CI docs preview](https://hloftis-docs-tooltip-self-managed--spectrum-web-components.netlify.app/components/tooltip/api/)

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
