### PR TITLE
chore: correct cache path

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
                 "!test/visual/rollup.config.js",
                 "!test/visual/src/review.js",
                 "!test/visual/src/index.html",
-                "!test/visual/src/wds-vrt.config.js"
+                "!test/visual/wds-vrt.config.js"
             ],
             "clean": "if-file-deleted"
         },


### PR DESCRIPTION
The wrong path here was causing the file to _sometimes_ get cleaned up by Wireit and leave changes at CI time....