### PR TITLE
Overlay over transforms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 93d95dd978a2d14dcdfe8b14628504d079211e54
+        default: 231befcecf8771df88ea4a0a146aab53e9ba40c3
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -126,8 +126,8 @@
         "lit-html"
     ],
     "dependencies": {
-        "@floating-ui/dom": "^1.5.1",
-        "@floating-ui/utils": "^0.1.1",
+        "@floating-ui/dom": "^1.5.3",
+        "@floating-ui/utils": "^0.1.6",
         "@spectrum-web-components/action-button": "^0.39.3",
         "@spectrum-web-components/base": "^0.39.3",
         "@spectrum-web-components/reactive-controllers": "^0.39.3",

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -613,7 +613,21 @@ export class Overlay extends OverlayFeatures {
         const messageType = isIOS() || isAndroid() ? 'touch' : 'keyboard';
         longpressDescription.textContent = LONGPRESS_INSTRUCTIONS[messageType];
         longpressDescription.slot = 'longpress-describedby-descriptor';
-        trigger.insertAdjacentElement('afterend', longpressDescription);
+        const triggerParent = trigger.getRootNode() as HTMLElement;
+        const overlayParent = this.getRootNode() as HTMLElement;
+        // Manage the placement of the helper element in an accessible place with
+        // the lowest chance of negatively affecting the layout of the page.
+        if (triggerParent === overlayParent) {
+            // Trigger and Overlay in same DOM tree...
+            // Append helper element to Overlay.
+            this.append(longpressDescription);
+        } else {
+            // If Trigger in <body>, hide helper
+            longpressDescription.hidden = !('host' in triggerParent);
+            // Trigger and Overlay in different DOM tree, Trigger in shadow tree...
+            // Insert helper element after Trigger.
+            trigger.insertAdjacentElement('afterend', longpressDescription);
+        }
 
         const releaseLongpressDescribedby = conditionAttributeWithId(
             trigger,

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -77,31 +77,38 @@ const Template = ({
     placement,
     type,
 }: Properties): TemplateResult => html`
-    <sp-action-button id="trigger">Open the overlay</sp-action-button>
-    <sp-overlay
-        ?open=${open}
-        trigger="trigger@${interaction}"
-        type=${ifDefined(type)}
-        placement=${ifDefined(placement)}
-        offset="-10"
-    >
-        <sp-popover dialog>
-            <p>
-                Content goes here.
-                ${type === 'modal' || type === 'page'
-                    ? html`
-                          Or, a link,
-                          <sp-link
-                              href="https://opensource.adobe.com/spectrum-web-components"
-                          >
-                              Spectrum Web Components
-                          </sp-link>
-                          .
-                      `
-                    : ''}
-            </p>
-        </sp-popover>
-    </sp-overlay>
+    <style>
+        .wrapper {
+            will-change: transform;
+        }
+    </style>
+    <div class="wrapper">
+        <sp-action-button id="trigger">Open the overlay</sp-action-button>
+        <sp-overlay
+            ?open=${open}
+            trigger="trigger@${interaction}"
+            type=${ifDefined(type)}
+            placement=${ifDefined(placement)}
+            offset="-10"
+        >
+            <sp-popover dialog>
+                <p>
+                    Content goes here.
+                    ${type === 'modal' || type === 'page'
+                        ? html`
+                              Or, a link,
+                              <sp-link
+                                  href="https://opensource.adobe.com/spectrum-web-components"
+                              >
+                                  Spectrum Web Components
+                              </sp-link>
+                              .
+                          `
+                        : ''}
+                </p>
+            </sp-popover>
+        </sp-overlay>
+    </div>
 `;
 
 export const modal = (args: Properties): TemplateResult => Template(args);

--- a/packages/overlay/test/overlay-trigger-click.test.ts
+++ b/packages/overlay/test/overlay-trigger-click.test.ts
@@ -28,11 +28,7 @@ import {
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { spy } from 'sinon';
 import { ActionButton } from '@spectrum-web-components/action-button';
-import {
-    fixture,
-    isInteractive,
-    isOnTopLayer,
-} from '../../../test/testing-helpers.js';
+import { fixture, isOnTopLayer } from '../../../test/testing-helpers.js';
 
 describe('Overlay Trigger - Click', () => {
     it('displays `click` declaratively', async () => {
@@ -72,18 +68,25 @@ describe('Overlay Trigger - Click', () => {
         });
     });
     describe('closes on scroll', () => {
-        afterEach(() => {
+        afterEach(async () => {
             if (document.scrollingElement) {
                 document.scrollingElement.scrollTop = 0;
             }
+            await waitUntil(() => {
+                if (document.scrollingElement) {
+                    return document.scrollingElement.scrollTop === 0;
+                }
+                return true;
+            });
         });
         (['click', 'replace', 'inline'] as TriggerInteractionsV1[]).map(
             (interaction) => {
-                it(`closes "${interaction}" overlay on scroll`, async () => {
+                it(`closes "${interaction}" overlay on scroll`, async function () {
                     const el = await fixture<OverlayTrigger>(html`
                         <overlay-trigger
-                            placement="right-start"
+                            placement="right"
                             type=${interaction}
+                            content="click"
                         >
                             <sp-action-button
                                 slot="trigger"
@@ -91,7 +94,9 @@ describe('Overlay Trigger - Click', () => {
                             >
                                 <sp-icon-magnify slot="icon"></sp-icon-magnify>
                             </sp-action-button>
-                            <sp-popover slot="click-content" tip></sp-popover>
+                            <sp-popover slot="click-content" tip>
+                                Content
+                            </sp-popover>
                         </overlay-trigger>
                     `);
                     await nextFrame();
@@ -100,19 +105,26 @@ describe('Overlay Trigger - Click', () => {
 
                     await elementUpdated(el);
                     const opened = oneEvent(el, 'sp-opened');
-                    el.open = 'click';
+                    const trigger = el.querySelector(
+                        'sp-action-button'
+                    ) as HTMLElement;
+                    trigger.click();
+
                     await opened;
 
                     expect(el.open).to.equal('click');
-                    expect(await isInteractive(popover)).to.be.true;
+
+                    expect(await isOnTopLayer(popover)).to.be.true;
 
                     const closed = oneEvent(el, 'sp-closed');
                     if (document.scrollingElement) {
                         document.scrollingElement.scrollTop = 100;
                     }
+
                     await closed;
 
                     expect(el.open).to.be.undefined;
+
                     expect(await isOnTopLayer(popover)).to.be.false;
                 });
             }

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -370,11 +370,11 @@ export const Open = (args: StoryArgs): TemplateResult => {
                 clear: left;
                 margin-bottom: 15px;
             }
-            .backdrop-filer-test {
+            .backdrop-filter-test {
                 backdrop-filter: saturate(80%);
             }
         </style>
-        <fieldset class="backdrop-filer-test">
+        <fieldset class="backdrop-filter-test">
             <sp-field-label for="picker-open">
                 Where do you live?
             </sp-field-label>

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -370,8 +370,11 @@ export const Open = (args: StoryArgs): TemplateResult => {
                 clear: left;
                 margin-bottom: 15px;
             }
+            .backdrop-filer-test {
+                backdrop-filter: saturate(80%);
+            }
         </style>
-        <fieldset>
+        <fieldset class="backdrop-filer-test">
             <sp-field-label for="picker-open">
                 Where do you live?
             </sp-field-label>

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.39.3"
     },
     "devDependencies": {
-        "@spectrum-css/statuslight": "^6.0.52"
+        "@spectrum-css/statuslight": "^6.0.57"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -215,7 +215,7 @@ governing permissions and limitations under the License.
         --mod-statuslight-line-height,
         var(--spectrum-statuslight-line-height)
     );
-    min-height: var(
+    min-block-size: var(
         --mod-statuslight-height,
         var(--spectrum-statuslight-height)
     );

--- a/packages/status-light/src/spectrum-status-light.css
+++ b/packages/status-light/src/spectrum-status-light.css
@@ -215,7 +215,7 @@ governing permissions and limitations under the License.
         --mod-statuslight-line-height,
         var(--spectrum-statuslight-line-height)
     );
-    min-block-size: var(
+    min-height: var(
         --mod-statuslight-height,
         var(--spectrum-statuslight-height)
     );

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -47,23 +47,6 @@ const config = {
             plugins: [json(), watchSWC()],
             http2: true,
             watch: true,
-            middleware: [
-                async (ctx, next) => {
-                    await next();
-                    if (
-                        // Icon packages
-                        ctx.url.search('/icons-') > -1 ||
-                        // Node modules
-                        (ctx.url.search('/node_modules/') > -1 &&
-                            ctx.url.search('/@spectrum-web-components') === -1)
-                    ) {
-                        ctx.set(
-                            'Cache-Control',
-                            'public, max-age=604800, stale-while-revalidate=86400'
-                        );
-                    }
-                },
-            ],
         });
     },
     rollupFinal(config) {

--- a/test/testing-helpers-a11y.ts
+++ b/test/testing-helpers-a11y.ts
@@ -20,7 +20,8 @@ export type DescribedNode = {
 
 export const findDescribedNode = async (
     name: string,
-    description: string
+    description: string,
+    debug?: boolean
 ): Promise<void> => {
     await nextFrame();
 
@@ -31,6 +32,11 @@ export const findDescribedNode = async (
     const snapshot = (await a11ySnapshot({})) as unknown as DescribedNode & {
         children: DescribedNode[];
     };
+
+    if (debug) {
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify(snapshot, undefined, '  '));
+    }
 
     // WebKit doesn't currently associate the `aria-describedby` element to the attribute
     // host in the accessibility tree. Give it an escape hatch for now.

--- a/tools/grid/stories/grid.stories.ts
+++ b/tools/grid/stories/grid.stories.ts
@@ -74,7 +74,12 @@ const renderItem = (
             />
             <div slot="description">10/15/18</div>
             <div slot="footer">Footer</div>
-            <sp-action-menu slot="actions" placement="bottom-end" quiet>
+            <sp-action-menu
+                label="File actions"
+                slot="actions"
+                placement="bottom-end"
+                quiet
+            >
                 <sp-tooltip slot="tooltip" self-managed placement="top">
                     Do stuff
                 </sp-tooltip>

--- a/tools/grid/stories/grid.stories.ts
+++ b/tools/grid/stories/grid.stories.ts
@@ -79,6 +79,7 @@ const renderItem = (
                 slot="actions"
                 placement="bottom-end"
                 quiet
+                tabindex="-1"
             >
                 <sp-tooltip slot="tooltip" self-managed placement="top">
                     Do stuff

--- a/tools/grid/stories/grid.stories.ts
+++ b/tools/grid/stories/grid.stories.ts
@@ -20,6 +20,9 @@ import {
 import '@spectrum-web-components/grid/sp-grid.js';
 import '@spectrum-web-components/action-bar/sp-action-bar.js';
 import '@spectrum-web-components/card/sp-card.js';
+import '@spectrum-web-components/action-menu/sp-action-menu.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import '@spectrum-web-components/checkbox/sp-checkbox.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/action-group/sp-action-group.js';
@@ -61,6 +64,7 @@ const renderItem = (
             value="card-${item.id}"
             .selected=${selected}
             key=${index}
+            draggable="true"
         >
             <img
                 alt=""
@@ -70,6 +74,18 @@ const renderItem = (
             />
             <div slot="description">10/15/18</div>
             <div slot="footer">Footer</div>
+            <sp-action-menu slot="actions" placement="bottom-end" quiet>
+                <sp-tooltip slot="tooltip" self-managed placement="top">
+                    Do stuff
+                </sp-tooltip>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-divider></sp-menu-divider>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-action-menu>
         </sp-card>
     `;
 };
@@ -111,7 +127,7 @@ export const Default = (): TemplateResult => {
             .focusableSelector=${'sp-card'}
             .renderItem=${renderItem}
         ></sp-grid>
-        <sp-action-bar variant="fixed" style="display: none">
+        <sp-action-bar variant="fixed">
             <sp-checkbox @click=${handleActionBarChange} checked>
                 <span class="selected"></span>
                 Selected

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -78,18 +78,14 @@ export default {
             'packages/*/stories/*',
             'packages/icons-ui/**',
             'packages/icons-workflow/**',
-            // The following file is no longer used in Chrome where coverage is calculated.
             'test/**',
             '**/test/**',
             'tools/*/stories/*',
-            'tools/shared/src/focus-visible.*',
             'tools/styles/**',
             '**/node_modules/**',
-            // The following are WIP removals for the Overlay API update
-            '**/ActiveOverlay.*',
-            '**/overlay-stack.*',
-            '**/overlay-utils.*',
-            '**/OverlayPopover.*',
+            // The following files are not used in Chrome where coverage is calculated.
+            '**/OverlayNoPopover.*',
+            'tools/shared/src/focus-visible.*',
         ],
         threshold: {
             statements: 98.5,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,6 +3385,13 @@
   dependencies:
     "@floating-ui/utils" "^0.1.1"
 
+"@floating-ui/core@^1.4.2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
+  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
+  dependencies:
+    "@floating-ui/utils" "^0.1.3"
+
 "@floating-ui/dom@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.1.tgz#88b70defd002fe851f17b4a25efb2d3c04d7a8d7"
@@ -3392,6 +3399,14 @@
   dependencies:
     "@floating-ui/core" "^1.4.1"
     "@floating-ui/utils" "^0.1.1"
+
+"@floating-ui/dom@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
+  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+  dependencies:
+    "@floating-ui/core" "^1.4.2"
+    "@floating-ui/utils" "^0.1.3"
 
 "@floating-ui/react-dom@^2.0.0":
   version "2.0.2"
@@ -3404,6 +3419,11 @@
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.1.tgz#1a5b1959a528e374e8037c4396c3e825d6cf4a83"
   integrity sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==
+
+"@floating-ui/utils@^0.1.3", "@floating-ui/utils@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
+  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
 "@formatjs/ecma402-abstract@1.14.3":
   version "1.14.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6458,7 +6458,7 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-3.0.48.tgz#0b90489bc4a65e87ff48373bd262273cd818194d"
   integrity sha512-zdOuXpAA20qBOt1TKMSUsEzE9eVv6xSlbb13KaDnMnt3hJ0VtC7U4imvw1OHAErm2kOghqBms5ZDf4XIAZg5ng==
 
-"@spectrum-css/statuslight@^6.0.52":
+"@spectrum-css/statuslight@^6.0.57":
   version "6.0.57"
   resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-6.0.57.tgz#218dfcd215634b88b309849e9d73768ec614dbfa"
   integrity sha512-+UXo2sqSKbQVEiw5yEJiZkz5WiSrVMhZbqQgc6HhS7qMTU32mAa7fXPuNXoU+DO08may5iGxf7tJeOp/mS8I4g==


### PR DESCRIPTION
## Description
- support Overlays over `will-change`
- support Overlays over `backdrop-filter`
- support Overlays over containers with `margin-{inline|block}-start`
- remove so obsessive caching in storybook
- correct the location of long press helper content

## Related issue(s)
- fixes #3710

## How has this been tested?
-   [x] _Test case 1_
    1. Go [here](https://overlay-over-transforms--spectrum-web-components.netlify.app/storybook/?path=/story/picker--open)
    2. See that the Menu is open in the correct location
    3. This change adds a `backdrop-filter` to the story context, which also runs into the default margin on `<fieldset>`
-   [ ] _Test case 2_
    1. Go [here](https://overlay-over-transforms--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-element--modal)
    2. See that the Popover is open in the correct location
    3. This change adds a `will-change` wrapper to all of the Element demos as per #3710

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)