### PR TITLE
fix(picker,action-menu,split- button): update interaction model

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -107,7 +107,6 @@ export class ActionMenu extends ObserveSlotPresence(
                 @blur=${this.handleButtonBlur}
                 @pointerdown=${this.handleButtonPointerdown}
                 @focus=${this.handleButtonFocus}
-                @click=${this.handleButtonClick}
                 @keydown=${{
                     handleEvent: this.handleEnterKeydown,
                     capture: true,

--- a/packages/action-menu/src/action-menu.css
+++ b/packages/action-menu/src/action-menu.css
@@ -84,3 +84,7 @@ governing permissions and limitations under the License.
     ); /* .spectrum-ActionButton-hold+.spectrum-ActionButton-icon,
    * .spectrum-ActionButton-icon:only-child */
 }
+
+sp-overlay:not(:defined) {
+    display: none;
+}

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -14,7 +14,6 @@ import {
     aTimeout,
     elementUpdated,
     expect,
-    fixture,
     html,
     nextFrame,
     oneEvent,
@@ -26,8 +25,8 @@ import { spy } from 'sinon';
 import { ActionMenu } from '@spectrum-web-components/action-menu';
 import type { Menu, MenuItem } from '@spectrum-web-components/menu';
 import {
+    fixture,
     ignoreResizeObserverLoopError,
-    fixture as styledFixture,
 } from '../../../test/testing-helpers.js';
 import '@spectrum-web-components/dialog/sp-dialog-base.js';
 import { tooltipDescriptionAndPlacement } from '../stories/action-menu.stories';
@@ -297,13 +296,66 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             const el = await actionMenuFixture();
 
             const button = el.button as HTMLButtonElement;
+            expect(button).to.have.attribute('aria-haspopup', 'true');
+            expect(button).to.not.have.attribute('aria-expanded', 'true');
+            expect(button).to.not.have.attribute('aria-controls', 'menu');
 
-            button.click();
+            el.click();
             await elementUpdated(el);
             expect(el.open).to.be.true;
             expect(button).to.have.attribute('aria-haspopup', 'true');
             expect(button).to.have.attribute('aria-expanded', 'true');
             expect(button).to.have.attribute('aria-controls', 'menu');
+        });
+        it('opens and selects in a single pointer button interaction', async () => {
+            const el = await actionMenuFixture();
+            const thirdItem = el.querySelector(
+                'sp-menu-item:nth-of-type(3)'
+            ) as MenuItem;
+            const boundingRect = el.button.getBoundingClientRect();
+
+            expect(el.value).to.not.equal(thirdItem.value);
+            const opened = oneEvent(el, 'sp-opened');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            boundingRect.x + boundingRect.width / 2,
+                            boundingRect.y + boundingRect.height / 2,
+                        ],
+                    },
+                    {
+                        type: 'down',
+                    },
+                ],
+            });
+            await opened;
+
+            const thirdItemRect = thirdItem.getBoundingClientRect();
+            const closed = oneEvent(el, 'sp-closed');
+            let selected = '';
+            el.addEventListener('change', (event: Event) => {
+                selected = (event.target as ActionMenu).value;
+            });
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            thirdItemRect.x + thirdItemRect.width / 2,
+                            thirdItemRect.y + thirdItemRect.height / 2,
+                        ],
+                    },
+                    {
+                        type: 'up',
+                    },
+                ],
+            });
+            await closed;
+
+            expect(el.open).to.be.false;
+            expect(selected).to.equal(thirdItem.value);
         });
         it('has attribute aria-describedby', async () => {
             const name = 'sp-picker';
@@ -324,9 +376,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
         it('opens unmeasured with deprecated syntax', async () => {
             const el = await deprecatedActionMenuFixture();
 
-            const button = el.button as HTMLButtonElement;
-
-            button.click();
+            el.click();
             await elementUpdated(el);
             expect(el.open).to.be.true;
         });
@@ -415,7 +465,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
                     });
                 }
             };
-            const root = await styledFixture<ActionMenu>(html`
+            const root = await fixture<ActionMenu>(html`
                 <sp-action-menu label="More Actions" @change=${handleChange}>
                     <sp-menu-item>One</sp-menu-item>
                     <sp-menu-item selected value="test" id="root-selected-item">
@@ -493,7 +543,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
         });
         it('shows tooltip', async function () {
             const openSpy = spy();
-            const el = await styledFixture<ActionMenu>(
+            const el = await fixture<ActionMenu>(
                 tooltipDescriptionAndPlacement(
                     tooltipDescriptionAndPlacement.args
                 )
@@ -513,7 +563,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
 
             expect(overlay.triggerElement === el.button).to.be.true;
             let open = oneEvent(tooltip, 'sp-opened');
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
                         position: [
@@ -530,7 +580,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
 
             const close = oneEvent(tooltip, 'sp-closed');
             open = oneEvent(el, 'sp-opened');
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
                         position: [
@@ -566,12 +616,16 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
 
             expect(openSpy.callCount).to.equal(1);
         });
-        it('opens, then closes, on subsequent clicks', async () => {
+        it('opens, then closes, on subsequent clicks', async function () {
+            this.retries(0);
             const el = await actionMenuFixture();
             const rect = el.getBoundingClientRect();
 
+            await nextFrame();
+            await nextFrame();
+
             const open = oneEvent(el, 'sp-opened');
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
                         position: [
@@ -589,7 +643,7 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             expect(el.open).to.be.true;
 
             const close = oneEvent(el, 'sp-closed');
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
                         position: [

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -309,6 +309,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
         );
 
         this.addEventListener('click', this.handleClick);
+        this.addEventListener('pointerup', this.handlePointerup);
         this.addEventListener('focusin', this.handleFocusin);
         this.addEventListener('blur', this.handleBlur);
         this.addEventListener('sp-opened', this.handleSubmenuOpened);
@@ -338,7 +339,24 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
         }
     }
 
+    private willSynthesizeClick = 0;
+
     private handleClick(event: Event): void {
+        if (this.willSynthesizeClick) {
+            cancelAnimationFrame(this.willSynthesizeClick);
+            return;
+        }
+        this.handlePointerBasedSelection(event);
+    }
+
+    private handlePointerup(event: Event): void {
+        this.willSynthesizeClick = requestAnimationFrame(() => {
+            event.target?.dispatchEvent(new Event('click'));
+        });
+        this.handlePointerBasedSelection(event);
+    }
+
+    private handlePointerBasedSelection(event: Event): void {
         const path = event.composedPath();
         const target = path.find((el) => {
             /* c8 ignore next 3 */

--- a/packages/menu/test/menu-selects.test.ts
+++ b/packages/menu/test/menu-selects.test.ts
@@ -16,12 +16,13 @@ import { Menu, MenuGroup, MenuItem } from '@spectrum-web-components/menu';
 import {
     elementUpdated,
     expect,
-    fixture,
     html,
+    nextFrame,
     oneEvent,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import { spy } from 'sinon';
+import { fixture } from '../../../test/testing-helpers.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('Menu [selects]', () => {
@@ -38,26 +39,23 @@ describe('Menu [selects]', () => {
             `
         );
         options = [...el.querySelectorAll('sp-menu-item')] as MenuItem[];
+        await Promise.all(options.map((option) => option.updateComplete));
+        await nextFrame();
+        await nextFrame();
     });
     describe('fires `change` events', async () => {
         it('on browser clicks', async () => {
             const item1 = options[0];
             const boundingRect = item1.getBoundingClientRect();
             const change = oneEvent(el, 'change');
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
-                        type: 'move',
+                        type: 'click',
                         position: [
                             boundingRect.x + boundingRect.width / 2,
                             boundingRect.y + boundingRect.height / 2,
                         ],
-                    },
-                    {
-                        type: 'down',
-                    },
-                    {
-                        type: 'up',
                     },
                 ],
             });
@@ -165,26 +163,23 @@ describe('Menu [selects] w/ group', () => {
             `
         );
         options = [...el.querySelectorAll('sp-menu-item')] as MenuItem[];
+        await Promise.all(options.map((option) => option.updateComplete));
+        await nextFrame();
+        await nextFrame();
     });
     describe('fires `change` events', async () => {
         it('on browser clicks', async () => {
             const item1 = options[0];
             const boundingRect = item1.getBoundingClientRect();
             const change = oneEvent(el, 'change');
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
-                        type: 'move',
+                        type: 'click',
                         position: [
                             boundingRect.x + boundingRect.width / 2,
                             boundingRect.y + boundingRect.height / 2,
                         ],
-                    },
-                    {
-                        type: 'down',
-                    },
-                    {
-                        type: 'up',
                     },
                 ],
             });
@@ -293,26 +288,23 @@ describe('Menu w/ group [selects]', () => {
         );
         group = el.querySelector('sp-menu-group') as MenuGroup;
         options = [...el.querySelectorAll('sp-menu-item')] as MenuItem[];
+        await Promise.all(options.map((option) => option.updateComplete));
+        await nextFrame();
+        await nextFrame();
     });
     describe('fires `change` events', async () => {
         it('on browser clicks', async () => {
             const item1 = options[0];
             const boundingRect = item1.getBoundingClientRect();
             const change = oneEvent(group, 'change');
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
-                        type: 'move',
+                        type: 'click',
                         position: [
                             boundingRect.x + boundingRect.width / 2,
                             boundingRect.y + boundingRect.height / 2,
                         ],
-                    },
-                    {
-                        type: 'down',
-                    },
-                    {
-                        type: 'up',
                     },
                 ],
             });
@@ -430,6 +422,9 @@ describe('Menu w/ groups [selects]', () => {
         groupA = el.querySelector('sp-menu-group:first-child') as MenuGroup;
         groupB = el.querySelector('sp-menu-group:last-child') as MenuGroup;
         options = [...el.querySelectorAll('sp-menu-item')] as MenuItem[];
+        await Promise.all(options.map((option) => option.updateComplete));
+        await nextFrame();
+        await nextFrame();
     });
     describe('fires `change` events', async () => {
         it('on browser clicks', async () => {
@@ -439,20 +434,14 @@ describe('Menu w/ groups [selects]', () => {
             expect(groupA.value).to.equal('');
             expect(groupB.value).to.equal('');
             let change = oneEvent(el, 'change');
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
-                        type: 'move',
+                        type: 'click',
                         position: [
                             boundingRectA.x + boundingRectA.width / 2,
                             boundingRectA.y + boundingRectA.height / 2,
                         ],
-                    },
-                    {
-                        type: 'down',
-                    },
-                    {
-                        type: 'up',
                     },
                 ],
             });
@@ -462,20 +451,14 @@ describe('Menu w/ groups [selects]', () => {
             expect(groupB.value).to.equal('');
             change = oneEvent(el, 'change');
             const boundingRectB = item1b.getBoundingClientRect();
-            sendMouse({
+            await sendMouse({
                 steps: [
                     {
-                        type: 'move',
+                        type: 'click',
                         position: [
                             boundingRectB.x + boundingRectB.width / 2,
                             boundingRectB.y + boundingRectB.height / 2,
                         ],
-                    },
-                    {
-                        type: 'down',
-                    },
-                    {
-                        type: 'up',
                     },
                 ],
             });

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -17,17 +17,13 @@ import {
     aTimeout,
     elementUpdated,
     expect,
-    fixture,
     html,
     nextFrame,
     oneEvent,
 } from '@open-wc/testing';
-import '@spectrum-web-components/theme/sp-theme.js';
-import '@spectrum-web-components/theme/src/themes.js';
+import { fixture } from '../../../test/testing-helpers.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import { spy } from 'sinon';
-import { Theme } from '@spectrum-web-components/theme';
-import { TemplateResult } from '@spectrum-web-components/base';
 import { sendKeys } from '@web/test-runner-commands';
 import { ActionMenu } from '@spectrum-web-components/action-menu';
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
@@ -35,55 +31,11 @@ import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/overlay/sp-overlay.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
 
-async function styledFixture<T extends Element>(
-    story: TemplateResult,
-    dir: 'ltr' | 'rtl' | 'auto' = 'ltr'
-): Promise<T> {
-    const test = await fixture<Theme>(html`
-        <sp-theme dir=${dir} scale="medium" color="light">
-            ${story}
-            <style>
-                sp-theme {
-                    --spectrum-global-animation-duration-100: 50ms;
-                    --spectrum-global-animation-duration-200: 50ms;
-                    --spectrum-global-animation-duration-300: 50ms;
-                    --spectrum-global-animation-duration-400: 50ms;
-                    --spectrum-global-animation-duration-500: 50ms;
-                    --spectrum-global-animation-duration-600: 50ms;
-                    --spectrum-global-animation-duration-700: 50ms;
-                    --spectrum-global-animation-duration-800: 50ms;
-                    --spectrum-global-animation-duration-900: 50ms;
-                    --spectrum-global-animation-duration-1000: 50ms;
-                    --spectrum-global-animation-duration-2000: 50ms;
-                    --spectrum-global-animation-duration-4000: 50ms;
-                    --spectrum-animation-duration-0: 50ms;
-                    --spectrum-animation-duration-100: 50ms;
-                    --spectrum-animation-duration-200: 50ms;
-                    --spectrum-animation-duration-300: 50ms;
-                    --spectrum-animation-duration-400: 50ms;
-                    --spectrum-animation-duration-500: 50ms;
-                    --spectrum-animation-duration-600: 50ms;
-                    --spectrum-animation-duration-700: 50ms;
-                    --spectrum-animation-duration-800: 50ms;
-                    --spectrum-animation-duration-900: 50ms;
-                    --spectrum-animation-duration-1000: 50ms;
-                    --spectrum-animation-duration-2000: 50ms;
-                    --spectrum-animation-duration-4000: 50ms;
-                    --spectrum-coachmark-animation-indicator-ring-duration: 50ms;
-                    --swc-test-duration: 1ms;
-                }
-            </style>
-        </sp-theme>
-    `);
-    document.documentElement.dir = dir;
-    return test.children[0] as T;
-}
-
 describe('Submenu', () => {
     it('selects - pointer', async () => {
         const rootChanged = spy();
         const submenuChanged = spy();
-        const el = await styledFixture<Menu>(
+        const el = await fixture<Menu>(
             html`
                 <sp-menu
                     @change=${(event: Event & { target: Menu }) => {
@@ -121,7 +73,7 @@ describe('Submenu', () => {
         expect(rootItem.open).to.be.false;
 
         const opened = oneEvent(rootItem, 'sp-opened');
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -142,7 +94,7 @@ describe('Submenu', () => {
         const item2BoundingRect = item2.getBoundingClientRect();
 
         const closed = oneEvent(rootItem, 'sp-closed');
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'click',
@@ -155,8 +107,10 @@ describe('Submenu', () => {
         });
         await closed;
 
-        expect(submenuChanged.withArgs('Two').calledOnce, 'submenu changed').to
-            .be.true;
+        expect(
+            submenuChanged.withArgs('Two').calledOnce,
+            `submenu changed ${submenuChanged.callCount} times`
+        ).to.be.true;
         expect(rootChanged.withArgs('Has submenu').calledOnce, 'root changed')
             .to.be.true;
     });
@@ -164,7 +118,7 @@ describe('Submenu', () => {
         const rootChanged = spy();
         const submenuChanged = spy();
         const subSubmenuChanged = spy();
-        const el = await styledFixture<Menu>(
+        const el = await fixture<Menu>(
             html`
                 <sp-menu
                     @change=${(event: Event & { target: Menu }) => {
@@ -219,7 +173,7 @@ describe('Submenu', () => {
 
         let opened = oneEvent(rootItem, 'sp-opened');
         // Hover the root menu item to open a submenu
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -240,7 +194,7 @@ describe('Submenu', () => {
 
         opened = oneEvent(item2, 'sp-opened');
         // Move to the submenu item to open a submenu
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -298,7 +252,7 @@ describe('Submenu', () => {
         it(`selects - keyboard: ${testData.dir}`, async function () {
             const rootChanged = spy();
             const submenuChanged = spy();
-            const el = await styledFixture<Menu>(
+            const el = await fixture<Menu>(
                 html`
                     <sp-menu
                         id="base"
@@ -397,7 +351,7 @@ describe('Submenu', () => {
         });
     });
     it('closes on `pointerleave`', async () => {
-        const el = await styledFixture<Menu>(
+        const el = await fixture<Menu>(
             html`
                 <sp-menu>
                     <sp-menu-item class="root">
@@ -424,7 +378,7 @@ describe('Submenu', () => {
         expect(rootItem.open).to.be.false;
 
         const opened = oneEvent(rootItem, 'sp-opened');
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -442,7 +396,7 @@ describe('Submenu', () => {
         expect(rootItem.open).to.be.true;
 
         const closed = oneEvent(rootItem, 'sp-closed');
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -460,7 +414,7 @@ describe('Submenu', () => {
         expect(rootItem.open).to.be.false;
     });
     it('stays open when mousing off menu item and back again', async () => {
-        const el = await styledFixture<Menu>(
+        const el = await fixture<Menu>(
             html`
                 <sp-menu>
                     <sp-menu-item class="root">
@@ -531,7 +485,7 @@ describe('Submenu', () => {
         expect(rootItem.open).to.be.true;
 
         const closed = oneEvent(rootItem, 'sp-closed');
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -548,7 +502,7 @@ describe('Submenu', () => {
     });
     it('continues to open when mousing between menu item and submenu', async function () {
         const clickSpy = spy();
-        const el = await styledFixture<Menu>(
+        const el = await fixture<Menu>(
             html`
                 <sp-menu>
                     <sp-menu-item class="root">
@@ -623,7 +577,7 @@ describe('Submenu', () => {
         expect(rootItem.open).to.be.true;
 
         const closed = oneEvent(rootItem, 'sp-closed');
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'click',
@@ -642,7 +596,7 @@ describe('Submenu', () => {
     });
     it('stays open when mousing between menu item and submenu', async () => {
         const clickSpy = spy();
-        const el = await styledFixture<Menu>(
+        const el = await fixture<Menu>(
             html`
                 <sp-menu>
                     <sp-menu-item class="root">
@@ -712,7 +666,7 @@ describe('Submenu', () => {
         expect(rootItem.open).to.be.true;
 
         const closed = oneEvent(rootItem, 'sp-closed');
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'click',
@@ -730,7 +684,7 @@ describe('Submenu', () => {
         expect(clickSpy.callCount).to.equal(1);
     });
     it('not opens if disabled', async () => {
-        const el = await styledFixture<Menu>(
+        const el = await fixture<Menu>(
             html`
                 <sp-menu>
                     <sp-menu-item disabled class="root">
@@ -756,7 +710,7 @@ describe('Submenu', () => {
         const rootItemBoundingRect = rootItem.getBoundingClientRect();
         expect(rootItem.open).to.be.false;
 
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'move',
@@ -775,7 +729,7 @@ describe('Submenu', () => {
         expect(rootItem.open).to.be.false;
     });
     it('closes all decendent submenus when closing a ancestor menu', async () => {
-        const el = await styledFixture<ActionMenu>(html`
+        const el = await fixture<ActionMenu>(html`
             <sp-action-menu>
                 <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
                 <sp-menu-group role="none" id="group">
@@ -851,7 +805,7 @@ describe('Submenu', () => {
     });
 
     it('closes back to the first overlay without a `root` when clicking away', async function () {
-        const el = await styledFixture<ActionMenu>(html`
+        const el = await fixture<ActionMenu>(html`
             <sp-action-menu>
                 <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
                 <sp-menu-group role="none">
@@ -916,7 +870,7 @@ describe('Submenu', () => {
             oneEvent(rootMenu1, 'sp-closed'),
             oneEvent(el, 'sp-closed'),
         ]);
-        sendMouse({
+        await sendMouse({
             steps: [
                 {
                     type: 'click',
@@ -928,7 +882,7 @@ describe('Submenu', () => {
     });
 
     it('closes decendent menus when Menu Item in ancestor without a submenu is pointerentered', async () => {
-        const el = await styledFixture<ActionMenu>(html`
+        const el = await fixture<ActionMenu>(html`
             <sp-action-menu>
                 <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
                 <sp-menu-group role="none">
@@ -981,7 +935,7 @@ describe('Submenu', () => {
     });
 
     it('closes decendent menus when Menu Item in ancestor is clicked', async function () {
-        const el = await styledFixture<ActionMenu>(html`
+        const el = await fixture<ActionMenu>(html`
             <sp-action-menu>
                 <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
                 <sp-menu-group role="none">
@@ -1022,6 +976,7 @@ describe('Submenu', () => {
                 </sp-menu-group>
             </sp-action-menu>
         `);
+        await nextFrame();
         await nextFrame();
 
         const rootMenu1 = el.querySelector('#submenu-item-1') as MenuItem;
@@ -1077,7 +1032,7 @@ describe('Submenu', () => {
                 },
             ],
         });
-        const el = await styledFixture<Menu>(
+        const el = await fixture<Menu>(
             html`
                 <sp-menu>
                     <sp-menu-item class="root-1">

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -151,13 +151,24 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
         this.focused = true;
     }
 
+    public override click(): void {
+        if (this.disabled) {
+            return;
+        }
+
+        this.toggle();
+    }
+
     public handleButtonBlur(): void {
         this.focused = false;
     }
 
     protected preventNextToggle: 'no' | 'maybe' | 'yes' = 'no';
 
-    protected handleButtonPointerdown(): void {
+    protected handleButtonPointerdown(event: PointerEvent): void {
+        if (event.button !== 0) {
+            return;
+        }
         this.preventNextToggle = 'maybe';
         const cleanup = (): void => {
             document.removeEventListener('pointerup', cleanup);
@@ -170,6 +181,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
         // Ensure that however the pointer goes up we do `cleanup()`.
         document.addEventListener('pointerup', cleanup);
         document.addEventListener('pointercancel', cleanup);
+        this.handleButtonClick();
     }
 
     protected handleButtonFocus(event: FocusEvent): void {
@@ -183,7 +195,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
         }
     }
 
-    protected handleButtonClick(): void {
+    protected handleButtonClick = (): void => {
         if (this.enterKeydownOn && this.enterKeydownOn !== this.button) {
             return;
         }
@@ -191,7 +203,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
             return;
         }
         this.toggle();
-    }
+    };
 
     public override focus(options?: FocusOptions): void {
         super.focus(options);
@@ -419,6 +431,9 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .placement=${this.isMobile.matches ? undefined : this.placement}
                 .type=${this.isMobile.matches ? 'modal' : 'auto'}
                 .receivesFocus=${'true'}
+                .willPreventClose=${this.preventNextToggle !== 'no' &&
+                this.open &&
+                this.dependenciesLoaded}
                 @beforetoggle=${(
                     event: Event & {
                         target: Overlay;
@@ -473,7 +488,6 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 @blur=${this.handleButtonBlur}
                 @pointerdown=${this.handleButtonPointerdown}
                 @focus=${this.handleButtonFocus}
-                @click=${this.handleButtonClick}
                 @keydown=${{
                     handleEvent: this.handleEnterKeydown,
                     capture: true,
@@ -716,19 +730,25 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
         if (this.enterKeydownOn) {
             event.preventDefault();
             return;
-        } else {
-            this.addEventListener(
-                'keyup',
-                (keyupEvent: KeyboardEvent) => {
-                    if (keyupEvent.code !== 'Enter') {
-                        return;
-                    }
-                    this.enterKeydownOn = null;
-                },
-                { once: true }
-            );
         }
-        this.enterKeydownOn = this.enterKeydownOn || event.target;
+        this.enterKeydownOn = event.target;
+        if (this.enterKeydownOn === this.button) {
+            this.button.addEventListener('click', this.handleButtonClick);
+        }
+        this.addEventListener(
+            'keyup',
+            (keyupEvent: KeyboardEvent) => {
+                if (keyupEvent.code !== 'Enter') {
+                    return;
+                }
+                this.enterKeydownOn = null;
+                this.button.removeEventListener(
+                    'click',
+                    this.handleButtonClick
+                );
+            },
+            { once: true }
+        );
     };
 
     public override connectedCallback(): void {

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -524,6 +524,53 @@ export function runPickerTests(): void {
             expect(el.open).to.be.true;
             expect(firstItem.focused, 'still not visually focused').to.be.false;
         });
+        it('opens and selects in a single pointer button interaction', async () => {
+            await nextFrame();
+            await nextFrame();
+            const thirdItem = el.querySelector(
+                'sp-menu-item:nth-of-type(3)'
+            ) as MenuItem;
+            const boundingRect = el.button.getBoundingClientRect();
+
+            expect(el.value).to.not.equal(thirdItem.value);
+            const opened = oneEvent(el, 'sp-opened');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            boundingRect.x + boundingRect.width / 2,
+                            boundingRect.y + boundingRect.height / 2,
+                        ],
+                    },
+                    {
+                        type: 'down',
+                    },
+                ],
+            });
+            await opened;
+
+            const thirdItemRect = thirdItem.getBoundingClientRect();
+            const closed = oneEvent(el, 'sp-closed');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            thirdItemRect.x + thirdItemRect.width / 2,
+                            thirdItemRect.y + thirdItemRect.height / 2,
+                        ],
+                    },
+                    {
+                        type: 'up',
+                    },
+                ],
+            });
+            await closed;
+
+            expect(el.open).to.be.false;
+            expect(el.value).to.equal(thirdItem.value);
+        });
         it('opens/closes multiple times', async () => {
             expect(el.open).to.be.false;
             const boundingRect = el.button.getBoundingClientRect();
@@ -623,10 +670,9 @@ export function runPickerTests(): void {
             const secondItem = el.querySelector(
                 'sp-menu-item:nth-of-type(2)'
             ) as MenuItem;
-            const button = el.button as HTMLButtonElement;
 
             const opened = oneEvent(el, 'sp-opened');
-            button.click();
+            el.click();
             await opened;
 
             expect(el.open).to.be.true;
@@ -648,10 +694,9 @@ export function runPickerTests(): void {
             const secondItem = el.querySelector(
                 'sp-menu-item:nth-of-type(2)'
             ) as MenuItem;
-            const button = el.button as HTMLButtonElement;
 
             let opened = oneEvent(el, 'sp-opened');
-            button.click();
+            el.click();
             await opened;
 
             expect(el.open).to.be.true;
@@ -667,7 +712,7 @@ export function runPickerTests(): void {
             expect(el.value).to.equal('option-2');
 
             opened = oneEvent(el, 'sp-opened');
-            button.click();
+            el.click();
             await opened;
 
             expect(el.open).to.be.true;
@@ -710,10 +755,9 @@ export function runPickerTests(): void {
             const secondItem = el.querySelector(
                 'sp-menu-item:nth-of-type(2)'
             ) as MenuItem;
-            const button = el.button as HTMLButtonElement;
 
             const opened = oneEvent(el, 'sp-opened');
-            button.click();
+            el.click();
             await opened;
 
             expect(el.open).to.be.true;
@@ -743,10 +787,9 @@ export function runPickerTests(): void {
             const secondItem = el.querySelector(
                 'sp-menu-item:nth-of-type(2)'
             ) as MenuItem;
-            const button = el.button as HTMLButtonElement;
 
             const opened = oneEvent(el, 'sp-opened');
-            button.click();
+            el.click();
             await opened;
             await elementUpdated(el);
 
@@ -1129,9 +1172,7 @@ export function runPickerTests(): void {
 
             await elementUpdated(el);
 
-            const button = el.button as HTMLButtonElement;
-
-            button.click();
+            el.click();
             await elementUpdated(el);
 
             expect(el.open).to.be.false;
@@ -1355,7 +1396,7 @@ export function runPickerTests(): void {
                 ) as MenuItem;
 
                 const opened = oneEvent(el, 'sp-opened');
-                el.button.click();
+                el.click();
                 await opened;
 
                 expect(el.open).to.be.true;

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -148,7 +148,6 @@ export class SplitButton extends SizedMixin(PickerBase) {
                     @blur=${this.handleButtonBlur}
                     @pointerdown=${this.handleButtonPointerdown}
                     @focus=${this.handleButtonFocus}
-                    @click=${this.handleButtonClick}
                     @keydown=${{
                         handleEvent: this.handleEnterKeydown,
                         capture: true,

--- a/packages/split-button/src/split-button.css
+++ b/packages/split-button/src/split-button.css
@@ -81,3 +81,7 @@ sp-button {
 ::slotted(sp-menu) {
     display: none;
 }
+
+sp-overlay:not(:defined) {
+    display: none;
+}

--- a/packages/split-button/test/index.ts
+++ b/packages/split-button/test/index.ts
@@ -29,11 +29,11 @@ import moreDefaults, {
     m as more,
 } from '../stories/split-button-accent-more.stories.js';
 
-import type { Button } from '@spectrum-web-components/button';
 import type { MenuItem } from '@spectrum-web-components/menu';
 import type { SplitButton } from '@spectrum-web-components/split-button';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import { fixture } from '../../../test/testing-helpers.js';
+import { Button } from '@spectrum-web-components/button';
 
 export function runSplitButtonTests(
     wrapInDiv: (storyArgument: TemplateResult) => TemplateResult,
@@ -199,7 +199,7 @@ export function runSplitButtonTests(
         await nextFrame();
         await nextFrame();
 
-        const trigger = el.shadowRoot?.querySelector('.trigger');
+        const trigger = el.shadowRoot.querySelector('.trigger');
         expect(trigger).to.have.attribute('aria-expanded', 'false');
         expect(trigger).not.to.have.attribute('aria-controls');
 
@@ -290,6 +290,66 @@ export function runSplitButtonTests(
         expect(el.open).to.be.false;
     });
 
+    it('[type="field"] opens and selects in a single pointer button interaction', async () => {
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(
+                field({
+                    ...fieldDefaults.args,
+                    ...field.args,
+                })
+            )
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+
+        const thirdItem = el.querySelector(
+            'sp-menu-item:nth-of-type(3)'
+        ) as MenuItem;
+        const trigger = el.shadowRoot.querySelector('.trigger') as Button;
+        const boundingRect = trigger.getBoundingClientRect();
+
+        expect(el.value).to.not.equal(thirdItem.value);
+        const opened = oneEvent(el, 'sp-opened');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        boundingRect.x + boundingRect.width / 2,
+                        boundingRect.y + boundingRect.height / 2,
+                    ],
+                },
+                {
+                    type: 'down',
+                },
+            ],
+        });
+        await opened;
+
+        const thirdItemRect = thirdItem.getBoundingClientRect();
+        const closed = oneEvent(el, 'sp-closed');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        thirdItemRect.x + thirdItemRect.width / 2,
+                        thirdItemRect.y + thirdItemRect.height / 2,
+                    ],
+                },
+                {
+                    type: 'up',
+                },
+            ],
+        });
+        await closed;
+
+        expect(el.open).to.be.false;
+        expect(el.value).to.equal(thirdItem.value);
+    });
+
     it('[type="more"] toggles open/close multiple time', async () => {
         const test = await fixture<HTMLDivElement>(
             wrapInDiv(more({ ...moreDefaults.args, ...more.args }))
@@ -300,7 +360,7 @@ export function runSplitButtonTests(
         await nextFrame();
         await nextFrame();
 
-        const trigger = el.shadowRoot?.querySelector('.trigger');
+        const trigger = el.shadowRoot.querySelector('.trigger');
         expect(trigger).to.have.attribute('aria-expanded', 'false');
         expect(trigger).not.to.have.attribute('aria-controls');
 
@@ -335,6 +395,68 @@ export function runSplitButtonTests(
         expect(el.open).to.be.false;
         expect(trigger).to.have.attribute('aria-expanded', 'false');
         expect(trigger).not.to.have.attribute('aria-controls');
+    });
+
+    it('[type="more"] opens and selects in a single pointer button interaction', async () => {
+        const thirdItemSpy = spy();
+        const test = await fixture<HTMLDivElement>(
+            wrapInDiv(
+                more({
+                    ...moreDefaults.args,
+                    ...more.args,
+                    thirdItemHandler: (): void => thirdItemSpy(),
+                })
+            )
+        );
+        const el = test.querySelector('sp-split-button') as SplitButton;
+        await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
+
+        const thirdItem = el.querySelector(
+            'sp-menu-item:nth-of-type(3)'
+        ) as MenuItem;
+        const trigger = el.shadowRoot.querySelector('.trigger') as Button;
+        const boundingRect = trigger.getBoundingClientRect();
+
+        expect(el.value).to.not.equal(thirdItem.value);
+        const opened = oneEvent(el, 'sp-opened');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        boundingRect.x + boundingRect.width / 2,
+                        boundingRect.y + boundingRect.height / 2,
+                    ],
+                },
+                {
+                    type: 'down',
+                },
+            ],
+        });
+        await opened;
+
+        const thirdItemRect = thirdItem.getBoundingClientRect();
+        const closed = oneEvent(el, 'sp-closed');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        thirdItemRect.x + thirdItemRect.width / 2,
+                        thirdItemRect.y + thirdItemRect.height / 2,
+                    ],
+                },
+                {
+                    type: 'up',
+                },
+            ],
+        });
+        await closed;
+
+        expect(el.open).to.be.false;
+        expect(thirdItemSpy.callCount).to.equal(1);
     });
 
     it('[type="more"] opens, then closes, on subsequent clicks', async () => {
@@ -432,12 +554,8 @@ export function runSplitButtonTests(
         expect(el.open).to.be.false;
 
         const item3 = el.querySelector('sp-menu-item:nth-child(3)') as MenuItem;
-        const root = el.shadowRoot ? el.shadowRoot : el;
-        const toggleButton = root.querySelector(
-            '.trigger'
-        ) as HTMLButtonElement;
         const opened = oneEvent(el, 'sp-opened');
-        toggleButton.click();
+        el.click();
         await opened;
         await elementUpdated(el);
 
@@ -468,12 +586,8 @@ export function runSplitButtonTests(
         expect(el.open).to.be.false;
 
         const item3 = el.querySelector('sp-menu-item:nth-child(3)') as MenuItem;
-        const root = el.shadowRoot ? el.shadowRoot : el;
-        const toggleButton = root.querySelector(
-            '.trigger'
-        ) as HTMLButtonElement;
         const opened = oneEvent(el, 'sp-opened');
-        toggleButton.click();
+        el.click();
         await opened;
 
         expect(el.open).to.be.true;
@@ -521,9 +635,8 @@ export function runSplitButtonTests(
         expect(firstItemSpy.called, 'first called').to.be.true;
         expect(firstItemSpy.calledOnce, 'first calledOnce').to.be.true;
 
-        const trigger = (el as unknown as { trigger: Button }).trigger;
         let opened = oneEvent(el, 'sp-opened');
-        trigger.click();
+        el.click();
         await opened;
 
         await elementUpdated(el);
@@ -580,7 +693,7 @@ export function runSplitButtonTests(
         expect(secondItemSpy.calledTwice, 'second twice').to.be.true;
 
         opened = oneEvent(el, 'sp-opened');
-        trigger.click();
+        el.click();
         await opened;
         await elementUpdated(el);
 
@@ -639,11 +752,8 @@ export function runSplitButtonTests(
         expect(firstItemSpy.calledOnce, '1st called once').to.be.true;
 
         expect(el.open).to.be.false;
-        const trigger = el.shadowRoot.querySelector(
-            '.trigger'
-        ) as HTMLButtonElement;
         let opened = oneEvent(el, 'sp-opened');
-        trigger.click();
+        el.click();
         await opened;
 
         await elementUpdated(el);
@@ -661,7 +771,7 @@ export function runSplitButtonTests(
         expect(thirdItemSpy.called, '3rd called').to.be.true;
         expect(thirdItemSpy.calledOnce, '3rd called once').to.be.true;
         opened = oneEvent(el, 'sp-opened');
-        trigger.click();
+        el.click();
         await opened;
 
         await elementUpdated(el);

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -227,12 +227,45 @@ export async function isInteractive(
 }
 
 export async function fixture<T extends Element>(
-    story: TemplateResult
+    story: TemplateResult,
+    dir: 'ltr' | 'rtl' | 'auto' = 'ltr'
 ): Promise<T> {
     const test = await owcFixture<Theme>(html`
         <sp-theme theme="spectrum" scale="medium" color="light">
             ${story}
+            <style>
+                sp-theme {
+                    --spectrum-global-animation-duration-100: 50ms;
+                    --spectrum-global-animation-duration-200: 50ms;
+                    --spectrum-global-animation-duration-300: 50ms;
+                    --spectrum-global-animation-duration-400: 50ms;
+                    --spectrum-global-animation-duration-500: 50ms;
+                    --spectrum-global-animation-duration-600: 50ms;
+                    --spectrum-global-animation-duration-700: 50ms;
+                    --spectrum-global-animation-duration-800: 50ms;
+                    --spectrum-global-animation-duration-900: 50ms;
+                    --spectrum-global-animation-duration-1000: 50ms;
+                    --spectrum-global-animation-duration-2000: 50ms;
+                    --spectrum-global-animation-duration-4000: 50ms;
+                    --spectrum-animation-duration-0: 50ms;
+                    --spectrum-animation-duration-100: 50ms;
+                    --spectrum-animation-duration-200: 50ms;
+                    --spectrum-animation-duration-300: 50ms;
+                    --spectrum-animation-duration-400: 50ms;
+                    --spectrum-animation-duration-500: 50ms;
+                    --spectrum-animation-duration-600: 50ms;
+                    --spectrum-animation-duration-700: 50ms;
+                    --spectrum-animation-duration-800: 50ms;
+                    --spectrum-animation-duration-900: 50ms;
+                    --spectrum-animation-duration-1000: 50ms;
+                    --spectrum-animation-duration-2000: 50ms;
+                    --spectrum-animation-duration-4000: 50ms;
+                    --spectrum-coachmark-animation-indicator-ring-duration: 50ms;
+                    --swc-test-duration: 1ms;
+                }
+            </style>
         </sp-theme>
     `);
+    document.documentElement.dir = dir;
     return test.children[0] as T;
 }


### PR DESCRIPTION
## Description
Support opening the element's Menu and selecting one of its Menu Items with a single pointer button interaction.

## Related issue(s)
- fixes #2966

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://picker-interaction--spectrum-web-components.netlify.app/storybook/?path=/story/menu-submenu--submenu)
    2. Make sure the Action Menu is closed
    3. Pointerdown on the Action Button
    4. See that the Menu opens
    5. With the pointer STILL DOWN move to a Menu Item in the _second_ fly out Menu
    6. Release the pointer
    7. See that all of the correct "selections" were made
-   [ ] _Test case 2_
    1. Go [here](https://picker-interaction--spectrum-web-components.netlify.app/storybook/?path=/story/picker--default)
    2. Pointerdown on the Picker
    3. Keep it down
    4. See that the Menu opened
    5. Move to a Menu Item
    6. Release the pointer
    7. See that the selection is made
-   [ ] _Test case 3_ For good measure
    1. Go [here](https://picker-interaction--spectrum-web-components.netlify.app/storybook/?path=/story/picker--default)
    2. Click on the Picker
    3. See that the Menu opened
    4. Move to a Menu Item
    5. Click the Menu Item
    6. See that the selection is made

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
