### PR TITLE
build: ensure publication of non-breaking changes includes ALL packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "icons": "wireit",
         "icons:ui": "wireit",
         "icons:workflow": "wireit",
-        "lerna-publish": "lerna publish --message \"chore: release new versions #publish\"",
+        "lerna-publish": "lerna publish --message \"chore: release new versions #publish\" --force-publish",
         "lint": "run-p lint:js lint:docs lint:ts lint:css lint:packagejson",
         "lint:css": "stylelint \"packages/**/*.css\" \"tools/**/*.css\"",
         "lint:docs": "eslint -f pretty \"projects/documentation/**/*.ts\"",


### PR DESCRIPTION
## Description
Ensure publications with no breaking changes (`0.x.0`) still include ALL packages, so that the unified version can be installed by consumers.

## How has this been tested?
-   [ ] _Test case 1_
    1. Open the branch locally
    2. Run `yarn lerna-publish`
    3. See that all packages are listed.
    4. Press `n` and `control + c` to escape the action

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.