### PR TITLE
ci: attempt firefox texts in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,25 +152,36 @@ jobs:
                   path: /root/project/results/
             - store_artifacts:
                   path: coverage
-            - run:
-                  name: Are there changes?
-                  command: git diff --exit-code
 
     test-firefox:
         executor: node
+        parallelism: 5
 
         steps:
             - downstream
             - run:
                   name: Run tests
-                  command: yarn test:ci --config web-test-runner.config.ci-firefox.js --group unit
+                  command: |
+                      TEST=$(circleci tests glob packages/*/test/*.test.js | circleci tests split --split-by=timings)
+                      yarn test:start --files $TEST --config web-test-runner.config.ci-firefox.js --group unit-ci
             - store_test_results:
                   path: /root/project/results/
-            - run:
-                  name: Are there changes?
-                  command: git diff-files
 
     test-webkit:
+        executor: node
+        parallelism: 5
+
+        steps:
+            - downstream
+            - run:
+                  name: Run tests
+                  command: |
+                      TEST=$(circleci tests glob packages/*/test/*.test.js | circleci tests split --split-by=timings)
+                      yarn test:start --files $TEST --config web-test-runner.config.ci-webkit.js --group unit-ci
+            - store_test_results:
+                  path: /root/project/results/
+
+    lint:
         executor: node
 
         steps:
@@ -179,11 +190,6 @@ jobs:
                   name: Lint
                   command: yarn lint
             - run: yarn analyze
-            - run:
-                  name: Run tests
-                  command: yarn test:ci --config web-test-runner.config.ci-webkit.js --group unit
-            - store_test_results:
-                  path: /root/project/results/
             - run:
                   name: Are there changes?
                   command: git diff-files
@@ -300,6 +306,7 @@ workflows:
             - test-chromium
             - test-firefox
             - test-webkit
+            - lint
             - hcm-visual:
                   filters:
                       branches:

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -135,6 +135,9 @@ export default {
             ],
             browsers: [chromium, firefox, webkit],
         },
+        {
+            name: 'unit-ci',
+        },
     ],
     group: 'unit',
     browsers: [firefox, chromiumWithMemoryTooling, webkit],


### PR DESCRIPTION
## Description
- run ff and webkit unit tests in parallel
  - chromium builds test coverage which is difficult to merge at the end of the process so exclude it from this
- split lint/analyze/check for changes step into its own job