### PR TITLE
fix(textfield): textarea-issue-3432

### DIFF
--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -44,7 +44,7 @@ textarea {
     forced-color-adjust: var(--swc-test-forced-color-adjust);
 }
 
-:host([grows]) .input {
+:host([grows]:not([quiet])) .input {
     position: absolute;
     top: 0;
     left: 0;
@@ -53,7 +53,7 @@ textarea {
     overflow: hidden;
 }
 
-:host([grows]) #textfield:after {
+:host([grows]:not([quiet])) #textfield:after {
     grid-area: unset;
     min-block-size: calc(
         var(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixes [#3432](https://github.com/adobe/spectrum-web-components/issues/3432)

<!--- Describe your changes in detail -->
I changed some conditions in textfield.css file so that while styling "grows" and "quite" property does not interfere/
## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Now the textarea with properties "grows" and "quite" is properly functioning when focused.
## How has this been tested?
using dev tools
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

https://github.com/adobe/spectrum-web-components/assets/32033946/e14f52a5-ba42-4360-9595-23f47bba298c


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x]  My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
