### PR TITLE
fix(tooltip): surface "delayed" and "disabled" functionality

### DIFF
--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -119,6 +119,22 @@ export class Tooltip extends SpectrumElement {
     }
 
     /**
+     * An Tooltip that is `delayed` will its Overlay wait until a warm-up period of
+     * 1000mshas completed before opening. Once the warmup period has completed, all
+     * subsequent Overlays will open immediately. When no Overlays are opened, a
+     * cooldown period of 1000ms will begin. Once the cooldown has completed, the next
+     * Overlay to be opened will be subject to the warm-up period if provided that option.
+     */
+    @property({ type: Boolean })
+    delayed = false;
+
+    /**
+     * Whether to prevent a self-managed Tooltip from responding to user input.
+     */
+    @property({ type: Boolean })
+    disabled = false;
+
+    /**
      * Automatically bind to the parent element of the assigned `slot` or the parent element of the `sp-tooltip`.
      * Without this, you must provide your own `overlay-trigger`.
      */
@@ -248,6 +264,8 @@ export class Tooltip extends SpectrumElement {
             import('@spectrum-web-components/overlay/sp-overlay.js');
             return html`
                 <sp-overlay
+                    ?delayed=${this.delayed}
+                    ?disabled=${this.disabled}
                     ?open=${this.open}
                     offset=${this.offset}
                     .placement=${this.placement}

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -119,8 +119,8 @@ export class Tooltip extends SpectrumElement {
     }
 
     /**
-     * An Tooltip that is `delayed` will its Overlay wait until a warm-up period of
-     * 1000mshas completed before opening. Once the warmup period has completed, all
+     * A Tooltip that is `delayed` will its Overlay wait until a warm-up period of
+     * 1000ms has completed before opening. Once the warmup period has completed, all
      * subsequent Overlays will open immediately. When no Overlays are opened, a
      * cooldown period of 1000ms will begin. Once the cooldown has completed, the next
      * Overlay to be opened will be subject to the warm-up period if provided that option.

--- a/packages/tooltip/stories/tooltip.stories.ts
+++ b/packages/tooltip/stories/tooltip.stories.ts
@@ -57,12 +57,13 @@ export default {
 };
 
 interface Properties {
+    delayed?: boolean;
+    disabled?: boolean;
     open?: boolean;
     placement?: Placement;
     variant?: string;
     text?: string;
     offset?: number;
-    delayed?: boolean;
 }
 
 export const Default = ({
@@ -310,6 +311,7 @@ export const selfManaged = ({
     open,
     offset,
     delayed,
+    disabled,
 }: Properties): TemplateResult => html`
     ${overlayStyles}
     <sp-action-button class="self-managed">
@@ -319,7 +321,8 @@ export const selfManaged = ({
             placement=${placement}
             offset=${offset}
             ?delayed=${delayed}
-            open=${open}
+            ?disabled=${disabled}
+            ?open=${open}
         >
             Add paragraph text by dragging the Text tool on the canvas to use
             this feature
@@ -331,12 +334,18 @@ selfManaged.args = {
     open: true,
     offset: 6,
     delayed: false,
+    disabled: false,
 };
 selfManaged.argTypes = {
     delayed: {
         name: 'delayed',
         type: { name: 'boolean', required: false },
         description: 'Whether to manage the tooltip with the warmup timer',
+    },
+    disabled: {
+        name: 'disabled',
+        type: { name: 'boolean', required: false },
+        description: 'Whether the Tooltip is active and can be displayed',
     },
     offset: {
         name: 'offset',


### PR DESCRIPTION
## Description
Allow self-managed Tooltip elements to accept `delayed` and/or `disabled` as boolean attributes.

This work is demonstrated for manual testing in Storybook.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://tooltip-delay-disabled--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--self-managed&args=open:!false;disabled:!true)
    2. Toggle on `delayed`
    3. Attempt to activate the Tooltip
    4. See that it is _delayed_
-   [ ] _Test case 2_
    1. Go [here](https://tooltip-delay-disabled--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--self-managed&args=open:!false;disabled:!true)
    2. Toggle on `disabled`
    3. Attempt to activate the Tooltip
    4. See that it will not activate

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.