### PR TITLE
refactor: replace html`` with nothing

### DIFF
--- a/packages/action-group/stories/action-group-tooltip.stories.ts
+++ b/packages/action-group/stories/action-group-tooltip.stories.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import {
     html,
+    nothing,
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -187,7 +188,7 @@ const template = (args: Properties): TemplateResult => {
             ? html`
                   <div>Selected:</div>
               `
-            : html``}
+            : nothing}
     `;
 };
 

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import { html, nothing, TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/icon/sp-icon.js';
@@ -42,12 +42,12 @@ export const ActionMenuMarkup = ({
             .selects=${selects ? selects : undefined}
             value=${selected ? 'Select Inverse' : ''}
         >
-            ${customIcon ? customIcon : html``}
+            ${customIcon ? customIcon : nothing}
             ${visibleLabel
                 ? html`
                       <span slot="label">${visibleLabel}</span>
                   `
-                : html``}
+                : nothing}
             <sp-menu-item>Deselect</sp-menu-item>
             <sp-menu-item ?selected=${selected}>Select Inverse</sp-menu-item>
             <sp-menu-item>Feather...</sp-menu-item>

--- a/packages/badge/src/Badge.ts
+++ b/packages/badge/src/Badge.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     SizedMixin,
     SpectrumElement,
     TemplateResult,
@@ -120,7 +121,7 @@ export class Badge extends SizedMixin(
                           ?icon-only=${!this.slotHasContent}
                       ></slot>
                   `
-                : html``}
+                : nothing}
             <div class="label">
                 <slot></slot>
             </div>

--- a/packages/card/src/Card.ts
+++ b/packages/card/src/Card.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SizedMixin,
     SpectrumElement,
@@ -225,7 +226,7 @@ export class Card extends LikeAnchor(
                 ? html`
                       <sp-divider size="s"></sp-divider>
                   `
-                : html``}
+                : nothing}
         `;
     }
 
@@ -238,7 +239,7 @@ export class Card extends LikeAnchor(
                 ? html`
                       <sp-divider size="s"></sp-divider>
                   `
-                : html``}
+                : nothing}
         `;
     }
 
@@ -276,7 +277,7 @@ export class Card extends LikeAnchor(
                     ${this.renderHeading}
                     ${this.variant === 'gallery'
                         ? this.renderSubtitleAndDescription
-                        : html``}
+                        : nothing}
                     ${this.variant !== 'quiet' || this.size !== 's'
                         ? html`
                               <div
@@ -286,7 +287,7 @@ export class Card extends LikeAnchor(
                                   <slot name="actions"></slot>
                               </div>
                           `
-                        : html``}
+                        : nothing}
                 </div>
                 ${this.variant !== 'gallery'
                     ? html`
@@ -294,19 +295,19 @@ export class Card extends LikeAnchor(
                               ${this.renderSubtitleAndDescription}
                           </div>
                       `
-                    : html``}
+                    : nothing}
             </div>
             ${this.href
                 ? this.renderAnchor({
                       id: 'like-anchor',
                       labelledby: 'heading',
                   })
-                : html``}
+                : nothing}
             ${this.variant === 'standard'
                 ? html`
                       <slot name="footer"></slot>
                   `
-                : html``}
+                : nothing}
             ${this.toggles
                 ? html`
                       <sp-quick-actions
@@ -321,7 +322,7 @@ export class Card extends LikeAnchor(
                           ></sp-checkbox>
                       </sp-quick-actions>
                   `
-                : html``}
+                : nothing}
             ${this.variant === 'quiet' && this.size === 's'
                 ? html`
                       <sp-quick-actions
@@ -331,7 +332,7 @@ export class Card extends LikeAnchor(
                           <slot name="actions"></slot>
                       </sp-quick-actions>
                   `
-                : html``}
+                : nothing}
         `;
     }
 

--- a/packages/dialog/src/DialogBase.ts
+++ b/packages/dialog/src/DialogBase.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SpectrumElement,
     TemplateResult,
@@ -188,7 +189,7 @@ export class DialogBase extends FocusVisiblePolyfillMixin(SpectrumElement) {
                           @transitioncancel=${this.handleTransitionEvent}
                       ></sp-underlay>
                   `
-                : html``}
+                : nothing}
             <div
                 class="modal ${this.mode}"
                 @transitionrun=${this.handleTransitionEvent}

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
@@ -22,7 +23,7 @@ import '@spectrum-web-components/underlay/sp-underlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 
 // Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
-import '@spectrum-web-components/dialog/sp-dialog.js'
+import '@spectrum-web-components/dialog/sp-dialog.js';
 import { DialogBase } from './DialogBase.js';
 import { Dialog } from './Dialog.js';
 
@@ -141,7 +142,7 @@ export class DialogWrapper extends DialogBase {
                               )}
                           />
                       `
-                    : html``}
+                    : nothing}
                 ${this.headline
                     ? html`
                           <h2
@@ -151,13 +152,13 @@ export class DialogWrapper extends DialogBase {
                               ${this.headline}
                           </h2>
                       `
-                    : html``}
+                    : nothing}
                 <slot></slot>
                 ${this.footer
                     ? html`
                           <div slot="footer">${this.footer}</div>
                       `
-                    : html``}
+                    : nothing}
                 ${this.cancelLabel
                     ? html`
                           <sp-button
@@ -169,7 +170,7 @@ export class DialogWrapper extends DialogBase {
                               ${this.cancelLabel}
                           </sp-button>
                       `
-                    : html``}
+                    : nothing}
                 ${this.secondaryLabel
                     ? html`
                           <sp-button
@@ -181,7 +182,7 @@ export class DialogWrapper extends DialogBase {
                               ${this.secondaryLabel}
                           </sp-button>
                       `
-                    : html``}
+                    : nothing}
                 ${this.confirmLabel
                     ? html`
                           <sp-button
@@ -192,7 +193,7 @@ export class DialogWrapper extends DialogBase {
                               ${this.confirmLabel}
                           </sp-button>
                       `
-                    : html``}
+                    : nothing}
             </sp-dialog>
         `;
     }

--- a/packages/field-label/src/FieldLabel.ts
+++ b/packages/field-label/src/FieldLabel.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SizedMixin,
     SpectrumElement,
@@ -155,7 +156,7 @@ export class FieldLabel extends SizedMixin(SpectrumElement) {
                               class="required-icon spectrum-UIIcon-Asterisk100"
                           ></sp-icon-asterisk100>
                       `
-                    : html``}
+                    : nothing}
             </label>
         `;
     }

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -310,7 +311,7 @@ export class MenuItem extends LikeAnchor(
                               : ''}"
                       ></sp-icon-checkmark100>
                   `
-                : html``}
+                : nothing}
             <slot name="icon"></slot>
             <div id="label">
                 <slot id="slot"></slot>
@@ -322,7 +323,7 @@ export class MenuItem extends LikeAnchor(
                       ariaHidden: true,
                       className: 'button anchor hidden',
                   })
-                : html``}
+                : nothing}
             ${this.renderSubmenu()}
         `;
     }

--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SizedMixin,
     SpectrumElement,
@@ -72,7 +73,7 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, '')) {
     protected override render(): TemplateResult {
         return html`
             <sp-field-label size=${this.size} class="label">
-                ${this.slotHasContent ? html`` : this.label}
+                ${this.slotHasContent ? nothing : this.label}
                 <slot @slotchange=${this.handleSlotchange}>${this.label}</slot>
             </sp-field-label>
             <sp-field-label size=${this.size} class="percentage">

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -561,7 +562,7 @@ export class NumberField extends TextfieldBase {
         return html`
             ${super.renderField()}
             ${this.hideStepper
-                ? html``
+                ? nothing
                 : html`
                       <span
                           class="buttons"

--- a/packages/picker-button/stories/index.ts
+++ b/packages/picker-button/stories/index.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import { html, nothing, TemplateResult } from '@spectrum-web-components/base';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
 export type StoryArgs = {
@@ -46,14 +46,14 @@ export const Template = ({
             ?rounded=${rounded}
             size=${size}
         >
-            ${icon ? icon : html``}
+            ${icon ? icon : nothing}
             ${label
                 ? html`
                       <span slot="label">
                           ${typeof label === 'string' ? label : 'All'}
                       </span>
                   `
-                : html``}
+                : nothing}
         </sp-picker-button>
     `;
 };

--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SizedMixin,
     SpectrumElement,
@@ -77,7 +78,7 @@ export class ProgressBar extends SizedMixin(
             ${this.label
                 ? html`
                       ${this.indeterminate
-                          ? html``
+                          ? nothing
                           : html`
                                 <sp-field-label
                                     size=${this.size}
@@ -93,7 +94,7 @@ export class ProgressBar extends SizedMixin(
                                 </sp-field-label>
                             `}
                   `
-                : html``}
+                : nothing}
             <div class="track">
                 <div
                     class="fill"

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -122,7 +123,7 @@ export class Search extends Textfield {
                               @keydown=${stopPropagation}
                           ></sp-clear-button>
                       `
-                    : html``}
+                    : nothing}
             </form>
         `;
     }

--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -146,7 +147,7 @@ export class SideNavItem extends LikeAnchor(Focusable) {
                           <slot name="descendant"></slot>
                       </div>
                   `
-                : html``}
+                : nothing}
         `;
     }
 

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import {
@@ -211,7 +212,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                           @change=${this.handleNumberChange}
                       ></sp-number-field>
                   `
-                : html``}
+                : nothing}
         `;
     }
 
@@ -251,7 +252,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                         : this.handleController.activeHandleInputId}
                     @click=${this.handleLabelClick}
                 >
-                    ${this.slotHasContent ? html`` : this.label}
+                    ${this.slotHasContent ? nothing : this.label}
                     <slot>${this.label}</slot>
                 </sp-field-label>
                 <output
@@ -316,7 +317,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                                           ${i * tickStep + this.min}
                                       </div>
                                   `
-                                : html``}
+                                : nothing}
                         </div>
                     `
                 )}

--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -217,7 +217,7 @@ export class SplitView extends SpectrumElement {
                               ? html`
                                     <div id="gripper"></div>
                                 `
-                              : html``}
+                              : nothing}
                       </div>
                   `
                 : nothing}

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     render,
     SizedMixin,
@@ -95,7 +96,7 @@ export class Table extends SizedMixin(SpectrumElement, {
                                   ?checked=${selected}
                               ></sp-table-checkbox-cell>
                           `
-                        : html``}
+                        : nothing}
                     ${fn(item, index)}
                 </sp-table-row>
             `;

--- a/packages/table/src/TableHeadCell.ts
+++ b/packages/table/src/TableHeadCell.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SpectrumElement,
     TemplateResult,
@@ -85,7 +86,7 @@ export class TableHeadCell extends SpectrumElement {
                           class="sortedIcon spectrum-UIIcon-ArrowDown100"
                       ></sp-icon-arrow100>
                   `
-                : html``}
+                : nothing}
         `;
     }
 

--- a/packages/tabs/src/Tab.ts
+++ b/packages/tabs/src/Tab.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SpectrumElement,
     TemplateResult,
@@ -73,9 +74,9 @@ export class Tab extends FocusVisiblePolyfillMixin(
                 ? html`
                       <slot name="icon"></slot>
                   `
-                : html``}
+                : nothing}
             <label id="item-label" ?hidden=${!this.hasLabel}>
-                ${this.slotHasContent ? html`` : this.label}
+                ${this.slotHasContent ? nothing : this.label}
                 <slot>${this.label}</slot>
             </label>
         `;

--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     PropertyValues,
     SizedMixin,
     SpectrumElement,
@@ -132,7 +133,7 @@ export class Tag extends SizedMixin(SpectrumElement, {
                           @click=${this.delete}
                       ></sp-clear-button>
                   `
-                : html``}
+                : nothing}
         `;
     }
 

--- a/packages/tooltip/stories/tooltip.stories.ts
+++ b/packages/tooltip/stories/tooltip.stories.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import { html, nothing, TemplateResult } from '@spectrum-web-components/base';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
@@ -158,7 +158,7 @@ export const wIcon = ({
 }: Properties): TemplateResult => {
     return html`
         <sp-tooltip ?open=${open} placement=${placement} variant=${variant}>
-            ${!!variant ? iconOptions[variant]() : html``} ${text}
+            ${!!variant ? iconOptions[variant]() : nothing} ${text}
         </sp-tooltip>
     `;
 };


### PR DESCRIPTION
As mentioned in the lit doc:
Prefer using nothing over other falsy values as it provides a consistent behavior between various expression binding contexts. 

Replaced empty html`` tag with nothing

doc: https://lit.dev/docs/api/templates/#nothing
## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
