### PR TITLE
fix(grid): plug a mememory leak from the render process

### DIFF
--- a/tools/grid/src/Grid.ts
+++ b/tools/grid/src/Grid.ts
@@ -17,6 +17,7 @@ import {
     PropertyValues,
     ReactiveElement,
     render,
+    RootPart,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
@@ -34,6 +35,8 @@ export class Grid extends LitVirtualizer {
     public static override get styles(): CSSResultArray {
         return [styles];
     }
+
+    private __gridPart: RootPart | undefined = undefined;
 
     @property({ type: String })
     public focusableSelector!: string;
@@ -147,13 +150,14 @@ export class Grid extends LitVirtualizer {
         }
 
         if (this.isConnected) {
-            render(super.render(), this);
+            this.__gridPart = render(super.render(), this);
         }
         super.update(changes);
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
+        this.__gridPart?.setConnected(true);
         this.addEventListener('change', this.handleChange, { capture: true });
     }
 
@@ -161,6 +165,7 @@ export class Grid extends LitVirtualizer {
         this.removeEventListener('change', this.handleChange, {
             capture: true,
         });
+        this.__gridPart?.setConnected(false);
         super.disconnectedCallback();
     }
 }

--- a/tools/grid/test/grid-memory.test.ts
+++ b/tools/grid/test/grid-memory.test.ts
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { expect, fixture, nextFrame } from '@open-wc/testing';
+import { html, render } from '@spectrum-web-components/base';
+import { Default } from '../stories/grid.stories';
+
+async function usedHeapMB(): Promise<number> {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const memorySample = performance.measureUserAgentSpecificMemory();
+    return (await memorySample).bytes / (1024 * 1024);
+}
+
+describe('Grid memory usage', () => {
+    it('releases references on disconnect', async function () {
+        if (!window.gc || !('measureUserAgentSpecificMemory' in performance))
+            this.skip();
+
+        this.timeout(10000);
+
+        const iterations = 50;
+        let active = false;
+
+        const el = await fixture<HTMLElement>(
+            html`
+                <div></div>
+            `
+        );
+
+        async function toggle(
+            forced: boolean | undefined = undefined
+        ): Promise<void> {
+            active = forced != null ? forced : !active;
+            render(active ? Default() : html``, el);
+            await nextFrame();
+            await nextFrame();
+        }
+
+        // "shake things out" to get a good first reading
+        for (let i = 0; i < 5; i++) {
+            await toggle();
+        }
+        await toggle(false);
+        const beforeMB = await usedHeapMB();
+
+        for (let i = 0; i < iterations; i++) {
+            await toggle();
+        }
+        await toggle(false);
+        const afterMB = await usedHeapMB();
+
+        /**
+         * An actually leak here shapes up to be more than 10MB per test,
+         * we could be more linient later, if needed, but the test currently
+         * shows less heap after the test cycle.
+         */
+        expect(
+            afterMB - beforeMB,
+            `before: ${beforeMB}, after: ${afterMB}`
+        ).to.be.lt(0);
+    });
+});

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -17,6 +17,7 @@ import { sendMousePlugin } from './test/plugins/send-mouse-plugin.js';
 import {
     chromium,
     chromiumWithFlags,
+    chromiumWithMemoryTooling,
     configuredVisualRegressionPlugin,
     firefox,
     packages,
@@ -52,6 +53,13 @@ export default {
                 ) {
                     context.body = context.body.toString();
                 }
+            },
+        },
+        {
+            name: 'measureUserAgentSpecificMemory-plugin',
+            transform(context) {
+                context.set('Cross-Origin-Opener-Policy', 'same-origin');
+                context.set('Cross-Origin-Embedder-Policy', 'credentialless');
             },
         },
     ],
@@ -135,5 +143,5 @@ export default {
         },
     ],
     group: 'unit',
-    browsers: [chromium, firefox, webkit],
+    browsers: [chromiumWithMemoryTooling, firefox, webkit],
 };

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -24,6 +24,28 @@ export const chromium = playwrightLauncher({
         }),
 });
 
+export const chromiumWithMemoryTooling = playwrightLauncher({
+    product: 'chromium',
+    createBrowserContext: ({ browser }) =>
+        browser.newContext({
+            ignoreHTTPSErrors: true,
+            permissions: ['clipboard-read', 'clipboard-write'],
+        }),
+    launchOptions: {
+        headless: false,
+        args: [
+            '--js-flags=--expose-gc',
+            '--headless=new',
+            /**
+             * Cause `measureUserAgentSpecificMemory()` to GC immediately,
+             * instead of up to 20s later:
+             * https://web.dev/articles/monitor-total-page-memory-usage#local_testing
+             **/
+            '--enable-blink-features=ForceEagerMeasureMemory',
+        ],
+    },
+});
+
 export const chromiumWithFlags = playwrightLauncher({
     product: 'chromium',
     launchOptions: {


### PR DESCRIPTION
## Description
Rendering a `lit-html` template with `render()` without caching it's root part means that you can't inform it when the template is connected to the DOM or not. This connection state is required to ensure clean up can happen to any of the template directives that might be leveraged therein. If the Virtualize template directive does not get disconnected it can leak references to the items it had previously rendered to the DOM.

Cache a reference to the "grid part" in the Grid element for the DOM that would otherwise have been rendered to the render root and managed directly by `LitElement`. Manage the connected state of this cached part.

## Related issue(s)
- fixes #3707

## How has this been tested?
-   [ ] _Test case 1_
    1. Follow the steps in https://github.com/adobe/spectrum-web-components/issues/3707#issuecomment-1754719002

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.