### PR TITLE
fix(overlay): surface "overlay" property to "sp-opened" and "sp-closed" events

### DIFF
--- a/packages/overlay/README.md
+++ b/packages/overlay/README.md
@@ -183,7 +183,19 @@ The `type` of an Overlay outlines a number of things about the interaction model
 
 ### Events
 
-When fully open the `<sp-overlay>` element will dispatch the `sp-opened` event, and when fully closed the `sp-closed` event will be dispatched. "Fully" in this context means that all CSS transitions that have dispatched `transitionrun` events on the direct children of the `<sp-overlay>` element have successfully dispatched their `transitionend` or `transitioncancel` event. Keep in mind the following:
+When fully open the `<sp-overlay>` element will dispatch the `sp-opened` event, and when fully closed the `sp-closed` event will be dispatched. Both of these events are of type:
+
+```ts
+type OverlayStateEvent = Event & {
+    overlay: Overlay;
+};
+```
+
+The `overlay` value in this case will hold a reference to the actual `<sp-overlay>` that is opening or closing to trigger this event. Remember that some `<sp-overlay>` element (like those creates via the imperative API) can be transiently available in the DOM, so if you choose to build a cache of Overlay elements to some end, be sure to leverage a weak reference so that the `<sp-overlay>` can be garbage collected as desired by the browser.
+
+#### When it is "fully" open or closed?
+
+"Fully" in this context means that all CSS transitions that have dispatched `transitionrun` events on the direct children of the `<sp-overlay>` element have successfully dispatched their `transitionend` or `transitioncancel` event. Keep in mind the following:
 
 -   `transition*` events bubble; this means that while transition events on light DOM content of those direct children will be heard, those events will not be taken into account
 -   `transition*` events are not composed; this means that transition events on shadow DOM content of the direct children will not propagate to a level in the DOM where they can be heard

--- a/packages/overlay/src/AbstractOverlay.ts
+++ b/packages/overlay/src/AbstractOverlay.ts
@@ -19,6 +19,7 @@ import type {
     OverlayState,
     OverlayTypes,
     Placement,
+    TriggerInteractions,
     TriggerInteractionsV1,
 } from './overlay-types.js';
 import type { Overlay } from './Overlay.js';
@@ -51,6 +52,43 @@ export class BeforetoggleOpenEvent extends Event {
             bubbles: false,
             composed: false,
         });
+    }
+}
+
+export class OverlayStateEvent extends Event {
+    detail!: {
+        interaction: string;
+        reason?: 'external-click';
+    };
+
+    constructor(
+        type: string,
+        public overlay: HTMLElement,
+        {
+            publish,
+            interaction,
+            reason,
+        }: {
+            publish?: boolean;
+            interaction: TriggerInteractions;
+            reason?: 'external-click';
+        }
+    ) {
+        super(type, {
+            bubbles: publish,
+            composed: publish,
+        });
+        this.detail = {
+            interaction,
+            reason,
+        };
+    }
+}
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-open': OverlayStateEvent;
+        'sp-close': OverlayStateEvent;
     }
 }
 

--- a/packages/overlay/src/OverlayDialog.ts
+++ b/packages/overlay/src/OverlayDialog.ts
@@ -15,15 +15,12 @@ import {
     firstFocusableSlottedIn,
 } from '@spectrum-web-components/shared/src/first-focusable-in.js';
 import { VirtualTrigger } from './VirtualTrigger.js';
-import {
-    Constructor,
-    OpenableElement,
-    OverlayOpenCloseDetail,
-} from './overlay-types.js';
+import { Constructor, OpenableElement } from './overlay-types.js';
 import {
     BeforetoggleClosedEvent,
     BeforetoggleOpenEvent,
     guaranteedAllTransitionend,
+    OverlayStateEvent,
 } from './AbstractOverlay.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
 import { userFocusableSelector } from '@spectrum-web-components/shared';
@@ -101,10 +98,9 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
                 const eventName = targetOpenState ? 'sp-opened' : 'sp-closed';
                 if (index > 0) {
                     el.dispatchEvent(
-                        new CustomEvent<OverlayOpenCloseDetail>(eventName, {
-                            bubbles: false,
-                            composed: false,
-                            detail: { interaction: this.type },
+                        new OverlayStateEvent(eventName, this, {
+                            interaction: this.type,
+                            publish: false,
                         })
                     );
                     return;
@@ -118,23 +114,22 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
                     const hasVirtualTrigger =
                         this.triggerElement instanceof VirtualTrigger;
                     this.dispatchEvent(
-                        new Event(eventName, {
-                            bubbles: hasVirtualTrigger,
-                            composed: hasVirtualTrigger,
+                        new OverlayStateEvent(eventName, this, {
+                            interaction: this.type,
+                            publish: hasVirtualTrigger,
                         })
                     );
                     el.dispatchEvent(
-                        new Event(eventName, {
-                            bubbles: false,
-                            composed: false,
+                        new OverlayStateEvent(eventName, this, {
+                            interaction: this.type,
+                            publish: false,
                         })
                     );
                     if (this.triggerElement && !hasVirtualTrigger) {
                         (this.triggerElement as HTMLElement).dispatchEvent(
-                            new CustomEvent<OverlayOpenCloseDetail>(eventName, {
-                                bubbles: true,
-                                composed: true,
-                                detail: { interaction: this.type },
+                            new OverlayStateEvent(eventName, this, {
+                                interaction: this.type,
+                                publish: true,
                             })
                         );
                     }

--- a/packages/overlay/src/OverlayNoPopover.ts
+++ b/packages/overlay/src/OverlayNoPopover.ts
@@ -15,16 +15,13 @@ import {
 } from '@spectrum-web-components/shared/src/first-focusable-in.js';
 import type { SpectrumElement } from '@spectrum-web-components/base';
 import { VirtualTrigger } from './VirtualTrigger.js';
-import {
-    Constructor,
-    OpenableElement,
-    OverlayOpenCloseDetail,
-} from './overlay-types.js';
+import { Constructor, OpenableElement } from './overlay-types.js';
 import {
     BeforetoggleClosedEvent,
     BeforetoggleOpenEvent,
     forcePaint,
     guaranteedAllTransitionend,
+    OverlayStateEvent,
     overlayTimer,
 } from './AbstractOverlay.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
@@ -100,10 +97,8 @@ export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
                 }
                 const eventName = targetOpenState ? 'sp-opened' : 'sp-closed';
                 el.dispatchEvent(
-                    new CustomEvent<OverlayOpenCloseDetail>(eventName, {
-                        bubbles: false,
-                        composed: false,
-                        detail: { interaction: this.type },
+                    new OverlayStateEvent(eventName, this, {
+                        interaction: this.type,
                     })
                 );
                 if (index > 0) {
@@ -112,17 +107,16 @@ export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
                 const hasVirtualTrigger =
                     this.triggerElement instanceof VirtualTrigger;
                 this.dispatchEvent(
-                    new Event(eventName, {
-                        bubbles: hasVirtualTrigger,
-                        composed: hasVirtualTrigger,
+                    new OverlayStateEvent(eventName, this, {
+                        interaction: this.type,
+                        publish: hasVirtualTrigger,
                     })
                 );
                 if (this.triggerElement && !hasVirtualTrigger) {
                     (this.triggerElement as HTMLElement).dispatchEvent(
-                        new CustomEvent<OverlayOpenCloseDetail>(eventName, {
-                            bubbles: true,
-                            composed: true,
-                            detail: { interaction: this.type },
+                        new OverlayStateEvent(eventName, this, {
+                            interaction: this.type,
+                            publish: true,
                         })
                     );
                 }

--- a/packages/overlay/src/OverlayPopover.ts
+++ b/packages/overlay/src/OverlayPopover.ts
@@ -15,16 +15,13 @@ import {
 } from '@spectrum-web-components/shared/src/first-focusable-in.js';
 import type { SpectrumElement } from '@spectrum-web-components/base';
 import { VirtualTrigger } from './VirtualTrigger.js';
-import {
-    Constructor,
-    OpenableElement,
-    OverlayOpenCloseDetail,
-} from './overlay-types.js';
+import { Constructor, OpenableElement } from './overlay-types.js';
 import {
     BeforetoggleClosedEvent,
     BeforetoggleOpenEvent,
     guaranteedAllTransitionend,
     nextFrame,
+    OverlayStateEvent,
     overlayTimer,
 } from './AbstractOverlay.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
@@ -173,10 +170,9 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
                         : 'sp-closed';
                     if (index > 0) {
                         el.dispatchEvent(
-                            new CustomEvent<OverlayOpenCloseDetail>(eventName, {
-                                bubbles: false,
-                                composed: false,
-                                detail: { interaction: this.type },
+                            new OverlayStateEvent(eventName, this, {
+                                interaction: this.type,
+                                publish: false,
                             })
                         );
                         return;
@@ -189,28 +185,23 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
                         const hasVirtualTrigger =
                             this.triggerElement instanceof VirtualTrigger;
                         this.dispatchEvent(
-                            new Event(eventName, {
-                                bubbles: hasVirtualTrigger,
-                                composed: hasVirtualTrigger,
+                            new OverlayStateEvent(eventName, this, {
+                                interaction: this.type,
+                                publish: hasVirtualTrigger,
                             })
                         );
                         el.dispatchEvent(
-                            new CustomEvent<OverlayOpenCloseDetail>(eventName, {
-                                bubbles: false,
-                                composed: false,
-                                detail: { interaction: this.type },
+                            new OverlayStateEvent(eventName, this, {
+                                interaction: this.type,
+                                publish: false,
                             })
                         );
                         if (this.triggerElement && !hasVirtualTrigger) {
                             (this.triggerElement as HTMLElement).dispatchEvent(
-                                new CustomEvent<OverlayOpenCloseDetail>(
-                                    eventName,
-                                    {
-                                        bubbles: true,
-                                        composed: true,
-                                        detail: { interaction: this.type },
-                                    }
-                                )
+                                new OverlayStateEvent(eventName, this, {
+                                    interaction: this.type,
+                                    publish: true,
+                                })
                             );
                         }
                         this.state = targetOpenState ? 'opened' : 'closed';

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -69,13 +69,6 @@ export type OverlayOptionsV1 = {
     virtualTrigger?: VirtualTrigger;
 };
 
-declare global {
-    interface GlobalEventHandlersEventMap {
-        'sp-open': CustomEvent<OverlayOpenCloseDetail>;
-        'sp-close': CustomEvent<OverlayOpenCloseDetail>;
-    }
-}
-
 export type OpenableElement = HTMLElement & {
     open: boolean;
     tipElement?: HTMLElement;

--- a/packages/overlay/test/overlay-element.test.ts
+++ b/packages/overlay/test/overlay-element.test.ts
@@ -813,7 +813,8 @@ describe('sp-overlay', () => {
 
                 const opened = oneEvent(el, 'sp-opened');
                 el.open = true;
-                await opened;
+                let { overlay } = await opened;
+                expect(el === overlay).to.be.true;
 
                 await sendMouse({
                     steps: [
@@ -830,7 +831,8 @@ describe('sp-overlay', () => {
 
                 const closed = oneEvent(el, 'sp-closed');
                 el.open = false;
-                await closed;
+                ({ overlay } = await closed);
+                expect(el === overlay).to.be.true;
 
                 expect(el.open).to.be.false;
             });


### PR DESCRIPTION
## Description
While bubbling `sp-opened` and `sp-closed` events can be tracked to their source via the `event.composedPath()[0]` API, when these events are not bubbling they are a notification of something that happened elsewhere and it is difficult to resolve where in fact that work happened/is happening. This adds an `overlay` property to the events dispatched with type `sp-opened` and `sp-closed`.

While this moves from a `CustomEvent` to an `extends Event {}` implementation, I am attempting to reduce breaks/type collisions by leaving the data previously available on these events in the `detail` property and adding only the `overlay` property to the class of the new event. The previous values could be duplicated to the class as well, for simpler consumption in the future, if that felt appropriatel.

**To do**
- [x] update documentation with this new inclusion

## Related issue(s)
- fixes #2939

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://overlay-reference--spectrum-web-components.netlify.app/storybook/index.html?path=/story/overlay--deep-nesting)
    2. Inspect the `<sp-theme>` on this page
    3. Add this event listener `$0.addEventListener('sp-opened', e => console.log(event.overlay))`
    4. Start opening overlays
    5. See that each overlay that opens references a different `sp-overlay` element

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
