### PR TITLE
Updated aria attribute management in Top Nav and Table

### DIFF
--- a/packages/table/src/TableRow.ts
+++ b/packages/table/src/TableRow.ts
@@ -78,6 +78,16 @@ export class TableRow extends SpectrumElement {
 
     protected async manageSelected(): Promise<void> {
         await this.updateComplete;
+        // Manage differently when parent table does not have `role="grid"`.
+        // See: https://github.com/adobe/spectrum-web-components/issues/3397 and https://github.com/adobe/spectrum-web-components/issues/3395
+        if (this.selectable) {
+            this.setAttribute(
+                'aria-selected',
+                this.selected ? 'true' : 'false'
+            );
+        } else {
+            this.removeAttribute('aria-selected');
+        }
         const [checkboxCell] = this.checkboxCells;
         if (!checkboxCell) return;
         checkboxCell.checked = this.selected;

--- a/packages/table/test/table-selects.test.ts
+++ b/packages/table/test/table-selects.test.ts
@@ -120,6 +120,7 @@ describe('Table Selects', () => {
 
         expect(rowTwoCheckbox.checked).to.be.false;
         expect(rowTwo.selected).to.be.false;
+        expect(rowTwo.getAttribute('aria-selected')).to.equal('false');
         expect(el.selected.length).to.equal(0);
     });
     it('ignores unexpected `change` events', async () => {
@@ -172,6 +173,8 @@ describe('Table Selects', () => {
             'sp-table-checkbox-cell'
         ) as TableCheckboxCell;
 
+        expect(rowTwo.getAttribute('aria-selected')).to.equal('false');
+
         const rowThree = el.querySelector('.row3') as TableRow;
         const rowThreeCheckbox = rowThree.querySelector(
             'sp-table-checkbox-cell'
@@ -182,6 +185,7 @@ describe('Table Selects', () => {
 
         expect(rowTwoCheckbox.checked).to.be.true;
         expect(el.selected).to.deep.equal(['row2']);
+        expect(rowTwo.getAttribute('aria-selected')).to.equal('true');
 
         rowThreeCheckbox.checkbox.click();
         await elementUpdated(el);

--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -48,6 +48,9 @@ export class TopNav extends SizedMixin(SpectrumElement) {
     @property({ reflect: true })
     public override dir!: 'ltr' | 'rtl';
 
+    @property({ type: String })
+    public label = '';
+
     @property()
     public selectionIndicatorStyle = noSelectionStyle;
 
@@ -120,6 +123,8 @@ export class TopNav extends SizedMixin(SpectrumElement) {
         );
         if (selectedChild) {
             this.selectTarget(selectedChild);
+        } else {
+            this.selected = '';
         }
     }
 
@@ -141,6 +146,7 @@ export class TopNav extends SizedMixin(SpectrumElement) {
     protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         this.setAttribute('direction', 'horizontal');
+        this.setAttribute('role', 'navigation');
     }
 
     protected override updated(changes: PropertyValues): void {
@@ -153,6 +159,16 @@ export class TopNav extends SizedMixin(SpectrumElement) {
             typeof changes.get('shouldAnimate') !== 'undefined'
         ) {
             this.shouldAnimate = true;
+        }
+        if (
+            changes.has('label') &&
+            (this.label || typeof changes.get('label') !== 'undefined')
+        ) {
+            if (this.label.length) {
+                this.setAttribute('aria-label', this.label);
+            } else {
+                this.removeAttribute('aria-label');
+            }
         }
     }
 

--- a/packages/top-nav/stories/top-nav.stories.ts
+++ b/packages/top-nav/stories/top-nav.stories.ts
@@ -77,7 +77,9 @@ export const Selected = (): TemplateResult => {
                 Page 1
             </sp-top-nav-item>
             <sp-top-nav-item href="#page-2">Page 2</sp-top-nav-item>
-            <sp-top-nav-item href=${href}>Page 3</sp-top-nav-item>
+            <sp-top-nav-item href=${href} class="selected">
+                Page 3
+            </sp-top-nav-item>
             <sp-top-nav-item href="#page-4">
                 Page with Really Long Name
             </sp-top-nav-item>

--- a/packages/top-nav/test/top-nav.test.ts
+++ b/packages/top-nav/test/top-nav.test.ts
@@ -26,6 +26,19 @@ describe('TopNav', () => {
 
         await expect(el).to.be.accessible();
     });
+    it('accepts and removes `label` accessibly', async () => {
+        const el = await fixture<TopNav>(Default());
+
+        await elementUpdated(el);
+
+        el.label = 'Page';
+        await elementUpdated(el);
+        await expect(el).to.be.accessible();
+
+        el.label = '';
+        await elementUpdated(el);
+        await expect(el).to.be.accessible();
+    });
     it('loads with a selected item accessible', async () => {
         const el = await fixture<TopNav>(Selected());
 
@@ -54,6 +67,20 @@ describe('TopNav', () => {
         const { width: widthEnd } = indicator.getBoundingClientRect();
 
         expect(widthStart).to.be.greaterThan(widthEnd);
+    });
+    it('can have an item removed', async () => {
+        const el = await fixture<TopNav>(Selected());
+        const item = el.querySelector('.selected') as TopNavItem;
+
+        await elementUpdated(el);
+        await elementUpdated(item);
+
+        expect(el.selected).to.equal(item.value);
+
+        item.remove();
+        await elementUpdated(el);
+
+        expect(el.selected).to.not.equal(item.value);
     });
 });
 


### PR DESCRIPTION
## Description
- manage `role` in Top Nav
- manage `aria-selected` in Table Row

## Related issue(s)
- fixes #3401
- fixes #3397

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://role-management--spectrum-web-components.netlify.app/storybook/?path=/story/top-nav--default)
    2. Turn on screen reader
    3. See that the Top nav element is announced as "navigation"
    4. You can also toggle the `label` attribute to a value and see that it is used as well.
-   [ ] _Test case 2_
    1. Go [here](https://role-management--spectrum-web-components.netlify.app/storybook/?path=/story/table--selects-single)
    2. See that the selected row has the `aria-selected="true"` value and that others have `aria-selected="false"`

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)