### PR TITLE
docs: ensure table loads

### DIFF
--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -246,8 +246,11 @@ For large amounts of data, the `<sp-table>` can be virtualised to easily add tab
         return items;
     }
 
-    const initTable = () => {
+    const initTable = async () => {
         const table = document.querySelector('#table-virtualized-demo');
+
+        await table.updateComplete;
+        await table.closest('code-example')?.updateComplete;
         table.items = initItems(50);
 
         table.renderItem = (item, index) => { 
@@ -260,8 +263,10 @@ For large amounts of data, the `<sp-table>` can be virtualised to easily add tab
             return [cell1, cell2, cell3];
         }
     };
-    customElements.whenDefined('sp-table').then(() => {
-        initTable();
+    customElements.whenDefined('code-example').then(() => {
+        customElements.whenDefined('sp-table').then(() => {
+            initTable();
+        });
     });
 </script>
 
@@ -373,8 +378,11 @@ By default the `selected` property will surface an array of item indexes that ar
         return items;
     }
 
-    const initTable = () => {
+    const initTable = async () => {
         const table = document.querySelector('#table-item-value-demo');
+
+        await table.updateComplete;
+        await table.closest('code-example')?.updateComplete;
         table.items = initItems(50);
         table.itemValue = (item) => item.id;
 
@@ -393,8 +401,10 @@ By default the `selected` property will surface an array of item indexes that ar
             selected.textContent = `Selected: ${JSON.stringify(event.target.selected, null, ' ')}`;
         });
     };
-    customElements.whenDefined('sp-table').then(() => {
-        initTable();
+    customElements.whenDefined('code-example').then(() => {
+        customElements.whenDefined('sp-table').then(() => {
+            initTable();
+        });
     });
 </script>
 
@@ -472,8 +482,11 @@ All values in the item array are assumed to be homogenous by default. This means
         return items;
     }
 
-    const initTable = () => {
+    const initTable = async () => {
         const table = document.querySelector('#table-row-type-demo');
+
+        await table.updateComplete;
+        await table.closest('code-example')?.updateComplete;
         const items = initItems(50);
         items.splice(3, 0, {
             _$rowType$: 1,
@@ -496,8 +509,10 @@ All values in the item array are assumed to be homogenous by default. This means
             return [cell1, cell2, cell3];
         };
     };
-    customElements.whenDefined('sp-table').then(() => {
-        initTable();
+    customElements.whenDefined('code-example').then(() => {
+        customElements.whenDefined('sp-table').then(() => {
+            initTable();
+        });
     });
 </script>
 
@@ -591,8 +606,11 @@ For each table column you want to sort, use the `sortable` attribute in its resp
 
     let items = initItems(50);
 
-    const initTable = () => {
+    const initTable = async () => {
         const table = document.querySelector('#sorted-virtualized-table');
+
+        await table.updateComplete;
+        await table.closest('code-example')?.updateComplete;
 
         table.items = items;
 
@@ -618,7 +636,9 @@ For each table column you want to sort, use the `sortable` attribute in its resp
         });
     };
 
-    customElements.whenDefined('sp-table').then(() => {
-        initTable();
+    customElements.whenDefined('code-example').then(() => {
+        customElements.whenDefined('sp-table').then(() => {
+            initTable();
+        });
     });
 </script>

--- a/projects/documentation/src/components/code-example.ts
+++ b/projects/documentation/src/components/code-example.ts
@@ -105,14 +105,20 @@ export class CodeExample extends FocusVisiblePolyfillMixin(LitElement) {
         `;
     }
 
+    private liveHTMLTransferred = false;
+
     private get renderedCode(): TemplateResult {
-        if (this.classList.contains('language-html-live')) {
+        if (
+            this.classList.contains('language-html-live') &&
+            !this.liveHTMLTransferred
+        ) {
             const demo =
                 this.querySelector('[slot="demo"]') ||
                 document.createElement('div');
             demo.slot = 'demo';
             demo.innerHTML = this.liveHTML;
             this.append(demo);
+            this.liveHTMLTransferred = true;
         }
         return toHtmlTemplateString(this.liveHTML);
     }


### PR DESCRIPTION
## Description
- don't rewrite HTML to the page after the first time (`code-example` isn't recycled, so this should be fine in our context)
- lazily init the Table demos by the availability of `code-example` AND `sp-table`

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://table-docs--spectrum-web-components.netlify.app/components/table/)
    2. See that the Virtualized table demos load
    3. Switch the color theme
    4. See that the Virtualized table demos are still live

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.