### PR TITLE
fix(number-field): negative numbers handled

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -464,8 +464,7 @@ export class NumberField extends TextfieldBase {
     }
 
     private validateInput(value: number): number {
-        const signMultiplier = value < 0 ? -1 : 1;  // Basically I am checking if the the number is negative or not, if it is I am multiplying it by -1 to make it positive and the the function validateinput is doing its job and at the end before returning I am again multiplying by -1.
- 'signMultiplier' adjusts 'value' for 'validateInput' and reverts it before returning.
+        const signMultiplier = value < 0 ? -1 : 1; // 'signMultiplier' adjusts 'value' for 'validateInput' and reverts it before returning.
         value *= signMultiplier;
         if (typeof this.min !== 'undefined') {
             value = Math.max(this.min, value);

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -464,7 +464,7 @@ export class NumberField extends TextfieldBase {
     }
 
     private validateInput(value: number): number {
-        const signMultiplier = value < 0 ? -1 : 1;
+        const signMultiplier = value < 0 ? -1 : 1;  // Basically I am checking if the the number is negative or not, if it is I am multiplying it by -1 to make it positive and the the function validateinput is doing its job and at the end before returning I am again multiplying by -1.
         value *= signMultiplier;
         if (typeof this.min !== 'undefined') {
             value = Math.max(this.min, value);

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -464,6 +464,8 @@ export class NumberField extends TextfieldBase {
     }
 
     private validateInput(value: number): number {
+        const signMultiplier = value < 0 ? -1 : 1;
+        value *= signMultiplier;
         if (typeof this.min !== 'undefined') {
             value = Math.max(this.min, value);
         }
@@ -489,6 +491,7 @@ export class NumberField extends TextfieldBase {
                 }
             }
         }
+        value *= signMultiplier;
         return value;
     }
 

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -465,6 +465,7 @@ export class NumberField extends TextfieldBase {
 
     private validateInput(value: number): number {
         const signMultiplier = value < 0 ? -1 : 1;  // Basically I am checking if the the number is negative or not, if it is I am multiplying it by -1 to make it positive and the the function validateinput is doing its job and at the end before returning I am again multiplying by -1.
+ 'signMultiplier' adjusts 'value' for 'validateInput' and reverts it before returning.
         value *= signMultiplier;
         if (typeof this.min !== 'undefined') {
             value = Math.max(this.min, value);

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -128,6 +128,20 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('5');
             expect(el.valueAsString).to.equal('5');
         });
+
+        it('supports both positive and negative decimal values', async () => {
+            const el = await getElFrom(
+                Default({
+                    step: 0.001,
+                    min: -10,
+                    max: 10,
+                    value: -2.4,
+                })
+            );
+            el.size = 'xl';
+            expect(el.value).to.equal(-2.4);
+            expect(el.valueAsString).to.equal('-2.4');
+        });
     });
     describe('Increments', () => {
         let el: NumberField;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Number field was not correctly handling negative numbers when step was a floating point number

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
