### PR TITLE
fix(tabs): allow bi-directional arrow key navigation in both orientations

### DIFF
--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -183,8 +183,7 @@ export class Tabs extends SizedMixin(Focusable) {
             });
             return firstFocusableElement ? focusInIndex : -1;
         },
-        direction: () =>
-            this.direction === 'horizontal' ? 'horizontal' : 'vertical',
+        direction: () => 'both',
         elementEnterAction: (el) => {
             if (!this.auto) return;
 

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -549,6 +549,16 @@ describe('Tabs', () => {
 
         await elementUpdated(el);
         expect(el.selected).to.be.equal('first');
+
+        firstTab.dispatchEvent(arrowRightEvent());
+
+        await elementUpdated(el);
+        expect(document.activeElement === secondTab, 'Focus second tab').to.be
+            .true;
+
+        secondTab.dispatchEvent(arrowLeftEvent());
+        expect(document.activeElement === firstTab, 'Focus first tab').to.be
+            .true;
     });
     it('selects through slotted DOM', async () => {
         const el = await fixture<Tabs>(

--- a/packages/tabs/test/tabs.test.ts
+++ b/packages/tabs/test/tabs.test.ts
@@ -419,7 +419,6 @@ describe('Tabs', () => {
             .true;
 
         firstTab.dispatchEvent(arrowLeftEvent());
-        firstTab.dispatchEvent(arrowUpEvent());
 
         await elementUpdated(el);
         expect(document.activeElement === secondTab, 'Focus second tab').to.be
@@ -440,6 +439,18 @@ describe('Tabs', () => {
 
         await elementUpdated(el);
         expect(el.selected).to.be.equal('first');
+
+        firstTab.dispatchEvent(arrowUpEvent());
+
+        await elementUpdated(el);
+        expect(document.activeElement === secondTab, 'Focus second tab').to.be
+            .true;
+
+        secondTab.dispatchEvent(arrowDownEvent());
+
+        await elementUpdated(el);
+        expect(document.activeElement === firstTab, 'Focus first tab').to.be
+            .true;
     });
 
     it('accepts keyboard based selection through shadow DOM', async () => {
@@ -481,7 +492,6 @@ describe('Tabs', () => {
         expect(activeElement === firstTab, 'Focus first tab').to.be.true;
 
         firstTab.dispatchEvent(arrowLeftEvent());
-        firstTab.dispatchEvent(arrowUpEvent());
 
         await elementUpdated(el);
         activeElement = rootNode.activeElement as Tab;
@@ -528,7 +538,6 @@ describe('Tabs', () => {
             .true;
 
         firstTab.dispatchEvent(arrowLeftEvent());
-        firstTab.dispatchEvent(arrowUpEvent());
 
         await elementUpdated(el);
         expect(document.activeElement === secondTab, 'Focus second tab').to.be

--- a/tools/reactive-controllers/src/FocusGroup.ts
+++ b/tools/reactive-controllers/src/FocusGroup.ts
@@ -230,9 +230,9 @@ export class FocusGroupController<T extends HTMLElement>
         }
         switch (this.direction) {
             case 'horizontal':
-                return code.startsWith('Arrow');
+                return code === 'ArrowLeft' || code === 'ArrowRight';
             case 'vertical':
-                return code.startsWith('Arrow');
+                return code === 'ArrowUp' || code === 'ArrowDown';
             case 'both':
             case 'grid':
                 return code.startsWith('Arrow');

--- a/tools/reactive-controllers/src/FocusGroup.ts
+++ b/tools/reactive-controllers/src/FocusGroup.ts
@@ -230,9 +230,9 @@ export class FocusGroupController<T extends HTMLElement>
         }
         switch (this.direction) {
             case 'horizontal':
-                return code === 'ArrowLeft' || code === 'ArrowRight';
+                return code.startsWith('Arrow');
             case 'vertical':
-                return code === 'ArrowUp' || code === 'ArrowDown';
+                return code.startsWith('Arrow');
             case 'both':
             case 'grid':
                 return code.startsWith('Arrow');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the logic to accept event code on arrow key press in TabGroup.ts allowing users to use both ArrowLeft and ArrowUp keys interchangeably (same for ArrowDown and ArrowRight)

## Related issue(s)

fixes #3263 

## Motivation and context

Currently a screen reader user would have to guess the orientation to figure out which arrow keys will work to navigate to the next or previous Tab since we can't rely on screen readers announcing the tablist orientation.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
