### PR TITLE
fix(picker): ensure the Menu opens in a Tray on mobile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 99f84ff5fe39f297b9fdc22095248a42f4028fb5
+        default: e9d37b882a8667fc4175ebe2fdf400dcc084bc25
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -390,7 +390,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .triggerElement=${this as HTMLElement}
                 .offset=${0}
                 ?open=${this.open}
-                .placement=${this.placement}
+                .placement=${this.isMobile.matches ? undefined : this.placement}
                 type="auto"
                 .receivesFocus=${'true'}
                 @beforetoggle=${(

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/underlay": "^0.37.0"
     },
     "devDependencies": {
-        "@spectrum-css/tray": "^2.1.3"
+        "@spectrum-css/tray": "^2.1.8"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tray/src/tray.css
+++ b/packages/tray/src/tray.css
@@ -24,14 +24,7 @@ sp-underlay {
     touch-action: none;
 }
 
-/**
- * Default padding along the x axis causes a weird interaction with inner content,
- * e.g. dismissable dialogs, that layout children based off of their own width and
- * can't correct into the larger tray width. Move the default to 0 while still
- * surfacing the `--spectrum-tray-padding-x` override as needed.
- **/
 .tray {
-    padding: var(--spectrum-tray-padding-y, 0) var(--spectrum-tray-padding-x, 0);
     display: inline-flex;
     overscroll-behavior: contain;
 }

--- a/tools/styles/package.json
+++ b/tools/styles/package.json
@@ -107,10 +107,10 @@
         "@spectrum-web-components/base": "^0.37.0"
     },
     "devDependencies": {
-        "@spectrum-css/commons": "^7.0.8",
+        "@spectrum-css/commons": "^8.0.0",
         "@spectrum-css/expressvars": "^3.0.9",
-        "@spectrum-css/tokens": "^11.2.0",
-        "@spectrum-css/typography": "^5.0.32",
+        "@spectrum-css/tokens": "^11.3.1",
+        "@spectrum-css/typography": "^5.0.37",
         "@spectrum-css/vars": "^9.0.8"
     },
     "customElements": "custom-elements.json",

--- a/tools/styles/tokens/global-vars.css
+++ b/tools/styles/tokens/global-vars.css
@@ -254,6 +254,7 @@
     --spectrum-progress-bar-maximum-width: 768px;
     --spectrum-meter-minimum-width: 48px;
     --spectrum-meter-maximum-width: 768px;
+    --spectrum-meter-default-width: var(--spectrum-meter-width);
     --spectrum-in-line-alert-minimum-width: 240px;
     --spectrum-popover-tip-width: 16px;
     --spectrum-popover-tip-height: 8px;

--- a/tools/styles/tokens/large-vars.css
+++ b/tools/styles/tokens/large-vars.css
@@ -57,7 +57,7 @@
     --spectrum-progress-bar-thickness-medium: 8px;
     --spectrum-progress-bar-thickness-large: 10px;
     --spectrum-progress-bar-thickness-extra-large: 13px;
-    --spectrum-meter-default-width: 240px;
+    --spectrum-meter-width: 240px;
     --spectrum-meter-thickness-small: 5px;
     --spectrum-meter-thickness-large: 8px;
     --spectrum-tag-top-to-avatar-small: 5px;
@@ -154,9 +154,12 @@
         --spectrum-heading-cjk-size-s
     );
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-xs);
-    --spectrum-coach-mark-minimum-width: 208px;
+    --spectrum-coach-mark-width: 216px;
+    --spectrum-coach-mark-minimum-width: 216px;
+    --spectrum-coach-mark-maximum-width: 248px;
     --spectrum-coach-mark-edge-to-content: var(--spectrum-spacing-300);
     --spectrum-coach-mark-pagination-text-to-bottom-edge: 22px;
+    --spectrum-coach-mark-media-height: 162px;
     --spectrum-coach-mark-media-minimum-height: 121px;
     --spectrum-coach-mark-title-size: var(--spectrum-heading-size-xxs);
     --spectrum-coach-mark-body-size: var(--spectrum-body-size-xs);

--- a/tools/styles/tokens/medium-vars.css
+++ b/tools/styles/tokens/medium-vars.css
@@ -57,7 +57,7 @@
     --spectrum-progress-bar-thickness-medium: 6px;
     --spectrum-progress-bar-thickness-large: 8px;
     --spectrum-progress-bar-thickness-extra-large: 10px;
-    --spectrum-meter-default-width: 192px;
+    --spectrum-meter-width: 192px;
     --spectrum-meter-thickness-small: 4px;
     --spectrum-meter-thickness-large: 6px;
     --spectrum-tag-top-to-avatar-small: 4px;
@@ -154,10 +154,16 @@
         --spectrum-heading-cjk-size-m
     );
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-s);
+    --spectrum-coach-mark-width: 296px;
     --spectrum-coach-mark-minimum-width: 296px;
+    --spectrum-coach-mark-maximum-width: 380px;
     --spectrum-coach-mark-edge-to-content: var(--spectrum-spacing-400);
     --spectrum-coach-mark-pagination-text-to-bottom-edge: 33px;
+    --spectrum-coach-mark-media-height: 222px;
     --spectrum-coach-mark-media-minimum-height: 166px;
+    --spectrum-coach-mark-title-size: var(--spectrum-heading-size-xs);
+    --spectrum-coach-mark-body-size: var(--spectrum-body-size-s);
+    --spectrum-coach-mark-pagination-body-size: var(--spectrum-body-size-s);
     --spectrum-accordion-top-to-text-compact-small: 2px;
     --spectrum-accordion-top-to-text-regular-small: 5px;
     --spectrum-accordion-small-top-to-text-spacious: 9px;

--- a/tools/styles/tokens/spectrum/custom-large-vars.css
+++ b/tools/styles/tokens/spectrum/custom-large-vars.css
@@ -51,4 +51,7 @@
     --spectrum-sidenav-heading-top-margin: 30px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is updated */
     --spectrum-sidenav-heading-bottom-margin: 10px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is added */
     --spectrum-sidenav-bottom-to-label: 10px; /* TODO replace with updated var(--spectrum-component-bottom-to-text-100); */
+
+    --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
+    --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
 }

--- a/tools/styles/tokens/spectrum/custom-medium-vars.css
+++ b/tools/styles/tokens/spectrum/custom-medium-vars.css
@@ -51,4 +51,7 @@
     --spectrum-sidenav-heading-top-margin: 24px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is updated */
     --spectrum-sidenav-heading-bottom-margin: 8px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is added */
     --spectrum-sidenav-bottom-to-label: 8px; /* TODO replace with updated var(--spectrum-component-bottom-to-text-100); */
+
+    --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
+    --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5403,10 +5403,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-3.0.33.tgz#4e980f38e56535abca5cd8e6570e189ad2d76f4d"
   integrity sha512-hnkiZms73dugvbc5twxKVBAc6nqI5OecaDOiSpctWJBxzsFADP0euikLeEdodh53QTIcYXMCM5olRH3qMTSa4Q==
 
-"@spectrum-css/commons@^7.0.8":
-  version "7.0.8"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-7.0.8.tgz#4c221d56eb296c21a259e5afcdddc2dd8fff878b"
-  integrity sha512-LTHHxD+GS+EHPp9sF1PiRg3B8XWKSXYMSRPgncQUc+6rG/w3G5lyJa4eobhuE5OjbcKnX8x7i15NMqltQ85TJg==
+"@spectrum-css/commons@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-8.0.0.tgz#c9e9eeaf87b17fee32a99674e9a126cf3af64d34"
+  integrity sha512-ohM/6ZEK0IVSGxKFoymkZIVqf3zwt2x/27u48SXq8ZgUXPl5l6IqdHHmP13vuJiyJ6hs341YLth5PamRlbQEjg==
 
 "@spectrum-css/dialog@^6.0.66":
   version "6.0.66"
@@ -5593,25 +5593,25 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-9.1.0.tgz#209b2397da9c1304b3b0e538025afcb5c29dc26b"
   integrity sha512-/DheKxtmvoAZneAs1Dql+1waSqCxTFIEAfzaPCaQvAYg+ctW9NhXMZjGz5cRbHTzCmeuE6reuCLfuFput9Z7bQ==
 
-"@spectrum-css/tokens@^11.2.0":
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-11.2.0.tgz#ad26bb021c76101d2f01383dbe1a4ac9f0c0f40a"
-  integrity sha512-beq++b5tSw2AjbBXbYlG8cZk4w2JvJVlsPHMiD15tq5SiSYcWFFL13lBPAi30XkPjW+1yAGPqMAHKkUxAFF/Rw==
+"@spectrum-css/tokens@^11.3.1":
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-11.3.1.tgz#743db7cb795769336bcd77d9e41d24c4ae54c7d2"
+  integrity sha512-Yn3M/1T1VxQETEAdOgj/00utCfD6esyDvOS+plxJWcpFtHhDh5J+qWgA1PitUG7glRfLyB1atx2/ZlD+ECHscA==
 
 "@spectrum-css/tooltip@^5.1.3":
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-5.1.3.tgz#734b48e5c41d248ef54ec2f87e67d252a78088b5"
   integrity sha512-ER4GUn+A4BvuZNTsJYw/TIefMMbms7HZ0HSoOTe4kwbq5C4zMnopd0PTa/oURMktz6Bz8JWZIoScRU88SWXVYQ==
 
-"@spectrum-css/tray@^2.1.3":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-2.1.6.tgz#a3b3bfab535f9364acaa63af1482fa4234ad669e"
-  integrity sha512-79f1PaU1ScjjS4W8F13vl+b0VWkD0Q+ScPTtFoeDTzOcnzPd0qfEqbi0KABvA1XSghTDEn1yIEcOgxgVo09kDQ==
+"@spectrum-css/tray@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-2.1.8.tgz#f91614e0a2bd89d291ac7dedfc83b4bbae65e3a8"
+  integrity sha512-GZF26vbwd+wD+gqwVRlIDLQNCVZ4jblvnwRJLrUhLDYRk0bvnuyqfr1lm9sIvNFWdQuPC0RJOf3P9tzQS/+xHg==
 
-"@spectrum-css/typography@^5.0.32":
-  version "5.0.35"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-5.0.35.tgz#84359b647397f9562aa19bf37480d38a90a6c8c5"
-  integrity sha512-Nk6rmpYfugs9qoq+pZEGM6pobdM3BY9AS39IcWg2S3CbKU6VdFsW8HZnJ/IiKEMZeVj0vL0JS1IG/7G2iERekg==
+"@spectrum-css/typography@^5.0.37":
+  version "5.0.37"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-5.0.37.tgz#d63177a4937122eaccf218eae5145b7f375fd1a5"
+  integrity sha512-buWiWksP38j194JdOuIq6EAJNE8xhzLCZsO9PUS0lkgFj0MVWLoMhBZY/7l7fJoUZHwYOE5yAo1/G6IOKq1TZg==
 
 "@spectrum-css/underlay@^2.0.53":
   version "2.0.53"


### PR DESCRIPTION
## Description
Picker accidentally passed `placement` to its overlay, even when in mobile, where it should be opening a Tray without positioning.

Catch an out of date style application in Tray.

Update some associated dependencies across the style ecosystem.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://picker-mobile--spectrum-web-components.netlify.app/storybook/iframe.html?id=picker--default&args=&viewMode=story)
    2. Use a mobile device or emulator
    3. Open the Picker
    4. See that it opens in a Tray

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.