### PR TITLE
refactor: replace nothing with falsy values 

### DIFF
--- a/packages/action-group/stories/action-group-tooltip.stories.ts
+++ b/packages/action-group/stories/action-group-tooltip.stories.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import { html, nothing, TemplateResult } from '@spectrum-web-components/base';
 import { spreadProps } from '../../../test/lit-helpers.js';
 
 import '@spectrum-web-components/action-group/sp-action-group.js';
@@ -182,7 +182,7 @@ const template = (args: Properties): TemplateResult => {
             ? html`
                   <div>Selected:</div>
               `
-            : html``}
+            : nothing}
     `;
 };
 

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import { html, nothing, TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/icon/sp-icon.js';
@@ -39,12 +39,12 @@ export const ActionMenuMarkup = ({
             .selects=${selects ? selects : undefined}
             value=${selected ? 'Select Inverse' : ''}
         >
-            ${customIcon ? customIcon : html``}
+            ${customIcon ? customIcon : nothing}
             ${visibleLabel
                 ? html`
                       <span slot="label">${visibleLabel}</span>
                   `
-                : html``}
+                : nothing}
             <sp-menu-item>Deselect</sp-menu-item>
             <sp-menu-item ?selected=${selected}>Select Inverse</sp-menu-item>
             <sp-menu-item>Feather...</sp-menu-item>

--- a/packages/badge/src/Badge.ts
+++ b/packages/badge/src/Badge.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     SizedMixin,
     SpectrumElement,
     TemplateResult,
@@ -120,7 +121,7 @@ export class Badge extends SizedMixin(
                           ?icon-only=${!this.slotHasContent}
                       ></slot>
                   `
-                : html``}
+                : nothing}
             <div class="label">
                 <slot></slot>
             </div>

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SizedMixin,
     SpectrumElement,
@@ -276,7 +277,7 @@ export class Card extends LikeAnchor(
                     ${this.renderHeading}
                     ${this.variant === 'gallery'
                         ? this.renderSubtitleAndDescription
-                        : html``}
+                        : nothing}
                     ${this.variant !== 'quiet' || this.size !== 's'
                         ? html`
                               <div
@@ -286,7 +287,7 @@ export class Card extends LikeAnchor(
                                   <slot name="actions"></slot>
                               </div>
                           `
-                        : html``}
+                        : nothing}
                 </div>
                 ${this.variant !== 'gallery'
                     ? html`
@@ -294,19 +295,19 @@ export class Card extends LikeAnchor(
                               ${this.renderSubtitleAndDescription}
                           </div>
                       `
-                    : html``}
+                    : nothing}
             </div>
             ${this.href
                 ? this.renderAnchor({
                       id: 'like-anchor',
                       labelledby: 'heading',
                   })
-                : html``}
+                : nothing}
             ${this.variant === 'standard'
                 ? html`
                       <slot name="footer"></slot>
                   `
-                : html``}
+                : nothing}
             ${this.toggles
                 ? html`
                       <sp-quick-actions
@@ -321,7 +322,7 @@ export class Card extends LikeAnchor(
                           ></sp-checkbox>
                       </sp-quick-actions>
                   `
-                : html``}
+                : nothing}
             ${this.variant === 'quiet' && this.size === 's'
                 ? html`
                       <sp-quick-actions
@@ -331,7 +332,7 @@ export class Card extends LikeAnchor(
                           <slot name="actions"></slot>
                       </sp-quick-actions>
                   `
-                : html``}
+                : nothing}
         `;
     }
 

--- a/packages/dialog/src/DialogBase.ts
+++ b/packages/dialog/src/DialogBase.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SpectrumElement,
     TemplateResult,
@@ -23,7 +24,7 @@ import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
 // Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
-import '@spectrum-web-components/dialog/sp-dialog.js'
+import '@spectrum-web-components/dialog/sp-dialog.js';
 import modalWrapperStyles from '@spectrum-web-components/modal/src/modal-wrapper.css.js';
 import modalStyles from '@spectrum-web-components/modal/src/modal.css.js';
 import { Dialog } from './Dialog.js';
@@ -176,7 +177,7 @@ export class DialogBase extends FocusVisiblePolyfillMixin(SpectrumElement) {
                           @transitionend=${this.handleUnderlayTransitionend}
                       ></sp-underlay>
                   `
-                : html``}
+                : nothing}
             <div
                 class="modal ${this.mode}"
                 @transitionend=${this.handleModalTransitionend}

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
@@ -22,7 +23,7 @@ import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
 // Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
-import '@spectrum-web-components/dialog/sp-dialog.js'
+import '@spectrum-web-components/dialog/sp-dialog.js';
 import { DialogBase } from './DialogBase.js';
 import { Dialog } from './Dialog.js';
 
@@ -141,7 +142,7 @@ export class DialogWrapper extends DialogBase {
                               )}
                           />
                       `
-                    : html``}
+                    : nothing}
                 ${this.headline
                     ? html`
                           <h2
@@ -151,13 +152,13 @@ export class DialogWrapper extends DialogBase {
                               ${this.headline}
                           </h2>
                       `
-                    : html``}
+                    : nothing}
                 <slot></slot>
                 ${this.footer
                     ? html`
                           <div slot="footer">${this.footer}</div>
                       `
-                    : html``}
+                    : nothing}
                 ${this.cancelLabel
                     ? html`
                           <sp-button
@@ -169,7 +170,7 @@ export class DialogWrapper extends DialogBase {
                               ${this.cancelLabel}
                           </sp-button>
                       `
-                    : html``}
+                    : nothing}
                 ${this.secondaryLabel
                     ? html`
                           <sp-button
@@ -181,7 +182,7 @@ export class DialogWrapper extends DialogBase {
                               ${this.secondaryLabel}
                           </sp-button>
                       `
-                    : html``}
+                    : nothing}
                 ${this.confirmLabel
                     ? html`
                           <sp-button
@@ -192,7 +193,7 @@ export class DialogWrapper extends DialogBase {
                               ${this.confirmLabel}
                           </sp-button>
                       `
-                    : html``}
+                    : nothing}
             </sp-dialog>
         `;
     }


### PR DESCRIPTION
As mentioned in the lit doc:
Prefer using nothing over other falsy values as it provides a consistent behavior between various expression binding contexts. 

Replaced empty html`` tag with nothing

doc: https://lit.dev/docs/api/templates/#nothing
## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
