### PR TITLE
docs: improves documentation for invalid selections in radio groups

### DIFF
--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -91,6 +91,8 @@ import {
 
 Standard radio buttons are the default style for radio buttons. They are optimal for application panels where all visual elements are monochrome in order to direct focus to the content.
 
+Invalid selections in radio groups are identified using the `negative-help-text` slot. Read more about using [help text](#help-text) below.
+
 ```html-live
 <div style="display: flex; justify-content: space-between;">
     <div style="display: flex; flex-direction: column;">
@@ -107,9 +109,12 @@ Standard radio buttons are the default style for radio buttons. They are optimal
         <sp-field-label for="example-2" size="l">
             <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
         </sp-field-label>
-        <sp-radio-group id="example-2" name="example" vertical>
+        <sp-radio-group invalid id="example-2" name="example" vertical>
             <sp-radio invalid value="kittens">Kittens</sp-radio>
             <sp-radio invalid value="puppies" checked>Puppies</sp-radio>
+             <sp-help-text slot="negative-help-text" icon>
+                This selection is invalid.
+            </sp-help-text>
         </sp-radio-group>
     </div>
 
@@ -129,6 +134,8 @@ Standard radio buttons are the default style for radio buttons. They are optimal
 
 Emphasized radio buttons are a secondary style for radio buttons. The blue color provides a visual prominence that is optimal for forms, settings, etc. where the radio buttons need to be noticed.
 
+Invalid selections in radio groups are identified using the `negative-help-text` slot. Read more about using [help text](#help-text) below.
+
 ```html-live
 <div style="display: flex; justify-content: space-between;">
     <div style="display: flex; flex-direction: column;">
@@ -145,9 +152,12 @@ Emphasized radio buttons are a secondary style for radio buttons. The blue color
         <sp-field-label for="example-b" size="l">
             <h4 class="spectrum-Heading--subtitle1">Invalid</h4>
         </sp-field-label>
-        <sp-radio-group id="example-b" name="example" vertical>
+        <sp-radio-group invalid id="example-b" name="example" vertical>
             <sp-radio emphasized invalid value="kittens">Kittens</sp-radio>
             <sp-radio emphasized invalid value="puppies" checked>Puppies</sp-radio>
+            <sp-help-text slot="negative-help-text" icon>
+                This selection is invalid.
+            </sp-help-text>
         </sp-radio-group>
     </div>
 


### PR DESCRIPTION
Updated documentation for radio button to show proper usage of an invalid radio group. Additionally, directed readers to read more about help text. Also, opened [equivalent PR to CSS project](https://github.com/adobe/spectrum-css/pull/2104).

## Related issue(s)

Issue #3005 

## Motivation and context

Clearer documentation is always good.

## How has this been tested?

Documentation only change.

## Screenshots (if appropriate)

<img width="1008" alt="Screenshot 2023-08-18 at 10 41 56 AM" src="https://github.com/adobe/spectrum-web-components/assets/66142/102b10e1-cdc6-4dd9-ad3f-58bf69356bbc">

## Types of changes

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [-] I have added tests to cover my changes.
-   [-] All new and existing tests passed.
-   [-] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
