### PR TITLE
chore: add GH action updates to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,17 +15,7 @@ updates:
           - 'najikahalsema'
           - 'westbrook'
 
-    # This sets up a daily check for Spectrum CSS updates
-    # focused on the @spectrum-css/* packages
-    - package-ecosystem: 'npm'
+    - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:
-          interval: 'daily'
-      allow:
-          - dependency-name: '@spectrum-css/*'
-      labels: ['Spectrum CSS']
-      assignees:
-          - 'jnjosh'
-          - 'rajdeepc'
-          - 'pfulton'
-          - 'castastrophe'
+          interval: 'monthly'


### PR DESCRIPTION
## Description

Adds a monthly task to check for updates to github actions used in the project.

## Motivation and context

Less frequently, the actions being used get a version bump. This will ensure the project receives notification of and the opportunity to incorporate those updated actions.


## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [N/A] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [N/A] I have added tests to cover my changes.
-   [N/A] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
