### PR TITLE
chore(icons,icons-ui): fetch icons from new @spectrum-css/ui-icons package

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
             "command": "yarn workspace @spectrum-web-components/icons-ui build",
             "files": [
                 "packages/icons-ui/bin/build.js",
-                "node_modules/@spectrum-css/icon/medium/**.svg"
+                "node_modules/@adobe/spectrum-css-ui-icons/dist/medium/**.svg"
             ],
             "output": [
                 "packages/icons-ui/**/*.ts",

--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
             "command": "yarn workspace @spectrum-web-components/icons-ui build",
             "files": [
                 "packages/icons-ui/bin/build.js",
-                "node_modules/@adobe/spectrum-css-ui-icons/dist/medium/**.svg"
+                "node_modules/@spectrum-css/ui-icons/dist/medium/**.svg"
             ],
             "output": [
                 "packages/icons-ui/**/*.ts",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -75,7 +75,7 @@
         "@spectrum-web-components/iconset": "^0.40.2"
     },
     "devDependencies": {
-        "@adobe/spectrum-css-ui-icons": "^1.0.0",
+        "@spectrum-css/ui-icons": "^1.0.0",
         "@spectrum-css/icon": "^4.0.3"
     },
     "types": "./src/index.d.ts",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -75,6 +75,7 @@
         "@spectrum-web-components/iconset": "^0.40.2"
     },
     "devDependencies": {
+        "@adobe/spectrum-css-ui-icons": "^1.0.0",
         "@spectrum-css/icon": "^4.0.3"
     },
     "types": "./src/index.d.ts",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -75,7 +75,6 @@
         "@spectrum-web-components/iconset": "^0.40.2"
     },
     "devDependencies": {
-        "@spectrum-css/ui-icons": "^1.0.0",
         "@spectrum-css/icon": "^4.0.3"
     },
     "types": "./src/index.d.ts",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -26,7 +26,7 @@
         "./package.json": "./package.json"
     },
     "scripts": {
-        "build": "node ./bin/build @spectrum-css/icon/medium"
+        "build": "node ./bin/build @adobe/spectrum-css-ui-icons/dist/medium"
     },
     "files": [
         "**/*.d.ts",
@@ -49,7 +49,7 @@
         "@spectrum-web-components/iconset": "^0.40.2"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^4.0.3",
+        "@adobe/spectrum-css-ui-icons": "^1.0.0",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fast-glob": "^3.2.12",

--- a/packages/icons-ui/package.json
+++ b/packages/icons-ui/package.json
@@ -26,7 +26,7 @@
         "./package.json": "./package.json"
     },
     "scripts": {
-        "build": "node ./bin/build @adobe/spectrum-css-ui-icons/dist/medium"
+        "build": "node ./bin/build @spectrum-css/ui-icons/dist/medium"
     },
     "files": [
         "**/*.d.ts",
@@ -49,7 +49,7 @@
         "@spectrum-web-components/iconset": "^0.40.2"
     },
     "devDependencies": {
-        "@adobe/spectrum-css-ui-icons": "^1.0.0",
+        "@spectrum-css/ui-icons": "^1.0.0",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fast-glob": "^3.2.12",


### PR DESCRIPTION
## Description

As part of a clean-up effort, Spectrum CSS is moving SVG processing for the UI icons library out of the @spectrum-css/icon styles package and into it's own @adobe/spectrum-css-ui-icons package.

This draft PR was tested against a linked local version and was successful. Once we release the new package on npm, we can migrate this to ready to review.

## How has this been tested?

-   [ ] _Validate no regressions in ui icons_
    1. Set up a local `yarn link` for the ui-icons folder
    2. Updated SWC references from @spectrum-css/icon to @adobe/spectrum-css-ui-icons
    3. Run the build and validate the results

## Types of changes

-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
