### PR TITLE
fix(field-group): apply role when none present

### DIFF
--- a/packages/field-group/src/FieldGroup.ts
+++ b/packages/field-group/src/FieldGroup.ts
@@ -61,6 +61,13 @@ export class FieldGroup extends ManageHelpText(SpectrumElement, {
         `;
     }
 
+    protected override firstUpdated(changes: PropertyValues): void {
+        super.firstUpdated(changes);
+        if (!this.hasAttribute('role')) {
+            this.setAttribute('role', 'group');
+        }
+    }
+
     protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
         if (changes.has('label')) {


### PR DESCRIPTION
## Description
Apply role when none provided

## Related issue(s)
- fixes #3362


## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://focus-group-role--spectrum-web-components.netlify.app/storybook/index.html?path=/story/field-group--horizontal)
    2. See that the Field Group has a `role` attribute

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)