### PR TITLE
fix(combobox): allow intern Menu to hold a selection when autocomplete === "none"

### DIFF
--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -367,6 +367,12 @@ export class Combobox extends Textfield {
                         aria-labelledby="label"
                         id="listbox-menu"
                         role="listbox"
+                        selects=${ifDefined(
+                            this.autocomplete === 'none' ? 'single' : undefined
+                        )}
+                        .selected=${this.autocomplete === 'none'
+                            ? [this.value]
+                            : []}
                         style="min-width: ${width}px;"
                         size=${this.size}
                     >


### PR DESCRIPTION
## Description
When there is autocomplete of some kind the 'selection' is displayed by filtering the list or so, which leaves only `autocomplete='none'` usage as benefiting from the selected item UI.

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://combobox-selects--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--kerning-light-dom)
    2. See that the Menu, when opened, displays empty padding to the start end of the inline direction
    3. Select a value via pointer or typing
    4. See that that value is given an selected ✅

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.