### PR TITLE
fix(action-group): separate first selection management from later selection management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 339dc4855f3160691168c7dc05f2e63ae615448b
+        default: 6dd257592c28a3cac7e287d329249af4c90299af
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/action-group/stories/action-group-tooltip.stories.ts
+++ b/packages/action-group/stories/action-group-tooltip.stories.ts
@@ -10,7 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import {
+    html,
+    SpectrumElement,
+    TemplateResult,
+} from '@spectrum-web-components/base';
+import { state } from '@spectrum-web-components/base/src/decorators.js';
 import { spreadProps } from '../../../test/lit-helpers.js';
 
 import '@spectrum-web-components/action-group/sp-action-group.js';
@@ -217,3 +222,192 @@ vertical.args = {
     vertical: true,
     selects: undefined,
 };
+
+class ActionGroupTooltips extends SpectrumElement {
+    @state()
+    alignment = 'left';
+
+    protected override render(): TemplateResult {
+        return html`
+            <sp-action-group quiet>
+                <sp-action-button
+                    quiet
+                    value="left"
+                    ?selected=${this.alignment === 'left'}
+                    @click=${() => {
+                        this.alignment = 'left';
+                    }}
+                >
+                    <sp-icon slot="icon">
+                        <svg
+                            role="img"
+                            fill="currentColor"
+                            viewBox="0 0 18 18"
+                            id="STextAlignLeft18N-icon"
+                            width="18"
+                            height="18"
+                            aria-hidden="true"
+                            focusable="false"
+                        >
+                            <rect
+                                fill-rule="evenodd"
+                                x="2"
+                                y="14"
+                                width="12"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="2"
+                                y="2"
+                                width="15"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="2"
+                                y="6"
+                                width="12"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="2"
+                                y="10"
+                                width="15"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                        </svg>
+                    </sp-icon>
+                    <sp-tooltip self-managed placement="bottom" offset="0">
+                        Left align
+                    </sp-tooltip>
+                </sp-action-button>
+                <sp-action-button
+                    quiet
+                    value="center"
+                    ?selected=${this.alignment === 'center'}
+                    @click=${() => {
+                        this.alignment = 'center';
+                    }}
+                >
+                    <sp-icon slot="icon">
+                        <svg
+                            role="img"
+                            fill="currentColor"
+                            viewBox="0 0 18 18"
+                            id="STextAlignCenter18N-icon"
+                            width="18"
+                            height="18"
+                            aria-hidden="true"
+                            focusable="false"
+                        >
+                            <rect
+                                fill-rule="evenodd"
+                                x="4"
+                                y="14"
+                                width="10"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="1"
+                                y="10"
+                                width="16"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="1"
+                                y="2"
+                                width="16"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="4"
+                                y="6"
+                                width="10"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                        </svg>
+                    </sp-icon>
+                    <sp-tooltip self-managed placement="bottom" offset="0">
+                        Center align
+                    </sp-tooltip>
+                </sp-action-button>
+                <sp-action-button
+                    quiet
+                    value="right"
+                    ?selected=${this.alignment === 'right'}
+                    @click=${() => {
+                        this.alignment = 'right';
+                    }}
+                >
+                    <sp-icon slot="icon">
+                        <svg
+                            role="img"
+                            fill="currentColor"
+                            viewBox="0 0 18 18"
+                            id="STextAlignRight18N-icon"
+                            width="18"
+                            height="18"
+                            aria-hidden="true"
+                            focusable="false"
+                        >
+                            <rect
+                                fill-rule="evenodd"
+                                x="4"
+                                y="14"
+                                width="12"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="1"
+                                y="2"
+                                width="15"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="4"
+                                y="6"
+                                width="12"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                            <rect
+                                fill-rule="evenodd"
+                                x="1"
+                                y="10"
+                                width="15"
+                                height="2"
+                                rx="0.5"
+                            ></rect>
+                        </svg>
+                    </sp-icon>
+                    <sp-tooltip self-managed placement="bottom" offset="0">
+                        Right align
+                    </sp-tooltip>
+                </sp-action-button>
+            </sp-action-group>
+        `;
+    }
+}
+
+customElements.define('action-group-tooltips', ActionGroupTooltips);
+
+export const controlled = (): TemplateResult => html`
+    <action-group-tooltips></action-group-tooltips>
+`;

--- a/packages/action-group/stories/action-group.stories.ts
+++ b/packages/action-group/stories/action-group.stories.ts
@@ -153,6 +153,7 @@ function displaySelectionState(): void {
         selectedDiv.textContent = `Selected: ${JSON.stringify(group.selected)}`;
     }
 }
+
 export const Default = (args: Properties): TemplateResult =>
     renderButtons(args);
 


### PR DESCRIPTION
## Description
Prevent selection management from happening in an Action Group that does not have `selects` after the first management when `selected` is acquired from the initial merging of `selected` and the DOM provided by the consumer.

Due to the Mutation Observer and the reparenting that happens in the Overlay API you could falsely construct a selection from the last selection AND the next selection without this gate.

## How has this been tested?
-   [ ] _Test case 1_
    1. Added a new test and a new story.
    2. [Story](https://action-group-selection--spectrum-web-components.netlify.app/storybook/?path=/story/action-group-tooltips--controlled)
    3. [Test](https://github.com/adobe/spectrum-web-components/pull/3529/files#diff-c7346234f129e6f42044c0dab13aa3c69a97010a58c078bb4bd10466bce543f5)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.