### PR TITLE
build: exclude all CSS vars from the theme styles

### DIFF
--- a/tools/theme/src/express/scale-large.css
+++ b/tools/theme/src/express/scale-large.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/express/scale-large.css');
+/* @import url('@spectrum-web-components/styles/express/scale-large.css'); */
 @import url('@spectrum-web-components/styles/tokens/large-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-large-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/custom-large-vars.css');
@@ -19,4 +19,5 @@ governing permissions and limitations under the License.
 :root,
 :host {
     --swc-scale-factor: 1.25;
+    --spectrum-global-alias-appframe-border-size: 1px;
 }

--- a/tools/theme/src/express/scale-medium.css
+++ b/tools/theme/src/express/scale-medium.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/express/scale-medium.css');
+/* @import url('@spectrum-web-components/styles/express/scale-medium.css'); */
 @import url('@spectrum-web-components/styles/tokens/medium-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-medium-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/custom-medium-vars.css');
@@ -19,4 +19,5 @@ governing permissions and limitations under the License.
 :root,
 :host {
     --swc-scale-factor: 1;
+    --spectrum-global-alias-appframe-border-size: 2px;
 }

--- a/tools/theme/src/express/theme-dark.css
+++ b/tools/theme/src/express/theme-dark.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/express/theme-dark.css');
+/* @import url('@spectrum-web-components/styles/express/theme-dark.css'); */
 @import url('@spectrum-web-components/styles/tokens/dark-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-dark-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/custom-dark-vars.css');

--- a/tools/theme/src/express/theme-light.css
+++ b/tools/theme/src/express/theme-light.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/express/theme-light.css');
+/* @import url('@spectrum-web-components/styles/express/theme-light.css'); */
 @import url('@spectrum-web-components/styles/tokens/light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/custom-light-vars.css');

--- a/tools/theme/src/express/theme.css
+++ b/tools/theme/src/express/theme.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/express/core-global.css');
+/* @import url('@spectrum-web-components/styles/express/core-global.css'); */
 @import url('@spectrum-web-components/styles/tokens/global-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/global-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-vars.css');

--- a/tools/theme/src/scale-large.css
+++ b/tools/theme/src/scale-large.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/scale-large.css');
+/* @import url('@spectrum-web-components/styles/scale-large.css'); */
 @import url('@spectrum-web-components/styles/tokens/large-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-large-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/large-vars.css');

--- a/tools/theme/src/scale-medium.css
+++ b/tools/theme/src/scale-medium.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/scale-medium.css');
+/* @import url('@spectrum-web-components/styles/scale-medium.css'); */
 @import url('@spectrum-web-components/styles/tokens/medium-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-medium-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/medium-vars.css');

--- a/tools/theme/src/theme-dark.css
+++ b/tools/theme/src/theme-dark.css
@@ -10,6 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/theme-dark.css');
+/* @import url('@spectrum-web-components/styles/theme-dark.css'); */
 @import url('@spectrum-web-components/styles/tokens/dark-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-dark-vars.css');

--- a/tools/theme/src/theme-darkest.css
+++ b/tools/theme/src/theme-darkest.css
@@ -10,6 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/theme-darkest.css');
+/* @import url('@spectrum-web-components/styles/theme-darkest.css'); */
 @import url('@spectrum-web-components/styles/tokens/darkest-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-darkest-vars.css');

--- a/tools/theme/src/theme-light.css
+++ b/tools/theme/src/theme-light.css
@@ -10,6 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/theme-light.css');
+/* @import url('@spectrum-web-components/styles/theme-light.css'); */
 @import url('@spectrum-web-components/styles/tokens/light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-light-vars.css');

--- a/tools/theme/src/theme-lightest.css
+++ b/tools/theme/src/theme-lightest.css
@@ -10,6 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/theme-lightest.css');
+/* @import url('@spectrum-web-components/styles/theme-lightest.css'); */
 @import url('@spectrum-web-components/styles/tokens/light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-light-vars.css');

--- a/tools/theme/src/theme.css
+++ b/tools/theme/src/theme.css
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('@spectrum-web-components/styles/core-global.css');
+/* @import url('@spectrum-web-components/styles/core-global.css'); */
 @import url('@spectrum-web-components/styles/tokens/global-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/global-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-vars.css');


### PR DESCRIPTION
Test branch to see what happens when we remove Spectrum Vars from the themes.