### PR TITLE
fix(overlay): automatically reposition overlay when the contents resize

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 28327170b75920a6b540be8fd320f99823eb350a
+        default: 399010224101760a8f5247862ef7f3eb900b2382
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -883,7 +883,6 @@ export class Overlay extends OverlayFeatures {
     }
 
     public override manuallyKeepOpen(): void {
-        super.manuallyKeepOpen();
         this.open = true;
         this.placementController.allowPlacementUpdate = true;
         this.manageOpen(false);

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 
 import { html, TemplateResult } from '@spectrum-web-components/base';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import '@spectrum-web-components/dialog/sp-dialog.js';
 import '@spectrum-web-components/overlay/sp-overlay.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
@@ -19,6 +20,7 @@ import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
+import '@spectrum-web-components/link/sp-link.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-anchor-select.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-polygon-select.js';
@@ -107,21 +109,23 @@ const Template = ({
             placement=${ifDefined(placement)}
             offset="-10"
         >
-            <sp-popover dialog ?delayed=${delayed}>
-                <p>
-                    Content goes here.
-                    ${type === 'modal' || type === 'page'
-                        ? html`
-                              Or, a link,
-                              <sp-link
-                                  href="https://opensource.adobe.com/spectrum-web-components"
-                              >
-                                  Spectrum Web Components
-                              </sp-link>
-                              .
-                          `
-                        : ''}
-                </p>
+            <sp-popover ?delayed=${delayed}>
+                <sp-dialog size="s" no-divider>
+                    <p>
+                        Content goes here.
+                        ${type === 'modal' || type === 'page'
+                            ? html`
+                                  Or, a link,
+                                  <sp-link
+                                      href="https://opensource.adobe.com/spectrum-web-components"
+                                  >
+                                      Spectrum Web Components
+                                  </sp-link>
+                                  .
+                              `
+                            : ''}
+                    </p>
+                </sp-dialog>
             </sp-popover>
         </sp-overlay>
     </div>
@@ -172,6 +176,35 @@ hover.args = {
     style: 'will-change',
 };
 
+export const hoverTooltip = ({
+    interaction,
+    open,
+    placement,
+    type,
+}: Properties): TemplateResult => html`
+    <style>
+        .wrapper {
+            will-change: transform;
+        }
+    </style>
+    <div class="wrapper">
+        <sp-action-button id="trigger">Open the overlay</sp-action-button>
+        <sp-overlay
+            ?open=${open}
+            trigger="trigger@${interaction}"
+            type=${ifDefined(type)}
+            placement=${ifDefined(placement)}
+            offset="-10"
+        >
+            <sp-tooltip>Tooltip goes here.</sp-tooltip>
+        </sp-overlay>
+    </div>
+`;
+hoverTooltip.args = {
+    interaction: 'hover',
+    placement: 'right',
+};
+
 export const longpress = (args: Properties): TemplateResult => Template(args);
 longpress.args = {
     interaction: 'longpress',
@@ -201,7 +234,11 @@ export const receivesFocus = ({
         placement=${ifDefined(placement)}
         .receivesFocus=${receivesFocus}
     >
-        <a href="https://example.com">Click Content</a>
+        <sp-popover>
+            <sp-dialog size="s" no-divider>
+                <a href="https://example.com">Click Content</a>
+            </sp-dialog>
+        </sp-popover>
     </sp-overlay>
 `;
 receivesFocus.args = {
@@ -258,13 +295,17 @@ export const all = ({ delayed }: Properties): TemplateResult => html`
         Open the overlay
     </sp-action-button>
     <sp-overlay trigger="trigger@click" type="auto" placement="right">
-        <sp-popover dialog>Click content</sp-popover>
+        <sp-popover>
+            <sp-dialog size="s" no-divider>Click content</sp-dialog>
+        </sp-popover>
     </sp-overlay>
     <sp-overlay ?delayed=${delayed} trigger="trigger@hover" type="hint">
         <sp-tooltip>Hover content</sp-tooltip>
     </sp-overlay>
     <sp-overlay trigger="trigger@longpress" type="auto" placement="right">
-        <sp-popover dialog>Longpress content</sp-popover>
+        <sp-popover>
+            <sp-dialog size="s" no-divider>Longpress content</sp-dialog>
+        </sp-popover>
     </sp-overlay>
 `;
 

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -229,7 +229,12 @@ export const Default = (args: Properties): TemplateResult => template(args);
 
 export const accordion = (): TemplateResult => {
     return html`
-        <overlay-trigger type="modal" placement="right">
+        <overlay-trigger type="modal" placement="top-start">
+            <style>
+                sp-button {
+                    margin-top: 70vh;
+                }
+            </style>
             <sp-button variant="primary" slot="trigger">
                 Open overlay w/ accordion
             </sp-button>

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -56,7 +56,9 @@ describe('Overlay Trigger - Longpress', () => {
             expect(this.content).to.not.be.null;
             expect(this.content.open).to.be.false;
 
+            const open = oneEvent(this.el, 'sp-opened');
             this.trigger.focus();
+            await open;
         });
         it('opens/closes for `Space`', async function () {
             const open = oneEvent(this.el, 'sp-opened');
@@ -134,7 +136,7 @@ describe('Overlay Trigger - Longpress', () => {
         });
         it('opens/closes for `longpress`', async function () {
             expect(this.trigger.holdAffordance).to.be.true;
-            let open = oneEvent(this.el, 'sp-opened');
+            const open = oneEvent(this.el, 'sp-opened');
             const rect = this.trigger.getBoundingClientRect();
             await sendMouse({
                 steps: [
@@ -150,12 +152,6 @@ describe('Overlay Trigger - Longpress', () => {
                     },
                 ],
             });
-            // Hover content opens, first.
-            await open;
-            await nextFrame();
-            await nextFrame();
-            open = oneEvent(this.el, 'sp-opened');
-            // Then, the longpress content opens.
             await open;
             await nextFrame();
             await nextFrame();
@@ -186,18 +182,39 @@ describe('Overlay Trigger - Longpress', () => {
             expect(await isOnTopLayer(this.content)).to.be.false;
             expect(this.content.open, 'closes for `pointerdown`').to.be.false;
         });
+    });
+    describe('opens/closes for `longpress`', () => {
+        beforeEach(async function () {
+            this.el = await fixture<OverlayTrigger>(longpress());
+            this.trigger = this.el.querySelector(
+                'sp-action-button'
+            ) as ActionButton;
+            this.tooltip = this.el.querySelector(
+                '[slot="hover-content"]'
+            ) as Tooltip;
+            this.content = this.el.querySelector(
+                '[slot="longpress-content"]'
+            ) as Popover;
+
+            expect(this.trigger).to.not.be.null;
+            expect(this.content).to.not.be.null;
+            expect(this.content.open).to.be.false;
+        });
         it('opens/closes for `longpress` with Button', async function () {
-            this.tooltip.placement = 'bottom-start';
             await elementUpdated(this.tooltip);
             const button = document.createElement('sp-button');
             button.slot = 'trigger';
-            this.trigger.remove();
+            button.textContent = 'Longpress button';
+            this.trigger.replaceWith(button);
             await elementUpdated(this.el);
-            this.el.append(button);
-            await elementUpdated(this.el);
-            // Inject synthetic wait to afford for late replacement of <sp-action-button> with <button>
-            await nextFrame();
-            await nextFrame();
+            await elementUpdated(button);
+            // Inject synthetic wait to afford for late replacement of <sp-action-button> with <sp-button>
+            await waitUntil(() => {
+                const localName = (
+                    this.el as unknown as { targetContent: HTMLElement[] }
+                ).targetContent[0].localName;
+                return localName === 'sp-button';
+            });
 
             let open = oneEvent(this.el, 'sp-opened');
             const rect = button.getBoundingClientRect();

--- a/packages/overlay/test/overlay-update.test.ts
+++ b/packages/overlay/test/overlay-update.test.ts
@@ -13,9 +13,13 @@ import { elementUpdated, expect, oneEvent } from '@open-wc/testing';
 import { AccordionItem } from '@spectrum-web-components/accordion/src/AccordionItem.js';
 import { OverlayTrigger } from '../src/OverlayTrigger.js';
 import { accordion } from '../stories/overlay.stories.js';
-import { fixture } from '../../../test/testing-helpers.js';
+import {
+    fixture,
+    ignoreResizeObserverLoopError,
+} from '../../../test/testing-helpers.js';
 
 describe('sp-update-overlays event', () => {
+    ignoreResizeObserverLoopError(before, after);
     it('updates overlay height', async () => {
         const el = await fixture<OverlayTrigger>(accordion());
         const container = el.querySelector('sp-popover') as HTMLElement;

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -136,7 +136,7 @@ export function ignoreResizeObserverLoopError(
         globalErrorHandler = window.onerror;
         addEventListener('error', (error) => {
             console.error('Uncaught global error:', error);
-            if (error.message?.match?.(/ResizeObserver loop limit exceeded/)) {
+            if (error.message?.match?.(/ResizeObserver loop/)) {
                 return;
             } else {
                 globalErrorHandler?.(error);


### PR DESCRIPTION
## Description
Remove the need for `Overlay.update()` by binding multiple `autoUpdate` listeners with different settings.
- clean up consumption of `<sp-popover>` in Overlay Element stories

## Related issue(s)
- fixes #3809

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://overlay-update--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--accordion)
    2. Open the overlay
    3. Open various Accordion Items
    4. See that through it all the size of the overlay is updated

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.