### PR TITLE
chore(overlay): shadow elements receives open when open is true in sp…

### DIFF
--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -169,6 +169,10 @@ When a `triggerElement` is present, either through an ID reference established v
     -   **if you have a `placement` but not a `triggerElement`** the `<sp-overlay>` will not be positioned due to their being nothing for the `plaement` to reference when so doing
 -   **if no `placement` is available** the content will not be placed with the expectation that the content itself or the consuming application will handle placement of the overlaid content. This is commonly what will happen for `type="modal"` and `type="page"` overlays as they are likely meant to cover the entire screen, whether visibly (via an `<sp-underlay>`, an element that includes one, or similar) or figuratively (as when modal content is not delivered with a backdrop or scrim).
 
+Additionally, a new behavior has been introduced to `<sp-overlay>`:
+
+-   **if a `open` is true**, the slotted shadow element of `<sp-overlay>` will receive an `open` attribute whenever the overlay is opened. This behavior is particularly useful when you want to add an `open` attribute to the slotted shadow element dynamically.
+
 ### Type
 
 The `type` of an Overlay outlines a number of things about the interaction model within which is works.

--- a/packages/overlay/src/OverlayDialog.ts
+++ b/packages/overlay/src/OverlayDialog.ts
@@ -55,9 +55,7 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
             const start =
                 (el: OpenableElement, index: number) =>
                 async (): Promise<void> => {
-                    if (typeof el.open !== 'undefined') {
-                        el.open = targetOpenState;
-                    }
+                    el.open = targetOpenState;
                     if (!targetOpenState) {
                         const close = (): void => {
                             el.removeEventListener('close', close);

--- a/packages/overlay/src/OverlayNoPopover.ts
+++ b/packages/overlay/src/OverlayNoPopover.ts
@@ -70,9 +70,7 @@ export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
                 if (targetOpenState !== this.open) {
                     return;
                 }
-                if (typeof el.open !== 'undefined') {
-                    el.open = targetOpenState;
-                }
+                el.open = targetOpenState;
                 if (index === 0) {
                     const event = targetOpenState
                         ? BeforetoggleOpenEvent

--- a/packages/overlay/src/OverlayPopover.ts
+++ b/packages/overlay/src/OverlayPopover.ts
@@ -138,9 +138,7 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
             }
             let focusEl = null as HTMLElement | null;
             const start = (el: OpenableElement, index: number) => (): void => {
-                if (typeof el.open !== 'undefined') {
-                    el.open = targetOpenState;
-                }
+                el.open = targetOpenState;
                 if (index === 0) {
                     const event = targetOpenState
                         ? BeforetoggleOpenEvent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
We have added the logic to the slotted shadow element of `<sp-overlay>` will receive an `open` attribute whenever the overlay is opened. This behavior is particularly useful when you want to add an `open` attribute to the slotted shadow element dynamically.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3855 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Picker is flickering on first load in mobile and clicking on ESC and then reopening it opens as tray as expected. Only fails in first load in mobile


## How has this been tested?

Fix: 
Uploading issue 7 fix.mov…


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
