### PR TITLE
docs: refactor story decorator usage to normalize a single Overlay helper

### DIFF
--- a/packages/action-menu/stories/action-menu-sizes.stories.ts
+++ b/packages/action-menu/stories/action-menu-sizes.stories.ts
@@ -13,6 +13,8 @@ import { TemplateResult } from '@spectrum-web-components/base';
 
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 import { ActionMenuMarkup } from './';
 
 export default {
@@ -23,15 +25,19 @@ export default {
 export const s = (): TemplateResult => ActionMenuMarkup({ size: 's' });
 export const sOpen = (): TemplateResult =>
     ActionMenuMarkup({ size: 's', open: true });
+sOpen.decorators = [isOverlayOpen];
 
 export const m = (): TemplateResult => ActionMenuMarkup({ size: 'm' });
 export const mOpen = (): TemplateResult =>
     ActionMenuMarkup({ size: 'm', open: true });
+mOpen.decorators = [isOverlayOpen];
 
 export const l = (): TemplateResult => ActionMenuMarkup({ size: 'l' });
 export const lOpen = (): TemplateResult =>
     ActionMenuMarkup({ size: 'l', open: true });
+lOpen.decorators = [isOverlayOpen];
 
 export const XL = (): TemplateResult => ActionMenuMarkup({ size: 'xl' });
 export const XLOpen = (): TemplateResult =>
     ActionMenuMarkup({ size: 'xl', open: true });
+XLOpen.decorators = [isOverlayOpen];

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -19,6 +19,8 @@ import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import { ActionMenuMarkup } from './';
 import { makeOverBackground } from '../../button/stories/index.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import type { MenuItem } from '@spectrum-web-components/menu/src/MenuItem.js';
@@ -221,6 +223,7 @@ export const selects = (args: StoryArgs = {}): TemplateResult =>
 selects.args = {
     open: true,
 };
+selects.decorators = [isOverlayOpen];
 
 export const iconOnly = (args: StoryArgs = {}): TemplateResult =>
     Template(args);
@@ -363,3 +366,5 @@ export const groups = ({
         </sp-menu-group>
     </sp-action-menu>
 `;
+
+groups.decorators = [isOverlayOpen];

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -22,7 +22,8 @@ import '@spectrum-web-components/overlay/overlay-trigger.js';
 
 import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
 import { landscape } from './images.js';
-import { overlayTriggerDecorator } from './index.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 import type { DialogWrapper } from '@spectrum-web-components/dialog';
 
 export default {
@@ -251,7 +252,7 @@ export const form = (
     `;
 };
 
-form.decorators = [overlayTriggerDecorator];
+form.decorators = [isOverlayOpen];
 
 export const longContent = (
     args: StoryArgs = {},
@@ -372,7 +373,7 @@ export const longContent = (
     `;
 };
 
-longContent.decorators = [overlayTriggerDecorator];
+longContent.decorators = [isOverlayOpen];
 
 export const wrapperDismissableUnderlayError = (
     args: StoryArgs = {},
@@ -568,7 +569,7 @@ export const tooltips = (
     `;
 };
 
-tooltips.decorators = [overlayTriggerDecorator];
+tooltips.decorators = [isOverlayOpen];
 
 export const lazyHero = ({ src }: { src: string }): TemplateResult => {
     const handleOpened = (): void => {

--- a/packages/dialog/stories/index.ts
+++ b/packages/dialog/stories/index.ts
@@ -12,54 +12,6 @@ governing permissions and limitations under the License.
 
 import { html, TemplateResult } from '@spectrum-web-components/base';
 
-function nextFrame(): Promise<void> {
-    return new Promise((res) => requestAnimationFrame(() => res()));
-}
-
-class OverlayTriggerReady extends HTMLElement {
-    ready!: (value: boolean | PromiseLike<boolean>) => void;
-
-    connectedCallback(): void {
-        this.readyPromise = new Promise((res) => {
-            this.ready = res;
-            this.setup();
-        });
-    }
-
-    async setup(): Promise<void> {
-        await nextFrame();
-        await nextFrame();
-
-        const overlay = document.querySelector(
-            `overlay-trigger[open]`
-        ) as HTMLElement;
-        overlay.addEventListener('sp-opened', this.handleTriggerOpened);
-    }
-
-    handleTriggerOpened = async (): Promise<void> => {
-        await nextFrame();
-
-        this.ready(true);
-    };
-
-    private readyPromise: Promise<boolean> = Promise.resolve(false);
-
-    get updateComplete(): Promise<boolean> {
-        return this.readyPromise;
-    }
-}
-
-customElements.define('overlay-trigger-ready', OverlayTriggerReady);
-
-export const overlayTriggerDecorator = (
-    story: () => TemplateResult
-): TemplateResult => {
-    return html`
-        ${story()}
-        <overlay-trigger-ready></overlay-trigger-ready>
-    `;
-};
-
 class CountdownWatcher extends HTMLElement {
     ready!: (value: boolean | PromiseLike<boolean>) => void;
 

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -22,6 +22,8 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-delete.js';
 import { states } from './states.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import { spreadProps } from '../../../test/lit-helpers.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 
 export default {
     title: 'Picker',
@@ -166,6 +168,7 @@ export const tooltip = (args: StoryArgs): TemplateResult => {
 tooltip.args = {
     open: true,
 };
+tooltip.decorators = [isOverlayOpen];
 
 export const noVisibleLabel = (args: StoryArgs): TemplateResult => {
     return html`
@@ -302,6 +305,7 @@ export const iconsNone = (args: StoryArgs): TemplateResult => {
 iconsNone.args = {
     open: true,
 };
+iconsNone.decorators = [isOverlayOpen];
 
 export const iconValue = (args: StoryArgs): TemplateResult => {
     return html`
@@ -361,6 +365,7 @@ export const iconsOnly = (args: StoryArgs): TemplateResult => {
 iconsOnly.args = {
     open: true,
 };
+iconsOnly.decorators = [isOverlayOpen];
 
 export const Open = (args: StoryArgs): TemplateResult => {
     return html`
@@ -415,6 +420,7 @@ export const Open = (args: StoryArgs): TemplateResult => {
 Open.args = {
     open: true,
 };
+Open.decorators = [isOverlayOpen];
 
 export const initialValue = (args: StoryArgs): TemplateResult => {
     return html`
@@ -459,58 +465,6 @@ export const readonly = (args: StoryArgs): TemplateResult => {
     `;
 };
 
-function nextFrame(): Promise<void> {
-    return new Promise((res) => requestAnimationFrame(() => res()));
-}
-
-class CustomPickerReady extends HTMLElement {
-    ready!: (value: boolean | PromiseLike<boolean>) => void;
-
-    constructor() {
-        super();
-        this.readyPromise = new Promise((res) => {
-            this.ready = res;
-            this.setup();
-        });
-    }
-
-    async setup(): Promise<void> {
-        await nextFrame();
-    }
-
-    handleTriggerOpened = async (): Promise<void> => {
-        await nextFrame();
-
-        const picker = document.querySelector('#picker-state') as Picker;
-        picker.addEventListener('sp-opened', this.handlePickerOpen);
-        picker.open = true;
-    };
-
-    handlePickerOpen = async (): Promise<void> => {
-        const picker = document.querySelector('#picker-state') as Picker;
-        const actions = [nextFrame, picker.updateComplete];
-
-        await Promise.all(actions);
-
-        this.ready(true);
-    };
-
-    private readyPromise: Promise<boolean> = Promise.resolve(false);
-
-    get updateComplete(): Promise<boolean> {
-        return this.readyPromise;
-    }
-}
-
-customElements.define('complex-picker-ready', CustomPickerReady);
-
-const customPickerDecorator = (story: () => TemplateResult): TemplateResult => {
-    return html`
-        ${story()}
-        <custom-picker-ready></custom-picker-ready>
-    `;
-};
-
 export const custom = (args: StoryArgs): TemplateResult => {
     const initialState = 'lb1-mo';
     return html`
@@ -546,9 +500,7 @@ export const custom = (args: StoryArgs): TemplateResult => {
         </p>
     `;
 };
-
-custom.decorators = [customPickerDecorator];
-
 custom.args = {
     open: true,
 };
+custom.decorators = [isOverlayOpen];

--- a/packages/popover/stories/popover.stories.ts
+++ b/packages/popover/stories/popover.stories.ts
@@ -15,7 +15,8 @@ import { Placement } from '@spectrum-web-components/overlay';
 import '@spectrum-web-components/dialog/sp-dialog.js';
 import '@spectrum-web-components/button/sp-button.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
-import { overlayTriggerDecorator } from '../../dialog/stories/index.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 
 export default {
     component: 'sp-popover',
@@ -201,10 +202,10 @@ const overlaid = (openPlacement: Placement): TemplateResult => {
 };
 
 export const overlaidTop = (): TemplateResult => overlaid('top');
-overlaidTop.decorators = [overlayTriggerDecorator];
+overlaidTop.decorators = [isOverlayOpen];
 export const overlaidRight = (): TemplateResult => overlaid('right');
-overlaidRight.decorators = [overlayTriggerDecorator];
+overlaidRight.decorators = [isOverlayOpen];
 export const overlaidBottom = (): TemplateResult => overlaid('bottom');
-overlaidBottom.decorators = [overlayTriggerDecorator];
+overlaidBottom.decorators = [isOverlayOpen];
 export const overlaidLeft = (): TemplateResult => overlaid('left');
-overlaidLeft.decorators = [overlayTriggerDecorator];
+overlaidLeft.decorators = [isOverlayOpen];

--- a/packages/split-button/stories/split-button-primary-field.stories.ts
+++ b/packages/split-button/stories/split-button-primary-field.stories.ts
@@ -13,8 +13,8 @@ governing permissions and limitations under the License.
 import { ElementSizes, TemplateResult } from '@spectrum-web-components/base';
 import { args, argTypes, renderSplitButtonSet, splitbutton } from './index.js';
 import type { Properties } from './index.js';
-import { openSplitButtonDecorator } from './helpers.js';
-import './helpers.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 
 import '@spectrum-web-components/split-button/sp-split-button.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
@@ -47,4 +47,4 @@ export const XL = (args: Properties): TemplateResult =>
 XL.args = { size: ElementSizes.xl };
 export const open = (args: Properties): TemplateResult => splitbutton(args);
 open.args = { open: true };
-open.decorators = [openSplitButtonDecorator];
+open.decorators = [isOverlayOpen];

--- a/packages/split-button/stories/split-button-primary-more.stories.ts
+++ b/packages/split-button/stories/split-button-primary-more.stories.ts
@@ -13,8 +13,8 @@ governing permissions and limitations under the License.
 import { ElementSizes, TemplateResult } from '@spectrum-web-components/base';
 import { args, argTypes, renderSplitButtonSet, splitbutton } from './index.js';
 import type { Properties } from './index.js';
-import { openSplitButtonDecorator } from './helpers.js';
-import './helpers.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 
 import '@spectrum-web-components/split-button/sp-split-button.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
@@ -47,4 +47,4 @@ export const XL = (args: Properties): TemplateResult =>
 XL.args = { size: ElementSizes.xl };
 export const open = (args: Properties): TemplateResult => splitbutton(args);
 open.args = { open: true };
-open.decorators = [openSplitButtonDecorator];
+open.decorators = [isOverlayOpen];

--- a/packages/split-button/stories/split-button-secondary-field.stories.ts
+++ b/packages/split-button/stories/split-button-secondary-field.stories.ts
@@ -13,8 +13,8 @@ governing permissions and limitations under the License.
 import { ElementSizes, TemplateResult } from '@spectrum-web-components/base';
 import { args, argTypes, renderSplitButtonSet, splitbutton } from './index.js';
 import type { Properties } from './index.js';
-import { openSplitButtonDecorator } from './helpers.js';
-import './helpers.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 
 import '@spectrum-web-components/split-button/sp-split-button.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
@@ -47,4 +47,4 @@ export const XL = (args: Properties): TemplateResult =>
 XL.args = { size: ElementSizes.xl };
 export const open = (args: Properties): TemplateResult => splitbutton(args);
 open.args = { open: true };
-open.decorators = [openSplitButtonDecorator];
+open.decorators = [isOverlayOpen];

--- a/packages/split-button/stories/split-button-secondary-more.stories.ts
+++ b/packages/split-button/stories/split-button-secondary-more.stories.ts
@@ -13,8 +13,8 @@ governing permissions and limitations under the License.
 import { ElementSizes, TemplateResult } from '@spectrum-web-components/base';
 import { args, argTypes, renderSplitButtonSet, splitbutton } from './index.js';
 import type { Properties } from './index.js';
-import { openSplitButtonDecorator } from './helpers.js';
-import './helpers.js';
+import { isOverlayOpen } from '../../overlay/stories/index.js';
+import '../../overlay/stories/index.js';
 
 import '@spectrum-web-components/split-button/sp-split-button.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
@@ -47,4 +47,4 @@ export const XL = (args: Properties): TemplateResult =>
 XL.args = { size: ElementSizes.xl };
 export const open = (args: Properties): TemplateResult => splitbutton(args);
 open.args = { open: true };
-open.decorators = [openSplitButtonDecorator];
+open.decorators = [isOverlayOpen];


### PR DESCRIPTION
## Description
Simplify waiting for a single `sp-opened` event before allow for a VRT to happen.

## How has this been tested?

-   [ ] _Test case 1_
    1. It is tests, the tests go green in CI.

## Types of changes
-   [x] refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.