### PR TITLE
fix(menu): support navigating to and selecting Menu Items in Menu Groups

### DIFF
--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -24,11 +24,13 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import type { MenuItem } from '@spectrum-web-components/menu/src/MenuItem.js';
 import { Placement } from '@spectrum-web-components/overlay/src/overlay-types.js';
 import { Menu } from '@spectrum-web-components/menu';
+import { ActionMenu } from '../src/ActionMenu';
 
 export default {
     component: 'sp-action-menu',
     title: 'Action menu',
     argTypes: {
+        onChange: { action: 'change' },
         disabled: {
             name: 'disabled',
             type: { name: 'boolean', required: false },
@@ -326,8 +328,16 @@ export const controlled = (): TemplateResult => {
     `;
 };
 
-export const groups = (): TemplateResult => html`
-    <sp-action-menu open>
+export const groups = ({
+    onChange,
+}: {
+    onChange(value: string): void;
+}): TemplateResult => html`
+    <sp-action-menu
+        @change=${({ target: { value } }: Event & { target: ActionMenu }) =>
+            onChange(value)}
+        open
+    >
         <sp-menu-group id="cms">
             <span slot="header">cms</span>
             <sp-menu-item value="updateAllSiteContent">

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -310,7 +310,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
 
         this.addEventListener('click', this.handleClick);
         this.addEventListener('focusin', this.handleFocusin);
-        this.addEventListener('focusout', this.handleFocusout);
+        this.addEventListener('blur', this.handleBlur);
         this.addEventListener('sp-opened', this.handleSubmenuOpened);
         this.addEventListener('sp-closed', this.handleSubmenuClosed);
     }
@@ -380,10 +380,6 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
     }
 
     public handleFocusin(event: FocusEvent): void {
-        const wasOrContainedRelatedTarget = elementIsOrContains(
-            this,
-            event.relatedTarget as Node
-        );
         if (
             this.childItems.some(
                 (childItem) => childItem.menuData.focusRoot !== this
@@ -397,10 +393,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
         const selectionRoot =
             this.childItems[this.focusedItemIndex]?.menuData.selectionRoot ||
             this;
-        if (
-            activeElement !== selectionRoot ||
-            (!wasOrContainedRelatedTarget && event.target !== this)
-        ) {
+        if (activeElement !== selectionRoot || event.target !== this) {
             selectionRoot.focus({ preventScroll: true });
             if (activeElement && this.focusedItemIndex === 0) {
                 const offset = this.childItems.findIndex(
@@ -416,7 +409,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
         this.addEventListener('keydown', this.handleKeydown);
     }
 
-    public handleFocusout(event: FocusEvent): void {
+    public handleBlur(event: FocusEvent): void {
         if (elementIsOrContains(this, event.relatedTarget as Node)) {
             return;
         }
@@ -593,10 +586,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
     }
 
     public handleKeydown(event: KeyboardEvent): void {
-        const isNotThisOrDirectChild =
-            event.target !== this &&
-            this !== (event.target as HTMLElement).parentElement;
-        if (isNotThisOrDirectChild || event.defaultPrevented) {
+        if (event.defaultPrevented) {
             return;
         }
         const lastFocusedItem = this.childItems[this.focusedItemIndex];
@@ -639,11 +629,23 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
             }
         }
         if (code === 'Space' || code === 'Enter') {
-            this.childItems[this.focusedItemIndex]?.click();
+            const childItem = this.childItems[this.focusedItemIndex];
+            if (
+                childItem &&
+                childItem.menuData.selectionRoot === event.target
+            ) {
+                childItem.click();
+            }
             return;
         }
         if (code === 'ArrowDown' || code === 'ArrowUp') {
-            this.navigateWithinMenu(event);
+            const childItem = this.childItems[this.focusedItemIndex];
+            if (
+                childItem &&
+                childItem.menuData.selectionRoot === event.target
+            ) {
+                this.navigateWithinMenu(event);
+            }
             return;
         }
         this.navigateBetweenRelatedMenus(event);

--- a/packages/menu/test/menu-group.test.ts
+++ b/packages/menu/test/menu-group.test.ts
@@ -399,7 +399,7 @@ describe('Menu group', () => {
         expect(subInheritItem1.getAttribute('role')).to.equal('menuitemradio');
         expect(subInheritItem2.getAttribute('role')).to.equal('menuitemradio');
     });
-    it('manages complex slotted menu items', async () => {
+    it('manages complex slotted menu items', async function () {
         const el = await fixture<ComplexSlottedMenu>(complexSlotted());
 
         await waitUntil(
@@ -409,6 +409,7 @@ describe('Menu group', () => {
             } manages ${focusableItems(el.menu).length}`
         );
 
+        const menu = el.menu;
         const items: Record<string, MenuItem> = {};
         items.i2 = el.querySelector('#i-2') as MenuItem;
         items.i8 = el.querySelector('#i-8') as MenuItem;
@@ -455,12 +456,15 @@ describe('Menu group', () => {
         const count = Object.keys(items).length + 1;
         while (!items.i9.focused) {
             i = Math.max(1, (i + 1 + count) % count);
+            await elementUpdated(menu);
             await elementUpdated(items[`i${i}`]);
             expect(items[`i${i}`].focused, `i${i} should be focused`).to.be
                 .true;
             await sendKeys({
                 press: 'ArrowDown',
             });
+            await elementUpdated(menu);
+            await elementUpdated(items[`i${i}`]);
         }
     });
 });

--- a/packages/menu/test/menu-selects.test.ts
+++ b/packages/menu/test/menu-selects.test.ts
@@ -647,7 +647,7 @@ describe('Menu w/ groups [selects]', () => {
         expect(groupA.value).to.equal('');
         expect(groupB.value).to.equal('');
     });
-    it('manages focus', async () => {
+    it('manages focus', async function () {
         await elementUpdated(groupA);
         await elementUpdated(groupB);
         const input = document.createElement('input');

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -329,7 +329,7 @@ describe('Submenu', () => {
             await elementUpdated(el);
 
             let opened = oneEvent(rootItem, 'sp-opened');
-            sendKeys({
+            await sendKeys({
                 press: testData.openKey,
             });
             await opened;
@@ -341,7 +341,7 @@ describe('Submenu', () => {
             ).to.be.true;
 
             let closed = oneEvent(rootItem, 'sp-closed');
-            sendKeys({
+            await sendKeys({
                 press: testData.closeKey,
             });
             await closed;
@@ -353,7 +353,7 @@ describe('Submenu', () => {
             ).to.be.true;
 
             opened = oneEvent(rootItem, 'sp-opened');
-            sendKeys({
+            await sendKeys({
                 press: testData.openKey,
             });
             await opened;
@@ -363,16 +363,15 @@ describe('Submenu', () => {
             await sendKeys({
                 press: 'ArrowDown',
             });
+            await elementUpdated(submenu);
             await elementUpdated(submenuItem);
-            await nextFrame();
-            await nextFrame();
 
             expect(submenu.getAttribute('aria-activedescendant')).to.equal(
                 submenuItem.id
             );
 
             closed = oneEvent(rootItem, 'sp-closed');
-            sendKeys({
+            await sendKeys({
                 press: 'Enter',
             });
             await closed;


### PR DESCRIPTION
## Description
Ensure that Menu Items contained within Menu Groups can be navigated to via the arrow keys and selected via the space bar.

## Related issue(s)
- fixes #3686

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://menu-group-navigation--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--groups)
    2. Use the Arrow Keys to navigate through the Menu Items
    3. Use the Space key to select one
    4. See that the selection is reported in the Actions tab of Storybook

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)