### PR TITLE
fix(slider): ensure first render when no "value" is supplied

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 38283d25d84170a3b3a6f3688275e35af22ed1ea
+        default: e9c36e00831e024b6167871385e2ba74fde479d3
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -190,7 +190,9 @@ Note: the polyfilling done here is very simplistic and is triggered by supplying
 
 ### Label Visibility
 
-By default, an `<sp-slider>` element has both a "text" label and a "value" label. Either or both of these can be suppressed visually as needed by your application UI. This delivery is controlled by the `label-visibility` attribute (or `labelVisibility` property) which accepts `text`, `value`, or `none` as values.
+By default, an `<sp-slider>` element has both a "text" label and a "value" label. The "value" label is output by the element itself based on its state, but the "text" label must be supplied by the consuming developer in order for the `<sp-slider>` to be delivered in an accessible manner.
+
+Either or both of these can be suppressed visually as needed by your application UI, while still fulfilling their role in delivering a quality accessibility tree to the browser. This delivery is controlled by the `label-visibility` attribute (or `labelVisibility` property) which accepts `text`, `value`, or `none` as values.
 
 Use `label-visibility="text"` to suppress the "value" label:
 

--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -17,11 +17,7 @@ import {
 } from '@spectrum-web-components/base/src/directives.js';
 import { MutationController } from '@lit-labs/observers/mutation-controller.js';
 import { Slider } from './Slider.js';
-import {
-    Controller,
-    SliderHandle,
-    SliderNormalization,
-} from './SliderHandle.js';
+import { SliderHandle, SliderNormalization } from './SliderHandle.js';
 
 interface HandleReference {
     handle: HTMLElement;
@@ -61,7 +57,7 @@ export interface HandleValueDictionary {
     [key: string]: number;
 }
 
-export class HandleController implements Controller {
+export class HandleController {
     private host!: Slider;
     private handles: Map<string, SliderHandle> = new Map();
     private model: ModelValue[] = [];

--- a/packages/slider/src/SliderHandle.ts
+++ b/packages/slider/src/SliderHandle.ts
@@ -21,6 +21,7 @@ import {
     NumberFormatOptions,
     NumberFormatter,
 } from '@internationalized/number';
+import { HandleController } from './HandleController.js';
 
 export type HandleMin = number | 'previous';
 export type HandleMax = number | 'next';
@@ -29,13 +30,6 @@ export type HandleValues = {
     name: string;
     value: number;
 }[];
-
-export interface Controller {
-    inputForHandle(handle: SliderHandle): HTMLInputElement | undefined;
-    requestUpdate(): void;
-    setValueFromHandle(handle: SliderHandle): void;
-    handleHasChanged(handle: SliderHandle): void;
-}
 
 export type SliderNormalization = {
     toNormalized: (value: number, min: number, max: number) => number;
@@ -78,7 +72,7 @@ const MaxConverter = {
  * @fires change - An alteration to the value of the element has been committed by the user.
  */
 export class SliderHandle extends Focusable {
-    public handleController?: Controller;
+    public handleController?: HandleController;
 
     public get handleName(): string {
         return this.name;
@@ -138,6 +132,7 @@ export class SliderHandle extends Focusable {
             if (this.value == null) {
                 if (!isNaN(max) && !isNaN(min)) {
                     this.value = max < min ? min : min + (max - min) / 2;
+                    this.handleController?.hostUpdate();
                 }
             }
         }

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -132,6 +132,14 @@ export const Default = (args: StoryArgs = {}): TemplateResult => {
     `;
 };
 
+export const minimalDOM = (): TemplateResult => {
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider>Opacity</sp-slider>
+        </div>
+    `;
+};
+
 export const noVisibleTextLabel = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">


### PR DESCRIPTION
## Description
Ensure the Slider displays correctly by default when a `value` attribute is not provided.

## Related issue(s)
- fixes #2940
- fixes #3118

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://slider-track--spectrum-web-components.netlify.app/storybook/?path=/story/slider--minimal-dom)
    2. See the track is visible
    3. Inspect the element, see that not `value` attribute is present

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.