### PR TITLE
fix(swatch): warn when mixed-value used with selects !== 'multiple'

### DIFF
--- a/packages/swatch/src/SwatchGroup.ts
+++ b/packages/swatch/src/SwatchGroup.ts
@@ -212,8 +212,11 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
                     ) {
                         window.__swc.warn(
                             this,
-                            `<sp-swatch> elements that are children of <sp-swatch-group> cannot have mixed-value attribute if sp-swatch-group does not have attribute selects="multiple"`,
-                            'https://opensource.adobe.com/spectrum-web-components/components/swatch-group/#multiple'
+                            `<sp-swatch> elements can only leverage the "mixed-value" attribute when their <sp-swatch-group> parent element is also leveraging "selects="multiple""`,
+                            'https://opensource.adobe.com/spectrum-web-components/components/swatch-group/#multiple',
+                            {
+                                type: 'accessibility',
+                            }
                         );
                     }
                 }

--- a/packages/swatch/src/SwatchGroup.ts
+++ b/packages/swatch/src/SwatchGroup.ts
@@ -206,7 +206,7 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
             passThroughSwatchActions.push((swatch) => {
                 if (
                     'selects' in targetValues &&
-                    targetValues['selects'] === 'multiple'
+                    targetValues['selects'] !== 'multiple'
                 )
                     swatch.mixedValue = false;
                 if ('border' in targetValues)

--- a/packages/swatch/src/SwatchGroup.ts
+++ b/packages/swatch/src/SwatchGroup.ts
@@ -32,6 +32,7 @@ import type {
 } from './Swatch.js';
 
 export type SwatchGroupSizes = Exclude<ElementSize, 'xxs' | 'xl' | 'xxl'>;
+export type SwatchSelects = 'single' | 'multiple' | undefined;
 
 /**
  * @element sp-swatch-group
@@ -55,7 +56,7 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
     public selected: string[] = [];
 
     @property()
-    public selects: 'single' | 'multiple' | undefined;
+    public selects: SwatchSelects;
 
     private selectedSet = new Set<string>();
 
@@ -168,7 +169,14 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
             rounding?: SwatchRounding;
             shape?: SwatchShape;
             size?: SwatchGroupSizes;
+            selects?: SwatchSelects;
         } = {};
+        if (
+            changes.has('selects') &&
+            (this.selects || typeof changes.get('selects') !== 'undefined')
+        ) {
+            targetValues.selects = this.selects;
+        }
         if (
             changes.has('border') &&
             (this.border || typeof changes.get('border') !== 'undefined')
@@ -196,6 +204,11 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
         const passThroughSwatchActions: ((swatch: Swatch) => void)[] = [];
         if (Object.keys(targetValues).length) {
             passThroughSwatchActions.push((swatch) => {
+                if (
+                    'selects' in targetValues &&
+                    targetValues['selects'] === 'multiple'
+                )
+                    swatch.mixedValue = false;
                 if ('border' in targetValues)
                     swatch.border = targetValues.border;
                 if ('rounding' in targetValues)

--- a/packages/swatch/src/SwatchGroup.ts
+++ b/packages/swatch/src/SwatchGroup.ts
@@ -207,7 +207,7 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
                 if (window.__swc.DEBUG) {
                     if (
                         'selects' in targetValues &&
-                        targetValues['selects'] !== 'multiple' &&
+                        targetValues.selects !== 'multiple' &&
                         swatch.mixedValue
                     ) {
                         window.__swc.warn(

--- a/packages/swatch/src/SwatchGroup.ts
+++ b/packages/swatch/src/SwatchGroup.ts
@@ -204,11 +204,18 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
         const passThroughSwatchActions: ((swatch: Swatch) => void)[] = [];
         if (Object.keys(targetValues).length) {
             passThroughSwatchActions.push((swatch) => {
-                if (
-                    'selects' in targetValues &&
-                    targetValues['selects'] !== 'multiple'
-                )
-                    swatch.mixedValue = false;
+                if (window.__swc.DEBUG) {
+                    if (
+                        'selects' in targetValues &&
+                        targetValues['selects'] !== 'multiple'
+                    ) {
+                        window.__swc.warn(
+                            this,
+                            `<sp-swatch> elements that are children of <sp-swatch-group> cannot have mixed-value attribute if sp-swatch-group does not have attribute selects="multiple"`,
+                            'https://opensource.adobe.com/spectrum-web-components/components/swatch-group/#multiple'
+                        );
+                    }
+                }
                 if ('border' in targetValues)
                     swatch.border = targetValues.border;
                 if ('rounding' in targetValues)

--- a/packages/swatch/src/SwatchGroup.ts
+++ b/packages/swatch/src/SwatchGroup.ts
@@ -207,7 +207,8 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
                 if (window.__swc.DEBUG) {
                     if (
                         'selects' in targetValues &&
-                        targetValues['selects'] !== 'multiple'
+                        targetValues['selects'] !== 'multiple' &&
+                        swatch.mixedValue
                     ) {
                         window.__swc.warn(
                             this,

--- a/packages/swatch/stories/swatch-group.stories.ts
+++ b/packages/swatch/stories/swatch-group.stories.ts
@@ -12,8 +12,7 @@ governing permissions and limitations under the License.
 import { html, TemplateResult } from '@spectrum-web-components/base';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
-import '../sp-swatch-group.js';
-import '../sp-swatch.js';
+import '@spectrum-web-components/swatch/sp-swatch-group.js';
 import type {
     SwatchBorder,
     SwatchRounding,

--- a/packages/swatch/stories/swatch-group.stories.ts
+++ b/packages/swatch/stories/swatch-group.stories.ts
@@ -13,6 +13,7 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
 import '@spectrum-web-components/swatch/sp-swatch-group.js';
+import '@spectrum-web-components/swatch/sp-swatch.js';
 import type {
     SwatchBorder,
     SwatchRounding,

--- a/packages/swatch/stories/swatch-sizes.stories.ts
+++ b/packages/swatch/stories/swatch-sizes.stories.ts
@@ -15,7 +15,7 @@ import {
     TemplateResult,
 } from '@spectrum-web-components/base';
 
-import '../sp-swatch.js';
+import '@spectrum-web-components/swatch/sp-swatch.js';
 
 export default {
     title: 'Swatch/Sizes',

--- a/packages/swatch/stories/swatch.stories.ts
+++ b/packages/swatch/stories/swatch.stories.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 import { html, TemplateResult } from '@spectrum-web-components/base';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
-import '../sp-swatch.js';
+import '@spectrum-web-components/swatch/sp-swatch.js';
 import type {
     SwatchBorder,
     SwatchRounding,

--- a/packages/swatch/test/swatch-group.test.ts
+++ b/packages/swatch/test/swatch-group.test.ts
@@ -321,11 +321,9 @@ describe('Swatch Group - DOM selected', () => {
 
             await elementUpdated(el);
 
-            // Make sure the console.warn was called
             expect(consoleWarnStub.called).to.be.true;
             const spyCall = consoleWarnStub.getCall(0);
 
-            // Ensure the correct warning message is triggered
             expect(
                 (spyCall.args.at(0) as string).includes(
                     '<sp-swatch> elements can only leverage the "mixed-value" attribute when their <sp-swatch-group> parent element is also leveraging "selects="multiple"'
@@ -333,7 +331,6 @@ describe('Swatch Group - DOM selected', () => {
                 'confirm warning message'
             ).to.be.true;
 
-            // Ensure the correct data object is passed to the warning
             expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
                 data: {
                     localName: 'sp-swatch-group',

--- a/packages/swatch/test/swatch-group.test.ts
+++ b/packages/swatch/test/swatch-group.test.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 import { elementUpdated, expect, fixture, nextFrame } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 
-import '../sp-swatch.js';
+import '@spectrum-web-components/swatch/sp-swatch.js';
 import { Swatch, SwatchGroup } from '../';
 import { Default } from '../stories/swatch-group.stories.js';
 import { spy, stub } from 'sinon';

--- a/packages/swatch/test/swatch-group.test.ts
+++ b/packages/swatch/test/swatch-group.test.ts
@@ -15,7 +15,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import '../sp-swatch.js';
 import { Swatch, SwatchGroup } from '../';
 import { Default } from '../stories/swatch-group.stories.js';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 import { html } from '@spectrum-web-components/base';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
@@ -357,5 +357,46 @@ describe('Swatch Group - DOM selected', () => {
         el.selected = ['color-2'];
         await elementUpdated(el);
         expect(el.selected).to.deep.equal(['color-2']);
+    });
+});
+
+describe('dev mode', () => {
+    let consoleWarnStub!: ReturnType<typeof stub>;
+    before(() => {
+        window.__swc.verbose = true;
+        consoleWarnStub = stub(console, 'warn');
+    });
+    afterEach(() => {
+        consoleWarnStub.resetHistory();
+    });
+    after(() => {
+        window.__swc.verbose = false;
+        consoleWarnStub.restore();
+    });
+
+    it('warns in Dev Mode when mixed-value attribute is added in sp-swatch when parent sp-swatch-group is not having selects="multiple"', async () => {
+        const el = await fixture<Swatch>(
+            html`
+                <sp-swatch-group selects="single">
+                    <sp-swatch mixed-value></sp-swatch>
+                </sp-swatch-group>
+            `
+        );
+
+        await elementUpdated(el);
+
+        expect(consoleWarnStub.called).to.be.true;
+        const spyCall = consoleWarnStub.getCall(0);
+        expect(
+            (spyCall.args.at(0) as string).includes('"selects"'),
+            'confirm mixed-value-message'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-swatch',
+                type: 'accessibility',
+                level: 'default',
+            },
+        });
     });
 });

--- a/packages/swatch/test/swatch.test.ts
+++ b/packages/swatch/test/swatch.test.ts
@@ -13,7 +13,7 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { spy } from 'sinon';
 import { sendKeys } from '@web/test-runner-commands';
 
-import '../sp-swatch.js';
+import '@spectrum-web-components/swatch/sp-swatch.js';
 import { Swatch } from '../src/Swatch.js';
 import { ElementSize } from '@spectrum-web-components/base';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Removed mixed-value attribute from swatch if swatch group selects !== 'multiple'

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/3458

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

Chrome, Accessibility tree

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
