### PR TITLE
chore(picker): fix for overlaid picker in mobile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c3176f5485ca101a7e3d3fda9fd251dbfe8cb759
+        default: a35e91536b6df008822b7066e413b89d6a65af85
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a35e91536b6df008822b7066e413b89d6a65af85
+        default: d8be48bd925210181c3ec6933abbc3aade090bcb
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: d8be48bd925210181c3ec6933abbc3aade090bcb
+        default: c3176f5485ca101a7e3d3fda9fd251dbfe8cb759
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -43,7 +43,7 @@ import type {
     MenuItem,
     MenuItemChildren,
 } from '@spectrum-web-components/menu';
-import { OverlayTypes, Placement } from '@spectrum-web-components/overlay';
+import { Placement } from '@spectrum-web-components/overlay';
 import {
     IS_MOBILE,
     MatchMediaController,
@@ -109,9 +109,6 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
 
     @property()
     public placement: Placement = 'bottom-start';
-
-    @property()
-    public overlayType: OverlayTypes = 'auto';
 
     @property({ type: Boolean, reflect: true })
     public quiet = false;
@@ -396,7 +393,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .offset=${0}
                 ?open=${this.open}
                 .placement=${this.isMobile.matches ? undefined : this.placement}
-                .type=${this.isMobile.matches ? 'modal' : this.overlayType}
+                .type=${this.isMobile.matches ? 'modal' : 'auto'}
                 .receivesFocus=${'true'}
                 @beforetoggle=${(
                     event: Event & {

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -43,7 +43,7 @@ import type {
     MenuItem,
     MenuItemChildren,
 } from '@spectrum-web-components/menu';
-import { Placement } from '@spectrum-web-components/overlay';
+import { OverlayTypes, Placement } from '@spectrum-web-components/overlay';
 import {
     IS_MOBILE,
     MatchMediaController,
@@ -109,6 +109,9 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
 
     @property()
     public placement: Placement = 'bottom-start';
+
+    @property()
+    public overlayType: OverlayTypes = 'auto';
 
     @property({ type: Boolean, reflect: true })
     public quiet = false;
@@ -393,7 +396,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .offset=${0}
                 ?open=${this.open}
                 .placement=${this.isMobile.matches ? undefined : this.placement}
-                type=${this.isMobile.matches ? 'modal' : 'auto'}
+                type=${this.isMobile.matches ? 'modal' : this.overlayType}
                 .receivesFocus=${'true'}
                 @beforetoggle=${(
                     event: Event & {

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -393,7 +393,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .offset=${0}
                 ?open=${this.open}
                 .placement=${this.isMobile.matches ? undefined : this.placement}
-                type="modal"
+                type=${this.isMobile.matches ? 'modal' : 'auto'}
                 .receivesFocus=${'true'}
                 @beforetoggle=${(
                     event: Event & {

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -396,7 +396,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .offset=${0}
                 ?open=${this.open}
                 .placement=${this.isMobile.matches ? undefined : this.placement}
-                type=${this.isMobile.matches ? 'modal' : this.overlayType}
+                .type=${this.isMobile.matches ? 'modal' : this.overlayType}
                 .receivesFocus=${'true'}
                 @beforetoggle=${(
                     event: Event & {

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -393,7 +393,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .offset=${0}
                 ?open=${this.open}
                 .placement=${this.isMobile.matches ? undefined : this.placement}
-                type="auto"
+                type="modal"
                 .receivesFocus=${'true'}
                 @beforetoggle=${(
                     event: Event & {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`type=auto` was taking up the root dialog component as its parent and rendering the `sp-tray` considering dialog as its root instead of the DOM.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/3834

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    Do this:
    1. Add the below code in `picker.stories.ts` and try to emulate it in a iphone simulatorwith `xcode`.
      ```
      <overlay-trigger type="modal" open="click">
        <div slot="click-content" role="dialog">
          <sp-underlay style="z-index: 10000;"></sp-underlay>
          <div style="  position: fixed;top: 50%;left: 50%;transform: translate(-50%, -50%);z-index: 10001; background-color: yellow; padding: 20px">
            <div style="display: flex; flex-direction: column; gap: 40px">
              <sp-picker id="picker-m" size="m" label="Selection type" ${spreadProps(args)}>
                <sp-menu-item>Deselect</sp-menu-item>
                <sp-menu-item>Select inverse</sp-menu-item>
                <sp-menu-item>Feather...</sp-menu-item>
                <sp-menu-item>Select and mask...</sp-menu-item>
                <sp-menu-divider></sp-menu-divider>
                <sp-menu-item>Save selection</sp-menu-item>
                <sp-menu-item disabled>Make work path</sp-menu-item>
              </sp-picker>
              <sp-picker id="picker-m" size="m" label="Selection type">
                <sp-menu-item>Deselect</sp-menu-item>
                <sp-menu-item>Select inverse</sp-menu-item>
                <sp-menu-item>Feather...</sp-menu-item>
                <sp-menu-item>Select and mask...</sp-menu-item>
                <sp-menu-item>Save selection</sp-menu-item>
                <sp-menu-item disabled>Make work path</sp-menu-item>
              </sp-picker>
            </div>
          </div>
      </overlay-trigger>
      ```




## Screenshots (if appropriate)

Before Fix:

![Screenshot 2023-11-29 at 8 58 28 PM](https://github.com/adobe/spectrum-web-components/assets/8790510/f97caa92-87f7-49d4-b20f-f62ae241a28d)

After Fix:
![Screenshot 2023-11-29 at 8 58 17 PM](https://github.com/adobe/spectrum-web-components/assets/8790510/66cf243b-aa51-44dc-89b1-93abc8b6a998)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
