### PR TITLE
docs: move to picsum.photos instead of place.dog

### DIFF
--- a/packages/asset/README.md
+++ b/packages/asset/README.md
@@ -28,7 +28,7 @@ import { Asset } from '@spectrum-web-components/asset';
 
 ```html
 <sp-asset style="height: 128px">
-    <img src="https://place.dog/500/500" alt="Demo Image" />
+    <img src="https://picsum.photos/500/500" alt="Demo Image" />
 </sp-asset>
 ```
 

--- a/packages/avatar/README.md
+++ b/packages/avatar/README.md
@@ -33,8 +33,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="50"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 
@@ -45,8 +45,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="75"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 
@@ -57,8 +57,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="100"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 
@@ -69,8 +69,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="200"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 
@@ -81,8 +81,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="300"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 
@@ -93,8 +93,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="400"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 
@@ -105,8 +105,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="500"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 
@@ -117,8 +117,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="600"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 
@@ -129,8 +129,8 @@ import { Avatar } from '@spectrum-web-components/avatar';
 ```html demo
 <sp-avatar
     size="700"
-    label="Dog the User"
-    src="https://place.dog/500/500"
+    label="Demo User"
+    src="https://picsum.photos/500/500"
 ></sp-avatar>
 ```
 

--- a/packages/avatar/test/avatar.test.ts
+++ b/packages/avatar/test/avatar.test.ts
@@ -20,7 +20,7 @@ describe('Avatar', () => {
                 html`
                     <sp-avatar
                         label="Shantanu Narayen"
-                        src="https://place.dog/500/500"
+                        src="https://picsum.photos/500/500"
                     ></sp-avatar>
                 `
             )
@@ -30,7 +30,7 @@ describe('Avatar', () => {
             html`
                 <sp-avatar
                     label="Shantanu Narayen"
-                    src="https://place.dog/500/500"
+                    src="https://picsum.photos/500/500"
                 ></sp-avatar>
             `
         );
@@ -44,7 +44,7 @@ describe('Avatar', () => {
             html`
                 <sp-avatar
                     label="Shantanu Narayen"
-                    src="https://place.dog/500/500"
+                    src="https://picsum.photos/500/500"
                 ></sp-avatar>
             `
         );
@@ -64,7 +64,7 @@ describe('Avatar', () => {
             html`
                 <sp-avatar
                     label="Shantanu Narayen"
-                    src="https://place.dog/500/500"
+                    src="https://picsum.photos/500/500"
                 ></sp-avatar>
             `
         );
@@ -80,7 +80,7 @@ describe('Avatar', () => {
     it('loads with no label', async () => {
         const el = await fixture<Avatar>(
             html`
-                <sp-avatar src="https://place.dog/500/500"></sp-avatar>
+                <sp-avatar src="https://picsum.photos/500/500"></sp-avatar>
             `
         );
 
@@ -97,7 +97,7 @@ describe('Avatar', () => {
                 html`
                     <sp-avatar
                         label="Shantanu Narayen"
-                        src="https://place.dog/500/500"
+                        src="https://picsum.photos/500/500"
                         tabindex="0"
                     ></sp-avatar>
                 `

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -137,7 +137,7 @@ Note: the `dissmissable` attribute will not be followed when `mode="fullscreen"`
 <sp-dialog size="medium" dismissable no-divider>
     <div
         slot="hero"
-        style="background-image: url(https://place.dog/500/280)"
+        style="background-image: url(https://picsum.photos/1400/260)"
     ></div>
     <h2 slot="heading">Disclaimer</h2>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -45,7 +45,7 @@ import {
         <sp-avatar
             slot="avatar"
             label="Tag 1"
-            src=https://place.dog/500/500
+            src=https://picsum.photos/500/500
         ></sp-avatar>
     </sp-tag>
     <sp-tag invalid>
@@ -53,7 +53,7 @@ import {
         <sp-avatar
             slot="avatar"
             label="Tag 1"
-            src=https://place.dog/500/500
+            src=https://picsum.photos/500/500
         ></sp-avatar>
     </sp-tag>
     <sp-tag disabled>
@@ -61,7 +61,7 @@ import {
         <sp-avatar
             slot="avatar"
             label="Tag 1"
-            src=https://place.dog/500/500
+            src=https://picsum.photos/500/500
         ></sp-avatar>
     </sp-tag>
 </sp-tags>
@@ -103,7 +103,7 @@ Use the `deletable` attribute to signify `sp-tags` elements that can be removed.
         <sp-avatar
             slot="avatar"
             label="Tag 1"
-            src=https://place.dog/500/500
+            src=https://picsum.photos/500/500
         ></sp-avatar>
     </sp-tag>
     <sp-tag invalid deletable>
@@ -111,7 +111,7 @@ Use the `deletable` attribute to signify `sp-tags` elements that can be removed.
         <sp-avatar
             slot="avatar"
             label="Tag 1"
-            src=https://place.dog/500/500
+            src=https://picsum.photos/500/500
         ></sp-avatar>
     </sp-tag>
     <sp-tag disabled deletable>
@@ -119,7 +119,7 @@ Use the `deletable` attribute to signify `sp-tags` elements that can be removed.
         <sp-avatar
             slot="avatar"
             label="Tag 1"
-            src=https://place.dog/500/500
+            src=https://picsum.photos/500/500
         ></sp-avatar>
     </sp-tag>
 </sp-tags>

--- a/packages/thumbnail/README.md
+++ b/packages/thumbnail/README.md
@@ -32,7 +32,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="50">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -42,7 +42,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="75">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -52,7 +52,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="100">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -62,7 +62,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="200">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -72,7 +72,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="300">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -82,7 +82,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="400">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -92,7 +92,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="500">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -102,7 +102,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="600">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -112,7 +112,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="700">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -122,7 +122,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="800">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -132,7 +132,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="900">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -142,7 +142,7 @@ import { Thumbnail } from '@spectrum-web-components/thumbnail';
 
 ```html
 <sp-thumbnail size="1000">
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -155,7 +155,7 @@ When `focused` the `sp-thumbnail` element will be displayed as follows:
 
 ```html
 <sp-thumbnail focused>
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -166,7 +166,7 @@ When `disabled` the `sp-thumbnail` element will be displayed as follows:
 
 ```html
 <sp-thumbnail disabled>
-    <img src="https://place.dog/100/100" alt="Demo Image" />
+    <img src="https://picsum.photos/100/100" alt="Demo Image" />
 </sp-thumbnail>
 ```
 
@@ -177,11 +177,11 @@ By default, an `sp-thumbnail` will ensure that the entirety of the content that 
 ```html
 <div style="display: flex; gap: var(--spectrum-spacing-100);">
     <sp-thumbnail>
-        <img src="https://place.dog/300/400" alt="Demo Image" />
+        <img src="https://picsum.photos/300/400" alt="Demo Image" />
     </sp-thumbnail>
 
     <sp-thumbnail>
-        <img src="https://place.dog/500/100" alt="Demo Image" />
+        <img src="https://picsum.photos/500/100" alt="Demo Image" />
     </sp-thumbnail>
 </div>
 ```
@@ -191,11 +191,11 @@ The `background` attribute takes a string value of the CSS "background" property
 ```html
 <div style="display: flex; gap: var(--spectrum-spacing-100);">
     <sp-thumbnail background="red">
-        <img src="https://place.dog/300/400" alt="Demo Image" />
+        <img src="https://picsum.photos/300/400" alt="Demo Image" />
     </sp-thumbnail>
 
     <sp-thumbnail background="#00ff00">
-        <img src="https://place.dog/500/100" alt="Demo Image" />
+        <img src="https://picsum.photos/500/100" alt="Demo Image" />
     </sp-thumbnail>
 </div>
 ```
@@ -205,11 +205,11 @@ The `cover` attribute will cause the content to fill the space provided by the `
 ```html
 <div style="display: flex; gap: var(--spectrum-spacing-100);">
     <sp-thumbnail cover>
-        <img src="https://place.dog/300/400" alt="Demo Image" />
+        <img src="https://picsum.photos/300/400" alt="Demo Image" />
     </sp-thumbnail>
 
     <sp-thumbnail cover>
-        <img src="https://place.dog/500/100" alt="Demo Image" />
+        <img src="https://picsum.photos/500/100" alt="Demo Image" />
     </sp-thumbnail>
 </div>
 ```
@@ -221,11 +221,11 @@ For when `sp-thumbail` is used in layer management (such as the Compact or Detai
 ```html
 <div style="display: flex; gap: var(--spectrum-spacing-100);">
     <sp-thumbnail layer>
-        <img src="https://place.dog/400/400" alt="Demo Image" />
+        <img src="https://picsum.photos/400/400" alt="Demo Image" />
     </sp-thumbnail>
 
     <sp-thumbnail layer selected>
-        <img src="https://place.dog/500/100" alt="Demo Image" />
+        <img src="https://picsum.photos/500/100" alt="Demo Image" />
     </sp-thumbnail>
 </div>
 ```

--- a/tools/styles/tokens/global-vars.css
+++ b/tools/styles/tokens/global-vars.css
@@ -254,6 +254,7 @@
     --spectrum-progress-bar-maximum-width: 768px;
     --spectrum-meter-minimum-width: 48px;
     --spectrum-meter-maximum-width: 768px;
+    --spectrum-meter-default-width: var(--spectrum-meter-width);
     --spectrum-in-line-alert-minimum-width: 240px;
     --spectrum-popover-tip-width: 16px;
     --spectrum-popover-tip-height: 8px;

--- a/tools/styles/tokens/large-vars.css
+++ b/tools/styles/tokens/large-vars.css
@@ -57,7 +57,7 @@
     --spectrum-progress-bar-thickness-medium: 8px;
     --spectrum-progress-bar-thickness-large: 10px;
     --spectrum-progress-bar-thickness-extra-large: 13px;
-    --spectrum-meter-default-width: 240px;
+    --spectrum-meter-width: 240px;
     --spectrum-meter-thickness-small: 5px;
     --spectrum-meter-thickness-large: 8px;
     --spectrum-tag-top-to-avatar-small: 5px;
@@ -154,9 +154,12 @@
         --spectrum-heading-cjk-size-s
     );
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-xs);
-    --spectrum-coach-mark-minimum-width: 208px;
+    --spectrum-coach-mark-width: 216px;
+    --spectrum-coach-mark-minimum-width: 216px;
+    --spectrum-coach-mark-maximum-width: 248px;
     --spectrum-coach-mark-edge-to-content: var(--spectrum-spacing-300);
     --spectrum-coach-mark-pagination-text-to-bottom-edge: 22px;
+    --spectrum-coach-mark-media-height: 162px;
     --spectrum-coach-mark-media-minimum-height: 121px;
     --spectrum-coach-mark-title-size: var(--spectrum-heading-size-xxs);
     --spectrum-coach-mark-body-size: var(--spectrum-body-size-xs);

--- a/tools/styles/tokens/medium-vars.css
+++ b/tools/styles/tokens/medium-vars.css
@@ -57,7 +57,7 @@
     --spectrum-progress-bar-thickness-medium: 6px;
     --spectrum-progress-bar-thickness-large: 8px;
     --spectrum-progress-bar-thickness-extra-large: 10px;
-    --spectrum-meter-default-width: 192px;
+    --spectrum-meter-width: 192px;
     --spectrum-meter-thickness-small: 4px;
     --spectrum-meter-thickness-large: 6px;
     --spectrum-tag-top-to-avatar-small: 4px;
@@ -154,10 +154,16 @@
         --spectrum-heading-cjk-size-m
     );
     --spectrum-illustrated-message-body-size: var(--spectrum-body-size-s);
+    --spectrum-coach-mark-width: 296px;
     --spectrum-coach-mark-minimum-width: 296px;
+    --spectrum-coach-mark-maximum-width: 380px;
     --spectrum-coach-mark-edge-to-content: var(--spectrum-spacing-400);
     --spectrum-coach-mark-pagination-text-to-bottom-edge: 33px;
+    --spectrum-coach-mark-media-height: 222px;
     --spectrum-coach-mark-media-minimum-height: 166px;
+    --spectrum-coach-mark-title-size: var(--spectrum-heading-size-xs);
+    --spectrum-coach-mark-body-size: var(--spectrum-body-size-s);
+    --spectrum-coach-mark-pagination-body-size: var(--spectrum-body-size-s);
     --spectrum-accordion-top-to-text-compact-small: 2px;
     --spectrum-accordion-top-to-text-regular-small: 5px;
     --spectrum-accordion-small-top-to-text-spacious: 9px;

--- a/tools/styles/tokens/spectrum/custom-large-vars.css
+++ b/tools/styles/tokens/spectrum/custom-large-vars.css
@@ -51,4 +51,7 @@
     --spectrum-sidenav-heading-top-margin: 30px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is updated */
     --spectrum-sidenav-heading-bottom-margin: 10px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is added */
     --spectrum-sidenav-bottom-to-label: 10px; /* TODO replace with updated var(--spectrum-component-bottom-to-text-100); */
+
+    --spectrum-alert-dialog-padding: var(--spectrum-spacing-400);
+    --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-600);
 }

--- a/tools/styles/tokens/spectrum/custom-medium-vars.css
+++ b/tools/styles/tokens/spectrum/custom-medium-vars.css
@@ -51,4 +51,7 @@
     --spectrum-sidenav-heading-top-margin: 24px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is updated */
     --spectrum-sidenav-heading-bottom-margin: 8px; /* TODO replace with var(--spectrum-side-navigation-item-to-header); once token is added */
     --spectrum-sidenav-bottom-to-label: 8px; /* TODO replace with updated var(--spectrum-component-bottom-to-text-100); */
+
+    --spectrum-alert-dialog-padding: var(--spectrum-spacing-500);
+    --spectrum-alert-dialog-description-to-buttons: var(--spectrum-spacing-700);
 }


### PR DESCRIPTION
## Description
Update all broken place.dog images to picsum.photos

## Related issue(s)

- fixes #3585


## How has this been tested?
-   [ ] _Test case 1_
    1. Go to the Asset, Avatar, Dialog, Tags, or Thumbnail pages in the docs
    2. See that images on the page actually load.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.