### PR TITLE
fix(alert-dialog): use resize observer in place of page resize event for content measurement work

### DIFF
--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -57,6 +57,7 @@
         "lit-html"
     ],
     "dependencies": {
+        "@lit-labs/observers": "^2.0.0",
         "@spectrum-web-components/base": "^0.39.0",
         "@spectrum-web-components/button": "^0.39.0",
         "@spectrum-web-components/button-group": "^0.39.0",

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -23,6 +23,7 @@ import '@spectrum-web-components/overlay/overlay-trigger.js';
 import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
 import { landscape } from './images.js';
 import { overlayTriggerDecorator } from './index.js';
+import type { DialogWrapper } from '@spectrum-web-components/dialog';
 
 export default {
     title: 'Dialog Wrapped',
@@ -568,3 +569,76 @@ export const tooltips = (
 };
 
 tooltips.decorators = [overlayTriggerDecorator];
+
+export const lazyHero = ({ src }: { src: string }): TemplateResult => {
+    const handleOpened = (): void => {
+        (document.querySelector('sp-dialog-wrapper') as DialogWrapper).hero =
+            src;
+    };
+    return html`
+        <overlay-trigger content="click" @sp-opened=${handleOpened}>
+            <sp-button slot="trigger">Toggle Dialog</sp-button>
+            <sp-dialog-wrapper
+                slot="click-content"
+                headline="Dialog title"
+                confirm-label="Primary"
+            >
+                <p>Content of the dialog</p>
+                <ol>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                    <li>
+                        Select the following checkbox to have the dialog close
+                        when clicking one of its buttons.
+                    </li>
+                </ol>
+            </sp-dialog-wrapper>
+        </overlay-trigger>
+    `;
+};
+
+lazyHero.args = {
+    src: 'https://dummyimage.com/800x400/000/fff',
+};
+
+lazyHero.swc_vrt = {
+    skip: true,
+};

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -17,7 +17,7 @@ import {
     fixture as owcFixture,
 } from '@open-wc/testing';
 import { html } from '@spectrum-web-components/base';
-import { spy, stub } from 'sinon';
+import { SinonStub, spy, stub } from 'sinon';
 import type { HookFunction } from 'mocha';
 import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
@@ -29,17 +29,27 @@ import { sendMouse } from './plugins/browser.js';
 export async function testForLitDevWarnings(
     fixture: () => Promise<HTMLElement>
 ): Promise<void> {
-    it('does not emit Lit Dev Mode warnings', async () => {
-        const consoleWarnStub = stub(console, 'warn');
-        const el = await fixture();
+    describe('lit dev mode', () => {
+        let consoleWarnStub!: SinonStub;
+        before(() => {
+            consoleWarnStub = stub(console, 'warn');
+        });
+        afterEach(() => {
+            consoleWarnStub.resetHistory();
+        });
+        after(() => {
+            consoleWarnStub.restore();
+        });
+        it('does not emit warnings', async () => {
+            const el = await fixture();
 
-        await elementUpdated(el);
+            await elementUpdated(el);
 
-        expect(
-            consoleWarnStub.called,
-            consoleWarnStub.getCall(0)?.args.join(', ')
-        ).to.be.false;
-        consoleWarnStub.restore();
+            expect(
+                consoleWarnStub.called,
+                consoleWarnStub.getCall(0)?.args.join(', ')
+            ).to.be.false;
+        });
     });
 }
 


### PR DESCRIPTION
## Description
Measure content length with a Resize Observer rather than the `resize` event. Allow late loading of hero images to trigger recalculation of content lengths that could enable scrolling and tab stop application.

## Related issue(s)
- fixes #3613

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://dialog-hero--spectrum-web-components.netlify.app/storybook/?path=/story/dialog-wrapped--lazy-hero)
    2. See that the lazily applied hero image causes the content area to scale down and force a scrollbar.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)