### PR TITLE
fix(slider): add t-shirt sizing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: dde875e38aff1cbbb5eea450b92080b23bd6e79d
+        default: 0cebb3fccf2241ffa7850ab5368ab3d8aef9f0e4
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.38.0"
     },
     "devDependencies": {
-        "@spectrum-css/fieldlabel": "^7.0.23"
+        "@spectrum-css/fieldlabel": "^7.0.32"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/slider/README.md
+++ b/packages/slider/README.md
@@ -30,6 +30,47 @@ When looking to leverage the `Slider` base class as a type and/or for extension 
 import { Slider } from '@spectrum-web-components/slider';
 ```
 
+## Sizes
+
+<sp-tabs selected="m" auto label="Size Attribute Options">
+<sp-tab value="s">Small</sp-tab>
+<sp-tab-panel value="s">
+
+```html
+<sp-slider label="Slider Label" size="s"></sp-slider>
+<sp-slider label="Slider Label - Editable" editable size="s"></sp-slider>
+```
+
+</sp-tab-panel>
+<sp-tab value="m">Medium</sp-tab>
+<sp-tab-panel value="m">
+
+```html
+<sp-slider label="Slider Label"></sp-slider>
+<sp-slider label="Slider Label - Editable" editable></sp-slider>
+```
+
+</sp-tab-panel>
+<sp-tab value="l">Large</sp-tab>
+<sp-tab-panel value="l">
+
+```html
+<sp-slider label="Slider Label" size="l"></sp-slider>
+<sp-slider label="Slider Label - Editable" editable size="l"></sp-slider>
+```
+
+</sp-tab-panel>
+<sp-tab value="xl">Extra Large</sp-tab>
+<sp-tab-panel value="xl">
+
+```html
+<sp-slider label="Slider Label" size="xl"></sp-slider>
+<sp-slider label="Slider Label - Editable" editable size="xl"></sp-slider>
+```
+
+</sp-tab-panel>
+</sp-tabs>
+
 ## Variants
 
 ### Standard

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -83,7 +83,7 @@
         "@spectrum-web-components/theme": "^0.38.0"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^4.1.0"
+        "@spectrum-css/slider": "^4.1.8"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -14,6 +14,7 @@ import {
     CSSResultArray,
     html,
     nothing,
+    SizedMixin,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import {
@@ -45,7 +46,10 @@ export const variants = ['filled', 'ramp', 'range', 'tick'];
  * @slot - text label for the Slider
  * @slot handle - optionally accepts two or more sp-slider-handle elements
  */
-export class Slider extends ObserveSlotText(SliderHandle, '') {
+export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
+    noDefaultSize: true,
+    validSizes: ['s', 'm', 'l', 'xl'],
+}) {
     public static override get styles(): CSSResultArray {
         return [sliderStyles];
     }
@@ -203,6 +207,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                           min=${this.min}
                           max=${this.max}
                           step=${this.step}
+                          size=${this.size}
                           value=${this.value}
                           ?hide-stepper=${this.hideStepper}
                           ?disabled=${this.disabled}
@@ -251,6 +256,7 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                         ? 'number-field'
                         : this.handleController.activeHandleInputId}
                     @click=${this.handleLabelClick}
+                    size=${this.size}
                 >
                     ${this.slotHasContent ? nothing : this.label}
                     <slot>${this.label}</slot>
@@ -259,9 +265,11 @@ export class Slider extends ObserveSlotText(SliderHandle, '') {
                     class=${classMap({
                         'visually-hidden': valueLabelVisible,
                     })}
+                    ?disabled=${this.disabled}
                     for=${this.editable
                         ? 'number-field'
                         : this.handleController.activeHandleInputId}
+                    size=${this.size}
                 >
                     <output id="value" aria-live="off" for="input">
                         ${this.ariaValueText}

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -12,11 +12,6 @@ governing permissions and limitations under the License.
 
 @import url('./spectrum-slider.css');
 
-sp-field-label {
-    padding-top: 0;
-    padding-bottom: 0;
-}
-
 /*
  * Removes blue outline from :host when it is being focused.
  * This situation is not addressed in spectrum-css because the slider element itself
@@ -32,7 +27,7 @@ sp-field-label {
     display: grid;
     grid-template-columns: 1fr auto;
     grid-template-areas:
-        'label .'
+        'label number'
         'slider number';
 }
 
@@ -46,26 +41,8 @@ sp-field-label {
 
 :host([editable]) sp-number-field {
     grid-area: number;
-
-    --mod-stepper-width: var(
-        --spectrum-slider-editable-number-field-width,
-        var(--spectrum-global-dimension-size-1000)
-    );
-}
-
-:host([hide-stepper]) sp-number-field {
-    --mod-stepper-width: var(
-        --spectrum-slider-editable-number-field-width,
-        var(--spectrum-global-dimension-size-900)
-    );
-}
-
-:host([editable][dir='ltr']) sp-number-field {
-    margin-left: var(--spectrum-global-dimension-size-200);
-}
-
-:host([editable][dir='rtl']) sp-number-field {
-    margin-right: var(--spectrum-global-dimension-size-200);
+    align-self: flex-end;
+    margin-inline-start: var(--spectrum-global-dimension-size-200);
 }
 
 :host([editable]) output {

--- a/packages/slider/src/spectrum-config.js
+++ b/packages/slider/src/spectrum-config.js
@@ -59,6 +59,16 @@ const config = {
                         },
                     ],
                 },
+                // Default to `size='m'` without needing the attribute
+                converter.classToHost('spectrum-Slider--sizeM'),
+                ...converter.enumerateAttributes(
+                    [
+                        ['spectrum-Slider--sizeS', 's'],
+                        ['spectrum-Slider--sizeL', 'l'],
+                        ['spectrum-Slider--sizeXL', 'xl'],
+                    ],
+                    'size'
+                ),
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Slider--color', 'color'],

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -28,7 +28,7 @@ governing permissions and limitations under the License.
     --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
     --spectrum-slider-value-inline-size: 18px;
 }
-.spectrum-Slider--sizeS {
+:host([size='s']) {
     --spectrum-slider-font-size: var(--spectrum-font-size-75);
     --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-small);
     --spectrum-slider-control-height: var(--spectrum-component-height-75);
@@ -44,7 +44,7 @@ governing permissions and limitations under the License.
     );
     --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-100);
 }
-.spectrum-Slider--sizeL {
+:host([size='l']) {
     --spectrum-slider-font-size: var(--spectrum-font-size-100);
     --spectrum-slider-handle-size: var(--spectrum-slider-handle-size-large);
     --spectrum-slider-control-height: var(--spectrum-component-height-200);
@@ -63,7 +63,7 @@ governing permissions and limitations under the License.
     --spectrum-slider-value-side-padding-inline: var(--spectrum-spacing-200);
     --spectrum-slider-value-inline-size: 18px;
 }
-.spectrum-Slider--sizeXL {
+:host([size='xl']) {
     --spectrum-slider-font-size: var(--spectrum-font-size-200);
     --spectrum-slider-handle-size: var(
         --spectrum-slider-handle-size-extra-large

--- a/packages/slider/stories/slider-sizes.stories.ts
+++ b/packages/slider/stories/slider-sizes.stories.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import '@spectrum-web-components/slider/sp-slider.js';
+
+export default {
+    component: 'sp-slider',
+    title: 'Slider/Sizes',
+};
+
+const template = ({
+    editable,
+    size,
+}: {
+    editable?: boolean;
+    size?: 's' | 'm' | 'l' | 'xl';
+} = {}): TemplateResult => {
+    return html`
+        <div style="width: 500px; margin-inline: 20px;">
+            <sp-slider
+                ?editable=${editable}
+                max="1"
+                min="0"
+                value=".5"
+                step="0.01"
+                size=${ifDefined(size)}
+            >
+                Opacity
+            </sp-slider>
+        </div>
+    `;
+};
+
+export const s = (): TemplateResult => template({ size: 's' });
+export const sEditable = (): TemplateResult =>
+    template({ size: 's', editable: true });
+export const m = (): TemplateResult => template();
+export const mEditable = (): TemplateResult => template({ editable: true });
+export const l = (): TemplateResult => template({ size: 'l' });
+export const lEditable = (): TemplateResult =>
+    template({ size: 'l', editable: true });
+export const XL = (): TemplateResult => template({ size: 'xl' });
+export const XLEditable = (): TemplateResult =>
+    template({ size: 'xl', editable: true });

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -115,7 +115,7 @@ const handleHandleEvent =
 
 export const Default = (args: StoryArgs = {}): TemplateResult => {
     return html`
-        <div style="width: 500px; margin: 12px 20px;">
+        <div style="width: 500px; margin-inline: 20px;">
             <sp-slider
                 max="1"
                 min="0"
@@ -332,7 +332,7 @@ editable.decorators = [editableDecorator];
 export const editableCustom = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div
-            style="width: 500px; margin: 12px 20px; --spectrum-slider-editable-number-field-width: 150px;"
+            style="width: 500px; margin: 12px 20px; --mod-stepper-width: 150px;"
         >
             <sp-slider
                 editable

--- a/yarn.lock
+++ b/yarn.lock
@@ -6282,10 +6282,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-4.0.62.tgz#b5c0a4f837a780ff6b6987ad4ee9bf4ffba5f433"
   integrity sha512-ESGF+WdKN5n4+aG8PMieuM2hERGExu01VwsJvKEbMRGLKTawycbb1UCNV6F7qaql1zeWeoqeYNTYLFdFOEfsOw==
 
-"@spectrum-css/fieldlabel@^7.0.23":
-  version "7.0.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-7.0.23.tgz#d46acb9072248ba0771827160a68056215d4b5f4"
-  integrity sha512-iDyPS5ZiZ6Omb1KrBOuSLQVNR0Z8nkLCtNTugIayBQSXGyCJiTyYRxmF2Pop+EKapUkw6tP9P8aw6MwVtOWmQg==
+"@spectrum-css/fieldlabel@^7.0.32":
+  version "7.0.32"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-7.0.32.tgz#ca415c851e7f9031c9021de6453a86d0d230001a"
+  integrity sha512-eBTIW5vUgpPjPsTsgzXdjnlBZHCoFJrlPWha/zN/Vddg5eR31A69GArQE7s2RwrNxjtqhN2/B5OYXBFuT4aEVQ==
 
 "@spectrum-css/helptext@^4.0.46":
   version "4.0.50"
@@ -6372,10 +6372,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-4.0.1.tgz#bab00a855d211d0541254b3a8d4a16e701551946"
   integrity sha512-M7ZNLIByXAZpeQpATzURc5aSZ7ftgRBQYF2nTzzyrhJsGyL9ezVTA3cOjj1BVbz8WcbFHFhVIwAyWDXTUAN73g==
 
-"@spectrum-css/slider@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.1.0.tgz#98d5ff69e8734aa5bd20e2f6f3bbf93cfdc4a2da"
-  integrity sha512-w26tc0YZI6/pyQj1HJTTRa42znbPzoKRbmK5tAalUHdzQ6HhlTd8N/AsVFftP0cCDWqb4o9llMEE36NmVn7gHQ==
+"@spectrum-css/slider@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.1.8.tgz#c85ab3461e6e39836fa68d61806b0fe978537c54"
+  integrity sha512-ZDixpjdH0pjgBoCyGGf7Gj//gB0YfzL6wcyvzmRDfraJSqEIc7GOL5ly3rJbCuHjsEB5tXyYc1AwHu4HFhhOFA==
 
 "@spectrum-css/splitbutton@^5.0.60":
   version "5.0.60"


### PR DESCRIPTION
## Description
Add the `s`, `m`, `l`, and `xl` t-shirt sizing to the `<sp-slider>` element.
- size applies to all slider handle/field-label/number-field shadow and light DOM children on the slider and is not customizable
- updated placement of number-field in the overall layout
- removed local margin/padding applications

Correct color delivery of disabled value label.

**TO DO**
- [x] Add "Sizes" section to documentation
- [x] Cycle VRT results for a large number of new new tests

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://sized-slider--spectrum-web-components.netlify.app/storybook/?path=/story/slider-sizes--xl-editable)
    2. Review the new "Sizes" section of the "Slider" stories

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.