### PR TITLE
build: correct webpack examples

### DIFF
--- a/projects/example-project-webpack/src/index.html
+++ b/projects/example-project-webpack/src/index.html
@@ -15,25 +15,27 @@
     </head>
 
     <body>
-        <sp-button variant="primary">Primary</sp-button>
-        <br />
-        <br />
-        <sp-button variant="secondary" quiet>secondary</sp-button>
-        <br />
-        <br />
-        <sp-field-label for="picker">Where do you live?</sp-field-label>
-        <sp-picker id="picker">
-            <span slot="label">
-                Select a Country with a very long label, too long in fact
-            </span>
-            <sp-menu-item>Deselect</sp-menu-item>
-            <sp-menu-item>Select Inverse</sp-menu-item>
-            <sp-menu-item>Feather...</sp-menu-item>
-            <sp-menu-item>Select and Mask...</sp-menu-item>
-            <sp-menu-divider></sp-menu-divider>
-            <sp-menu-item>Save Selection</sp-menu-item>
-            <sp-menu-item disabled>Make Work Path</sp-menu-item>
-        </sp-picker>
+        <sp-theme scale="medium" color="light">
+            <sp-button variant="primary">Primary</sp-button>
+            <br />
+            <br />
+            <sp-button variant="secondary" quiet>secondary</sp-button>
+            <br />
+            <br />
+            <sp-field-label for="picker">Where do you live?</sp-field-label>
+            <sp-picker id="picker">
+                <span slot="label">
+                    Select a Country with a very long label, too long in fact
+                </span>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-picker>
+        </sp-theme>
         <script async src="main.bundle.js"></script>
     </body>
 </html>

--- a/projects/example-project-webpack/src/index.js
+++ b/projects/example-project-webpack/src/index.js
@@ -14,8 +14,11 @@ governing permissions and limitations under the License.
 // import './styles.css';
 
 // import the components we'll use in this page
-import '@spectrum-web-components/button/sp-button';
-import '@spectrum-web-components/field-label/sp-field-label';
-import '@spectrum-web-components/picker/sp-picker';
-import '@spectrum-web-components/menu/sp-menu';
-import '@spectrum-web-components/menu/sp-menu-item';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/scale-medium.js';
+import '@spectrum-web-components/theme/theme-light.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
+import '@spectrum-web-components/picker/sp-picker.js';
+import '@spectrum-web-components/menu/sp-menu.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';


### PR DESCRIPTION
## Description
We've apparently not followed up on the Webpack example for quite some time. It didn't include file extensions that have been required for a while.

## Related issue(s)
- fixes #3420

## How has this been tested?
-   [ ] _Test case 1_
    1. `cd` into the webpack example directory
    2. run `yarn build`
    3. run `npx servor dist`
    4. ensure you get no errors
    5. ensure you get a page that loads in the browser

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.`main`.
