### PR TITLE
fix(number-field): update button label to use number-field-labels as part of the text

### DIFF
--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -101,9 +101,11 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
             const applyLabel = this.target.applyFocusElementLabel;
             const focusable = this.target.focusElement || this.target;
             const targetParent = focusable.getRootNode() as HTMLElement;
+
             if (typeof applyLabel !== 'undefined') {
                 applyLabel(this.labelText);
-            } else if (targetParent === (this.getRootNode() as HTMLElement)) {
+            }
+            if (targetParent === (this.getRootNode() as HTMLElement)) {
                 const conditionAttribute = target
                     ? conditionAttributeWithId
                     : conditionAttributeWithoutId;

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -104,8 +104,7 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
 
             if (typeof applyLabel !== 'undefined') {
                 applyLabel(this.labelText);
-            }
-            if (targetParent === (this.getRootNode() as HTMLElement)) {
+            } else if (targetParent === (this.getRootNode() as HTMLElement)) {
                 const conditionAttribute = target
                     ? conditionAttributeWithId
                     : conditionAttributeWithoutId;

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -101,7 +101,6 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
             const applyLabel = this.target.applyFocusElementLabel;
             const focusable = this.target.focusElement || this.target;
             const targetParent = focusable.getRootNode() as HTMLElement;
-
             if (typeof applyLabel !== 'undefined') {
                 applyLabel(this.labelText);
             } else if (targetParent === (this.getRootNode() as HTMLElement)) {

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -19,7 +19,6 @@ import {
 import {
     property,
     query,
-    state,
 } from '@spectrum-web-components/base/src/decorators.js';
 import {
     LanguageResolutionController,
@@ -100,9 +99,6 @@ export class NumberField extends TextfieldBase {
     public static override get styles(): CSSResultArray {
         return [...super.styles, styles, chevronStyles];
     }
-
-    @state()
-    override appliedLabel?: string;
 
     @query('.buttons')
     private buttons!: HTMLDivElement;

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -19,6 +19,7 @@ import {
 import {
     property,
     query,
+    state,
 } from '@spectrum-web-components/base/src/decorators.js';
 import {
     LanguageResolutionController,
@@ -99,6 +100,9 @@ export class NumberField extends TextfieldBase {
     public static override get styles(): CSSResultArray {
         return [...super.styles, styles, chevronStyles];
     }
+
+    @state()
+    appliedLabel?: string;
 
     @query('.buttons')
     private buttons!: HTMLDivElement;
@@ -549,6 +553,10 @@ export class NumberField extends TextfieldBase {
         return this.focused ? this._numberParserFocused : this._numberParser;
     }
 
+    applyFocusElementLabel = (value?: string): void => {
+        this.appliedLabel = value;
+    };
+
     private _numberParser?: NumberParser;
     private _numberParserFocused?: NumberParser;
 
@@ -587,7 +595,8 @@ export class NumberField extends TextfieldBase {
                       >
                           <sp-action-button
                               class="step-up"
-                              label="Increment"
+                              aria-describedby=${this.helpTextId}
+                              label=${'Increase ' + this.appliedLabel}
                               tabindex="-1"
                               ?focused=${this.focused}
                               ?disabled=${this.disabled ||
@@ -600,7 +609,8 @@ export class NumberField extends TextfieldBase {
                           </sp-action-button>
                           <sp-action-button
                               class="step-down"
-                              label="Decrement"
+                              aria-describedby=${this.helpTextId}
+                              label=${'Decrease ' + this.appliedLabel}
                               tabindex="-1"
                               ?focused=${this.focused}
                               ?disabled=${this.disabled ||

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -102,7 +102,7 @@ export class NumberField extends TextfieldBase {
     }
 
     @state()
-    appliedLabel?: string;
+    override appliedLabel?: string;
 
     @query('.buttons')
     private buttons!: HTMLDivElement;

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -15,6 +15,7 @@ import {
     aTimeout,
     elementUpdated,
     expect,
+    fixture,
     nextFrame,
     oneEvent,
 } from '@open-wc/testing';
@@ -36,7 +37,12 @@ import {
     indeterminatePlaceholder,
     NumberField,
 } from '@spectrum-web-components/number-field';
-import { sendKeys, setUserAgent } from '@web/test-runner-commands';
+import {
+    a11ySnapshot,
+    findAccessibilityNode,
+    sendKeys,
+    setUserAgent,
+} from '@web/test-runner-commands';
 import { spy } from 'sinon';
 import { clickBySelector, getElFrom } from './helpers.js';
 import { createLanguageContext } from '../../../tools/reactive-controllers/test/helpers.js';
@@ -1258,6 +1264,42 @@ describe('NumberField', () => {
         });
         it('prevents decrement via stepper button', async () => {
             await clickBySelector(el, '.step-down');
+        });
+    });
+    describe('accessibility model', () => {
+        it('buttons have proper label', async () => {
+            await fixture<HTMLDivElement>(html`
+                <div>
+                    ${Default({
+                        onChange: () => {
+                            return;
+                        },
+                    })}
+                </div>
+            `);
+
+            type NamedNode = { name: string };
+            const snapshot = (await a11ySnapshot(
+                {}
+            )) as unknown as NamedNode & {
+                children: NamedNode[];
+            };
+
+            expect(
+                findAccessibilityNode<NamedNode>(
+                    snapshot,
+                    (node) => node.name === 'Increase Enter a number'
+                ),
+                '`name` is the label text'
+            ).to.not.be.null;
+
+            expect(
+                findAccessibilityNode<NamedNode>(
+                    snapshot,
+                    (node) => node.name === 'Decrease Enter a number'
+                ),
+                '`name` is the label text'
+            ).to.not.be.null;
         });
     });
 });

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -52,6 +52,9 @@ export class TextfieldBase extends ManageHelpText(
         return [textfieldStyles, checkmarkStyles];
     }
 
+    @state()
+    appliedLabel?: string;
+
     @property({ attribute: 'allowed-keys' })
     allowedKeys = '';
 
@@ -235,7 +238,9 @@ export class TextfieldBase extends ManageHelpText(
             <!-- @ts-ignore -->
             <textarea
                 aria-describedby=${this.helpTextId}
-                aria-label=${this.label || this.placeholder}
+                aria-label=${this.label ||
+                this.appliedLabel ||
+                this.placeholder}
                 aria-invalid=${ifDefined(this.invalid || undefined)}
                 class="input"
                 maxlength=${ifDefined(
@@ -266,7 +271,9 @@ export class TextfieldBase extends ManageHelpText(
             <input
                 type=${this.type}
                 aria-describedby=${this.helpTextId}
-                aria-label=${this.label || this.placeholder}
+                aria-label=${this.label ||
+                this.appliedLabel ||
+                this.placeholder}
                 aria-invalid=${ifDefined(this.invalid || undefined)}
                 class="input"
                 maxlength=${ifDefined(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated the Number field increase/decrease buttons to use the number fields label as part of their label text

## Description

Previously the number field increase/decrease buttons were using hardcoded labels as Increment/Decrement but now with this update buttons label text would use the number-field-label text as a part of it to give more context and clarity.

So for
```
<sp-field-label for="units">Package width</sp-field-label>
<sp-number-field
    id="units"
    style="width: 200px"
    value="4"
    format-options='{
        "style": "unit",
        "unit": "inch",
        "unitDisplay": "long"
    }'
></sp-number-field>
````

The buttons would have their labels as "Increase Package width" and "Decrease Package Width".

## Related issue(s)
<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes #3273 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
