### PR TITLE
fix(top-nav): allow consumers to "ignore-url-parts" or "search" or "hash"

### DIFF
--- a/packages/top-nav/src/TopNav.ts
+++ b/packages/top-nav/src/TopNav.ts
@@ -51,6 +51,15 @@ export class TopNav extends SizedMixin(SpectrumElement) {
     @property({ type: String })
     public label = '';
 
+    /**
+     * A space separated list of part of the URL to ignore when matching
+     * for the "selected" Top Nav Item. Currently supported values are
+     * `hash` and `search`, which will remove the `#hash` and
+     * `?search=value` respectively.
+     */
+    @property({ attribute: 'ignore-url-parts' })
+    public ignoreURLParts = '';
+
     @property()
     public selectionIndicatorStyle = noSelectionStyle;
 
@@ -118,9 +127,15 @@ export class TopNav extends SizedMixin(SpectrumElement) {
         this.items = this.slotEl
             .assignedElements({ flatten: true })
             .filter((el) => el.localName === 'sp-top-nav-item') as TopNavItem[];
-        const selectedChild = this.items.find(
-            (item) => item.value === window.location.href
-        );
+        let { href } = window.location;
+        const ignoredURLParts = this.ignoreURLParts.split(' ');
+        if (ignoredURLParts.includes('hash')) {
+            href = href.replace(window.location.hash, '');
+        }
+        if (ignoredURLParts.includes('search')) {
+            href = href.replace(window.location.search, '');
+        }
+        const selectedChild = this.items.find((item) => item.value === href);
         if (selectedChild) {
             this.selectTarget(selectedChild);
         } else {

--- a/packages/top-nav/stories/top-nav.stories.ts
+++ b/packages/top-nav/stories/top-nav.stories.ts
@@ -64,14 +64,15 @@ export const Default = (): TemplateResult => {
 };
 
 export const Selected = (): TemplateResult => {
-    const { href } = location;
+    let { href } = location;
+    href = href.replace(location.search, '');
     /**
      * The location's `href` is leveraged as the value of "Page 3" here
      * so that within the default Storybook UI there can be a `href` attribute
      * driven "selection" that ensures the delivery of a visible selection.
      */
     return html`
-        <sp-top-nav>
+        <sp-top-nav ignore-url-parts="search">
             <sp-top-nav-item href="#">Site Name</sp-top-nav-item>
             <sp-top-nav-item href="#page-1" style="margin-inline-start: auto;">
                 Page 1


### PR DESCRIPTION
## Description
Add `ignore-url-parts` attribute and `ignoreURLParts` property that accept a space separated list of things to remove from the URL when comparing for the "selected" item in a Top Nav. Values of `hash` and `search` are currently supported.

This makes it so that consumers can opt-in to which part of the URL they would like their "selected" Top Nav Item to be matched against.

## Related issue(s)
- fixes #1983

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://top-nav-search--spectrum-web-components.netlify.app/storybook/iframe.html?id=top-nav--selected&viewMode=story#test)
    2. See that the selected item in the Top Nav does not include the `search` params in its `href`.

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.