### PR TITLE
fix(toast): switches toast[open] to use visibility hidden to fix overlay handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: d159cee8aebe6bc8c08c163aecc068ec8df3ccf0
+        default: 592bdbdf7b59f9b27fade2d47a56e1f63dba3f6f
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/toast/src/toast.css
+++ b/packages/toast/src/toast.css
@@ -12,6 +12,23 @@ governing permissions and limitations under the License.
 
 @import './spectrum-toast.css';
 
-:host(:not([open])) {
-    display: none;
+:host {
+    --spectrum-overlay-animation-distance: 6px;
+    --spectrum-overlay-animation-duration: var(
+        --spectrum-animation-duration-100
+    );
+
+    opacity: 0;
+    pointer-events: none;
+    transition: transform var(--spectrum-overlay-animation-duration) ease-in-out,
+        opacity var(--spectrum-overlay-animation-duration) ease-in-out,
+        visibility 0s linear var(--spectrum-overlay-animation-duration);
+    visibility: hidden;
+}
+
+:host([open]) {
+    opacity: 1;
+    pointer-events: auto;
+    transition-delay: 0s;
+    visibility: visible;
 }

--- a/packages/toast/stories/toast.stories.ts
+++ b/packages/toast/stories/toast.stories.ts
@@ -14,6 +14,10 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 import '@spectrum-web-components/toast/sp-toast.js';
 import '@spectrum-web-components/button/sp-button.js';
 
+import { Placement } from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+
 const toast = ({
     variant = '',
     open = true,
@@ -104,3 +108,74 @@ export const Negative = (args: Properties): TemplateResult =>
 
 export const Info = (args: Properties): TemplateResult =>
     variantDemo({ ...args, variant: 'info' });
+
+const overlayStyles = html`
+    <style>
+        html,
+        body,
+        #root,
+        #root-inner,
+        sp-story-decorator {
+            height: 100%;
+            margin: 0;
+        }
+
+        sp-story-decorator > div {
+            display: contents;
+        }
+
+        sp-story-decorator::part(container) {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            height: 100%;
+            align-items: center;
+            justify-content: center;
+        }
+
+        overlay-trigger {
+            flex: none;
+            margin: 24px 0;
+        }
+
+        .self-managed:nth-child(3) {
+            margin-left: 50px;
+        }
+    </style>
+`;
+
+const overlaid = (openPlacement: Placement): TemplateResult => {
+    return html`
+        ${overlayStyles}
+        ${(
+            [
+                ['bottom', ''],
+                ['left', 'negative'],
+                ['right', 'positive'],
+                ['top', 'info'],
+            ] as [Placement, string][]
+        ).map(([placement, variant]) => {
+            return html`
+                <overlay-trigger
+                    placement=${placement}
+                    open=${ifDefined(
+                        openPlacement === placement ? 'hover' : undefined
+                    )}
+                >
+                    <sp-button label="${placement} test" slot="trigger">
+                        Hover for ${variant ? variant : 'toast'} on the
+                        ${placement}
+                    </sp-button>
+                    <sp-toast slot="hover-content" variant=${variant}>
+                        ${placement}
+                    </sp-toast>
+                </overlay-trigger>
+            `;
+        })}
+    `;
+};
+
+export const overlaidTop = (): TemplateResult => overlaid('top');
+export const overlaidRight = (): TemplateResult => overlaid('right');
+export const overlaidBottom = (): TemplateResult => overlaid('bottom');
+export const overlaidLeft = (): TemplateResult => overlaid('left');

--- a/packages/toast/stories/toast.stories.ts
+++ b/packages/toast/stories/toast.stories.ts
@@ -159,14 +159,14 @@ const overlaid = (openPlacement: Placement): TemplateResult => {
                 <overlay-trigger
                     placement=${placement}
                     open=${ifDefined(
-                        openPlacement === placement ? 'hover' : undefined
+                        openPlacement === placement ? 'click' : undefined
                     )}
                 >
                     <sp-button label="${placement} test" slot="trigger">
-                        Hover for ${variant ? variant : 'toast'} on the
+                        Click for ${variant ? variant : 'toast'} on the
                         ${placement}
                     </sp-button>
-                    <sp-toast slot="hover-content" variant=${variant}>
+                    <sp-toast slot="click-content" variant=${variant}>
                         ${placement}
                     </sp-toast>
                 </overlay-trigger>


### PR DESCRIPTION
## Description

Switches `sp-toast` to use the same behavior as `sp-tooltip` for controlling visibility with the `[open]` attribute. This switches from `display: none` to `visibility:hidden` which means the element now has size when hidden allowing the overlay behavior to properly measure it and therefore position it.

## Related issue(s)

#3510 
<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Fixes the placement in overlays.

## How has this been tested?

Added storybook to cover this case, and tested locally in Chrome.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
