### PR TITLE
chore: switch to fast-glob from glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
         "fs-extra": "^11.1.1",
         "geckodriver": "4.2.0",
         "gh-pages": "^4.0.0",
-        "glob": "^10.3.0",
         "gunzip-maybe": "^1.4.2",
         "husky": "^8.0.3",
         "latest-version": "^7.0.0",

--- a/packages/icons-ui/bin/build.js
+++ b/packages/icons-ui/bin/build.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import fs from 'fs';
-import { glob } from 'glob';
+import fg from 'fast-glob';
 import path from 'path';
 import { load } from 'cheerio';
 import prettier from 'prettier';
@@ -38,9 +38,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */`;
 
-const icons = (
-    await glob(`${rootDir}/node_modules/${iconsPath}/**.svg`)
-).sort();
+const icons = (await fg(`${rootDir}node_modules/${iconsPath}/*.svg`)).sort();
 
 if (!fs.existsSync(`${rootDir}packages/icons-ui/src`)) {
     fs.mkdirSync(`${rootDir}packages/icons-ui/src`);

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -52,8 +52,8 @@
         "@spectrum-css/icon": "^3.0.50",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
+        "fast-glob": "^3.2.12",
         "fs": "^0.0.1-security",
-        "glob": "^10.3.0",
         "path": "^0.12.7",
         "prettier": "^2.7.1"
     },

--- a/packages/icons-workflow/bin/build.js
+++ b/packages/icons-workflow/bin/build.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import fs from 'fs';
-import { glob } from 'glob';
+import fg from 'fast-glob';
 import path from 'path';
 import { load } from 'cheerio';
 import prettier from 'prettier';
@@ -38,9 +38,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */`;
 
-const icons = (
-    await glob(`${rootDir}/node_modules/${iconsPath}/**.svg`)
-).sort();
+const icons = (await fg(`${rootDir}/node_modules/${iconsPath}/**.svg`)).sort();
 
 if (!fs.existsSync(`${rootDir}packages/icons-workflow/src`)) {
     fs.mkdirSync(`${rootDir}packages/icons-workflow/src`);

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -52,8 +52,8 @@
         "@spectrum-css/icon": "^3.0.50",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
+        "fast-glob": "^3.2.12",
         "fs": "^0.0.1-security",
-        "glob": "^10.3.0",
         "path": "^0.12.7",
         "prettier": "^2.7.1"
     },

--- a/scripts/cem-plugin-react-wrapper.js
+++ b/scripts/cem-plugin-react-wrapper.js
@@ -15,7 +15,7 @@ import fsExtra from 'fs-extra';
 import { basename, dirname, resolve } from 'path';
 import prettier from 'prettier';
 import Case from 'case';
-import { glob } from 'glob';
+import fg from 'fast-glob';
 import yaml from 'js-yaml';
 import { fileURLToPath } from 'url';
 
@@ -444,7 +444,7 @@ export const Icon${displayName}: ComponentType<Partial<Icon${displayName}Type> |
  * Core entry function
  */
 export async function generateIconWrapper(iconType) {
-    const icons = await glob(
+    const icons = await fg(
         resolve(__dirname, '..', `packages/${iconType}/src/elements/**.d.ts`)
     );
     for (let icon of icons) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13075,7 +13075,7 @@ glob@7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.2.5, glob@^10.3.0:
+glob@^10.2.5:
   version "10.3.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.3.tgz#8360a4ffdd6ed90df84aa8d52f21f452e86a123b"
   integrity sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==


### PR DESCRIPTION
## Description
Not sure why this started to fail at `get-ready` time, but normalizing to `fast-glob` which we use most other places seems to do the trick!

## How has this been tested?
-   [ ] _Test case 1_
    1. run `yarn`
    2. don't get failures

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
