### PR TITLE
test: use long tooltip content in VRTs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: b9ba5bb4f00c3616870378c9791129c484f30e92
+        default: 2c2d4e142e8db7488930f32611e7bbcadb934deb
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/tooltip/stories/tooltip.stories.ts
+++ b/packages/tooltip/stories/tooltip.stories.ts
@@ -319,7 +319,8 @@ export const selfManaged = ({
             ?delayed=${delayed}
             open=${open}
         >
-            This is a tooltip.
+            Add paragraph text by dragging the Text tool on the canvas to use
+            this feature
         </sp-tooltip>
     </sp-action-button>
 `;


### PR DESCRIPTION
## Description
Prep Tooltip testing in for delivery changes in subsequent work, e.g. Overlay V2!

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://2e798b0e2c9927efdde9c7275b32b474--spectrum-web-components.netlify.app/review/)
    2. See the that Tooltip has a really long piece of text

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.