### PR TITLE
fix(action-bar): actionBar after actionButton 3257

### DIFF
--- a/packages/action-bar/README.md
+++ b/packages/action-bar/README.md
@@ -48,14 +48,16 @@ When using `[variant="fixed"]`, the `<sp-action-bar>` will display by default at
 
 ```html
 <h4>Look down and to the left when toggling.</h4>
-<sp-action-bar variant="fixed">
-    <sp-checkbox indeterminate>228 Selected</sp-checkbox>
-</sp-action-bar>
 <sp-button
-    onclick="javascript:this.previousElementSibling.open = !this.previousElementSibling.open;"
+    onclick="javascript:this.nextElementSibling.open = !this.nextElementSibling.open; this.setAttribute('aria-expanded', this.nextElementSibling.open);"
+    aria-expanded="false"
+    aria-controls="fixed-variant-id"
 >
     Toggle fixed action bar
 </sp-button>
+<sp-action-bar variant="fixed">
+    <sp-checkbox indeterminate>228 Selected</sp-checkbox>
+</sp-action-bar>
 ```
 
 ### Sticky


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->


the action-bar was appearing before the action-button which opens it so I corrected this order by placing the action-bar after the action-button that opens it in example because sp-actionbar should follow the button that expands or collapses it. So that the sp-actionbar renders in a logical tab order rather than before the button, which forces the user to Shift+Tab or navigate backwards using a screen reader to find it.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?
Using Dev Tools(see screenshot attached)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)
<img width="1562" alt="Screenshot 2023-07-18 at 1 46 53 PM" src="https://github.com/adobe/spectrum-web-components/assets/32033946/4fcc0b05-4a7f-441b-9f6e-4702343bbaef">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
