### PR TITLE
chore: take latest breaking Spectrum CSS updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 41737ba178493d2f095891f4961dde87e4e7e97f
+        default: 32141e5454098a538a4ce6921c9367e2f4922f67
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -73,7 +73,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/accordion": "^4.0.3"
+        "@spectrum-css/accordion": "^4.0.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-bar/package.json
+++ b/packages/action-bar/package.json
@@ -63,7 +63,7 @@
         "@spectrum-web-components/popover": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbar": "^6.0.39"
+        "@spectrum-css/actionbar": "^6.0.52"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^3.0.45"
+        "@spectrum-css/actionbutton": "^4.0.9"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -82,6 +82,18 @@ governing permissions and limitations under the License.
     );
     --spectrum-actionbutton-border-radius: var(--spectrum-corner-radius-100);
     --spectrum-actionbutton-border-width: var(--spectrum-border-width-100);
+    --spectrum-actionbutton-content-color-default: var(
+        --spectrum-neutral-content-color-default
+    );
+    --spectrum-actionbutton-content-color-hover: var(
+        --spectrum-neutral-content-color-hover
+    );
+    --spectrum-actionbutton-content-color-down: var(
+        --spectrum-neutral-content-color-down
+    );
+    --spectrum-actionbutton-content-color-focus: var(
+        --spectrum-neutral-content-color-key-focus
+    );
     --spectrum-actionbutton-focus-indicator-gap: var(
         --spectrum-focus-indicator-gap
     );
@@ -94,6 +106,74 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-focus-indicator-border-radius: calc(
         var(--spectrum-actionbutton-border-radius) +
             var(--spectrum-actionbutton-focus-indicator-gap)
+    );
+}
+:host([selected]) {
+    --mod-actionbutton-background-color-default: var(
+        --mod-actionbutton-background-color-default-selected,
+        var(--spectrum-neutral-background-color-selected-default)
+    );
+    --mod-actionbutton-background-color-hover: var(
+        --mod-actionbutton-background-color-hover-selected,
+        var(--spectrum-neutral-background-color-selected-hover)
+    );
+    --mod-actionbutton-background-color-down: var(
+        --mod-actionbutton-background-color-down-selected,
+        var(--spectrum-neutral-background-color-selected-down)
+    );
+    --mod-actionbutton-background-color-focus: var(
+        --mod-actionbutton-background-color-focus-selected,
+        var(--spectrum-neutral-background-color-selected-key-focus)
+    );
+    --mod-actionbutton-content-color-default: var(
+        --mod-actionbutton-content-color-default-selected,
+        var(--spectrum-gray-50)
+    );
+    --mod-actionbutton-content-color-hover: var(
+        --mod-actionbutton-content-color-hover-selected,
+        var(--spectrum-gray-50)
+    );
+    --mod-actionbutton-content-color-down: var(
+        --mod-actionbutton-content-color-down-selected,
+        var(--spectrum-gray-50)
+    );
+    --mod-actionbutton-content-color-focus: var(
+        --mod-actionbutton-content-color-focus-selected,
+        var(--spectrum-gray-50)
+    );
+}
+:host([selected][emphasized]) {
+    --mod-actionbutton-background-color-default: var(
+        --mod-actionbutton-background-color-default-selected-emphasized,
+        var(--spectrum-accent-background-color-default)
+    );
+    --mod-actionbutton-background-color-hover: var(
+        --mod-actionbutton-background-color-hover-selected-emphasized,
+        var(--spectrum-accent-background-color-hover)
+    );
+    --mod-actionbutton-background-color-down: var(
+        --mod-actionbutton-background-color-down-selected-emphasized,
+        var(--spectrum-accent-background-color-down)
+    );
+    --mod-actionbutton-background-color-focus: var(
+        --mod-actionbutton-background-color-focus-selected-emphasized,
+        var(--spectrum-accent-background-color-key-focus)
+    );
+    --mod-actionbutton-content-color-default: var(
+        --mod-actionbutton-content-color-default-selected-emphasized,
+        var(--spectrum-white)
+    );
+    --mod-actionbutton-content-color-hover: var(
+        --mod-actionbutton-content-color-hover-selected-emphasized,
+        var(--spectrum-white)
+    );
+    --mod-actionbutton-content-color-down: var(
+        --mod-actionbutton-content-color-down-selected-emphasized,
+        var(--spectrum-white)
+    );
+    --mod-actionbutton-content-color-focus: var(
+        --mod-actionbutton-content-color-focus-selected-emphasized,
+        var(--spectrum-white)
     );
 }
 :host([size='xs']) {
@@ -466,7 +546,7 @@ governing permissions and limitations under the License.
     );
 }
 #label {
-    color: inherit;
+    color: var(--mod-actionbutton-label-color, inherit);
     font-size: var(
         --mod-actionbutton-font-size,
         var(--spectrum-actionbutton-font-size)
@@ -597,18 +677,6 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-border-color-focus: var(
         --system-spectrum-actionbutton-border-color-focus
     );
-    --spectrum-actionbutton-content-color-default: var(
-        --system-spectrum-actionbutton-content-color-default
-    );
-    --spectrum-actionbutton-content-color-hover: var(
-        --system-spectrum-actionbutton-content-color-hover
-    );
-    --spectrum-actionbutton-content-color-down: var(
-        --system-spectrum-actionbutton-content-color-down
-    );
-    --spectrum-actionbutton-content-color-focus: var(
-        --system-spectrum-actionbutton-content-color-focus
-    );
     --spectrum-actionbutton-background-color-disabled: var(
         --system-spectrum-actionbutton-background-color-disabled
     );
@@ -652,18 +720,6 @@ governing permissions and limitations under the License.
     );
 }
 :host([selected]) {
-    --spectrum-actionbutton-background-color-default: var(
-        --system-spectrum-actionbutton-selected-background-color-default
-    );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-spectrum-actionbutton-selected-background-color-hover
-    );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-spectrum-actionbutton-selected-background-color-down
-    );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-spectrum-actionbutton-selected-background-color-focus
-    );
     --spectrum-actionbutton-border-color-default: var(
         --system-spectrum-actionbutton-selected-border-color-default
     );
@@ -676,37 +732,11 @@ governing permissions and limitations under the License.
     --spectrum-actionbutton-border-color-focus: var(
         --system-spectrum-actionbutton-selected-border-color-focus
     );
-    --spectrum-actionbutton-content-color-default: var(
-        --system-spectrum-actionbutton-selected-content-color-default
-    );
-    --spectrum-actionbutton-content-color-hover: var(
-        --system-spectrum-actionbutton-selected-content-color-hover
-    );
-    --spectrum-actionbutton-content-color-down: var(
-        --system-spectrum-actionbutton-selected-content-color-down
-    );
-    --spectrum-actionbutton-content-color-focus: var(
-        --system-spectrum-actionbutton-selected-content-color-focus
-    );
     --spectrum-actionbutton-background-color-disabled: var(
         --system-spectrum-actionbutton-selected-background-color-disabled
     );
     --spectrum-actionbutton-border-color-disabled: var(
         --system-spectrum-actionbutton-selected-border-color-disabled
-    );
-}
-:host([selected][emphasized]) {
-    --spectrum-actionbutton-background-color-default: var(
-        --system-spectrum-actionbutton-selected-emphasized-background-color-default
-    );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-spectrum-actionbutton-selected-emphasized-background-color-hover
-    );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-spectrum-actionbutton-selected-emphasized-background-color-down
-    );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-spectrum-actionbutton-selected-emphasized-background-color-focus
     );
 }
 :host([static='black'][quiet]) {
@@ -794,47 +824,47 @@ governing permissions and limitations under the License.
     );
 }
 :host([static='black'][selected]) {
-    --spectrum-actionbutton-background-color-default: var(
-        --system-spectrum-actionbutton-staticblack-selected-background-color-default
+    --mod-actionbutton-background-color-default: var(
+        --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-default
     );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-spectrum-actionbutton-staticblack-selected-background-color-hover
+    --mod-actionbutton-background-color-hover: var(
+        --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-hover
     );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-spectrum-actionbutton-staticblack-selected-background-color-down
+    --mod-actionbutton-background-color-down: var(
+        --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-down
     );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-spectrum-actionbutton-staticblack-selected-background-color-focus
+    --mod-actionbutton-background-color-focus: var(
+        --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-focus
     );
-    --spectrum-actionbutton-border-color-disabled: var(
-        --system-spectrum-actionbutton-staticblack-selected-border-color-disabled
-    );
-    --spectrum-actionbutton-content-color-default: var(
+    --mod-actionbutton-content-color-default: var(
         --mod-actionbutton-static-content-color,
         var(
-            --system-spectrum-actionbutton-staticblack-selected-content-color-default
+            --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-default
         )
     );
-    --spectrum-actionbutton-content-color-hover: var(
+    --mod-actionbutton-content-color-hover: var(
         --mod-actionbutton-static-content-color,
         var(
-            --system-spectrum-actionbutton-staticblack-selected-content-color-hover
+            --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-hover
         )
     );
-    --spectrum-actionbutton-content-color-down: var(
+    --mod-actionbutton-content-color-down: var(
         --mod-actionbutton-static-content-color,
         var(
-            --system-spectrum-actionbutton-staticblack-selected-content-color-down
+            --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-down
         )
     );
-    --spectrum-actionbutton-content-color-focus: var(
+    --mod-actionbutton-content-color-focus: var(
         --mod-actionbutton-static-content-color,
         var(
-            --system-spectrum-actionbutton-staticblack-selected-content-color-focus
+            --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-focus
         )
     );
-    --spectrum-actionbutton-background-color-disabled: var(
-        --system-spectrum-actionbutton-staticblack-selected-background-color-disabled
+    --mod-actionbutton-background-color-disabled: var(
+        --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-disabled
+    );
+    --mod-actionbutton-border-color-disabled: var(
+        --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-border-color-disabled
     );
 }
 :host([static='white']) {
@@ -888,46 +918,46 @@ governing permissions and limitations under the License.
     );
 }
 :host([static='white'][selected]) {
-    --spectrum-actionbutton-background-color-default: var(
-        --system-spectrum-actionbutton-staticwhite-selected-background-color-default
+    --mod-actionbutton-background-color-default: var(
+        --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-default
     );
-    --spectrum-actionbutton-background-color-hover: var(
-        --system-spectrum-actionbutton-staticwhite-selected-background-color-hover
+    --mod-actionbutton-background-color-hover: var(
+        --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-hover
     );
-    --spectrum-actionbutton-background-color-down: var(
-        --system-spectrum-actionbutton-staticwhite-selected-background-color-down
+    --mod-actionbutton-background-color-down: var(
+        --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-down
     );
-    --spectrum-actionbutton-background-color-focus: var(
-        --system-spectrum-actionbutton-staticwhite-selected-background-color-focus
+    --mod-actionbutton-background-color-focus: var(
+        --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-focus
     );
-    --spectrum-actionbutton-content-color-default: var(
+    --mod-actionbutton-content-color-default: var(
         --mod-actionbutton-static-content-color,
         var(
-            --system-spectrum-actionbutton-staticwhite-selected-content-color-default
+            --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-default
         )
     );
-    --spectrum-actionbutton-content-color-hover: var(
+    --mod-actionbutton-content-color-hover: var(
         --mod-actionbutton-static-content-color,
         var(
-            --system-spectrum-actionbutton-staticwhite-selected-content-color-hover
+            --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-hover
         )
     );
-    --spectrum-actionbutton-content-color-down: var(
+    --mod-actionbutton-content-color-down: var(
         --mod-actionbutton-static-content-color,
         var(
-            --system-spectrum-actionbutton-staticwhite-selected-content-color-down
+            --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-down
         )
     );
-    --spectrum-actionbutton-content-color-focus: var(
+    --mod-actionbutton-content-color-focus: var(
         --mod-actionbutton-static-content-color,
         var(
-            --system-spectrum-actionbutton-staticwhite-selected-content-color-focus
+            --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-focus
         )
     );
-    --spectrum-actionbutton-background-color-disabled: var(
-        --system-spectrum-actionbutton-staticwhite-selected-background-color-disabled
+    --mod-actionbutton-background-color-disabled: var(
+        --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-disabled
     );
-    --spectrum-actionbutton-border-color-disabled: var(
-        --system-spectrum-actionbutton-staticwhite-selected-border-color-disabled
+    --mod-actionbutton-border-color-disabled: var(
+        --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-border-color-disabled
     );
 }

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/reactive-controllers": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/actiongroup": "^3.0.55"
+        "@spectrum-css/actiongroup": "^3.0.57"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -69,7 +69,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionmenu": "^4.0.43"
+        "@spectrum-css/actionmenu": "^4.0.45"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/avatar": "^6.0.38"
+        "@spectrum-css/avatar": "^6.0.40"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/badge": "^3.0.40"
+        "@spectrum-css/badge": "^3.0.42"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/button": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/buttongroup": "^6.0.55"
+        "@spectrum-css/buttongroup": "^6.0.57"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -90,7 +90,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/button": "^10.1.8"
+        "@spectrum-css/button": "^10.1.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -549,6 +549,10 @@ governing permissions and limitations under the License.
     );
 }
 @media (forced-colors: active) {
+    :host {
+        --highcontrast-button-content-color-disabled: GrayText;
+        --highcontrast-button-border-color-disabled: GrayText;
+    }
     :host(.focus-visible):after {
         box-shadow: 0 0 0
             var(
@@ -568,24 +572,15 @@ governing permissions and limitations under the License.
         forced-color-adjust: none;
     }
     :host([variant='accent'][treatment='fill']) {
-        background-color: ButtonText;
-        color: ButtonFace;
-    }
-    :host([variant='accent'][treatment='fill'][disabled]) {
-        background-color: ButtonFace;
-        color: GrayText;
-    }
-    :host([variant='accent'][treatment='fill'].focus-visible),
-    :host([variant='accent'][treatment='fill']:hover),
-    :host([variant='accent'][treatment='fill'][active]),
-    :host([variant='accent'][treatment='fill'][focused]) {
-        background-color: Highlight;
-    }
-    :host([variant='accent'][treatment='fill']:focus-visible),
-    :host([variant='accent'][treatment='fill']:hover),
-    :host([variant='accent'][treatment='fill'][active]),
-    :host([variant='accent'][treatment='fill'][focused]) {
-        background-color: Highlight;
+        --highcontrast-button-background-color-default: ButtonText;
+        --highcontrast-button-content-color-default: ButtonFace;
+        --highcontrast-button-background-color-disabled: ButtonFace;
+        --highcontrast-button-background-color-hover: Highlight;
+        --highcontrast-button-background-color-down: Highlight;
+        --highcontrast-button-background-color-focus: Highlight;
+        --highcontrast-button-content-color-hover: ButtonFace;
+        --highcontrast-button-content-color-down: ButtonFace;
+        --highcontrast-button-content-color-focus: ButtonFace;
     }
     :host([variant='accent'][treatment='fill']) #label {
         forced-color-adjust: none;

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -66,7 +66,7 @@
         "@spectrum-web-components/styles": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/card": "^6.0.2"
+        "@spectrum-css/card": "^6.0.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -67,7 +67,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/checkbox": "^6.1.6"
+        "@spectrum-css/checkbox": "^6.1.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -36,25 +36,25 @@ const checkmarkIcon = {
     s: html`
         <sp-icon-checkmark75
             id="checkmark"
-            class="spectrum-UIIcon-Checkmark75"
+            class="spectrum-Icon spectrum-UIIcon-Checkmark75"
         ></sp-icon-checkmark75>
     `,
     m: html`
         <sp-icon-checkmark100
             id="checkmark"
-            class="spectrum-UIIcon-Checkmark100"
+            class="spectrum-Icon spectrum-UIIcon-Checkmark100"
         ></sp-icon-checkmark100>
     `,
     l: html`
         <sp-icon-checkmark200
             id="checkmark"
-            class="spectrum-UIIcon-Checkmark200"
+            class="spectrum-Icon spectrum-UIIcon-Checkmark200"
         ></sp-icon-checkmark200>
     `,
     xl: html`
         <sp-icon-checkmark300
             id="checkmark"
-            class="spectrum-UIIcon-Checkmark300"
+            class="spectrum-Icon spectrum-UIIcon-Checkmark300"
         ></sp-icon-checkmark300>
     `,
 };
@@ -63,25 +63,25 @@ const dashIcon = {
     s: html`
         <sp-icon-dash75
             id="partialCheckmark"
-            class="spectrum-UIIcon-Dash75"
+            class="spectrum-Icon spectrum-UIIcon-Dash75"
         ></sp-icon-dash75>
     `,
     m: html`
         <sp-icon-dash100
             id="partialCheckmark"
-            class="spectrum-UIIcon-Dash100"
+            class="spectrum-Icon spectrum-UIIcon-Dash100"
         ></sp-icon-dash100>
     `,
     l: html`
         <sp-icon-dash200
             id="partialCheckmark"
-            class="spectrum-UIIcon-Dash200"
+            class="spectrum-Icon spectrum-UIIcon-Dash200"
         ></sp-icon-dash200>
     `,
     xl: html`
         <sp-icon-dash300
             id="partialCheckmark"
-            class="spectrum-UIIcon-Dash300"
+            class="spectrum-Icon spectrum-UIIcon-Dash300"
         ></sp-icon-dash300>
     `,
 };

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -296,8 +296,8 @@ governing permissions and limitations under the License.
 :host([indeterminate]) #input:checked + #box #checkmark {
     display: none;
 }
-:host([indeterminate]) #box #partialCheckmark,
-:host([indeterminate]) #input:checked + #box #partialCheckmark {
+:host([indeterminate]) #box .spectrum-Icon#partialCheckmark,
+:host([indeterminate]) #input:checked + #box .spectrum-Icon#partialCheckmark {
     display: block;
     opacity: 1;
     transform: scale(1);
@@ -493,7 +493,7 @@ governing permissions and limitations under the License.
         )
         ease-in-out;
 }
-#label:lang(js),
+#label:lang(ja),
 #label:lang(ko),
 #label:lang(zh) {
     line-height: var(

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -45,7 +45,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/closebutton": "^3.1.8"
+        "@spectrum-css/closebutton": "^3.1.10"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/coachmark": "^5.0.52"
+        "@spectrum-css/coachmark": "^5.0.54"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-area/package.json
+++ b/packages/color-area/package.json
@@ -67,7 +67,7 @@
         "@spectrum-web-components/reactive-controllers": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorarea": "^3.0.10"
+        "@spectrum-css/colorarea": "^4.0.29"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-area/src/spectrum-color-area.css
+++ b/packages/color-area/src/spectrum-color-area.css
@@ -75,12 +75,6 @@ governing permissions and limitations under the License.
 :host([focused]) {
     z-index: 2;
 }
-:host([focused]) .handle {
-    block-size: calc(var(--spectrum-color-handle-size) * 2);
-    inline-size: calc(var(--spectrum-color-handle-size) * 2);
-    margin-block-start: calc(var(--spectrum-color-handle-size) * -1);
-    margin-inline-start: calc(var(--spectrum-color-handle-size) * -1);
-}
 :host([disabled]) {
     background: var(
         --highcontrast-colorarea-fill-color-disabled,

--- a/packages/color-handle/package.json
+++ b/packages/color-handle/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/color-loupe": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorhandle": "^5.0.13"
+        "@spectrum-css/colorhandle": "^5.0.15"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-loupe/package.json
+++ b/packages/color-loupe/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorloupe": "^4.1.4"
+        "@spectrum-css/colorloupe": "^4.1.6"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-slider/package.json
+++ b/packages/color-slider/package.json
@@ -68,7 +68,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorslider": "^3.0.21"
+        "@spectrum-css/colorslider": "^3.0.23"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-wheel/package.json
+++ b/packages/color-wheel/package.json
@@ -68,7 +68,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/colorwheel": "^2.0.12"
+        "@spectrum-css/colorwheel": "^3.0.27"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-wheel/src/spectrum-color-wheel.css
+++ b/packages/color-wheel/src/spectrum-color-wheel.css
@@ -64,12 +64,6 @@ governing permissions and limitations under the License.
 :host([focused]) {
     z-index: 2;
 }
-:host([focused]) .handle {
-    block-size: calc(var(--spectrum-color-handle-size) * 2);
-    inline-size: calc(var(--spectrum-color-handle-size) * 2);
-    margin-block-start: calc(var(--spectrum-color-handle-size) * -1);
-    margin-inline-start: calc(var(--spectrum-color-handle-size) * -1);
-}
 :host([disabled]) {
     pointer-events: none;
 }
@@ -115,13 +109,8 @@ governing permissions and limitations under the License.
 }
 .handle {
     inset-block-start: 50%;
+    inset-inline: 50%;
     transform: translate(var(--spectrum-colorwheel-colorhandle-position));
-}
-:host([dir='ltr']) .handle {
-    inset-inline-start: 50%;
-}
-:host([dir='rtl']) .handle {
-    inset-inline-end: 50%;
 }
 .border {
     background-color: var(

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -83,7 +83,7 @@
         "@spectrum-web-components/underlay": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/dialog": "^6.0.60"
+        "@spectrum-css/dialog": "^6.0.62"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/divider": "^2.1.11"
+        "@spectrum-css/divider": "^2.1.13"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/dropzone": "^5.0.7"
+        "@spectrum-css/dropzone": "^5.0.9"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/help-text": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldgroup": "^4.0.55"
+        "@spectrum-css/fieldgroup": "^4.0.57"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldlabel": "^7.0.14"
+        "@spectrum-css/fieldlabel": "^7.0.16"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/help-text/package.json
+++ b/packages/help-text/package.json
@@ -81,7 +81,7 @@
         "@spectrum-web-components/icons-workflow": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/helptext": "^4.0.40"
+        "@spectrum-css/helptext": "^4.0.42"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/styles": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/illustratedmessage": "^5.0.18"
+        "@spectrum-css/illustratedmessage": "^6.0.9"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/illustrated-message/src/spectrum-illustratedmessage.css
+++ b/packages/illustrated-message/src/spectrum-illustratedmessage.css
@@ -81,9 +81,11 @@ governing permissions and limitations under the License.
 :host {
     align-items: center;
     block-size: 100%;
-    display: flex;
+    display: var(--mod-illustrated-message-display, flex);
     flex-direction: column;
     justify-content: center;
+    max-inline-size: var(--mod-illustrated-message-content-maximum-width);
+    pointer-events: var(--mod-illustrated-message-pointer-events);
     text-align: center;
 }
 #illustration {
@@ -137,7 +139,8 @@ governing permissions and limitations under the License.
         --mod-illustrated-message-title-line-height,
         var(--spectrum-illustrated-message-title-line-height)
     );
-    margin-block: 0;
+    margin-block-end: var(--mod-illustrated-message-heading-to-body, 0);
+    margin-block-start: 0;
     max-inline-size: var(
         --mod-illustrated-message-heading-max-inline-size,
         var(--spectrum-illustrated-message-heading-max-inline-size)
@@ -177,4 +180,7 @@ governing permissions and limitations under the License.
         --mod-illustrated-message-description-max-inline-size,
         var(--spectrum-illustrated-message-description-max-inline-size)
     );
+    pointer-events: var(--mod-illustrated-message-description-pointer-events);
+    position: var(--mod-illustrated-message-description-position);
+    z-index: var(--mod-illustrated-message-description-z-index);
 }

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/link": "^4.0.51"
+        "@spectrum-css/link": "^4.0.53"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -94,7 +94,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/menu": "^4.0.46"
+        "@spectrum-css/menu": "^4.0.48"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^3.0.52"
+        "@spectrum-css/progressbar": "^3.0.54"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -68,7 +68,7 @@
     },
     "devDependencies": {
         "@formatjs/intl-numberformat": "^8.3.5",
-        "@spectrum-css/stepper": "^4.0.41"
+        "@spectrum-css/stepper": "^4.0.43"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker-button/package.json
+++ b/packages/picker-button/package.json
@@ -56,7 +56,7 @@
         "@spectrum-web-components/icons-ui": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/pickerbutton": "^2.0.12"
+        "@spectrum-css/pickerbutton": "^3.0.33"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker-button/src/spectrum-picker-button.css
+++ b/packages/picker-button/src/spectrum-picker-button.css
@@ -1184,5 +1184,4 @@ governing permissions and limitations under the License.
 }
 .spectrum-PickerButton-icon {
     flex-shrink: 0;
-    margin: 0 !important;
 }

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -78,7 +78,7 @@
         "@spectrum-web-components/tray": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/picker": "^4.0.19"
+        "@spectrum-css/picker": "^4.0.21"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/overlay": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/popover": "^6.0.58"
+        "@spectrum-css/popover": "^6.0.60"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/field-label": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^3.0.52"
+        "@spectrum-css/progressbar": "^3.0.54"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/progresscircle": "^2.0.51"
+        "@spectrum-css/progresscircle": "^2.0.53"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/quick-actions/package.json
+++ b/packages/quick-actions/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/quickaction": "^3.0.67"
+        "@spectrum-css/quickaction": "^3.0.69"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -72,7 +72,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/radio": "^5.0.1"
+        "@spectrum-css/radio": "^7.0.42"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -68,7 +68,7 @@ governing permissions and limitations under the License.
 :host(:lang(ja)),
 :host(:lang(ko)),
 :host(:lang(zh)) {
-    --spectrum-radio-cjk-line-height: var(--spectrum-cjk-line-height-100);
+    --spectrum-radio-line-height-cjk: var(--spectrum-cjk-line-height-100);
 }
 :host([size='s']) {
     --spectrum-radio-height: var(--spectrum-component-height-75);
@@ -525,7 +525,10 @@ governing permissions and limitations under the License.
 #label:lang(ja),
 #label:lang(ko),
 #label:lang(zh) {
-    line-height: var(--spectrum-radio-cjk-line-height);
+    line-height: var(
+        --mod-radio-line-height-cjk,
+        var(--spectrum-radio-line-height-cjk)
+    );
 }
 #button {
     block-size: var(

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/textfield": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/search": "^6.0.5"
+        "@spectrum-css/search": "^6.0.7"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -83,7 +83,7 @@
         "@spectrum-web-components/theme": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^4.0.13"
+        "@spectrum-css/slider": "^4.0.15"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -70,7 +70,7 @@
         "@spectrum-web-components/picker": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/splitbutton": "^5.0.54"
+        "@spectrum-css/splitbutton": "^5.0.56"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/statuslight": "^6.0.38"
+        "@spectrum-css/statuslight": "^6.0.40"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/swatch/package.json
+++ b/packages/swatch/package.json
@@ -74,8 +74,8 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/swatch": "^4.0.29",
-        "@spectrum-css/swatchgroup": "^2.0.53"
+        "@spectrum-css/swatch": "^4.0.31",
+        "@spectrum-css/swatchgroup": "^2.0.55"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/checkbox": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/switch": "^3.1.6"
+        "@spectrum-css/switch": "^3.1.8"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -123,7 +123,7 @@
         "@spectrum-web-components/icons-ui": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/table": "^4.0.59"
+        "@spectrum-css/table": "^4.0.61"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -93,7 +93,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/tabs": "^4.0.0"
+        "@spectrum-css/tabs": "^4.0.2"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -72,8 +72,8 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/tag": "^5.0.40",
-        "@spectrum-css/taggroup": "^3.3.53"
+        "@spectrum-css/tag": "^5.0.42",
+        "@spectrum-css/taggroup": "^3.3.55"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -65,7 +65,7 @@
         "@spectrum-web-components/shared": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/textfield": "^6.0.5"
+        "@spectrum-css/textfield": "^6.0.7"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/thumbnail/package.json
+++ b/packages/thumbnail/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/thumbnail": "^3.0.15"
+        "@spectrum-css/thumbnail": "^3.0.17"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -63,7 +63,7 @@
         "@spectrum-web-components/icons-workflow": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/toast": "^9.0.40"
+        "@spectrum-css/toast": "^9.0.42"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/overlay": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/tooltip": "^4.0.10"
+        "@spectrum-css/tooltip": "^5.0.42"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tooltip/src/spectrum-tooltip.css
+++ b/packages/tooltip/src/spectrum-tooltip.css
@@ -87,8 +87,8 @@ governing permissions and limitations under the License.
     --spectrum-tooltip-icon-height: var(--spectrum-workflow-icon-size-50);
     --spectrum-tooltip-font-size: var(--spectrum-font-size-75);
     --spectrum-tooltip-line-height: var(--spectrum-line-height-100);
-    --spectrum-tooltip-cjk-line-height: var(--spectrum-line-height-cjk-100);
-    --spectrum-tooltip-font-weight: var(--spectrum-font-weight-regular);
+    --spectrum-tooltip-cjk-line-height: var(--spectrum-cjk-line-height-100);
+    --spectrum-tooltip-font-weight: var(--spectrum-regular-font-weight);
     --spectrum-tooltip-spacing-inline: var(
         --spectrum-component-edge-to-text-75
     );

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/underlay": "^0.34.0"
     },
     "devDependencies": {
-        "@spectrum-css/tray": "^2.0.55"
+        "@spectrum-css/tray": "^2.0.57"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/tools/styles/package.json
+++ b/tools/styles/package.json
@@ -109,8 +109,8 @@
     "devDependencies": {
         "@spectrum-css/commons": "^7.0.8",
         "@spectrum-css/expressvars": "^3.0.9",
-        "@spectrum-css/tokens": "^10.2.2",
-        "@spectrum-css/typography": "^5.0.26",
+        "@spectrum-css/tokens": "^11.0.1",
+        "@spectrum-css/typography": "^5.0.28",
         "@spectrum-css/vars": "^9.0.8"
     },
     "customElements": "custom-elements.json",

--- a/tools/styles/tokens/express/global-vars.css
+++ b/tools/styles/tokens/express/global-vars.css
@@ -27,6 +27,16 @@ governing permissions and limitations under the License.
     );
     --spectrum-slider-track-thickness: 4px;
     --spectrum-slider-handle-gap: 0px;
+    --spectrum-in-field-button-fill-stacked-inner-border-rounding: 1px;
+    --spectrum-in-field-button-edge-to-fill: 4px;
+    --spectrum-in-field-button-stacked-inner-edge-to-fill: 1px;
+    --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-medium: 5px;
+    --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-large: 7px;
+    --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large: 8px;
+    --spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-small: 1px;
+    --spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-medium: 1px;
+    --spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-large: 3px;
+    --spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large: 4px;
     --spectrum-border-width-100: 2px;
     --spectrum-accent-color-100: var(--spectrum-indigo-100);
     --spectrum-accent-color-200: var(--spectrum-indigo-200);
@@ -73,18 +83,6 @@ governing permissions and limitations under the License.
     --system-spectrum-actionbutton-border-color-hover: transparent;
     --system-spectrum-actionbutton-border-color-down: transparent;
     --system-spectrum-actionbutton-border-color-focus: transparent;
-    --system-spectrum-actionbutton-content-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --system-spectrum-actionbutton-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-spectrum-actionbutton-content-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-spectrum-actionbutton-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
     --system-spectrum-actionbutton-background-color-disabled: var(
         --spectrum-disabled-background-color
     );
@@ -94,13 +92,13 @@ governing permissions and limitations under the License.
     );
     --system-spectrum-actionbutton-quiet-background-color-default: transparent;
     --system-spectrum-actionbutton-quiet-background-color-hover: var(
-        --spectrum-gray-200
-    );
-    --system-spectrum-actionbutton-quiet-background-color-down: var(
         --spectrum-gray-300
     );
+    --system-spectrum-actionbutton-quiet-background-color-down: var(
+        --spectrum-gray-400
+    );
     --system-spectrum-actionbutton-quiet-background-color-focus: var(
-        --spectrum-gray-200
+        --spectrum-gray-300
     );
     --system-spectrum-actionbutton-quiet-border-color-default: transparent;
     --system-spectrum-actionbutton-quiet-border-color-hover: transparent;
@@ -108,50 +106,14 @@ governing permissions and limitations under the License.
     --system-spectrum-actionbutton-quiet-border-color-focus: transparent;
     --system-spectrum-actionbutton-quiet-background-color-disabled: transparent;
     --system-spectrum-actionbutton-quiet-border-color-disabled: transparent;
-    --system-spectrum-actionbutton-selected-background-color-default: var(
-        --spectrum-neutral-background-color-default
-    );
-    --system-spectrum-actionbutton-selected-background-color-hover: var(
-        --spectrum-neutral-background-color-hover
-    );
-    --system-spectrum-actionbutton-selected-background-color-down: var(
-        --spectrum-neutral-background-color-down
-    );
-    --system-spectrum-actionbutton-selected-background-color-focus: var(
-        --spectrum-neutral-background-color-key-focus
-    );
     --system-spectrum-actionbutton-selected-border-color-default: transparent;
     --system-spectrum-actionbutton-selected-border-color-hover: transparent;
     --system-spectrum-actionbutton-selected-border-color-down: transparent;
     --system-spectrum-actionbutton-selected-border-color-focus: transparent;
-    --system-spectrum-actionbutton-selected-content-color-default: var(
-        --spectrum-white
-    );
-    --system-spectrum-actionbutton-selected-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-spectrum-actionbutton-selected-content-color-down: var(
-        --spectrum-white
-    );
-    --system-spectrum-actionbutton-selected-content-color-focus: var(
-        --spectrum-white
-    );
     --system-spectrum-actionbutton-selected-background-color-disabled: var(
         --spectrum-disabled-background-color
     );
     --system-spectrum-actionbutton-selected-border-color-disabled: transparent;
-    --system-spectrum-actionbutton-selected-emphasized-background-color-default: var(
-        --spectrum-accent-background-color-default
-    );
-    --system-spectrum-actionbutton-selected-emphasized-background-color-hover: var(
-        --spectrum-accent-background-color-hover
-    );
-    --system-spectrum-actionbutton-selected-emphasized-background-color-down: var(
-        --spectrum-accent-background-color-down
-    );
-    --system-spectrum-actionbutton-selected-emphasized-background-color-focus: var(
-        --spectrum-accent-background-color-key-focus
-    );
     --system-spectrum-actionbutton-staticblack-quiet-border-color-default: transparent;
     --system-spectrum-actionbutton-staticwhite-quiet-border-color-default: transparent;
     --system-spectrum-actionbutton-staticblack-quiet-border-color-hover: transparent;
@@ -200,34 +162,34 @@ governing permissions and limitations under the License.
     --system-spectrum-actionbutton-staticblack-content-color-disabled: var(
         --spectrum-disabled-static-black-content-color
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-default: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-default: var(
         --spectrum-transparent-black-800
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-hover: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-hover: var(
         --spectrum-transparent-black-900
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-down: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-down: var(
         --spectrum-transparent-black-900
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-focus: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-focus: var(
         --spectrum-transparent-black-900
     );
-    --system-spectrum-actionbutton-staticblack-selected-border-color-disabled: transparent;
-    --system-spectrum-actionbutton-staticblack-selected-content-color-default: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-default: var(
         --spectrum-white
     );
-    --system-spectrum-actionbutton-staticblack-selected-content-color-hover: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-hover: var(
         --spectrum-white
     );
-    --system-spectrum-actionbutton-staticblack-selected-content-color-down: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-down: var(
         --spectrum-white
     );
-    --system-spectrum-actionbutton-staticblack-selected-content-color-focus: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-focus: var(
         --spectrum-white
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-disabled: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-disabled: var(
         --spectrum-disabled-static-black-background-color
     );
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-border-color-disabled: transparent;
     --system-spectrum-actionbutton-staticwhite-background-color-default: var(
         --spectrum-transparent-white-200
     );
@@ -266,34 +228,34 @@ governing permissions and limitations under the License.
     --system-spectrum-actionbutton-staticwhite-content-color-disabled: var(
         --spectrum-disabled-static-white-content-color
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-default: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-default: var(
         --spectrum-transparent-white-800
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-hover: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-hover: var(
         --spectrum-transparent-white-900
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-down: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-down: var(
         --spectrum-transparent-white-900
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-focus: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-focus: var(
         --spectrum-transparent-white-900
     );
-    --system-spectrum-actionbutton-staticwhite-selected-content-color-default: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-default: var(
         --spectrum-black
     );
-    --system-spectrum-actionbutton-staticwhite-selected-content-color-hover: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-hover: var(
         --spectrum-black
     );
-    --system-spectrum-actionbutton-staticwhite-selected-content-color-down: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-down: var(
         --spectrum-black
     );
-    --system-spectrum-actionbutton-staticwhite-selected-content-color-focus: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-focus: var(
         --spectrum-black
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-disabled: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-disabled: var(
         --spectrum-disabled-static-white-background-color
     );
-    --system-spectrum-actionbutton-staticwhite-selected-border-color-disabled: transparent;
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-border-color-disabled: transparent;
 }
 
 :host,
@@ -1249,6 +1211,7 @@ governing permissions and limitations under the License.
         --spectrum-component-pill-edge-to-visual-200
     );
 }
+
 :host,
 :root {
     --system-spectrum-tooltip-backgound-color-default-neutral: var(

--- a/tools/styles/tokens/global-vars.css
+++ b/tools/styles/tokens/global-vars.css
@@ -391,6 +391,15 @@ governing permissions and limitations under the License.
         --spectrum-component-height-300
     );
     --spectrum-tab-item-start-to-edge-quiet: 0px;
+    --spectrum-in-field-button-width-stacked-small: 20px;
+    --spectrum-in-field-button-width-stacked-medium: 28px;
+    --spectrum-in-field-button-width-stacked-large: 36px;
+    --spectrum-in-field-button-width-stacked-extra-large: 44px;
+    --spectrum-in-field-button-edge-to-disclosure-icon-stacked-small: 7px;
+    --spectrum-in-field-button-edge-to-disclosure-icon-stacked-medium: 9px;
+    --spectrum-in-field-button-edge-to-disclosure-icon-stacked-large: 13px;
+    --spectrum-in-field-button-edge-to-disclosure-icon-stacked-extra-large: 16px;
+    --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-small: 3px;
     --spectrum-android-elevation: 2dp;
     --spectrum-spacing-50: 2px;
     --spectrum-spacing-75: 4px;

--- a/tools/styles/tokens/large-vars.css
+++ b/tools/styles/tokens/large-vars.css
@@ -321,6 +321,7 @@ governing permissions and limitations under the License.
     --spectrum-side-navigation-with-icon-third-level-edge-to-text: 77px;
     --spectrum-side-navigation-item-to-item: 5px;
     --spectrum-side-navigation-item-to-header: 20px;
+    --spectrum-side-navigation-bottom-to-text: 10px;
     --spectrum-tray-top-to-content-area: 5px;
     --spectrum-workflow-icon-size-50: 18px;
     --spectrum-workflow-icon-size-75: 20px;

--- a/tools/styles/tokens/medium-vars.css
+++ b/tools/styles/tokens/medium-vars.css
@@ -318,6 +318,7 @@ governing permissions and limitations under the License.
     --spectrum-side-navigation-with-icon-third-level-edge-to-text: 62px;
     --spectrum-side-navigation-item-to-item: 4px;
     --spectrum-side-navigation-item-to-header: 16px;
+    --spectrum-side-navigation-bottom-to-text: 8px;
     --spectrum-tray-top-to-content-area: 4px;
     --spectrum-workflow-icon-size-50: 14px;
     --spectrum-workflow-icon-size-75: 16px;

--- a/tools/styles/tokens/spectrum/custom-dark-vars.css
+++ b/tools/styles/tokens/spectrum/custom-dark-vars.css
@@ -32,4 +32,32 @@ governing permissions and limitations under the License.
     --spectrum-drop-zone-background-color-rgb: var(
         --spectrum-blue-900-rgb
     ); /* var(--spectrum-accent-color-900);*/
+
+    --spectrum-calendar-day-background-color-selected: rgba(
+        var(--spectrum-blue-800-rgb),
+        0.15
+    );
+    --spectrum-calendar-day-background-color-hover: rgba(
+        var(--spectrum-white-rgb),
+        0.07
+    );
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
+        var(--spectrum-blue-800-rgb),
+        0.25
+    );
+    --spectrum-calendar-day-background-color-selected-hover: rgba(
+        var(--spectrum-blue-800-rgb),
+        0.25
+    );
+    --spectrum-calendar-day-background-color-down: var(
+        --spectrum-transparent-white-200
+    );
+    --spectrum-calendar-day-background-color-cap-selected: rgba(
+        var(--spectrum-blue-800-rgb),
+        0.25
+    );
+    --spectrum-calendar-day-background-color-key-focus: var(
+        --spectrum-transparent-white-600
+    );
+    --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
 }

--- a/tools/styles/tokens/spectrum/custom-darkest-vars.css
+++ b/tools/styles/tokens/spectrum/custom-darkest-vars.css
@@ -32,4 +32,34 @@ governing permissions and limitations under the License.
     --spectrum-drop-zone-background-color-rgb: var(
         --spectrum-blue-900-rgb
     ); /* var(--spectrum-accent-color-900);*/
+
+    --spectrum-calendar-day-background-color-selected: rgba(
+        var(--spectrum-blue-800-rgb),
+        0.2
+    );
+    --spectrum-calendar-day-background-color-hover: rgba(
+        var(--spectrum-white-rgb),
+        0.08
+    );
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
+        var(--spectrum-blue-800-rgb),
+        0.3
+    );
+    --spectrum-calendar-day-background-color-selected-hover: rgba(
+        var(--spectrum-blue-800-rgb),
+        0.3
+    );
+    --spectrum-calendar-day-background-color-down: rgba(
+        var(--spectrum-white-rgb),
+        0.15
+    );
+    --spectrum-calendar-day-background-color-cap-selected: rgba(
+        var(--spectrum-blue-800-rgb),
+        0.3
+    );
+    --spectrum-calendar-day-background-color-key-focus: rgba(
+        var(--spectrum-white-rgb),
+        0.08
+    );
+    --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-700);
 }

--- a/tools/styles/tokens/spectrum/custom-large-vars.css
+++ b/tools/styles/tokens/spectrum/custom-large-vars.css
@@ -59,4 +59,8 @@ governing permissions and limitations under the License.
     --spectrum-alert-banner-text-to-button-vertical: var(
         --spectrum-spacing-200
     );
+
+    --spectrum-sidenav-heading-top-margin: 30px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is updated */
+    --spectrum-sidenav-heading-bottom-margin: 10px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is added */
+    --spectrum-sidenav-bottom-to-label: 10px; /* TODO replace with updated var(--spectrum-component-bottom-to-text-100); */
 }

--- a/tools/styles/tokens/spectrum/custom-light-vars.css
+++ b/tools/styles/tokens/spectrum/custom-light-vars.css
@@ -32,4 +32,33 @@ governing permissions and limitations under the License.
     --spectrum-drop-zone-background-color-rgb: var(
         --spectrum-blue-800-rgb
     ); /* var(--spectrum-accent-color-800);*/
+
+    --spectrum-calendar-day-background-color-selected: rgba(
+        var(--spectrum-blue-900-rgb),
+        0.1
+    );
+    --spectrum-calendar-day-background-color-hover: rgba(
+        var(--spectrum-black-rgb),
+        0.06
+    );
+    --spectrum-calendar-day-today-background-color-selected-hover: rgba(
+        var(--spectrum-blue-900-rgb),
+        0.2
+    );
+    --spectrum-calendar-day-background-color-selected-hover: rgba(
+        var(--spectrum-blue-900-rgb),
+        0.2
+    );
+    --spectrum-calendar-day-background-color-down: var(
+        --spectrum-transparent-black-200
+    );
+    --spectrum-calendar-day-background-color-cap-selected: rgba(
+        var(--spectrum-blue-900-rgb),
+        0.2
+    );
+    --spectrum-calendar-day-background-color-key-focus: rgba(
+        var(--spectrum-black-rgb),
+        0.06
+    );
+    --spectrum-calendar-day-border-color-key-focus: var(--spectrum-blue-800);
 }

--- a/tools/styles/tokens/spectrum/custom-medium-vars.css
+++ b/tools/styles/tokens/spectrum/custom-medium-vars.css
@@ -59,4 +59,8 @@ governing permissions and limitations under the License.
     --spectrum-alert-banner-text-to-button-vertical: var(
         --spectrum-spacing-100
     );
+
+    --spectrum-sidenav-heading-top-margin: 24px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is updated */
+    --spectrum-sidenav-heading-bottom-margin: 8px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is added */
+    --spectrum-sidenav-bottom-to-label: 8px; /* TODO replace with updated var(--spectrum-component-bottom-to-text-100); */
 }

--- a/tools/styles/tokens/spectrum/custom-vars.css
+++ b/tools/styles/tokens/spectrum/custom-vars.css
@@ -32,20 +32,21 @@ governing permissions and limitations under the License.
     --spectrum-animation-ease-out: cubic-bezier(0, 0, 0.4, 1);
     --spectrum-animation-ease-linear: cubic-bezier(0, 0, 1, 1);
 
-    --spectrum-sans-serif-font: var(--spectrum-sans-serif-font-family);
-    --spectrum-sans-font-family-stack: var(--spectrum-sans-serif-font),
-        adobe-clean, 'Source Sans Pro', -apple-system, BlinkMacSystemFont,
-        'Segoe UI', Roboto, Ubuntu, 'Trebuchet MS', 'Lucida Grande', sans-serif;
+    --spectrum-sans-font-family-stack: adobe-clean,
+        var(--spectrum-sans-serif-font-family), 'Source Sans Pro', -apple-system,
+        BlinkMacSystemFont, 'Segoe UI', Roboto, Ubuntu, 'Trebuchet MS',
+        'Lucida Grande', sans-serif;
+    --spectrum-sans-serif-font: var(--spectrum-sans-font-family-stack);
 
-    --spectrum-serif-font: var(--spectrum-serif-font-family);
-    --spectrum-serif-font-family-stack: var(--spectrum-serif-font),
-        adobe-clean-serif, 'Source Serif Pro', Georgia, serif;
+    --spectrum-serif-font-family-stack: adobe-clean-serif,
+        var(--spectrum-serif-font-family), 'Source Serif Pro', Georgia, serif;
+    --spectrum-serif-font: var(--spectrum-serif-font-family-stack);
 
     --spectrum-code-font-family-stack: 'Source Code Pro', Monaco, monospace;
 
-    --spectrum-cjk-font: var(--spectrum-cjk-font-family);
-    --spectrum-cjk-font-family-stack: var(--spectrum-cjk-font),
-        adobe-clean-han-japanese, sans-serif;
+    --spectrum-cjk-font-family-stack: adobe-clean-han-japanese,
+        var(--spectrum-cjk-font-family), sans-serif;
+    --spectrum-cjk-font: var(--spectrum-code-font-family-stack);
 
     /* static white / black background color for docs containers */
     --spectrum-docs-static-white-background-color-rgb: 15, 121, 125;

--- a/tools/styles/tokens/spectrum/global-vars.css
+++ b/tools/styles/tokens/spectrum/global-vars.css
@@ -26,6 +26,24 @@ governing permissions and limitations under the License.
     --spectrum-slider-track-thickness: 2px;
     --spectrum-slider-handle-gap: 4px;
     --spectrum-picker-border-width: var(--spectrum-border-width-100);
+    --spectrum-in-field-button-fill-stacked-inner-border-rounding: 0px;
+    --spectrum-in-field-button-edge-to-fill: 0px;
+    --spectrum-in-field-button-stacked-inner-edge-to-fill: 0px;
+    --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-medium: 3px;
+    --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-large: 4px;
+    --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large: 5px;
+    --spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-small: var(
+        --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-small
+    );
+    --spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-medium: var(
+        --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-medium
+    );
+    --spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-large: var(
+        --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-large
+    );
+    --spectrum-in-field-button-inner-edge-to-disclosure-icon-stacked-extra-large: var(
+        --spectrum-in-field-button-outer-edge-to-disclosure-icon-stacked-extra-large
+    );
     --spectrum-border-width-100: 1px;
     --spectrum-accent-color-100: var(--spectrum-blue-100);
     --spectrum-accent-color-200: var(--spectrum-blue-200);
@@ -72,18 +90,6 @@ governing permissions and limitations under the License.
     --system-spectrum-actionbutton-border-color-hover: var(--spectrum-gray-500);
     --system-spectrum-actionbutton-border-color-down: var(--spectrum-gray-600);
     --system-spectrum-actionbutton-border-color-focus: var(--spectrum-gray-500);
-    --system-spectrum-actionbutton-content-color-default: var(
-        --spectrum-neutral-content-color-default
-    );
-    --system-spectrum-actionbutton-content-color-hover: var(
-        --spectrum-neutral-content-color-hover
-    );
-    --system-spectrum-actionbutton-content-color-down: var(
-        --spectrum-neutral-content-color-down
-    );
-    --system-spectrum-actionbutton-content-color-focus: var(
-        --spectrum-neutral-content-color-key-focus
-    );
     --system-spectrum-actionbutton-background-color-disabled: transparent;
     --system-spectrum-actionbutton-border-color-disabled: var(
         --spectrum-disabled-border-color
@@ -107,50 +113,14 @@ governing permissions and limitations under the License.
     --system-spectrum-actionbutton-quiet-border-color-focus: transparent;
     --system-spectrum-actionbutton-quiet-background-color-disabled: transparent;
     --system-spectrum-actionbutton-quiet-border-color-disabled: transparent;
-    --system-spectrum-actionbutton-selected-background-color-default: var(
-        --spectrum-neutral-subdued-background-color-default
-    );
-    --system-spectrum-actionbutton-selected-background-color-hover: var(
-        --spectrum-neutral-subdued-background-color-hover
-    );
-    --system-spectrum-actionbutton-selected-background-color-down: var(
-        --spectrum-neutral-subdued-background-color-down
-    );
-    --system-spectrum-actionbutton-selected-background-color-focus: var(
-        --spectrum-neutral-subdued-background-color-key-focus
-    );
     --system-spectrum-actionbutton-selected-border-color-default: transparent;
     --system-spectrum-actionbutton-selected-border-color-hover: transparent;
     --system-spectrum-actionbutton-selected-border-color-down: transparent;
     --system-spectrum-actionbutton-selected-border-color-focus: transparent;
-    --system-spectrum-actionbutton-selected-content-color-default: var(
-        --spectrum-white
-    );
-    --system-spectrum-actionbutton-selected-content-color-hover: var(
-        --spectrum-white
-    );
-    --system-spectrum-actionbutton-selected-content-color-down: var(
-        --spectrum-white
-    );
-    --system-spectrum-actionbutton-selected-content-color-focus: var(
-        --spectrum-white
-    );
     --system-spectrum-actionbutton-selected-background-color-disabled: var(
         --spectrum-disabled-background-color
     );
     --system-spectrum-actionbutton-selected-border-color-disabled: transparent;
-    --system-spectrum-actionbutton-selected-emphasized-background-color-default: var(
-        --spectrum-accent-background-color-default
-    );
-    --system-spectrum-actionbutton-selected-emphasized-background-color-hover: var(
-        --spectrum-accent-background-color-hover
-    );
-    --system-spectrum-actionbutton-selected-emphasized-background-color-down: var(
-        --spectrum-accent-background-color-down
-    );
-    --system-spectrum-actionbutton-selected-emphasized-background-color-focus: var(
-        --spectrum-accent-background-color-key-focus
-    );
     --system-spectrum-actionbutton-staticblack-quiet-border-color-default: transparent;
     --system-spectrum-actionbutton-staticwhite-quiet-border-color-default: transparent;
     --system-spectrum-actionbutton-staticblack-quiet-border-color-hover: transparent;
@@ -205,34 +175,34 @@ governing permissions and limitations under the License.
     --system-spectrum-actionbutton-staticblack-content-color-disabled: var(
         --spectrum-disabled-static-black-content-color
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-default: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-default: var(
         --spectrum-transparent-black-800
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-hover: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-hover: var(
         --spectrum-transparent-black-900
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-down: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-down: var(
         --spectrum-transparent-black-900
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-focus: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-focus: var(
         --spectrum-transparent-black-900
     );
-    --system-spectrum-actionbutton-staticblack-selected-border-color-disabled: transparent;
-    --system-spectrum-actionbutton-staticblack-selected-content-color-default: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-default: var(
         --spectrum-white
     );
-    --system-spectrum-actionbutton-staticblack-selected-content-color-hover: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-hover: var(
         --spectrum-white
     );
-    --system-spectrum-actionbutton-staticblack-selected-content-color-down: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-down: var(
         --spectrum-white
     );
-    --system-spectrum-actionbutton-staticblack-selected-content-color-focus: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-content-color-focus: var(
         --spectrum-white
     );
-    --system-spectrum-actionbutton-staticblack-selected-background-color-disabled: var(
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-disabled: var(
         --spectrum-disabled-static-black-background-color
     );
+    --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-border-color-disabled: transparent;
     --system-spectrum-actionbutton-staticwhite-background-color-default: transparent;
     --system-spectrum-actionbutton-staticwhite-background-color-hover: var(
         --spectrum-transparent-white-300
@@ -277,34 +247,34 @@ governing permissions and limitations under the License.
     --system-spectrum-actionbutton-staticwhite-content-color-disabled: var(
         --spectrum-disabled-static-white-content-color
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-default: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-default: var(
         --spectrum-transparent-white-800
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-hover: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-hover: var(
         --spectrum-transparent-white-900
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-down: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-down: var(
         --spectrum-transparent-white-900
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-focus: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-focus: var(
         --spectrum-transparent-white-900
     );
-    --system-spectrum-actionbutton-staticwhite-selected-content-color-default: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-default: var(
         --spectrum-black
     );
-    --system-spectrum-actionbutton-staticwhite-selected-content-color-hover: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-hover: var(
         --spectrum-black
     );
-    --system-spectrum-actionbutton-staticwhite-selected-content-color-down: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-down: var(
         --spectrum-black
     );
-    --system-spectrum-actionbutton-staticwhite-selected-content-color-focus: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-content-color-focus: var(
         --spectrum-black
     );
-    --system-spectrum-actionbutton-staticwhite-selected-background-color-disabled: var(
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-disabled: var(
         --spectrum-disabled-static-white-background-color
     );
-    --system-spectrum-actionbutton-staticwhite-selected-border-color-disabled: transparent;
+    --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-border-color-disabled: transparent;
 }
 
 :host,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5284,315 +5284,315 @@
     dotenv "^16.0.2"
     winston "^3.8.2"
 
-"@spectrum-css/accordion@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-4.0.3.tgz#8fa6fb1cd504993c7199dcd9156528944dd3d862"
-  integrity sha512-Syd8g5KzQwFTCBsxs0pLjObzE05Doo84j26/pufYbJcHX66ofyzotIZHSjToDo1oj2FJwVaHfwprg0I/17Zb+A==
+"@spectrum-css/accordion@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-4.0.5.tgz#754c45bd4fcb4bcf616d000589aca37a922f3dec"
+  integrity sha512-+SU7Y2Fyddv8PtsQ2VCMSibink9tx6FiivUMVS6JY/2Frd2/N1xXdshx21GSbwHDz7MIsvyip1mmviNSAwqgNA==
 
-"@spectrum-css/actionbar@^6.0.39":
-  version "6.0.39"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-6.0.39.tgz#cde964e62fc45d6a40cc86f3f731482fe43d37b7"
-  integrity sha512-uSshJfXBOoB1dSRG8DgQzG/n7QWcIP/+ik4jZ8DRepQuwSy3VmBXLvAeFBRdT0USjEfm3kCw/7cLlrrOlCbfoQ==
+"@spectrum-css/actionbar@^6.0.52":
+  version "6.0.52"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-6.0.52.tgz#3dc762b0fe9e6ca93a17652ac96d26de31c068bd"
+  integrity sha512-6iSyJLLEZif3SUWpwdrhu43RhFNnZAbegBMFOAnEDULGUTwv7VUYijpfGH7qpZiqUR/ejoURsxyYcV1k4HzTEg==
 
-"@spectrum-css/actionbutton@^3.0.45":
-  version "3.0.45"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-3.0.45.tgz#481c6a779a8d68bf80a4532e2f7bb9ca1e8d49a0"
-  integrity sha512-6hO4hyBMDLqQsa96zqlKEKyjrFxcNMj8iFX54bEr7tGzqz4LapQLg9/aMZIhPXdoNPLi2ipt82t8dSvV+fCHgA==
+"@spectrum-css/actionbutton@^4.0.9":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-4.0.9.tgz#4fe9dbfff8f7dae2dac760067f55087883d14ae6"
+  integrity sha512-ahkws6HL2+SjNYMyabTOSKyuosxu5PqRqiYyOlcJD5pBsuzkBNsHck0OwNAQPPWGbnrEXebEvRCF2eo9lhlAOA==
 
-"@spectrum-css/actiongroup@^3.0.55":
-  version "3.0.55"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-3.0.55.tgz#03052df8d647ba0813bd71ea90f06e403fd53f54"
-  integrity sha512-WOXaGgdnsFmPPWxVY0oHONZcfo+Wf3T1B8N2t6BhaF3vFUYICbD2xxHSEv/sX+fv+74DfTxmuc2Fvw7Qjn5EQg==
+"@spectrum-css/actiongroup@^3.0.57":
+  version "3.0.57"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-3.0.57.tgz#938989267b6e760860fa8662df66c699753e390b"
+  integrity sha512-O9JNkoMJBvdAhemnPqLL6rlUacZ7D5PkjZYeSKg33MdQmBMzyisw2ZSYAiTe+DJl9Vi4u/mXRHhDSW2l7B8mvQ==
 
-"@spectrum-css/actionmenu@^4.0.43":
-  version "4.0.43"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-4.0.43.tgz#b7b8fe9ffc143f8e776bf67631e95090acc0d3ce"
-  integrity sha512-x2OhMtIaA58x0mJg5k4yGS1muxXqSEnhi4EQxhosi4ssuQzK1x/I3nwPLjW6B4xKqhCntcWpLB5LZmQqrnT1ww==
+"@spectrum-css/actionmenu@^4.0.45":
+  version "4.0.45"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-4.0.45.tgz#95192a1279ff9930e4d065e30711f88460831b1a"
+  integrity sha512-dwTbQlxsUl0OqIzIOb7vyZHCNRClXF+MEi5JrCAnEIiT1j1wnDHOf3Cbf5i9Wh/o5rxuPR0CS9eJdwF8C2ZUkw==
 
 "@spectrum-css/asset@^3.0.46":
   version "3.0.46"
   resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.0.46.tgz#c351869dc711f903a3cba65f8b1cc0eb21d071ba"
   integrity sha512-h1Wzn/leSnROvMGGf0tCSooQ8szF/QAxv00r+ujSafTzx64YC0oximD+L731VyWnIg3FuUNX7Op5B4ojuxPlvg==
 
-"@spectrum-css/avatar@^6.0.38":
-  version "6.0.38"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-6.0.38.tgz#100bd0f7277fb8bb66158f052ec499c20e5c3abe"
-  integrity sha512-hhJWFD/33PaWHKSqTADgKqAqEpPIvTpODu84Hk3k7y9jTajky53jcb3lNUqnZ+/Kqsa7/9PH/+Wjn41Gs8zZZg==
+"@spectrum-css/avatar@^6.0.40":
+  version "6.0.40"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-6.0.40.tgz#2020bec0c35a48863f82491c3c9d0c36bdb66f71"
+  integrity sha512-CO7Zrl7STVsp208K9p8DA4Rw7Zi2cOJjhfVBy8tbSmrQbxerk2dZPeBbuTTJAw/AJlxnakC5mDnwxdP3gAm97A==
 
-"@spectrum-css/badge@^3.0.40":
-  version "3.0.40"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/badge/-/badge-3.0.40.tgz#e56356394e0691644bf99637423667865fb9ace9"
-  integrity sha512-5qTKn7lg9/dXT+mAYGlRmiHHBzJH8bRHwIqlUuZIaZOEUaQFvDMB5ZnRQjAywxosZ63X097h5Eu5cT4RUz2vEQ==
+"@spectrum-css/badge@^3.0.42":
+  version "3.0.42"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/badge/-/badge-3.0.42.tgz#f29bfd63b88e80c2ad8cf0ba7f8fa49faa316620"
+  integrity sha512-jN8OpHpEpxytT/5KBlotX3Q2VH+VK2WWflie1Sdd99ZiPcutHhyutIBnZtzehHk+g7e+P5oj36nX7Mxc3qywww==
 
 "@spectrum-css/banner@3.0.0-beta.2":
   version "3.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-3.0.0-beta.2.tgz#df448a3dcb8ac63448bd628843a2895cec305780"
   integrity sha512-NqrT03ItWzj+L0dtqjedhop6wKOspBmaowzp9IOY/2kL561kRqYTLKR9vTteZ3cEDVD3ajKA8y+bKIW0eN+X7A==
 
-"@spectrum-css/button@^10.1.8":
-  version "10.1.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-10.1.8.tgz#11ea96032585a11b3cafcbb1af063cc03fe18b75"
-  integrity sha512-PWzM8EDjnHZWyKfthq4jIEYky6f2yrH5uvZ5fYmPkVYmdu48QUrBYgywRX1SLrbsU9ONA8JZDuzN2d/EOIiHjw==
+"@spectrum-css/button@^10.1.10":
+  version "10.1.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-10.1.10.tgz#0bfcd18e3ff236e036bb967e2088264f2de14958"
+  integrity sha512-eYMvP6m+jvqPhOZykvJMpsgSsyCrvMAX0F/PTVlh86Q4RHyrF7ItBXNcqsQnwitdGGPFEsNPEclqRrxwFwPLog==
 
-"@spectrum-css/buttongroup@^6.0.55":
-  version "6.0.55"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-6.0.55.tgz#b855b1082db94bb746aa1dd264d7811b129c9580"
-  integrity sha512-woW1mzxgLX1+d4Yu4okebol/pH+5W4JXhv4LrOuL3IP+hwqxPugkZioMGVdYqsYoxu462FQjdN8OTqiOpx0+mg==
+"@spectrum-css/buttongroup@^6.0.57":
+  version "6.0.57"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-6.0.57.tgz#e393ecef4c352e56c289fa660005db294be9d506"
+  integrity sha512-pVdfGIcZdPeWv0Ha0BKICrQx7YiENwKlnT9mZXy3Dw8EAxWbR45zsb1xpsMOLFQ/UZtNn5njKD5FcC3gD2ZVRw==
 
-"@spectrum-css/card@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-6.0.2.tgz#e7ded533dbfa809f4f8fb00a87b35fb281dff2ea"
-  integrity sha512-KhHQXm9AJFpHgP5nuGN+QDykb4i35mX8KLOXHlrwDzA33A6Ao9Mb/MMCRNacaw6+ELXmHwQpkBeUPVE4s55KCA==
+"@spectrum-css/card@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-6.0.4.tgz#0dc81c5753c3c1540939061778576336852af135"
+  integrity sha512-aMewMSViuA5TyQkrJ4pSYhpdVjUHvKu/aoKR8tm+od0eX5iV93JJaStfdgB4LF26vvTbxjdbJ6uktxc16JTMfg==
 
-"@spectrum-css/checkbox@^6.1.6":
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-6.1.6.tgz#1b08c66b61e9ffbedc84047072e368d264c102ef"
-  integrity sha512-76IH+vt+U2tJLEvf3QDDCJxdNWmDSduyer21n+NGQb25wLqRt+TWobR+yejHU7hJD0QKyUYmIH7fmKPH8pqINA==
+"@spectrum-css/checkbox@^6.1.10":
+  version "6.1.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-6.1.10.tgz#7349cfe58c75d4e7dc6cb9228cdf72ae3bbf02bd"
+  integrity sha512-v1Of5dB2vkB1ZBRPR5Y/AMk/G1vkL6EeQI8m35/s4Jo98Pl70UzgDxZ822ke+3n6mPULJ2KZi5fK5+jnAHcOKQ==
 
 "@spectrum-css/clearbutton@^1.2.36":
   version "1.2.36"
   resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.36.tgz#62313aa0b102392ea046c2acab70dfaf15c1cde1"
   integrity sha512-wDu3gqYndeDadNA6yes0DOfGYXnvp3y8cKd16BJeNwKFvyEw2f5Lp0ENvqgd35Ybp/SW7wnHo+CtPBpVLdZ9xg==
 
-"@spectrum-css/closebutton@^3.1.8":
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-3.1.8.tgz#49c0bfeb9b52337b03b8065576a5b049928b59d9"
-  integrity sha512-/DMqG2hvm6jP9CE/fswG/eOO6uBwt5VKYodvJ2fEgqlRWcIp1VUq3qpZdqj/YLiYt+sD/0T85GJ3Lk1zGCjgaQ==
+"@spectrum-css/closebutton@^3.1.10":
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-3.1.10.tgz#1f629af92b6d1432ff7add195b54fa0d7693fb52"
+  integrity sha512-BbPjLbXo8tDeayAVGCMAc6PS8VkaZ9t4GalthhjkUU5HD22MX7kesE1TDRmJl1FHVmHB2zU+dz7Lj5yDRXEEMw==
 
-"@spectrum-css/coachmark@^5.0.52":
-  version "5.0.52"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-5.0.52.tgz#cabaa39362c1169ec7a8e1f56d651228edadcec1"
-  integrity sha512-Wk6AJ8pe+bHDN371FEk4iDQIldfDnxFyelDC4VGlS5U+O7xyaymwrpKZW+8riYPYVcbsv4ZoLZnX4RZuefc2Kw==
+"@spectrum-css/coachmark@^5.0.54":
+  version "5.0.54"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-5.0.54.tgz#80d8cf22648550b35f7ee7c4090ce4927644c505"
+  integrity sha512-A849zq/jvaE4lN5PxA5gyciTG6xfP66s6gtgsT1J3nAOhbcYeHWmQgIJQCkqv3F05+QiZrp8IgfOzRwmYL9bUg==
 
-"@spectrum-css/colorarea@^3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-3.0.10.tgz#1c05a4ed4e9148047f1f585cd629fec76b9613f3"
-  integrity sha512-94veu17ZCWEX2H7M0AZcyJV+/TYvkELGwqA9LG6509yNNnNuk8h/lGCZ/bOcbyzqnrgt5pZ2pYlGdrhCq0tQDQ==
+"@spectrum-css/colorarea@^4.0.29":
+  version "4.0.29"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-4.0.29.tgz#cba9f41b2360887df0a13c2b3310ead2539963a5"
+  integrity sha512-HUGgePK4/E1sU4gJCaJrESpO2dAxIxqxDE39R6KOpHILMXCm38ERxbQtzesDsScRsvF7QD+j+HpqtRSEtAXFbg==
 
-"@spectrum-css/colorhandle@^5.0.13":
-  version "5.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-5.0.13.tgz#a0935a2cbb8d4edb0ce3900a1dbafd478630b826"
-  integrity sha512-tW0k2y3rr+vKZkEAKym8Bf9XnY7h/X8cf0g0evu8KqxpyLQMiAR94cXFSdv3k8NM2YKj8avur7t69tjZVQH3RA==
+"@spectrum-css/colorhandle@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-5.0.15.tgz#933adead24b83e8850c98ed59bf9b3e263f35773"
+  integrity sha512-2m/L0vTJ4hbbmDCKpvvkqBP8G0Ek5+R6iglAjPtL1sdb9U/LgNEwqqlJHCmknpWZmciQqphP7XB217HGQDTayg==
 
-"@spectrum-css/colorloupe@^4.1.4":
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-4.1.4.tgz#a59b97827924ff60c10c02d9e4a82c92f83689a2"
-  integrity sha512-3nAZdrlCWGZ97Gemu8avvNFUY9SX5V8cNxsZOge8GEuL8HpY8TQGHru+ehoWIPSuUDQkkbtfnL+AkoFIx7DxRg==
+"@spectrum-css/colorloupe@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-4.1.6.tgz#bae06e661a5bf11c0eb8ec7627ef569974262bcc"
+  integrity sha512-pd68Gc1OdZFm7d+GdRvITnavgYXv8JunhfD+n/on3Ot/wm6x4482gfM6x6iMa6l+hdGFl61VwrUFkarawiOwJQ==
 
-"@spectrum-css/colorslider@^3.0.21":
-  version "3.0.21"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-3.0.21.tgz#f314d646094088f4ef84a1756a2c5205b26d7006"
-  integrity sha512-ddDDkqomIF3zG/hSwZoYQN7KZqK/4f3c/6UXx9xmQI/WU0jaV1J+SHP2aqDnLw4Xl4ZvAKSGk4WDs17dwahHog==
+"@spectrum-css/colorslider@^3.0.23":
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-3.0.23.tgz#7bce9e0b4f06f90d0660fde9553486bbe2ff3dc2"
+  integrity sha512-H9ew4UZ9dHNuZGBHMu3JmovrrJja49mwuF6H3OyOwUU+c8ldytgzkMMmpFr0P9qZ93P4Nr0LPYO26Pmp9vChoA==
 
-"@spectrum-css/colorwheel@^2.0.12":
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-2.0.12.tgz#3dcf5590a2b54e28d9826e7cf056f03bfeb4378f"
-  integrity sha512-ZyocQGQvVBHVv79Ozv4koQOm9APKU7BmRsAgOndZtudQS3YAAFBTCjKdLL8NDRlW3w+XBL4ih8LsBwZtPySe4w==
+"@spectrum-css/colorwheel@^3.0.27":
+  version "3.0.27"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-3.0.27.tgz#0d62f6d9f0425823a8a1035a3f569fc927513913"
+  integrity sha512-BaU076P9ucbc23MGTSNscdxfxMxCPZ4ctM2ywixljcPFEExIF08h7WIuzO/EUusF0qB0fzaSEABYJHv++D/89A==
 
 "@spectrum-css/commons@^7.0.8":
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-7.0.8.tgz#4c221d56eb296c21a259e5afcdddc2dd8fff878b"
   integrity sha512-LTHHxD+GS+EHPp9sF1PiRg3B8XWKSXYMSRPgncQUc+6rG/w3G5lyJa4eobhuE5OjbcKnX8x7i15NMqltQ85TJg==
 
-"@spectrum-css/dialog@^6.0.60":
-  version "6.0.60"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.60.tgz#5c2ae6405c01c9173bc628733a4f0e5572d5e03b"
-  integrity sha512-DZs1FVKSolBYWjcE18aHKFO2IuCSpNsaQvqZfys//jbcVmtUZEQf5BweTEwPKbkqYh2sXpgURiZTB6Z5M+6Qyw==
+"@spectrum-css/dialog@^6.0.62":
+  version "6.0.62"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-6.0.62.tgz#652b8eee9890029bbb5c9afde744e07949d6f327"
+  integrity sha512-XOYZfkGAr/IVpxlKLfDnVhfFf1WwP4ksSQk8WXojxRSEA425kbRNNavGcW8PZDFdKd3eUUJXsFPuC+XGYRAoow==
 
-"@spectrum-css/divider@^2.1.11":
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-2.1.11.tgz#604c40b033aa2560445931d6b7fbf71a442328b4"
-  integrity sha512-5G8CwAIP/+GZrRo9f818BT1UtiBsjL6q0yXiorpkbQ+gmyEN9j0oyvjKmrT6bximLEWsUa5vrNFG9IXMfXqd2A==
+"@spectrum-css/divider@^2.1.13":
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-2.1.13.tgz#48c8f4a4dd15cf415e827bb72597a6e332444a6f"
+  integrity sha512-0WNQyUpFxm2H2n91/tnS+f8TwEldKd4NdoGg2WbRpriX2iOHDz07ebegJZSCplbanBkUUD7gqvekdnH/sf6k5w==
 
-"@spectrum-css/dropzone@^5.0.7":
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-5.0.7.tgz#000e6ce4d45ad40f9a8fbac16b1861c0103e3396"
-  integrity sha512-ifYGbfou2C/46W5Yqcjo66YPuU18Q+50nQP86U3xxmauqAyVmYnk65Bj8HVCInBfnYul2eqaVftFmXi+vP7Hww==
+"@spectrum-css/dropzone@^5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-5.0.9.tgz#34308da4ecfaa82c6773407fcffe9e4e7558a859"
+  integrity sha512-+bTP+/WGTo2PQoTE2NnWyBvVTP6OEW2JKx7vWvGCvok9VeiPuNWSH4B8GNoFkFAQJL3h4ydJta3WcZUtcWPQeA==
 
 "@spectrum-css/expressvars@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-3.0.9.tgz#72678e0845c240bc9cb6b4d828f20806810f4cab"
   integrity sha512-mnxdnF2NGNdba+3OomwFURPG0XqNRD+S2cmX0ARYnia9lv84HpzhbSoGuqmQO4+4+dXe46zYjnKRe2L8oJM/zw==
 
-"@spectrum-css/fieldgroup@^4.0.55":
-  version "4.0.55"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-4.0.55.tgz#c924b01076e0fd9825dd92f579f5985fc7c48ee0"
-  integrity sha512-VQUOt69eNQLhDrBHu1fFjkGQ9mZ5AHUXcLdVY8sHcPtN6tALIyDGYy8dBRogfVasZVaAcpt2YLUq2pPTIizvzg==
+"@spectrum-css/fieldgroup@^4.0.57":
+  version "4.0.57"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-4.0.57.tgz#503b67f4d618dbd1916efa09cddbe773d7db671a"
+  integrity sha512-MBreca2cSkkgttp2NgNiJY+rzo3zwOxUZ7UCBBO/csH/3wt4RSHIusU5Xk8G88mbP/f9EINvree5uSZ+jxxreQ==
 
-"@spectrum-css/fieldlabel@^7.0.14":
-  version "7.0.14"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-7.0.14.tgz#c627d2b622e70114cc45081a0001a6bd5a23b36c"
-  integrity sha512-XkibMpdpewe5DNzNU33jWgRxIilR8s9MXua+23nkn5dlr+sAa8WycoiiHvXZZwjgiFDwEwd/dXst0g5tzCPDew==
+"@spectrum-css/fieldlabel@^7.0.16":
+  version "7.0.16"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-7.0.16.tgz#7ac4ffb8f5c488ce406397a244c88017e7480fe5"
+  integrity sha512-fTeo9zAvYJODIikfCGYSFfi9py1GCl+Y7eU82a3RMmL/w08D++oN5kfGVCK5D19Rs+2Llr8FY4UT0KkjlG2odQ==
 
-"@spectrum-css/helptext@^4.0.40":
-  version "4.0.40"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-4.0.40.tgz#8468cff12d8c9fa30bd0f4082775bf641f0c9e44"
-  integrity sha512-9fusN2mVX1606Crkd4YgjuBZ7ql77xrGhhASny1eMsKK9e3nfnZkbu2xfStC6aova+RviLJ2K0sQTgyazf7A/g==
+"@spectrum-css/helptext@^4.0.42":
+  version "4.0.42"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-4.0.42.tgz#436fccd1f9a5beb49ee8b919630fa172ecfb163e"
+  integrity sha512-OFhyVzugAo3ACPGQVyxiLY2c/BX5KhGbSatJqvYZyi7dko4jK3VjA78arfaWoxKRU12pLRix0mRzuwCJAqRnOw==
 
 "@spectrum-css/icon@^3.0.49":
   version "3.0.49"
   resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-3.0.49.tgz#17a32ba053ae2714120463203def2a0153fe5caf"
   integrity sha512-CQAPZqn2l4/osbeSIUlB9DstA8dTipvitWeyXwLjEPO68CKkVgAu9Iq10HlxEKdAO3sdG6aET3S9BURdWvZO+w==
 
-"@spectrum-css/illustratedmessage@^5.0.18":
-  version "5.0.18"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-5.0.18.tgz#a1ced6652b80afd2eb549aec9ab04247a70054e9"
-  integrity sha512-892jnXWFt0N4aBjdmO8VjKfI25NwrDiuUiBOOODdbjDRT1R0VwP8LhBnA3NbNliIGul/V9T9iMyxBIdAaVAXNQ==
+"@spectrum-css/illustratedmessage@^6.0.9":
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-6.0.9.tgz#fb87a8ae2655affba9781d1a94de38bd967a3603"
+  integrity sha512-hD+/AJsnNwuWo9AAn993Q8R+MQ2yEVvQjBZhyesV75yc7YEkQgoK+i6dQ3TjpQoNyGrgUilOwdQG8OgikVcU4g==
 
-"@spectrum-css/link@^4.0.51":
-  version "4.0.51"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-4.0.51.tgz#1861daffdef604c9b35000df9da4d2ab882378c1"
-  integrity sha512-KrqWcX8STBNSdsg/v2TugBjgtFZW6PsgjR32OqpVIGpUkgMKkzKokw5V64NdcEYNdA00PfdJIYM7FqbloT75TA==
+"@spectrum-css/link@^4.0.53":
+  version "4.0.53"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-4.0.53.tgz#bd36c98a11fc7852ea488d8b3fed483e61e6cabd"
+  integrity sha512-fnplhTaCp+kWlPa0iLmGg+UoSTAlhCYRCd40ya+E9mFk/RPNMPM5t/5Gf/u1DUNYX0hmLcTb8JeSz58TRx34dQ==
 
-"@spectrum-css/menu@^4.0.46":
-  version "4.0.46"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.46.tgz#a9ac9b365f3c1934347136ea964fc6b42972d170"
-  integrity sha512-WIRN2WQrR0ipP2nZUaReSvw3bD10LcPUjuGZtL4ku89iK7apuZrtnMZRtimqFeJKhEsS5BSiaBWH++/womouvA==
+"@spectrum-css/menu@^4.0.48":
+  version "4.0.48"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-4.0.48.tgz#6d7df3cd1909b28f92b9899aefa327506d8b5bd6"
+  integrity sha512-9eWvUxAtbNXZPv5rSNGFiWlBQx9f/MbmZRNRW2ifs5X5x7Z69C6bagzJU5V1qud9g5UktBgZof6xlhORaz2SiQ==
 
 "@spectrum-css/modal@^3.0.47":
   version "3.0.47"
   resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-3.0.47.tgz#128f96def4218f5ed011793a8d589b545034ed20"
   integrity sha512-qTEze1f0QNS5RER4kKZTTPWfakB92ATAAAYrDtvFm6pjg2iKKvlqdtMq4QOoooNXhE4nPeO/JWI9HWOTMboF6g==
 
-"@spectrum-css/picker@^4.0.19":
-  version "4.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-4.0.19.tgz#978676dbad35ea07f3f8756d374a88172f118b07"
-  integrity sha512-DFfQzmzvK1UlvT5kF8KNc2z2ZBs7hLP691OXPkTUdp8aIk4d0J9aEddyLBOpDHzasy+C7/Exh2/NghwxXCL7tg==
+"@spectrum-css/picker@^4.0.21":
+  version "4.0.21"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-4.0.21.tgz#09f1263ff4f0cd40698f7c898509640375b15ea9"
+  integrity sha512-dSfk7ksroxdmqPmPXiSSLMAYfkDgRtD935bimQrAmKDf/pXV5Ik6oflmtOaHx0NSTavd3PUISBnkL+rzSprmWQ==
 
-"@spectrum-css/pickerbutton@^2.0.12":
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/pickerbutton/-/pickerbutton-2.0.12.tgz#cba66576d6340c78f898fe163cb884593bbcbf43"
-  integrity sha512-GUKSb5NnOmLe1r1V8oV28E+sZh98EDrtkzDnWrr5vHYgzeu6/W0HYFe/4d4FyyZsTyD3yh3tMRXOY9KgJ3rdzQ==
+"@spectrum-css/pickerbutton@^3.0.33":
+  version "3.0.33"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/pickerbutton/-/pickerbutton-3.0.33.tgz#a52ccac1037217c0c956e47d7e4f839da3e6b1db"
+  integrity sha512-NGH5gZnkh+F0/wjc7HmJDvRoZocSlizr820z34JUHgn3moHLqvN2lpHnyvxLUqGlLCf5B8nxaCffmRwFmmV/sg==
 
-"@spectrum-css/popover@^6.0.58":
-  version "6.0.58"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-6.0.58.tgz#5e49b0f89681cfa94c059a4e3a8cf1793b09e781"
-  integrity sha512-Lyk4YztI8JSBGAcdLpzyMsa2vnPDErY2aLkDkovicFJeoa4AoqVNe3FMjQk8uyAkCgminGwkiTLDB5JXGdk16g==
+"@spectrum-css/popover@^6.0.60":
+  version "6.0.60"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-6.0.60.tgz#884d8ceb2fdea5771d76c60a17065a24208aa3f0"
+  integrity sha512-RkQ1W+cmfFLMlYLA6nMQhgRYoDkT0i19Q4GvxLX7tp57NmjUlZX4lk4/N5VjRxdo2Ibn4F7MEwLaJn0HaJe07w==
 
-"@spectrum-css/progressbar@^3.0.52":
-  version "3.0.52"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-3.0.52.tgz#321506f55e4f8aa872d5a211a2c4b88d78a27c2f"
-  integrity sha512-zbI37aUJUgE9WB2sMEYNVfgYzff23aj+hjXlg8L2ykNMFb/YXDtpPzjGsk6hS7H6GZnWIhhqvw/RBL6S9ffg+Q==
+"@spectrum-css/progressbar@^3.0.54":
+  version "3.0.54"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-3.0.54.tgz#540cabec4160ccf3ec79d9ab7a2da5954b852158"
+  integrity sha512-1+GpRb98sF81HZs+e64FjGkbCCluQ+fKNHZYMQoatbYs3wml0910piERmCy83Ry/9HFiAziJEoJPVU+ek8H4QA==
 
-"@spectrum-css/progresscircle@^2.0.51":
-  version "2.0.51"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-2.0.51.tgz#aaf1c39997fbc40f1dad895dff340d0907da7301"
-  integrity sha512-nHkeTWKOx/h2qMEfVTOV0p1t0p1oh4wgj3U6PeIsjyGwB7EKpsfMP/ultrV+ohQ72i3Zw+hmZSrL3zuledXLzQ==
+"@spectrum-css/progresscircle@^2.0.53":
+  version "2.0.53"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-2.0.53.tgz#1df3387d289e6f66ffe652c977e3c3ba9ab38898"
+  integrity sha512-dN239sw3Pz0C5SUv5TQsfTMxNfLMMy7iGGLlnfJv/YcRt8GDkjCfa6XgHdOiYzwlU/NQxPeGqPh1kwnOgCpjdQ==
 
-"@spectrum-css/quickaction@^3.0.67":
-  version "3.0.67"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.67.tgz#17d47829630ea346548837ffcfec2fdbfeca2fdc"
-  integrity sha512-sW7bNL8Ol51dZ5tW9YX+WOY2PbEY6eup9oLPmY6wyamwrK8rVVn/ZXhxQLy319PoZ7Fx7SUq9asCbSN71siMVg==
+"@spectrum-css/quickaction@^3.0.69":
+  version "3.0.69"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.69.tgz#7e238c290e66c226ad171d18630fb74ba969ed99"
+  integrity sha512-y8YoSlSsrPJKq/8V5gx0AB+gbS9/i75E8INgFT2OJLfN0Fx8V+JVGrwR2bbK5ZgmlbgnHuUF+nM4QDkbCjpaNA==
 
-"@spectrum-css/radio@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-5.0.1.tgz#4e2b896599ec9bad61cba389e59c6dcd4f002f10"
-  integrity sha512-dJ1+YOaEmBiZl2dXSufn+M3akAWrLnuvVanHZTn//Xdq1vjmAK2IPtYAEuJpA6ckwLU5GXypQ4MjCFmxbhC9rQ==
+"@spectrum-css/radio@^7.0.42":
+  version "7.0.42"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-7.0.42.tgz#c609155555b016774b433406950ee823f5434b31"
+  integrity sha512-0a/QGmnLiOwuKMnHBQbluEPMu+gdtQZ87UEM7r7drlfBZ9HolNTcvJav1A9Tu6o4gSsHoS5Nf8nToC8Sz+vyUg==
 
-"@spectrum-css/search@^6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-6.0.5.tgz#3c91ebfabd9918d59714051006e9bb1993c106c4"
-  integrity sha512-NTe/WGhY9WjPs+yue5kIhaPHUV0DxHCp8jMaM8lSKP55kkqcodi0dtuu5Bmc+ULeBObqEx/Nu8onCs4+mjQh8w==
+"@spectrum-css/search@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-6.0.7.tgz#bbce60b852c72f0825ee5125b45af007c1c87248"
+  integrity sha512-scFgE6x7enGe5EysUPS9FJxouBxC1ikr/s+R3uSPBRQEhLAyYUKSxCtWZA4gyrH5XWmBXEfBoN7y6SanLPjEyw==
 
 "@spectrum-css/sidenav@^3.0.50":
   version "3.0.50"
   resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-3.0.50.tgz#342c62402270caa23c088921eded4f8ef7ed4ee1"
   integrity sha512-yU9NxhUL4+KYQFS0DgY1K/qC4Fnyc1rBa+ThvcNZVUG55mzf6D2bvTHzwjihXdVMGEjBvE8T5L8JcPQ3MoXk2A==
 
-"@spectrum-css/slider@^4.0.13":
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.0.13.tgz#6915d1f1afecda6eeefbe12795d5242862fd1b90"
-  integrity sha512-qVQWsKMu4OJW2+mp3/p2N/vBZsOZSMrWBGSI50ofmv9iH4ykbzP+7Qccta96i4WuJg0c1KyLDI813hehnppT8A==
+"@spectrum-css/slider@^4.0.15":
+  version "4.0.15"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.0.15.tgz#3ea2329244c0263ee53e5021d5c71388eefed5f5"
+  integrity sha512-dOtUCL9Ea/splAPb2GL0U5wm3lzDQQi0mHgLwQMWPdXSQvgnBhkCVtdEq6D0pCzhVtsh9wdwPgUP++SV6z+vtw==
 
-"@spectrum-css/splitbutton@^5.0.54":
-  version "5.0.54"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.54.tgz#32c85c97cee1645c882609b9a1d8004f4a41e87c"
-  integrity sha512-UtS7BggutTSx6cmVHnFSRd25iw115CR1As3g2INoeqLMKMoH/rO++G8mY560JZ79Pn5HF3xlbnNfeC+tN4dFcw==
+"@spectrum-css/splitbutton@^5.0.56":
+  version "5.0.56"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.56.tgz#38ffdcd12f9d44bb7383db5b3b438de2f9263af1"
+  integrity sha512-vqqRYTFwLMtYZtqPykQmHoerY7rx+ku0HyhF6ReHaTFJewpgBS2IjWUmvB4ZwWSiJikbCGbhD1V00XGHT49nAA==
 
 "@spectrum-css/splitview@^3.0.46":
   version "3.0.46"
   resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.46.tgz#5bc487ded939110af82d723c37f5c7a68d1c716e"
   integrity sha512-up8RRN4AGFpMKYPSbn0z2M6jKx+g4BzGTSSj4NUrrrmJcXjDDtsb6ROzmD4/tEJvPoJMHvPyFSuXe6G4OqBN+A==
 
-"@spectrum-css/statuslight@^6.0.38":
-  version "6.0.38"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-6.0.38.tgz#7810323c061090fa7d35f8e82b050e53abcced17"
-  integrity sha512-nFp+7Wn7X0C9AX1MfzdfW6raBtONBh3ZhjUQQlb8GKbvH8NIg9hdOro0kG4j+ExTE8jFAusA3tLTggwXcYDt5g==
+"@spectrum-css/statuslight@^6.0.40":
+  version "6.0.40"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-6.0.40.tgz#c8a1be7f7bdcdcbc3e75166c579d80ac560d0219"
+  integrity sha512-sxDCh77xC2jX/V7vx/TNgFDxmA+k1hHumNv0JmISh392/BCMMVoqIp5mUtZJyQ2h2JHAk7eEVE0BcnFhSSPLGA==
 
-"@spectrum-css/stepper@^4.0.41":
-  version "4.0.41"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-4.0.41.tgz#620924cc3512b4a538232775c1070cad659c03be"
-  integrity sha512-Nxi+E0vfsjgHn34QbMDQOKipYNjN1Cl/v2BUSiM+A4R9JXy/oN4LUEYmBK1n10wTThk3/aR6I+pJxtNbuwkZyg==
+"@spectrum-css/stepper@^4.0.43":
+  version "4.0.43"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-4.0.43.tgz#e56fd84efacc398d6b6659d601aab275d9021aa7"
+  integrity sha512-o65UuyYRctcgMW8UdB4fIrl1P6U5qCO6Bo9pNH449tNm1ZvtK+hK6Kycf4dxzA++a4lrY+vK1MUEiHHGJLEPoQ==
 
-"@spectrum-css/swatch@^4.0.29":
-  version "4.0.29"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/swatch/-/swatch-4.0.29.tgz#2554138ad881906d23bb22380fadb24b5492a4f8"
-  integrity sha512-qOgN23ntpafZYVp6L2lPK9GHYmu2b4s+j9/NeDH4/yeOTaZN00TYyKZ+77OG6OVl4HDGf15DN+5LxI49wajpXw==
+"@spectrum-css/swatch@^4.0.31":
+  version "4.0.31"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/swatch/-/swatch-4.0.31.tgz#ae54acf19240998e83d49c8a9057518b1c8715b4"
+  integrity sha512-P/CvmWTR8iGtwb6hFPdw18hlxrOcTblcd4CHZyAKSWRGbyN+tFlK5bvV5tiI+rR0A2b+/k0PhUGXYqfAxs57vQ==
 
-"@spectrum-css/swatchgroup@^2.0.53":
-  version "2.0.53"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/swatchgroup/-/swatchgroup-2.0.53.tgz#c8c94ede4dcec33524927078fd3855bc484999a6"
-  integrity sha512-kaVi0nxiz9KMTE98LcCJd2wwINywfhiagRhS9xhk6pB0DeyqRLaGcbsfHRBwUQMwH/H2sCy6TJgAkW31PE6fjg==
-
-"@spectrum-css/switch@^3.1.6":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-3.1.6.tgz#6f9df50a542c95131acb73a080019674bdd65bf0"
-  integrity sha512-dS9W6htmD3Gmsn3sLoRHrALYZfrhvrJ55+IPYH4LbxGZf2icPPM8lOrnOp5oC87g+7Bn2Ve/AE0EYlF3ycxp8g==
-
-"@spectrum-css/table@^4.0.59":
-  version "4.0.59"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.59.tgz#e49e864ebdaee5963b7128b979b9de933a39195e"
-  integrity sha512-yOGirl/+lFYpNselGD8z3yEm9m4YzwM+cDqrTbgr2ITkuUDwaaPZl8htGp3kPxeRhxDVIGzcUSmo8cee1IbqOA==
-
-"@spectrum-css/tabs@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-4.0.0.tgz#278c5ab404f213fc6fafa8be86b379b41f088fd6"
-  integrity sha512-LDl3mcnTwhgKWb/oAOfiQ+kTNF3GZZbUphTO8UaAXYUzfmzS+BqDJSQ4BHMCc34NnMow+Qxfz+y5xner3ZhOCw==
-
-"@spectrum-css/tag@^5.0.40":
-  version "5.0.40"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-5.0.40.tgz#6f22e0ad9e0ace21131493833d7e4f3f2a74660f"
-  integrity sha512-49jvz9hCjnwXYTFHqF2qDfs28H8KJSMk1oivCxf9r8ZQtHx+qi2yXLO+t/dTXrm4zwZgCSr9bcms90ndvaAiGQ==
-
-"@spectrum-css/taggroup@^3.3.53":
-  version "3.3.53"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-3.3.53.tgz#a774663496ca28db7f719b1c80efe080e506aeb8"
-  integrity sha512-q2z2HdAy5M5dC3av877kBSvoCmPIygdhs5QyAtjUmrU7kvgmwf5VYdRo46HnIbZRjo7p/Ccl6/AVHp/XAHheAg==
-
-"@spectrum-css/textfield@^6.0.5":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-6.0.5.tgz#ffd378878b2a9375d0a32d1722328076fd36edac"
-  integrity sha512-qh4v8JYF40C8AF0y223QqFEG/4//P4AeeARkHRZqLlMY1E+JfNTbb/zqtYs981p4Mgf0b7F+NOdpncJmfJ2nUA==
-
-"@spectrum-css/thumbnail@^3.0.15":
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-3.0.15.tgz#6c1a15f85cd309b75e1809813d834e1111b863ae"
-  integrity sha512-UnQDLrDl28VNVZCmksg5zVu65nWKMDpqDvb5QkOlslJrmouQ8LuB7RCEHUlEwJ/f4adkZ6EOjS09B6OZp02MDg==
-
-"@spectrum-css/toast@^9.0.40":
-  version "9.0.40"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-9.0.40.tgz#cea4a42f698ba5c9721c5a9855160f4b58840e88"
-  integrity sha512-7s6Xd4nupKVBbz9VdOtwMSKBAZLFm7SLhGJqutgm3kGanduC25rianauoHBjZZsqSdKPoEBM4giQk1G8zmpqtg==
-
-"@spectrum-css/tokens@^10.2.2":
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-10.2.2.tgz#461697381575446542bbce8ae6d8ea948195ab3f"
-  integrity sha512-ljNXDPIJiS2q58dYn1EsXYF78gZaUCrLkOv8T8A5RBy/hM8fI85BghgiRkM0Dvsh87ej0juw3fO71Vkv3fuWlg==
-
-"@spectrum-css/tooltip@^4.0.10":
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-4.0.10.tgz#5bc64d2a1285a0f0771742a5c58e1f3c3601c0dd"
-  integrity sha512-E1lo7TOzpUq/YLg8F8PyTPOaCVvR/CiHKdd5v34UG4dXFGRjJiliZZ9pZUzdmvjkYnAlF9GrYX3p6WEEIdDIZg==
-
-"@spectrum-css/tray@^2.0.55":
+"@spectrum-css/swatchgroup@^2.0.55":
   version "2.0.55"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-2.0.55.tgz#ea0f291cbea2271d41534f42e00b5effa7ff03a5"
-  integrity sha512-ThATsDmKYjEU7vAS3V+mWHOEAKdmvwkVZUzBrM3TP1Vee4rEEOI/S25hYcdH+ZBtQxaVcDhiNwqwC0kFn94c+g==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/swatchgroup/-/swatchgroup-2.0.55.tgz#3f5fdeca9266cd36dec54731adc60a2f4edbde9d"
+  integrity sha512-8sfFwGf7hysA9uHvl0EagLWkVSTfm6EElPtMzk225FqI1+eI6BCRqXvjf1YYzEV8rtsHyU4Eh9xN26yZV0ryHg==
 
-"@spectrum-css/typography@^5.0.26":
-  version "5.0.26"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-5.0.26.tgz#6d856024b5fcaa1b5e0808dde395ec19d09605b4"
-  integrity sha512-EhHZnhetKKMC7QPxC6KmN3bMhHeSBTkeEO8kL/iHeZXwG7ZZDbV+JwQHZRRQ44izjFI9xy0rGhE4SG/lD7m3Hw==
+"@spectrum-css/switch@^3.1.8":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-3.1.8.tgz#c01b3aeddf34766c3d3ee55d42d4340ff6ffd9aa"
+  integrity sha512-p0wJ+Z8rT+ftvXrRZN5IbAM2B2pnkxgBC4UpZBAgTAMOpLPTd2BoWymAnzOrzgtJ0+PlbZcCXhdHZQ0XzqxAOQ==
+
+"@spectrum-css/table@^4.0.61":
+  version "4.0.61"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-4.0.61.tgz#58a3f85f2168402b7ed629532c23188b45ad7013"
+  integrity sha512-sruXTm/sNiENJUJ+tREgrvmI0tpIDu5HSWcWRCsNkLYL0gT9eNG7Ye9FPwzciyXB3CsE59Pj0Iz5k9necUtN8Q==
+
+"@spectrum-css/tabs@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-4.0.2.tgz#4d5592caf60dfb1184c90644a97018934d021166"
+  integrity sha512-+5TnivJjyO0LCD+wGcg/2z1vHT9q1tFtoTFvHy4Adlf+XbyxoIZ5n0EsrFZ+s8VdoAgtCFFBq+BuQvoSp0cGmQ==
+
+"@spectrum-css/tag@^5.0.42":
+  version "5.0.42"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-5.0.42.tgz#66a4c85f62261f25e43286c1aefada4b73ce38c1"
+  integrity sha512-Wq/tvTpFNZl/B8/rhD56FtaomtZ9zPXjyMUpw0YY1svaXUFpNWcc8OCHIC/dZdu6dakhW+IpcnVpuewg3EFvwg==
+
+"@spectrum-css/taggroup@^3.3.55":
+  version "3.3.55"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-3.3.55.tgz#424705cad1e5b5119549fd4bfae8c89375ab94bf"
+  integrity sha512-EAn7AzvPkBWdSyOGz5HatNi73vhTDuGmNxLOmSvTZAZk+3upwznsPQdiXYgenNnOpMhO+o4HOpRMPOnX3bmR+g==
+
+"@spectrum-css/textfield@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-6.0.7.tgz#85c337966bf71d211c27c33eb3741d22200cd9b3"
+  integrity sha512-KCEJYr/bX+LwAZ08IcbQCVD4X5oo+LUWVA69Ndf81B3aNE83Egl0VyrlcdS5U8zbufNk0ltSZkCW0Nq6NdpNaQ==
+
+"@spectrum-css/thumbnail@^3.0.17":
+  version "3.0.17"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-3.0.17.tgz#1cd2f00e5b374aa0617ba3061c325f5174598ad3"
+  integrity sha512-EuL9dpniOcm8KHp9s+7bbyphrnjuj+VnjlgI8YFZwivTXizId3di4t9uDgoLuooYef5+h21xs1wE4ofGraXzKg==
+
+"@spectrum-css/toast@^9.0.42":
+  version "9.0.42"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-9.0.42.tgz#8f185e161969d9ae0ec343a2e05bb45638cd3b8d"
+  integrity sha512-g3bB09tSsE2O/ZiacVgz1/YrbvL4OLYG9ZKoceAc7vm+X5lt6YSP+q5B6jiEG3ZxY3bZdrls2Ds8pwwhOHZcFA==
+
+"@spectrum-css/tokens@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-11.0.1.tgz#1a581f76885d0dfd892126523df4dcc24f36b941"
+  integrity sha512-sEjacNNQyk5AbcViYbsmc4ROW24x2XMxFt+FZx5xA3a8adZAEDRlMM93UpOEZ1Cgh6w5vDIvQoOBm2lIEsBDfw==
+
+"@spectrum-css/tooltip@^5.0.42":
+  version "5.0.42"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-5.0.42.tgz#45acabfb7aa5c85d0fdcaad8eac3cb0710dcd862"
+  integrity sha512-swPdSDHPGpVYLnTn6Zxf8ltDAlPJknpf2qdFgUzE7MkZrct8wBAfMmBfJ2OiGx9qhkV1Ax06f8L55ajWo94OXQ==
+
+"@spectrum-css/tray@^2.0.57":
+  version "2.0.57"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-2.0.57.tgz#e334f1c88ebb17e1380151a8f8d491b08120110a"
+  integrity sha512-HnHMBWGKhhjgaFFB4yIv4H7/P2pJt/FwSzBqTkoBoDvfMcQKaJK/+Ue/UsbYT22iP++pErBUHwBNbqGIG8QNSg==
+
+"@spectrum-css/typography@^5.0.28":
+  version "5.0.28"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-5.0.28.tgz#9842bca1168d851264b530528f84713743fbe3f3"
+  integrity sha512-QegzJKGaZSYOXShJ4MmCPJCtufS00Nq4bDvLqRhAkISRKM3d2xExHiETr0PzsLPXSdi0hTIkHjqH4jcjePJmmA==
 
 "@spectrum-css/underlay@^2.0.52":
   version "2.0.52"


### PR DESCRIPTION
## Description
Take breaking changes as time of PR creation and updates to Color Area and Checkbox to address prior comments.

There are _newer_ versions at Spectrum CSS latest, but many of those versions require the changes in https://github.com/adobe/spectrum-web-components/pull/3416 which are not yet ready to merge.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://c40bbfdd62fa1c608457ddf71f72102e--spectrum-web-components.netlify.app/review/)
    2. Review the VRT changes for expected outcomes

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.