### PR TITLE
fix(textfield): set "title" when textfield is invalid

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -249,6 +249,7 @@ export class TextfieldBase extends ManageHelpText(
                 minlength=${ifDefined(
                     this.minlength > -1 ? this.minlength : undefined
                 )}
+                title=${this.invalid ? '' : nothing}
                 pattern=${ifDefined(this.pattern)}
                 placeholder=${this.placeholder}
                 .value=${this.displayValue}
@@ -276,6 +277,7 @@ export class TextfieldBase extends ManageHelpText(
                 this.placeholder}
                 aria-invalid=${ifDefined(this.invalid || undefined)}
                 class="input"
+                title=${this.invalid ? '' : nothing}
                 maxlength=${ifDefined(
                     this.maxlength > -1 ? this.maxlength : undefined
                 )}

--- a/packages/textfield/test/textfield.test.ts
+++ b/packages/textfield/test/textfield.test.ts
@@ -168,7 +168,9 @@ describe('Textfield', () => {
 
         const boundsDefaultElement = defaultTextarea?.getBoundingClientRect();
         const boundsOneRowElement = oneRowTextarea?.getBoundingClientRect();
-        expect(boundsDefaultElement?.height).to.be.greaterThan(boundsOneRowElement?.height ?? 0);
+        expect(boundsDefaultElement?.height).to.be.greaterThan(
+            boundsOneRowElement?.height ?? 0
+        );
     });
     it('multiline with rows does not resize', async () => {
         const el = await litFixture<Textfield>(
@@ -429,6 +431,41 @@ describe('Textfield', () => {
             : null;
         expect(input).to.not.be.null;
     });
+    it('valid - boundary-type assertions and title', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    pattern="^[\\d]+$"
+                    value="123"
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot.querySelector('#valid');
+        expect(input).to.not.be.null;
+        expect(el.focusElement).to.not.have.attribute('title');
+    });
+    it('valid - multiline - boundary-type assertions and title', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    multiline
+                    placeholder="Enter your number"
+                    pattern="^[\\d]+$"
+                    value="123"
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot.querySelector('#valid');
+        expect(input).to.not.be.null;
+        expect(el.focusElement).to.not.have.attribute('title');
+    });
     it('valid - unicode', async () => {
         const el = await litFixture<Textfield>(
             html`
@@ -601,6 +638,43 @@ describe('Textfield', () => {
             ? el.shadowRoot.querySelector('#invalid')
             : null;
         expect(input).to.not.be.null;
+    });
+    it('invalid - boundary-type assertions and title', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    placeholder="Enter your number"
+                    type="url"
+                    value="invalid-email"
+                    invalid
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot.querySelector('#invalid');
+        expect(input).to.not.be.null;
+        expect(el.focusElement).to.have.attribute('title');
+    });
+    it('invalid - multiline - boundary-type assertions and title', async () => {
+        const el = await litFixture<Textfield>(
+            html`
+                <sp-textfield
+                    multiline
+                    placeholder="Enter your number"
+                    type="url"
+                    value="invalid-email"
+                    invalid
+                ></sp-textfield>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el).to.not.equal(undefined);
+        const input = el.shadowRoot.querySelector('#invalid');
+        expect(input).to.not.be.null;
+        expect(el.focusElement).to.have.attribute('title');
     });
     it('invalid - multiline - boundary-type assertions', async () => {
         const el = await litFixture<Textfield>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a textfield is marked as invalid, we should mark the title as an empty string to prevent non-intended text from appearing in the the DOM

<!--- Describe your changes in detail -->

## Related issue(s)

- fixes #3099

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->


## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Fixes Adobe Express internal issue

## How has this been tested?

Changes were tested in the storybook environment

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to the default page for TextField in storybook
    2. Hover over the invalid field
    3. Notice that you no longer get the system level text: "Please match the requested format"

## Screenshots (if appropriate)

### Before

<img width="537" alt="Screenshot 2023-07-25 at 2 09 32 PM" src="https://github.com/adobe/spectrum-web-components/assets/3059715/050d614c-c388-403b-8df9-d392e74ab438">

### After

<img width="595" alt="Screenshot 2023-07-25 at 2 09 50 PM" src="https://github.com/adobe/spectrum-web-components/assets/3059715/2570ba53-c32e-4441-be6c-9ee1c444b214">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.

## Why this approach?

See discussion on [various approaches](https://github.com/adobe/spectrum-web-components/issues/3099#issuecomment-1506859616)