### PR TITLE
fix(number-field): update display value on scroll and arrow up/down

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -319,8 +319,11 @@ export class NumberField extends TextfieldBase {
         if (isNaN(this.value)) {
             value = min;
         }
+
         this._value = this.validateInput(value);
-        this.dispatchEvent(
+        this.inputElement.value = value.toString();
+
+        this.inputElement.dispatchEvent(
             new Event('input', { bubbles: true, composed: true })
         );
         this.indeterminate = false;

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -73,10 +73,12 @@ describe('NumberField', () => {
     describe('receives input', () => {
         it('without language context', async () => {
             const el = await getElFrom(Default({ value: 1337 }));
+
             el.size = 's';
             expect(el.formattedValue).to.equal('1,337');
             expect(el.valueAsString).to.equal('1337');
             expect(el.value).to.equal(1337);
+            expect(el.focusElement.value).to.equal('1,337');
             el.focus();
             await sendKeys({ type: '7331' });
             await elementUpdated(el);
@@ -85,6 +87,7 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('13,377,331');
             expect(el.valueAsString).to.equal('13377331');
             expect(el.value).to.equal(13377331);
+            expect(el.focusElement.value).to.equal('13,377,331');
         });
         it('with language context', async () => {
             const [languageContext] = createLanguageContext('fr');
@@ -93,10 +96,12 @@ describe('NumberField', () => {
                     ${Default({ value: 1337 })}
                 </div>
             `);
+
             el.size = 'l';
             expect(el.formattedValue).to.equal('1 337');
             expect(el.valueAsString).to.equal('1337');
             expect(el.value).to.equal(1337);
+            expect(el.focusElement.value).to.equal('1 337');
             el.focus();
             await sendKeys({ type: '7331' });
             await elementUpdated(el);
@@ -105,6 +110,7 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('13 377 331');
             expect(el.valueAsString).to.equal('13377331');
             expect(el.value).to.equal(13377331);
+            expect(el.focusElement.value).to.equal('13 377 331');
         });
     });
     describe('Step', () => {
@@ -117,10 +123,12 @@ describe('NumberField', () => {
                     value: 5,
                 })
             );
+
             el.size = 'xl';
             expect(el.value).to.equal(5);
             expect(el.formattedValue).to.equal('5');
             expect(el.valueAsString).to.equal('5');
+            expect(el.focusElement.value).to.equal('5');
         });
 
         it('supports both positive and negative decimal values', async () => {
@@ -132,34 +140,41 @@ describe('NumberField', () => {
                     value: -2.4,
                 })
             );
+
             el.size = 'xl';
             expect(el.value).to.equal(-2.4);
             expect(el.valueAsString).to.equal('-2.4');
+            expect(el.focusElement.value).to.equal('-2.4');
         });
     });
     describe('Increments', () => {
         let el: NumberField;
+
         beforeEach(async () => {
             el = await getElFrom(Default({}));
             expect(el.value).to.be.NaN;
             expect(el.formattedValue).to.equal('');
             expect(el.valueAsString).to.equal('NaN');
+            expect(el.focusElement.value).to.equal('');
         });
         it('via pointer, only "left" button', async () => {
             await clickBySelector(el, '.step-up', { button: 'middle' });
             expect(el.formattedValue).to.equal('');
             expect(el.valueAsString).to.equal('NaN');
             expect(el.value).to.be.NaN;
+            expect(el.focusElement.value).to.equal('');
         });
         it('via pointer', async () => {
             await clickBySelector(el, '.step-up');
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             await clickBySelector(el, '.step-up');
             expect(el.formattedValue).to.equal('1');
             expect(el.valueAsString).to.equal('1');
             expect(el.value).to.equal(1);
+            expect(el.focusElement.value).to.equal('1');
         });
         it('via arrow up', async () => {
             el.focus();
@@ -169,11 +184,13 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             await sendKeys({ press: 'ArrowUp' });
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('1');
             expect(el.valueAsString).to.equal('1');
             expect(el.value).to.equal(1);
+            expect(el.focusElement.value).to.equal('1');
         });
         it('via arrow up (shift modified)', async () => {
             el.focus();
@@ -183,11 +200,13 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             await sendKeys({ press: 'Shift+ArrowUp' });
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
+            expect(el.focusElement.value).to.equal('10');
         });
         it('via arrow up (custom shift modified value)', async () => {
             el.focus();
@@ -199,11 +218,13 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             await sendKeys({ press: 'Shift+ArrowUp' });
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('15');
             expect(el.valueAsString).to.equal('15');
             expect(el.value).to.equal(15);
+            expect(el.focusElement.value).to.equal('15');
         });
         it('via scroll', async () => {
             el.focus();
@@ -214,11 +235,13 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             el.dispatchEvent(new WheelEvent('wheel', { deltaY: 100 }));
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('1');
             expect(el.valueAsString).to.equal('1');
             expect(el.value).to.equal(1);
+            expect(el.focusElement.value).to.equal('1');
         });
         it('via scroll (shift modified)', async () => {
             el.focus();
@@ -234,6 +257,7 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             el.dispatchEvent(
                 new WheelEvent('wheel', {
                     deltaX: 100,
@@ -244,31 +268,37 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
+            expect(el.focusElement.value).to.equal('10');
         });
     });
     describe('Decrements', () => {
         let el: NumberField;
+
         beforeEach(async () => {
             el = await getElFrom(Default({}));
             expect(el.value).to.be.NaN;
             expect(el.formattedValue).to.equal('');
             expect(el.valueAsString).to.equal('NaN');
+            expect(el.focusElement.value).to.equal('');
         });
         it('via pointer, only "left" button', async () => {
             await clickBySelector(el, '.step-down', { button: 'middle' });
             expect(el.formattedValue).to.equal('');
             expect(el.valueAsString).to.equal('NaN');
             expect(el.value).to.be.NaN;
+            expect(el.focusElement.value).to.equal('');
         });
         it('via pointer', async () => {
             await clickBySelector(el, '.step-down');
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             await clickBySelector(el, '.step-down');
             expect(el.formattedValue).to.equal('-1');
             expect(el.valueAsString).to.equal('-1');
             expect(el.value).to.equal(-1);
+            expect(el.focusElement.value).to.equal('-1');
         });
         it('via arrow down', async () => {
             el.focus();
@@ -278,11 +308,13 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             await sendKeys({ press: 'ArrowDown' });
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('-1');
             expect(el.valueAsString).to.equal('-1');
             expect(el.value).to.equal(-1);
+            expect(el.focusElement.value).to.equal('-1');
         });
         it('via arrow down (shift modified)', async () => {
             el.focus();
@@ -292,11 +324,13 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             await sendKeys({ press: 'Shift+ArrowDown' });
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('-10');
             expect(el.valueAsString).to.equal('-10');
             expect(el.value).to.equal(-10);
+            expect(el.focusElement.value).to.equal('-10');
         });
         it('via arrow up (custom shift modified value)', async () => {
             el.focus();
@@ -308,11 +342,13 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             await sendKeys({ press: 'Shift+ArrowDown' });
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('-15');
             expect(el.valueAsString).to.equal('-15');
             expect(el.value).to.equal(-15);
+            expect(el.focusElement.value).to.equal('-15');
         });
         it('via scroll', async () => {
             el.focus();
@@ -323,11 +359,13 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             el.dispatchEvent(new WheelEvent('wheel', { deltaY: -100 }));
             await elementUpdated(el);
             expect(el.formattedValue).to.equal('-1');
             expect(el.valueAsString).to.equal('-1');
             expect(el.value).to.equal(-1);
+            expect(el.focusElement.value).to.equal('-1');
         });
         it('via scroll (shift modified)', async () => {
             el.focus();
@@ -343,6 +381,7 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('0');
             expect(el.valueAsString).to.equal('0');
             expect(el.value).to.equal(0);
+            expect(el.focusElement.value).to.equal('0');
             el.dispatchEvent(
                 new WheelEvent('wheel', {
                     deltaX: -100,
@@ -353,6 +392,7 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('-10');
             expect(el.valueAsString).to.equal('-10');
             expect(el.value).to.equal(-10);
+            expect(el.focusElement.value).to.equal('-10');
         });
     });
     describe('dispatched events', () => {


### PR DESCRIPTION
Fixing the displayed value of sp-number-field on arrow keys and on scroll interactions.

## Related issue(s)

https://github.com/adobe/spectrum-web-components/issues/3753


## Motivation and context

It improves the user experience by showing in real time the changing value.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to number-field storybook
    2. Click on the number field to focus it
    3. Tap the ArrowUp/ArrowDown key or scroll
    4. See that the value updates in real time

## Screenshots (if appropriate)
In the first part of the video you can see the behaviour while I'm scrolling with focus on number field, while the second part shows what happens when tapping the ArrowUp/ArrowDown keys.

https://github.com/adobe/spectrum-web-components/assets/67201262/3d4270ce-5c02-487b-b1d4-066b62aa1e96



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
