### PR TITLE
docs: spelling fix in swatch-group docs

### DIFF
--- a/packages/swatch/swatch-group.md
+++ b/packages/swatch/swatch-group.md
@@ -150,7 +150,7 @@ An `<sp-swatch-group>` element can carry a selection of a `single` swatch or of 
 
 When the value of `selected` is updated via user input, the `change` event will be dispatched on the `<sp-swatch-group>` element to announce that interaction. Calling `preventDefault()` on the `chagne` event will prevent both the `<sp-swatch-group>` and the `<sp-swatch>` that initiated the `change` interaction from updating their `selected` values.
 
-The value of `selected` can also be privited directly from the `<sp-swatch>` children. Child `<sp-swatch>` elements with their own `selected` attribute will be gathered and merged with any other selection data on the `<sp-swatch-group>` parent to populate `selected`.
+The value of `selected` can also be provided directly from the `<sp-swatch>` children. Child `<sp-swatch>` elements with their own `selected` attribute will be gathered and merged with any other selection data on the `<sp-swatch-group>` parent to populate `selected`.
 
 ### Single
 


### PR DESCRIPTION
## Description

minor documentation fix