### PR TITLE
fix: support numeric IDs when resolving elements

### DIFF
--- a/packages/field-label/test/field-label.test.ts
+++ b/packages/field-label/test/field-label.test.ts
@@ -169,6 +169,23 @@ describe('FieldLabel', () => {
         expect(input.hasAttribute('aria-labelledby'));
         expect(input.getAttribute('aria-labelledby')).to.equal(el.id);
     });
+    it('associates via "id" starting with number', async () => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <div>
+                    <sp-field-label required for="1"></sp-field-label>
+                    <input id="1" />
+                </div>
+            `
+        );
+        const el = test.querySelector('sp-field-label') as FieldLabel;
+        const input = test.querySelector('input') as HTMLInputElement;
+
+        await elementUpdated(el);
+
+        expect(input.hasAttribute('aria-labelledby'));
+        expect(input.getAttribute('aria-labelledby')).to.equal(el.id);
+    });
     it('passed clicks to assiciated form element as focus', async () => {
         const test = await fixture<HTMLDivElement>(
             html`


### PR DESCRIPTION
## Description
Cleaning up old branches.

This allows the element resolution controller to switch between CSS selectors and ID selectors as needed (needed when an ID that starts with a number) to resolve the element it targets.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
