### PR TITLE
docs: remove placement attribute from theme controls

### DIFF
--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -376,7 +376,6 @@ export class LayoutElement extends LitElement {
                         quiet
                         value=${this.theme}
                         @change=${this.updateTheme}
-                        placement="bottom-end"
                     >
                         <sp-menu-item value="spectrum">Spectrum</sp-menu-item>
                         <sp-menu-item value="express">
@@ -393,7 +392,6 @@ export class LayoutElement extends LitElement {
                         quiet
                         value=${this.color}
                         @change=${this.updateColor}
-                        placement="bottom-end"
                     >
                         <sp-menu-item value="lightest">Lightest</sp-menu-item>
                         <sp-menu-item value="light">Light</sp-menu-item>
@@ -409,7 +407,6 @@ export class LayoutElement extends LitElement {
                         quiet
                         value=${this.scale}
                         @change=${this.updateScale}
-                        placement="bottom-end"
                     >
                         <sp-menu-item value="medium">Medium</sp-menu-item>
                         <sp-menu-item value="large">Large</sp-menu-item>
@@ -425,7 +422,6 @@ export class LayoutElement extends LitElement {
                         quiet
                         value=${this.dir}
                         @change=${this.updateDirection}
-                        placement="bottom-end"
                     >
                         <sp-menu-item value="ltr">LTR</sp-menu-item>
                         <sp-menu-item value="rtl">RTL</sp-menu-item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Picker is off centre in docs site, so I removed `placement` attribute since it seems to be unneeded. 

## Related issue(s)

- fixes #3885 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go to [the docs site](https://opensource.adobe.com/spectrum-web-components/)
    2. Make your browser less than 960px wide
    3. Open the "options" menu in the top right
    4. Open a picker
    5. See that the overlay is not aligned with the picker
-   [ ] _Test case 2_
    1. Go to [the branch docs site](https://halsema-picker-docs-fix--spectrum-web-components.netlify.app/)
    2. Make your browser less than 960px wide
    3. Open the "options" menu in the top right
    4. Open a picker
    5. See that the overlay is aligned with the picker

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
