### PR TITLE
refactor(overlay): change base type of the Overlay mixins to extension of preivous base

### DIFF
--- a/packages/overlay/src/OverlayDialog.ts
+++ b/packages/overlay/src/OverlayDialog.ts
@@ -9,7 +9,7 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { ReactiveElement } from 'lit';
+import type { SpectrumElement } from '@spectrum-web-components/base';
 import {
     firstFocusableIn,
     firstFocusableSlottedIn,
@@ -30,7 +30,7 @@ import { userFocusableSelector } from '@spectrum-web-components/shared';
 
 export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
     constructor: T
-): T & Constructor<ReactiveElement> {
+): T & Constructor<SpectrumElement> {
     class OverlayWithDialog extends constructor {
         protected override async manageDialogOpen(): Promise<void> {
             const targetOpenState = this.open;

--- a/packages/overlay/src/OverlayNoPopover.ts
+++ b/packages/overlay/src/OverlayNoPopover.ts
@@ -13,7 +13,7 @@ import {
     firstFocusableIn,
     firstFocusableSlottedIn,
 } from '@spectrum-web-components/shared/src/first-focusable-in.js';
-import { ReactiveElement } from 'lit';
+import type { SpectrumElement } from '@spectrum-web-components/base';
 import { VirtualTrigger } from './VirtualTrigger.js';
 import {
     Constructor,
@@ -32,7 +32,7 @@ import { userFocusableSelector } from '@spectrum-web-components/shared';
 
 export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
     constructor: T
-): T & Constructor<ReactiveElement> {
+): T & Constructor<SpectrumElement> {
     class OverlayWithNoPopover extends constructor {
         protected override async managePopoverOpen(): Promise<void> {
             await this.managePosition();

--- a/packages/overlay/src/OverlayPopover.ts
+++ b/packages/overlay/src/OverlayPopover.ts
@@ -13,7 +13,7 @@ import {
     firstFocusableIn,
     firstFocusableSlottedIn,
 } from '@spectrum-web-components/shared/src/first-focusable-in.js';
-import { ReactiveElement } from 'lit';
+import type { SpectrumElement } from '@spectrum-web-components/base';
 import { VirtualTrigger } from './VirtualTrigger.js';
 import {
     Constructor,
@@ -46,7 +46,7 @@ function isOpen(el: HTMLElement): boolean {
 
 export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
     constructor: T
-): T & Constructor<ReactiveElement> {
+): T & Constructor<SpectrumElement> {
     class OverlayWithPopover extends constructor {
         protected override async manageDelay(
             targetOpenState: boolean


### PR DESCRIPTION
## Description
Use a different base return type of Overlay mixins in order to guarantee that the requested type is already available to the package and it's dependency listing.

## How has this been tested?
-   [ ] _Test case 1_
    1. Install the dependency in a strict dependency context
    2. See that it will now build

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.