### PR TITLE
ci: stop using a fallback wireit cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ commands:
             - restore_cache:
                   keys:
                       - v3b-<< pipeline.parameters.wireit_cache_name >>-{{ arch }}-{{ checksum "package.json" }}-
-                      - v3b-<< pipeline.parameters.wireit_cache_name >>-{{ arch }}-
             - run:
                   name: Installing Dependencies
                   command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn


### PR DESCRIPTION
Don't let wireit build from a cache that it doesn't own. That allows stale date in the cache created by the run that perpetuates across future runs and branches.