### PR TITLE
feat: wrap hover rules in a media query

### DIFF
--- a/packages/accordion/src/spectrum-accordion-item.css
+++ b/packages/accordion/src/spectrum-accordion-item.css
@@ -209,21 +209,23 @@ governing permissions and limitations under the License.
     inset-inline-start: 0;
     position: absolute;
 }
-#header:hover {
-    background-color: var(
-        --mod-accordion-background-color-hover,
-        var(--spectrum-accordion-background-color-hover)
-    );
-    color: var(
-        --mod-accordion-item-header-color-hover,
-        var(--spectrum-accordion-item-header-color-hover)
-    );
-}
-#header:hover + .iconContainer {
-    color: var(
-        --mod-accordion-item-header-color-hover,
-        var(--spectrum-accordion-item-header-color-hover)
-    );
+@media (hover: hover) {
+    #header:hover {
+        background-color: var(
+            --mod-accordion-background-color-hover,
+            var(--spectrum-accordion-background-color-hover)
+        );
+        color: var(
+            --mod-accordion-item-header-color-hover,
+            var(--spectrum-accordion-item-header-color-hover)
+        );
+    }
+    #header:hover + .iconContainer {
+        color: var(
+            --mod-accordion-item-header-color-hover,
+            var(--spectrum-accordion-item-header-color-hover)
+        );
+    }
 }
 #header.focus-visible {
     background-color: var(
@@ -293,15 +295,16 @@ governing permissions and limitations under the License.
         var(--spectrum-accordion-item-header-color-down)
     );
 }
-:host([open]) #header:hover {
-    background-color: var(
-        --mod-accordion-background-color-hover,
-        var(--spectrum-accordion-background-color-hover)
-    );
+@media (hover: hover) {
+    :host([open]) #header:hover {
+        background-color: var(
+            --mod-accordion-background-color-hover,
+            var(--spectrum-accordion-background-color-hover)
+        );
+    }
 }
 :host([disabled]) #header,
-:host([disabled]) #header.focus-visible,
-:host([disabled]) #header:hover {
+:host([disabled]) #header.focus-visible {
     background-color: #0000;
     color: var(
         --mod-accordion-item-header-disabled-color,
@@ -309,13 +312,32 @@ governing permissions and limitations under the License.
     );
 }
 :host([disabled]) #header,
-:host([disabled]) #header:focus-visible,
-:host([disabled]) #header:hover {
+:host([disabled]) #header:focus-visible {
     background-color: #0000;
     color: var(
         --mod-accordion-item-header-disabled-color,
         var(--spectrum-accordion-item-header-disabled-color)
     );
+}
+@media (hover: hover) {
+    :host([disabled]) #header,
+    :host([disabled]) #header.focus-visible,
+    :host([disabled]) #header:hover {
+        background-color: #0000;
+        color: var(
+            --mod-accordion-item-header-disabled-color,
+            var(--spectrum-accordion-item-header-disabled-color)
+        );
+    }
+    :host([disabled]) #header,
+    :host([disabled]) #header:focus-visible,
+    :host([disabled]) #header:hover {
+        background-color: #0000;
+        color: var(
+            --mod-accordion-item-header-disabled-color,
+            var(--spectrum-accordion-item-header-disabled-color)
+        );
+    }
 }
 :host([disabled]) #header + .iconContainer {
     color: var(

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -306,28 +306,30 @@ governing permissions and limitations under the License.
     );
     position: relative;
 }
-:host(:hover) {
-    background-color: var(
-        --highcontrast-actionbutton-background-color-hover,
-        var(
-            --mod-actionbutton-background-color-hover,
-            var(--spectrum-actionbutton-background-color-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-actionbutton-border-color-hover,
-        var(
-            --mod-actionbutton-border-color-hover,
-            var(--spectrum-actionbutton-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-actionbutton-content-color-hover,
-        var(
-            --mod-actionbutton-content-color-hover,
-            var(--spectrum-actionbutton-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        background-color: var(
+            --highcontrast-actionbutton-background-color-hover,
+            var(
+                --mod-actionbutton-background-color-hover,
+                var(--spectrum-actionbutton-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-actionbutton-border-color-hover,
+            var(
+                --mod-actionbutton-border-color-hover,
+                var(--spectrum-actionbutton-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-actionbutton-content-color-hover,
+            var(
+                --mod-actionbutton-content-color-hover,
+                var(--spectrum-actionbutton-content-color-hover)
+            )
+        );
+    }
 }
 :host(.focus-visible) {
     background-color: var(

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -260,9 +260,14 @@ governing permissions and limitations under the License.
     );
     position: relative;
 }
-:host(:hover),
 :host([active]) {
     box-shadow: none;
+}
+@media (hover: hover) {
+    :host(:hover),
+    :host([active]) {
+        box-shadow: none;
+    }
 }
 ::slotted([slot='icon']) {
     color: inherit;
@@ -433,28 +438,30 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:hover) {
-    background-color: var(
-        --highcontrast-button-background-color-hover,
-        var(
-            --mod-button-background-color-hover,
-            var(--spectrum-button-background-color-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-button-border-color-hover,
-        var(
-            --mod-button-border-color-hover,
-            var(--spectrum-button-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-button-content-color-hover,
-        var(
-            --mod-button-content-color-hover,
-            var(--spectrum-button-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        background-color: var(
+            --highcontrast-button-background-color-hover,
+            var(
+                --mod-button-background-color-hover,
+                var(--spectrum-button-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-button-border-color-hover,
+            var(
+                --mod-button-border-color-hover,
+                var(--spectrum-button-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-button-content-color-hover,
+            var(
+                --mod-button-content-color-hover,
+                var(--spectrum-button-content-color-hover)
+            )
+        );
+    }
 }
 :host(.focus-visible) {
     background-color: var(
@@ -576,16 +583,28 @@ governing permissions and limitations under the License.
         color: GrayText;
     }
     :host([variant='accent'][treatment='fill'].focus-visible),
-    :host([variant='accent'][treatment='fill']:hover),
     :host([variant='accent'][treatment='fill'][active]),
     :host([variant='accent'][treatment='fill'][focused]) {
         background-color: Highlight;
     }
     :host([variant='accent'][treatment='fill']:focus-visible),
-    :host([variant='accent'][treatment='fill']:hover),
     :host([variant='accent'][treatment='fill'][active]),
     :host([variant='accent'][treatment='fill'][focused]) {
         background-color: Highlight;
+    }
+    @media (hover: hover) {
+        :host([variant='accent'][treatment='fill'].focus-visible),
+        :host([variant='accent'][treatment='fill']:hover),
+        :host([variant='accent'][treatment='fill'][active]),
+        :host([variant='accent'][treatment='fill'][focused]) {
+            background-color: Highlight;
+        }
+        :host([variant='accent'][treatment='fill']:focus-visible),
+        :host([variant='accent'][treatment='fill']:hover),
+        :host([variant='accent'][treatment='fill'][active]),
+        :host([variant='accent'][treatment='fill'][focused]) {
+            background-color: Highlight;
+        }
     }
     :host([variant='accent'][treatment='fill']) #label {
         forced-color-adjust: none;

--- a/packages/card/src/spectrum-card.css
+++ b/packages/card/src/spectrum-card.css
@@ -189,14 +189,16 @@ governing permissions and limitations under the License.
             )
     );
 }
-:host(:hover) {
-    border-color: var(
-        --highcontrast-card-border-color-hover,
-        var(
-            --mod-card-border-color-hover,
-            var(--spectrum-card-border-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        border-color: var(
+            --highcontrast-card-border-color-hover,
+            var(
+                --mod-card-border-color-hover,
+                var(--spectrum-card-border-color-hover)
+            )
+        );
+    }
 }
 :host([selected]) {
     border-color: var(
@@ -246,8 +248,6 @@ governing permissions and limitations under the License.
 }
 :host(:focus) .actions,
 :host(:focus) .quick-actions,
-:host(:hover) .actions,
-:host(:hover) .quick-actions,
 :host([focused]) .actions,
 :host([focused]) .quick-actions,
 :host([selected]) .actions,
@@ -255,6 +255,20 @@ governing permissions and limitations under the License.
     opacity: 1;
     pointer-events: all;
     visibility: visible;
+}
+@media (hover: hover) {
+    :host(:focus) .actions,
+    :host(:focus) .quick-actions,
+    :host(:hover) .actions,
+    :host(:hover) .quick-actions,
+    :host([focused]) .actions,
+    :host([focused]) .quick-actions,
+    :host([selected]) .actions,
+    :host([selected]) .quick-actions {
+        opacity: 1;
+        pointer-events: all;
+        visibility: visible;
+    }
 }
 .quick-actions {
     background-color: rgba(
@@ -629,16 +643,18 @@ governing permissions and limitations under the License.
     );
     position: absolute;
 }
-:host([variant='gallery']:hover),
-:host([variant='quiet']:hover) {
-    border-color: #0000;
-}
-:host([variant='gallery']:hover) #preview,
-:host([variant='quiet']:hover) #preview {
-    background-color: var(
-        --mod-card-background-color-hover,
-        var(--spectrum-card-background-color-hover)
-    );
+@media (hover: hover) {
+    :host([variant='gallery']:hover),
+    :host([variant='quiet']:hover) {
+        border-color: #0000;
+    }
+    :host([variant='gallery']:hover) #preview,
+    :host([variant='quiet']:hover) #preview {
+        background-color: var(
+            --mod-card-background-color-hover,
+            var(--spectrum-card-background-color-hover)
+        );
+    }
 }
 :host([variant='gallery'][drop-target]),
 :host([variant='quiet'][drop-target]) {
@@ -694,11 +710,13 @@ governing permissions and limitations under the License.
 :host([horizontal]) {
     flex-direction: row;
 }
-:host([horizontal]:hover) #preview {
-    border-color: var(
-        --mod-card-border-color-hover,
-        var(--spectrum-card-border-color-hover)
-    );
+@media (hover: hover) {
+    :host([horizontal]:hover) #preview {
+        border-color: var(
+            --mod-card-border-color-hover,
+            var(--spectrum-card-border-color-hover)
+        );
+    }
 }
 :host([horizontal]) #preview {
     align-items: center;

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -129,32 +129,34 @@ governing permissions and limitations under the License.
     position: relative;
     vertical-align: top;
 }
-:host(:hover) #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-hover,
-        var(
-            --mod-checkbox-control-color-hover,
-            var(--spectrum-checkbox-control-color-hover)
-        )
-    );
-}
-:host(:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-hover,
-        var(
-            --mod-checkbox-control-selected-color-hover,
-            var(--spectrum-checkbox-control-selected-color-hover)
-        )
-    );
-}
-:host(:hover) #label {
-    color: var(
-        --highcontrast-checkbox-content-color-hover,
-        var(
-            --mod-checkbox-content-color-hover,
-            var(--spectrum-checkbox-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-control-color-hover,
+                var(--spectrum-checkbox-control-color-hover)
+            )
+        );
+    }
+    :host(:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-control-selected-color-hover,
+                var(--spectrum-checkbox-control-selected-color-hover)
+            )
+        );
+    }
+    :host(:hover) #label {
+        color: var(
+            --highcontrast-checkbox-content-color-hover,
+            var(
+                --mod-checkbox-content-color-hover,
+                var(--spectrum-checkbox-content-color-hover)
+            )
+        );
+    }
 }
 :host:active #box:before {
     border-color: var(
@@ -213,15 +215,17 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid][invalid]:hover) #box:before,
-:host([invalid][invalid]:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-hover,
-        var(
-            --mod-checkbox-invalid-color-hover,
-            var(--spectrum-checkbox-invalid-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid][invalid]:hover) #box:before,
+    :host([invalid][invalid]:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-hover,
+            var(
+                --mod-checkbox-invalid-color-hover,
+                var(--spectrum-checkbox-invalid-color-hover)
+            )
+        );
+    }
 }
 :host([readonly]) {
     border-color: var(
@@ -232,14 +236,16 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([readonly]:hover) #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-control-selected-color-default,
-            var(--spectrum-checkbox-control-selected-color-default)
-        )
-    );
+@media (hover: hover) {
+    :host([readonly]:hover) #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-default,
+            var(
+                --mod-checkbox-control-selected-color-default,
+                var(--spectrum-checkbox-control-selected-color-default)
+            )
+        );
+    }
 }
 :host([readonly]):active #box:before {
     border-color: var(
@@ -302,15 +308,17 @@ governing permissions and limitations under the License.
     opacity: 1;
     transform: scale(1);
 }
-:host([indeterminate]:hover) #box:before,
-:host([indeterminate]:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-hover,
-        var(
-            --mod-checkbox-control-selected-color-hover,
-            var(--spectrum-checkbox-control-selected-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([indeterminate]:hover) #box:before,
+    :host([indeterminate]:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-control-selected-color-hover,
+                var(--spectrum-checkbox-control-selected-color-hover)
+            )
+        );
+    }
 }
 :host([invalid][invalid][indeterminate]) #box:before,
 :host([invalid][invalid][indeterminate]) #input:checked + #box:before {
@@ -326,24 +334,28 @@ governing permissions and limitations under the License.
         var(--spectrum-checkbox-selected-border-width)
     );
 }
-:host([invalid][invalid][indeterminate]:hover) #box:before,
-:host([invalid][invalid][indeterminate]:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-invalid-color-hover,
-            var(--spectrum-checkbox-invalid-color-hover)
-        )
-    );
-}
-:host([invalid][invalid][indeterminate]:hover) #label {
-    color: var(
-        --highcontrast-checkbox-content-color-hover,
-        var(
-            --mod-checkbox-content-color-hover,
-            var(--spectrum-checkbox-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid][invalid][indeterminate]:hover) #box:before,
+    :host([invalid][invalid][indeterminate]:hover)
+        #input:checked
+        + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-default,
+            var(
+                --mod-checkbox-invalid-color-hover,
+                var(--spectrum-checkbox-invalid-color-hover)
+            )
+        );
+    }
+    :host([invalid][invalid][indeterminate]:hover) #label {
+        color: var(
+            --highcontrast-checkbox-content-color-hover,
+            var(
+                --mod-checkbox-content-color-hover,
+                var(--spectrum-checkbox-content-color-hover)
+            )
+        );
+    }
 }
 :host([emphasized]) #input:checked + #box:before,
 :host([emphasized][indeterminate]) #box:before {
@@ -355,14 +367,16 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([emphasized]:hover) #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-hover,
-        var(
-            --mod-checkbox-emphasized-color-hover,
-            var(--spectrum-checkbox-emphasized-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([emphasized]:hover) #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-hover,
+            var(
+                --mod-checkbox-emphasized-color-hover,
+                var(--spectrum-checkbox-emphasized-color-hover)
+            )
+        );
+    }
 }
 :host([emphasized]) #input.focus-visible + #box:before,
 :host([emphasized]) #input.focus-visible:checked + #box:before,
@@ -408,25 +422,27 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([emphasized][invalid][invalid]:hover) #input:checked + #box:before,
-:host([emphasized][invalid][invalid][indeterminate]:hover) #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-hover,
-        var(
-            --mod-checkbox-invalid-color-hover,
-            var(--spectrum-checkbox-invalid-color-hover)
-        )
-    );
-}
-:host([emphasized]:hover) #input:checked + #box:before,
-:host([emphasized][indeterminate]:hover) #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-hover,
-        var(
-            --mod-checkbox-emphasized-color-hover,
-            var(--spectrum-checkbox-emphasized-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([emphasized][invalid][invalid]:hover) #input:checked + #box:before,
+    :host([emphasized][invalid][invalid][indeterminate]:hover) #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-hover,
+            var(
+                --mod-checkbox-invalid-color-hover,
+                var(--spectrum-checkbox-invalid-color-hover)
+            )
+        );
+    }
+    :host([emphasized]:hover) #input:checked + #box:before,
+    :host([emphasized][indeterminate]:hover) #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-emphasized-color-hover,
+                var(--spectrum-checkbox-emphasized-color-hover)
+            )
+        );
+    }
 }
 :host([emphasized]):active #input:checked + #box:before,
 :host([emphasized][indeterminate]):active #box:before {

--- a/packages/clear-button/src/spectrum-clear-button.css
+++ b/packages/clear-button/src/spectrum-clear-button.css
@@ -291,8 +291,10 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-component-icon-color-default)
     );
 }
-:host(:hover) {
-    color: var(--spectrum-clearbutton-fill-uiicon-color);
+@media (hover: hover) {
+    :host(:hover) {
+        color: var(--spectrum-clearbutton-fill-uiicon-color);
+    }
 }
 :host([active]) {
     color: var(--spectrum-clearbutton-fill-uiicon-color-down);
@@ -306,8 +308,12 @@ governing permissions and limitations under the License.
 :host([disabled]) {
     color: var(--spectrum-clearbutton-fill-uiicon-color-disabled);
 }
-:host(:hover) .fill {
-    background-color: var(--spectrum-clearbutton-fill-background-color-hover);
+@media (hover: hover) {
+    :host(:hover) .fill {
+        background-color: var(
+            --spectrum-clearbutton-fill-background-color-hover
+        );
+    }
 }
 :host([active]) .fill {
     background-color: var(--spectrum-clearbutton-fill-background-color-down);
@@ -333,11 +339,13 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground']:hover) {
-    color: var(
-        --spectrum-alias-icon-color-overbackground,
-        var(--spectrum-global-color-static-white)
-    );
+@media (hover: hover) {
+    :host([variant='overBackground']:hover) {
+        color: var(
+            --spectrum-alias-icon-color-overbackground,
+            var(--spectrum-global-color-static-white)
+        );
+    }
 }
 :host([variant='overBackground'][active]) {
     color: var(
@@ -378,19 +386,21 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-static-white)
     );
 }
-:host([variant='overBackground']:hover) {
-    background-color: var(
-        --spectrum-button-m-primary-outline-white-texticon-background-color-hover,
-        var(--spectrum-global-color-static-transparent-white-300)
-    );
-    border-color: var(
-        --spectrum-button-m-primary-outline-white-texticon-border-color-hover,
-        var(--spectrum-global-color-static-white)
-    );
-    color: var(
-        --spectrum-button-m-primary-outline-white-texticon-text-color-hover,
-        var(--spectrum-global-color-static-white)
-    );
+@media (hover: hover) {
+    :host([variant='overBackground']:hover) {
+        background-color: var(
+            --spectrum-button-m-primary-outline-white-texticon-background-color-hover,
+            var(--spectrum-global-color-static-transparent-white-300)
+        );
+        border-color: var(
+            --spectrum-button-m-primary-outline-white-texticon-border-color-hover,
+            var(--spectrum-global-color-static-white)
+        );
+        color: var(
+            --spectrum-button-m-primary-outline-white-texticon-text-color-hover,
+            var(--spectrum-global-color-static-white)
+        );
+    }
 }
 :host([variant='overBackground'].focus-visible) {
     background-color: var(
@@ -505,8 +515,10 @@ governing permissions and limitations under the License.
         --spectrum-clearbutton-fill-uiicon-color-key-focus: Highlight;
         --spectrum-clearbutton-m-fill-uiicon-color: ButtonText;
     }
-    :host(:hover) {
-        color: var(--spectrum-clearbutton-fill-uiicon-color-key-focus);
+    @media (hover: hover) {
+        :host(:hover) {
+            color: var(--spectrum-clearbutton-fill-uiicon-color-key-focus);
+        }
     }
     :host([disabled]) {
         color: var(--spectrum-clearbutton-fill-uiicon-color-disabled);

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -352,20 +352,22 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:not([disabled]):hover) {
-    background-color: var(
-        --mod-closebutton-background-color-hover,
-        var(--spectrum-closebutton-background-color-hover)
-    );
-}
-:host(:not([disabled]):hover) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-hover,
-        var(
-            --mod-closebutton-icon-color-hover,
-            var(--spectrum-closebutton-icon-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:not([disabled]):hover) {
+        background-color: var(
+            --mod-closebutton-background-color-hover,
+            var(--spectrum-closebutton-background-color-hover)
+        );
+    }
+    :host(:not([disabled]):hover) .icon {
+        color: var(
+            --highcontrast-closebutton-icon-color-hover,
+            var(
+                --mod-closebutton-icon-color-hover,
+                var(--spectrum-closebutton-icon-color-hover)
+            )
+        );
+    }
 }
 :host(:not([disabled])[active]) {
     background-color: var(
@@ -457,25 +459,27 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([variant='black']:not([disabled]):hover),
-:host([variant='white']:not([disabled]):hover) {
-    background-color: var(
-        --highcontrast-closebutton-static-background-color-hover,
-        var(
-            --mod-closebutton-static-background-color-hover,
-            var(--spectrum-closebutton-static-background-color-hover)
-        )
-    );
-}
-:host([variant='black']:not([disabled]):hover) .icon,
-:host([variant='white']:not([disabled]):hover) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-default,
-        var(
-            --mod-closebutton-icon-color-default,
-            var(--spectrum-closebutton-icon-color-default)
-        )
-    );
+@media (hover: hover) {
+    :host([variant='black']:not([disabled]):hover),
+    :host([variant='white']:not([disabled]):hover) {
+        background-color: var(
+            --highcontrast-closebutton-static-background-color-hover,
+            var(
+                --mod-closebutton-static-background-color-hover,
+                var(--spectrum-closebutton-static-background-color-hover)
+            )
+        );
+    }
+    :host([variant='black']:not([disabled]):hover) .icon,
+    :host([variant='white']:not([disabled]):hover) .icon {
+        color: var(
+            --highcontrast-closebutton-icon-color-default,
+            var(
+                --mod-closebutton-icon-color-default,
+                var(--spectrum-closebutton-icon-color-default)
+            )
+        );
+    }
 }
 :host([variant='black']:not([disabled])[active]),
 :host([variant='white']:not([disabled])[active]) {

--- a/packages/dropzone/src/spectrum-dropzone.css
+++ b/packages/dropzone/src/spectrum-dropzone.css
@@ -307,12 +307,20 @@ governing permissions and limitations under the License.
         var(--spectrum-drop-zone-content-top-to-text)
     );
 }
-.spectrum-DropZone-button:focus,
-.spectrum-DropZone-button:hover {
+.spectrum-DropZone-button:focus {
     background-color: var(
         --mod-drop-zone-content-background-color,
         var(--spectrum-drop-zone-content-background-color)
     );
+}
+@media (hover: hover) {
+    .spectrum-DropZone-button:focus,
+    .spectrum-DropZone-button:hover {
+        background-color: var(
+            --mod-drop-zone-content-background-color,
+            var(--spectrum-drop-zone-content-background-color)
+        );
+    }
 }
 @media (forced-colors: active) {
     :host {

--- a/packages/link/src/spectrum-link.css
+++ b/packages/link/src/spectrum-link.css
@@ -75,14 +75,16 @@ a {
         )
         ease-in-out;
 }
-a:hover {
-    color: var(
-        --highcontrast-link-text-color-primary-hover,
-        var(
-            --mod-link-text-color-primary-hover,
-            var(--spectrum-link-text-color-primary-hover)
-        )
-    );
+@media (hover: hover) {
+    a:hover {
+        color: var(
+            --highcontrast-link-text-color-primary-hover,
+            var(
+                --mod-link-text-color-primary-hover,
+                var(--spectrum-link-text-color-primary-hover)
+            )
+        );
+    }
 }
 a:active {
     color: var(
@@ -128,14 +130,16 @@ a:focus-visible {
         )
     );
 }
-:host([variant='secondary']) a:hover {
-    color: var(
-        --highcontrast-link-text-color-secondary-hover,
-        var(
-            --mod-link-text-color-secondary-hover,
-            var(--spectrum-link-text-color-secondary-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([variant='secondary']) a:hover {
+        color: var(
+            --highcontrast-link-text-color-secondary-hover,
+            var(
+                --mod-link-text-color-secondary-hover,
+                var(--spectrum-link-text-color-secondary-hover)
+            )
+        );
+    }
 }
 :host([variant='secondary']) a:active {
     color: var(
@@ -159,9 +163,11 @@ a:focus-visible {
     -webkit-text-decoration: none;
     text-decoration: none;
 }
-:host([quiet]) a:hover {
-    -webkit-text-decoration: underline;
-    text-decoration: underline;
+@media (hover: hover) {
+    :host([quiet]) a:hover {
+        -webkit-text-decoration: underline;
+        text-decoration: underline;
+    }
 }
 :host([static='white']) a {
     color: var(
@@ -170,12 +176,24 @@ a:focus-visible {
     );
 }
 :host([static='white']) a:active,
-:host([static='white']) a:focus,
-:host([static='white']) a:hover {
+:host([static='white']) a:focus {
     color: var(
         --highcontrast-link-text-color-white,
         var(--mod-link-text-color-white, var(--spectrum-link-text-color-white))
     );
+}
+@media (hover: hover) {
+    :host([static='white']) a:active,
+    :host([static='white']) a:focus,
+    :host([static='white']) a:hover {
+        color: var(
+            --highcontrast-link-text-color-white,
+            var(
+                --mod-link-text-color-white,
+                var(--spectrum-link-text-color-white)
+            )
+        );
+    }
 }
 :host([static='black']) a {
     color: var(
@@ -184,10 +202,22 @@ a:focus-visible {
     );
 }
 :host([static='black']) a:active,
-:host([static='black']) a:focus,
-:host([static='black']) a:hover {
+:host([static='black']) a:focus {
     color: var(
         --highcontrast-link-text-color-black,
         var(--mod-link-text-color-black, var(--spectrum-link-text-color-black))
     );
+}
+@media (hover: hover) {
+    :host([static='black']) a:active,
+    :host([static='black']) a:focus,
+    :host([static='black']) a:hover {
+        color: var(
+            --highcontrast-link-text-color-black,
+            var(
+                --mod-link-text-color-black,
+                var(--spectrum-link-text-color-black)
+            )
+        );
+    }
 }

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -175,8 +175,7 @@ governing permissions and limitations under the License.
 }
 :host .is-highlighted,
 :host .is-open,
-:host(:focus),
-:host(:hover) {
+:host(:focus) {
     background-color: var(
         --spectrum-listitem-m-texticon-background-color-hover,
         var(--spectrum-alias-background-color-hover-overlay)
@@ -185,6 +184,21 @@ governing permissions and limitations under the License.
         --spectrum-listitem-m-texticon-text-color-hover,
         var(--spectrum-alias-component-text-color-hover)
     );
+}
+@media (hover: hover) {
+    :host .is-highlighted,
+    :host .is-open,
+    :host(:focus),
+    :host(:hover) {
+        background-color: var(
+            --spectrum-listitem-m-texticon-background-color-hover,
+            var(--spectrum-alias-background-color-hover-overlay)
+        );
+        color: var(
+            --spectrum-listitem-m-texticon-text-color-hover,
+            var(--spectrum-alias-component-text-color-hover)
+        );
+    }
 }
 :host([selected]) {
     color: var(
@@ -238,7 +252,6 @@ governing permissions and limitations under the License.
     :host(:not([disabled])) .is-open,
     :host(:not([disabled]).focus-visible),
     :host(:not([disabled]):focus),
-    :host(:not([disabled]):hover),
     :host(:not([disabled])[focused]) {
         background-color: var(
             --spectrum-listitem-m-texticon-background-color-key-focus,
@@ -253,7 +266,6 @@ governing permissions and limitations under the License.
     :host(:not([disabled])) .is-open,
     :host(:not([disabled]):focus),
     :host(:not([disabled]):focus-visible),
-    :host(:not([disabled]):hover),
     :host(:not([disabled])[focused]) {
         background-color: var(
             --spectrum-listitem-m-texticon-background-color-key-focus,
@@ -264,20 +276,68 @@ governing permissions and limitations under the License.
             var(--spectrum-alias-component-text-color-key-focus)
         );
     }
+    @media (hover: hover) {
+        :host(:not([disabled])) .is-highlighted,
+        :host(:not([disabled])) .is-open,
+        :host(:not([disabled]).focus-visible),
+        :host(:not([disabled]):focus),
+        :host(:not([disabled]):hover),
+        :host(:not([disabled])[focused]) {
+            background-color: var(
+                --spectrum-listitem-m-texticon-background-color-key-focus,
+                var(--spectrum-alias-background-color-hover-overlay)
+            );
+            color: var(
+                --spectrum-listitem-m-texticon-text-color-key-focus,
+                var(--spectrum-alias-component-text-color-key-focus)
+            );
+        }
+        :host(:not([disabled])) .is-highlighted,
+        :host(:not([disabled])) .is-open,
+        :host(:not([disabled]):focus),
+        :host(:not([disabled]):focus-visible),
+        :host(:not([disabled]):hover),
+        :host(:not([disabled])[focused]) {
+            background-color: var(
+                --spectrum-listitem-m-texticon-background-color-key-focus,
+                var(--spectrum-alias-background-color-hover-overlay)
+            );
+            color: var(
+                --spectrum-listitem-m-texticon-text-color-key-focus,
+                var(--spectrum-alias-component-text-color-key-focus)
+            );
+        }
+    }
     :host(:not([disabled]).focus-visible[selected]) .checkmark,
     :host(:not([disabled])[focused][selected]) .checkmark,
     :host(:not([disabled])[selected]) .is-highlighted .checkmark,
     :host(:not([disabled])[selected]) .is-open .checkmark,
-    :host(:not([disabled])[selected]:focus) .checkmark,
-    :host(:not([disabled])[selected]:hover) .checkmark {
+    :host(:not([disabled])[selected]:focus) .checkmark {
         color: HighlightText;
     }
     :host(:not([disabled]):focus-visible[selected]) .checkmark,
     :host(:not([disabled])[focused][selected]) .checkmark,
     :host(:not([disabled])[selected]) .is-highlighted .checkmark,
     :host(:not([disabled])[selected]) .is-open .checkmark,
-    :host(:not([disabled])[selected]:focus) .checkmark,
-    :host(:not([disabled])[selected]:hover) .checkmark {
+    :host(:not([disabled])[selected]:focus) .checkmark {
         color: HighlightText;
+    }
+    @media (hover: hover) {
+        :host(:not([disabled]).focus-visible[selected]) .checkmark,
+        :host(:not([disabled])[focused][selected]) .checkmark,
+        :host(:not([disabled])[selected]) .is-highlighted .checkmark,
+        :host(:not([disabled])[selected]) .is-open .checkmark,
+        :host(:not([disabled])[selected]:focus) .checkmark,
+        :host(:not([disabled])[selected]:hover) .checkmark {
+            color: HighlightText;
+        }
+        :host(:not([disabled]):focus-visible[selected]) .checkmark,
+        :host(:not([disabled])[focused][selected]) .checkmark,
+        :host(:not([disabled])[selected]) .is-highlighted .checkmark,
+        :host(:not([disabled])[selected]) .is-open .checkmark,
+        :host(:not([disabled])[selected]:focus) .checkmark,
+        :host(:not([disabled])[selected]:hover) .checkmark {
+            color: HighlightText;
+        }
     }
 }

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -112,25 +112,27 @@ governing permissions and limitations under the License.
     line-height: 0;
     position: relative;
 }
-:host(:hover:not([disabled]):not([invalid]):not([focused]))
-    #textfield:not(.is-keyboardFocused)
-    .buttons,
-:host(:hover:not([disabled]):not([invalid]):not([focused]))
-    #textfield:not(.is-keyboardFocused)
-    .input,
-:host(:hover:not([disabled]):not([invalid]):not([focused]))
-    #textfield:not(.is-keyboardFocused)
-    .step-down,
-:host(:hover:not([disabled]):not([invalid]):not([focused]))
-    #textfield:not(.is-keyboardFocused)
-    .step-up {
-    border-color: var(
-        --highcontrast-stepper-border-color-hover,
-        var(
-            --mod-stepper-border-color-hover,
-            var(--spectrum-stepper-border-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover:not([disabled]):not([invalid]):not([focused]))
+        #textfield:not(.is-keyboardFocused)
+        .buttons,
+    :host(:hover:not([disabled]):not([invalid]):not([focused]))
+        #textfield:not(.is-keyboardFocused)
+        .input,
+    :host(:hover:not([disabled]):not([invalid]):not([focused]))
+        #textfield:not(.is-keyboardFocused)
+        .step-down,
+    :host(:hover:not([disabled]):not([invalid]):not([focused]))
+        #textfield:not(.is-keyboardFocused)
+        .step-up {
+        border-color: var(
+            --highcontrast-stepper-border-color-hover,
+            var(
+                --mod-stepper-border-color-hover,
+                var(--spectrum-stepper-border-color-hover)
+            )
+        );
+    }
 }
 :host([focused]) #textfield .input {
     outline: none;
@@ -157,17 +159,19 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([focused]:hover) #textfield .buttons,
-:host([focused]:hover) #textfield .input,
-:host([focused]:hover) #textfield .step-down,
-:host([focused]:hover) #textfield .step-up {
-    border-color: var(
-        --highcontrast-stepper-border-color-focus-hover,
-        var(
-            --mod-stepper-border-color-focus-hover,
-            var(--spectrum-stepper-border-color-focus-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([focused]:hover) #textfield .buttons,
+    :host([focused]:hover) #textfield .input,
+    :host([focused]:hover) #textfield .step-down,
+    :host([focused]:hover) #textfield .step-up {
+        border-color: var(
+            --highcontrast-stepper-border-color-focus-hover,
+            var(
+                --mod-stepper-border-color-focus-hover,
+                var(--spectrum-stepper-border-color-focus-hover)
+            )
+        );
+    }
 }
 :host([focused][invalid]) #textfield .buttons,
 :host([focused][invalid]) #textfield .input,
@@ -327,17 +331,19 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid]:hover) #textfield .buttons,
-:host([invalid]:hover) #textfield .input,
-:host([invalid]:hover) #textfield .step-down,
-:host([invalid]:hover) #textfield .step-up {
-    border-color: var(
-        --highcontrast-stepper-border-color-invalid-hover,
-        var(
-            --mod-stepper-border-color-invalid-hover,
-            var(--spectrum-stepper-border-color-invalid-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid]:hover) #textfield .buttons,
+    :host([invalid]:hover) #textfield .input,
+    :host([invalid]:hover) #textfield .step-down,
+    :host([invalid]:hover) #textfield .step-up {
+        border-color: var(
+            --highcontrast-stepper-border-color-invalid-hover,
+            var(
+                --mod-stepper-border-color-invalid-hover,
+                var(--spectrum-stepper-border-color-invalid-hover)
+            )
+        );
+    }
 }
 :host([invalid][focused]) #textfield .buttons,
 :host([invalid][focused]) #textfield .input,
@@ -351,17 +357,19 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid][focused]:hover) #textfield .buttons,
-:host([invalid][focused]:hover) #textfield .input,
-:host([invalid][focused]:hover) #textfield .step-down,
-:host([invalid][focused]:hover) #textfield .step-up {
-    border-color: var(
-        --highcontrast-stepper-border-color-invalid-focus-hover,
-        var(
-            --mod-stepper-border-color-invalid-focus-hover,
-            var(--spectrum-stepper-border-color-invalid-focus-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid][focused]:hover) #textfield .buttons,
+    :host([invalid][focused]:hover) #textfield .input,
+    :host([invalid][focused]:hover) #textfield .step-down,
+    :host([invalid][focused]:hover) #textfield .step-up {
+        border-color: var(
+            --highcontrast-stepper-border-color-invalid-focus-hover,
+            var(
+                --mod-stepper-border-color-invalid-focus-hover,
+                var(--spectrum-stepper-border-color-invalid-focus-hover)
+            )
+        );
+    }
 }
 :host([invalid][keyboard-focused]) #textfield .buttons,
 :host([invalid][keyboard-focused]) #textfield .input,
@@ -461,11 +469,15 @@ governing permissions and limitations under the License.
 :host([quiet]) .buttons,
 :host([quiet]) .input,
 :host([quiet]) .step-down,
-:host([quiet]) .step-up,
-:host([quiet]:hover) .buttons,
-:host([quiet]:hover) .step-down,
-:host([quiet]:hover) .step-up {
+:host([quiet]) .step-up {
     background-color: #0000;
+}
+@media (hover: hover) {
+    :host([quiet]:hover) .buttons,
+    :host([quiet]:hover) .step-down,
+    :host([quiet]:hover) .step-up {
+        background-color: #0000;
+    }
 }
 :host([quiet][disabled]) #textfield .buttons,
 :host([quiet][disabled]) #textfield .input,
@@ -510,17 +522,19 @@ governing permissions and limitations under the License.
 :host([quiet][focused]) .step-up {
     background-color: #0000;
 }
-:host([quiet][focused]:hover) .buttons,
-:host([quiet][focused]:hover) .input,
-:host([quiet][focused]:hover) .step-down,
-:host([quiet][focused]:hover) .step-up {
-    border-color: var(
-        --highcontrast-stepper-border-color-focus-hover,
-        var(
-            --mod-stepper-border-color-focus-hover,
-            var(--spectrum-stepper-border-color-focus-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([quiet][focused]:hover) .buttons,
+    :host([quiet][focused]:hover) .input,
+    :host([quiet][focused]:hover) .step-down,
+    :host([quiet][focused]:hover) .step-up {
+        border-color: var(
+            --highcontrast-stepper-border-color-focus-hover,
+            var(
+                --mod-stepper-border-color-focus-hover,
+                var(--spectrum-stepper-border-color-focus-hover)
+            )
+        );
+    }
 }
 :host([quiet][focused][invalid]) .buttons,
 :host([quiet][focused][invalid]) .input,
@@ -670,15 +684,17 @@ governing permissions and limitations under the License.
     margin-inline-start: var(--spectrum-stepper-button-icon-nudge);
     opacity: 1;
 }
-:host(:hover) .step-down,
-:host(:hover) .step-up {
-    background-color: var(
-        --highcontrast-stepper-button-background-color-hover,
-        var(
-            --mod-stepper-button-background-color-hover,
-            var(--spectrum-stepper-button-background-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) .step-down,
+    :host(:hover) .step-up {
+        background-color: var(
+            --highcontrast-stepper-button-background-color-hover,
+            var(
+                --mod-stepper-button-background-color-hover,
+                var(--spectrum-stepper-button-background-color-hover)
+            )
+        );
+    }
 }
 .step-down:disabled,
 .step-up:disabled {

--- a/packages/picker-button/src/spectrum-picker-button.css
+++ b/packages/picker-button/src/spectrum-picker-button.css
@@ -335,11 +335,15 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-component-background-color-default)
     );
 }
-:host(:not([disabled]):not([open])) .root:hover .spectrum-PickerButton-fill {
-    background-color: var(
-        --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover,
-        var(--spectrum-alias-component-background-color-hover)
-    );
+@media (hover: hover) {
+    :host(:not([disabled]):not([open]))
+        .root:hover
+        .spectrum-PickerButton-fill {
+        background-color: var(
+            --spectrum-alias-infieldbutton-fill-loudnessHigh-background-color-hover,
+            var(--spectrum-alias-component-background-color-hover)
+        );
+    }
 }
 :host(:not([disabled]):not([open])[active]) .root .spectrum-PickerButton-fill {
     background-color: var(
@@ -353,11 +357,13 @@ governing permissions and limitations under the License.
         var(--spectrum-semantic-negative-color-default)
     );
 }
-:host([invalid]:not([disabled])) .root:hover .spectrum-PickerButton-fill {
-    border-color: var(
-        --spectrum-alias-input-border-color-invalid-hover,
-        var(--spectrum-semantic-negative-color-hover)
-    );
+@media (hover: hover) {
+    :host([invalid]:not([disabled])) .root:hover .spectrum-PickerButton-fill {
+        border-color: var(
+            --spectrum-alias-input-border-color-invalid-hover,
+            var(--spectrum-semantic-negative-color-hover)
+        );
+    }
 }
 :host([invalid]:not([disabled])[active]) .root .spectrum-PickerButton-fill {
     border-color: var(
@@ -400,11 +406,15 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-input-border-color-default)
     );
 }
-:host(:not([invalid]):not([disabled])) .root:hover .spectrum-PickerButton-fill {
-    border-color: var(
-        --spectrum-alias-infieldbutton-fill-border-color-hover,
-        var(--spectrum-alias-input-border-color-hover)
-    );
+@media (hover: hover) {
+    :host(:not([invalid]):not([disabled]))
+        .root:hover
+        .spectrum-PickerButton-fill {
+        border-color: var(
+            --spectrum-alias-infieldbutton-fill-border-color-hover,
+            var(--spectrum-alias-input-border-color-hover)
+        );
+    }
 }
 :host(:not([invalid]):not([disabled])[active])
     .root
@@ -955,13 +965,15 @@ governing permissions and limitations under the License.
         transparent
     );
 }
-:host(:not([disabled]):not([open]))
-    .root.spectrum-PickerButton--quiet:hover
-    .spectrum-PickerButton-fill {
-    background-color: var(
-        --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover,
-        transparent
-    );
+@media (hover: hover) {
+    :host(:not([disabled]):not([open]))
+        .root.spectrum-PickerButton--quiet:hover
+        .spectrum-PickerButton-fill {
+        background-color: var(
+            --spectrum-alias-infieldbutton-fill-loudnessLow-background-color-hover,
+            transparent
+        );
+    }
 }
 :host(:not([disabled]):not([open])[active])
     .root.spectrum-PickerButton--quiet
@@ -974,6 +986,18 @@ governing permissions and limitations under the License.
 :host(:not([invalid]):not([disabled]))
     .root.spectrum-PickerButton--quiet
     .spectrum-PickerButton-fill,
+:host([invalid]:not([disabled]))
+    .root.spectrum-PickerButton--quiet
+    .spectrum-PickerButton-fill {
+    border-color: #0000;
+}
+@media (hover: hover) {
+    :host(:not([invalid]):not([disabled]))
+        .root.spectrum-PickerButton--quiet:hover
+        .spectrum-PickerButton-fill {
+        border-color: #0000;
+    }
+}
 :host(:not([invalid]):not([disabled]))
     .root.spectrum-PickerButton--quiet.focus-visible
     .spectrum-PickerButton-fill,
@@ -986,20 +1010,11 @@ governing permissions and limitations under the License.
 :host(:not([invalid]):not([disabled]))
     .root.spectrum-PickerButton--quiet:focus
     .spectrum-PickerButton-fill,
-:host(:not([invalid]):not([disabled]))
-    .root.spectrum-PickerButton--quiet:hover
-    .spectrum-PickerButton-fill,
 :host(:not([invalid]):not([disabled])[active])
-    .root.spectrum-PickerButton--quiet
-    .spectrum-PickerButton-fill,
-:host([invalid]:not([disabled]))
     .root.spectrum-PickerButton--quiet
     .spectrum-PickerButton-fill {
     border-color: #0000;
 }
-:host(:not([invalid]):not([disabled]))
-    .root.spectrum-PickerButton--quiet
-    .spectrum-PickerButton-fill,
 :host(:not([invalid]):not([disabled]))
     .root.spectrum-PickerButton--quiet.is-focused
     .spectrum-PickerButton-fill,
@@ -1012,13 +1027,7 @@ governing permissions and limitations under the License.
 :host(:not([invalid]):not([disabled]))
     .root.spectrum-PickerButton--quiet:focus-visible
     .spectrum-PickerButton-fill,
-:host(:not([invalid]):not([disabled]))
-    .root.spectrum-PickerButton--quiet:hover
-    .spectrum-PickerButton-fill,
 :host(:not([invalid]):not([disabled])[active])
-    .root.spectrum-PickerButton--quiet
-    .spectrum-PickerButton-fill,
-:host([invalid]:not([disabled]))
     .root.spectrum-PickerButton--quiet
     .spectrum-PickerButton-fill {
     border-color: #0000;
@@ -1074,18 +1083,26 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-800)
     );
 }
-:host(:not([disabled]):not([open])) .root:hover .spectrum-PickerButton-label {
-    color: var(
-        --spectrum-alias-component-text-color-hover,
-        var(--spectrum-global-color-gray-900)
-    );
-}
-:host(:not([disabled]):not([open])) .root:hover .spectrum-PickerButton-UIIcon,
-:host(:not([disabled]):not([open])) .root:hover .spectrum-PickerButton-icon {
-    color: var(
-        --spectrum-alias-component-icon-color-hover,
-        var(--spectrum-alias-icon-color-hover)
-    );
+@media (hover: hover) {
+    :host(:not([disabled]):not([open]))
+        .root:hover
+        .spectrum-PickerButton-label {
+        color: var(
+            --spectrum-alias-component-text-color-hover,
+            var(--spectrum-global-color-gray-900)
+        );
+    }
+    :host(:not([disabled]):not([open]))
+        .root:hover
+        .spectrum-PickerButton-UIIcon,
+    :host(:not([disabled]):not([open]))
+        .root:hover
+        .spectrum-PickerButton-icon {
+        color: var(
+            --spectrum-alias-component-icon-color-hover,
+            var(--spectrum-alias-icon-color-hover)
+        );
+    }
 }
 :host(:not([disabled]):not([open])[active]) .root .spectrum-PickerButton-label {
     color: var(
@@ -1115,13 +1132,15 @@ governing permissions and limitations under the License.
         var(--spectrum-semantic-negative-text-color-small)
     );
 }
-:host(:not([disabled]):not([open]))
-    .root.spectrum-PickerButton--error:hover
-    .spectrum-PickerButton-label {
-    color: var(
-        --spectrum-alias-component-text-color-error-hover,
-        var(--spectrum-semantic-negative-text-color-small-hover)
-    );
+@media (hover: hover) {
+    :host(:not([disabled]):not([open]))
+        .root.spectrum-PickerButton--error:hover
+        .spectrum-PickerButton-label {
+        color: var(
+            --spectrum-alias-component-text-color-error-hover,
+            var(--spectrum-semantic-negative-text-color-small-hover)
+        );
+    }
 }
 :host(:not([disabled]):not([open])[active])
     .root.spectrum-PickerButton--error

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -96,3 +96,27 @@ sp-popover {
 #label.visually-hidden ~ .picker {
     margin-inline-start: auto;
 }
+
+#button:active {
+    background-color: var(
+        --highcontrast-picker-background-default-open,
+        var(
+            --mod-picker-background-color-default-open,
+            var(--spectrum-picker-background-color-default-open)
+        )
+    );
+    border-color: var(
+        --highcontrast-picker-border-color-default-open,
+        var(
+            --mod-picker-border-default-open,
+            var(--spectrum-picker-border-color-default-open)
+        )
+    );
+    color: var(
+        --highcontrast-picker-font-color-default-open,
+        var(
+            --mod-picker-font-color-default-open,
+            var(--spectrum-picker-font-color-default-open)
+        )
+    );
+}

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -441,37 +441,39 @@ governing permissions and limitations under the License.
     pointer-events: none;
     position: absolute;
 }
-#button:hover {
-    background-color: var(
-        --highcontrast-picker-background-color-default,
-        var(
-            --mod-picker-background-color-hover,
-            var(--spectrum-picker-background-color-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-picker-border-color-default,
-        var(
-            --mod-picker-border-color-hover,
-            var(--spectrum-picker-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-picker-font-color-default,
-        var(
-            --mod-picker-font-color-hover,
-            var(--spectrum-picker-font-color-hover)
-        )
-    );
-}
-#button:hover .picker {
-    color: var(
-        --highcontrast-picker-icon-color-hover,
-        var(
-            --mod-picker-icon-color-hover,
-            var(--spectrum-picker-icon-color-hover)
-        )
-    );
+@media (hover: hover) {
+    #button:hover {
+        background-color: var(
+            --highcontrast-picker-background-color-default,
+            var(
+                --mod-picker-background-color-hover,
+                var(--spectrum-picker-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-picker-border-color-default,
+            var(
+                --mod-picker-border-color-hover,
+                var(--spectrum-picker-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-picker-font-color-default,
+            var(
+                --mod-picker-font-color-hover,
+                var(--spectrum-picker-font-color-hover)
+            )
+        );
+    }
+    #button:hover .picker {
+        color: var(
+            --highcontrast-picker-icon-color-hover,
+            var(
+                --mod-picker-icon-color-hover,
+                var(--spectrum-picker-icon-color-hover)
+            )
+        );
+    }
 }
 #button:active {
     background-color: var(
@@ -642,37 +644,39 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([open]) #button:hover {
-    background-color: var(
-        --highcontrast-picker-background-color-hover-open,
-        var(
-            --mod-picker-background-color-hover-open,
-            var(--spectrum-picker-background-color-hover-open)
-        )
-    );
-    border-color: var(
-        --highcontrast-picker-border-color-hover-open,
-        var(
-            --mod-picker-border-color-hover-open,
-            var(--spectrum-picker-border-color-hover-open)
-        )
-    );
-    color: var(
-        --highcontrast-picker-font-color-default,
-        var(
-            --mod-picker-font-color-hover-open,
-            var(--spectrum-picker-font-color-hover-open)
-        )
-    );
-}
-:host([open]) #button:hover .picker {
-    color: var(
-        --highcontrast-picker-icon-color-hover-open,
-        var(
-            --mod-picker-icon-color-hover-open,
-            var(--spectrum-picker-icon-color-hover-open)
-        )
-    );
+@media (hover: hover) {
+    :host([open]) #button:hover {
+        background-color: var(
+            --highcontrast-picker-background-color-hover-open,
+            var(
+                --mod-picker-background-color-hover-open,
+                var(--spectrum-picker-background-color-hover-open)
+            )
+        );
+        border-color: var(
+            --highcontrast-picker-border-color-hover-open,
+            var(
+                --mod-picker-border-color-hover-open,
+                var(--spectrum-picker-border-color-hover-open)
+            )
+        );
+        color: var(
+            --highcontrast-picker-font-color-default,
+            var(
+                --mod-picker-font-color-hover-open,
+                var(--spectrum-picker-font-color-hover-open)
+            )
+        );
+    }
+    :host([open]) #button:hover .picker {
+        color: var(
+            --highcontrast-picker-icon-color-hover-open,
+            var(
+                --mod-picker-icon-color-hover-open,
+                var(--spectrum-picker-icon-color-hover-open)
+            )
+        );
+    }
 }
 :host([open]) #button .picker {
     color: var(
@@ -701,14 +705,16 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid]) #button:hover {
-    border-color: var(
-        --highcontrast-picker-border-color-error-hover,
-        var(
-            --mod-picker-border-color-error-hover,
-            var(--spectrum-picker-border-color-error-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid]) #button:hover {
+        border-color: var(
+            --highcontrast-picker-border-color-error-hover,
+            var(
+                --mod-picker-border-color-error-hover,
+                var(--spectrum-picker-border-color-error-hover)
+            )
+        );
+    }
 }
 :host([invalid]) #button:active {
     border-color: var(
@@ -728,14 +734,16 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid][open]) #button:hover {
-    border-color: var(
-        --highcontrast-picker-border-color-error-hover-open,
-        var(
-            --mod-picker-border-color-error-hover-open,
-            var(--spectrum-picker-border-color-error-hover-open)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid][open]) #button:hover {
+        border-color: var(
+            --highcontrast-picker-border-color-error-hover-open,
+            var(
+                --mod-picker-border-color-error-hover-open,
+                var(--spectrum-picker-border-color-error-hover-open)
+            )
+        );
+    }
 }
 :host([invalid]) #button.focus-visible,
 :host([invalid][focused]) #button {
@@ -872,14 +880,16 @@ governing permissions and limitations under the License.
         )
         ease-in-out;
 }
-#label.placeholder:hover {
-    color: var(
-        --highcontrast-picker-font-color-default,
-        var(
-            --mod-picker-font-color-hover,
-            var(--spectrum-picker-font-color-hover)
-        )
-    );
+@media (hover: hover) {
+    #label.placeholder:hover {
+        color: var(
+            --highcontrast-picker-font-color-default,
+            var(
+                --mod-picker-font-color-hover,
+                var(--spectrum-picker-font-color-hover)
+            )
+        );
+    }
 }
 #label.placeholder:active {
     color: var(
@@ -972,8 +982,10 @@ governing permissions and limitations under the License.
     border: none;
     inline-size: auto;
 }
-:host([quiet]) #button:hover {
-    background-color: #0000;
+@media (hover: hover) {
+    :host([quiet]) #button:hover {
+        background-color: #0000;
+    }
 }
 :host([quiet]) #button.focus-visible,
 :host([quiet][focused]) #button {

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -172,32 +172,34 @@ governing permissions and limitations under the License.
     position: relative;
     vertical-align: top;
 }
-:host(:hover) #button:before {
-    border-color: var(
-        --highcontrast-radio-button-border-color-hover,
-        var(
-            --mod-radio-button-border-color-hover,
-            var(--spectrum-radio-button-border-color-hover)
-        )
-    );
-}
-:host([checked]:hover) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-button-checked-border-color-hover,
-        var(
-            --mod-radio-button-checked-border-color-hover,
-            var(--spectrum-radio-button-checked-border-color-hover)
-        )
-    );
-}
-:host(:hover) #label {
-    color: var(
-        --highcontrast-radio-neutral-content-color-hover,
-        var(
-            --mod-radio-neutral-content-color-hover,
-            var(--spectrum-radio-neutral-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) #button:before {
+        border-color: var(
+            --highcontrast-radio-button-border-color-hover,
+            var(
+                --mod-radio-button-border-color-hover,
+                var(--spectrum-radio-button-border-color-hover)
+            )
+        );
+    }
+    :host([checked]:hover) #input + #button:before {
+        border-color: var(
+            --highcontrast-radio-button-checked-border-color-hover,
+            var(
+                --mod-radio-button-checked-border-color-hover,
+                var(--spectrum-radio-button-checked-border-color-hover)
+            )
+        );
+    }
+    :host(:hover) #label {
+        color: var(
+            --highcontrast-radio-neutral-content-color-hover,
+            var(
+                --mod-radio-neutral-content-color-hover,
+                var(--spectrum-radio-neutral-content-color-hover)
+            )
+        );
+    }
 }
 :host(:active) #button:before {
     border-color: var(
@@ -359,14 +361,16 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([emphasized][checked]:hover) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-emphasized-accent-color-hover,
-        var(
-            --mod-radio-emphasized-accent-color-hover,
-            var(--spectrum-radio-emphasized-accent-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([emphasized][checked]:hover) #input + #button:before {
+        border-color: var(
+            --highcontrast-radio-emphasized-accent-color-hover,
+            var(
+                --mod-radio-emphasized-accent-color-hover,
+                var(--spectrum-radio-emphasized-accent-color-hover)
+            )
+        );
+    }
 }
 :host([emphasized]:active[checked]) #input + #button:before {
     border-color: var(

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -237,11 +237,13 @@ governing permissions and limitations under the License.
     margin-block: auto;
     position: absolute;
 }
-#textfield:hover .icon-search {
-    --spectrum-search-color: var(
-        --highcontrast-search-color-hover,
-        var(--mod-search-color-hover, var(--spectrum-search-color-hover))
-    );
+@media (hover: hover) {
+    #textfield:hover .icon-search {
+        --spectrum-search-color: var(
+            --highcontrast-search-color-hover,
+            var(--mod-search-color-hover, var(--spectrum-search-color-hover))
+        );
+    }
 }
 #textfield.is-focused .icon-search {
     --spectrum-search-color: var(
@@ -249,14 +251,16 @@ governing permissions and limitations under the License.
         var(--mod-search-color-focus, var(--spectrum-search-color-focus))
     );
 }
-#textfield.is-focused:hover .icon-search {
-    --spectrum-search-color: var(
-        --highcontrast-search-color-focus,
-        var(
-            --mod-search-color-focus-hover,
-            var(--spectrum-search-color-focus-hover)
-        )
-    );
+@media (hover: hover) {
+    #textfield.is-focused:hover .icon-search {
+        --spectrum-search-color: var(
+            --highcontrast-search-color-focus,
+            var(
+                --mod-search-color-focus-hover,
+                var(--spectrum-search-color-focus-hover)
+            )
+        );
+    }
 }
 #textfield.is-keyboardFocused .icon-search {
     --spectrum-search-color: var(
@@ -267,12 +271,23 @@ governing permissions and limitations under the License.
         )
     );
 }
-#textfield.is-disabled .icon-search,
-#textfield.is-disabled:hover .icon-search {
+#textfield.is-disabled .icon-search {
     --spectrum-search-color: var(
         --highcontrast-search-color-disabled,
         var(--mod-search-color-disabled, var(--spectrum-search-color-disabled))
     );
+}
+@media (hover: hover) {
+    #textfield.is-disabled .icon-search,
+    #textfield.is-disabled:hover .icon-search {
+        --spectrum-search-color: var(
+            --highcontrast-search-color-disabled,
+            var(
+                --mod-search-color-disabled,
+                var(--spectrum-search-color-disabled)
+            )
+        );
+    }
 }
 .input {
     -webkit-appearance: none;

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -152,15 +152,17 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-text-color)
     );
 }
-#item-link:hover {
-    background-color: var(
-        --spectrum-sidenav-item-background-color-hover,
-        var(--spectrum-alias-highlight-hover)
-    );
-    color: var(
-        --spectrum-sidenav-item-text-color-hover,
-        var(--spectrum-alias-text-color-hover)
-    );
+@media (hover: hover) {
+    #item-link:hover {
+        background-color: var(
+            --spectrum-sidenav-item-background-color-hover,
+            var(--spectrum-alias-highlight-hover)
+        );
+        color: var(
+            --spectrum-sidenav-item-text-color-hover,
+            var(--spectrum-alias-text-color-hover)
+        );
+    }
 }
 #item-link:active {
     background-color: var(

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -753,14 +753,16 @@ governing permissions and limitations under the License.
         )
     );
 }
-.handle:hover {
-    border-color: var(
-        --highcontrast-slider-handle-border-color-hover,
-        var(
-            --mod-slider-handle-border-color-hover,
-            var(--spectrum-slider-handle-border-color-hover)
-        )
-    );
+@media (hover: hover) {
+    .handle:hover {
+        border-color: var(
+            --highcontrast-slider-handle-border-color-hover,
+            var(
+                --mod-slider-handle-border-color-hover,
+                var(--spectrum-slider-handle-border-color-hover)
+            )
+        );
+    }
 }
 .handle.handle-highlight {
     border-color: var(
@@ -875,8 +877,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([disabled]) .handle:active,
-:host([disabled]) .handle:hover {
+:host([disabled]) .handle:active {
     background: var(
         --highcontrast-slider-handle-background-color-disabled,
         var(
@@ -888,6 +889,25 @@ governing permissions and limitations under the License.
         --highcontrast-disabled-border-color,
         var(--mod-disabled-border-color, var(--spectrum-disabled-border-color))
     );
+}
+@media (hover: hover) {
+    :host([disabled]) .handle:active,
+    :host([disabled]) .handle:hover {
+        background: var(
+            --highcontrast-slider-handle-background-color-disabled,
+            var(
+                --mod-slider-handle-background-color-disabled,
+                var(--spectrum-slider-handle-background-color-disabled)
+            )
+        );
+        border-color: var(
+            --highcontrast-disabled-border-color,
+            var(
+                --mod-disabled-border-color,
+                var(--spectrum-disabled-border-color)
+            )
+        );
+    }
 }
 :host([disabled]) .track:before {
     background: var(

--- a/packages/split-view/src/spectrum-split-view.css
+++ b/packages/split-view/src/spectrum-split-view.css
@@ -244,26 +244,50 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-300)
     );
 }
-:host([resizable]) #splitter.is-hovered,
-:host([resizable]) #splitter:hover {
+:host([resizable]) #splitter.is-hovered {
     background-color: var(
         --spectrum-dragbar-handle-background-color-hover,
         var(--spectrum-global-color-gray-400)
     );
 }
-:host([resizable]) #splitter.is-hovered #gripper,
-:host([resizable]) #splitter:hover #gripper {
+@media (hover: hover) {
+    :host([resizable]) #splitter.is-hovered,
+    :host([resizable]) #splitter:hover {
+        background-color: var(
+            --spectrum-dragbar-handle-background-color-hover,
+            var(--spectrum-global-color-gray-400)
+        );
+    }
+}
+:host([resizable]) #splitter.is-hovered #gripper {
     border-color: var(
         --spectrum-dragbar-handle-background-color-hover,
         var(--spectrum-global-color-gray-400)
     );
 }
-:host([resizable]) #splitter.is-hovered #gripper:before,
-:host([resizable]) #splitter:hover #gripper:before {
+@media (hover: hover) {
+    :host([resizable]) #splitter.is-hovered #gripper,
+    :host([resizable]) #splitter:hover #gripper {
+        border-color: var(
+            --spectrum-dragbar-handle-background-color-hover,
+            var(--spectrum-global-color-gray-400)
+        );
+    }
+}
+:host([resizable]) #splitter.is-hovered #gripper:before {
     background-color: var(
         --spectrum-dragbar-handle-background-color-hover,
         var(--spectrum-global-color-gray-400)
     );
+}
+@media (hover: hover) {
+    :host([resizable]) #splitter.is-hovered #gripper:before,
+    :host([resizable]) #splitter:hover #gripper:before {
+        background-color: var(
+            --spectrum-dragbar-handle-background-color-hover,
+            var(--spectrum-global-color-gray-400)
+        );
+    }
 }
 :host([resizable]) #splitter.is-active,
 :host([resizable]) #splitter:active {

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -367,96 +367,98 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:hover) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-hover,
-        var(
-            --mod-switch-handle-border-color-hover,
-            var(--spectrum-switch-handle-border-color-hover)
-        )
-    );
-    box-shadow: none;
-}
-:host(:hover) #input ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-hover,
-        var(
-            --mod-switch-label-color-hover,
-            var(--spectrum-switch-label-color-hover)
-        )
-    );
-}
-:host([checked]:hover) #input:enabled + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-selected-hover,
-        var(
-            --mod-switch-background-color-selected-hover,
-            var(--spectrum-switch-background-color-selected-hover)
-        )
-    );
-}
-:host([checked]:hover) #input:enabled + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-selected-hover,
-        var(
-            --mod-switch-handle-border-color-selected-hover,
-            var(--spectrum-switch-handle-border-color-selected-hover)
-        )
-    );
-}
-:host([disabled]:hover) #input + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-disabled,
-        var(
-            --mod-switch-background-color-disabled,
-            var(--spectrum-switch-background-color-disabled)
-        )
-    );
-}
-:host([disabled]:hover) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-disabled,
-        var(
-            --mod-switch-handle-border-color-disabled,
-            var(--spectrum-switch-handle-border-color-disabled)
-        )
-    );
-}
-:host([disabled]:hover) #input ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-disabled,
-        var(
-            --mod-switch-label-color-disabled,
-            var(--spectrum-switch-label-color-disabled)
-        )
-    );
-}
-:host([disabled][checked]:hover) #input + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-selected-disabled,
-        var(
-            --mod-switch-background-color-selected-disabled,
-            var(--spectrum-switch-background-color-selected-disabled)
-        )
-    );
-}
-:host([disabled][checked]:hover) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-disabled,
-        var(
-            --mod-switch-handle-border-color-disabled,
-            var(--spectrum-switch-handle-border-color-disabled)
-        )
-    );
-}
-:host([disabled][checked]:hover) #input ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-disabled,
-        var(
-            --mod-switch-label-color-disabled,
-            var(--spectrum-switch-label-color-disabled)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) #input + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-hover,
+            var(
+                --mod-switch-handle-border-color-hover,
+                var(--spectrum-switch-handle-border-color-hover)
+            )
+        );
+        box-shadow: none;
+    }
+    :host(:hover) #input ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-hover,
+            var(
+                --mod-switch-label-color-hover,
+                var(--spectrum-switch-label-color-hover)
+            )
+        );
+    }
+    :host([checked]:hover) #input:enabled + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-selected-hover,
+            var(
+                --mod-switch-background-color-selected-hover,
+                var(--spectrum-switch-background-color-selected-hover)
+            )
+        );
+    }
+    :host([checked]:hover) #input:enabled + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-selected-hover,
+            var(
+                --mod-switch-handle-border-color-selected-hover,
+                var(--spectrum-switch-handle-border-color-selected-hover)
+            )
+        );
+    }
+    :host([disabled]:hover) #input + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-disabled,
+            var(
+                --mod-switch-background-color-disabled,
+                var(--spectrum-switch-background-color-disabled)
+            )
+        );
+    }
+    :host([disabled]:hover) #input + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-disabled,
+            var(
+                --mod-switch-handle-border-color-disabled,
+                var(--spectrum-switch-handle-border-color-disabled)
+            )
+        );
+    }
+    :host([disabled]:hover) #input ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-disabled,
+            var(
+                --mod-switch-label-color-disabled,
+                var(--spectrum-switch-label-color-disabled)
+            )
+        );
+    }
+    :host([disabled][checked]:hover) #input + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-selected-disabled,
+            var(
+                --mod-switch-background-color-selected-disabled,
+                var(--spectrum-switch-background-color-selected-disabled)
+            )
+        );
+    }
+    :host([disabled][checked]:hover) #input + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-disabled,
+            var(
+                --mod-switch-handle-border-color-disabled,
+                var(--spectrum-switch-handle-border-color-disabled)
+            )
+        );
+    }
+    :host([disabled][checked]:hover) #input ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-disabled,
+            var(
+                --mod-switch-label-color-disabled,
+                var(--spectrum-switch-label-color-disabled)
+            )
+        );
+    }
 }
 :host(:active) #input + #switch:before {
     border-color: var(
@@ -494,8 +496,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-#input.focus-visible + #switch:after,
-:host(:hover) #input.focus-visible + #switch:after {
+#input.focus-visible + #switch:after {
     box-shadow: 0 0 0
         var(
             --mod-switch-focus-indicator-thickness,
@@ -509,8 +510,7 @@ governing permissions and limitations under the License.
             )
         );
 }
-#input:focus-visible + #switch:after,
-:host(:hover) #input:focus-visible + #switch:after {
+#input:focus-visible + #switch:after {
     box-shadow: 0 0 0
         var(
             --mod-switch-focus-indicator-thickness,
@@ -524,8 +524,39 @@ governing permissions and limitations under the License.
             )
         );
 }
-#input.focus-visible + #switch:before,
-:host(:hover) #input.focus-visible + #switch:before {
+@media (hover: hover) {
+    #input.focus-visible + #switch:after,
+    :host(:hover) #input.focus-visible + #switch:after {
+        box-shadow: 0 0 0
+            var(
+                --mod-switch-focus-indicator-thickness,
+                var(--spectrum-switch-focus-indicator-thickness)
+            )
+            var(
+                --highcontrast-switch-focus-indicator-color,
+                var(
+                    --mod-switch-focus-indicator-color,
+                    var(--spectrum-switch-focus-indicator-color)
+                )
+            );
+    }
+    #input:focus-visible + #switch:after,
+    :host(:hover) #input:focus-visible + #switch:after {
+        box-shadow: 0 0 0
+            var(
+                --mod-switch-focus-indicator-thickness,
+                var(--spectrum-switch-focus-indicator-thickness)
+            )
+            var(
+                --highcontrast-switch-focus-indicator-color,
+                var(
+                    --mod-switch-focus-indicator-color,
+                    var(--spectrum-switch-focus-indicator-color)
+                )
+            );
+    }
+}
+#input.focus-visible + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-focus,
         var(
@@ -534,8 +565,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-#input:focus-visible + #switch:before,
-:host(:hover) #input:focus-visible + #switch:before {
+#input:focus-visible + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-focus,
         var(
@@ -544,8 +574,29 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([checked]) #input.focus-visible + #switch,
-:host([checked]:hover) #input.focus-visible + #switch {
+@media (hover: hover) {
+    #input.focus-visible + #switch:before,
+    :host(:hover) #input.focus-visible + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-focus,
+            var(
+                --mod-switch-handle-border-color-focus,
+                var(--spectrum-switch-handle-border-color-focus)
+            )
+        );
+    }
+    #input:focus-visible + #switch:before,
+    :host(:hover) #input:focus-visible + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-focus,
+            var(
+                --mod-switch-handle-border-color-focus,
+                var(--spectrum-switch-handle-border-color-focus)
+            )
+        );
+    }
+}
+:host([checked]) #input.focus-visible + #switch {
     background-color: var(
         --highcontrast-switch-background-color-selected-focus,
         var(
@@ -554,8 +605,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([checked]) #input:focus-visible + #switch,
-:host([checked]:hover) #input:focus-visible + #switch {
+:host([checked]) #input:focus-visible + #switch {
     background-color: var(
         --highcontrast-switch-background-color-selected-focus,
         var(
@@ -564,8 +614,29 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([checked]) #input.focus-visible + #switch:before,
-:host([checked]:hover) #input.focus-visible + #switch:before {
+@media (hover: hover) {
+    :host([checked]) #input.focus-visible + #switch,
+    :host([checked]:hover) #input.focus-visible + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-selected-focus,
+            var(
+                --mod-switch-background-color-selected-focus,
+                var(--spectrum-switch-background-color-selected-focus)
+            )
+        );
+    }
+    :host([checked]) #input:focus-visible + #switch,
+    :host([checked]:hover) #input:focus-visible + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-selected-focus,
+            var(
+                --mod-switch-background-color-selected-focus,
+                var(--spectrum-switch-background-color-selected-focus)
+            )
+        );
+    }
+}
+:host([checked]) #input.focus-visible + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-selected-focus,
         var(
@@ -574,8 +645,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([checked]) #input:focus-visible + #switch:before,
-:host([checked]:hover) #input:focus-visible + #switch:before {
+:host([checked]) #input:focus-visible + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-selected-focus,
         var(
@@ -584,8 +654,29 @@ governing permissions and limitations under the License.
         )
     );
 }
-#input.focus-visible ~ #label,
-:host(:hover) #input.focus-visible ~ #label {
+@media (hover: hover) {
+    :host([checked]) #input.focus-visible + #switch:before,
+    :host([checked]:hover) #input.focus-visible + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-selected-focus,
+            var(
+                --mod-switch-handle-border-color-selected-focus,
+                var(--spectrum-switch-handle-border-color-selected-focus)
+            )
+        );
+    }
+    :host([checked]) #input:focus-visible + #switch:before,
+    :host([checked]:hover) #input:focus-visible + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-selected-focus,
+            var(
+                --mod-switch-handle-border-color-selected-focus,
+                var(--spectrum-switch-handle-border-color-selected-focus)
+            )
+        );
+    }
+}
+#input.focus-visible ~ #label {
     color: var(
         --highcontrast-switch-label-color-focus,
         var(
@@ -594,8 +685,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-#input:focus-visible ~ #label,
-:host(:hover) #input:focus-visible ~ #label {
+#input:focus-visible ~ #label {
     color: var(
         --highcontrast-switch-label-color-focus,
         var(
@@ -603,6 +693,28 @@ governing permissions and limitations under the License.
             var(--spectrum-switch-label-color-focus)
         )
     );
+}
+@media (hover: hover) {
+    #input.focus-visible ~ #label,
+    :host(:hover) #input.focus-visible ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-focus,
+            var(
+                --mod-switch-label-color-focus,
+                var(--spectrum-switch-label-color-focus)
+            )
+        );
+    }
+    #input:focus-visible ~ #label,
+    :host(:hover) #input:focus-visible ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-focus,
+            var(
+                --mod-switch-label-color-focus,
+                var(--spectrum-switch-label-color-focus)
+            )
+        );
+    }
 }
 :host([checked]) #input + #switch {
     background-color: var(
@@ -705,16 +817,18 @@ governing permissions and limitations under the License.
     #input:not(:checked) + #switch {
         box-shadow: inset 0 0 0 1px ButtonText;
     }
-    :host(:hover) #input:not(:checked) + #switch {
-        box-shadow: inset 0 0 0 1px Highlight;
-    }
-    :host([disabled][checked]:hover) #input + #switch {
-        background-color: GrayText;
-        box-shadow: inset 0 0 0 1px GrayText;
-    }
-    :host([disabled][checked]:hover) #input + #switch:before {
-        background-color: ButtonFace;
-        border-color: GrayText;
+    @media (hover: hover) {
+        :host(:hover) #input:not(:checked) + #switch {
+            box-shadow: inset 0 0 0 1px Highlight;
+        }
+        :host([disabled][checked]:hover) #input + #switch {
+            background-color: GrayText;
+            box-shadow: inset 0 0 0 1px GrayText;
+        }
+        :host([disabled][checked]:hover) #input + #switch:before {
+            background-color: ButtonFace;
+            border-color: GrayText;
+        }
     }
     :host([disabled]) #input:not(:checked) + #switch {
         background-color: ButtonFace;

--- a/packages/table/src/spectrum-table-head-cell.css
+++ b/packages/table/src/spectrum-table-head-cell.css
@@ -187,17 +187,19 @@ governing permissions and limitations under the License.
         var(--spectrum-global-color-gray-600)
     );
 }
-:host([sortable]:hover) {
-    color: var(
-        --spectrum-table-m-regular-header-text-color-hover,
-        var(--spectrum-alias-text-color-hover)
-    );
-}
-:host([sortable]:hover) .sortedIcon {
-    color: var(
-        --spectrum-table-m-regular-header-sort-icon-color-hover,
-        var(--spectrum-alias-icon-color-hover)
-    );
+@media (hover: hover) {
+    :host([sortable]:hover) {
+        color: var(
+            --spectrum-table-m-regular-header-text-color-hover,
+            var(--spectrum-alias-text-color-hover)
+        );
+    }
+    :host([sortable]:hover) .sortedIcon {
+        color: var(
+            --spectrum-table-m-regular-header-sort-icon-color-hover,
+            var(--spectrum-alias-icon-color-hover)
+        );
+    }
 }
 :host([sortable].focus-visible),
 :host([sortable][focused]) {

--- a/packages/table/src/spectrum-table-row.css
+++ b/packages/table/src/spectrum-table-row.css
@@ -50,11 +50,13 @@ governing permissions and limitations under the License.
             var(--spectrum-alias-border-color-mid)
         );
 }
-:host(:hover) {
-    background-color: var(
-        --spectrum-table-m-regular-row-background-color-hover,
-        var(--spectrum-alias-highlight-hover)
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        background-color: var(
+            --spectrum-table-m-regular-row-background-color-hover,
+            var(--spectrum-alias-highlight-hover)
+        );
+    }
 }
 :host(.focus-visible),
 :host([focused]) {
@@ -82,11 +84,13 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-highlight-selected)
     );
 }
-:host([selected]:hover) {
-    background-color: var(
-        --spectrum-table-m-regular-row-background-color-selected-hover,
-        var(--spectrum-alias-highlight-selected-hover)
-    );
+@media (hover: hover) {
+    :host([selected]:hover) {
+        background-color: var(
+            --spectrum-table-m-regular-row-background-color-selected-hover,
+            var(--spectrum-alias-highlight-selected-hover)
+        );
+    }
 }
 :host([selected].focus-visible),
 :host([selected][focused]) {

--- a/packages/tabs/src/spectrum-tab.css
+++ b/packages/tabs/src/spectrum-tab.css
@@ -89,11 +89,13 @@ governing permissions and limitations under the License.
     pointer-events: none;
     position: absolute;
 }
-:host(:hover) {
-    color: var(
-        --highcontrast-tabs-color-hover,
-        var(--mod-tabs-color-hover, var(--spectrum-tabs-color-hover))
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        color: var(
+            --highcontrast-tabs-color-hover,
+            var(--mod-tabs-color-hover, var(--spectrum-tabs-color-hover))
+        );
+    }
 }
 :host([selected]) {
     color: var(

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -422,28 +422,30 @@ governing permissions and limitations under the License.
     text-overflow: ellipsis;
     white-space: nowrap;
 }
-:host(:hover) {
-    background-color: var(
-        --highcontrast-tag-background-color-hover,
-        var(
-            --mod-tag-background-color-hover,
-            var(--spectrum-tag-background-color-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-tag-border-color-hover,
-        var(
-            --mod-tag-border-color-hover,
-            var(--spectrum-tag-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-hover,
-        var(
-            --mod-tag-content-color-hover,
-            var(--spectrum-tag-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        background-color: var(
+            --highcontrast-tag-background-color-hover,
+            var(
+                --mod-tag-background-color-hover,
+                var(--spectrum-tag-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-tag-border-color-hover,
+            var(
+                --mod-tag-border-color-hover,
+                var(--spectrum-tag-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-tag-content-color-hover,
+            var(
+                --mod-tag-content-color-hover,
+                var(--spectrum-tag-content-color-hover)
+            )
+        );
+    }
 }
 :host(:active) {
     background-color: var(
@@ -667,21 +669,23 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([selected]:hover) {
-    background-color: var(
-        --highcontrast-tag-background-color-selected-hover,
-        var(
-            --mod-tag-background-color-selected-hover,
-            var(--spectrum-tag-background-color-selected-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-tag-border-color-selected-hover,
-        var(
-            --mod-tag-border-color-selected-hover,
-            var(--spectrum-tag-border-color-selected-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([selected]:hover) {
+        background-color: var(
+            --highcontrast-tag-background-color-selected-hover,
+            var(
+                --mod-tag-background-color-selected-hover,
+                var(--spectrum-tag-background-color-selected-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-tag-border-color-selected-hover,
+            var(
+                --mod-tag-border-color-selected-hover,
+                var(--spectrum-tag-border-color-selected-hover)
+            )
+        );
+    }
 }
 :host([selected]:active) {
     background-color: var(
@@ -749,21 +753,23 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid]:hover) {
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-hover,
-        var(
-            --mod-tag-border-color-invalid-hover,
-            var(--spectrum-tag-border-color-invalid-hover)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-invalid-hover,
-        var(
-            --mod-tag-content-color-invalid-hover,
-            var(--spectrum-tag-content-color-invalid-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid]:hover) {
+        border-color: var(
+            --highcontrast-tag-border-color-invalid-hover,
+            var(
+                --mod-tag-border-color-invalid-hover,
+                var(--spectrum-tag-border-color-invalid-hover)
+            )
+        );
+        color: var(
+            --highcontrast-tag-content-color-invalid-hover,
+            var(
+                --mod-tag-content-color-invalid-hover,
+                var(--spectrum-tag-content-color-invalid-hover)
+            )
+        );
+    }
 }
 :host([invalid]:active) {
     border-color: var(
@@ -838,21 +844,23 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid][selected]:hover) {
-    background-color: var(
-        --highcontrast-tag-background-color-invalid-selected-hover,
-        var(
-            --mod-tag-background-color-invalid-selected-hover,
-            var(--spectrum-tag-background-color-invalid-selected-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-selected-hover,
-        var(
-            --mod-tag-border-color-invalid-selected-hover,
-            var(--spectrum-tag-border-color-invalid-selected-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid][selected]:hover) {
+        background-color: var(
+            --highcontrast-tag-background-color-invalid-selected-hover,
+            var(
+                --mod-tag-background-color-invalid-selected-hover,
+                var(--spectrum-tag-background-color-invalid-selected-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-tag-border-color-invalid-selected-hover,
+            var(
+                --mod-tag-border-color-invalid-selected-hover,
+                var(--spectrum-tag-border-color-invalid-selected-hover)
+            )
+        );
+    }
 }
 :host([invalid][selected]:active) {
     background-color: var(
@@ -927,21 +935,23 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([emphasized]:hover) {
-    background-color: var(
-        --highcontrast-tag-background-color-emphasized-hover,
-        var(
-            --mod-tag-background-color-emphasized-hover,
-            var(--spectrum-tag-background-color-emphasized-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-tag-border-color-emphasized-hover,
-        var(
-            --mod-tag-border-color-emphasized-hover,
-            var(--spectrum-tag-border-color-emphasized-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([emphasized]:hover) {
+        background-color: var(
+            --highcontrast-tag-background-color-emphasized-hover,
+            var(
+                --mod-tag-background-color-emphasized-hover,
+                var(--spectrum-tag-background-color-emphasized-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-tag-border-color-emphasized-hover,
+            var(
+                --mod-tag-border-color-emphasized-hover,
+                var(--spectrum-tag-border-color-emphasized-hover)
+            )
+        );
+    }
 }
 :host([emphasized]:active) {
     background-color: var(

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -748,32 +748,34 @@ governing permissions and limitations under the License.
 .input:lang(zh)::-moz-placeholder {
     font-style: normal;
 }
-#textfield:hover .input,
-.input:hover {
-    border-color: var(
-        --highcontrast-textfield-border-color-hover,
-        var(
-            --mod-textfield-border-color-hover,
-            var(--spectrum-textfield-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-textfield-text-color-hover,
-        var(
-            --mod-textfield-text-color-hover,
-            var(--spectrum-textfield-text-color-hover)
-        )
-    );
-}
-#textfield:hover .input::placeholder,
-.input:hover::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-hover,
-        var(
-            --mod-textfield-text-color-hover,
-            var(--spectrum-textfield-text-color-hover)
-        )
-    );
+@media (hover: hover) {
+    #textfield:hover .input,
+    .input:hover {
+        border-color: var(
+            --highcontrast-textfield-border-color-hover,
+            var(
+                --mod-textfield-border-color-hover,
+                var(--spectrum-textfield-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-textfield-text-color-hover,
+            var(
+                --mod-textfield-text-color-hover,
+                var(--spectrum-textfield-text-color-hover)
+            )
+        );
+    }
+    #textfield:hover .input::placeholder,
+    .input:hover::placeholder {
+        color: var(
+            --highcontrast-textfield-text-color-hover,
+            var(
+                --mod-textfield-text-color-hover,
+                var(--spectrum-textfield-text-color-hover)
+            )
+        );
+    }
 }
 .input:focus,
 :host([focused]) .input {
@@ -802,32 +804,34 @@ governing permissions and limitations under the License.
         )
     );
 }
-.input:focus:hover,
-:host([focused]) .input:hover {
-    border-color: var(
-        --highcontrast-textfield-border-color-focus-hover,
-        var(
-            --mod-textfield-border-color-focus-hover,
-            var(--spectrum-textfield-border-color-focus-hover)
-        )
-    );
-    color: var(
-        --highcontrast-textfield-text-color-focus-hover,
-        var(
-            --mod-textfield-text-color-focus-hover,
-            var(--spectrum-textfield-text-color-focus-hover)
-        )
-    );
-}
-.input:focus:hover::placeholder,
-:host([focused]) .input:hover::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-focus-hover,
-        var(
-            --mod-textfield-text-color-focus-hover,
-            var(--spectrum-textfield-text-color-focus-hover)
-        )
-    );
+@media (hover: hover) {
+    .input:focus:hover,
+    :host([focused]) .input:hover {
+        border-color: var(
+            --highcontrast-textfield-border-color-focus-hover,
+            var(
+                --mod-textfield-border-color-focus-hover,
+                var(--spectrum-textfield-border-color-focus-hover)
+            )
+        );
+        color: var(
+            --highcontrast-textfield-text-color-focus-hover,
+            var(
+                --mod-textfield-text-color-focus-hover,
+                var(--spectrum-textfield-text-color-focus-hover)
+            )
+        );
+    }
+    .input:focus:hover::placeholder,
+    :host([focused]) .input:hover::placeholder {
+        color: var(
+            --highcontrast-textfield-text-color-focus-hover,
+            var(
+                --mod-textfield-text-color-focus-hover,
+                var(--spectrum-textfield-text-color-focus-hover)
+            )
+        );
+    }
 }
 .input.focus-visible,
 :host([focused]) .input {
@@ -940,15 +944,17 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid]) .input:hover,
-:host([invalid]:hover) .input {
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-hover,
-        var(
-            --mod-textfield-border-color-invalid-hover,
-            var(--spectrum-textfield-border-color-invalid-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid]) .input:hover,
+    :host([invalid]:hover) .input {
+        border-color: var(
+            --highcontrast-textfield-border-color-invalid-hover,
+            var(
+                --mod-textfield-border-color-invalid-hover,
+                var(--spectrum-textfield-border-color-invalid-hover)
+            )
+        );
+    }
 }
 :host([invalid]) .input:focus,
 :host([invalid]:focus) .input,
@@ -961,16 +967,18 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid]) .input:focus:hover,
-:host([invalid]:focus) .input:hover,
-:host([invalid][focused]) .input:hover {
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-focus-hover,
-        var(
-            --mod-textfield-border-color-invalid-focus-hover,
-            var(--spectrum-textfield-border-color-invalid-focus-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid]) .input:focus:hover,
+    :host([invalid]:focus) .input:hover,
+    :host([invalid][focused]) .input:hover {
+        border-color: var(
+            --highcontrast-textfield-border-color-invalid-focus-hover,
+            var(
+                --mod-textfield-border-color-invalid-focus-hover,
+                var(--spectrum-textfield-border-color-invalid-focus-hover)
+            )
+        );
+    }
 }
 :host([invalid]) .input.focus-visible,
 :host([invalid][focused]) .input {
@@ -993,8 +1001,7 @@ governing permissions and limitations under the License.
     );
 }
 .input:disabled,
-:host([disabled]) #textfield .input,
-:host([disabled]) #textfield:hover .input {
+:host([disabled]) #textfield .input {
     -webkit-text-fill-color: var(
         --highcontrast-textfield-text-color-disabled,
         var(
@@ -1017,9 +1024,35 @@ governing permissions and limitations under the License.
     opacity: 1;
     resize: none;
 }
+@media (hover: hover) {
+    .input:disabled,
+    :host([disabled]) #textfield .input,
+    :host([disabled]) #textfield:hover .input {
+        -webkit-text-fill-color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+        background-color: var(
+            --mod-textfield-background-color-disabled,
+            var(--spectrum-textfield-background-color-disabled)
+        );
+        border-color: #0000;
+        color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+        opacity: 1;
+        resize: none;
+    }
+}
 .input:disabled::placeholder,
-:host([disabled]) #textfield .input::placeholder,
-:host([disabled]) #textfield:hover .input::placeholder {
+:host([disabled]) #textfield .input::placeholder {
     color: var(
         --highcontrast-textfield-text-color-disabled,
         var(
@@ -1027,6 +1060,19 @@ governing permissions and limitations under the License.
             var(--spectrum-textfield-text-color-disabled)
         )
     );
+}
+@media (hover: hover) {
+    .input:disabled::placeholder,
+    :host([disabled]) #textfield .input::placeholder,
+    :host([disabled]) #textfield:hover .input::placeholder {
+        color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+    }
 }
 :host([quiet]) .input {
     background-color: #0000;
@@ -1050,8 +1096,7 @@ governing permissions and limitations under the License.
     resize: none;
 }
 .input:disabled,
-:host([quiet][disabled]) .input,
-:host([quiet][disabled]:hover) .input {
+:host([quiet][disabled]) .input {
     background-color: #0000;
     border-color: var(
         --mod-textfield-border-color-disabled,
@@ -1065,9 +1110,26 @@ governing permissions and limitations under the License.
         )
     );
 }
+@media (hover: hover) {
+    .input:disabled,
+    :host([quiet][disabled]) .input,
+    :host([quiet][disabled]:hover) .input {
+        background-color: #0000;
+        border-color: var(
+            --mod-textfield-border-color-disabled,
+            var(--spectrum-textfield-border-color-disabled)
+        );
+        color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+    }
+}
 .input:disabled::placeholder,
-:host([quiet][disabled]) .input::placeholder,
-:host([quiet][disabled]:hover) .input::placeholder {
+:host([quiet][disabled]) .input::placeholder {
     color: var(
         --highcontrast-textfield-text-color-disabled,
         var(
@@ -1076,9 +1138,21 @@ governing permissions and limitations under the License.
         )
     );
 }
+@media (hover: hover) {
+    .input:disabled::placeholder,
+    :host([quiet][disabled]) .input::placeholder,
+    :host([quiet][disabled]:hover) .input::placeholder {
+        color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+    }
+}
 .input:read-only,
-:host([readonly]) #textfield .input,
-:host([readonly]) #textfield:hover .input {
+:host([readonly]) #textfield .input {
     background-color: #0000;
     border-color: #0000;
     color: var(
@@ -1090,9 +1164,24 @@ governing permissions and limitations under the License.
     );
     outline: none;
 }
+@media (hover: hover) {
+    .input:read-only,
+    :host([readonly]) #textfield .input,
+    :host([readonly]) #textfield:hover .input {
+        background-color: #0000;
+        border-color: #0000;
+        color: var(
+            --highcontrast-textfield-text-color-readonly,
+            var(
+                --mod-textfield-text-color-readonly,
+                var(--spectrum-textfield-text-color-readonly)
+            )
+        );
+        outline: none;
+    }
+}
 .input:read-only::placeholder,
-:host([readonly]) #textfield .input::placeholder,
-:host([readonly]) #textfield:hover .input::placeholder {
+:host([readonly]) #textfield .input::placeholder {
     background-color: #0000;
     color: var(
         --highcontrast-textfield-text-color-readonly,
@@ -1101,6 +1190,20 @@ governing permissions and limitations under the License.
             var(--spectrum-textfield-text-color-readonly)
         )
     );
+}
+@media (hover: hover) {
+    .input:read-only::placeholder,
+    :host([readonly]) #textfield .input::placeholder,
+    :host([readonly]) #textfield:hover .input::placeholder {
+        background-color: #0000;
+        color: var(
+            --highcontrast-textfield-text-color-readonly,
+            var(
+                --mod-textfield-text-color-readonly,
+                var(--spectrum-textfield-text-color-readonly)
+            )
+        );
+    }
 }
 .spectrum-Textfield--sideLabel {
     grid-template-columns: auto auto auto;


### PR DESCRIPTION
## Description
Expand the processing of Spectrum CSS output to wrap al usage of `:hover` in `@media (hover: hover) {}`.

In mobile delivery the `:hover` state is synthesized as a "sort of" first touch of an element (which causes the need to tab twice in some instances), and is difficult to remove, without passing the state to another element, which can cause the state to hangout passed it's usefulness. Wrapping the `:hover` rule in the media query prevents it from applying in touch only contexts. However, in some cases "active" styling and "hover" styling as _possibly_ conflated in a way that we'd need the Spectrum CSS source to take into account that we're doing this.

This effects the delivery of the following patterns:
- Accordion
- Action Button
- Button
- Card
- Checkbox
- Clear Button
- Close Button
- Dropzone
- Link
- Menu Item
- Number Field
- Picker Button
- Picker
- Radio
- Search
- Side Nav Item
- Slider
- Split View
- Switch
- Table Head Cell
- Table Row
- Tab
- Tag
- Textfield

Before moving forward, we'd need to review these patterns with design in a touch context to ensure we're continuing to deliver the experience specified for that environment.

## Related issue(s)
- fixes #2598

## How has this been tested?
-   [ ] _Test case 1_
    1. Visit each of the patterns above in [Storybook](https://control-hover--spectrum-web-components.netlify.app/storybook/) in a touch context
    2. Ensure that when touching them, then surface the expected "active" states.
-   [ ] _Test case 2_
    1. Visit each of the patterns above in [Storybook](https://control-hover--spectrum-web-components.netlify.app/storybook/) in a hover context, mouse/touch pag
    2. Ensure that when _hovering_ them, then surface the expected "hover" states.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.