### PR TITLE
Issue(3146)-Use innerText when label is not provided (meter, progress-bar, progress-circle)

### DIFF
--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -18,7 +18,10 @@ import {
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import { property } from '@spectrum-web-components/base/src/decorators.js';
+import {
+    property,
+    query,
+} from '@spectrum-web-components/base/src/decorators.js';
 
 import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
 import { LanguageResolutionController } from '@spectrum-web-components/reactive-controllers/src/LanguageResolution.js';
@@ -53,6 +56,9 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
     @property({ type: String, reflect: true })
     public label = '';
 
+    @query('slot')
+    private slotEl!: HTMLSlotElement;
+
     private languageResolver = new LanguageResolutionController(this);
 
     @property({ type: Boolean, reflect: true, attribute: 'side-label' })
@@ -66,7 +72,7 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
         return html`
             <sp-field-label size=${this.size} class="label">
                 ${this.slotHasContent ? html`` : this.label}
-                <slot>${this.label}</slot>
+                <slot @slotchange=${this.onSlotChange}>${this.label}</slot>
             </sp-field-label>
             <sp-field-label size=${this.size} class="percentage">
                 ${new Intl.NumberFormat(this.languageResolver.language, {
@@ -81,6 +87,12 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
                 ></div>
             </div>
         `;
+    }
+
+    private onSlotChange(): void {
+        if (!this.label && this.slotHasContent) {
+            this.label = this.slotEl.assignedNodes()[0].textContent || '';
+        }
     }
 
     protected override firstUpdated(changes: PropertyValues): void {

--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -115,6 +115,7 @@ export class ProgressBar extends SizedMixin(
             if (this.indeterminate) {
                 this.removeAttribute('aria-valuemin');
                 this.removeAttribute('aria-valuemax');
+                this.removeAttribute('aria-valuenow');
             } else {
                 this.setAttribute('aria-valuemin', '0');
                 this.setAttribute('aria-valuemax', '100');
@@ -122,8 +123,6 @@ export class ProgressBar extends SizedMixin(
         }
         if (!this.indeterminate && changes.has('progress')) {
             this.setAttribute('aria-valuenow', '' + this.progress);
-        } else if (this.hasAttribute('aria-valuenow')) {
-            this.removeAttribute('aria-valuenow');
         }
         if (this.label && changes.has('label')) {
             this.setAttribute('aria-label', this.label);

--- a/packages/progress-bar/stories/progress-bar.stories.ts
+++ b/packages/progress-bar/stories/progress-bar.stories.ts
@@ -21,7 +21,7 @@ export default {
 
 export const label = (): TemplateResult => {
     return html`
-        <sp-progress-bar label="Loading" progress="50"></sp-progress-bar>
+        <sp-progress-bar label="Loading"></sp-progress-bar>
     `;
 };
 

--- a/packages/progress-circle/src/ProgressCircle.ts
+++ b/packages/progress-circle/src/ProgressCircle.ts
@@ -18,7 +18,11 @@ import {
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import { property } from '@spectrum-web-components/base/src/decorators.js';
+import {
+    property,
+    query,
+} from '@spectrum-web-components/base/src/decorators.js';
+import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
 import progressCircleStyles from './progress-circle.css.js';
@@ -26,9 +30,12 @@ import progressCircleStyles from './progress-circle.css.js';
 /**
  * @element sp-progress-circle
  */
-export class ProgressCircle extends SizedMixin(SpectrumElement, {
-    validSizes: ['s', 'm', 'l'],
-}) {
+export class ProgressCircle extends SizedMixin(
+    ObserveSlotText(SpectrumElement, ''),
+    {
+        validSizes: ['s', 'm', 'l'],
+    }
+) {
     public static override get styles(): CSSResultArray {
         return [progressCircleStyles];
     }
@@ -47,6 +54,9 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
 
     @property({ type: Number })
     public progress = 0;
+
+    @query('slot')
+    private slotEl!: HTMLSlotElement;
 
     private makeRotation(rotation: number): string | undefined {
         return this.indeterminate
@@ -83,6 +93,9 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
         ];
         const masks = ['Mask1', 'Mask2'];
         return html`
+            <div style="display:none">
+                <slot @slotchange=${this.onSlotChange}></slot>
+            </div>
             <div class="track"></div>
             <div class="fills">
                 ${masks.map(
@@ -99,6 +112,12 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
                 )}
             </div>
         `;
+    }
+
+    private onSlotChange(): void {
+        if (!this.label && this.slotHasContent) {
+            this.label = this.slotEl.assignedNodes()[0].textContent || '';
+        }
     }
 
     protected override firstUpdated(changes: PropertyValues): void {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use innerText when label is not provided (meter, progress-bar, progress-circle)
## Description

To improve accessibility, the component should be updated to set the aria-label attribute based on the following conditions:

- If only label is provided, use the label attribute value as both the aria-label and the visible label (For ProgressBar and Meter).
- If only textContent is provided, use the textContent as both the aria-label and the visible label for progress bar and Meter. For ProgressCircle use it to update just aria-label since there is no visible label.
- If both label and textContent are provided, use the label attribute value as the aria-label, and display textContent as the visible label (in the sp-field-label element).

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3146 

## Motivation and context

Currently, the component sets the aria-label attribute only if the label attribute is provided. When only textContent is provided, the component doesn't set the aria-label, leading to an accessibility issue flagged by Axe DevTools.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
