### PR TITLE
fix(overlay): allow overlay to persist on hover

### DIFF
--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -808,57 +808,18 @@ export class Overlay extends OverlayFeatures {
     // set a timeout once the pointer enters and the overlay is shown
     // give the user time to enter the overlay
 
-    protected handleOverlayPointerenter = (event: PointerEvent): void => {
-        if (
-            this.triggerElement === event.relatedTarget ||
-            (this.hasNonVirtualTrigger &&
-                (this.triggerElement as HTMLElement).contains(
-                    event.relatedTarget as Node
-                ))
-        ) {
-            return;
-        }
-
+    protected handleOverlayPointerenter = (): void => {
         if (this.hoverTimeout) {
             clearTimeout(this.hoverTimeout);
             delete this.hoverTimeout;
         }
     };
 
-    protected handlePointerleave = (event: PointerEvent): void => {
-        if (
-            this === event.relatedTarget ||
-            this.contains(event.relatedTarget as Node) ||
-            [...this.children].find((child) => {
-                if (child.localName !== 'slot') {
-                    return false;
-                }
-                return (child as HTMLSlotElement)
-                    .assignedElements({ flatten: true })
-                    .find((el) => {
-                        return (
-                            el === event.relatedTarget ||
-                            el.contains(event.relatedTarget as Node)
-                        );
-                    });
-            })
-        ) {
-            return;
-        }
-
+    protected handlePointerleave = (): void => {
         this.doPointerleave();
     };
 
-    protected handleOverlayPointerleave = (event: PointerEvent): void => {
-        if (
-            this.triggerElement === event.relatedTarget ||
-            (this.hasNonVirtualTrigger &&
-                (this.triggerElement as HTMLElement).contains(
-                    event.relatedTarget as Node
-                ))
-        ) {
-            return;
-        }
+    protected handleOverlayPointerleave = (): void => {
         this.doPointerleave();
     };
 

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -53,6 +53,7 @@ import { PlacementController } from './PlacementController.js';
 import styles from './overlay.css.js';
 
 const LONGPRESS_DURATION = 300;
+const HOVER_DELAY = 300;
 
 type LongpressEvent = {
     source: 'pointer' | 'keyboard';
@@ -146,6 +147,7 @@ export class Overlay extends OverlayFeatures {
         'null';
 
     private longressTimeout!: ReturnType<typeof setTimeout>;
+    private hoverTimeout?: ReturnType<typeof setTimeout>;
 
     /**
      * The `offset` property accepts either a single number, to
@@ -562,6 +564,11 @@ export class Overlay extends OverlayFeatures {
             options
         );
         this.addEventListener(
+            'pointerenter',
+            this.handleOverlayPointerenter,
+            options
+        );
+        this.addEventListener(
             'pointerleave',
             this.handleOverlayPointerleave,
             options
@@ -789,9 +796,33 @@ export class Overlay extends OverlayFeatures {
     private pointerentered = false;
 
     protected handlePointerenter = (): void => {
+        if (this.hoverTimeout) {
+            clearTimeout(this.hoverTimeout);
+            delete this.hoverTimeout;
+        }
         if (this.disabled) return;
         this.open = true;
         this.pointerentered = true;
+    };
+
+    // set a timeout once the pointer enters and the overlay is shown
+    // give the user time to enter the overlay
+
+    protected handleOverlayPointerenter = (event: PointerEvent): void => {
+        if (
+            this.triggerElement === event.relatedTarget ||
+            (this.hasNonVirtualTrigger &&
+                (this.triggerElement as HTMLElement).contains(
+                    event.relatedTarget as Node
+                ))
+        ) {
+            return;
+        }
+
+        if (this.hoverTimeout) {
+            clearTimeout(this.hoverTimeout);
+            delete this.hoverTimeout;
+        }
     };
 
     protected handlePointerleave = (event: PointerEvent): void => {
@@ -814,6 +845,7 @@ export class Overlay extends OverlayFeatures {
         ) {
             return;
         }
+
         this.doPointerleave();
     };
 
@@ -834,7 +866,10 @@ export class Overlay extends OverlayFeatures {
         this.pointerentered = false;
         const triggerElement = this.triggerElement as HTMLElement;
         if (this.focusedin && triggerElement.matches(':focus-visible')) return;
-        this.open = false;
+
+        this.hoverTimeout = setTimeout(() => {
+            this.open = false;
+        }, HOVER_DELAY);
     }
 
     protected handleLongpress = (): void => {

--- a/packages/overlay/test/overlay-trigger-hover.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover.test.ts
@@ -120,17 +120,33 @@ describe('Overlay Trigger - Hover', () => {
             await nextFrame();
             await nextFrame();
             expect(tooltip.open).to.be.true;
+
             button.dispatchEvent(
                 new MouseEvent('pointerleave', {
-                    relatedTarget: tooltip,
                     bubbles: true,
                     composed: true,
                 })
             );
             await nextFrame();
+
+            button.dispatchEvent(
+                new MouseEvent('pointerenter', {
+                    bubbles: true,
+                    composed: true,
+                })
+            );
+            await nextFrame();
+
             tooltip.dispatchEvent(
                 new MouseEvent('pointerleave', {
-                    relatedTarget: button,
+                    bubbles: true,
+                    composed: true,
+                })
+            );
+            await nextFrame();
+
+            button.dispatchEvent(
+                new MouseEvent('pointerenter', {
                     bubbles: true,
                     composed: true,
                 })

--- a/packages/overlay/test/overlay.test.ts
+++ b/packages/overlay/test/overlay.test.ts
@@ -26,6 +26,7 @@ import {
 } from '@spectrum-web-components/overlay';
 
 import {
+    aTimeout,
     elementUpdated,
     expect,
     html,
@@ -768,7 +769,7 @@ describe('Overlay - type="modal"', () => {
     });
 });
 describe('Overlay - timing', () => {
-    it('manages multiple modals in a row without preventing them from closing', async () => {
+    it.only('manages multiple modals in a row without preventing them from closing', async () => {
         const test = await fixture<HTMLDivElement>(html`
             <div>
                 <overlay-trigger id="test-1" placement="right">
@@ -824,6 +825,7 @@ describe('Overlay - timing', () => {
         });
         await nextFrame();
         await nextFrame();
+
         // Move pointer out of "Trigger 1", should _start_ to close "hover" content.
         await sendMouse({
             steps: [
@@ -833,8 +835,9 @@ describe('Overlay - timing', () => {
                 },
             ],
         });
-        await nextFrame();
-        await nextFrame();
+        // allow "hover" content to close by waiting for its timer to complete
+        await aTimeout(400);
+
         // Move pointer over "Trigger 2", should _start_ to open "hover" content.
         await sendMouse({
             steps: [
@@ -875,7 +878,7 @@ describe('Overlay - timing', () => {
             ],
         });
         await closed;
-
+        await aTimeout(200);
         // Both overlays are closed.
         // Neither trigger received "focus" because the pointer "clicked" away, redirecting focus to <body>
         expect(overlayTrigger1.hasAttribute('open')).to.be.false;

--- a/packages/overlay/test/overlay.test.ts
+++ b/packages/overlay/test/overlay.test.ts
@@ -26,7 +26,6 @@ import {
 } from '@spectrum-web-components/overlay';
 
 import {
-    // aTimeout,
     elementUpdated,
     expect,
     html,
@@ -772,7 +771,7 @@ describe('Overlay - timing', () => {
     it('manages multiple modals in a row without preventing them from closing', async () => {
         const test = await fixture<HTMLDivElement>(html`
             <div>
-                <overlay-trigger id="test-1" placement="right">
+                <overlay-trigger id="test-1" placement="bottom">
                     <sp-button slot="trigger">Trigger 1</sp-button>
                     <sp-popover slot="hover-content">
                         <p>Hover contentent for "Trigger 1".</p>
@@ -814,7 +813,7 @@ describe('Overlay - timing', () => {
             boundingRectTrigger2.top + boundingRectTrigger2.height / 4,
         ];
 
-        // Move poitner over "Trigger 1", should _start_ to open "hover" content.
+        // Move pointer over "Trigger 1", should _start_ to open "hover" content.
         await sendMouse({
             steps: [
                 {
@@ -827,7 +826,6 @@ describe('Overlay - timing', () => {
         await nextFrame();
 
         // Move pointer out of "Trigger 1", should _start_ to close "hover" content.
-        const closed = oneEvent(trigger1, 'sp-closed');
         await sendMouse({
             steps: [
                 {
@@ -836,8 +834,8 @@ describe('Overlay - timing', () => {
                 },
             ],
         });
-        await closed;
-
+        await nextFrame();
+        await nextFrame();
         // Move pointer over "Trigger 2", should _start_ to open "hover" content.
         await sendMouse({
             steps: [
@@ -869,7 +867,7 @@ describe('Overlay - timing', () => {
         expect(overlayTrigger2.hasAttribute('open')).to.be.true;
         expect(overlayTrigger2.getAttribute('open')).to.equal('click');
 
-        const closedOverlayTrigger = oneEvent(overlayTrigger2, 'sp-closed');
+        const closed = oneEvent(overlayTrigger2, 'sp-closed');
         await sendMouse({
             steps: [
                 {
@@ -878,7 +876,7 @@ describe('Overlay - timing', () => {
                 },
             ],
         });
-        await closedOverlayTrigger;
+        await closed;
 
         // Both overlays are closed.
         // Neither trigger received "focus" because the pointer "clicked" away, redirecting focus to <body>

--- a/packages/overlay/test/overlay.test.ts
+++ b/packages/overlay/test/overlay.test.ts
@@ -26,7 +26,7 @@ import {
 } from '@spectrum-web-components/overlay';
 
 import {
-    aTimeout,
+    // aTimeout,
     elementUpdated,
     expect,
     html,
@@ -769,7 +769,7 @@ describe('Overlay - type="modal"', () => {
     });
 });
 describe('Overlay - timing', () => {
-    it.only('manages multiple modals in a row without preventing them from closing', async () => {
+    it('manages multiple modals in a row without preventing them from closing', async () => {
         const test = await fixture<HTMLDivElement>(html`
             <div>
                 <overlay-trigger id="test-1" placement="right">
@@ -827,6 +827,7 @@ describe('Overlay - timing', () => {
         await nextFrame();
 
         // Move pointer out of "Trigger 1", should _start_ to close "hover" content.
+        const closed = oneEvent(trigger1, 'sp-closed');
         await sendMouse({
             steps: [
                 {
@@ -835,8 +836,7 @@ describe('Overlay - timing', () => {
                 },
             ],
         });
-        // allow "hover" content to close by waiting for its timer to complete
-        await aTimeout(400);
+        await closed;
 
         // Move pointer over "Trigger 2", should _start_ to open "hover" content.
         await sendMouse({
@@ -849,6 +849,7 @@ describe('Overlay - timing', () => {
         });
         await nextFrame();
         await nextFrame();
+
         const opened = oneEvent(trigger2, 'sp-opened');
         // Click "Trigger 2", should _start_ to open "click" content and _start_ to close "hover" content.
         await sendMouse({
@@ -868,7 +869,7 @@ describe('Overlay - timing', () => {
         expect(overlayTrigger2.hasAttribute('open')).to.be.true;
         expect(overlayTrigger2.getAttribute('open')).to.equal('click');
 
-        const closed = oneEvent(overlayTrigger2, 'sp-closed');
+        const closedOverlayTrigger = oneEvent(overlayTrigger2, 'sp-closed');
         await sendMouse({
             steps: [
                 {
@@ -877,8 +878,8 @@ describe('Overlay - timing', () => {
                 },
             ],
         });
-        await closed;
-        await aTimeout(200);
+        await closedOverlayTrigger;
+
         // Both overlays are closed.
         // Neither trigger received "focus" because the pointer "clicked" away, redirecting focus to <body>
         expect(overlayTrigger1.hasAttribute('open')).to.be.false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A timer based approach to allowing hover content to persist so that a user can hover over it. 

## Related issue(s)
- fixes #3366 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Blocks Coachmark PR and Rich Tooltip PR. This also matches the expected behaviour for tooltips outlined by [WACG](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Before_
    1. Go [here](https://opensource.adobe.com/spectrum-web-components/storybook/?path=/story/tooltip--overlaid-top)
    2. Hover over any of the trigger elements
    3. Attempt to hover over a tooltip
    4. See that it is not possible! 
    5. You can also try the same test [here](https://opensource.adobe.com/spectrum-web-components/storybook/?path=/story/overlay--click-and-hover-targets)
-   [ ] _After_
    1. Go [here](https://halsema-overlay-hover-handler--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--overlaid-top)
    2. Hover over any of the trigger elements
    3. Attempt to hover over a tooltip
    4. See that it is now possible! 
    5. Once you leave the triggerElement and go somewhere that isn't the overlay, the tooltip should close shortly after. 
    6. You can try the same test [here](https://halsema-overlay-hover-handler--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--click-and-hover-targets).

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
