### PR TITLE
docs: include missing step in adding a new package

### DIFF
--- a/projects/documentation/content/guides/generating-components.md
+++ b/projects/documentation/content/guides/generating-components.md
@@ -45,6 +45,7 @@ Open `tsconfig-all.json`, find "references", and add an entry for your package (
 
 Include a listing for your package in `bundle/elements.ts` and `bundle/src/index.js`. Then, confirm that your new package is already listed in `tools/bundle/package.json`. The `bundle` package makes it possible to build demo projects with _all_ of the components from the library registered in a single place, and is also leveraged for ease of component consumption in the documentation site build.
 
+-   In `bundle/tsconfig.json`, please add a listing for your new package to the `"references"` field, e.g. `{ "path": "../../packages/spectrum-pattern" },`. This will ensure the types of your new package are built before the `bundle` package is built.
 -   In `bundle/elements.ts`, please add any, and all (if your package registers more than one element), element registration files to the imports there in, e.g. `import '@spectrum-web-components/spectrum-pattern/sp-spectrum-pattern.js';`.
 -   In `bundle/src/index.js`, please add an export for your new packages default entry, e.g. `export * from '@spectrum-web-components/spectrum-pattern';`, so that any classes exported from your package can be imported from this location.
 


### PR DESCRIPTION
## Description
Add missing step in package creation.

## Related issue(s)
- fixes #3462

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://new-package-docs--spectrum-web-components.netlify.app/guides/generating-components/)
    2. See the new content

## Types of changes
-   [x] Docs update

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.