### PR TITLE
docs(split-view): added label for resizable examples for documentation

### DIFF
--- a/packages/split-view/README.md
+++ b/packages/split-view/README.md
@@ -38,7 +38,13 @@ import { SplitView } from '@spectrum-web-components/split-view';
 ### Horizontal Resizable
 
 ```html
-<sp-split-view resizable primary-min="50" secondary-min="50" primary-size="100">
+<sp-split-view
+    resizable
+    primary-min="50"
+    secondary-min="50"
+    primary-size="100"
+    label
+>
     <div>
         <h1>Left panel</h1>
         <p>
@@ -59,7 +65,7 @@ import { SplitView } from '@spectrum-web-components/split-view';
 ### Horizontal Resizable & Collapsible
 
 ```html
-<sp-split-view resizable>
+<sp-split-view resizable label>
     <div>
         <h1>Left panel</h1>
         <p>
@@ -95,6 +101,7 @@ import { SplitView } from '@spectrum-web-components/split-view';
     primary-min="50"
     primary-max="150"
     secondary-min="50"
+    label
 >
     <div>
         <h1>Top panel</h1>
@@ -116,7 +123,7 @@ import { SplitView } from '@spectrum-web-components/split-view';
 ### Vertical Resizable & Collapsible
 
 ```html
-<sp-split-view vertical resizable style="height: 300px;">
+<sp-split-view vertical resizable style="height: 300px;" label>
     <div>
         <h1>Top panel</h1>
         <p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added label property for resizable elements of split-view

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/3383

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
