### PR TITLE
refactor(reactive-controllers): update attach and post clear cache update timings

### DIFF
--- a/packages/tags/test/tags.test.ts
+++ b/packages/tags/test/tags.test.ts
@@ -28,7 +28,8 @@ import {
     pageUpEvent,
     testForLitDevWarnings,
 } from '../../../test/testing-helpers.js';
-import { executeServerCommand } from '@web/test-runner-commands';
+import { sendKeys } from '@web/test-runner-commands';
+import { nextFrame } from '@spectrum-web-components/overlay/src/AbstractOverlay.js';
 
 describe('Tags', () => {
     testForLitDevWarnings(
@@ -176,6 +177,74 @@ describe('Tags', () => {
 
         tag1.blur();
     });
+
+    it('handles focus when Tag is deleted', async () => {
+        const el = await fixture<Tags>(
+            html`
+                <sp-tags>
+                    <sp-tag deletable id="t1">Tag 1</sp-tag>
+                    <sp-tag deletable id="t2">Tag 2</sp-tag>
+                    <sp-tag deletable id="t3">Tag 3</sp-tag>
+                    <sp-tag deletable id="t4">Tag 4</sp-tag>
+                    <sp-tag deletable id="t5">Tag 5</sp-tag>
+                </sp-tags>
+            `
+        );
+
+        await elementUpdated(el);
+
+        const tag1 = el.querySelector('sp-tag#t1') as Tag;
+        const tag2 = el.querySelector('sp-tag#t2') as Tag;
+        const tag3 = el.querySelector('sp-tag#t3') as Tag;
+        const tag4 = el.querySelector('sp-tag#t4') as Tag;
+        const tag5 = el.querySelector('sp-tag#t5') as Tag;
+
+        tag1.focus();
+        await elementUpdated(el);
+
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+
+        expect(document.activeElement === tag2).to.be.true;
+
+        await sendKeys({
+            press: 'Delete',
+        });
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+
+        expect(document.activeElement === tag3).to.be.true;
+
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+
+        expect(document.activeElement === tag5).to.be.true;
+
+        await sendKeys({
+            press: 'Delete',
+        });
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+
+        expect(document.activeElement === tag4).to.be.true;
+    });
+
     it('will not focus [disabled] children', async () => {
         const el = await fixture<Tags>(
             html`
@@ -288,12 +357,12 @@ describe('Tags', () => {
         const tagA = tagset2.querySelector('sp-tag:nth-child(1)') as Tag;
         const tagB = tagset2.querySelector('sp-tag:nth-child(2)') as Tag;
 
-        await executeServerCommand('send-keys', {
+        await sendKeys({
             press: 'Tab',
         });
         expect(document.activeElement === tag1).to.be.true;
 
-        await executeServerCommand('send-keys', {
+        await sendKeys({
             press: 'Tab',
         });
         expect(document.activeElement === tagA).to.be.true;

--- a/tools/reactive-controllers/src/FocusGroup.ts
+++ b/tools/reactive-controllers/src/FocusGroup.ts
@@ -113,6 +113,8 @@ export class FocusGroupController<T extends HTMLElement>
     // and the first rendered element.
     offset = 0;
 
+    recentlyConnected = false;
+
     constructor(
         host: ReactiveElement,
         {
@@ -193,9 +195,11 @@ export class FocusGroupController<T extends HTMLElement>
         this.mutationObserver.disconnect();
         delete this.cachedElements;
         this.offset = offset;
-        this.elements.forEach((element) => {
-            this.mutationObserver.observe(element, {
-                attributes: true,
+        requestAnimationFrame(() => {
+            this.elements.forEach((element) => {
+                this.mutationObserver.observe(element, {
+                    attributes: true,
+                });
             });
         });
     }
@@ -333,16 +337,23 @@ export class FocusGroupController<T extends HTMLElement>
     }
 
     hostConnected(): void {
-        this.elements.forEach((element) => {
-            this.mutationObserver.observe(element, {
-                attributes: true,
-            });
-        });
+        this.recentlyConnected = true;
         this.addEventListeners();
     }
 
     hostDisconnected(): void {
         this.mutationObserver.disconnect();
         this.removeEventListeners();
+    }
+
+    hostUpdated(): void {
+        if (this.recentlyConnected) {
+            this.recentlyConnected = false;
+            this.elements.forEach((element) => {
+                this.mutationObserver.observe(element, {
+                    attributes: true,
+                });
+            });
+        }
     }
 }

--- a/tools/reactive-controllers/src/RovingTabindex.ts
+++ b/tools/reactive-controllers/src/RovingTabindex.ts
@@ -86,7 +86,8 @@ export class RovingTabindexController<
         super.unmanage();
     }
 
-    hostUpdated(): void {
+    override hostUpdated(): void {
+        super.hostUpdated();
         if (!this.host.hasUpdated) {
             this.manageTabindexes();
         }


### PR DESCRIPTION
## Description
Test focus management in deletable Tags.

Ensure MO is bound to Focus Group items after a rAF when clearing the cache.

Ensure MO is bound to Focus Group items after an update when connecting the host.

## Related issue(s)
- fixes #3590

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://westbrook-grid--spectrum-web-components.netlify.app/tools/grid/)
    2. See that the page loads/scrolls/is interactive and doesn't crash

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.