### PR TITLE
fix: add delay to overlay-trigger

### DIFF
--- a/packages/overlay/src/AbstractOverlay.ts
+++ b/packages/overlay/src/AbstractOverlay.ts
@@ -150,6 +150,9 @@ export class AbstractOverlay extends SpectrumElement {
     get delayed(): boolean {
         return false;
     }
+    set delayed(_delayed: boolean) {
+        return;
+    }
     dialogEl!: HTMLDialogElement & {
         showPopover(): void;
         hidePopover(): void;

--- a/packages/overlay/src/AbstractOverlay.ts
+++ b/packages/overlay/src/AbstractOverlay.ts
@@ -147,7 +147,9 @@ export class AbstractOverlay extends SpectrumElement {
     ): Promise<void> {
         return;
     }
-    delayed!: boolean;
+    get delayed(): boolean {
+        return false;
+    }
     dialogEl!: HTMLDialogElement & {
         showPopover(): void;
         hidePopover(): void;

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -86,6 +86,12 @@ export class Overlay extends OverlayFeatures {
 
     abortController!: AbortController;
 
+    @query('.dialog')
+    override dialogEl!: HTMLDialogElement & {
+        showPopover(): void;
+        hidePopover(): void;
+    };
+
     /**
      * An Overlay that is `delayed` will wait until a warm-up period of 1000ms
      * has completed before opening. Once the warmup period has completed, all
@@ -95,13 +101,17 @@ export class Overlay extends OverlayFeatures {
      * provided that option.
      */
     @property({ type: Boolean })
-    override delayed = false;
+    override get delayed(): boolean {
+        if (this.elements.length === 0) {
+            return false;
+        }
 
-    @query('.dialog')
-    override dialogEl!: HTMLDialogElement & {
-        showPopover(): void;
-        hidePopover(): void;
-    };
+        if (this.elements[0].getAttribute('delayed') !== null) {
+            return true;
+        }
+
+        return false;
+    }
 
     /**
      * Whether the overlay is currently functional or not

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -86,12 +86,6 @@ export class Overlay extends OverlayFeatures {
 
     abortController!: AbortController;
 
-    @query('.dialog')
-    override dialogEl!: HTMLDialogElement & {
-        showPopover(): void;
-        hidePopover(): void;
-    };
-
     /**
      * An Overlay that is `delayed` will wait until a warm-up period of 1000ms
      * has completed before opening. Once the warmup period has completed, all
@@ -102,15 +96,7 @@ export class Overlay extends OverlayFeatures {
      */
     @property({ type: Boolean })
     override get delayed(): boolean {
-        if (this.elements.length === 0) {
-            return false;
-        }
-
-        if (this.elements[0].getAttribute('delayed') !== null) {
-            return true;
-        }
-
-        return this._delayed;
+        return this.elements.at(-1)?.hasAttribute('delayed') || this._delayed;
     }
 
     override set delayed(delayed: boolean) {
@@ -118,6 +104,12 @@ export class Overlay extends OverlayFeatures {
     }
 
     private _delayed = false;
+
+    @query('.dialog')
+    override dialogEl!: HTMLDialogElement & {
+        showPopover(): void;
+        hidePopover(): void;
+    };
 
     /**
      * Whether the overlay is currently functional or not

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -110,8 +110,14 @@ export class Overlay extends OverlayFeatures {
             return true;
         }
 
-        return false;
+        return this._delayed;
     }
+
+    override set delayed(delayed: boolean) {
+        this._delayed = delayed;
+    }
+
+    private _delayed = false;
 
     /**
      * Whether the overlay is currently functional or not

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -180,10 +180,6 @@ export class OverlayTrigger extends SpectrumElement {
         `;
     }
 
-    protected isDelayed(element: HTMLElement): boolean {
-        return element.hasAttribute('delayed');
-    }
-
     protected renderClickOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('click-content');
@@ -193,7 +189,6 @@ export class OverlayTrigger extends SpectrumElement {
         return html`
             <sp-overlay
                 id="click-overlay"
-                ?delayed=${this.isDelayed(this.clickContent[0])}
                 ?disabled=${this.disabled || !this.clickContent.length}
                 ?open=${this.open === 'click' && !!this.clickContent.length}
                 .offset=${this.offset}
@@ -217,7 +212,6 @@ export class OverlayTrigger extends SpectrumElement {
         return html`
             <sp-overlay
                 id="hover-overlay"
-                ?delayed=${this.isDelayed(this.hoverContent[0])}
                 ?disabled=${this.disabled ||
                 !this.hoverContent.length ||
                 (!!this.open && this.open !== 'hover')}
@@ -243,7 +237,6 @@ export class OverlayTrigger extends SpectrumElement {
         return html`
             <sp-overlay
                 id="longpress-overlay"
-                ?delayed=${this.isDelayed(this.longpressContent[0])}
                 ?disabled=${this.disabled || !this.longpressContent.length}
                 ?open=${this.open === 'longpress' &&
                 !!this.longpressContent.length}

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -180,6 +180,10 @@ export class OverlayTrigger extends SpectrumElement {
         `;
     }
 
+    protected isDelayed(element: HTMLElement): boolean {
+        return element.hasAttribute('delayed');
+    }
+
     protected renderClickOverlay(): TemplateResult {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         const slot = this.renderSlot('click-content');
@@ -189,6 +193,7 @@ export class OverlayTrigger extends SpectrumElement {
         return html`
             <sp-overlay
                 id="click-overlay"
+                ?delayed=${this.isDelayed(this.clickContent[0])}
                 ?disabled=${this.disabled || !this.clickContent.length}
                 ?open=${this.open === 'click' && !!this.clickContent.length}
                 .offset=${this.offset}
@@ -212,6 +217,7 @@ export class OverlayTrigger extends SpectrumElement {
         return html`
             <sp-overlay
                 id="hover-overlay"
+                ?delayed=${this.isDelayed(this.hoverContent[0])}
                 ?disabled=${this.disabled ||
                 !this.hoverContent.length ||
                 (!!this.open && this.open !== 'hover')}
@@ -237,6 +243,7 @@ export class OverlayTrigger extends SpectrumElement {
         return html`
             <sp-overlay
                 id="longpress-overlay"
+                ?delayed=${this.isDelayed(this.longpressContent[0])}
                 ?disabled=${this.disabled || !this.longpressContent.length}
                 ?open=${this.open === 'longpress' &&
                 !!this.longpressContent.length}

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -76,6 +76,7 @@ const Template = ({
     open,
     placement,
     type,
+    delayed,
 }: Properties): TemplateResult => html`
     <style>
         .wrapper {
@@ -91,7 +92,7 @@ const Template = ({
             placement=${ifDefined(placement)}
             offset="-10"
         >
-            <sp-popover dialog>
+            <sp-popover dialog ?delayed=${delayed}>
                 <p>
                     Content goes here.
                     ${type === 'modal' || type === 'page'

--- a/packages/overlay/test/overlay-trigger-click.test.ts
+++ b/packages/overlay/test/overlay-trigger-click.test.ts
@@ -179,17 +179,8 @@ describe('Overlay Trigger - Click', () => {
     });
 
     it('opens with a delay on click', async () => {
-        const openedSpy = spy();
-        const closedSpy = spy();
-
-        const start = performance.now();
-
         const el = await fixture<OverlayTrigger>(html`
-            <overlay-trigger
-                placement="right-start"
-                @sp-opened=${() => openedSpy()}
-                @sp-closed=${() => closedSpy()}
-            >
+            <overlay-trigger placement="right-start">
                 <sp-button slot="trigger" variant="primary"></sp-button>
                 <sp-tooltip
                     slot="click-content"
@@ -198,14 +189,11 @@ describe('Overlay Trigger - Click', () => {
                 ></sp-tooltip>
             </overlay-trigger>
         `);
+        const start = performance.now();
+        const opened = oneEvent(el, 'sp-opened');
 
-        await elementUpdated(el);
         el.setAttribute('open', 'click');
-        await waitUntil(
-            () => openedSpy.calledOnce,
-            'hover content projected to overlay',
-            { timeout: 8000 }
-        );
+        await opened;
 
         const end = performance.now();
         expect(end - start).to.be.greaterThan(1000);

--- a/packages/overlay/test/overlay-trigger-click.test.ts
+++ b/packages/overlay/test/overlay-trigger-click.test.ts
@@ -19,6 +19,9 @@ import {
 } from '@open-wc/testing';
 import type { Popover } from '@spectrum-web-components/popover';
 import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+
+import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 import {
@@ -173,5 +176,38 @@ describe('Overlay Trigger - Click', () => {
             { timeout: 2000 }
         );
         expect(el.open).to.equal('click');
+    });
+
+    it('opens with a delay on click', async () => {
+        const openedSpy = spy();
+        const closedSpy = spy();
+
+        const start = performance.now();
+
+        const el = await fixture<OverlayTrigger>(html`
+            <overlay-trigger
+                placement="right-start"
+                @sp-opened=${() => openedSpy()}
+                @sp-closed=${() => closedSpy()}
+            >
+                <sp-button slot="trigger" variant="primary"></sp-button>
+                <sp-tooltip
+                    slot="click-content"
+                    id="content"
+                    delayed
+                ></sp-tooltip>
+            </overlay-trigger>
+        `);
+
+        await elementUpdated(el);
+        el.setAttribute('open', 'click');
+        await waitUntil(
+            () => openedSpy.calledOnce,
+            'hover content projected to overlay',
+            { timeout: 8000 }
+        );
+
+        const end = performance.now();
+        expect(end - start).to.be.greaterThan(1000);
     });
 });


### PR DESCRIPTION
This PR adds the `delay` capability back to `overlay-trigger`

## Motivation and context

Adding back the capability of delayed overlays.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
     Inside storybook created a button with a delayed tooltip through overlay-trigger.

-   [ ] _Test case 2_
     Called the Overlay.open() method to test backwards compatibility.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
