### PR TITLE
fix(number-field): validate min/max in more contexts

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -319,7 +319,9 @@ export class NumberField extends TextfieldBase {
         if (isNaN(this.value)) {
             value = min;
         }
+        value = this.valueWithLimits(value);
 
+        this.requestUpdate();
         this._value = this.validateInput(value);
         this.inputElement.value = value.toString();
 
@@ -474,15 +476,22 @@ export class NumberField extends TextfieldBase {
         this.inputElement.setSelectionRange(nextSelectStart, nextSelectStart);
     }
 
-    private validateInput(value: number): number {
-        const signMultiplier = value < 0 ? -1 : 1; // 'signMultiplier' adjusts 'value' for 'validateInput' and reverts it before returning.
-        value *= signMultiplier;
+    private valueWithLimits(nextValue: number): number {
+        let value = nextValue;
         if (typeof this.min !== 'undefined') {
             value = Math.max(this.min, value);
         }
         if (typeof this.max !== 'undefined') {
             value = Math.min(this.max, value);
         }
+        return value;
+    }
+
+    private validateInput(value: number): number {
+        value = this.valueWithLimits(value);
+        const signMultiplier = value < 0 ? -1 : 1; // 'signMultiplier' adjusts 'value' for 'validateInput' and reverts it before returning.
+        value *= signMultiplier;
+
         // Step shouldn't validate when 0...
         if (this.step) {
             const min = typeof this.min !== 'undefined' ? this.min : 0;

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -903,6 +903,34 @@ describe('NumberField', () => {
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
         });
+        it('constrains ArrowUp usage', async () => {
+            expect(el.value).to.equal(10);
+            el.focus();
+            await sendKeys({ press: 'ArrowUp' });
+            expect(el.focusElement.value).to.equal('10');
+            await sendKeys({ press: 'Shift+ArrowUp' });
+            expect(el.focusElement.value).to.equal('10');
+        });
+        it('constrains pointer usage', async () => {
+            expect(el.value).to.equal(10);
+            const buttonUp = el.shadowRoot.querySelector(
+                '.step-up'
+            ) as HTMLElement;
+            const buttonUpRect = buttonUp.getBoundingClientRect();
+            const buttonUpPosition: [number, number] = [
+                buttonUpRect.x + buttonUpRect.width / 2,
+                buttonUpRect.y + buttonUpRect.height / 2,
+            ];
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'click',
+                        position: buttonUpPosition,
+                    },
+                ],
+            });
+            expect(el.value).to.equal(10);
+        });
         it('validates on commit', async () => {
             el.focus();
             await sendKeys({ type: '15' });
@@ -992,6 +1020,14 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
+            el.focus();
+            await sendKeys({ press: 'Backspace' });
+            await sendKeys({ press: 'Backspace' });
+            await sendKeys({ type: '-2000' });
+            await sendKeys({ press: 'Enter' });
+            expect(el.formattedValue).to.equal('10');
+            expect(el.valueAsString).to.equal('10');
+            expect(el.value).to.equal(10);
         });
         it('dispatches onchange on setting min value', async () => {
             el.value = 15;
@@ -1061,6 +1097,45 @@ describe('NumberField', () => {
             expect(el.formattedValue).to.equal('10');
             expect(el.valueAsString).to.equal('10');
             expect(el.value).to.equal(10);
+        });
+        it('constrains ArrowDown usage', async () => {
+            el.min = 0;
+            el.value = 0;
+            expect(el.value).to.equal(0);
+            el.focus();
+            await sendKeys({ press: 'ArrowDown' });
+            expect(el.formattedValue).to.equal('0');
+            expect(el.valueAsString).to.equal('0');
+            expect(el.value).to.equal(0);
+            await sendKeys({ press: 'Shift+ArrowDown' });
+            await elementUpdated(el);
+            expect(el.formattedValue).to.equal('0');
+            expect(el.valueAsString).to.equal('0');
+            expect(el.value).to.equal(0);
+        });
+        it('constrains pointer usage', async () => {
+            el.min = 0;
+            el.value = 0;
+            await elementUpdated(el);
+            expect(el.value).to.equal(0);
+            const buttonDown = el.shadowRoot.querySelector(
+                '.step-down'
+            ) as HTMLElement;
+            const buttonDownRect = buttonDown.getBoundingClientRect();
+            const buttonDownPosition: [number, number] = [
+                buttonDownRect.x + buttonDownRect.width / 2,
+                buttonDownRect.y + buttonDownRect.height / 2,
+            ];
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'click',
+                        position: buttonDownPosition,
+                    },
+                ],
+            });
+            await elementUpdated(el);
+            expect(el.value).to.equal(0);
         });
         it('validates on commit', async () => {
             el.focus();


### PR DESCRIPTION
## Description
Validate limits more regularly to prevent slippage and ensure the value stays within them.

## Related issue(s)
- fixes #3827

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://number-field-limits--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--min-max)
    2. Use the `ArrowDown` key until the Number Field hits `0`, the min value
    3. See that the value does not go below that value
-   [ ] _Test case 2_
    1. Go [here](https://number-field-limits--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--min-max)
    2. Set the value to 254
    3. use the `ArrowUp` key until the Number Field hits `255`, the max value
    4. See that the value does not go above that

See other use cases in #3827

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.