### PR TITLE
fix(combobox): add support for external tooltip elements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c0dc478a43f6c75df5171bf1fbea37cad9cba1c9
+        default: cd59af5fc3fb16d2c5e42f5c65ae90f247fc2eb6
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -35,6 +35,7 @@ import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/picker-button/sp-picker-button.js';
 import { Textfield } from '@spectrum-web-components/textfield';
+import type { Tooltip } from '@spectrum-web-components/tooltip';
 
 import styles from './combobox.css.js';
 import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
@@ -93,6 +94,8 @@ export class Combobox extends Textfield {
      **/
     @property({ type: Array })
     public optionEls: MenuItem[] = [];
+
+    protected tooltipEl?: Tooltip;
 
     // { value: "String thing", id: "string1" }
     public override focus(): void {
@@ -163,6 +166,14 @@ export class Combobox extends Textfield {
                 childList: true,
             });
         });
+    }
+
+    protected handleTooltipSlotchange(
+        event: Event & { target: HTMLSlotElement }
+    ): void {
+        this.tooltipEl = event.target.assignedElements()[0] as
+            | Tooltip
+            | undefined;
     }
 
     public setOptionsFromSlottedItems(): void {
@@ -337,6 +348,9 @@ export class Combobox extends Textfield {
 
     protected override render(): TemplateResult {
         const width = (this.input || this).offsetWidth;
+        if (this.tooltipEl) {
+            this.tooltipEl.disabled = this.open;
+        }
         return html`
             ${super.render()}
             <sp-picker-button
@@ -367,7 +381,7 @@ export class Combobox extends Textfield {
                 >
                     <sp-menu
                         @change=${this.handleMenuChange}
-                        tabindex="0"
+                        tabindex="-1"
                         aria-labelledby="label"
                         id="listbox-menu"
                         role="listbox"
@@ -401,6 +415,12 @@ export class Combobox extends Textfield {
                     </sp-menu>
                 </sp-popover>
             </sp-overlay>
+            <slot
+                aria-hidden="true"
+                name="tooltip"
+                id="tooltip"
+                @slotchange=${this.handleTooltipSlotchange}
+            ></slot>
         `;
     }
 

--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -234,24 +234,17 @@ export class Combobox extends Textfield {
         this.open = true;
     }
 
-    public handleListPointerenter(event: PointerEvent): void {
-        const descendent = event
-            .composedPath()
-            .find((el) => typeof (el as MenuItem).value !== 'undefined');
-        if (descendent) this.activeDescendent = descendent as MenuItem;
-    }
-
-    public handleListPointerleave(): void {
-        this.activeDescendent = undefined;
-    }
-
-    public handleMenuChange(event: PointerEvent & { target: Menu }): void {
+    protected handleMenuChange(event: PointerEvent & { target: Menu }): void {
         const { target } = event;
         this.value = target.selected[0];
         event.preventDefault();
         this.open = false;
         this._returnItems();
         this.focus();
+    }
+
+    public handleClosed(): void {
+        this.open = false;
     }
 
     public handleOpened(): void {
@@ -270,16 +263,6 @@ export class Combobox extends Textfield {
             this.filterAvailableOptions();
         }
         return super.shouldUpdate(changed);
-    }
-
-    private positionListbox(): void {
-        const targetRect = this.overlay.getBoundingClientRect();
-        const rootRect = this.getBoundingClientRect();
-        this.listbox.style.transform = `translate(${
-            targetRect.x - rootRect.x
-        }px, ${targetRect.y - rootRect.y}px)`;
-        this.listbox.style.height = `${targetRect.height}px`;
-        this.listbox.style.maxHeight = `${targetRect.height}px`;
     }
 
     protected override onBlur(event: FocusEvent): void {
@@ -319,9 +302,7 @@ export class Combobox extends Textfield {
                 type="text"
                 .value=${live(this.displayValue)}
                 tabindex="0"
-                @sp-closed=${() => {
-                    this.open = false;
-                }}
+                @sp-closed=${this.handleClosed}
                 @sp-opened=${this.handleOpened}
                 type=${this.type}
                 aria-describedby=${this.helpTextId}
@@ -456,9 +437,6 @@ export class Combobox extends Textfield {
         }
         if (!this.focused && this.open) {
             this.open = false;
-        }
-        if (changed.has('value')) {
-            if (this.overlay && this.open) this.positionListbox();
         }
         if (changed.has('activeDescendent')) {
             if (changed.get('activeDescendent')) {

--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -48,6 +48,7 @@ export type ComboboxOption = {
 
 /**
  * @element sp-combobox
+ * @slot tooltip - Tooltip to to be applied to the the Picker Button
  */
 export class Combobox extends Textfield {
     public static override get styles(): CSSResultArray {

--- a/packages/combobox/stories/combobox.stories.ts
+++ b/packages/combobox/stories/combobox.stories.ts
@@ -13,8 +13,9 @@ governing permissions and limitations under the License.
 import { html, TemplateResult } from '@spectrum-web-components/base';
 
 import { ComboboxOption } from '..';
-import '../sp-combobox.js';
-import '../sp-combobox-item.js';
+import '@spectrum-web-components/combobox/sp-combobox.js';
+import '@spectrum-web-components/combobox/sp-combobox-item.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
 
 export default {
     title: 'Combobox',
@@ -156,6 +157,28 @@ export const kerningLightDOM = (): TemplateResult => {
                     </sp-menu-item>
                 `
             )}
+        </sp-combobox>
+    `;
+};
+
+export const withTooltip = (): TemplateResult => {
+    return html`
+        <sp-combobox
+            .autocomplete=${'none'}
+            id="combobox-6"
+            label="Kerning"
+            style="min-width: 80px;--spectrum-textfield-m-min-width:0;width:100px;"
+        >
+            ${optionsL.map(
+                (option) => html`
+                    <sp-menu-item id=${option.id} value=${option.value}>
+                        ${option.value}
+                    </sp-menu-item>
+                `
+            )}
+            <sp-tooltip slot="tooltip" self-managed placement="right" open>
+                Kerning
+            </sp-tooltip>
         </sp-combobox>
     `;
 };

--- a/packages/combobox/test/combobox.data.test.ts
+++ b/packages/combobox/test/combobox.data.test.ts
@@ -13,14 +13,14 @@ governing permissions and limitations under the License.
 import {
     elementUpdated,
     expect,
-    fixture,
     html,
     nextFrame,
     waitUntil,
 } from '@open-wc/testing';
 
-import '../sp-combobox.js';
-import '../sp-combobox-item.js';
+import '@spectrum-web-components/combobox/sp-combobox.js';
+import '@spectrum-web-components/combobox/sp-combobox-item.js';
+import { fixture } from '../../../test/testing-helpers.js';
 import { Combobox, ComboboxOption } from '..';
 import { TestableCombobox } from './index.js';
 import { SpectrumElement, TemplateResult } from '@spectrum-web-components/base';


### PR DESCRIPTION
## Description
Allow an `<sp-tooltip>` to be addressed to the `tooltip` slot of an `<sp-combobox>`.

It doesn't look 100% accessible at current, but we'll revisit that aspect in the a11y audit coming up for this element.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://combobox-tooltip--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--with-tooltip)
    2. Hover in and out of the Combobox
    3. See the Tooltip open/close

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.