### PR TITLE
fix(number-field): prevent over excited "change" events

### DIFF
--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -384,17 +384,25 @@ describe('Slider', () => {
 
     it('dispatches `input` of the animation frame', async () => {
         const inputSpy = spy();
+        const changeSpy = spy();
         const el = await fixture<Slider>(
             html`
                 <sp-slider
                     value="50"
                     style="width: 100px"
-                    @input=${({ target }: Event & { target: Slider }) =>
-                        inputSpy(target.value)}
+                    @input=${(event: Event & { target: Slider }) => {
+                        inputSpy(event.target.value);
+                    }}
+                    @change=${(event: Event & { target: Slider }) => {
+                        changeSpy(event.target.value);
+                    }}
                 ></sp-slider>
             `
         );
         await elementUpdated(el);
+
+        expect(inputSpy.callCount, 'start clean').to.equal(0);
+        expect(changeSpy.callCount, 'start clean').to.equal(0);
 
         let frames = 0;
         let shouldCountFrames = true;
@@ -435,6 +443,7 @@ describe('Slider', () => {
             inputSpy.callCount,
             'should not have more "input"s than frames'
         ).to.lte(frames);
+        expect(changeSpy.callCount, 'only one change').to.equal(1);
     });
 
     it('manages RTL when min != 0', async () => {

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -230,7 +230,7 @@ export async function fixture<T extends Element>(
     story: TemplateResult
 ): Promise<T> {
     const test = await owcFixture<Theme>(html`
-        <sp-theme theme="spectrum" scale="medium" color="dark">
+        <sp-theme theme="spectrum" scale="medium" color="light">
             ${story}
         </sp-theme>
     `);


### PR DESCRIPTION
## Description
Refactor `change` event dispatching so that setting the `value` from the outside does not trigger a `change` event.

## Related issue(s)

- fixes #3720

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://slider-events--spectrum-web-components.netlify.app/storybook/index.html?path=/story/slider--editable)
    2. Slide the slider
    3. See that only one `change` event is dispatched per interaction
    4. Go [here](https://opensource.adobe.com/spectrum-web-components/storybook/index.html?path=/story/slider--editable) for comparison.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)