### PR TITLE
fix(dialog): include tab order management at slotchange time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 95fc7baf1ff5ec1894c8692e6674435a0be5a757
+        default: 38283d25d84170a3b3a6f3688275e35af22ed1ea
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -250,6 +250,10 @@ export class Dialog extends FocusVisiblePolyfillMixin(
     protected onContentSlotChange({
         target,
     }: Event & { target: HTMLSlotElement }): void {
+        requestAnimationFrame(() => {
+            // Content must be available _AND_ styles must be applied.
+            this.shouldManageTabOrderForScrolling();
+        });
         if (this.conditionDescribedby) {
             this.conditionDescribedby();
             delete this.conditionDescribedby;

--- a/packages/dialog/stories/dialog.stories.ts
+++ b/packages/dialog/stories/dialog.stories.ts
@@ -493,3 +493,44 @@ export const fullscreenTakeover = (): TemplateResult => {
         </sp-dialog>
     `;
 };
+
+export const forcedScrolling = (): TemplateResult => html`
+    <style>
+        .container {
+            max-height: 300px;
+            border: 1px solid white;
+        }
+    </style>
+    <div class="container">
+        <sp-dialog size="m">
+            <h2 slot="heading">Disclaimer</h2>
+            <div class="contents">
+                The contents of this dialog is specifically prepared to force
+                scrolling, allowing us to test whether the scroll bar is
+                appopriately activated in this context.
+                <span style="color: red;">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Auctor augue mauris augue neque gravida. Libero
+                    volutpat sed ornare arcu. Quisque egestas diam in arcu
+                    cursus euismod quis viverra.
+                </span>
+                <span style="color: green;">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Auctor augue mauris augue neque gravida. Libero
+                    volutpat sed ornare arcu. Quisque egestas diam in arcu
+                    cursus euismod quis viverra.
+                </span>
+                <span style="color: blue;">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Auctor augue mauris augue neque gravida. Libero
+                    volutpat sed ornare arcu. Quisque egestas diam in arcu
+                    cursus euismod quis viverra.
+                </span>
+            </div>
+            <sp-button slot="button">Footer button</sp-button>
+        </sp-dialog>
+    </div>
+`;


### PR DESCRIPTION
## Description
Recalculate scroll/tabindex presence at slotchange + style application time to ensure scrolling is available. Previous calculation would only happen at resize time, which can be prevented by placing the Dialog in a sized container.

## Related issue(s)
- fixes #3073

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://dialog-scrolling--spectrum-web-components.netlify.app/storybook/?path=/story/dialog--forced-scrolling)
    2. See that scrolling is possible in the Dialog content

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.