### PR TITLE
docs: responsive side-nav and settings overlays should be modal and keyboard accessible #3428

### DIFF
--- a/projects/documentation/content/_includes/partials/logo.njk
+++ b/projects/documentation/content/_includes/partials/logo.njk
@@ -7,7 +7,8 @@
         viewBox="0 0 30 26"
         width="36px"
         xml:space="preserve"
-        aria-hidden="true"
+        role="img"
+        aria-label="Adobe"
     >
         <path
             fill="#FA0F00"

--- a/projects/documentation/src/components/adobe-logo.ts
+++ b/projects/documentation/src/components/adobe-logo.ts
@@ -40,6 +40,8 @@ export class SpectrumLogo extends LitElement {
                 viewBox="0 0 30 26"
                 width="${this.size}"
                 xml:space="preserve"
+                role="img"
+                aria-label="Adobe"
             >
                 <path
                     fill="#FA0F00"

--- a/projects/documentation/src/components/layout.css
+++ b/projects/documentation/src/components/layout.css
@@ -251,11 +251,17 @@ aside {
     background-color: var(--spectrum-global-color-gray-75);
     width: var(--spectrum-global-dimension-size-2400);
     transition: transform
-        var(
-            --spectrum-dialog-confirm-background-entry-animation-duration,
-            var(--spectrum-global-animation-duration-600)
-        )
-        cubic-bezier(0, 0, 0.4, 1);
+            var(
+                --spectrum-dialog-confirm-background-entry-animation-duration,
+                var(--spectrum-global-animation-duration-600)
+            )
+            cubic-bezier(0, 0, 0.4, 1),
+        visibility 0s linear
+            var(
+                --spectrum-dialog-confirm-background-entry-animation-duration,
+                var(--spectrum-global-animation-duration-600)
+            );
+    visibility: visible;
 }
 
 aside .manage-theme {
@@ -281,6 +287,21 @@ aside .theme-control {
     margin: 0 0 var(--spectrum-spacing-300);
 }
 
+aside.show {
+    transition-delay: 0ms, 0ms;
+    visibility: visible;
+}
+
 aside:not(.show) {
     transform: translateX(100%);
+    visibility: hidden;
+}
+
+:host([dir='rtl']) aside {
+    left: 0;
+    right: auto;
+}
+
+:host([dir='rtl']) aside:not(.show) {
+    transform: translateX(-100%);
 }

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -50,7 +50,7 @@ import {
     DARK_MODE,
     IS_MOBILE,
 } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
-import { ActionButton } from '@spectrum-web-components/bundle';
+import type { ActionButton } from '@spectrum-web-components/bundle';
 
 const SWC_THEME_COLOR_KEY = 'swc-docs:theme:color';
 const SWC_THEME_SCALE_KEY = 'swc-docs:theme:scale';
@@ -204,23 +204,13 @@ export class LayoutElement extends LitElement {
             if (this.settings) {
                 this.toggleSettings();
             } else if (this.open) {
-                this.open = false;
-                (this.shadowRoot!.querySelector(
-                    '#toggle-nav-id'
-                ) as ActionButton)!.focus();
+                this.toggleNav();
             }
         }
     };
 
     toggleNav() {
         this.open = !this.open;
-        requestAnimationFrame(() => {
-            this.open
-                ? this.focus()
-                : (this.shadowRoot!.querySelector(
-                      '#toggle-nav-id'
-                  ) as ActionButton)!.focus();
-        });
     }
 
     toggleSettings() {
@@ -589,8 +579,12 @@ export class LayoutElement extends LitElement {
         if (changes.has('dir') && window.localStorage) {
             localStorage.setItem(SWC_THEME_DIR_KEY, this.dir);
         }
-        if (changes.has('open') && this.open) {
-            this.focus();
+        if (changes.has('open')) {
+            this.open
+                ? this.focus()
+                : (this.shadowRoot!.querySelector(
+                      '#toggle-nav-id'
+                  ) as ActionButton)!.focus();
         }
         if (loadStyleFragments) {
             lazyStyleFragment(this.color, this.theme);

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -215,24 +215,6 @@ export class LayoutElement extends LitElement {
 
     toggleSettings() {
         this.settings = !this.settings;
-        requestAnimationFrame(() =>
-            (this.shadowRoot?.querySelector(
-                this.settings ? '#close-settings-id' : '#toggle-settings-id'
-            ) as ActionButton)!.focus()
-        );
-        if (this.settings && this.isNarrow) {
-            this.ownerDocument!.addEventListener(
-                'keydown',
-                this.handleEscapeKey,
-                true
-            );
-        } else {
-            this.ownerDocument!.removeEventListener(
-                'keydown',
-                this.handleEscapeKey,
-                true
-            );
-        }
     }
 
     private updateColor(event: Event) {
@@ -586,6 +568,33 @@ export class LayoutElement extends LitElement {
                       '#toggle-nav-id'
                   ) as ActionButton)!.focus();
         }
+
+        if (changes.has('settings')) {
+            (this.shadowRoot!.querySelector(
+                this.settings ? '#close-settings-id' : '#toggle-settings-id'
+            ) as ActionButton)!.focus();
+            if (this.settings && this.isNarrow) {
+                this.ownerDocument!.addEventListener(
+                    'keydown',
+                    this.handleEscapeKey,
+                    true
+                );
+            } else {
+                this.ownerDocument!.removeEventListener(
+                    'keydown',
+                    this.handleEscapeKey,
+                    true
+                );
+            }
+        }
+
+        if (changes.has('isNarrow')) {
+            if (!this.isNarrow) {
+                this.open = false;
+                this.settings = false;
+            }
+        }
+
         if (loadStyleFragments) {
             lazyStyleFragment(this.color, this.theme);
             lazyStyleFragment(this.scale, this.theme);

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -50,6 +50,7 @@ import {
     DARK_MODE,
     IS_MOBILE,
 } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
+import { ActionButton } from '@spectrum-web-components/bundle';
 
 const SWC_THEME_COLOR_KEY = 'swc-docs:theme:color';
 const SWC_THEME_SCALE_KEY = 'swc-docs:theme:scale';
@@ -193,12 +194,55 @@ export class LayoutElement extends LitElement {
         this.isNarrow = event.matches;
     };
 
+    handleEscapeKey = (event: KeyboardEvent) => {
+        if (
+            event.key === 'Escape' &&
+            (event.target! as Element).closest(
+                '[role="listbox"],[role="menu"]'
+            ) === null
+        ) {
+            if (this.settings) {
+                this.toggleSettings();
+            } else if (this.open) {
+                this.open = false;
+                (this.shadowRoot!.querySelector(
+                    '#toggle-nav-id'
+                ) as ActionButton)!.focus();
+            }
+        }
+    };
+
     toggleNav() {
         this.open = !this.open;
+        requestAnimationFrame(() => {
+            this.open
+                ? this.focus()
+                : (this.shadowRoot!.querySelector(
+                      '#toggle-nav-id'
+                  ) as ActionButton)!.focus();
+        });
     }
 
     toggleSettings() {
         this.settings = !this.settings;
+        requestAnimationFrame(() =>
+            (this.shadowRoot?.querySelector(
+                this.settings ? '#close-settings-id' : '#toggle-settings-id'
+            ) as ActionButton)!.focus()
+        );
+        if (this.settings && this.isNarrow) {
+            this.ownerDocument!.addEventListener(
+                'keydown',
+                this.handleEscapeKey,
+                true
+            );
+        } else {
+            this.ownerDocument!.removeEventListener(
+                'keydown',
+                this.handleEscapeKey,
+                true
+            );
+        }
     }
 
     private updateColor(event: Event) {
@@ -308,7 +352,7 @@ export class LayoutElement extends LitElement {
                 id="side-nav"
                 ?inert=${this.isNarrow && !this.open}
                 ?open=${this.open}
-                @close=${this.toggleNav}
+                @close=${this.open ? this.toggleNav : undefined}
             >
                 ${this._sidenavRendered ? navContent : nothing}
             </docs-side-nav>
@@ -319,31 +363,40 @@ export class LayoutElement extends LitElement {
         if (this.settings || !this.isNarrow) {
             import('./settings.js');
         }
-        return html`
-            <sp-underlay
-                class="scrim"
-                ?open=${this.settings}
-                @click=${this.toggleSettings}
-                ?hidden=${!this.isNarrow}
-            ></sp-underlay>
-            <aside class=${this.settings ? 'show' : ''}>
-                <header>
-                    <sp-action-button
-                        quiet
-                        label="Cloase Navigation"
-                        @click=${this.toggleSettings}
-                    >
-                        <sp-icon-close slot="icon"></sp-icon-close>
-                    </sp-action-button>
-                </header>
-                ${this.manageTheme}
-            </aside>
-        `;
+        return (
+            this.isNarrow
+                ? html`
+                      <sp-underlay
+                          class="scrim"
+                          ?open=${this.settings}
+                          @click=${this.toggleSettings}
+                          ?hidden=${!this.isNarrow}
+                      ></sp-underlay>
+                      <aside
+                          aria-label="Settings"
+                          ?inert=${!this.settings}
+                          class=${this.settings ? 'show' : ''}
+                      >
+                          <header>
+                              <sp-action-button
+                                  quiet
+                                  label="Close Settings"
+                                  @click=${this.toggleSettings}
+                                  id="close-settings-id"
+                              >
+                                  <sp-icon-close slot="icon"></sp-icon-close>
+                              </sp-action-button>
+                          </header>
+                          ${this.manageTheme}
+                      </aside>
+                  `
+                : nothing
+        ) as TemplateResult;
     }
 
     private get manageTheme(): TemplateResult {
         return html`
-            <div class="manage-theme">
+            <div class="manage-theme" role="form" aria-label="Settings">
                 <div class="theme-control">
                     <sp-field-label for="theme-theme">Theme</sp-field-label>
                     <sp-picker
@@ -425,8 +478,15 @@ export class LayoutElement extends LitElement {
                           <header>
                               <sp-action-button
                                   quiet
-                                  label="Open Navigation"
+                                  label=${this.open
+                                      ? 'Close Navigation'
+                                      : 'Open Navigation'}
+                                  tabindex=${this.isNarrow && this.open
+                                      ? '-1'
+                                      : '0'}
+                                  ?inert=${this.isNarrow && this.settings}
                                   @click=${this.toggleNav}
+                                  id="toggle-nav-id"
                               >
                                   <sp-icon-show-menu
                                       slot="icon"
@@ -435,8 +495,15 @@ export class LayoutElement extends LitElement {
 
                               <sp-action-button
                                   quiet
-                                  label="Open Settings"
+                                  label=${this.settings
+                                      ? 'Close Settings'
+                                      : 'Open Settings'}
+                                  tabindex=${this.isNarrow && this.settings
+                                      ? '-1'
+                                      : '0'}
+                                  ?inert=${this.isNarrow && this.open}
                                   @click=${this.toggleSettings}
+                                  id="toggle-settings-id"
                               >
                                   <sp-icon-settings
                                       slot="icon"
@@ -449,7 +516,7 @@ export class LayoutElement extends LitElement {
                     ${this.sideNav} ${this.settingsContent}
                     <div
                         id="page"
-                        ?inert=${this.isNarrow && this.open}
+                        ?inert=${this.isNarrow && (this.open || this.settings)}
                         @alert=${this.addAlert}
                         @copy-text=${this.copyText}
                     >

--- a/projects/documentation/src/components/side-nav.css
+++ b/projects/documentation/src/components/side-nav.css
@@ -32,18 +32,29 @@ aside {
         top: 0;
         left: 0;
         transition: transform
-            var(
-                --spectrum-dialog-confirm-background-entry-animation-duration,
-                var(--spectrum-global-animation-duration-600)
-            )
-            cubic-bezier(0, 0, 0.4, 1);
+                var(
+                    --spectrum-dialog-confirm-background-entry-animation-duration,
+                    var(--spectrum-global-animation-duration-600)
+                )
+                cubic-bezier(0, 0, 0.4, 1),
+            visibility 0s linear var(--spectrum-global-animation-duration-600);
         transform: translateX(-100%);
         z-index: 10;
         min-height: 100vh;
+        visibility: hidden;
+    }
+
+    [dir='rtl'] + aside {
+        right: 0;
+        left: auto;
+        transform: translateX(100%);
+        visibility: hidden;
     }
 
     :host([open]) aside {
         transform: translateX(0);
+        visibility: visible;
+        transition-delay: 0s, 0s;
     }
 
     .scrim {

--- a/projects/documentation/src/components/side-nav.ts
+++ b/projects/documentation/src/components/side-nav.ts
@@ -36,9 +36,27 @@ export class SideNav extends LitElement {
     @property({ type: Boolean, reflect: true })
     public open = false;
 
-    public toggle() {
+    public toggle(event: MouseEvent | KeyboardEvent) {
+        if (
+            event.type === 'keydown' &&
+            (event as KeyboardEvent).code !== 'Enter' &&
+            (event as KeyboardEvent).code !== 'Space'
+        ) {
+            return;
+        }
         this.open = !this.open;
     }
+
+    handleKeydown = (event: KeyboardEvent) => {
+        if (
+            event.code === 'Escape' &&
+            (event.target! as Element).closest(
+                '[role="listbox"],[role="menu"]'
+            ) === null
+        ) {
+            this.open = false;
+        }
+    };
 
     public override focus() {
         const target = document.querySelector(
@@ -82,8 +100,21 @@ export class SideNav extends LitElement {
     }
 
     override updated(changes: PropertyValues) {
-        if (changes.has('open') && !this.open && changes.get('open')) {
-            this.dispatchEvent(new Event('close'));
+        if (changes.has('open')) {
+            if (!this.open && changes.get('open')) {
+                this.dispatchEvent(new Event('close'));
+                this.ownerDocument.removeEventListener(
+                    'keydown',
+                    this.handleKeydown,
+                    true
+                );
+            } else if (this.open && !changes.get('open')) {
+                this.ownerDocument.addEventListener(
+                    'keydown',
+                    this.handleKeydown,
+                    true
+                );
+            }
         }
     }
 }

--- a/projects/documentation/src/components/styles.css
+++ b/projects/documentation/src/components/styles.css
@@ -179,6 +179,7 @@ body {
     color: var(--spectrum-global-color-gray-800);
     text-decoration: none;
     width: var(--spectrum-global-dimension-size-2400);
+    position: relative;
 }
 
 #logo svg {
@@ -203,6 +204,18 @@ body {
         --spectrum-alias-body-text-font-family,
         var(--spectrum-global-font-family-base)
     );
+}
+
+#logo:focus-visible::before {
+    content: '';
+    position: absolute;
+    top: calc(var(--spectrum-global-dimension-size-350) - 4px);
+    right: calc(var(--spectrum-global-dimension-size-300) - 4px);
+    bottom: calc(var(--spectrum-global-dimension-size-350) - 4px);
+    left: calc(var(--spectrum-global-dimension-size-300) - 4px);
+    border: 2px solid
+        var(--spectrum-alias-focus-color, var(--spectrum-global-color-blue-400));
+    border-radius: 4px;
 }
 
 docs-page:not(:defined) #title-header {


### PR DESCRIPTION
## Description

Make it so responsive side-nav and settings overlays are modal and can be closed using the Escape key.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3428 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
