### PR TITLE
bug(number-field): update number-field value on pressing "enter"

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -160,10 +160,11 @@ export class NumberField extends TextfieldBase {
         }
         const oldValue = this._value;
         this._value = value;
-        if (!this.managedInput) {
+        if (!this.managedInput && this.lastCommitedValue != this.value) {
             this.dispatchEvent(
                 new Event('change', { bubbles: true, composed: true })
             );
+            this.lastCommitedValue = this.value;
         }
         this.requestUpdate('value', oldValue);
     }
@@ -180,6 +181,7 @@ export class NumberField extends TextfieldBase {
 
     public override _value = NaN;
     private _trackingValue = '';
+    private lastCommitedValue = NaN;
 
     /**
      * Retreive the value of the element parsed to a Number.
@@ -285,9 +287,12 @@ export class NumberField extends TextfieldBase {
         this.buttons.releasePointerCapture(event.pointerId);
         cancelAnimationFrame(this.nextChange);
         clearTimeout(this.safty);
-        this.dispatchEvent(
-            new Event('change', { bubbles: true, composed: true })
-        );
+        if (this.lastCommitedValue != this.value) {
+            this.dispatchEvent(
+                new Event('change', { bubbles: true, composed: true })
+            );
+            this.lastCommitedValue = this.value;
+        }
         this.managedInput = false;
     }
 
@@ -357,6 +362,7 @@ export class NumberField extends TextfieldBase {
                 this.dispatchEvent(
                     new Event('change', { bubbles: true, composed: true })
                 );
+                this.lastCommitedValue = this.value;
             }, CHANGE_DEBOUNCE_MS) as unknown as number;
         }
         this.managedInput = false;
@@ -400,7 +406,10 @@ export class NumberField extends TextfieldBase {
         }
         this.value = value;
         this.inputElement.value = this.formattedValue;
-        super.handleChange();
+        if (this.lastCommitedValue != this.value) {
+            this.lastCommitedValue = this.value;
+            super.handleChange();
+        }
     }
 
     protected handleCompositionStart(): void {

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -160,7 +160,7 @@ export class NumberField extends TextfieldBase {
         }
         const oldValue = this._value;
         this._value = value;
-        if (!this.managedInput && this.lastCommitedValue != this.value) {
+        if (!this.managedInput && this.lastCommitedValue !== this.value) {
             this.dispatchEvent(
                 new Event('change', { bubbles: true, composed: true })
             );
@@ -287,7 +287,7 @@ export class NumberField extends TextfieldBase {
         this.buttons.releasePointerCapture(event.pointerId);
         cancelAnimationFrame(this.nextChange);
         clearTimeout(this.safty);
-        if (this.lastCommitedValue != this.value) {
+        if (this.lastCommitedValue !== this.value) {
             this.dispatchEvent(
                 new Event('change', { bubbles: true, composed: true })
             );
@@ -406,7 +406,7 @@ export class NumberField extends TextfieldBase {
         }
         this.value = value;
         this.inputElement.value = this.formattedValue;
-        if (this.lastCommitedValue != this.value) {
+        if (this.lastCommitedValue !== this.value) {
             this.lastCommitedValue = this.value;
             super.handleChange();
         }

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -160,6 +160,11 @@ export class NumberField extends TextfieldBase {
         }
         const oldValue = this._value;
         this._value = value;
+        if (!this.managedInput) {
+            this.dispatchEvent(
+                new Event('change', { bubbles: true, composed: true })
+            );
+        }
         this.requestUpdate('value', oldValue);
     }
 
@@ -329,16 +334,10 @@ export class NumberField extends TextfieldBase {
             case 'ArrowUp':
                 event.preventDefault();
                 this.increment(event.shiftKey ? this.stepModifier : 1);
-                this.dispatchEvent(
-                    new Event('change', { bubbles: true, composed: true })
-                );
                 break;
             case 'ArrowDown':
                 event.preventDefault();
                 this.decrement(event.shiftKey ? this.stepModifier : 1);
-                this.dispatchEvent(
-                    new Event('change', { bubbles: true, composed: true })
-                );
                 break;
         }
     }
@@ -400,6 +399,7 @@ export class NumberField extends TextfieldBase {
             }
         }
         this.value = value;
+        this.inputElement.value = this.formattedValue;
         super.handleChange();
     }
 

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -566,7 +566,7 @@ describe('NumberField', () => {
                 ],
             });
             expect(inputSpy.callCount).to.equal(4);
-            expect(changeSpy.callCount).to.equal(1);
+            expect(changeSpy.callCount).to.equal(0); // the actual value hasn't changed so changespy won't be called
         });
     });
     it('accepts pointer interactions with the stepper UI', async () => {
@@ -751,7 +751,7 @@ describe('NumberField', () => {
             await sendKeys({ press: 'Enter' });
             await elementUpdated(el);
             expect(lastInputValue, 'last input value').to.equal(10);
-            expect(lastChangeValue, 'last change value').to.equal(10);
+            expect(lastChangeValue, 'last change value').to.equal(0); // value wouldn't go beyond max, so it remains unchanged after pressing enter and thus no changeSpy called
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
@@ -811,7 +811,7 @@ describe('NumberField', () => {
             await sendKeys({ press: 'Enter' });
             await elementUpdated(el);
             expect(lastInputValue, 'last input value').to.equal(10);
-            expect(lastChangeValue, 'last change value').to.equal(10);
+            expect(lastChangeValue, 'last change value').to.equal(0);
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -362,6 +362,16 @@ describe('NumberField', () => {
                 changeSpy((event.target as NumberField)?.value);
             });
         });
+        it('on changing `value`', async () => {
+            el.focus();
+            await elementUpdated(el);
+            expect(el.focused).to.be.true;
+            el.value = 51;
+            expect(changeSpy.callCount).to.equal(1);
+            await elementUpdated(el);
+            el.value = 52;
+            expect(changeSpy.callCount).to.equal(2);
+        });
         it('via scroll', async () => {
             el.focus();
             await elementUpdated(el);
@@ -542,6 +552,72 @@ describe('NumberField', () => {
             expect(el.value).to.equal(52);
             expect(inputSpy.callCount).to.equal(2);
             expect(changeSpy.callCount).to.equal(0);
+            await oneEvent(el, 'input');
+            expect(el.value).to.equal(53);
+            expect(inputSpy.callCount).to.equal(3);
+            expect(changeSpy.callCount).to.equal(0);
+            sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: buttonDownPosition,
+                    },
+                ],
+            });
+            let framesToWait = FRAMES_PER_CHANGE * 2;
+            while (framesToWait) {
+                // input is only processed onces per FRAMES_PER_CHANGE number of frames
+                framesToWait -= 1;
+                await nextFrame();
+            }
+            expect(inputSpy.callCount).to.equal(5);
+            expect(changeSpy.callCount).to.equal(0);
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'up',
+                    },
+                ],
+            });
+            expect(inputSpy.callCount).to.equal(5);
+            expect(changeSpy.callCount).to.equal(1);
+        });
+        it('no change in committed value - using buttons', async () => {
+            const buttonUp = el.shadowRoot.querySelector(
+                '.step-up'
+            ) as HTMLElement;
+            const buttonUpRect = buttonUp.getBoundingClientRect();
+            const buttonUpPosition: [number, number] = [
+                buttonUpRect.x + buttonUpRect.width / 2,
+                buttonUpRect.y + buttonUpRect.height / 2,
+            ];
+            const buttonDown = el.shadowRoot.querySelector(
+                '.step-down'
+            ) as HTMLElement;
+            const buttonDownRect = buttonDown.getBoundingClientRect();
+            const buttonDownPosition: [number, number] = [
+                buttonDownRect.x + buttonDownRect.width / 2,
+                buttonDownRect.y + buttonDownRect.height / 2,
+            ];
+            sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: buttonUpPosition,
+                    },
+                    {
+                        type: 'down',
+                    },
+                ],
+            });
+            await oneEvent(el, 'input');
+            expect(el.value).to.equal(51);
+            expect(inputSpy.callCount).to.equal(1);
+            expect(changeSpy.callCount).to.equal(0);
+            await oneEvent(el, 'input');
+            expect(el.value).to.equal(52);
+            expect(inputSpy.callCount).to.equal(2);
+            expect(changeSpy.callCount).to.equal(0);
             sendMouse({
                 steps: [
                     {
@@ -566,7 +642,10 @@ describe('NumberField', () => {
                 ],
             });
             expect(inputSpy.callCount).to.equal(4);
-            expect(changeSpy.callCount).to.equal(0); // the actual value hasn't changed so changespy won't be called
+            expect(
+                changeSpy.callCount,
+                'value does not change from initial value so no "change" event is dispatched'
+            ).to.equal(0);
         });
     });
     it('accepts pointer interactions with the stepper UI', async () => {
@@ -751,7 +830,10 @@ describe('NumberField', () => {
             await sendKeys({ press: 'Enter' });
             await elementUpdated(el);
             expect(lastInputValue, 'last input value').to.equal(10);
-            expect(lastChangeValue, 'last change value').to.equal(0); // value wouldn't go beyond max, so it remains unchanged after pressing enter and thus no changeSpy called
+            expect(lastChangeValue, 'last change value').to.equal(
+                0,
+                'value does not change from initial value so no "change" event is dispatched'
+            );
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
@@ -785,6 +867,14 @@ describe('NumberField', () => {
             expect(el.valueAsString).to.equal('5');
             expect(el.value).to.equal(5);
         });
+        it('dispatches onchange on setting max value', async () => {
+            el.value = 5;
+            await elementUpdated(el);
+            expect(lastChangeValue, 'last change value').to.equal(5);
+            el.value = 15;
+            await elementUpdated(el);
+            expect(lastChangeValue, 'last change value').to.equal(10);
+        });
     });
     describe('min', () => {
         let el: NumberField;
@@ -811,10 +901,21 @@ describe('NumberField', () => {
             await sendKeys({ press: 'Enter' });
             await elementUpdated(el);
             expect(lastInputValue, 'last input value').to.equal(10);
-            expect(lastChangeValue, 'last change value').to.equal(0);
+            expect(lastChangeValue, 'last change value').to.equal(
+                0,
+                'value does not change from initial value so no "change" event is dispatched'
+            );
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
+        });
+        it('dispatches onchange on setting min value', async () => {
+            el.value = 15;
+            await elementUpdated(el);
+            expect(lastChangeValue, 'last change value').to.equal(15);
+            el.value = 5;
+            await elementUpdated(el);
+            expect(lastChangeValue, 'last change value').to.equal(10);
         });
         xit('manages `inputMode` in iPhone', async () => {
             // setUserAgent is not currently supported by Playwright


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If you type in a number larger than the max attribute and press "return", it should change the number to the max.
i.e. The value inside the number-field should update on pressing "return" however right now it only happens when the input is blurred out.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3000

## Motivation and context

If you type in a number larger than the max attribute and press "return", it doesn't always change the number. However, the number is always changed when the input is blurred. In addition, the number is never changed when format-options is used, and the number is only changed the first time you press "return" even without format-options.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
