### PR TITLE
fix(picker): prevent the Menu opening until required dependencies are loaded

### DIFF
--- a/packages/picker/src/picker.css
+++ b/packages/picker/src/picker.css
@@ -105,3 +105,7 @@ sp-menu {
     width: 1px;
     white-space: nowrap;
 }
+
+sp-overlay:not(:defined) {
+    display: none;
+}


### PR DESCRIPTION
## Description
Load dependencies, even lazily, before allowing the Menu to be displayed open in a Picker

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://picker-dependencies--spectrum-web-components.netlify.app/)
    2. Make your browser less than 960px wide
    3. Refresh the page (at this point it can be helpful to reduce connection and processor resources to ensure delay in content delivery)
    4. Open the "options" menu in the top right
    5. Open a picker
    6. See that there wasn't a flash of non-upgraded layout

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.