### PR TITLE
refactor: leverage "m" as default in size application via CSS

### DIFF
--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -51,6 +51,7 @@ export type LongpressEvent = {
  */
 export class ActionButton extends SizedMixin(ButtonBase, {
     validSizes: ['xs', 's', 'm', 'l', 'xl'],
+    noDefaultSize: true,
 }) {
     public static override get styles(): CSSResultArray {
         return [...super.styles, buttonStyles, cornerTriangleStyles];

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -226,7 +226,7 @@ governing permissions and limitations under the License.
             var(--spectrum-actionbutton-border-width)
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-actionbutton-min-width: calc(
         var(--spectrum-component-edge-to-visual-only-100) * 2 +
             var(--spectrum-workflow-icon-size-100)

--- a/packages/action-button/src/spectrum-config.js
+++ b/packages/action-button/src/spectrum-config.js
@@ -54,11 +54,12 @@ const config = {
                     ],
                     'static'
                 ),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-ActionButton--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-ActionButton--sizeXS', 'xs'],
                         ['spectrum-ActionButton--sizeS', 's'],
-                        ['spectrum-ActionButton--sizeM', 'm'],
                         ['spectrum-ActionButton--sizeL', 'l'],
                         ['spectrum-ActionButton--sizeXL', 'xl'],
                     ],

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -87,7 +87,22 @@ describe('ActionButton', () => {
         expect(el.tabIndex).to.equal(-1);
         expect(el.disabled).to.be.false;
     });
-    it('maintains a `size` attribute', async () => {
+    it('manages a `size` attribute', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-button size="xl">Button</sp-action-button>
+            `
+        );
+
+        await elementUpdated(el);
+        expect(el.size).to.equal('xl');
+        expect(el.getAttribute('size')).to.equal('xl');
+        el.removeAttribute('size');
+        await elementUpdated(el);
+        expect(el.size).to.equal('m');
+        expect(el.hasAttribute('size')).to.be.false;
+    });
+    it('does not apply a default `size` attribute', async () => {
         const el = await fixture<ActionButton>(
             html`
                 <sp-action-button>Button</sp-action-button>
@@ -96,11 +111,7 @@ describe('ActionButton', () => {
 
         await elementUpdated(el);
         expect(el.size).to.equal('m');
-        expect(el.getAttribute('size')).to.equal('m');
-        el.removeAttribute('size');
-        await elementUpdated(el);
-        expect(el.size).to.equal('m');
-        expect(el.getAttribute('size')).to.equal('m');
+        expect(el.hasAttribute('size')).to.be.false;
     });
     it('dispatches `longpress` events when [hold-affordance]', async () => {
         const longpressSpy = spy();

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -38,6 +38,7 @@ const EMPTY_SELECTION: string[] = [];
  */
 export class ActionGroup extends SizedMixin(SpectrumElement, {
     validSizes: ['xs', 's', 'm', 'l', 'xl'],
+    noDefaultSize: true,
 }) {
     public static override get styles(): CSSResultArray {
         return [styles];
@@ -374,7 +375,11 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
             if (this.selects || !this.hasManaged) {
                 button.selected = this.selected.includes(button.value);
             }
-            if (this.size) {
+            if (
+                this.size &&
+                (this.size !== 'm' ||
+                    typeof changes?.get('size') !== 'undefined')
+            ) {
                 button.size = this.size;
             }
         });

--- a/packages/action-group/src/spectrum-action-group.css
+++ b/packages/action-group/src/spectrum-action-group.css
@@ -22,8 +22,8 @@ governing permissions and limitations under the License.
     );
     --spectrum-actiongroup-vertical-spacing-regular: var(--spectrum-spacing-75);
 }
+:host,
 :host([size='l']),
-:host([size='m']),
 :host([size='xl']) {
     --spectrum-actiongroup-horizontal-spacing-regular: var(
         --spectrum-spacing-100

--- a/packages/action-group/src/spectrum-config.js
+++ b/packages/action-group/src/spectrum-config.js
@@ -37,10 +37,11 @@ const config = {
                 converter.classToAttribute('spectrum-ActionGroup--compact'),
                 converter.classToAttribute('spectrum-ActionGroup--quiet'),
                 converter.classToAttribute('spectrum-ActionGroup--justified'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-ActionGroup--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-ActionGroup--sizeS', 's'],
-                        ['spectrum-ActionGroup--sizeM', 'm'],
                         ['spectrum-ActionGroup--sizeL', 'l'],
                         ['spectrum-ActionGroup--sizeXL', 'xl'],
                     ],

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -1017,8 +1017,32 @@ describe('ActionGroup', () => {
         expect(secondElement.selected, 'second child not selected').to.be.false;
     });
 
-    it('maintains a `size` attribute', async () => {
-        const el = await fixture<ActionGroup>(
+    it('manages a `size` attribute', async () => {
+        const el = await fixture<ActionButton>(
+            html`
+                <sp-action-group size="xl">
+                    <sp-action-button>Button</sp-action-button>
+                </sp-action-group>
+            `
+        );
+
+        const button = el.querySelector('sp-action-button') as ActionButton;
+
+        await elementUpdated(el);
+        expect(el.size).to.equal('xl');
+        expect(button.size).to.equal('xl');
+        expect(el.getAttribute('size')).to.equal('xl');
+        expect(button.getAttribute('size')).to.equal('xl');
+        el.removeAttribute('size');
+        await elementUpdated(el);
+        expect(el.size).to.equal('m');
+        expect(el.hasAttribute('size')).to.be.false;
+        expect(button.size).to.equal('m');
+        expect(button.getAttribute('size')).to.equal('m');
+    });
+
+    it('does not apply a default `size` attribute', async () => {
+        const el = await fixture<ActionButton>(
             html`
                 <sp-action-group>
                     <sp-action-button>Button</sp-action-button>
@@ -1026,13 +1050,13 @@ describe('ActionGroup', () => {
             `
         );
 
+        const button = el.querySelector('sp-action-button') as ActionButton;
+
         await elementUpdated(el);
         expect(el.size).to.equal('m');
-        expect(el.getAttribute('size')).to.equal('m');
-        el.removeAttribute('size');
-        await elementUpdated(el);
-        expect(el.size).to.equal('m');
-        expect(el.getAttribute('size')).to.equal('m');
+        expect(button.size).to.equal('m');
+        expect(el.hasAttribute('size')).to.be.false;
+        expect(button.hasAttribute('size')).to.be.false;
     });
 
     it('will accept selected as a JSON string', async () => {

--- a/packages/badge/src/Badge.ts
+++ b/packages/badge/src/Badge.ts
@@ -56,7 +56,10 @@ export type FixedValues =
  * @slot icon - Optional icon that appears to the left of the label
  */
 export class Badge extends SizedMixin(
-    ObserveSlotText(ObserveSlotPresence(SpectrumElement, '[slot="icon"]'), '')
+    ObserveSlotText(ObserveSlotPresence(SpectrumElement, '[slot="icon"]'), ''),
+    {
+        noDefaultSize: true,
+    }
 ) {
     public static override get styles(): CSSResultArray {
         return [styles];

--- a/packages/badge/src/spectrum-config.js
+++ b/packages/badge/src/spectrum-config.js
@@ -32,10 +32,11 @@ const config = {
             ],
             components: [
                 converter.classToHost(),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Badge--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Badge--sizeS', 's'],
-                        ['spectrum-Badge--sizeM', 'm'],
                         ['spectrum-Badge--sizeL', 'l'],
                         ['spectrum-Badge--sizeXL', 'xl'],
                     ],

--- a/packages/button-group/src/ButtonGroup.ts
+++ b/packages/button-group/src/ButtonGroup.ts
@@ -26,7 +26,9 @@ import styles from './button-group.css.js';
  * @element sp-button-group
  * @slot - the sp-button elements that make up the group
  */
-export class ButtonGroup extends SizedMixin(SpectrumElement) {
+export class ButtonGroup extends SizedMixin(SpectrumElement, {
+    noDefaultSize: true,
+}) {
     public static override get styles(): CSSResultArray {
         return [styles];
     }
@@ -34,9 +36,11 @@ export class ButtonGroup extends SizedMixin(SpectrumElement) {
     @property({ type: Boolean, reflect: true })
     public vertical = false;
 
-    protected handleSlotchange({ target: slot }: Event & { target: HTMLSlotElement }): void {
+    protected handleSlotchange({
+        target: slot,
+    }: Event & { target: HTMLSlotElement }): void {
         const assignedElements = slot.assignedElements() as Button[];
-        assignedElements.forEach(button => {
+        assignedElements.forEach((button) => {
             button.size = this.size;
         });
     }

--- a/packages/button-group/src/spectrum-button-group.css
+++ b/packages/button-group/src/spectrum-button-group.css
@@ -11,15 +11,11 @@ governing permissions and limitations under the License.
 */
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
-:host {
-    --spectrum-buttongroup-spacing-horizontal: var(--spectrum-spacing-300);
-    --spectrum-buttongroup-spacing-vertical: var(--spectrum-spacing-300);
-}
 :host([size='s']) {
     --spectrum-buttongroup-spacing-horizontal: var(--spectrum-spacing-200);
     --spectrum-buttongroup-spacing-vertical: var(--spectrum-spacing-200);
 }
-:host([size='m']) {
+:host {
     --spectrum-buttongroup-spacing-horizontal: var(--spectrum-spacing-300);
     --spectrum-buttongroup-spacing-vertical: var(--spectrum-spacing-300);
 }

--- a/packages/button-group/src/spectrum-config.js
+++ b/packages/button-group/src/spectrum-config.js
@@ -27,10 +27,11 @@ const config = {
             components: [
                 converter.classToHost(),
                 converter.classToAttribute('spectrum-ButtonGroup--vertical'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-ButtonGroup--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-ButtonGroup--sizeS', 's'],
-                        ['spectrum-ButtonGroup--sizeM', 'm'],
                         ['spectrum-ButtonGroup--sizeL', 'l'],
                         ['spectrum-ButtonGroup--sizeXL', 'xl'],
                     ],

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -46,7 +46,7 @@ export type ButtonTreatments = 'fill' | 'outline';
  * @slot - text label of the Button
  * @slot icon - The icon to use for Button
  */
-export class Button extends SizedMixin(ButtonBase) {
+export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
     public static override get styles(): CSSResultArray {
         return [...super.styles, buttonStyles];
     }

--- a/packages/button/src/ClearButton.ts
+++ b/packages/button/src/ClearButton.ts
@@ -58,7 +58,9 @@ const crossIcon: Record<string, () => TemplateResult> = {
  * @slot - text label of the Clear Button
  * @slot icon - The icon to use for Clear Button
  */
-export class ClearButton extends SizedMixin(StyledButton) {
+export class ClearButton extends SizedMixin(StyledButton, {
+    noDefaultSize: true,
+}) {
     public static override get styles(): CSSResultArray {
         return [...super.styles, buttonStyles, crossMediumStyles];
     }

--- a/packages/button/src/CloseButton.ts
+++ b/packages/button/src/CloseButton.ts
@@ -59,7 +59,9 @@ const crossIcon: Record<string, () => TemplateResult> = {
  * @slot - text label of the Close Button
  * @slot icon - The icon to use for Close Button
  */
-export class CloseButton extends SizedMixin(StyledButton) {
+export class CloseButton extends SizedMixin(StyledButton, {
+    noDefaultSize: true,
+}) {
     public static override get styles(): CSSResultArray {
         return [...super.styles, buttonStyles, crossMediumStyles];
     }

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -145,7 +145,7 @@ governing permissions and limitations under the License.
         --spectrum-button-bottom-to-text-small
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-button-min-width: calc(
         var(--spectrum-component-height-100) *
             var(--spectrum-button-minimum-width-multiplier)

--- a/packages/button/src/spectrum-config.js
+++ b/packages/button/src/spectrum-config.js
@@ -44,10 +44,11 @@ const config = {
                 converter.classToAttribute('is-focused', 'focused'),
                 converter.pseudoToAttribute('disabled', 'disabled'),
                 converter.pseudoToAttribute('active', 'active'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Button--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Button--sizeS', 's'],
-                        ['spectrum-Button--sizeM', 'm'],
                         ['spectrum-Button--sizeL', 'l'],
                         ['spectrum-Button--sizeXL', 'xl'],
                     ],

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -57,6 +57,7 @@ export class Card extends LikeAnchor(
         ]),
         {
             validSizes: ['s', 'm'],
+            noDefaultSize: true,
         }
     )
 ) {

--- a/packages/card/src/spectrum-config.js
+++ b/packages/card/src/spectrum-config.js
@@ -48,10 +48,11 @@ const config = {
                 converter.classToAttribute('is-focused', 'focused'),
                 converter.classToAttribute('is-selected', 'selected'),
                 converter.classToAttribute('is-drop-target', 'drop-target'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Card--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Card--sizeS', 's'],
-                        ['spectrum-Card--sizeM', 'm'],
                         ['spectrum-Card--sizeL', 'l'],
                         ['spectrum-Card--sizeXL', 'xl'],
                     ],

--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -91,7 +91,9 @@ const dashIcon = {
  * @slot - content to display as the label for the Checkbox
  * @fires change - Announces a change in the `checked` property of a Checkbox
  */
-export class Checkbox extends SizedMixin(CheckboxBase) {
+export class Checkbox extends SizedMixin(CheckboxBase, {
+    noDefaultSize: true,
+}) {
     @property({ type: Boolean, reflect: true })
     public indeterminate = false;
 

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -68,13 +68,8 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-control-selected-color-focus: var(
         --spectrum-neutral-background-color-selected-key-focus
     );
-    --spectrum-checkbox-font-size: var(--spectrum-font-size-100);
     --spectrum-checkbox-line-height: var(--spectrum-line-height-100);
     --spectrum-checkbox-line-height-cjk: var(--spectrum-cjk-line-height-100);
-    --spectrum-checkbox-height: var(--spectrum-component-height-100);
-    --spectrum-checkbox-control-size: var(
-        --spectrum-checkbox-control-size-medium
-    );
     --spectrum-checkbox-control-corner-radius: var(--spectrum-corner-radius-75);
     --spectrum-checkbox-focus-indicator-gap: var(
         --spectrum-focus-indicator-gap
@@ -86,8 +81,6 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-selected-border-width: calc(
         var(--spectrum-checkbox-control-size) / 2
     );
-    --spectrum-checkbox-top-to-text: var(--spectrum-component-top-to-text-100);
-    --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-100);
     --spectrum-checkbox-animation-duration: var(
         --spectrum-animation-duration-100
     );
@@ -101,7 +94,7 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-top-to-text: var(--spectrum-component-top-to-text-75);
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-75);
 }
-:host([size='m']) {
+:host {
     --spectrum-checkbox-font-size: var(--spectrum-font-size-100);
     --spectrum-checkbox-height: var(--spectrum-component-height-100);
     --spectrum-checkbox-control-size: var(

--- a/packages/checkbox/src/spectrum-config.js
+++ b/packages/checkbox/src/spectrum-config.js
@@ -30,10 +30,11 @@ const config = {
                 // converter.classToAttribute('is-invalid', 'invalid'),
                 converter.classToAttribute('is-readOnly', 'readonly'),
                 converter.classToAttribute('spectrum-Checkbox--emphasized'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Checkbox--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Checkbox--sizeS', 's'],
-                        ['spectrum-Checkbox--sizeM', 'm'],
                         ['spectrum-Checkbox--sizeL', 'l'],
                         ['spectrum-Checkbox--sizeXL', 'xl'],
                     ],

--- a/packages/clear-button/src/spectrum-clear-button.css
+++ b/packages/clear-button/src/spectrum-clear-button.css
@@ -114,7 +114,7 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-infieldbutton-padding-s)
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-clearbutton-fill-uiicon-color-disabled: var(
         --spectrum-clearbutton-m-fill-uiicon-color-disabled,
         var(--spectrum-alias-component-icon-color-disabled)

--- a/packages/clear-button/src/spectrum-config.js
+++ b/packages/clear-button/src/spectrum-config.js
@@ -39,10 +39,11 @@ const config = {
                     ],
                     'variant'
                 ),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-ClearButton--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-ClearButton--sizeS', 's'],
-                        ['spectrum-ClearButton--sizeM', 'm'],
                         ['spectrum-ClearButton--sizeL', 'l'],
                         ['spectrum-ClearButton--sizeXL', 'xl'],
                     ],

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -96,10 +96,6 @@ governing permissions and limitations under the License.
     --spectrum-closebutton-focus-indicator-color: var(
         --spectrum-focus-indicator-color
     );
-    --spectrum-closebutton-height: var(--spectrum-component-height-100);
-    --spectrum-closebutton-width: var(--spectrum-closebutton-height);
-    --spectrum-closebutton-size: var(--spectrum-closebutton-size-400);
-    --spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-400);
     --spectrum-closebutton-animation-duration: var(
         --spectrum-animation-duration-100
     );
@@ -110,7 +106,7 @@ governing permissions and limitations under the License.
     --spectrum-closebutton-size: var(--spectrum-closebutton-size-300);
     --spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-300);
 }
-:host([size='m']) {
+:host {
     --spectrum-closebutton-height: var(--spectrum-component-height-100);
     --spectrum-closebutton-width: var(--spectrum-closebutton-height);
     --spectrum-closebutton-size: var(--spectrum-closebutton-size-400);

--- a/packages/close-button/src/spectrum-config.js
+++ b/packages/close-button/src/spectrum-config.js
@@ -38,10 +38,11 @@ const config = {
                     ],
                     'static'
                 ),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Closebutton--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Closebutton--sizeS', 's'],
-                        ['spectrum-Closebutton--sizeM', 'm'],
                         ['spectrum-Closebutton--sizeL', 'l'],
                         ['spectrum-Closebutton--sizeXL', 'xl'],
                     ],

--- a/packages/divider/src/Divider.ts
+++ b/packages/divider/src/Divider.ts
@@ -27,6 +27,7 @@ import styles from './divider.css.js';
  */
 export class Divider extends SizedMixin(SpectrumElement, {
     validSizes: ['s', 'm', 'l'],
+    noDefaultSize: true,
 }) {
     public static override styles: CSSResultArray = [styles];
 

--- a/packages/divider/src/spectrum-config.js
+++ b/packages/divider/src/spectrum-config.js
@@ -27,10 +27,11 @@ const config = {
             components: [
                 converter.classToHost(),
                 converter.classToAttribute('spectrum-Divider--vertical'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Divider--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Divider--sizeS', 's'],
-                        ['spectrum-Divider--sizeM', 'm'],
                         ['spectrum-Divider--sizeL', 'l'],
                     ],
                     'size'

--- a/packages/divider/src/spectrum-divider.css
+++ b/packages/divider/src/spectrum-divider.css
@@ -12,10 +12,6 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-divider-thickness: var(--spectrum-divider-thickness-medium);
-    --spectrum-divider-background-color: var(
-        --spectrum-divider-background-color-medium
-    );
     --spectrum-divider-background-color-small: var(--spectrum-gray-300);
     --spectrum-divider-background-color-medium: var(--spectrum-gray-300);
     --spectrum-divider-background-color-large: var(--spectrum-gray-800);
@@ -44,7 +40,7 @@ governing permissions and limitations under the License.
         --spectrum-divider-background-color-small
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-divider-thickness: var(--spectrum-divider-thickness-medium);
     --spectrum-divider-background-color: var(
         --spectrum-divider-background-color-medium
@@ -59,7 +55,6 @@ governing permissions and limitations under the License.
 @media (forced-colors: active) {
     :host,
     :host([size='l']),
-    :host([size='m']),
     :host([size='s']) {
         --spectrum-divider-background-color: CanvasText;
         --spectrum-divider-background-color-small-static-white: CanvasText;
@@ -94,7 +89,7 @@ governing permissions and limitations under the License.
         var(--spectrum-divider-background-color-small-static-white)
     );
 }
-:host([static='white'][size='m']) {
+:host([static='white']) {
     --spectrum-divider-background-color: var(
         --mod-divider-background-color-medium-static-white,
         var(--spectrum-divider-background-color-medium-static-white)
@@ -112,7 +107,7 @@ governing permissions and limitations under the License.
         var(--spectrum-divider-background-color-small-static-black)
     );
 }
-:host([static='black'][size='m']) {
+:host([static='black']) {
     --spectrum-divider-background-color: var(
         --mod-divider-background-color-medium-static-black,
         var(--spectrum-divider-background-color-medium-static-black)

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -47,7 +47,9 @@ type Labelable = Focusable & {
  *
  * @slot - text content of the label
  */
-export class FieldLabel extends SizedMixin(SpectrumElement) {
+export class FieldLabel extends SizedMixin(SpectrumElement, {
+    noDefaultSize: true,
+}) {
     public static override get styles(): CSSResultArray {
         return [styles, asteriskIconStyles];
     }

--- a/packages/field-label/src/spectrum-config.js
+++ b/packages/field-label/src/spectrum-config.js
@@ -37,10 +37,11 @@ const config = {
                     ],
                     'side-aligned'
                 ),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-FieldLabel--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-FieldLabel--sizeS', 's'],
-                        ['spectrum-FieldLabel--sizeM', 'm'],
                         ['spectrum-FieldLabel--sizeL', 'l'],
                         ['spectrum-FieldLabel--sizeXL', 'xl'],
                     ],

--- a/packages/field-label/src/spectrum-field-label.css
+++ b/packages/field-label/src/spectrum-field-label.css
@@ -12,15 +12,8 @@ governing permissions and limitations under the License.
 
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
-    --spectrum-fieldlabel-min-height: var(--spectrum-component-height-75);
     --spectrum-fieldlabel-color: var(
         --spectrum-neutral-subdued-content-color-default
-    );
-    --spectrum-field-label-top-to-asterisk: var(
-        --spectrum-field-label-top-to-asterisk-medium
-    );
-    --spectrum-field-label-text-to-asterisk: var(
-        --spectrum-field-label-text-to-asterisk-medium
     );
     --spectrum-fieldlabel-font-weight: var(--spectrum-regular-font-weight);
     --spectrum-fieldlabel-line-height: var(--spectrum-line-height-100);
@@ -44,7 +37,7 @@ governing permissions and limitations under the License.
         --spectrum-field-label-text-to-asterisk-small
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-fieldlabel-min-height: var(--spectrum-component-height-75);
     --spectrum-fieldlabel-top-to-text: var(--spectrum-component-top-to-text-75);
     --spectrum-fieldlabel-bottom-to-text: var(

--- a/packages/help-text/src/HelpText.ts
+++ b/packages/help-text/src/HelpText.ts
@@ -28,7 +28,9 @@ type HelpTextVariants = 'neutral' | 'negative';
 /**
  * @element sp-help-text
  */
-export class HelpText extends SizedMixin(SpectrumElement) {
+export class HelpText extends SizedMixin(SpectrumElement, {
+    noDefaultSize: true,
+}) {
     public static override get styles(): CSSResultArray {
         return [styles];
     }

--- a/packages/help-text/src/spectrum-config.js
+++ b/packages/help-text/src/spectrum-config.js
@@ -34,10 +34,11 @@ const config = {
                     ],
                     'variant'
                 ),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-HelpText--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-HelpText--sizeS', 's'],
-                        ['spectrum-HelpText--sizeM', 'm'],
                         ['spectrum-HelpText--sizeL', 'l'],
                         ['spectrum-HelpText--sizeXL', 'xl'],
                     ],

--- a/packages/help-text/src/spectrum-help-text.css
+++ b/packages/help-text/src/spectrum-help-text.css
@@ -66,7 +66,7 @@ governing permissions and limitations under the License.
         --spectrum-component-bottom-to-text-75
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-helptext-min-height: var(--spectrum-component-height-75);
     --spectrum-helptext-icon-size: var(--spectrum-workflow-icon-size-100);
     --spectrum-helptext-font-size: var(--spectrum-font-size-75);

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -59,7 +59,7 @@ function elementIsOrContains(
  *   When the `selects` attribute is not present a `value` will not be maintained and the Menu
  *   Item children of this Menu will not have their `selected` state managed.
  */
-export class Menu extends SizedMixin(SpectrumElement) {
+export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
     public static override get styles(): CSSResultArray {
         return [menuStyles];
     }

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -381,10 +381,11 @@ const config = {
             components: [
                 converter.classToHost(),
                 converter.classToAttribute('is-selectable', 'selects'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Menu--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Menu--sizeS', 's'],
-                        ['spectrum-Menu--sizeM', 'm'],
                         ['spectrum-Menu--sizeL', 'l'],
                         ['spectrum-Menu--sizeXL', 'xl'],
                     ],

--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -35,7 +35,9 @@ import styles from './meter.css.js';
  *
  * @slot - text labeling the Meter
  */
-export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
+export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, ''), {
+    noDefaultSize: true,
+}) {
     public static override get styles(): CSSResultArray {
         return [styles];
     }

--- a/packages/meter/src/spectrum-config.js
+++ b/packages/meter/src/spectrum-config.js
@@ -48,10 +48,11 @@ const config = {
                 converter.classToAttribute('is-positive', 'positive'),
                 converter.classToAttribute('is-notice', 'notice'),
                 converter.classToAttribute('is-negative', 'negative'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-ProgressBar--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-ProgressBar--sizeS', 's'],
-                        ['spectrum-ProgressBar--sizeM', 'm'],
                         ['spectrum-ProgressBar--sizeL', 'l'],
                         ['spectrum-ProgressBar--sizeXL', 'xl'],
                     ],

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -23,7 +23,6 @@ governing permissions and limitations under the License.
     --spectrum-progressbar-size-2400: 192px;
     --spectrum-progressbar-size-2500: 200px;
     --spectrum-progressbar-size-2800: 224px;
-    --spectrum-progressbar-font-size: var(--spectrum-font-size-75);
     --spectrum-progressbar-line-height-cjk: var(--spectrum-cjk-line-height-100);
     --spectrum-progressbar-min-size: var(--spectrum-progress-bar-minimum-width);
     --spectrum-progressbar-max-size: var(--spectrum-progress-bar-maximum-width);
@@ -68,7 +67,7 @@ governing permissions and limitations under the License.
         --spectrum-component-top-to-text-75
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-progressbar-size-default: var(--spectrum-progressbar-size-2400);
     --spectrum-progressbar-font-size: var(--spectrum-font-size-75);
     --spectrum-progressbar-thickness: var(

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -57,7 +57,7 @@ const chevronClass = {
     xl: 'spectrum-UIIcon-ChevronDown300',
 };
 
-export class PickerBase extends SizedMixin(Focusable) {
+export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
     protected isMobile = new MatchMediaController(this, IS_MOBILE);
 
     @state()

--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -20,19 +20,20 @@ governing permissions and limitations under the License.
      * .spectrum-Picker
      * Move width management to :host
      **/
-    max-width: 100%;
-    width: var(--spectrum-picker-width);
-    min-width: var(--spectrum-picker-min-width);
+    max-inline-size: 100%;
+    inline-size: var(
+        --spectrum-picker-width,
+        var(--spectrum-global-dimension-size-2400)
+    );
+    min-inline-size: calc(
+        var(--spectrum-picker-minimum-width-multiplier) *
+            var(--mod-picker-block-size, var(--spectrum-picker-block-size))
+    );
 }
 
 :host([quiet]) {
     width: auto;
     min-width: 0;
-}
-
-:host([size]) {
-    /* TODO: https://github.com/adobe/spectrum-css/blob/011ca5408ae5eb32bb55e1cf79c06e40171fd17c/components/picker/index.css#L93 */
-    --spectrum-picker-width: var(--spectrum-global-dimension-size-2400);
 }
 
 #button {

--- a/packages/picker/src/spectrum-config.js
+++ b/packages/picker/src/spectrum-config.js
@@ -35,10 +35,11 @@ const config = {
                 converter.classToAttribute('is-invalid', 'invalid'),
                 converter.classToAttribute('is-open', 'open'),
                 converter.classToAttribute('is-focused', 'focused'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Picker--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Picker--sizeS', 's'],
-                        ['spectrum-Picker--sizeM', 'm'],
                         ['spectrum-Picker--sizeL', 'l'],
                         ['spectrum-Picker--sizeXL', 'xl'],
                     ],

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -77,32 +77,17 @@ governing permissions and limitations under the License.
     --spectrum-picker-popover-quiet-offset-x: 14px;
 }
 :host {
-    --spectrum-picker-font-size: var(--spectrum-font-size-100);
     --spectrum-picker-font-weight: var(--spectrum-regular-font-weight);
     --spectrum-picker-placeholder-font-style: var(
         --spectrum-default-font-style
     );
     --spectrum-picker-line-height: var(--spectrum-line-height-100);
-    --spectrum-picker-block-size: var(--spectrum-component-height-100);
     --spectrum-picker-border-radius: var(--spectrum-corner-radius-100);
     --spectrum-picker-spacing-edge-to-text: var(
         --spectrum-component-edge-to-text-100
     );
     --spectrum-picker-spacing-edge-to-text-quiet: var(
         --spectrum-field-edge-to-text-quiet
-    );
-    --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);
-    --spectrum-picker-spacing-text-to-alert-icon-inline-start: var(
-        --spectrum-field-text-to-alert-icon-medium
-    );
-    --spectrum-picker-spacing-icon-to-disclosure-icon: var(
-        --spectrum-picker-visual-to-disclosure-icon-medium
-    );
-    --spectrum-picker-spacing-label-to-picker-quiet: var(
-        --spectrum-field-label-to-component-quiet-medium
-    );
-    --spectrum-picker-spacing-top-to-disclosure-icon: var(
-        --spectrum-field-top-to-disclosure-icon-100
     );
     --spectrum-picker-spacing-edge-to-disclosure-icon: var(
         --spectrum-field-top-to-disclosure-icon-100
@@ -205,7 +190,7 @@ governing permissions and limitations under the License.
         --spectrum-field-end-edge-to-disclosure-icon-75
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-picker-font-size: var(--spectrum-font-size-100);
     --spectrum-picker-block-size: var(--spectrum-component-height-100);
     --spectrum-picker-spacing-text-to-icon: var(--spectrum-text-to-visual-100);

--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -34,7 +34,10 @@ import styles from './progress-bar.css.js';
  * @element sp-progress-bar
  */
 export class ProgressBar extends SizedMixin(
-    ObserveSlotText(SpectrumElement, '')
+    ObserveSlotText(SpectrumElement, ''),
+    {
+        noDefaultSize: true,
+    }
 ) {
     public static override get styles(): CSSResultArray {
         return [styles];

--- a/packages/progress-bar/src/spectrum-config.js
+++ b/packages/progress-bar/src/spectrum-config.js
@@ -48,10 +48,11 @@ const config = {
                 converter.classToAttribute('is-positive', 'positive'),
                 converter.classToAttribute('is-notice', 'notice'),
                 converter.classToAttribute('is-negative', 'negative'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-ProgressBar--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-ProgressBar--sizeS', 's'],
-                        ['spectrum-ProgressBar--sizeM', 'm'],
                         ['spectrum-ProgressBar--sizeL', 'l'],
                         ['spectrum-ProgressBar--sizeXL', 'xl'],
                     ],

--- a/packages/progress-bar/src/spectrum-progress-bar.css
+++ b/packages/progress-bar/src/spectrum-progress-bar.css
@@ -23,7 +23,6 @@ governing permissions and limitations under the License.
     --spectrum-progressbar-size-2400: 192px;
     --spectrum-progressbar-size-2500: 200px;
     --spectrum-progressbar-size-2800: 224px;
-    --spectrum-progressbar-font-size: var(--spectrum-font-size-75);
     --spectrum-progressbar-line-height-cjk: var(--spectrum-cjk-line-height-100);
     --spectrum-progressbar-min-size: var(--spectrum-progress-bar-minimum-width);
     --spectrum-progressbar-max-size: var(--spectrum-progress-bar-maximum-width);
@@ -68,7 +67,7 @@ governing permissions and limitations under the License.
         --spectrum-component-top-to-text-75
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-progressbar-size-default: var(--spectrum-progressbar-size-2400);
     --spectrum-progressbar-font-size: var(--spectrum-font-size-75);
     --spectrum-progressbar-thickness: var(

--- a/packages/radio/src/Radio.ts
+++ b/packages/radio/src/Radio.ts
@@ -35,7 +35,8 @@ import radioStyles from './radio.css.js';
  * @fires change - When the input is interacted with and its state is changed
  */
 export class Radio extends SizedMixin(
-    FocusVisiblePolyfillMixin(SpectrumElement)
+    FocusVisiblePolyfillMixin(SpectrumElement),
+    { noDefaultSize: true }
 ) {
     public static override get styles(): CSSResultArray {
         return [radioStyles];

--- a/packages/radio/src/spectrum-config.js
+++ b/packages/radio/src/spectrum-config.js
@@ -97,10 +97,11 @@ const config = {
                 converter.classToAttribute('is-invalid', 'invalid'),
                 converter.classToAttribute('is-readOnly', 'readonly'),
                 converter.classToAttribute('spectrum-Radio--emphasized'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Radio--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Radio--sizeS', 's'],
-                        ['spectrum-Radio--sizeM', 'm'],
                         ['spectrum-Radio--sizeL', 'l'],
                         ['spectrum-Radio--sizeXL', 'xl'],
                     ],

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -61,21 +61,6 @@ governing permissions and limitations under the License.
     );
     --spectrum-radio-line-height: var(--spectrum-line-height-100);
     --spectrum-radio-animation-duration: var(--spectrum-animation-duration-100);
-    --spectrum-radio-height: var(--spectrum-component-height-100);
-    --spectrum-radio-button-control-size: var(
-        --spectrum-radio-button-control-size-medium
-    );
-    --spectrum-radio-text-to-control: var(--spectrum-text-to-control-100);
-    --spectrum-radio-label-top-to-text: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-radio-label-bottom-to-text: var(
-        --spectrum-component-bottom-to-text-100
-    );
-    --spectrum-radio-button-top-to-control: var(
-        --spectrum-radio-button-top-to-control-medium
-    );
-    --spectrum-radio-font-size: var(--spectrum-font-size-100);
 }
 :host(:lang(ja)),
 :host(:lang(ko)),
@@ -99,7 +84,7 @@ governing permissions and limitations under the License.
     );
     --spectrum-radio-font-size: var(--spectrum-font-size-75);
 }
-:host([size='m']) {
+:host {
     --spectrum-radio-height: var(--spectrum-component-height-100);
     --spectrum-radio-button-control-size: var(
         --spectrum-radio-button-control-size-medium

--- a/packages/search/src/search.css
+++ b/packages/search/src/search.css
@@ -16,6 +16,18 @@ governing permissions and limitations under the License.
     --mod-textfield-spacing-inline: var(
         --spectrum-alias-infieldbutton-full-height-m
     );
+    --spectrum-icon-tshirt-size-height: var(
+        --spectrum-alias-workflow-icon-size-m
+    );
+    --spectrum-icon-tshirt-size-width: var(
+        --spectrum-alias-workflow-icon-size-m
+    );
+    --spectrum-ui-icon-tshirt-size-height: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-100
+    );
+    --spectrum-ui-icon-tshirt-size-width: var(
+        --spectrum-alias-ui-icon-cornertriangle-size-100
+    );
 }
 
 input::-webkit-search-cancel-button {
@@ -34,21 +46,6 @@ input::-webkit-search-cancel-button {
     );
     --spectrum-ui-icon-tshirt-size-width: var(
         --spectrum-alias-ui-icon-cornertriangle-size-75
-    );
-}
-
-:host([size='m']) {
-    --spectrum-icon-tshirt-size-height: var(
-        --spectrum-alias-workflow-icon-size-m
-    );
-    --spectrum-icon-tshirt-size-width: var(
-        --spectrum-alias-workflow-icon-size-m
-    );
-    --spectrum-ui-icon-tshirt-size-height: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-100
-    );
-    --spectrum-ui-icon-tshirt-size-width: var(
-        --spectrum-alias-ui-icon-cornertriangle-size-100
     );
 }
 
@@ -80,4 +77,18 @@ input::-webkit-search-cancel-button {
     --spectrum-ui-icon-tshirt-size-width: var(
         --spectrum-alias-ui-icon-cornertriangle-size-300
     );
+}
+
+/**
+ * While overriding the need for `size="m"` in SWC, these values correct the
+ * cascade when attempting to delivery the Clear Button within the Search UI.
+ **/
+@media (forced-colors: active) {
+    sp-clear-button {
+        --spectrum-clearbutton-fill-background-color: transparent;
+        --spectrum-clearbutton-fill-background-color-disabled: transparent;
+        --spectrum-clearbutton-fill-background-color-down: transparent;
+        --spectrum-clearbutton-fill-background-color-hover: transparent;
+        --spectrum-clearbutton-fill-background-color-key-focus: transparent;
+    }
 }

--- a/packages/search/src/spectrum-config.js
+++ b/packages/search/src/spectrum-config.js
@@ -36,10 +36,11 @@ const config = {
                 converter.classToAttribute('spectrum-Search--quiet', 'quiet'),
                 converter.classToId('spectrum-Search-clearButton', 'button'),
                 converter.classToId('spectrum-Search-textfield', 'textfield'),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Search--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Search--sizeS', 's'],
-                        ['spectrum-Search--sizeM', 'm'],
                         ['spectrum-Search--sizeL', 'l'],
                         ['spectrum-Search--sizeXL', 'xl'],
                     ],

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -380,7 +380,7 @@ governing permissions and limitations under the License.
         --system-spectrum-search-sizes-edge-to-visual
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-search-border-radius: var(
         --system-spectrum-search-sizem-border-radius
     );

--- a/packages/status-light/src/StatusLight.ts
+++ b/packages/status-light/src/StatusLight.ts
@@ -26,7 +26,9 @@ import statusLightStyles from './status-light.css.js';
  *
  * @slot - text label of the Status Light
  */
-export class StatusLight extends SizedMixin(SpectrumElement) {
+export class StatusLight extends SizedMixin(SpectrumElement, {
+    noDefaultSize: true,
+}) {
     public static override get styles(): CSSResultArray {
         return [statusLightStyles];
     }

--- a/packages/status-light/src/spectrum-config.js
+++ b/packages/status-light/src/spectrum-config.js
@@ -49,10 +49,11 @@ export default {
                     ],
                     'variant'
                 ),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-StatusLight--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-StatusLight--sizeS', 's'],
-                        ['spectrum-StatusLight--sizeM', 'm'],
                         ['spectrum-StatusLight--sizeL', 'l'],
                         ['spectrum-StatusLight--sizeXL', 'xl'],
                     ],

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -120,7 +120,7 @@ governing permissions and limitations under the License.
         --spectrum-component-bottom-to-text-75
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-statuslight-height: var(--spectrum-component-height-100);
     --spectrum-statuslight-dot-size: var(
         --spectrum-status-light-dot-size-medium

--- a/packages/swatch/src/Swatch.ts
+++ b/packages/swatch/src/Swatch.ts
@@ -63,6 +63,7 @@ const dashIcon: Record<string, () => TemplateResult> = {
  */
 export class Swatch extends SizedMixin(Focusable, {
     validSizes: ['xs', 's', 'm', 'l'],
+    noDefaultSize: true,
 }) {
     public static override get styles(): CSSResultArray {
         return [styles, dashStyles];

--- a/packages/swatch/src/SwatchGroup.ts
+++ b/packages/swatch/src/SwatchGroup.ts
@@ -41,6 +41,7 @@ export type SwatchSelects = 'single' | 'multiple' | undefined;
  */
 export class SwatchGroup extends SizedMixin(SpectrumElement, {
     validSizes: ['xs', 's', 'm', 'l'],
+    noDefaultSize: true,
 }) {
     public static override get styles(): CSSResultArray {
         return [styles];
@@ -191,7 +192,7 @@ export class SwatchGroup extends SizedMixin(SpectrumElement, {
         }
         if (
             changes.has('size') &&
-            (this.size || typeof changes.get('size') !== 'undefined')
+            (this.size !== 'm' || typeof changes.get('size') !== 'undefined')
         ) {
             targetValues.size = this.size as SwatchGroupSizes;
         }

--- a/packages/swatch/src/spectrum-config.js
+++ b/packages/swatch/src/spectrum-config.js
@@ -69,11 +69,12 @@ export default {
                     [['spectrum-Swatch--rectangle', 'rectangle']],
                     'shape'
                 ),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Swatch--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Swatch--sizeXS', 'xs'],
                         ['spectrum-Swatch--sizeS', 's'],
-                        ['spectrum-Swatch--sizeM', 'm'],
                         ['spectrum-Swatch--sizeL', 'l'],
                     ],
                     'size'

--- a/packages/swatch/src/spectrum-swatch.css
+++ b/packages/swatch/src/spectrum-swatch.css
@@ -54,7 +54,7 @@ governing permissions and limitations under the License.
         --spectrum-swatch-slash-thickness-small
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-swatch-size: var(--spectrum-swatch-size-medium);
     --spectrum-swatch-disabled-icon-size: var(
         --spectrum-workflow-icon-size-100

--- a/packages/switch/src/spectrum-config.js
+++ b/packages/switch/src/spectrum-config.js
@@ -48,10 +48,11 @@ const config = {
                     hoist: true,
                 },
                 converter.classToHost(),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Switch--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Switch--sizeS', 's'],
-                        ['spectrum-Switch--sizeM', 'm'],
                         ['spectrum-Switch--sizeL', 'l'],
                         ['spectrum-Switch--sizeXL', 'xl'],
                     ],

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -102,7 +102,7 @@ governing permissions and limitations under the License.
     );
     --spectrum-switch-font-size: var(--spectrum-font-size-75);
 }
-:host([size='m']) {
+:host {
     --spectrum-switch-min-height: var(--spectrum-component-height-100);
     --spectrum-switch-control-width: var(
         --spectrum-switch-control-width-medium

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -60,7 +60,7 @@ export interface TableItem extends Record<string, unknown> {
 
 export class Table extends SizedMixin(SpectrumElement, {
     validSizes: ['s', 'm'],
-    defaultSize: 'm',
+    noDefaultSize: true,
 }) {
     public static override get styles(): CSSResultArray {
         return [styles];

--- a/packages/table/src/spectrum-config.js
+++ b/packages/table/src/spectrum-config.js
@@ -31,11 +31,10 @@ const config = {
             fileName: 'table',
             components: [
                 converter.classToHost(),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Table--sizeM'),
                 ...converter.enumerateAttributes(
-                    [
-                        ['spectrum-Table--sizeS', 's'],
-                        ['spectrum-Table--sizeM', 'm'],
-                    ],
+                    [['spectrum-Table--sizeS', 's']],
                     'size'
                 ),
                 ...converter.enumerateAttributes(

--- a/packages/table/src/spectrum-table.css
+++ b/packages/table/src/spectrum-table.css
@@ -341,7 +341,7 @@ governing permissions and limitations under the License.
         var(--spectrum-alias-border-size-thin)
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-table-compact-quiet-border-radius: var(
         --spectrum-table-m-compact-quiet-border-radius,
         var(--spectrum-global-dimension-static-size-0)

--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -74,7 +74,7 @@ export const ScaledIndicator = {
  *
  * @fires change - The selected Tab child has changed.
  */
-export class Tabs extends SizedMixin(Focusable) {
+export class Tabs extends SizedMixin(Focusable, { noDefaultSize: true }) {
     public static override get styles(): CSSResultArray {
         return [tabSizes, tabStyles, ScaledIndicator.baseStyles()];
     }

--- a/packages/tabs/src/spectrum-config.js
+++ b/packages/tabs/src/spectrum-config.js
@@ -272,10 +272,11 @@ const config = {
             outPackage: 'tabs',
             fileName: 'tabs-sizes',
             components: [
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Tabs--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Tabs--sizeS', 's'],
-                        ['spectrum-Tabs--sizeM', 'm'],
                         ['spectrum-Tabs--sizeL', 'l'],
                         ['spectrum-Tabs--sizeXL', 'xl'],
                     ],

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -34,6 +34,7 @@ import styles from './tag.css.js';
  */
 export class Tag extends SizedMixin(SpectrumElement, {
     validSizes: ['s', 'm', 'l'],
+    noDefaultSize: true,
 }) {
     public static override get styles(): CSSResultArray {
         return [styles];

--- a/packages/tags/src/spectrum-config.js
+++ b/packages/tags/src/spectrum-config.js
@@ -66,10 +66,11 @@ const config = {
                     'spectrum-Tag--removable',
                     'deletable'
                 ),
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Tag--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Tag--sizeS', 's'],
-                        ['spectrum-Tag--sizeM', 'm'],
                         ['spectrum-Tag--sizeL', 'l'],
                     ],
                     'size'

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -98,34 +98,6 @@ governing permissions and limitations under the License.
     --spectrum-tag-content-color-disabled: var(
         --spectrum-disabled-content-color
     );
-    --spectrum-tag-icon-spacing-inline-end: var(--spectrum-text-to-visual-100);
-    --spectrum-tag-icon-size: var(--spectrum-workflow-icon-size-100);
-    --spectrum-tag-icon-spacing-block-start: var(
-        --spectrum-component-top-to-workflow-icon-100
-    );
-    --spectrum-tag-icon-spacing-block-end: var(
-        --spectrum-component-top-to-workflow-icon-100
-    );
-    --spectrum-tag-avatar-spacing-block-start: var(
-        --spectrum-tag-top-to-avatar-medium
-    );
-    --spectrum-tag-avatar-spacing-block-end: var(
-        --spectrum-tag-top-to-avatar-medium
-    );
-    --spectrum-tag-avatar-spacing-inline-end: var(
-        --spectrum-text-to-visual-100
-    );
-    --spectrum-tag-label-spacing-block: var(
-        --spectrum-component-top-to-text-100
-    );
-    --spectrum-tag-clear-button-spacing-inline-start: var(
-        --spectrum-text-to-visual-100
-    );
-    --spectrum-tag-height: var(--spectrum-component-height-100);
-    --spectrum-tag-font-size: var(--spectrum-font-size-100);
-    --spectrum-tag-clear-button-spacing-block: var(
-        --spectrum-tag-top-to-cross-icon-medium
-    );
 }
 :host([size='s']) {
     --spectrum-tag-height: var(--spectrum-component-height-75);
@@ -165,7 +137,7 @@ governing permissions and limitations under the License.
         --spectrum-tag-size-small-clear-button-spacing-inline-end
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-tag-height: var(--spectrum-component-height-100);
     --spectrum-tag-font-size: var(--spectrum-font-size-100);
     --spectrum-tag-icon-size: var(--spectrum-workflow-icon-size-100);

--- a/packages/textfield/src/spectrum-config.js
+++ b/packages/textfield/src/spectrum-config.js
@@ -43,10 +43,11 @@ export default {
                     ],
                     hoist: false,
                 },
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Textfield--sizeM'),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Textfield--sizeS', 's'],
-                        ['spectrum-Textfield--sizeM', 'm'],
                         ['spectrum-Textfield--sizeL', 'l'],
                         ['spectrum-Textfield--sizeXL', 'xl'],
                     ],

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -20,10 +20,6 @@ governing permissions and limitations under the License.
         --spectrum-text-field-minimum-width-multiplier
     );
     --spectrum-textfield-corner-radius: var(--spectrum-corner-radius-100);
-    --spectrum-textfield-height: var(--spectrum-component-height-100);
-    --spectrum-textfield-spacing-inline: var(
-        --spectrum-component-edge-to-text-100
-    );
     --spectrum-textfield-spacing-inline-quiet: var(
         --spectrum-field-edge-to-text-quiet
     );
@@ -39,68 +35,34 @@ governing permissions and limitations under the License.
     --spectrum-textfield-label-spacing-block: var(
         --spectrum-field-label-to-component
     );
-    --spectrum-textfield-label-spacing-block-quiet: var(
-        --spectrum-field-label-to-component-quiet-medium
-    );
     --spectrum-textfield-label-spacing-inline-side-label: var(
         --spectrum-spacing-100
     );
     --spectrum-textfield-helptext-spacing-block: var(
         --spectrum-help-text-to-component
     );
-    --spectrum-textfield-icon-size-invalid: var(
-        --spectrum-workflow-icon-size-100
-    );
-    --spectrum-textfield-icon-spacing-inline-start-invalid: var(
-        --spectrum-field-text-to-alert-icon-medium
-    );
-    --spectrum-textfield-icon-spacing-inline-end-invalid: var(
-        --spectrum-field-edge-to-alert-icon-medium
-    );
     --spectrum-textfield-icon-spacing-inline-end-quiet-invalid: var(
         --spectrum-field-edge-to-alert-icon-quiet
     );
-    --spectrum-textfield-icon-spacing-block-invalid: var(
-        --spectrum-field-top-to-alert-icon-medium
-    );
-    --spectrum-textfield-icon-spacing-inline-start-valid: var(
-        --spectrum-field-text-to-validation-icon-medium
-    );
-    --spectrum-textfield-icon-spacing-inline-end-valid: var(
-        --spectrum-field-edge-to-validation-icon-medium
-    );
     --spectrum-textfield-icon-spacing-inline-end-quiet-valid: var(
         --spectrum-field-edge-to-validation-icon-quiet
-    );
-    --spectrum-textfield-icon-spacing-block-valid: var(
-        --spectrum-field-top-to-validation-icon-medium
     );
     --spectrum-textfield-icon-spacing-inline-end-override: 32px;
     --spectrum-Textfield-workflow-icon-width: 18px;
     --spectrum-Textfield-workflow-icon-gap: 6px;
     --spectrum-textfield-font-family: var(--spectrum-sans-font-family-stack);
     --spectrum-textfield-font-weight: var(--spectrum-regular-font-weight);
-    --spectrum-textfield-placeholder-font-size: var(--spectrum-font-size-100);
     --spectrum-textfield-character-count-font-family: var(
         --spectrum-sans-font-family-stack
     );
     --spectrum-textfield-character-count-font-weight: var(
         --spectrum-regular-font-weight
     );
-    --spectrum-textfield-character-count-font-size: var(
-        --spectrum-font-size-75
-    );
     --spectrum-textfield-character-count-spacing-inline: var(
         --spectrum-spacing-200
     );
-    --spectrum-textfield-character-count-spacing-block: var(
-        --spectrum-component-bottom-to-text-75
-    );
     --spectrum-textfield-character-count-spacing-inline-side: var(
         --spectrum-side-label-character-count-to-field
-    );
-    --spectrum-textfield-character-count-spacing-block-side: var(
-        --spectrum-side-label-character-count-top-margin-medium
     );
     --spectrum-textfield-focus-indicator-width: var(
         --spectrum-focus-indicator-thickness
@@ -172,9 +134,6 @@ governing permissions and limitations under the License.
     --spectrum-text-area-min-block-size: var(
         --spectrum-text-area-minimum-height
     );
-    --spectrum-text-area-min-block-size-quiet: var(
-        --spectrum-component-height-100
-    );
 }
 :host([size='s']) {
     --spectrum-textfield-height: var(--spectrum-component-height-75);
@@ -225,7 +184,7 @@ governing permissions and limitations under the License.
         --spectrum-component-height-75
     );
 }
-:host([size='m']) {
+:host {
     --spectrum-textfield-height: var(--spectrum-component-height-100);
     --spectrum-textfield-label-spacing-block-quiet: var(
         --spectrum-field-label-to-component-quiet-medium

--- a/tools/styles/tokens/global-vars.css
+++ b/tools/styles/tokens/global-vars.css
@@ -254,7 +254,6 @@
     --spectrum-progress-bar-maximum-width: 768px;
     --spectrum-meter-minimum-width: 48px;
     --spectrum-meter-maximum-width: 768px;
-    --spectrum-meter-default-width: var(--spectrum-meter-width);
     --spectrum-in-line-alert-minimum-width: 240px;
     --spectrum-popover-tip-width: 16px;
     --spectrum-popover-tip-height: 8px;

--- a/tools/styles/tokens/large-vars.css
+++ b/tools/styles/tokens/large-vars.css
@@ -57,7 +57,7 @@
     --spectrum-progress-bar-thickness-medium: 8px;
     --spectrum-progress-bar-thickness-large: 10px;
     --spectrum-progress-bar-thickness-extra-large: 13px;
-    --spectrum-meter-width: 240px;
+    --spectrum-meter-default-width: 240px;
     --spectrum-meter-thickness-small: 5px;
     --spectrum-meter-thickness-large: 8px;
     --spectrum-tag-top-to-avatar-small: 5px;
@@ -154,12 +154,9 @@
         --spectrum-heading-cjk-size-s
     );
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-xs);
-    --spectrum-coach-mark-width: 216px;
-    --spectrum-coach-mark-minimum-width: 216px;
-    --spectrum-coach-mark-maximum-width: 248px;
+    --spectrum-coach-mark-minimum-width: 208px;
     --spectrum-coach-mark-edge-to-content: var(--spectrum-spacing-300);
     --spectrum-coach-mark-pagination-text-to-bottom-edge: 22px;
-    --spectrum-coach-mark-media-height: 162px;
     --spectrum-coach-mark-media-minimum-height: 121px;
     --spectrum-coach-mark-title-size: var(--spectrum-heading-size-xxs);
     --spectrum-coach-mark-body-size: var(--spectrum-body-size-xs);

--- a/tools/styles/tokens/medium-vars.css
+++ b/tools/styles/tokens/medium-vars.css
@@ -57,7 +57,7 @@
     --spectrum-progress-bar-thickness-medium: 6px;
     --spectrum-progress-bar-thickness-large: 8px;
     --spectrum-progress-bar-thickness-extra-large: 10px;
-    --spectrum-meter-width: 192px;
+    --spectrum-meter-default-width: 192px;
     --spectrum-meter-thickness-small: 4px;
     --spectrum-meter-thickness-large: 6px;
     --spectrum-tag-top-to-avatar-small: 4px;
@@ -154,16 +154,10 @@
         --spectrum-heading-cjk-size-m
     );
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-s);
-    --spectrum-coach-mark-width: 296px;
     --spectrum-coach-mark-minimum-width: 296px;
-    --spectrum-coach-mark-maximum-width: 380px;
     --spectrum-coach-mark-edge-to-content: var(--spectrum-spacing-400);
     --spectrum-coach-mark-pagination-text-to-bottom-edge: 33px;
-    --spectrum-coach-mark-media-height: 222px;
     --spectrum-coach-mark-media-minimum-height: 166px;
-    --spectrum-coach-mark-title-size: var(--spectrum-heading-size-xs);
-    --spectrum-coach-mark-body-size: var(--spectrum-body-size-s);
-    --spectrum-coach-mark-pagination-body-size: var(--spectrum-body-size-s);
     --spectrum-accordion-top-to-text-compact-small: 2px;
     --spectrum-accordion-top-to-text-regular-small: 5px;
     --spectrum-accordion-small-top-to-text-spacious: 9px;

--- a/tools/styles/tokens/spectrum/custom-large-vars.css
+++ b/tools/styles/tokens/spectrum/custom-large-vars.css
@@ -51,7 +51,4 @@
     --spectrum-sidenav-heading-top-margin: 30px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is updated */
     --spectrum-sidenav-heading-bottom-margin: 10px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is added */
     --spectrum-sidenav-bottom-to-label: 10px; /* TODO replace with updated var(--spectrum-component-bottom-to-text-100); */
-
-    --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
-    --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
 }

--- a/tools/styles/tokens/spectrum/custom-medium-vars.css
+++ b/tools/styles/tokens/spectrum/custom-medium-vars.css
@@ -51,7 +51,4 @@
     --spectrum-sidenav-heading-top-margin: 24px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is updated */
     --spectrum-sidenav-heading-bottom-margin: 8px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is added */
     --spectrum-sidenav-bottom-to-label: 8px; /* TODO replace with updated var(--spectrum-component-bottom-to-text-100); */
-
-    --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
-    --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
 }


### PR DESCRIPTION
## Description
Use CSS processing to hoist medium t-shirt size values onto the naked `:host`.

## Motivation and context
Increased rendering perf.

## How has this been tested?
-   [ ] _Test case 1_
    1. Running CI now
    2. Hopefully VRTs pass just fine 🤞🏼 
-   [ ] _Test case 2_
    1. Tachometer benchmarks will publish below
    3. Hopefully they all show the ~3% perf boost I saw locally

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.