### PR TITLE
fix(menu): manage deeply slotted menu items and initial focus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 707045e284a1aa060762b7441c320c3f48222234
+        default: 9494051c6e69193df911d0f2571c794fe6f20f00
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/menu/stories/index.ts
+++ b/packages/menu/stories/index.ts
@@ -10,11 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import {
+    html,
+    LitElement,
+    TemplateResult,
+} from '@spectrum-web-components/base';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/popover/sp-popover.js';
+import { Menu } from '@spectrum-web-components/menu';
 
 export const MenuMarkup = ({
     size = 'm' as 's' | 'm' | 'l' | 'xl',
@@ -43,3 +48,54 @@ export const MenuMarkup = ({
         </sp-popover>
     `;
 };
+
+export class ComplexSlottedGroup extends LitElement {
+    get menu(): Menu {
+        return this.renderRoot.querySelector('sp-menu') as Menu;
+    }
+    protected override render(): TemplateResult {
+        return html`
+            <sp-menu>
+                <sp-menu-group>
+                    <sp-menu-item id="i-1">Before First</sp-menu-item>
+                    <slot name="before"></slot>
+                </sp-menu-group>
+                <sp-menu-group>
+                    <sp-menu-item id="i-4">Sibling 1</sp-menu-item>
+                    <slot></slot>
+                    <sp-menu-item id="i-10">Sibling 2</sp-menu-item>
+                </sp-menu-group>
+                <sp-menu-group>
+                    <sp-menu-item id="i-11">After 1</sp-menu-item>
+                    <sp-menu-item id="i-12">After 2</sp-menu-item>
+                </sp-menu-group>
+            </sp-menu>
+        `;
+    }
+}
+
+customElements.define('complex-slotted-group', ComplexSlottedGroup);
+
+export class ComplexSlottedMenu extends LitElement {
+    get menu(): Menu {
+        return (
+            this.renderRoot.querySelector(
+                'complex-slotted-group'
+            ) as ComplexSlottedGroup
+        ).menu;
+    }
+    protected override render(): TemplateResult {
+        return html`
+            <complex-slotted-group id="group">
+                <sp-menu-item id="i-5">Middle 1</sp-menu-item>
+                <sp-menu-item id="i-6">Middle 2</sp-menu-item>
+                <sp-menu-item id="i-7">Middle 3</sp-menu-item>
+                <slot></slot>
+                <slot name="before" slot="before"></slot>
+                <sp-menu-item slot="before" id="i-3">Before Last</sp-menu-item>
+            </complex-slotted-group>
+        `;
+    }
+}
+
+customElements.define('complex-slotted-menu', ComplexSlottedMenu);

--- a/packages/menu/stories/menu-group.stories.ts
+++ b/packages/menu/stories/menu-group.stories.ts
@@ -20,9 +20,21 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/menu/sp-menu-group.js';
 
+import './index.js';
+
 export default {
     component: 'sp-menu',
     title: 'Menu Group',
+};
+
+export const complexSlotted = (): TemplateResult => {
+    return html`
+        <complex-slotted-menu>
+            <sp-menu-item slot="before" id="i-2">External A</sp-menu-item>
+            <sp-menu-item id="i-8">External 1</sp-menu-item>
+            <sp-menu-item id="i-9">External 2</sp-menu-item>
+        </complex-slotted-menu>
+    `;
 };
 
 export const mixed = (): TemplateResult => {


### PR DESCRIPTION
## Description
Allow `<sp-menu>` to coalesce slotted content across multiple composed slots, across multiple Menu Groups, into its Menu Items cache.

## Related issue(s)
- fixes #3647

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://deep-slotted-items--spectrum-web-components.netlify.app/storybook/?path=/story/menu-group--complex-slotted)
    2. See that the tab focus enters the group and the arrow based focus group includes all of the Menu Items

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)