### PR TITLE
fix(overlay): allow "receives-focus" to target the root of an overlay

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 9494051c6e69193df911d0f2571c794fe6f20f00
+        default: a1b36206c9a867825429a05c55190164ddfeb3be
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/overlay/src/OverlayDialog.ts
+++ b/packages/overlay/src/OverlayDialog.ts
@@ -26,6 +26,7 @@ import {
     guaranteedAllTransitionend,
 } from './AbstractOverlay.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
+import { userFocusableSelector } from '@spectrum-web-components/shared';
 
 export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
     constructor: T
@@ -75,6 +76,9 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
                     if (!targetOpenState) {
                         // Show/focus workflow when opening _only_.
                         return;
+                    }
+                    if (el.matches(userFocusableSelector)) {
+                        focusEl = el;
                     }
                     focusEl = focusEl || firstFocusableIn(el);
                     if (!focusEl) {

--- a/packages/overlay/src/OverlayNoPopover.ts
+++ b/packages/overlay/src/OverlayNoPopover.ts
@@ -28,6 +28,7 @@ import {
     overlayTimer,
 } from './AbstractOverlay.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
+import { userFocusableSelector } from '@spectrum-web-components/shared';
 
 export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
     constructor: T
@@ -80,6 +81,9 @@ export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
                 }
                 if (targetOpenState !== true) {
                     return;
+                }
+                if (el.matches(userFocusableSelector)) {
+                    focusEl = el;
                 }
                 focusEl = focusEl || firstFocusableIn(el);
                 if (focusEl) {

--- a/packages/overlay/src/OverlayPopover.ts
+++ b/packages/overlay/src/OverlayPopover.ts
@@ -28,6 +28,7 @@ import {
     overlayTimer,
 } from './AbstractOverlay.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
+import { userFocusableSelector } from '@spectrum-web-components/shared';
 
 function isOpen(el: HTMLElement): boolean {
     let popoverOpen = false;
@@ -148,6 +149,9 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
                 }
                 if (!targetOpenState) {
                     return;
+                }
+                if (el.matches(userFocusableSelector)) {
+                    focusEl = el;
                 }
                 focusEl = focusEl || firstFocusableIn(el);
                 if (focusEl) {

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -67,6 +67,7 @@ type Properties = {
     interaction: 'click' | 'hover' | 'longpress';
     open?: boolean;
     placement?: Placement;
+    receivesFocus?: 'true' | 'false' | 'auto';
     type?: OverlayTypes;
 };
 
@@ -151,6 +152,37 @@ longpress.args = {
     placement: 'right',
     type: 'auto',
 };
+
+/**
+ * Proxy for fully encapsulated overlay containers that need to
+ * pass `focus` into a shadow child element.
+ */
+export const receivesFocus = ({
+    interaction,
+    open,
+    placement,
+    receivesFocus,
+    type,
+}: Properties): TemplateResult => html`
+    <sp-action-button id="trigger">
+        Open the overlay (with focus)
+    </sp-action-button>
+    <sp-overlay
+        ?open=${open}
+        trigger="trigger@${interaction}"
+        type=${ifDefined(type)}
+        placement=${ifDefined(placement)}
+        .receivesFocus=${receivesFocus || 'auto'}
+    >
+        <a href="https://example.com">Click Content</a>
+    </sp-overlay>
+`;
+receivesFocus.args = {
+    interaction: 'click',
+    placement: 'bottom-start',
+    type: 'auto',
+    receivesFocus: 'true',
+} as Properties;
 
 export const transformed = (args: Properties): TemplateResult => html`
     <style>

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -67,7 +67,7 @@ type Properties = {
     interaction: 'click' | 'hover' | 'longpress';
     open?: boolean;
     placement?: Placement;
-    receivesFocus?: 'true' | 'false' | 'auto';
+    receivesFocus: 'true' | 'false' | 'auto';
     type?: OverlayTypes;
 };
 
@@ -172,7 +172,7 @@ export const receivesFocus = ({
         trigger="trigger@${interaction}"
         type=${ifDefined(type)}
         placement=${ifDefined(placement)}
-        .receivesFocus=${receivesFocus || 'auto'}
+        .receivesFocus=${receivesFocus}
     >
         <a href="https://example.com">Click Content</a>
     </sp-overlay>

--- a/packages/overlay/test/overlay-element.test.ts
+++ b/packages/overlay/test/overlay-element.test.ts
@@ -31,6 +31,7 @@ import '@spectrum-web-components/button/sp-button.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import { Button } from '@spectrum-web-components/button';
 import { sendKeys } from '@web/test-runner-commands';
+import { receivesFocus } from '../stories/overlay-element.stories.js';
 
 const OVERLAY_TYPES = ['modal', 'page', 'hint', 'auto', 'manual'] as const;
 type OverlayTypes = typeof OVERLAY_TYPES[number];
@@ -652,6 +653,21 @@ describe('sp-overlay', () => {
     });
     describe('[type="auto"]', () => {
         opensDeclaratively('auto');
+        it('receives focus', async () => {
+            const test = await fixture(html`
+                <div>${receivesFocus(receivesFocus.args)}</div>
+            `);
+            const trigger = test.querySelector('#trigger') as Button;
+            const overlay = test.querySelector('a');
+
+            expect(document.activeElement === overlay).to.be.false;
+
+            const opened = oneEvent(trigger, 'sp-opened');
+            trigger.click();
+            await opened;
+
+            expect(document.activeElement === overlay).to.be.true;
+        });
     });
     describe('[type="manual"]', () => {
         opensDeclaratively('manual');


### PR DESCRIPTION
## Description
Adds ability for the Overlay to pass focus focus to a root element in the Overlay rather than only child content.

## Related issue(s)
- fixes #3640

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://receives-focus--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-element--receives-focus)
    2. See that focus is on the link by default when the overlay is first opened

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)