### PR TITLE
fix(slider): ensure z-index in Express theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: af8817593fda162c2d2799b4ce593ea10037ea2e
+        default: d9753afda922e1231ca00c526993367854742104
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/slider/src/HandleController.ts
+++ b/packages/slider/src/HandleController.ts
@@ -533,7 +533,7 @@ export class HandleController {
     public render(): TemplateResult[] {
         this.clearHandleComponentCache();
         return this.model.map((model, index) => {
-            const zIndex = this.handleOrder.indexOf(model.name) + 1;
+            const zIndex = this.handleOrder.indexOf(model.name) + 2;
             return this.renderHandle(
                 model,
                 index,

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -132,6 +132,26 @@ export const Default = (args: StoryArgs = {}): TemplateResult => {
     `;
 };
 
+export const autofocus = (args: StoryArgs = {}): TemplateResult => {
+    return html`
+        <div style="width: 500px; margin-inline: 20px;">
+            <sp-slider
+                autofocus
+                max="1"
+                min="0"
+                value=".5"
+                step="0.01"
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
+                .formatOptions=${{ style: 'percent' }}
+                ...=${spreadProps(args)}
+            >
+                Opacity
+            </sp-slider>
+        </div>
+    `;
+};
+
 export const minimalDOM = (): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">


### PR DESCRIPTION
## Description
Make sure the focus loupe of the Slider handle does not fall behind the slider track in the Express theme.

## Related issue(s)
- fixes #3688

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://slider-handle--spectrum-web-components.netlify.app/storybook/?path=/story/slider--autofocus&sp_theme=express)
    2. See that the _right_ edge of the focus loupe is over the right track.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)