### PR TITLE
chore(field-group): added role='group'

### DIFF
--- a/packages/field-group/src/FieldGroup.ts
+++ b/packages/field-group/src/FieldGroup.ts
@@ -63,6 +63,7 @@ export class FieldGroup extends ManageHelpText(SpectrumElement, {
 
     protected override updated(changes: PropertyValues<this>): void {
         super.updated(changes);
+        this.setAttribute('role', 'group');
         if (changes.has('label')) {
             if (this.label) {
                 this.setAttribute('aria-label', this.label);

--- a/packages/field-group/test/field-group.test.ts
+++ b/packages/field-group/test/field-group.test.ts
@@ -80,6 +80,19 @@ describe('FieldGroup', () => {
 
             await findDescribedNode(name, description);
         });
+        it('has attribute role', async () => {
+            const el = await fixture(html`
+                <sp-field-group label=${name}>
+                    <sp-help-text slot="help-text" id="help-text-id-1">
+                        ${description}
+                    </sp-help-text>
+                </sp-field-group>
+            `);
+
+            await elementUpdated(el);
+            expect(el.hasAttribute('role')).to.be.true;
+            expect(el.getAttribute('role')).to.equal('group');
+        });
         it('manages neutral/negative help text pairs', async () => {
             const el = await fixture<FieldGroup>(html`
                 <sp-field-group label=${name}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added role='group' attribute to field-group

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
