### PR TITLE
fix(overlay): ensure position when closing overlays over the top-layer

### DIFF
--- a/packages/overlay/src/OverlayPopover.ts
+++ b/packages/overlay/src/OverlayPopover.ts
@@ -29,6 +29,20 @@ import {
 } from './AbstractOverlay.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
 
+function isOpen(el: HTMLElement): boolean {
+    let popoverOpen = false;
+    try {
+        popoverOpen = el.matches(':popover-open');
+        // eslint-disable-next-line no-empty
+    } catch (error) {}
+    let open = false;
+    try {
+        open = el.matches(':open');
+        // eslint-disable-next-line no-empty
+    } catch (error) {}
+    return popoverOpen || open;
+}
+
 export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
     constructor: T
 ): T & Constructor<ReactiveElement> {
@@ -48,16 +62,37 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
             }
         }
 
+        /**
+         * A popover should be hidden _after_ it is no longer on top-layer because
+         * the position metrics will have changed from when it was originally positioned.
+         */
         private async shouldHidePopover(
             targetOpenState: boolean
         ): Promise<void> {
             if (targetOpenState && this.open !== targetOpenState) {
                 return;
             }
-            // When in a parent Overlay, this Overlay may need to position itself
-            // while closing in due to the parent _also_ closing which means the
-            // location can no longer rely on "top layer over transform" math.
-            await this.placementController.resetOverlayPosition();
+            const update = async ({
+                newState,
+            }: { newState?: string } = {}): Promise<void> => {
+                if (newState === 'open') {
+                    return;
+                }
+                // When in a parent Overlay, this Overlay may need to position itself
+                // while closing in due to the parent _also_ closing which means the
+                // location can no longer rely on "top layer over transform" math.
+                await this.placementController.resetOverlayPosition();
+            };
+            if (!isOpen(this.dialogEl)) {
+                // The means the Overlay was closed from the outside, it is already off of top-layer
+                // so we need to position it in regards to this new state.
+                update();
+                return;
+            }
+            // `toggle` is an async event, so it's possible for this handler to run a frame late
+            this.dialogEl.addEventListener('toggle', update as EventListener, {
+                once: true,
+            });
         }
 
         private async shouldShowPopover(
@@ -181,21 +216,8 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
                     if (this.open !== targetOpenState) {
                         return;
                     }
-                    let popoverOpen = false;
-                    try {
-                        popoverOpen = this.dialogEl.matches(':popover-open');
-                        // eslint-disable-next-line no-empty
-                    } catch (error) {}
-                    let open = false;
-                    try {
-                        open = this.dialogEl.matches(':open');
-                        // eslint-disable-next-line no-empty
-                    } catch (error) {}
-                    if (
-                        targetOpenState !== true &&
-                        (popoverOpen || open) &&
-                        this.isConnected
-                    ) {
+                    const open = isOpen(this.dialogEl);
+                    if (targetOpenState !== true && open && this.isConnected) {
                         this.dialogEl.addEventListener(
                             'beforetoggle',
                             () => {


### PR DESCRIPTION
## Description
When manually closing a Overlay that leverages `popover`, wait till the Overlay has left top-layer before measuring its position.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/overlay--complex-modal)
    2. Once the Picker is all the way open, click the Picker to close it
    3. See the Menu jump down and to the right
    4. This sometimes requires the Animations speed to be turned down to 25 or 10% in order to see.
-   [ ] _Test case 2_
    1. Go [here](https://overlay-close-position--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--complex-modal)
    2. Once the Picker is all the way open, click the Picker to close it
    3. See the Menu DOES NOT jump down and to the right
    4. This sometimes requires the Animations speed to be turned down to 25 or 10% in order to see.


## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.