### PR TITLE
fix(action-menu,split-button): ensure toggling the Menu closed completes

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -74,6 +74,8 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
                 class="button"
                 size=${this.size}
                 @blur=${this.handleButtonBlur}
+                @pointerdown=${this.handleButtonPointerdown}
+                @focus=${this.handleButtonFocus}
                 @click=${this.handleButtonClick}
                 @keydown=${{
                     handleEvent: this.handleEnterKeydown,

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -551,5 +551,45 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
 
             expect(openSpy.callCount).to.equal(2);
         });
+        it('opens, then closes, on subsequent clicks', async () => {
+            const el = await actionMenuFixture();
+            const rect = el.getBoundingClientRect();
+
+            const open = oneEvent(el, 'sp-opened');
+            sendMouse({
+                steps: [
+                    {
+                        position: [
+                            rect.left + rect.width / 2,
+                            rect.top + rect.height / 2,
+                        ],
+                        type: 'click',
+                    },
+                ],
+            });
+            await open;
+
+            expect(el.open).to.be.true;
+            await aTimeout(50);
+            expect(el.open).to.be.true;
+
+            const close = oneEvent(el, 'sp-closed');
+            sendMouse({
+                steps: [
+                    {
+                        position: [
+                            rect.left + rect.width / 2,
+                            rect.top + rect.height / 2,
+                        ],
+                        type: 'click',
+                    },
+                ],
+            });
+            await close;
+
+            expect(el.open).to.be.false;
+            await aTimeout(50);
+            expect(el.open).to.be.false;
+        });
     });
 };

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -153,7 +153,7 @@ export class PickerBase extends SizedMixin(Focusable) {
 
     protected preventNextToggle: 'no' | 'maybe' | 'yes' = 'no';
 
-    protected handlebuttonPointerdown(): void {
+    protected handleButtonPointerdown(): void {
         this.preventNextToggle = 'maybe';
         const cleanup = (): void => {
             document.removeEventListener('pointerup', cleanup);
@@ -433,7 +433,7 @@ export class PickerBase extends SizedMixin(Focusable) {
                 id="button"
                 class="button"
                 @blur=${this.handleButtonBlur}
-                @pointerdown=${this.handlebuttonPointerdown}
+                @pointerdown=${this.handleButtonPointerdown}
                 @focus=${this.handleButtonFocus}
                 @click=${this.handleButtonClick}
                 @keydown=${{

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -142,6 +142,8 @@ export class SplitButton extends SizedMixin(PickerBase) {
                     aria-controls=${ifDefined(this.open ? 'menu' : undefined)}
                     class="button trigger ${this.variant}"
                     @blur=${this.handleButtonBlur}
+                    @pointerdown=${this.handleButtonPointerdown}
+                    @focus=${this.handleButtonFocus}
                     @click=${this.handleButtonClick}
                     @keydown=${{
                         handleEvent: this.handleEnterKeydown,

--- a/packages/split-button/test/index.ts
+++ b/packages/split-button/test/index.ts
@@ -11,9 +11,9 @@ governing permissions and limitations under the License.
 */
 
 import {
+    aTimeout,
     elementUpdated,
     expect,
-    fixture,
     nextFrame,
     oneEvent,
 } from '@open-wc/testing';
@@ -32,6 +32,8 @@ import moreDefaults, {
 import type { Button } from '@spectrum-web-components/button';
 import type { MenuItem } from '@spectrum-web-components/menu';
 import type { SplitButton } from '@spectrum-web-components/split-button';
+import { sendMouse } from '../../../test/plugins/browser.js';
+import { fixture } from '../../../test/testing-helpers.js';
 
 export function runSplitButtonTests(
     wrapInDiv: (storyArgument: TemplateResult) => TemplateResult,
@@ -233,6 +235,61 @@ export function runSplitButtonTests(
         expect(trigger).to.have.attribute('aria-expanded', 'false');
         expect(trigger).not.to.have.attribute('aria-controls');
     });
+
+    it('[type="field"] opens, then closes, on subsequent clicks', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(
+                field({
+                    ...fieldDefaults.args,
+                    ...field.args,
+                })
+            )
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+
+        const { trigger } = el as unknown as { trigger: HTMLButtonElement };
+        const rect = trigger.getBoundingClientRect();
+
+        const open = oneEvent(el, 'sp-opened');
+        sendMouse({
+            steps: [
+                {
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                    type: 'click',
+                },
+            ],
+        });
+        await open;
+
+        expect(el.open).to.be.true;
+        await aTimeout(50);
+        expect(el.open).to.be.true;
+
+        const close = oneEvent(el, 'sp-closed');
+        sendMouse({
+            steps: [
+                {
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                    type: 'click',
+                },
+            ],
+        });
+        await close;
+
+        expect(el.open).to.be.false;
+        await aTimeout(50);
+        expect(el.open).to.be.false;
+    });
+
     it('[type="more"] toggles open/close multiple time', async () => {
         const test = await fixture<HTMLDivElement>(
             wrapInDiv(more({ ...moreDefaults.args, ...more.args }))
@@ -279,6 +336,56 @@ export function runSplitButtonTests(
         expect(trigger).to.have.attribute('aria-expanded', 'false');
         expect(trigger).not.to.have.attribute('aria-controls');
     });
+
+    it('[type="more"] opens, then closes, on subsequent clicks', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(more({ ...moreDefaults.args, ...more.args }))
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+
+        const { trigger } = el as unknown as { trigger: HTMLButtonElement };
+        const rect = trigger.getBoundingClientRect();
+
+        const open = oneEvent(el, 'sp-opened');
+        sendMouse({
+            steps: [
+                {
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                    type: 'click',
+                },
+            ],
+        });
+        await open;
+
+        expect(el.open).to.be.true;
+        await aTimeout(50);
+        expect(el.open).to.be.true;
+
+        const close = oneEvent(el, 'sp-closed');
+        sendMouse({
+            steps: [
+                {
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                    type: 'click',
+                },
+            ],
+        });
+        await close;
+
+        expect(el.open).to.be.false;
+        await aTimeout(50);
+        expect(el.open).to.be.false;
+    });
+
     it('receives "focus()"', async () => {
         const test = await fixture<HTMLDivElement>(
             wrapInDiv(


### PR DESCRIPTION
## Description
Some event listeners in Picker were not correctly bound in its class extensions Action Menu and Split Button. This caused their respective Menu to stay open when clicking to close them.

Correctly binds the event listeners to the derivative classes.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://action-menu-overlay--spectrum-web-components.netlify.app/storybook/?path=/story/split-button-accent-field--s)
    2. Click on a "carat"
    3. See that the Menu opens
    4. Click the "carat" again
    5. See that the Menu closes
-   [ ] _Test case 2_
    1. Go [here](https://action-menu-overlay--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--default)
    2. Click the Action Button
    3. See that the Menu opens
    4. Click the Action Button again
    5. See that the Menu closes

## Screenshots (if appropriate)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.