### PR TITLE
Unresolved dependency on buttonBase by sp-picker-button

### DIFF
--- a/packages/picker-button/package.json
+++ b/packages/picker-button/package.json
@@ -53,7 +53,8 @@
     ],
     "dependencies": {
         "@spectrum-web-components/base": "^0.35.0",
-        "@spectrum-web-components/icons-ui": "^0.35.0"
+        "@spectrum-web-components/icons-ui": "^0.35.0",
+        "@spectrum-web-components/button": "^0.35.0"
     },
     "devDependencies": {
         "@spectrum-css/pickerbutton": "^4.0.0"


### PR DESCRIPTION
This issue is happening when only `sp-picker-button` is being used or along with any other control which is not dependent on `sp-button` somewhow.  As <sp-picker-button> is dependent on <sp-button> for buttonBase and sp-button is not getting pulled as transitive dependency, this case arises. We caught this issue while working on SWC support in UXP.
