### PR TITLE
fix(tooltip): update default offset to match Spectrum defs

### DIFF
--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -25,6 +25,10 @@ import type {
     OverlayOpenCloseDetail,
     Placement,
 } from '@spectrum-web-components/overlay';
+import {
+    IS_MOBILE,
+    MatchMediaController,
+} from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
 
 import tooltipStyles from './tooltip.css.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -117,6 +121,7 @@ export class Tooltip extends SpectrumElement {
     public static override get styles(): CSSResultArray {
         return [tooltipStyles];
     }
+    protected isMobile = new MatchMediaController(this, IS_MOBILE);
 
     /**
      * Automatically bind to the parent element of the assigned `slot` or the parent element of the `sp-tooltip`.
@@ -126,7 +131,7 @@ export class Tooltip extends SpectrumElement {
     public selfManaged = false;
 
     @property({ type: Number })
-    public offset = 0;
+    public offset = this.isMobile.matches ? 5 : 4;
 
     @property({ type: Boolean, reflect: true })
     public open = false;


### PR DESCRIPTION
This PR fixes the default tooltip offset regarding to latest Spectrum defs

## Description

Tooltip offset is aligned to latest Spectrum defs, see: https://spectrum.adobe.com/page/tooltip/#Offset

## Related issue(s)
[#3631](https://github.com/adobe/spectrum-web-components/issues/3631)

## Motivation and context
This change aligns tooltip offset with current application and sync with latest Spectrum definitions

## How has this been tested?

manual tested

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
