### PR TITLE
fix(overlay): ensure manual overlays persist through interactions outside of their subtree

### DIFF
--- a/packages/overlay/src/OverlayStack.ts
+++ b/packages/overlay/src/OverlayStack.ts
@@ -68,7 +68,11 @@ class OverlayStack {
             const inStack = composedPath.find(
                 (el) => el === overlay || el === overlay?.triggerElement
             );
-            return !inStack && !overlay.shouldPreventClose();
+            return (
+                !inStack &&
+                !overlay.shouldPreventClose() &&
+                overlay.type !== 'manual'
+            );
         }) as Overlay[];
         nonAncestorOverlays.reverse();
         nonAncestorOverlays.forEach((overlay) => {

--- a/packages/overlay/test/overlay-element.test.ts
+++ b/packages/overlay/test/overlay-element.test.ts
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import {
+    aTimeout,
     elementUpdated,
     expect,
     fixture,
@@ -31,7 +32,7 @@ import '@spectrum-web-components/button/sp-button.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import { Button } from '@spectrum-web-components/button';
 import { sendKeys } from '@web/test-runner-commands';
-import { receivesFocus } from '../stories/overlay-element.stories.js';
+import { click, receivesFocus } from '../stories/overlay-element.stories.js';
 
 const OVERLAY_TYPES = ['modal', 'page', 'hint', 'auto', 'manual'] as const;
 type OverlayTypes = typeof OVERLAY_TYPES[number];
@@ -790,6 +791,48 @@ describe('sp-overlay', () => {
                 expect(this.hint.open).to.be.false;
                 expect(this.auto.open).to.be.true;
                 expect(this.manual.open).to.be.true;
+            });
+        });
+        describe('only close when mnually closed', function () {
+            it('does not close when clicking away', async () => {
+                const test = await fixture(html`
+                    <div>
+                        ${click({
+                            ...click.args,
+                            interaction: 'click',
+                            placement: 'bottom',
+                            type: 'manual',
+                            delayed: false,
+                            receivesFocus: 'auto',
+                        })}
+                    </div>
+                `);
+                const el = test.querySelector('sp-overlay') as Overlay;
+
+                expect(el.open).to.be.false;
+
+                const opened = oneEvent(el, 'sp-opened');
+                el.open = true;
+                await opened;
+
+                await sendMouse({
+                    steps: [
+                        {
+                            type: 'click',
+                            position: [50, 400],
+                        },
+                    ],
+                });
+
+                await aTimeout(200);
+
+                expect(el.open).to.be.true;
+
+                const closed = oneEvent(el, 'sp-closed');
+                el.open = false;
+                await closed;
+
+                expect(el.open).to.be.false;
             });
         });
     });


### PR DESCRIPTION
## Description
Persist `<sp-overlay type="manual">` elements through interaction that occur outside of their subtree, as is documented/expected/etc but was missed... 😞 

## Related issue(s)
- fixes #3702


## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://manual-overlay--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-element--click&args=type:manual)
    2. Ensure "type" is set to "manual" in the story controls
    3. Open the overlay
    4. Click outside of it
    5. See that it does not close

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.