### PR TITLE
feat(overlay,tooltip): adds trigger and tooltip directives, implements #3549

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -58,6 +58,10 @@
             "development": "./src/overlay-timer.dev.js",
             "default": "./src/overlay-timer.js"
         },
+        "./src/overlay-trigger-directive.js": {
+            "development": "./src/overlay-trigger-directive.dev.js",
+            "default": "./src/overlay-trigger-directive.js"
+        },
         "./src/overlay-trigger.css.js": "./src/overlay-trigger.css.js",
         "./src/overlay-types.js": {
             "development": "./src/overlay-types.dev.js",

--- a/packages/overlay/src/index.ts
+++ b/packages/overlay/src/index.ts
@@ -15,3 +15,4 @@ export * from './overlay-types.js';
 export * from './ActiveOverlay.js';
 export * from './loader.js';
 export * from './VirtualTrigger.js';
+export * from './overlay-trigger-directive.js';

--- a/packages/overlay/src/overlay-trigger-directive.ts
+++ b/packages/overlay/src/overlay-trigger-directive.ts
@@ -1,0 +1,200 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { ElementPart, nothing, render, TemplateResult } from 'lit';
+import { AsyncDirective, directive } from 'lit/async-directive.js';
+import { Overlay } from './overlay.js';
+import { OverlayContentTypes } from './OverlayTrigger.js';
+import {
+    OverlayOpenCloseDetail,
+    OverlayTriggerInteractions,
+    Placement,
+} from './overlay-types.js';
+
+export type OverlayTriggerOptions = {
+    triggerOn: OverlayContentTypes;
+    placement: Placement;
+    type: OverlayTriggerInteractions;
+    offset: number;
+};
+
+export class OverlayTriggerDirective extends AsyncDirective {
+    private template?: TemplateResult;
+    private target?: HTMLElement;
+
+    protected defaultOptions: OverlayTriggerOptions = {
+        triggerOn: 'hover',
+        placement: 'top-start',
+        type: 'inline',
+        offset: 0,
+    };
+    protected options: OverlayTriggerOptions = { ...this.defaultOptions };
+
+    private open = false;
+    private overlaidContent?: HTMLElement;
+    private closeOverlay?: Promise<() => void>;
+    private abortOverlay?: (value: boolean) => void;
+
+    render(
+        _template: TemplateResult,
+        _options?: Partial<OverlayTriggerOptions>
+    ): unknown {
+        // render function here just defines the interface to the update call later
+        // we don't have anything to render since this is tintended to be an ElementPart directive
+        // so will be used on an element and is not itself rendered
+        return nothing;
+    }
+
+    override update(
+        part: ElementPart,
+        [template, options]: Parameters<this['render']>
+    ): void {
+        if (this.target !== part.element) {
+            this.removeListeners();
+        }
+        this.options = {
+            ...this.defaultOptions,
+            ...options,
+        };
+        this.template = template;
+
+        this.target = part.element as HTMLElement;
+        // start listening for trigger events
+        this.addListeners();
+    }
+
+    private async handleOpen(): Promise<void> {
+        if (this.open) {
+            return;
+        }
+        if (!this.template || !this.target) {
+            return;
+        }
+        this.open = true;
+        // render the template into an empty span (we'll discard later)
+        const fragment = document.createElement('span');
+        render(this.template, fragment);
+        // create an abort promise to exit overlay show early if we're rapidly closing
+        const abortPromise: Promise<boolean> = new Promise((res) => {
+            this.abortOverlay = res;
+        });
+        // we're going to capture the child of the span, since thats the content we actually want
+        this.overlaidContent = fragment.children[0] as HTMLElement;
+        // actually open the overlay with this content
+        this.closeOverlay = Overlay.open(
+            this.target,
+            this.options.triggerOn,
+            this.overlaidContent,
+            {
+                placement: this.options.placement,
+                offset: this.options.offset,
+                abortPromise,
+            }
+        );
+    }
+
+    private handleClosed = (
+        event: CustomEvent<OverlayOpenCloseDetail>
+    ): void => {
+        // closed outside of our control?
+        if (event?.detail.interaction === this.options.triggerOn) {
+            this.open = false;
+        }
+    };
+
+    private async doClose(): Promise<void> {
+        if (this.abortOverlay) {
+            this.abortOverlay(true);
+            this.abortOverlay = undefined;
+        }
+        if (this.closeOverlay) {
+            const closeOverlay = this.closeOverlay;
+            this.closeOverlay = undefined;
+            (await closeOverlay)();
+        }
+        this.overlaidContent = undefined;
+        this.open = false;
+    }
+
+    private removeListeners(): void {
+        if (!this.target) {
+            return;
+        }
+        this.target.removeEventListener('mouseenter', this.activate);
+        this.target.removeEventListener('focusin', this.activate);
+        this.target.removeEventListener('mouseleave', this.deactivate);
+        this.target.removeEventListener('focusout', this.deactivate);
+        this.target.removeEventListener('click', this.activate);
+        this.target.removeEventListener('longpress', this.activate);
+        this.target.removeEventListener('sp-closed', this.handleClosed);
+    }
+
+    private addListeners(): void {
+        if (!this.template || !this.target) {
+            return;
+        }
+        this.target.addEventListener('sp-closed', this.handleClosed);
+
+        switch (this.options.triggerOn) {
+            case 'hover': {
+                this.target.addEventListener('mouseenter', this.activate);
+                this.target.addEventListener('focusin', this.activate);
+                this.target.addEventListener('mouseleave', this.deactivate);
+                this.target.addEventListener('focusout', this.deactivate);
+                break;
+            }
+            case 'click': {
+                this.target.addEventListener('click', this.activate);
+                break;
+            }
+            case 'longpress': {
+                this.target.addEventListener('longpress', this.activate);
+            }
+        }
+    }
+
+    private deactivate = (event: Event): void => {
+        const mouseIsEnteringHoverContent =
+            event.type === 'mouseleave' &&
+            this.options.triggerOn === 'hover' &&
+            this.open &&
+            (event as unknown as MouseEvent).relatedTarget ===
+                this.overlaidContent;
+        if (mouseIsEnteringHoverContent && this.overlaidContent) {
+            // mouse is moving from the trigger to the hover content
+            // start listening on the overlay to see if we leave it
+            this.overlaidContent.addEventListener(
+                'mouseleave',
+                (event: MouseEvent) => {
+                    // did the mouse exit back onto the trigger?
+                    const mouseIsEnteringTrigger =
+                        event.relatedTarget === this.target;
+                    if (mouseIsEnteringTrigger) {
+                        // then do nothing
+                        return;
+                    }
+                    // otherwise let the overlay close with the regular mouse leave behavior
+                    this.deactivate(event);
+                },
+                { once: true }
+            );
+            return;
+        }
+        this.doClose();
+    };
+
+    private activate = (_event: Event): void => {
+        if (!this.target) return;
+        this.handleOpen();
+    };
+}
+
+export const trigger = directive(OverlayTriggerDirective);

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -82,5 +82,6 @@ declare global {
         'sp-overlay-query': CustomEvent<OverlayDisplayQueryDetail>;
         'sp-open': CustomEvent<OverlayOpenCloseDetail>;
         'sp-close': CustomEvent<OverlayOpenCloseDetail>;
+        'sp-closed': CustomEvent<OverlayOpenCloseDetail>;
     }
 }

--- a/packages/overlay/stories/overlay-directive.stories.ts
+++ b/packages/overlay/stories/overlay-directive.stories.ts
@@ -123,17 +123,22 @@ export default {
         placement: 'bottom',
         offset: 0,
         colorStop: 'light',
+        triggerOn: 'click',
     },
 };
 
 interface Properties {
     placement: Placement;
     offset: number;
-    open?: OverlayContentTypes;
+    triggerOn?: OverlayContentTypes;
     type?: Extract<TriggerInteractions, 'inline' | 'modal' | 'replace'>;
 }
 
-const template = ({ placement, offset, open }: Properties): TemplateResult => {
+const template = ({
+    placement,
+    offset,
+    triggerOn,
+}: Properties): TemplateResult => {
     return html`
         ${storyStyles}
         <sp-button
@@ -186,7 +191,7 @@ const template = ({ placement, offset, open }: Properties): TemplateResult => {
                 `,
                 {
                     placement,
-                    triggerOn: open,
+                    triggerOn,
                     offset,
                 }
             )}

--- a/packages/overlay/stories/overlay-directive.stories.ts
+++ b/packages/overlay/stories/overlay-directive.stories.ts
@@ -1,0 +1,199 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import {
+    OverlayContentTypes,
+    Placement,
+    TriggerInteractions,
+} from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/action-group/sp-action-group.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-open-in.js';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import { trigger } from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
+
+import '@spectrum-web-components/picker/sp-picker.js';
+import '@spectrum-web-components/menu/sp-menu.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/menu/sp-menu-divider.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/slider/sp-slider.js';
+import '@spectrum-web-components/radio/sp-radio.js';
+import '@spectrum-web-components/radio/sp-radio-group.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/src/themes.js';
+import '@spectrum-web-components/accordion/sp-accordion.js';
+import '@spectrum-web-components/accordion/sp-accordion-item.js';
+import '../../../projects/story-decorator/src/types.js';
+
+import './overlay-story-components.js';
+import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
+
+const storyStyles = html`
+    <style>
+        html,
+        body,
+        #root,
+        #root-inner,
+        sp-story-decorator {
+            height: 100%;
+            margin: 0;
+        }
+
+        sp-story-decorator::part(container) {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            height: 100%;
+            align-items: center;
+            justify-content: center;
+        }
+
+        overlay-trigger {
+            flex: none;
+        }
+
+        #styled-div {
+            background-color: var(--styled-div-background-color, blue);
+            color: white;
+            padding: 4px 10px;
+            margin-bottom: 10px;
+        }
+
+        #inner-trigger {
+            display: inline-block;
+        }
+    </style>
+`;
+
+export default {
+    title: 'Overlay Directive',
+    argTypes: {
+        offset: { control: 'number' },
+        placement: {
+            control: {
+                type: 'inline-radio',
+                options: [
+                    'top',
+                    'top-start',
+                    'top-end',
+                    'bottom',
+                    'bottom-start',
+                    'bottom-end',
+                    'left',
+                    'left-start',
+                    'left-end',
+                    'right',
+                    'right-start',
+                    'right-end',
+                    'auto',
+                    'auto-start',
+                    'auto-end',
+                    'none',
+                ],
+            },
+        },
+        type: {
+            control: {
+                type: 'inline-radio',
+                options: ['modal', 'replace', 'inline'],
+            },
+        },
+        colorStop: {
+            control: {
+                type: 'inline-radio',
+                options: ['light', 'dark'],
+            },
+        },
+    },
+    args: {
+        placement: 'bottom',
+        offset: 0,
+        colorStop: 'light',
+    },
+};
+
+interface Properties {
+    placement: Placement;
+    offset: number;
+    open?: OverlayContentTypes;
+    type?: Extract<TriggerInteractions, 'inline' | 'modal' | 'replace'>;
+}
+
+const template = ({ placement, offset, open }: Properties): TemplateResult => {
+    return html`
+        ${storyStyles}
+        <sp-button
+            variant="primary"
+            ${tooltip('Click to open a popover.')}
+            ${trigger(
+                html`
+                    <sp-popover placement="${placement}" tip>
+                        <sp-dialog no-divider>
+                            <div class="options-popover-content">
+                                <sp-slider
+                                    value="5"
+                                    step="0.5"
+                                    min="0"
+                                    max="20"
+                                    label="Awesomeness"
+                                ></sp-slider>
+                                <div id="styled-div">
+                                    The background of this div should be blue
+                                </div>
+                                <sp-button
+                                    ${tooltip('Click to open another popover.')}
+                                    ${trigger(
+                                        html`
+                                            <sp-popover
+                                                placement="bottom"
+                                                tip
+                                                open
+                                            >
+                                                <sp-dialog size="s" no-divider>
+                                                    <div
+                                                        class="options-popover-content"
+                                                    >
+                                                        Another Popover
+                                                    </div>
+                                                </sp-dialog>
+                                            </sp-popover>
+                                        `,
+                                        {
+                                            placement: 'bottom',
+                                            triggerOn: 'click',
+                                        }
+                                    )}
+                                >
+                                    Press Me
+                                </sp-button>
+                            </div>
+                        </sp-dialog>
+                    </sp-popover>
+                `,
+                {
+                    placement,
+                    triggerOn: open,
+                    offset,
+                }
+            )}
+        >
+            Show Popover
+        </sp-button>
+    `;
+};
+
+export const Default = (args: Properties): TemplateResult => template(args);

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -28,6 +28,7 @@ import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-open-in.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
+
 import { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/menu/sp-menu.js';

--- a/packages/overlay/test/benchmark/directive-test.ts
+++ b/packages/overlay/test/benchmark/directive-test.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import * as overlayTools from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import { html } from 'lit';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+if ('trigger' in overlayTools) {
+    const trigger = overlayTools.trigger;
+    measureFixtureCreation(
+        html`
+            <sp-button
+                ${trigger(html`
+                    <sp-popover>
+                        <p>This is the content.</p>
+                    </sp-popover>
+                `)}
+            >
+                Trigger
+            </sp-button>
+        `
+    );
+} else {
+    // TODO: Remove this hackery once we land an official version of the directive approach
+    measureFixtureCreation(
+        html`
+            <overlay-trigger>
+                <sp-button slot="trigger">Trigger</sp-button>
+                <sp-popover slot="content">
+                    <p>This is the content.</p>
+                </sp-popover>
+            </overlay-trigger>
+        `
+    );
+}

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -33,6 +33,10 @@
             "development": "./src/index.dev.js",
             "default": "./src/index.js"
         },
+        "./src/tooltip-directive.js": {
+            "development": "./src/tooltip-directive.dev.js",
+            "default": "./src/tooltip-directive.js"
+        },
         "./src/tooltip.css.js": "./src/tooltip.css.js",
         "./sp-tooltip.js": {
             "development": "./sp-tooltip.dev.js",

--- a/packages/tooltip/src/tooltip-directive.ts
+++ b/packages/tooltip/src/tooltip-directive.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import {
+    OverlayTriggerOptions,
+    trigger,
+} from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
+import { html } from 'lit';
+import '../sp-tooltip.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+export const tooltip = function tooltip(
+    tooltipText: string,
+    options?: Partial<OverlayTriggerOptions & { variant: string }>
+): ReturnType<typeof trigger> {
+    return trigger(
+        html`
+            <sp-tooltip variant=${ifDefined(options?.variant)}>
+                ${tooltipText}
+            </sp-tooltip>
+        `,
+        options
+    );
+};

--- a/packages/tooltip/stories/tooltip-directive.stories.ts
+++ b/packages/tooltip/stories/tooltip-directive.stories.ts
@@ -1,0 +1,119 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import { Placement } from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+
+export default {
+    component: 'sp-tooltip',
+    title: 'Tooltip Directive',
+};
+
+interface Properties {
+    open?: boolean;
+    placement?: Placement;
+    text?: string;
+    variant?: string;
+    offset?: number;
+    delayed?: boolean;
+}
+
+export const Default = ({
+    placement,
+    text,
+    variant,
+}: Properties): TemplateResult => {
+    return html`
+        <sp-button ${tooltip(text || 'Tooltip', { placement, variant })}>
+            Hover me
+        </sp-button>
+    `;
+};
+Default.args = {
+    open: true,
+    placement: 'top',
+    variant: '',
+    text: 'Tooltip',
+};
+Default.argTypes = {
+    open: {
+        name: 'open',
+        type: { name: 'boolean', required: false },
+        description: 'Whether the tooltip is open.',
+        table: {
+            type: { summary: 'boolean' },
+            defaultValue: { summary: false },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+    placement: {
+        name: 'placement',
+        type: { name: 'string', required: false },
+        description: 'The placement of the tooltip in relation to its parent',
+        table: {
+            type: { summary: 'string' },
+            defaultValue: { summary: 'top' },
+        },
+        control: {
+            type: 'inline-radio',
+            options: [
+                'auto',
+                'auto-start',
+                'auto-end',
+                'top',
+                'bottom',
+                'right',
+                'left',
+                'top-start',
+                'top-end',
+                'bottom-start',
+                'bottom-end',
+                'right-start',
+                'right-end',
+                'left-start',
+                'left-end',
+                'none',
+            ],
+        },
+    },
+    text: {
+        name: 'text',
+        type: { name: 'string', required: false },
+        table: {
+            type: { summary: 'string' },
+            defaultValue: { summary: '' },
+        },
+        control: 'text',
+    },
+    variant: {
+        name: 'variant',
+        type: { name: 'string', required: false },
+        description: 'The style of the tooltip.',
+        table: {
+            type: { summary: 'string' },
+            defaultValue: { summary: '' },
+        },
+        control: {
+            type: 'inline-radio',
+            options: ['info', 'positive', 'negative', ''],
+        },
+    },
+};


### PR DESCRIPTION
## Description

Adds two new directives:

* `trigger` which is an ElementDirective that creates an overlay from template content when a trigger event happens on the element. This supports click / hover events, and enables similar functionality to `overlay-trigger` but crucially only renders the overlay content if the trigger event occurs.
* `tooltip` which is also an ElementDirective and uses the `trigger` directive under the hood to create a tooltip, this is just a convenience wrapper to make it even more trivial to add textual tooltips.

## Related issue(s)

#3549 

## Motivation and context

Improving performance of `overlay-trigger` which is used extensively in our apps is the main motivator here. `overlay-trigger` currently creates the full dom of the overlay content, even if the trigger event never occurs. It also creates multiple slots unnecessarily. A directive based approach on the other hand does nothing besides parse the template until the trigger event occurs at which point the template is rendered into a fragment and shown via the Overlay API.

## How has this been tested?

Rudimentary testing thus far, have implemented basic storybooks for both directives, and added a benchmark for the trigger directive to show the performance improvement on initial render (20%!).

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
