### PR TITLE
fix(picker): force close slotted Tooltip elements with disabled when Menu openes

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -79,7 +79,10 @@ export class ActionMenu extends ObserveSlotPresence(
                       `}
                 <slot name="label" ?hidden=${!this.hasLabel}></slot>
                 <slot name="label-only"></slot>
-                <slot name="tooltip"></slot>
+                <slot
+                    name="tooltip"
+                    @slotchange=${this.handleTooltipSlotchange}
+                ></slot>
             `,
         ];
     }

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -512,7 +512,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             await elementUpdated(overlay);
 
             expect(overlay.triggerElement === el.button).to.be.true;
-            let open = oneEvent(tooltip, 'sp-opened');
+            const open = oneEvent(tooltip, 'sp-opened');
             sendMouse({
                 steps: [
                     {
@@ -528,47 +528,22 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
 
             expect(tooltip.open).to.be.true;
 
-            let close = oneEvent(tooltip, 'sp-closed');
-            el.click();
-            await close;
-
-            expect(tooltip.open).to.be.false;
-            expect(el.open).to.be.true;
-
-            open = oneEvent(tooltip, 'sp-opened');
-            sendMouse({
+            const close = oneEvent(tooltip, 'sp-closed');
+            await sendMouse({
                 steps: [
-                    {
-                        position: [
-                            rect.left + rect.width * 2,
-                            rect.top + rect.height / 2,
-                        ],
-                        type: 'move',
-                    },
                     {
                         position: [
                             rect.left + rect.width / 2,
                             rect.top + rect.height / 2,
                         ],
-                        type: 'move',
-                    },
-                ],
-            });
-            await open;
-
-            close = oneEvent(tooltip, 'sp-closed');
-            sendMouse({
-                steps: [
-                    {
-                        position: [
-                            rect.left + rect.width * 2,
-                            rect.top + rect.height / 2,
-                        ],
-                        type: 'move',
+                        type: 'click',
                     },
                 ],
             });
             await close;
+
+            expect(tooltip.open).to.be.false;
+            expect(el.open).to.be.true;
 
             const menu = (el as unknown as TestablePicker).optionsMenu;
             const menuRect = menu.getBoundingClientRect();
@@ -587,7 +562,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
 
             await aTimeout(150);
 
-            expect(openSpy.callCount).to.equal(2);
+            expect(openSpy.callCount).to.equal(1);
         });
         it('opens, then closes, on subsequent clicks', async () => {
             const el = await actionMenuFixture();

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -75,6 +75,7 @@
         "@spectrum-web-components/popover": "^0.40.2",
         "@spectrum-web-components/reactive-controllers": "^0.40.2",
         "@spectrum-web-components/shared": "^0.40.2",
+        "@spectrum-web-components/tooltip": "^0.40.2",
         "@spectrum-web-components/tray": "^0.40.2"
     },
     "devDependencies": {

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -35,6 +35,7 @@ import pickerStyles from './picker.css.js';
 import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
 
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
+import type { Tooltip } from '@spectrum-web-components/tooltip';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron100.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
 import '@spectrum-web-components/menu/sp-menu.js';
@@ -101,6 +102,8 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
 
     @query('sp-overlay')
     protected overlayElement!: Overlay;
+
+    protected tooltipEl?: Tooltip;
 
     /**
      * @type {"top" | "top-start" | "top-end" | "right" | "right-start" | "right-end" | "bottom" | "bottom-start" | "bottom-end" | "left" | "left-start" | "left-end"}
@@ -319,6 +322,14 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
 
     _selectedItemContent?: MenuItemChildren;
 
+    protected handleTooltipSlotchange(
+        event: Event & { target: HTMLSlotElement }
+    ): void {
+        this.tooltipEl = event.target.assignedElements()[0] as
+            | Tooltip
+            | undefined;
+    }
+
     protected renderLabelContent(content: Node[]): TemplateResult | Node[] {
         if (this.value && this.selectedItem) {
             return content;
@@ -382,7 +393,12 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                         this.size as DefaultElementSize
                     ]}"
                 ></sp-icon-chevron100>
-                <slot aria-hidden="true" name="tooltip" id="tooltip"></slot>
+                <slot
+                    aria-hidden="true"
+                    name="tooltip"
+                    id="tooltip"
+                    @slotchange=${this.handleTooltipSlotchange}
+                ></slot>
             `,
         ];
     }
@@ -436,6 +452,9 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
     // a helper to throw focus to the button is needed because Safari
     // won't include buttons in the tab order even with tabindex="0"
     protected override render(): TemplateResult {
+        if (this.tooltipEl) {
+            this.tooltipEl.disabled = this.open;
+        }
         return html`
             <span
                 id="focus-helper"

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -1605,20 +1605,12 @@ export function runPickerTests(): void {
         expect(openedSpy.calledOnce).to.be.true;
         expect(closedSpy.calledOnce).to.be.false;
 
-        // const openedEvent = openedSpy
-        //     .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
-        // expect(openedEvent.detail.interaction).to.equal('modal');
-
         const closed = oneEvent(el, 'sp-closed');
         el.open = false;
         await closed;
         await elementUpdated(el);
 
         expect(closedSpy.calledOnce).to.be.true;
-
-        // const closedEvent = closedSpy
-        //     .args[0][0] as CustomEvent<OverlayOpenCloseDetail>;
-        // expect(closedEvent.detail.interaction).to.equal('modal');
     });
     it('closes tooltip on button blur', async () => {
         const test = await styledFixture(html`

--- a/packages/picker/tsconfig.json
+++ b/packages/picker/tsconfig.json
@@ -13,6 +13,7 @@
         { "path": "../icon" },
         { "path": "../icons-ui" },
         { "path": "../icons-workflow" },
-        { "path": "../popover" }
+        { "path": "../popover" },
+        { "path": "../tooltip" }
     ]
 }

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -264,9 +264,9 @@ export class Tooltip extends SpectrumElement {
             import('@spectrum-web-components/overlay/sp-overlay.js');
             return html`
                 <sp-overlay
+                    ?open=${this.open && !this.disabled}
                     ?delayed=${this.delayed}
                     ?disabled=${this.disabled}
-                    ?open=${this.open}
                     offset=${this.offset}
                     .placement=${this.placement}
                     type="hint"


### PR DESCRIPTION
## Description
Ensure reasonability of Tooltip state when Menu is open.

## Motivation and context
This came up while addressing #3596. This change fast forwards the work that was needed to make that happen.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://picker-tooltip-management--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--tooltip-description-and-placement)
    2. Hover over the Action Menu
    3. See the Tooltip open
    4. Click the Action Menu
    5. See the Menu open and Tooltip close
    6. Focus away from the Menu
    7. See the Menu close and the Tooltip _stay_ closed

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.