### PR TITLE
fix(number-field): correct composition entry of multi-byte numbers

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -324,6 +324,7 @@ export class NumberField extends TextfieldBase {
     }
 
     private handleKeydown(event: KeyboardEvent): void {
+        if (this.isComposing) return;
         switch (event.code) {
             case 'ArrowUp':
                 event.preventDefault();
@@ -402,7 +403,27 @@ export class NumberField extends TextfieldBase {
         super.handleChange();
     }
 
-    protected override handleInput(): void {
+    protected handleCompositionStart(): void {
+        this.isComposing = true;
+    }
+
+    protected handleCompositionEnd(): void {
+        this.isComposing = false;
+        requestAnimationFrame(() => {
+            this.inputElement.dispatchEvent(
+                new Event('input', {
+                    composed: true,
+                    bubbles: true,
+                })
+            );
+        });
+    }
+
+    protected override handleInput(event: Event): void {
+        if (this.isComposing) {
+            event.stopPropagation();
+            return;
+        }
         if (this.indeterminate) {
             this.wasIndeterminate = true;
             this.indeterminateValue = this.value;
@@ -427,16 +448,18 @@ export class NumberField extends TextfieldBase {
             }
             this._trackingValue = value;
             this.inputElement.value = value;
+            this.inputElement.setSelectionRange(selectionStart, selectionStart);
             return;
+        } else {
+            this.inputElement.value = this.indeterminate
+                ? indeterminatePlaceholder
+                : this._trackingValue;
         }
         const currentLength = value.length;
         const previousLength = this._trackingValue.length;
         const nextSelectStart =
             (selectionStart || currentLength) -
             (currentLength - previousLength);
-        this.inputElement.value = this.indeterminate
-            ? indeterminatePlaceholder
-            : this._trackingValue;
         this.inputElement.setSelectionRange(nextSelectStart, nextSelectStart);
     }
 
@@ -643,9 +666,13 @@ export class NumberField extends TextfieldBase {
         }
     }
 
+    private isComposing = false;
+
     protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.addEventListener('keydown', this.handleKeydown);
+        this.addEventListener('compositionstart', this.handleCompositionStart);
+        this.addEventListener('compositionend', this.handleCompositionEnd);
     }
 
     protected override updated(changes: PropertyValues<this>): void {

--- a/packages/number-field/stories/number-field.stories.ts
+++ b/packages/number-field/stories/number-field.stories.ts
@@ -242,6 +242,7 @@ export const decimals = (args: StoryArgs): TemplateResult => {
             style="width: 200px"
             ...=${spreadProps(args)}
             @change=${args.onChange}
+            @input=${args.onInput}
             .formatOptions=${{
                 signDisplay: 'exceptZero',
                 minimumFractionDigits: 1,

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -171,7 +171,7 @@ export class TextfieldBase extends ManageHelpText(
         this.inputElement.select();
     }
 
-    protected handleInput(): void {
+    protected handleInput(_event: Event): void {
         if (this.allowedKeys && this.inputElement.value) {
             const regExp = new RegExp(`^[${this.allowedKeys}]*$`, 'u');
             if (!regExp.test(this.inputElement.value)) {


### PR DESCRIPTION
## Description

Current implementation: Intercepts IME-based keystrokes and replaces them with their single-byte cousin. 

This change: Accepts all keystrokes until the component is blurred (loses focus), then converts all IME-based characters into their single-byte cousins. 

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/2269

## Motivation and context

Fix Number Field issues with certain Input Method Editor (IME) input types.

## How has this been tested?

- All existing tests pass
- Manual testing of both IME and non-IME cases

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
