### PR TITLE
chore: custom Spectrum CSS dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,24 @@ updates:
           time: '12:00'
           timezone: 'America/Los_Angeles'
       open-pull-requests-limit: 5
+      ignore:
+          - dependency-name: '@spectrum-css/*'
       reviewers:
           - 'hunterloftis'
           - 'najikahalsema'
           - 'westbrook'
+
+    # This sets up a daily check for Spectrum CSS updates
+    # focused on the @spectrum-css/* packages
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'daily'
+      allow:
+          - dependency-name: '@spectrum-css/*'
+      labels: ['Spectrum CSS']
+      assignees:
+          - 'jnjosh'
+          - 'rajdeepc'
+          - 'pfulton'
+          - 'castastrophe'


### PR DESCRIPTION
## Why

There seems to be a lot of value in more frequent alignment with Spectrum CSS releases for components already built in SWC. Adding a separate set of configurations for Spectrum CSS allows the appropriate labels be applied and the PRs be assigned to the Spectrum Engineering crew to review & provide feedback.


## Motivation and context

As we move into a more rapid update cycle, this will help us see those changes show up in SWC in real-time.

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [N/A] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [N/A] I have added tests to cover my changes.
-   [N/A] All new and existing tests passed.
-   [N/A] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
