### PR TITLE
fix(sidenav): reintroduce support for slotted label content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 6b9557f623c5d298c097a8df4bf08b2620e74db7
+        default: 99f84ff5fe39f297b9fdc22095248a42f4028fb5
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/sidenav/src/SidenavItem.ts
+++ b/packages/sidenav/src/SidenavItem.ts
@@ -138,8 +138,10 @@ export class SideNavItem extends LikeAnchor(Focusable) {
                 )}
             >
                 <slot name="icon"></slot>
-
-                <span id="link-text">${this.label}</span>
+                <span id="link-text">
+                    ${this.label}
+                    <slot></slot>
+                </span>
             </a>
             ${this.expanded
                 ? html`

--- a/packages/sidenav/stories/sidenav.stories.ts
+++ b/packages/sidenav/stories/sidenav.stories.ts
@@ -84,6 +84,34 @@ export const Multilevel = ({
 
 Multilevel.storyName = 'Multi-level';
 
+export const MultilevelSlotted = ({
+    onChange,
+}: {
+    onChange: () => void;
+}): TemplateResult => {
+    return html`
+        <sp-sidenav variant="multilevel" value="2.3.1" @change=${onChange}>
+            <sp-sidenav-item value="foo">foo</sp-sidenav-item>
+            <sp-sidenav-item value="baz">
+                baz
+                <sp-sidenav-item value="2.1">2.1</sp-sidenav-item>
+                <sp-sidenav-item value="2.2">2.2</sp-sidenav-item>
+                <sp-sidenav-item value="2.3">
+                    2.3
+                    <sp-sidenav-item value="2.3.1">2.3.1</sp-sidenav-item>
+                    <sp-sidenav-item disabled value="2.3.2">
+                        2.3.2
+                    </sp-sidenav-item>
+                </sp-sidenav-item>
+            </sp-sidenav-item>
+            <sp-sidenav-item value="test">test</sp-sidenav-item>
+            <sp-sidenav-item value="hi">hi</sp-sidenav-item>
+        </sp-sidenav>
+    `;
+};
+
+MultilevelSlotted.storyName = 'Multi-level Slotted';
+
 export const levelsAndDisabled = (): TemplateResult => {
     return html`
         <sp-sidenav>


### PR DESCRIPTION
## Description
"Revert" work that accidentally removed the `<slot>` that accepted label text.

## Related issue(s)

- fixes #3557

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://sidenav-labels--spectrum-web-components.netlify.app/storybook/?path=/story/sidenav--multilevel-slotted)
    2. See that the labels display as expected
    3. Expectation can be divided from [here](https://sidenav-labels--spectrum-web-components.netlify.app/storybook/?path=/story/sidenav--multilevel)

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.