### PR TITLE
fix(menu): allow Menu elements to be controlled

### DIFF
--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -386,10 +386,22 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             ).to.be.true;
         });
         it('allows top-level selection state to change', async () => {
+            let selected = true;
+            const handleChange = (
+                event: Event & { target: ActionMenu }
+            ): void => {
+                if (event.target.value === 'test') {
+                    selected = !selected;
+
+                    event.target.updateComplete.then(() => {
+                        event.target.value = selected ? 'test' : '';
+                    });
+                }
+            };
             const root = await styledFixture<ActionMenu>(html`
-                <sp-action-menu label="More Actions">
+                <sp-action-menu label="More Actions" @change=${handleChange}>
                     <sp-menu-item>One</sp-menu-item>
-                    <sp-menu-item selected id="root-selected-item">
+                    <sp-menu-item selected value="test" id="root-selected-item">
                         Two
                     </sp-menu-item>
                     <sp-menu-item id="item-with-submenu">
@@ -411,12 +423,6 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             const selectedItem = root.querySelector(
                 '#root-selected-item'
             ) as MenuItem;
-            let selected = true;
-
-            selectedItem.addEventListener('click', () => {
-                selected = !selected;
-                selectedItem.selected = selected;
-            });
 
             expect(unselectedItem.textContent).to.include('One');
             expect(unselectedItem.selected).to.be.false;

--- a/packages/menu/stories/menu.stories.ts
+++ b/packages/menu/stories/menu.stories.ts
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 import { html, TemplateResult } from '@spectrum-web-components/base';
 
+import { Menu } from '@spectrum-web-components/menu';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
@@ -105,6 +106,39 @@ export const multipleSelect = (): TemplateResult => {
             </sp-menu>
         </sp-popover>
     `;
+};
+
+export const controlled = (): TemplateResult => {
+    const forceSelection = (event: Event & { target: Menu }): void => {
+        event.target.updateComplete.then(() => {
+            event.target.selected = ['Select and Mask...'];
+        });
+    };
+    return html`
+        <p>
+            This Menu will default to a
+            <code>selected</code>
+            value of
+            <code>[ 'Feather...', 'Save Selection' ]</code>
+            but then on any subsequent interaction be forced to a
+            <code>selected</code>
+            value of
+            <code>[ 'Select and Mask...' ]</code>
+            .
+        </p>
+        <sp-menu selects="multiple" @change=${forceSelection}>
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item selected>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item selected>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-menu>
+    `;
+};
+controlled.swc_vrt = {
+    skip: true,
 };
 
 export const menuItemWithDescription = (): TemplateResult => {

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -511,4 +511,49 @@ describe('Menu', () => {
         expect(el.value).to.equal('Second');
         expect(el.selectedItems.length).to.equal(1);
     });
+    it('can be controlled to manage a single togglable selection', async () => {
+        const toggleSingleSelected = (
+            event: Event & { target: Menu }
+        ): void => {
+            event.preventDefault();
+            const selected: string[] = [];
+            if (event.target.selected.length) {
+                selected.push(event.target.selected.at(-1) as string);
+            }
+            event.target.updateComplete.then(() => {
+                event.target.selected = selected;
+            });
+        };
+        const el = await fixture<Menu>(
+            html`
+                <sp-menu selects="multiple" @change=${toggleSingleSelected}>
+                    <sp-menu-item value="1">First</sp-menu-item>
+                    <sp-menu-item value="2">Second</sp-menu-item>
+                    <sp-menu-item value="3">Third</sp-menu-item>
+                </sp-menu>
+            `
+        );
+        expect(el.selected).to.deep.equal([]);
+
+        const items = [...el.querySelectorAll('[value]')] as MenuItem[];
+
+        items[0].click();
+        await nextFrame();
+        await nextFrame();
+
+        items[0].click();
+        await nextFrame();
+        await nextFrame();
+        expect(el.selected).to.deep.equal([]);
+
+        items[1].click();
+        await nextFrame();
+        await nextFrame();
+        expect(el.selected).to.deep.equal(['2']);
+
+        items[2].click();
+        await nextFrame();
+        await nextFrame();
+        expect(el.selected).to.deep.equal(['3']);
+    });
 });


### PR DESCRIPTION
## Description
Allow the `selected` property of an `<sp-menu>` to drive associated state so that the element can be leveraged as a "controlled component".

## Related issue(s)
- fixes #3667

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://controlled-menu--spectrum-web-components.netlify.app/storybook/?path=/story/menu--controlled)
    2. Click any item
    3. See that the `selected` value is forced to `[ 'Select and Mask...' ]`.
    4. Click any _other_ item
    5. See that the `selected` value is forced to `[ 'Select and Mask...' ]`.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.