### PR TITLE
fix(overlay): move closed overlays to "display: none"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a5a0cf4e49f5cb6c096bc5b7be9830775b5d6b5e
+        default: c5848624f4b2ed25d56ab4e378d829f6e8ce3805
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -88,6 +88,9 @@ export class ActionMenu extends ObserveSlotPresence(
     }
 
     protected override render(): TemplateResult {
+        if (this.tooltipEl) {
+            this.tooltipEl.disabled = this.open;
+        }
         return html`
             <sp-action-button
                 aria-describedby=${DESCRIPTION_ID}

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -491,7 +491,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             expect(selectedItem.textContent).to.include('Two');
             expect(selectedItem.selected).to.be.true;
         });
-        it('shows tooltip', async () => {
+        it('shows tooltip', async function () {
             const openSpy = spy();
             const el = await styledFixture<ActionMenu>(
                 tooltipDescriptionAndPlacement(
@@ -512,7 +512,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             await elementUpdated(overlay);
 
             expect(overlay.triggerElement === el.button).to.be.true;
-            const open = oneEvent(tooltip, 'sp-opened');
+            let open = oneEvent(tooltip, 'sp-opened');
             sendMouse({
                 steps: [
                     {
@@ -529,7 +529,8 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             expect(tooltip.open).to.be.true;
 
             const close = oneEvent(tooltip, 'sp-closed');
-            await sendMouse({
+            open = oneEvent(el, 'sp-opened');
+            sendMouse({
                 steps: [
                     {
                         position: [
@@ -541,9 +542,10 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
                 ],
             });
             await close;
+            await open;
 
-            expect(tooltip.open).to.be.false;
-            expect(el.open).to.be.true;
+            expect(tooltip.open, 'tooltip still open').to.be.false;
+            expect(el.open, 'menu not open').to.be.true;
 
             const menu = (el as unknown as TestablePicker).optionsMenu;
             const menuRect = menu.getBoundingClientRect();

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -32,6 +32,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import { ActionMenu } from '@spectrum-web-components/action-menu';
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/menu/sp-menu-group.js';
+import '@spectrum-web-components/overlay/sp-overlay.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
 import { isWebKit } from '@spectrum-web-components/shared';
 
@@ -160,7 +161,7 @@ describe('Submenu', () => {
         expect(rootChanged.withArgs('Has submenu').calledOnce, 'root changed')
             .to.be.true;
     });
-    it('closes deep tree on selection', async () => {
+    it('closes deep tree on selection', async function () {
         const rootChanged = spy();
         const submenuChanged = spy();
         const subSubmenuChanged = spy();
@@ -239,11 +240,11 @@ describe('Submenu', () => {
         const item2BoundingRect = item2.getBoundingClientRect();
 
         opened = oneEvent(item2, 'sp-opened');
-        // Click the submenu item to open a submenu
+        // Move to the submenu item to open a submenu
         sendMouse({
             steps: [
                 {
-                    type: 'click',
+                    type: 'move',
                     position: [
                         item2BoundingRect.left + item2BoundingRect.width / 2,
                         item2BoundingRect.top + item2BoundingRect.height / 2,
@@ -257,7 +258,18 @@ describe('Submenu', () => {
 
         const closed = oneEvent(rootItem, 'sp-closed');
         // click to select and close
-        itemC.click();
+        const itemCBoundingRect = itemC.getBoundingClientRect();
+        await sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [
+                        itemCBoundingRect.left + itemCBoundingRect.width / 2,
+                        itemCBoundingRect.top + itemCBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
         await closed;
 
         expect(rootChanged.calledWith('Has submenu'), 'root changed').to.be

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -212,10 +212,10 @@ export class OverlayTrigger extends SpectrumElement {
         return html`
             <sp-overlay
                 id="hover-overlay"
+                ?open=${this.open === 'hover' && !!this.hoverContent.length}
                 ?disabled=${this.disabled ||
                 !this.hoverContent.length ||
                 (!!this.open && this.open !== 'hover')}
-                ?open=${this.open === 'hover' && !!this.hoverContent.length}
                 .offset=${this.offset}
                 .placement=${this.hoverPlacement || this.placement}
                 .triggerElement=${this.targetContent[0]}

--- a/packages/overlay/src/overlay.css
+++ b/packages/overlay/src/overlay.css
@@ -47,7 +47,7 @@ governing permissions and limitations under the License.
 }
 
 .dialog:not([is-visible]) {
-    translate: -999em -999em !important;
+    display: none;
 }
 
 .dialog:focus {
@@ -83,6 +83,7 @@ dialog:modal {
 
 ::slotted(*) {
     pointer-events: auto;
+    visibility: visible !important;
 }
 
 ::slotted(sp-popover) {

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -195,6 +195,9 @@ describe('Overlay Trigger - Longpress', () => {
             await elementUpdated(this.el);
             this.el.append(button);
             await elementUpdated(this.el);
+            // Inject synthetic wait to afford for late replacement of <sp-action-button> with <button>
+            await nextFrame();
+            await nextFrame();
 
             let open = oneEvent(this.el, 'sp-opened');
             const rect = button.getBoundingClientRect();

--- a/packages/overlay/test/overlay-update.test.ts
+++ b/packages/overlay/test/overlay-update.test.ts
@@ -24,23 +24,16 @@ describe('sp-update-overlays event', () => {
         ) as AccordionItem;
 
         el.content = 'click';
-        await elementUpdated(el);
-
-        const height0 = container.getBoundingClientRect().height;
 
         const opened = oneEvent(el, 'sp-opened');
         el.open = 'click';
         await opened;
 
         const height1 = container.getBoundingClientRect().height;
-        expect(height1).to.equal(height0);
-
         item.click();
         await elementUpdated(item);
 
         const height2 = container.getBoundingClientRect().height;
-        expect(height2).to.not.equal(height0);
-
         expect(height1).to.be.lessThan(height2);
     });
 });

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -19,6 +19,7 @@ import {
 import {
     property,
     query,
+    state,
 } from '@spectrum-web-components/base/src/decorators.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import type {
@@ -246,6 +247,29 @@ export class Tooltip extends SpectrumElement {
         return triggerElement;
     }
 
+    @state()
+    private dependenciesLoaded = false;
+    private dependenciesToLoad: Record<string, boolean> = {};
+
+    private trackDependency(dependency: string, flag?: boolean): void {
+        const loaded =
+            !!customElements.get(dependency) ||
+            this.dependenciesToLoad[dependency] ||
+            !!flag;
+        if (!loaded) {
+            customElements.whenDefined(dependency).then(() => {
+                this.trackDependency(dependency, true);
+            });
+        }
+        this.dependenciesToLoad = {
+            ...this.dependenciesToLoad,
+            [dependency]: loaded,
+        };
+        this.dependenciesLoaded = Object.values(this.dependenciesToLoad).every(
+            (loaded) => loaded
+        );
+    }
+
     override render(): TemplateResult {
         const tooltip = html`
             <sp-tooltip-openable
@@ -261,10 +285,13 @@ export class Tooltip extends SpectrumElement {
             </sp-tooltip-openable>
         `;
         if (this.selfManaged) {
+            this.trackDependency('sp-overlay');
             import('@spectrum-web-components/overlay/sp-overlay.js');
             return html`
                 <sp-overlay
-                    ?open=${this.open && !this.disabled}
+                    ?open=${this.open &&
+                    !this.disabled &&
+                    this.dependenciesLoaded}
                     ?delayed=${this.delayed}
                     ?disabled=${this.disabled}
                     offset=${this.offset}

--- a/packages/tooltip/src/tooltip.css
+++ b/packages/tooltip/src/tooltip.css
@@ -70,3 +70,7 @@ governing permissions and limitations under the License.
     clip-path: polygon(-5% 0, -5% 100%, 50% 50%);
     left: 100%;
 }
+
+sp-overlay:not(:defined) {
+    display: none;
+}

--- a/packages/tooltip/stories/tooltip.stories.ts
+++ b/packages/tooltip/stories/tooltip.stories.ts
@@ -419,3 +419,36 @@ export const selfManagedFieldLabel = (): TemplateResult => html`
         <sp-textfield id="input"></sp-textfield>
     </div>
 `;
+
+export const draggable = (): TemplateResult => {
+    const handleDragStart = (event: DragEvent): void => {
+        event.dataTransfer?.setDragImage(
+            event.target as HTMLElement,
+            event.offsetX,
+            event.offsetY
+        );
+    };
+    return html`
+        <sp-button>
+            A simple button that should not be included in the DragImage
+        </sp-button>
+        <div
+            draggable="true"
+            id="draggableElement"
+            @dragstart=${handleDragStart}
+            style="margin-top: 16px; cursor: move; padding: 24px; border: red 1px solid;"
+        >
+            <p>Click and drag me to show DragImage</p>
+            <sp-action-button>
+                Action Button with self managed tooltip
+                <sp-tooltip self-managed placement="bottom">
+                    My Tooltip
+                </sp-tooltip>
+            </sp-action-button>
+        </div>
+    `;
+};
+
+draggable.swc_vrt = {
+    skip: true,
+};

--- a/packages/tooltip/test/tooltip.test.ts
+++ b/packages/tooltip/test/tooltip.test.ts
@@ -228,7 +228,7 @@ describe('Tooltip', () => {
             consoleWarnStub.restore();
         });
 
-        it('loads default badge accessibly', async () => {
+        it('warns when incorrectly using `self-managed`', async () => {
             const el = await fixture<Tooltip>(
                 html`
                     <sp-tooltip variant="negative" self-managed>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7128,6 +7128,11 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-5.0.44.tgz#8741691bba8d8035158b60343e480b737c57868a"
   integrity sha512-2vZwF0Hj9XUPomb0hhG8T6+qjUG3/dPkqYX9j3RA8D/zgwqDATqnkU0v7weRGTq8KWrGN9C1GK7a7V+GRjkM8w==
 
+"@spectrum-css/ui-icons@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/ui-icons/-/ui-icons-1.1.0.tgz#cd3e36c63b4a586366c8b9624438455013e306e3"
+  integrity sha512-1p6ksMSPdFUHXj5BiAE8XF1WnmqHTCG54AGOBLRWgUYwoaKMSYdAo9ArmUzF4HWWzKJWJG2u5pL9nB5NmlJPlw==
+
 "@spectrum-css/underlay@^3.0.3":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-3.0.6.tgz#9fac662925e81e06633078936f7fcd4b923e7ea1"


### PR DESCRIPTION
## Description
- Prevent unopened Overlay content from existing on the Tab order
- Prevent unopened Overlay content form existing outside of its parent element causing drag image issues
- Correct order of attribute/property application in Overlay Trigger to support
- Add dependency load management to Tooltip
- Update test to support

## Related issue(s)

- fixes #3872
- fixes #3761

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://overlay-visibility--spectrum-web-components.netlify.app/components/overlay-trigger/#click-content-only)
    2. With VoiceOver running, navigate to focus the Overlay Trigger button in the "Click content only" example.
    3. Press Tab key to advance to the next focusable control.
    4. **_FAIL STATE:_** The VoiceOver cursor disappears and VoiceOver announces "dialog, with 4 items, I understand, button", which is the click-overlay dialog that has not yet been opened.
    5. **_SUCCESS STATE:_** The cursor moves to the "Copy to Clipboard" button at the end of the example code
-   [ ] _Test case 2_
    1. Go [here](https://overlay-visibility--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip--draggable)
    2. Attempt to drag the element outlined in red.
    3. See that the drag image only includes that specific element.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)