### PR TITLE
Deliver Action Menu without an Icon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 6ca0efa669a0e4a16b342ec9958083dce28e4a41
+        default: 948872240fa9b5aab9c814086e0dfd4c9fcba423
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/action-menu/README.md
+++ b/packages/action-menu/README.md
@@ -157,6 +157,36 @@ import { ActionMenu } from '@spectrum-web-components/action-menu';
 
 ## Variants
 
+### No icon
+
+In order to deliver an `<sp-action-menu>` without an icon, use the `label-only` slot. This will supress any icon from being displayed, both the default ellipsis icon or any icon the user might provide to the element.
+
+<!-- prettier-ignore -->
+```html
+<sp-action-menu>
+    <span slot="label-only">More Actions</span>
+    <sp-menu-item>
+        Deselect
+    </sp-menu-item>
+    <sp-menu-item>
+        Select inverse
+    </sp-menu-item>
+    <sp-menu-item>
+        Feather...
+    </sp-menu-item>
+    <sp-menu-item>
+        Select and mask...
+    </sp-menu-item>
+    <sp-menu-divider></sp-menu-divider>
+    <sp-menu-item>
+        Save selection
+    </sp-menu-item>
+    <sp-menu-item disabled>
+        Make work path
+    </sp-menu-item>
+</sp-action-menu>
+```
+
 ### No visible label
 
 The visible label that is be provided via the default `<slot>` interface can be ommitted in preference of an icon only interface. In this context be sure that the `<sp-action-menu>` continued to be accessible to screen readers by applying the `label` attribute. This will apply an `aria-label` attribute of the same value to the `<button>` element that toggles the menu list.

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -16,10 +16,12 @@ import {
     PropertyValues,
     TemplateResult,
 } from '@spectrum-web-components/base';
+import { state } from '@spectrum-web-components/base/src/decorators.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { PickerBase } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/action-button/sp-action-button.js';
+import { ObserveSlotPresence } from '@spectrum-web-components/shared/src/observe-slot-presence.js';
 import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-more.js';
 import actionMenuStyles from './action-menu.css.js';
@@ -35,7 +37,10 @@ import actionMenuStyles from './action-menu.css.js';
  *   you'd like for a selection to be held by the `sp-menu` that it presents in
  *   its overlay, use `selects="single" to activate this functionality.
  */
-export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
+export class ActionMenu extends ObserveSlotPresence(
+    ObserveSlotText(PickerBase, 'label'),
+    '[slot="label-only"]'
+) {
     public static override get styles(): CSSResultArray {
         return [actionMenuStyles];
     }
@@ -52,13 +57,28 @@ export class ActionMenu extends ObserveSlotText(PickerBase, 'label') {
         return this.slotHasContent;
     }
 
+    @state()
+    private get labelOnly(): boolean {
+        return this.slotContentIsPresent;
+    }
+
     protected override get buttonContent(): TemplateResult[] {
         return [
             html`
-                <slot name="icon" slot="icon" ?icon-only=${!this.hasLabel}>
-                    <sp-icon-more class="icon"></sp-icon-more>
-                </slot>
+                ${this.labelOnly
+                    ? html``
+                    : html`
+                          <slot
+                              name="icon"
+                              slot="icon"
+                              ?icon-only=${!this.hasLabel}
+                              ?hidden=${this.labelOnly}
+                          >
+                              <sp-icon-more class="icon"></sp-icon-more>
+                          </slot>
+                      `}
                 <slot name="label" ?hidden=${!this.hasLabel}></slot>
+                <slot name="label-only"></slot>
                 <slot name="tooltip"></slot>
             `,
         ];

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -178,6 +178,33 @@ quiet.args = {
     quiet: true,
 };
 
+export const labelOnly = ({
+    changeHandler = (() => undefined) as (event: Event) => void,
+    disabled = false,
+    open = false,
+    size = 'm' as 'm' | 's' | 'l' | 'xl' | 'xxl',
+    selects = '' as 'single',
+    selected = false,
+} = {}): TemplateResult => html`
+    <sp-action-menu
+        ?disabled=${disabled}
+        ?open=${open}
+        size=${size}
+        @change="${changeHandler}"
+        .selects=${selects ? selects : undefined}
+        value=${selected ? 'Select Inverse' : ''}
+    >
+        <span slot="label-only">Label Only</span>
+        <sp-menu-item>Deselect</sp-menu-item>
+        <sp-menu-item ?selected=${selected}>Select Inverse</sp-menu-item>
+        <sp-menu-item>Feather...</sp-menu-item>
+        <sp-menu-item>Select and Mask...</sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>Save Selection</sp-menu-item>
+        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+    </sp-action-menu>
+`;
+
 export const selects = (args: StoryArgs = {}): TemplateResult =>
     Template({
         ...args,

--- a/tools/shared/src/observe-slot-presence.ts
+++ b/tools/shared/src/observe-slot-presence.ts
@@ -82,13 +82,13 @@ export function ObserveSlotPresence<T extends Constructor<ReactiveElement>>(
         public managePresenceObservedSlot = (): void => {
             let changes = false;
             lightDomSelectors.forEach((selector) => {
-                const nextValue = !!this.querySelector(selector);
+                const nextValue = !!this.querySelector(`:scope > ${selector}`);
                 const previousValue =
                     this[slotContentIsPresent].get(selector) || false;
                 changes = changes || previousValue !== nextValue;
                 this[slotContentIsPresent].set(
                     selector,
-                    !!this.querySelector(selector)
+                    !!this.querySelector(`:scope > ${selector}`)
                 );
             });
             if (changes) {


### PR DESCRIPTION
## Description
Add slot-based API for delivering a Action Menu without an icon in its Action Button

## Related issue(s)
- fixes #2557 

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://action-menu-label-only--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--label-only)
    2. See it in _action_ 😉 

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
