### PR TITLE
fix(tabs): prevent vertical scrolling in overflow tabs

### DIFF
--- a/packages/tabs/src/tabs.css
+++ b/packages/tabs/src/tabs.css
@@ -40,6 +40,10 @@ governing permissions and limitations under the License.
     justify-content: var(--swc-tabs-list-justify-content);
 }
 
+:host([disabled]) #list {
+    pointer-events: none;
+}
+
 :host([disabled]) #list #selection-indicator {
     background-color: var(
         --mod-tabs-color-disabled,
@@ -49,10 +53,6 @@ governing permissions and limitations under the License.
 
 :host([disabled]) ::slotted(sp-tab) {
     color: var(--mod-tabs-color-disabled, var(--spectrum-tabs-color-disabled));
-}
-
-:host([disabled]) #list {
-    pointer-events: none;
 }
 
 /*
@@ -70,8 +70,9 @@ governing permissions and limitations under the License.
 }
 
 :host([dir][direction='horizontal']) #list.scroll {
-    overflow-x: auto;
     scrollbar-width: none;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 :host([dir][direction='horizontal']) #list.scroll::-webkit-scrollbar {


### PR DESCRIPTION
## Description
Use a more complete value for `overflow`, `auto hidden`, to prevent overflow scrolling in touch environments.

I'm not sure how one might do a regression test on this sort of thing, but maybe we don't need to? 

## Related issue(s)
- fixes #3813

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://opensource.adobe.com/spectrum-web-components/components/tabs-overflow/#example)
    2. In an actual iOS device, maybe an emulator would be enough, but I didn't try
    3. See that the Tabs will scroll up/down as well as left/right, even if they always go back to root
-   [ ] _Test case 2_
    1. Go [here](https://overflow-tabs-scrolling--spectrum-web-components.netlify.app/components/tabs-overflow/#example)
    2. In the same device
    3. See that the Tabs will NO LONGER scroll up/down

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.