### PR TITLE
fix(overlay): reduce circular dependencies

### DIFF
--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -155,7 +155,7 @@ export class Overlay extends OverlayFeatures {
      * when there is no trigger element.
      */
     @property({ type: Number })
-    offset: number | [number, number] = 6;
+    override offset: number | [number, number] = 6;
 
     protected override placementController = new PlacementController(this);
 
@@ -197,7 +197,7 @@ export class Overlay extends OverlayFeatures {
      * @type {"top" | "top-start" | "top-end" | "right" | "right-start" | "right-end" | "bottom" | "bottom-start" | "bottom-end" | "left" | "left-start" | "left-end"}
      */
     @property()
-    placement?: Placement;
+    override placement?: Placement;
 
     /**
      * Whether to pass focus to the overlay once opened, or
@@ -879,8 +879,6 @@ export class Overlay extends OverlayFeatures {
             );
         }
     }
-
-    public willPreventClose = false;
 
     public shouldPreventClose(): boolean {
         const shouldPreventClose = this.willPreventClose;

--- a/packages/overlay/src/VirtualTrigger.ts
+++ b/packages/overlay/src/VirtualTrigger.ts
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { Overlay } from './Overlay.js';
+import { AbstractOverlay } from './AbstractOverlay.js';
 
 export class VirtualTrigger {
     private x = 0;
@@ -23,7 +23,7 @@ export class VirtualTrigger {
     public updateBoundingClientRect(x: number, y: number): void {
         this.x = x;
         this.y = y;
-        Overlay.update();
+        AbstractOverlay.update();
     }
 
     public getBoundingClientRect(): DOMRect {

--- a/packages/overlay/src/loader.ts
+++ b/packages/overlay/src/loader.ts
@@ -10,6 +10,36 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import type {
+    OverlayOptions,
+    OverlayOptionsV1,
+    TriggerInteractionsV1,
+} from './overlay-types.js';
 import { Overlay } from './Overlay.js';
 
-export const openOverlay = Overlay.open;
+// Re-export Overlay.open and openOverlay to persist functionality from before 0.37.0.
+// Wrap it in a method (which needs duplicate argument typings) instead of exporting
+// the static member directly to ensure `this` is bound correctly therein.
+export async function openOverlay(
+    trigger: HTMLElement,
+    interaction: TriggerInteractionsV1,
+    content: HTMLElement,
+    optionsV1: OverlayOptionsV1
+): Promise<() => void>;
+export async function openOverlay(
+    content: HTMLElement,
+    options?: OverlayOptions
+): Promise<Overlay>;
+export async function openOverlay(
+    triggerOrContent: HTMLElement,
+    interactionOrOptions: TriggerInteractionsV1 | OverlayOptions | undefined,
+    content?: HTMLElement,
+    optionsV1?: OverlayOptionsV1
+): Promise<Overlay | (() => void)> {
+    return Overlay.open(
+        triggerOrContent,
+        interactionOrOptions as TriggerInteractionsV1,
+        content as HTMLElement,
+        optionsV1 as OverlayOptionsV1
+    );
+}


### PR DESCRIPTION
## Description
Remove some circular dependencies from the Overlay class architecture.

## Related issue(s)
- fixes #3563

## How has this been tested?
-   [ ] _Test case 1_
    1. All of the tests pass
    2. Not sure how to test the fail context, however.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.