### PR TITLE
test: update timing and naming for clarity and stability

### DIFF
--- a/tools/reactive-controllers/test/element-resolution.test.ts
+++ b/tools/reactive-controllers/test/element-resolution.test.ts
@@ -14,8 +14,8 @@ import { html, LitElement } from 'lit';
 import { elementUpdated, expect, fixture } from '@open-wc/testing';
 import { ElementResolutionController } from '@spectrum-web-components/reactive-controllers/src/ElementResolution.js';
 
-describe('Match Media', () => {
-    it('responds to media changes', async () => {
+describe('Element Resolution', () => {
+    it('responds to DOM changes', async () => {
         class TestEl extends LitElement {}
         if (!customElements.get('test-element-resolution-el')) {
             customElements.define('test-element-resolution-el', TestEl);

--- a/tools/reactive-controllers/test/match-media.test.ts
+++ b/tools/reactive-controllers/test/match-media.test.ts
@@ -29,9 +29,14 @@ describe('Match Media', () => {
             el as LitElement & { shadowRoot: ShadowRoot },
             '(min-width: 500px)'
         );
+        // Allow Controller to initialize
+        await nextFrame();
+        await nextFrame();
         expect(controller.matches).to.be.true;
+
         await setViewport({ width: 360, height: 640 });
         // Allow viewport update to propagate.
+        await nextFrame();
         await nextFrame();
         expect(controller.matches).to.be.false;
     });


### PR DESCRIPTION
## Description
The "responds to media changes" test has been flaky as of late: https://app.circleci.com/insights/github/adobe/spectrum-web-components/workflows/build/tests this attempts to resolve that with some extra frame between configuration and tests.

Also, I discovered that the test name was used in multiple locations, so I corrected the non-related test to have a more accurate name.

## How has this been tested?
-   [ ] _Test case 1_
    1. CI stability increases?

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.