### PR TITLE
fix(slider): align editable slider when no label provided

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: e961862c518bfcb973e1873828f5fd93775ebdd2
+        default: d8be48bd925210181c3ec6933abbc3aade090bcb
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -139,6 +139,5 @@ governing permissions and limitations under the License.
 }
 
 :host([label-visibility='none']) #track {
-    grid-area: number;
-    align-self: flex-end;
+    align-self: center;
 }

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -139,5 +139,5 @@ governing permissions and limitations under the License.
 }
 
 :host([label-visibility='none']) #track {
-    align-self: center;
+    align-self: flex-end;
 }

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -137,3 +137,8 @@ governing permissions and limitations under the License.
     padding: 0;
     margin: 0;
 }
+
+:host([label-visibility='none']) #track {
+    grid-area: number;
+    align-self: flex-end;
+}

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -373,6 +373,32 @@ export const editableCustom = (args: StoryArgs = {}): TemplateResult => {
 
 editableCustom.decorators = [editableDecorator];
 
+export const editableWithoutVisibleLabels = (
+    args: StoryArgs = {}
+): TemplateResult => {
+    return html`
+        <div style="width: 500px; margin: 12px 20px;">
+            <sp-slider
+                editable
+                max="1"
+                min="0"
+                value=".5"
+                step="0.01"
+                @input=${handleEvent(args)}
+                @change=${handleEvent(args)}
+                .formatOptions=${{ style: 'percent' }}
+                ...=${spreadProps(args)}
+            >
+                Opacity
+            </sp-slider>
+        </div>
+    `;
+};
+
+editableWithoutVisibleLabels.args = {
+    labelVisibility: 'none',
+};
+
 export const hideStepper = (args: StoryArgs = {}): TemplateResult => {
     return html`
         <div style="width: 500px; margin: 12px 20px;">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixed track alignment in editable `sp-slider` with label-visibility="none"

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3812

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
slider line of sp-slider is not aligned in centre of the value input box when we dont have the label for slider (label-visibility="none" in sp-slider)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

Before - 
<img width="702" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/137032355/24d5cdca-83e0-45e3-a44e-f4111896c959">

After - 
<img width="900" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/137032355/a15c5d9d-87da-46cc-9581-cf0b1b04ba83">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
