### PR TITLE
fix(action-group): bug fixed where it causes revert selection of button on click 

### DIFF
--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -187,7 +187,6 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
             }
             case 'multiple': {
                 const selected = [...this.selected];
-                target.selected = !target.selected;
                 target.setAttribute(
                     'aria-checked',
                     target.selected ? 'true' : 'false'


### PR DESCRIPTION
Creating Draft PR just to review changes. If everything looks good, I'll update description of this PR:

Consider the case where `ActionGroup` has multiple `ActionButton` and `ActionGroup` is controlled component. When I click one of the `ActionButton`, in [onClick](https://github.com/adobe/spectrum-web-components/blob/main/packages/action-button/src/ActionButton.ts#L123) event, ActionButton already changes `selected` property of ActionButton. Later, when `handleClick` event is fired on `ActionGroup`, we unnecessarily changes ActionButton's `selected` property to opposite of current state which is already changed before in ActionButton. This causes issue and later ActionButton's `value` property's value [is not added](https://github.com/adobe/spectrum-web-components/pull/3369/files#diff-b86e1ad24ea1fd0c7ca6cc46a20dd4f7e8626d26f8aa77fccbeb388cf42c9d1dR195) in `this.selected` array and thus ActionButton selection UI is not working. 

I tested this changes in ccx-commenting filter component and it works fine. But, that breaks action group's 3 unit tests. I was wondering if this change is valid or not. Or, if there is any better solution. Please have a look when you get a chance. Thanks a lot.

<img width="898" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/6495820/261eb5ba-25ea-4f3c-9106-380263b928ac">

## Description

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
