### PR TITLE
feat(base): add re-export of lit/directive.js

### DIFF
--- a/tools/base/exports.json
+++ b/tools/base/exports.json
@@ -3,6 +3,7 @@
     "./condition-attribute-with-id.js": "./src/condition-attribute-with-id.js",
     "./decorators.js": "./src/decorators.js",
     "./directives.js": "./src/directives.js",
+    "./directive.js": "./src/directive.js",
     "./html.js": "./src/html.js",
     "./streaming-listener.js": "./src/streaming-listener.js"
 }

--- a/tools/base/package.json
+++ b/tools/base/package.json
@@ -41,6 +41,10 @@
             "development": "./src/define-element.dev.js",
             "default": "./src/define-element.js"
         },
+        "./src/directive.js": {
+            "development": "./src/directive.dev.js",
+            "default": "./src/directive.js"
+        },
         "./src/directives.js": {
             "development": "./src/directives.dev.js",
             "default": "./src/directives.js"

--- a/tools/base/package.json
+++ b/tools/base/package.json
@@ -77,6 +77,10 @@
             "development": "./directives.dev.js",
             "default": "./directives.js"
         },
+        "./directive.js": {
+            "development": "./directive.dev.js",
+            "default": "./directive.js"
+        },
         "./html.js": {
             "development": "./html.dev.js",
             "default": "./html.js"

--- a/tools/base/src/directive.ts
+++ b/tools/base/src/directive.ts
@@ -1,0 +1,13 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export * from 'lit/directive.js';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add an export so that items from `lit/directive.js` can be imported through `@spectrum-web-components/base`

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
