### PR TITLE
chore(tooltip): extend tooltip self-managed documentation

### DIFF
--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -46,8 +46,7 @@ Tooltips can be top, bottom, left, or right.
 By default, Tooltip provides styling without behavior.
 You must combine it with an [Overlay Trigger](https://opensource.adobe.com/spectrum-web-components/components/overlay-trigger/#%22hover%22-content-only) in order to manage its overlay behavior.
 
-You can instead apply the `self-managed` attribute for this common case,
-which automaticaly binds to the parent element's hover interaction:
+You can use the tooltip as the descendant of an interactive element, such as [Action Button](https://opensource.adobe.com/spectrum-web-components/components/action-button/), by applying the `self-managed` attribute which automatically binds the Tooltip to its first interactive ancestor element's focus/hover interactions:
 
 ```html
 <sp-action-button>
@@ -58,6 +57,21 @@ which automaticaly binds to the parent element's hover interaction:
 
 This is especially useful when inserting an intermediate `<overlay-trigger>` would interfere with
 parent/child relationships, such as between `<sp-action-group>` and `<sp-action-button>`.
+
+Note that an interactive element is an element that can receive focus during tab navigation, such as `sp-action-button`, `sp-action-menu`, `sp-field-label` etc.
+
+Given that tooltip is not focusable by itself, it would not show up during tab navigation. Thus a tooltip would not be accessible if used with a non-interactive element, such as `<sp-icon-*>`.
+
+The correct way to make it accessible would be to wrap it under an interactive element, such as `sp-action-button`:
+
+```html
+<sp-action-button size="s">
+    <sp-icon-info></sp-icon-info>
+    <sp-tooltip self-managed placement="right">
+        Display something here
+    </sp-tooltip>
+</sp-action-button>
+```
 
 ## Variants
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Expand https://opensource.adobe.com/spectrum-web-components/components/tooltip/#self-managed-overlays to include information about a focusable element, as per the Dev Mode warning and the discussion in https://github.com/adobe/spectrum-web-components/discussions/3781#discussioncomment-7504620

## Description

<!--- Describe your changes in detail -->
Extended `self-managed` tooltip documentation to include an example of how to use tooltip for non-interactive elements by wrapping them with an interactive element and added notes about why the current pattern is supported the way it is.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3787

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
