### PR TITLE
fix(picker,split-button): include "tooltip" slot in the main button

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 3a64ac12c8f693d633deef93ca1f7556163a2565
+        default: af8817593fda162c2d2799b4ce593ea10037ea2e
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -32,7 +32,7 @@ import actionMenuStyles from './action-menu.css.js';
  * @slot - menu items to be listed in the Action Menu
  * @slot icon - The icon to use for Action Menu
  * @slot label - The label to use on for the Action Menu
- * @slot tooltip - Tooltip to use on for the Action menu
+ * @slot tooltip - Tooltip to to be applied to the the Action Button
  * @attr selects - By default `sp-action-menu` does not manage a selection. If
  *   you'd like for a selection to be held by the `sp-menu` that it presents in
  *   its overlay, use `selects="single" to activate this functionality.

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -22,6 +22,7 @@ import { makeOverBackground } from '../../button/stories/index.js';
 
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import type { MenuItem } from '@spectrum-web-components/menu/src/MenuItem.js';
+import { Placement } from '@spectrum-web-components/overlay/src/overlay-types.js';
 
 export default {
     component: 'sp-action-menu',
@@ -153,7 +154,7 @@ interface StoryArgs {
     quiet?: boolean;
     staticValue?: 'white' | 'black' | undefined;
     tooltipDescription?: string | 'none';
-    tooltipPlacement?: string | 'none';
+    tooltipPlacement?: Placement;
 }
 
 const Template = (args: StoryArgs = {}): TemplateResult =>
@@ -228,7 +229,7 @@ tooltipDescriptionAndPlacement.args = {
     tooltipDescription: 'Your tooltip string here',
     visibleLabel: '',
     tooltipPlacement: 'bottom',
-};
+} as StoryArgs;
 
 export const customIcon = (args: StoryArgs): TemplateResult => Template(args);
 customIcon.args = {

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -18,6 +18,7 @@ import '@spectrum-web-components/icon/sp-icon.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import { Placement } from '@spectrum-web-components/overlay/src/overlay-types.js';
 
 export const ActionMenuMarkup = ({
     ariaLabel = 'More Actions',
@@ -32,7 +33,7 @@ export const ActionMenuMarkup = ({
     selects = '' as 'single',
     selected = false,
     tooltipDescription = '',
-    tooltipPlacement = 'bottom',
+    tooltipPlacement = 'bottom' as Placement,
 } = {}): TemplateResult => {
     return html`
         <sp-action-menu
@@ -41,7 +42,9 @@ export const ActionMenuMarkup = ({
             ?open=${open}
             ?quiet=${quiet}
             static=${ifDefined(
-                staticValue === 'none' ? undefined : staticValue
+                staticValue === 'none'
+                    ? undefined
+                    : (staticValue as 'black' | 'white')
             )}
             size=${size}
             @change="${changeHandler}"

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -450,7 +450,7 @@ export class Overlay extends OverlayFeatures {
                 );
             }
         }
-        if (!this.open) {
+        if (!this.open && this.type !== 'hint') {
             // If the focus remains inside of the overlay or
             // a slotted descendent of the overlay you need to return
             // focus back to the trigger.

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -537,7 +537,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
         `;
     }
 
-    protected hasOpened = false;
+    protected hasRenderedOverlay = false;
 
     protected get renderMenu(): TemplateResult {
         const menu = html`
@@ -558,8 +558,12 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 <slot @slotchange=${this.shouldScheduleManageSelection}></slot>
             </sp-menu>
         `;
-        this.hasOpened = this.hasOpened || this.open || !!this.deprecatedMenu;
-        if (this.hasOpened) {
+        this.hasRenderedOverlay =
+            this.hasRenderedOverlay ||
+            this.focused ||
+            this.open ||
+            !!this.deprecatedMenu;
+        if (this.hasRenderedOverlay) {
             return this.renderOverlay(menu);
         }
         return menu;
@@ -704,23 +708,19 @@ export class Picker extends PickerBase {
     protected override handleKeydown = (event: KeyboardEvent): void => {
         const { code } = event;
         this.focused = true;
-        if (code === 'ArrowUp' || code === 'ArrowDown') {
-            this.toggle(true);
-            return;
-        }
         if (!code.startsWith('Arrow') || this.readonly) {
             return;
         }
-        event.preventDefault();
         if (code === 'ArrowUp' || code === 'ArrowDown') {
             this.toggle(true);
             return;
         }
+        event.preventDefault();
         const selectedIndex = this.selectedItem
             ? this.menuItems.indexOf(this.selectedItem)
             : -1;
         // use a positive offset to find the first non-disabled item when no selection is available.
-        const nextOffset = !this.value || code === 'ArrowRight' ? 1 : -1;
+        const nextOffset = selectedIndex < 0 || code === 'ArrowRight' ? 1 : -1;
         let nextIndex = selectedIndex + nextOffset;
         while (
             this.menuItems[nextIndex] &&

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -375,6 +375,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                         this.size as DefaultElementSize
                     ]}"
                 ></sp-icon-chevron100>
+                <slot aria-hidden="true" name="tooltip" id="tooltip"></slot>
             `,
         ];
     }
@@ -426,9 +427,10 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 @focus=${this.handleHelperFocus}
             ></span>
             <button
-                aria-haspopup="true"
                 aria-controls=${ifDefined(this.open ? 'menu' : undefined)}
+                aria-describedby="tooltip"
                 aria-expanded=${this.open ? 'true' : 'false'}
+                aria-haspopup="true"
                 aria-labelledby="icon label applied-label"
                 id="button"
                 class="button"
@@ -680,6 +682,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
  * @element sp-picker
  *
  * @slot label - The placeholder content for the Picker
+ * @slot tooltip - Tooltip to to be applied to the the Picker Button
  * @slot - menu items to be listed in the Picker
  * @fires change - Announces that the `value` of the element has changed
  * @fires sp-opened - Announces that the overlay has been opened

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -15,6 +15,7 @@ import { html, TemplateResult } from '@spectrum-web-components/base';
 import '@spectrum-web-components/picker/sp-picker.js';
 import { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-copy.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-delete.js';
@@ -124,6 +125,46 @@ export const Default = (args: StoryArgs): TemplateResult => {
             .
         </p>
     `;
+};
+
+export const tooltip = (args: StoryArgs): TemplateResult => {
+    const { open, ...rest } = args;
+    return html`
+        <sp-field-label for="picker-1">Where do you live?</sp-field-label>
+        <sp-picker
+            id="picker-1"
+            @change=${handleChange(args)}
+            label="Select a Country with a very long label, too long, in fact"
+            ${spreadProps(rest)}
+        >
+            <sp-menu-item value="option-1">Deselect</sp-menu-item>
+            <sp-menu-item value="option-2">Select Inverse</sp-menu-item>
+            <sp-menu-item value="option-3">Feather...</sp-menu-item>
+            <sp-menu-item value="option-4">Select and Mask...</sp-menu-item>
+            <sp-menu-item value="option-5">Save Selection</sp-menu-item>
+            <sp-menu-item disabled value="option-6">
+                Make Work Path
+            </sp-menu-item>
+            <sp-tooltip
+                slot="tooltip"
+                ?open=${open}
+                self-managed
+                placement="right"
+            >
+                This Picker wants to know where you live.
+            </sp-tooltip>
+        </sp-picker>
+        <p>This is some text.</p>
+        <p>This is some text.</p>
+        <p>
+            This is a
+            <a href="#anchor">link</a>
+            .
+        </p>
+    `;
+};
+tooltip.args = {
+    open: true,
 };
 
 export const noVisibleLabel = (args: StoryArgs): TemplateResult => {

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -27,7 +27,6 @@ import '@spectrum-web-components/shared/src/focus-visible.js';
 import { spy, stub } from 'sinon';
 import {
     arrowDownEvent,
-    arrowLeftEvent,
     arrowRightEvent,
     arrowUpEvent,
     testForLitDevWarnings,
@@ -43,9 +42,13 @@ import {
     iconsOnly,
     noVisibleLabel,
     slottedLabel,
+    tooltip,
 } from '../stories/picker.stories.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
-import { ignoreResizeObserverLoopError } from '../../../test/testing-helpers.js';
+import {
+    ignoreResizeObserverLoopError,
+    fixture as styledFixture,
+} from '../../../test/testing-helpers.js';
 import { isFirefox } from '@spectrum-web-components/shared/src/platform.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
@@ -54,6 +57,7 @@ import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/theme/src/themes.js';
 import type { Menu } from '@spectrum-web-components/menu';
+import { Tooltip } from '@spectrum-web-components/tooltip';
 
 export type TestablePicker = { optionsMenu: Menu };
 
@@ -838,39 +842,64 @@ export function runPickerTests(): void {
             expect(el.value).to.equal('Deselect');
         });
         it('quick selects on ArrowLeft/Right', async () => {
-            await nextFrame();
             const selectionSpy = spy();
             el.addEventListener('change', (event: Event) => {
                 const { value } = event.target as Picker;
                 selectionSpy(value);
             });
-            const button = el.button as HTMLButtonElement;
 
             el.focus();
-            button.dispatchEvent(arrowLeftEvent());
+            await elementUpdated(el);
+            await waitUntil(
+                () =>
+                    (el as unknown as { menuItems: MenuItem[] }).menuItems
+                        .length === 6
+            );
 
+            await sendKeys({
+                press: 'ArrowLeft',
+            });
             await elementUpdated(el);
 
             expect(selectionSpy.callCount).to.equal(1);
             expect(selectionSpy.calledWith('Deselected'));
-            button.dispatchEvent(arrowLeftEvent());
+            await sendKeys({
+                press: 'ArrowLeft',
+            });
 
             await elementUpdated(el);
             expect(selectionSpy.callCount).to.equal(1);
-            button.dispatchEvent(arrowRightEvent());
+            await sendKeys({
+                press: 'ArrowRight',
+            });
 
-            await elementUpdated(el);
+            await nextFrame();
+            await nextFrame();
             expect(selectionSpy.calledWith('option-2'));
 
-            button.dispatchEvent(arrowRightEvent());
-            button.dispatchEvent(arrowRightEvent());
-            button.dispatchEvent(arrowRightEvent());
-            button.dispatchEvent(arrowRightEvent());
-
-            await elementUpdated(el);
-            expect(selectionSpy.callCount).to.equal(5);
+            await sendKeys({
+                press: 'ArrowRight',
+            });
+            await nextFrame();
+            await nextFrame();
+            await sendKeys({
+                press: 'ArrowRight',
+            });
+            await nextFrame();
+            await nextFrame();
+            await sendKeys({
+                press: 'ArrowRight',
+            });
+            await nextFrame();
+            await nextFrame();
+            await sendKeys({
+                press: 'ArrowRight',
+            });
+            await nextFrame();
+            await nextFrame();
             expect(selectionSpy.calledWith('Save Selection'));
             expect(selectionSpy.calledWith('Make Work Path')).to.be.false;
+            expect(selectionSpy.callCount).to.equal(5);
         });
         it('quick selects first item on ArrowRight when no value', async () => {
             await nextFrame();
@@ -1604,5 +1633,51 @@ export function runPickerTests(): void {
         // const closedEvent = closedSpy
         //     .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
         // expect(closedEvent.detail.interaction).to.equal('modal');
+    });
+    it('closes tooltip on button blur', async () => {
+        const test = await styledFixture(html`
+            <div>${tooltip(tooltip.args)}</div>
+        `);
+        const el = test.querySelector('sp-picker') as Picker;
+        await elementUpdated(el);
+        const input1 = document.createElement('input');
+        const input2 = document.createElement('input');
+        const tooltipEl = el.querySelector('sp-tooltip') as Tooltip;
+        el.insertAdjacentElement('beforebegin', input1);
+        el.insertAdjacentElement('afterend', input2);
+        input1.focus();
+        expect(document.activeElement === input1).to.be.true;
+        const tooltipOpened = oneEvent(el, 'sp-opened');
+        await sendKeys({
+            press: 'Tab',
+        });
+        await tooltipOpened;
+        expect(
+            document.activeElement === el,
+            `Actually, ${document.activeElement?.localName}`
+        ).to.be.true;
+        expect(tooltipEl.open).to.be.true;
+        expect(el.open).to.be.false;
+        expect(el.focused).to.be.true;
+
+        const menuOpen = oneEvent(el, 'sp-opened');
+        const tooltipClosed = oneEvent(el, 'sp-closed');
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        await menuOpen;
+        await tooltipClosed;
+        expect(document.activeElement === el).to.be.true;
+        expect(tooltipEl.open).to.be.false;
+        expect(el.open).to.be.true;
+
+        const menuClosed = oneEvent(el, 'sp-closed');
+        await sendKeys({
+            press: 'Tab',
+        });
+        await menuClosed;
+        expect(document.activeElement === el).to.be.false;
+        expect(tooltipEl.open).to.be.false;
+        expect(el.open).to.be.false;
     });
 }

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -47,6 +47,7 @@ export type SplitButtonTypes = 'field' | 'more';
  * @element sp-split-button
  *
  * @slot - menu items to be listed in the Button
+ * @slot tooltip - Tooltip to to be applied to the the main Button
  **/
 export class SplitButton extends SizedMixin(PickerBase) {
     public static override get styles(): CSSResultArray {
@@ -101,6 +102,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
                 >
                     ${this.selectedItem?.itemText || ''}
                 </div>
+                <slot name="tooltip"></slot>
             `,
         ];
     }


### PR DESCRIPTION
## Description
Add `tooltip` slot to `<sp-picker>` and `<sp-split-button>`. Prepare for #3596 with better ID referencing.

## Related issue(s)
- fixes #3629

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://picker-tooltip--spectrum-web-components.netlify.app/storybook/?path=/story/picker--tooltip)
    2. See that the Tooltip on the Picker opens/closes
    3. See that it _only_ does so when hovering/focusing the main "picker" button.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.