### PR TITLE
fix(radio-group): onChange event not triggering on keyboard navigation

### DIFF
--- a/packages/radio/src/RadioGroup.ts
+++ b/packages/radio/src/RadioGroup.ts
@@ -52,7 +52,7 @@ export class RadioGroup extends FocusVisiblePolyfillMixin(FieldGroup) {
             });
         },
         elementEnterAction: (el: Radio) => {
-            this.selected = el.value;
+            this._setSelected(el.value);
         },
         elements: () => this.buttons,
         isFocusableElement: (el: Radio) => !el.disabled,

--- a/packages/radio/test/radio-group.test.ts
+++ b/packages/radio/test/radio-group.test.ts
@@ -666,4 +666,33 @@ describe('Radio Group - late children', () => {
         expect(group.buttons.length).to.equal(4);
         expect(group.selected).to.equal('first');
     });
+    it('emits change events on arrow key events', async () => {
+        const changeSpy = spy();
+        const onChange = (event: Event & { target: RadioGroup }): void => {
+            changeSpy(event.target.selected);
+        };
+        const el = await fixture<RadioGroup>(html`
+            <sp-radio-group @change=${onChange}>
+                <sp-radio value="bulbasaur">Bulbasaur</sp-radio>
+                <sp-radio value="squirtle">Squirtle</sp-radio>
+                <sp-radio value="charmander">Charmander</sp-radio>
+            </sp-radio-group>
+        `);
+        const bulbasaur = el.querySelector('[value="bulbasaur"]') as Radio;
+        const squirtle = el.querySelector('[value="squirtle"]') as Radio;
+
+        bulbasaur.focus();
+        await elementUpdated(el);
+        expect(changeSpy.callCount).to.equal(0);
+
+        el.dispatchEvent(arrowRightEvent());
+        await elementUpdated(el);
+        expect(changeSpy.callCount).to.equal(1);
+        expect(document.activeElement === squirtle).to.be.true;
+
+        el.dispatchEvent(arrowLeftEvent());
+        await elementUpdated(el);
+        expect(changeSpy.callCount).to.equal(2);
+        expect(document.activeElement === bulbasaur).to.be.true;
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added onChange trigger when radio buttons are navigated via keyboard in a radio-group
<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/3262

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
