### PR TITLE
fix(table): include all dependencies, @lit-labs/observers was missing

### DIFF
--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -115,6 +115,7 @@
         "lit-html"
     ],
     "dependencies": {
+        "@lit-labs/observers": "^2.0.0",
         "@lit-labs/virtualizer": "^2.0.2",
         "@spectrum-web-components/base": "^0.33.2",
         "@spectrum-web-components/checkbox": "^0.33.2",


### PR DESCRIPTION
## Description
Include missing dependency on `@lit-labs/observers`

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.