### PR TITLE
fix(overlay): [Bug] Overlay Trigger unopened click-content dialog remains accessible using VoiceOver

### DIFF
--- a/packages/overlay/src/overlay.css
+++ b/packages/overlay/src/overlay.css
@@ -59,6 +59,8 @@ dialog:modal {
 }
 
 :host(:not([open])) .dialog {
+    display: none;
+
     --sp-overlay-open: false;
 }
 


### PR DESCRIPTION
## Description

The problem is that we override the user agent stylesheet's rule
```css
[popover]:not(:popover-open):not(dialog[open]) {
  display: none;
}
```
With `display: flex` in the rule for `.dialog` at https://github.com/adobe/spectrum-web-components/blob/35b56490e9c03dccbb852935caf51bc52f922143/packages/overlay/src/overlay.css#L33

And we do not ensure that the dialog remains hidden from assistive technology when the dialog is not open at https://github.com/adobe/spectrum-web-components/blob/35b56490e9c03dccbb852935caf51bc52f922143/packages/overlay/src/overlay.css#L61-L63

Solution is to add `display: none` or `visibility: hidden` as follows:
```css
:host(:not([open])) .dialog {
    display: none;

    --sp-overlay-open: false;
}
```

## Related issue(s)

#3872 

## Motivation and context

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
