### PR TITLE
docs(overlay): Overlay clipping in Safari (bug 160953)

### DIFF
--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -315,3 +315,13 @@ Here, again, working with your content needs (whether or not you want to leverag
     }
 </style>
 ```
+
+### Non-overflowing, relative containers with z-index in Safari
+
+Under very specific conditions, [WebKit will incorrectly clip fixed-position content](https://bugs.webkit.org/show_bug.cgi?id=160953).
+WebKit clips `position: fixed` elements within containers that have all of:
+1. `position: relative`
+2. `overflow: clip` or `overflow: hidden`
+3. `z-index` greater than zero
+  
+If you notice overlay clipping *only* in Safari, this is likely the culprit. The solution is to break up the conditions into separate elements to avoid triggering WebKit's bug. For example, leaving relative positioning and z-index on the outermost container while creating an inner container that enforces the overflow rules.


### PR DESCRIPTION
## Description

Document the impact on https://bugs.webkit.org/show_bug.cgi?id=160953 on our overlay fallbacks

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [X] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
