### PR TITLE
fix(overlay): ensure events are only bound once

### DIFF
--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -504,6 +504,8 @@ export class Overlay extends OverlayFeatures {
 
     protected bindEvents(): void {
         if (!this.hasNonVirtualTrigger) return;
+        // Clean up listeners if they've already been bound
+        this.abortController?.abort();
         this.abortController = new AbortController();
         const nextTriggerElement = this.triggerElement as HTMLElement;
         switch (this.triggerInteraction) {
@@ -583,7 +585,9 @@ export class Overlay extends OverlayFeatures {
         );
     }
 
-    protected manageTriggerElement(triggerElement: HTMLElement | null): void {
+    protected manageTriggerElement(
+        triggerElement: HTMLElement | undefined
+    ): void {
         if (triggerElement) {
             this.unbindEvents();
             this.releaseAriaDescribedby();
@@ -928,13 +932,17 @@ export class Overlay extends OverlayFeatures {
                 | 'hover'
                 | undefined;
         }
-        const oldTrigger = this.triggerElement as HTMLElement;
+        // Merge multiple possible calls to manageTriggerElement().
+        let oldTrigger: HTMLElement | false | undefined = false;
         if (changes.has(elementResolverUpdatedSymbol)) {
+            oldTrigger = this.triggerElement as HTMLElement;
             this.triggerElement = this.elementResolver.element;
-            this.manageTriggerElement(oldTrigger);
         }
         if (changes.has('triggerElement')) {
-            this.manageTriggerElement(changes.get('triggerElement'));
+            oldTrigger = changes.get('triggerElement');
+        }
+        if (oldTrigger !== false) {
+            this.manageTriggerElement(oldTrigger);
         }
     }
 

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -26,6 +26,7 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-rect-select.js';
 import { Placement } from '@floating-ui/dom';
 import { OverlayTypes } from '../src/overlay-types.js';
 import { notAgain } from '../../dialog/stories/dialog-base.stories.js';
+import './overlay-story-components.js';
 
 export default {
     title: 'Overlay Element',
@@ -586,4 +587,12 @@ export const actionGroupWithFilters = ({
             </sp-popover>
         </sp-overlay>
     `;
+};
+
+// Test #3795 in browser
+export const transientHover = (): TemplateResult => html`
+    <transient-hover></transient-hover>
+`;
+transientHover.swc_vrt = {
+    skip: true,
 };

--- a/packages/overlay/stories/overlay-story-components.ts
+++ b/packages/overlay/stories/overlay-story-components.ts
@@ -344,3 +344,35 @@ declare global {
         'popover-content': PopoverContent;
     }
 }
+
+export default class TransientHover extends LitElement {
+    @property()
+    open = false;
+
+    protected override render(): TemplateResult {
+        return html`
+            <sp-button variant="primary" id="triggerButton">
+                Button popover
+            </sp-button>
+            <sp-overlay
+                type="auto"
+                trigger="triggerButton@click"
+                @sp-opened=${() => {
+                    this.open = true;
+                }}
+            >
+                <sp-popover>My Popover</sp-popover>
+            </sp-overlay>
+
+            ${!this.open
+                ? html`
+                      <sp-overlay trigger="triggerButton@hover" type="hint">
+                          <sp-tooltip placement="right">My tooltip</sp-tooltip>
+                      </sp-overlay>
+                  `
+                : html``}
+        `;
+    }
+}
+
+customElements.define('transient-hover', TransientHover);


### PR DESCRIPTION
## Description
- clean up event bindings before binding.
- merge multiple possible calls to `manageTriggerElement()` into a single call

## Related issue(s)
- fixes #3795

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://do-pointer-leave--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-element--transient-hover)
    2. Trigger the tooltip on the button
    3. Click the button to trigger the popover
    4. Move the mouse out of the button
    5. See that no error in thrown in the console

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.