### PR TITLE
docs: fix element resolution typo

### DIFF
--- a/tools/reactive-controllers/element-resolution.md
+++ b/tools/reactive-controllers/element-resolution.md
@@ -30,7 +30,7 @@ class RootEl extends LitElement {
 
     costructor() {
         super();
-        this.resovledElement.selector = '.other-element';
+        this.resolvedElement.selector = '.other-element';
     }
 }
 
@@ -70,7 +70,7 @@ class RootEl extends LitElement {
 
     costructor() {
         super();
-        this.resovledElement.selector = '.other-element';
+        this.resolvedElement.selector = '.other-element';
     }
 
     protected override willUpdate(changes: PropertyValues): void {


### PR DESCRIPTION
## Description

Fix some typos in element resolution docs.

## Related issue(s)

N/A

-

## Motivation and context

N/A

## How has this been tested?

N/A

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
