### PR TITLE
fix: opacity checkerboard inclusion order

### DIFF
--- a/packages/color-loupe/src/ColorLoupe.ts
+++ b/packages/color-loupe/src/ColorLoupe.ts
@@ -26,7 +26,7 @@ import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerb
  */
 export class ColorLoupe extends SpectrumElement {
     public static override get styles(): CSSResultArray {
-        return [styles, opacityCheckerboardStyles];
+        return [opacityCheckerboardStyles, styles];
     }
 
     @property({ type: Boolean, reflect: true })

--- a/tools/opacity-checkerboard/README.md
+++ b/tools/opacity-checkerboard/README.md
@@ -4,21 +4,22 @@ The `opacity-checkerboard` class is used to highlight opacity. Leverage these st
 
 ## Usage
 
-Import the styles from `opacity-checkerboard` css
+Import the styles from the `opacity-checkerboard` CSS:
 
 ```
-import opacityCheckeryBoardStyles from '@spectrum-web-components/tools/opacity-checkerboard/src/opacity-checkerboard.css.js';
+import opacityCheckerBoardStyles from '@spectrum-web-components/opacity-checkerboard/src/opacity-checkerboard.css.js';
 ```
 
-Add it to your component's styles array
+Add it to your component's styles array before your component's styles. The order that you include the styles in makes a difference, because selectors within opacity checkerboard may have the same
+specificity as those within your component.
 
 ```js
 public static override get styles(): CSSResultArray {
-    return [...styles, opacityCheckeryBoardStyles];
+    return [opacityCheckerBoardStyles, styles];
 }
 ```
 
-Use the `opacity-checkerboard` class in `render()` method
+Use the `opacity-checkerboard` class in your component's `render()` method:
 
 ```html-live demo
 <div


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Updated docs around opacity-checkerboard inclusion order and fixed a path that was wrong there
- Updated order of styles in only component I found where the checkerboard styles were after the component styles

Related to some discussion around an open issue around inclusion order in Spectrum CSS, and thoughts around doc updates when I was integrating opacity-checkerboard with ColorSlider.

## How has this been tested?

### Validation Steps
-   [ ] _Make sure ColorLoupe visuals have not changed_
-   [ ] _Review [updated docs](https://checkerboard-inclusion-order--spectrum-web-components.netlify.app/tools/opacity-checkerboard/) for opacity-checkerboard_

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
