### PR TITLE
fix(tags): make the 'delete' event cancelable

### DIFF
--- a/packages/tags/src/Tag.ts
+++ b/packages/tags/src/Tag.ts
@@ -87,6 +87,7 @@ export class Tag extends SizedMixin(SpectrumElement, {
         const applyDefault = this.dispatchEvent(
             new Event('delete', {
                 bubbles: true,
+                cancelable: true,
                 composed: true,
             })
         );

--- a/packages/tags/test/tag.test.ts
+++ b/packages/tags/test/tag.test.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import { elementUpdated, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 
 import '@spectrum-web-components/tags/sp-tag.js';
 import '@spectrum-web-components/tags/sp-tags.js';
@@ -185,5 +185,34 @@ describe('Tag', () => {
             deleteSpy.callCount,
             'Does not respond after `focusout`'
         ).to.equal(expectedEventCount);
+    });
+    it('can have delete event prevented', async () => {
+        const deleteSpy = spy();
+        const handleDelete = (event: Event): void => {
+            event.preventDefault();
+            deleteSpy();
+        };
+        const el = await fixture<Tag>(
+            html`
+                <sp-tag deletable @delete=${handleDelete}>Tag</sp-tag>
+            `
+        );
+
+        const removeStub = stub(el, 'remove');
+
+        await elementUpdated(el);
+
+        expect(deleteSpy.called).to.be.false;
+
+        const root: HTMLElement | DocumentFragment = el.shadowRoot
+            ? el.shadowRoot
+            : el;
+        const deleteButton = root.querySelector(
+            'sp-clear-button'
+        ) as ClearButton;
+        deleteButton.click();
+
+        expect(deleteSpy.callCount).to.equal(1);
+        expect(removeStub.called).to.be.false;
     });
 });

--- a/packages/tags/test/tag.test.ts
+++ b/packages/tags/test/tag.test.ts
@@ -204,10 +204,7 @@ describe('Tag', () => {
 
         expect(deleteSpy.called).to.be.false;
 
-        const root: HTMLElement | DocumentFragment = el.shadowRoot
-            ? el.shadowRoot
-            : el;
-        const deleteButton = root.querySelector(
+        const deleteButton = el.shadowRoot.querySelector(
             'sp-clear-button'
         ) as ClearButton;
         deleteButton.click();


### PR DESCRIPTION
Make the `delete` event cancelable for the `sp-tag` element.

## Related issue(s)

- fixes #3777 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
