### PR TITLE
feat: bump updated packages to beta releases; update tooling

### DIFF
--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.35.0"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^4.0.13"
+        "@spectrum-css/actionbutton": "^5.0.0-beta.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -620,9 +620,11 @@ governing permissions and limitations under the License.
 }
 :host(.focus-visible) {
     box-shadow: none;
+    outline: none;
 }
 :host(:focus-visible) {
     box-shadow: none;
+    outline: none;
 }
 :host(.focus-visible):after {
     box-shadow: 0 0 0

--- a/packages/action-button/src/spectrum-config.js
+++ b/packages/action-button/src/spectrum-config.js
@@ -40,6 +40,18 @@ const config = {
             ],
             components: [
                 converter.classToHost(),
+                {
+                    find: [builder.pseudoClass('focus-visible')],
+                    replace: [
+                        {
+                            replace: {
+                                type: 'pseudo-class',
+                                kind: 'focus-visible',
+                            },
+                            hoist: true,
+                        },
+                    ],
+                },
                 converter.classToAttribute('spectrum-ActionButton--quiet'),
                 converter.classToAttribute('is-disabled', 'disabled'),
                 converter.pseudoToAttribute('disabled', 'disabled'),

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/reactive-controllers": "^0.35.0"
     },
     "devDependencies": {
-        "@spectrum-css/actiongroup": "^3.0.61"
+        "@spectrum-css/actiongroup": "^4.0.0-beta.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-group/src/spectrum-action-group.css
+++ b/packages/action-group/src/spectrum-action-group.css
@@ -43,6 +43,12 @@ governing permissions and limitations under the License.
 ::slotted(*) {
     flex-shrink: 0;
 }
+::slotted(.focus-visible) {
+    z-index: 3;
+}
+::slotted(:focus-visible) {
+    z-index: 3;
+}
 :host(:not([vertical]):not([compact])) ::slotted(*) {
     flex-shrink: 0;
 }

--- a/packages/action-group/src/spectrum-config.js
+++ b/packages/action-group/src/spectrum-config.js
@@ -89,7 +89,7 @@ const config = {
                 {
                     find: [
                         builder.class('spectrum-ActionGroup-item'),
-                        builder.class('focus-ring'),
+                        builder.pseudoClass('focus-visible'),
                     ],
                     replace: [
                         {

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -90,7 +90,7 @@
         "@spectrum-web-components/shared": "^0.35.0"
     },
     "devDependencies": {
-        "@spectrum-css/button": "^10.1.14"
+        "@spectrum-css/button": "^11.0.0-beta.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -372,9 +372,11 @@ governing permissions and limitations under the License.
 }
 :host(.focus-visible) {
     box-shadow: none;
+    outline: none;
 }
 :host(:focus-visible) {
     box-shadow: none;
+    outline: none;
 }
 :host(.focus-visible):after {
     box-shadow: 0 0 0

--- a/packages/button/src/spectrum-config.js
+++ b/packages/button/src/spectrum-config.js
@@ -37,6 +37,18 @@ const config = {
             ],
             components: [
                 converter.classToHost(),
+                {
+                    find: [builder.pseudoClass('focus-visible')],
+                    replace: [
+                        {
+                            replace: {
+                                type: 'pseudo-class',
+                                kind: 'focus-visible',
+                            },
+                            hoist: true,
+                        },
+                    ],
+                },
                 converter.classToAttribute('spectrum-Button--quiet'),
                 converter.classToAttribute('spectrum-Button--emphasized'),
                 converter.classToAttribute('is-disabled', 'disabled'),

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -45,7 +45,7 @@
         "@spectrum-web-components/base": "^0.35.0"
     },
     "devDependencies": {
-        "@spectrum-css/closebutton": "^3.1.14"
+        "@spectrum-css/closebutton": "^4.0.0-beta.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -176,28 +176,11 @@ governing permissions and limitations under the License.
         --highcontrast-closebutton-focus-indicator-color: ButtonText;
     }
     :host(.focus-visible):after {
-        border-radius: 100%;
-        box-shadow: 0 0 0
-            var(
-                --mod-closebutton-focus-indicator-thickness,
-                var(--spectrum-closebutton-focus-indicator-thickness)
-            )
-            var(
-                --highcontrast-closebutton-focus-indicator-color,
-                var(
-                    --mod-closebutton-focus-indicator-color,
-                    var(--spectrum-closebutton-focus-indicator-color)
-                )
-            );
-        content: '';
-        display: block;
         forced-color-adjust: none;
-        inset: 0;
         margin: var(
             --mod-closebutton-focus-indicator-gap,
             var(--spectrum-closebutton-focus-indicator-gap)
         );
-        position: absolute;
         transition: opacity
                 var(
                     --mod-closebutton-animation-duration,
@@ -212,28 +195,11 @@ governing permissions and limitations under the License.
                 ease-out;
     }
     :host(:focus-visible):after {
-        border-radius: 100%;
-        box-shadow: 0 0 0
-            var(
-                --mod-closebutton-focus-indicator-thickness,
-                var(--spectrum-closebutton-focus-indicator-thickness)
-            )
-            var(
-                --highcontrast-closebutton-focus-indicator-color,
-                var(
-                    --mod-closebutton-focus-indicator-color,
-                    var(--spectrum-closebutton-focus-indicator-color)
-                )
-            );
-        content: '';
-        display: block;
         forced-color-adjust: none;
-        inset: 0;
         margin: var(
             --mod-closebutton-focus-indicator-gap,
             var(--spectrum-closebutton-focus-indicator-gap)
         );
-        position: absolute;
         transition: opacity
                 var(
                     --mod-closebutton-animation-duration,
@@ -311,9 +277,11 @@ governing permissions and limitations under the License.
 }
 :host(.focus-visible) {
     box-shadow: none;
+    outline: none;
 }
 :host(:focus-visible) {
     box-shadow: none;
+    outline: none;
 }
 :host(.focus-visible):after {
     box-shadow: 0 0 0

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -72,7 +72,7 @@
         "@spectrum-web-components/shared": "^0.35.0"
     },
     "devDependencies": {
-        "@spectrum-css/radio": "^7.0.46"
+        "@spectrum-css/radio": "^8.0.0-beta.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -461,8 +461,7 @@ governing permissions and limitations under the License.
             var(--spectrum-radio-button-selection-indicator) / 2
     );
 }
-#input.focus-visible + #button:after,
-:host(.focus-visible) #input + #button:after {
+#input.focus-visible + #button:after {
     border-color: var(
         --highcontrast-radio-focus-indicator-color,
         var(
@@ -484,8 +483,7 @@ governing permissions and limitations under the License.
             var(--spectrum-radio-focus-indicator-gap) * 2
     );
 }
-#input:focus-visible + #button:after,
-:host(:focus-visible) #input + #button:after {
+#input:focus-visible + #button:after {
     border-color: var(
         --highcontrast-radio-focus-indicator-color,
         var(

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -70,7 +70,7 @@
         "@spectrum-web-components/picker": "^0.35.0"
     },
     "devDependencies": {
-        "@spectrum-css/splitbutton": "^5.0.60"
+        "@spectrum-css/splitbutton": "^6.0.0-beta.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/split-button/src/spectrum-config.js
+++ b/packages/split-button/src/spectrum-config.js
@@ -40,7 +40,7 @@ const config = {
                     hoist: false,
                 },
                 {
-                    find: [builder.class('focus-ring')],
+                    find: [builder.pseudoClass('focus-visible')],
                     replace: [
                         {
                             replace: builder.pseudoClass('focus-visible'),

--- a/packages/split-button/src/spectrum-split-button.css
+++ b/packages/split-button/src/spectrum-split-button.css
@@ -253,8 +253,14 @@ governing permissions and limitations under the License.
 .trigger {
     position: relative;
 }
-#button:focus,
-.trigger:focus {
+#button.focus-visible,
+.trigger.focus-visible {
+    outline: none;
+    z-index: 1;
+}
+#button:focus-visible,
+.trigger:focus-visible {
+    outline: none;
     z-index: 1;
 }
 :host([dir='ltr']) #button .label + .spectrum-Icon {

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/checkbox": "^0.35.0"
     },
     "devDependencies": {
-        "@spectrum-css/switch": "^3.1.13"
+        "@spectrum-css/switch": "^4.0.0-beta.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/switch/src/spectrum-config.js
+++ b/packages/switch/src/spectrum-config.js
@@ -31,7 +31,7 @@ const config = {
                 {
                     find: [
                         builder.class('spectrum-Switch-input'),
-                        builder.class('focus-ring'),
+                        builder.pseudoClass('focus-visible'),
                     ],
                     replace: [
                         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5281,15 +5281,15 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-6.0.59.tgz#1d57dcbb80fe3a57d051bb8d63594c1f8d6701f1"
   integrity sha512-66KeRA8zU3o57XzsbzuCuNNvfhepyuWd0I9MQpPxze2GfmsT/ZgqGlesN6pdyzpSkZ5nVvTsYgDnI8r32MIjWw==
 
-"@spectrum-css/actionbutton@^4.0.13":
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-4.0.13.tgz#5ff2f77f907b5c091ec0dca8c7cce5a6b2513c2c"
-  integrity sha512-KfxlqWKGyUsjOUDBOzCWE2nWU3xPuGfr0itTfjQY2ndlUpbqwjz3rEMM9o/0B5mJ4NvJ+1NXTxD+a+t8kA1cBQ==
+"@spectrum-css/actionbutton@^5.0.0-beta.0":
+  version "5.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-5.0.0-beta.0.tgz#90d142455b3370375224e8e1c67b12c221c39ad1"
+  integrity sha512-ZOGEa61QIfwhcn/GRkoSvx10QoIcjpstUu6nukXQk/FaRoRbKtQEdtL52wgi7uo/slKMov86AJ9/u0+6fseI7w==
 
-"@spectrum-css/actiongroup@^3.0.61":
-  version "3.0.61"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-3.0.61.tgz#86d734adeade6cc0a56b7d20dd42fcd31b8533e8"
-  integrity sha512-oRDpEHbmtfBaJ6RcIdDhD2wtk/D4jqhmRzDSwJB4BVKE+16EmctVkvhPBh3bJSZFW8QTpxPbIlgdzTAtcOGVGQ==
+"@spectrum-css/actiongroup@^4.0.0-beta.0":
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-4.0.0-beta.0.tgz#611092c374f2484820897943d7edc3596030a77f"
+  integrity sha512-hTQ6YrGxMHgI2BdE6TtTTysrBb3Bm3bW9TJTNgBw4Qxs80ot5cWMQBdtDnr4gvxq6CS0Jr7dQ/lM4Hb+j2o8XQ==
 
 "@spectrum-css/actionmenu@^4.0.50":
   version "4.0.50"
@@ -5316,10 +5316,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-3.0.0-beta.2.tgz#df448a3dcb8ac63448bd628843a2895cec305780"
   integrity sha512-NqrT03ItWzj+L0dtqjedhop6wKOspBmaowzp9IOY/2kL561kRqYTLKR9vTteZ3cEDVD3ajKA8y+bKIW0eN+X7A==
 
-"@spectrum-css/button@^10.1.14":
-  version "10.1.14"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-10.1.14.tgz#9d8dcb29d3a0c82ea725107cf07e299f49d6611c"
-  integrity sha512-xxbsu5di1e0lxG9//LqZGpvsNWRBzGwLwIMDGPcbSbvCxZPCLFuqn7S1FQ3v6D9ENjXoB/OHwDoPQZzr23SP8w==
+"@spectrum-css/button@^11.0.0-beta.0":
+  version "11.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-11.0.0-beta.0.tgz#fbfe29b99df1715a66f0335548d640f08ee8b5e0"
+  integrity sha512-yY9vVXPl3kPx5N00TirpviCk+B7PRJyeCZWTvnCdmB44M9R8voYwb479Mpd34TJb4fbeIY15QfPIToJz8O9+PQ==
 
 "@spectrum-css/buttongroup@^6.0.61":
   version "6.0.61"
@@ -5341,10 +5341,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-1.2.38.tgz#22979649c16300256beda41da2697169cb941c46"
   integrity sha512-FRs5iMImltVCqndh9uYPWu4lk9hPz3COZ6rOTRBpinlYkEXLRO12AB+Ba/JChjz7KcsGz8hTLG+Il5TlYwH8AQ==
 
-"@spectrum-css/closebutton@^3.1.14":
-  version "3.1.14"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-3.1.14.tgz#b19445d2f3754830a0f084349f457f54ea8ca720"
-  integrity sha512-RelV4cZe8GJYXjMbFruvlDwBRQfUye7/e3Va0ysnQyk6dxtNjjS+wcriL1JvyzbbSgzaCLooMNLsstSiJBvalQ==
+"@spectrum-css/closebutton@^4.0.0-beta.0":
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-4.0.0-beta.0.tgz#cb567c8b9bf0185ff1a3b2dbeb75dcbb4357df4b"
+  integrity sha512-QjdGMh67FjDQz3L64/CG49XMLoR7vzsw9x4lyuUiK2wqgqJ/O4ONO5bsyPkuyFKkPJ6tHhvkARyY2tePpDdN9w==
 
 "@spectrum-css/coachmark@^5.0.58":
   version "5.0.58"
@@ -5471,10 +5471,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.0.74.tgz#40db06217f9b0bbf2804325bcaf65112e33c0c90"
   integrity sha512-w1qvJTlhIr9Gc9N0fht0cmVT3vcNfSoqSLbHyv0/uI/uy9gMyyW1G8prgXtH0K8XlqfwAUOBxPSh6NnV1D8WXQ==
 
-"@spectrum-css/radio@^7.0.46":
-  version "7.0.46"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-7.0.46.tgz#a61cb0411a5021c40b1a542766a50a455d9f99e4"
-  integrity sha512-vSwJULAcsRBa3F2U23eQKZYqn3wZ6IZwDElq01McExlMd0w4sAmi5HrOfOw3cf5Po744VfvIAJI+FgNQvYmZ0w==
+"@spectrum-css/radio@^8.0.0-beta.0":
+  version "8.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-8.0.0-beta.0.tgz#aaca9aac41a09b8565851bb4c785c40abb37dc2a"
+  integrity sha512-pJ5cFJ7j/mEtfX1h5GsYiOLizciO4Wgaq+xVqACCXtB28oQuV6lY0IHZpwRSCw9/l4TbXtc8i24noWJCrGBuiQ==
 
 "@spectrum-css/search@^6.0.11":
   version "6.0.11"
@@ -5491,10 +5491,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.1.0.tgz#98d5ff69e8734aa5bd20e2f6f3bbf93cfdc4a2da"
   integrity sha512-w26tc0YZI6/pyQj1HJTTRa42znbPzoKRbmK5tAalUHdzQ6HhlTd8N/AsVFftP0cCDWqb4o9llMEE36NmVn7gHQ==
 
-"@spectrum-css/splitbutton@^5.0.60":
-  version "5.0.60"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-5.0.60.tgz#6e740966eaf6153670530151ce4a27d413fbdd5f"
-  integrity sha512-rgNF6DAtM3IPbi1A9kkeiHQ4PxZI8JjgGDlKB8yXBh/5Ly7l4BvUgKzs5xbEyuTYKWinz8NAqgTgnnP6YQUZIA==
+"@spectrum-css/splitbutton@^6.0.0-beta.0":
+  version "6.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-6.0.0-beta.0.tgz#be3705240eec520c7974bec0aac95c0ba0a79be6"
+  integrity sha512-eCSSOHdimlnLjC20KVfFaU7fSwrYh1GmzqXJNumERjeS1W3iYNC254IVj56WrQIjDCaeBBwD3pz2OVBCzhGYPg==
 
 "@spectrum-css/splitview@^3.0.47":
   version "3.0.47"
@@ -5521,10 +5521,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/swatchgroup/-/swatchgroup-2.0.60.tgz#0848aea0f6930474b6797d49edba1ad6fe22a219"
   integrity sha512-dRuF3QDB1VBh/HFBMQoTcNpmozyx2VLhqKjtOOLHtIl9Z/G1+mwPWnKZ+z5FQHw3XDBcUKMyv85O5ezxam9d7w==
 
-"@spectrum-css/switch@^3.1.13":
-  version "3.1.13"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-3.1.13.tgz#d1ef3d8b82a39700e96f21c42eaeca42a59bf018"
-  integrity sha512-biaRRXvl3Ve6131vy9z3zttTyhgY1Pr52ZtK5NERX03m/X20nc1zXTuC/U8LlkINfdolfBroHwp61caSLMwRpg==
+"@spectrum-css/switch@^4.0.0-beta.0":
+  version "4.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-4.0.0-beta.0.tgz#41c6f9f45dfae5fcdecb2a1888f17e4fcbeea4a4"
+  integrity sha512-w9Dn6znq8xTAa3qcjaf7mAjCsbjifZX9NMYY2cHeSLrtaSLWMZQjUnmUTJHlNEID3s2x6Egq+l1vFyFtEi7ZXg==
 
 "@spectrum-css/table@^4.0.66":
   version "4.0.66"


### PR DESCRIPTION
## Description

Spectrum CSS has opened several PRs (linked below) to deprecate the use of `focus-ring`.

This pull request brings in the beta tags for the updated packages in Spectrum CSS as well as updating the SWC tooling that was transpiling the focus-ring code into focus-visible.

## Related issue(s)

- https://github.com/adobe/spectrum-css/pull/2082
- https://github.com/adobe/spectrum-css/pull/2095

## Motivation and context

A polyfill for focus-visible is no longer necessary as focus-visible support now appears in all evergreen browsers. [caniuse.com#focus-visible](https://caniuse.com/?search=focus-visible)


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Keyboard focus state visible, not visible for mouse active state_
    1. Visit [actionbutton storybook](https://feat-deprecation-focus-ring--spectrum-web-components.netlify.app/storybook/?path=/story/action-button-static-black-quiet--xl)
    2. Click the first button
    3. Validate no focus outline shows up
    4. Hit the tab key, then ctrl + tab to go back 1; the first button clicked should now show a focus outline state

## Types of changes

@Westbrook how would you like to classify this update? It's a breaking change from Spectrum CSS but due to the tooling in place in SWC, it doesn't result in a breaking change for SWC. In fact, it doesn't really influence the compiled output at all, just tooling.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] All new and existing tests passed.

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
