### PR TITLE
fix(overlay): support positioning overlays within parents leveraging container-type rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c5848624f4b2ed25d56ab4e378d829f6e8ce3805
+        default: 28327170b75920a6b540be8fd320f99823eb350a
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/overlay/src/topLayerOverTransforms.ts
+++ b/packages/overlay/src/topLayerOverTransforms.ts
@@ -85,6 +85,14 @@ export const topLayerOverTransforms = (): Middleware => ({
                     css.transform !== 'none' ||
                     // the `translate` property
                     css.translate !== 'none' ||
+                    // the `containerType` property
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    (css.containerType
+                        ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                          // @ts-ignore
+                          css.containerType !== 'normal'
+                        : false) ||
                     // the `backdropFilter` property
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -63,12 +63,15 @@ export default {
     },
 };
 
+type WrapperStyleType = 'will-change' | 'container-type';
+
 type Properties = {
     delayed: boolean;
     interaction: 'click' | 'hover' | 'longpress';
     open?: boolean;
     placement?: Placement;
     receivesFocus: 'true' | 'false' | 'auto';
+    style?: WrapperStyleType;
     type?: OverlayTypes;
 };
 
@@ -78,12 +81,23 @@ const Template = ({
     placement,
     type,
     delayed,
+    style,
 }: Properties): TemplateResult => html`
-    <style>
-        .wrapper {
-            will-change: transform;
-        }
-    </style>
+    ${style === 'will-change'
+        ? html`
+              <style>
+                  .wrapper {
+                      will-change: transform;
+                  }
+              </style>
+          `
+        : html`
+              <style>
+                  .wrapper {
+                      container-type: size;
+                  }
+              </style>
+          `}
     <div class="wrapper">
         <sp-action-button id="trigger">Open the overlay</sp-action-button>
         <sp-overlay
@@ -117,6 +131,7 @@ export const modal = (args: Properties): TemplateResult => Template(args);
 modal.args = {
     interaction: 'click',
     placement: 'right',
+    style: 'will-change',
     type: 'modal',
 };
 
@@ -146,6 +161,7 @@ export const click = (args: Properties): TemplateResult => Template(args);
 click.args = {
     interaction: 'click',
     placement: 'right',
+    style: 'container-type' as WrapperStyleType,
     type: 'auto',
 };
 
@@ -153,12 +169,14 @@ export const hover = (args: Properties): TemplateResult => Template(args);
 hover.args = {
     interaction: 'hover',
     placement: 'right',
+    style: 'will-change',
 };
 
 export const longpress = (args: Properties): TemplateResult => Template(args);
 longpress.args = {
     interaction: 'longpress',
     placement: 'right',
+    style: 'container-type',
     type: 'auto',
 };
 


### PR DESCRIPTION
## Description
Expand rules processing for overlay over new layer calculations to include `container-type`.

## Related issue(s)

- fixes #3874 
- refs #3718

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://overlay-container-type--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-element--longpress)
    2. See that the overlay is in the right place
    3. Inspect the overlay to see it has a parent with `container-type: size;`

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.