### PR TITLE
fix(overlay): clean position data on close

### DIFF
--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import { html, TemplateResult } from '@spectrum-web-components/base';
+import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/menu/sp-menu.js';
@@ -137,8 +138,25 @@ export default {
                 options: ['white', 'black', 'none'],
             },
         },
+        align: {
+            name: 'align',
+            type: { name: 'string', required: false },
+            description: 'Alignment of the Action Menu',
+            table: {
+                defaultValue: { summary: 'start' },
+            },
+            control: {
+                type: 'select',
+                labels: {
+                    start: 'start',
+                    end: 'end',
+                },
+            },
+            options: ['start', 'end'],
+        },
     },
     args: {
+        align: 'start',
         visibleLabel: 'More Actions',
         disabled: false,
         open: false,
@@ -150,6 +168,7 @@ export default {
 };
 
 interface StoryArgs {
+    align?: 'start' | 'end';
     visibleLabel?: string;
     disabled?: boolean;
     open?: boolean;
@@ -185,6 +204,7 @@ quiet.args = {
 };
 
 export const labelOnly = ({
+    align = 'start',
     changeHandler = (() => undefined) as (event: Event) => void,
     disabled = false,
     open = false,
@@ -202,6 +222,7 @@ export const labelOnly = ({
         }}
         .selects=${selects ? selects : undefined}
         value=${selected ? 'Select Inverse' : ''}
+        style=${ifDefined(align === 'end' ? 'float: inline-end;' : undefined)}
     >
         <span slot="label-only">Label Only</span>
         <sp-menu-item>Deselect</sp-menu-item>
@@ -248,9 +269,14 @@ customIcon.args = {
     visibleLabel: '',
 };
 
-export const submenu = (): TemplateResult => {
+export const submenu = ({ align = 'start' } = {}): TemplateResult => {
     return html`
-        <sp-action-menu label="More Actions">
+        <sp-action-menu
+            label="More Actions"
+            style=${ifDefined(
+                align === 'end' ? 'float: inline-end;' : undefined
+            )}
+        >
             <sp-menu-item>One</sp-menu-item>
             <sp-menu-item>Two</sp-menu-item>
             <sp-menu-item>
@@ -265,7 +291,7 @@ export const submenu = (): TemplateResult => {
     `;
 };
 
-export const controlled = (): TemplateResult => {
+export const controlled = ({ align = 'start' } = {}): TemplateResult => {
     const state = {
         snap: true,
         grid: false,
@@ -292,7 +318,13 @@ export const controlled = (): TemplateResult => {
         )!.textContent = `application state: ${JSON.stringify(state)}`;
     }
     return html`
-        <sp-action-menu label="View" @change=${onChange}>
+        <sp-action-menu
+            label="View"
+            @change=${onChange}
+            style=${ifDefined(
+                align === 'end' ? 'float: inline-end;' : undefined
+            )}
+        >
             <sp-menu-item value="action" @click=${() => alert('action')}>
                 Non-selectable action
             </sp-menu-item>
@@ -332,14 +364,17 @@ export const controlled = (): TemplateResult => {
 };
 
 export const groups = ({
+    align = 'start',
     onChange,
 }: {
+    align: 'start' | 'end';
     onChange(value: string): void;
 }): TemplateResult => html`
     <sp-action-menu
         @change=${({ target: { value } }: Event & { target: ActionMenu }) =>
             onChange(value)}
         open
+        style=${ifDefined(align === 'end' ? 'float: inline-end;' : undefined)}
     >
         <sp-menu-group id="cms">
             <span slot="header">cms</span>

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -22,6 +22,7 @@ import { Placement } from '@spectrum-web-components/overlay/src/overlay-types.js
 import type { ActionMenu } from '@spectrum-web-components/action-menu';
 
 export const ActionMenuMarkup = ({
+    align = 'start',
     ariaLabel = 'More Actions',
     onChange = (() => undefined) as (value: string) => void,
     changeHandler = (() => undefined) as (value: string) => void,
@@ -55,6 +56,9 @@ export const ActionMenuMarkup = ({
             }}
             .selects=${selects ? selects : undefined}
             value=${selected ? 'Select Inverse' : ''}
+            style=${ifDefined(
+                align === 'end' ? 'float: inline-end;' : undefined
+            )}
         >
             ${customIcon ? customIcon : nothing}
             ${visibleLabel

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -29,12 +29,16 @@ import {
     ignoreResizeObserverLoopError,
 } from '../../../test/testing-helpers.js';
 import '@spectrum-web-components/dialog/sp-dialog-base.js';
-import { tooltipDescriptionAndPlacement } from '../stories/action-menu.stories';
+import {
+    iconOnly,
+    tooltipDescriptionAndPlacement,
+} from '../stories/action-menu.stories.js';
 import { findDescribedNode } from '../../../test/testing-helpers-a11y.js';
 import type { Tooltip } from '@spectrum-web-components/tooltip';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import type { TestablePicker } from '../../picker/test/index.js';
 import type { Overlay } from '@spectrum-web-components/overlay';
+import { sendKeys } from '@web/test-runner-commands';
 
 ignoreResizeObserverLoopError(before, after);
 
@@ -306,6 +310,46 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             expect(button).to.have.attribute('aria-haspopup', 'true');
             expect(button).to.have.attribute('aria-expanded', 'true');
             expect(button).to.have.attribute('aria-controls', 'menu');
+        });
+        it('opens repeatedly with Menu in the correct location', async function () {
+            const el = await fixture<ActionMenu>(
+                iconOnly({
+                    ...iconOnly.args,
+                    align: 'end',
+                })
+            );
+
+            await elementUpdated(el);
+
+            el.focus();
+            await elementUpdated(el);
+            let opened = oneEvent(el, 'sp-opened');
+            await sendKeys({ press: 'ArrowRight' });
+            await sendKeys({ press: 'ArrowLeft' });
+            await sendKeys({ press: 'Space' });
+            await opened;
+
+            const firstRect = (
+                el as unknown as { overlayElement: Overlay }
+            ).overlayElement.dialogEl.getBoundingClientRect();
+
+            let closed = oneEvent(el, 'sp-closed');
+            await sendKeys({ press: 'Space' });
+            await closed;
+
+            opened = oneEvent(el, 'sp-opened');
+            await sendKeys({ press: 'Space' });
+            await opened;
+
+            const secondRect = (
+                el as unknown as { overlayElement: Overlay }
+            ).overlayElement.dialogEl.getBoundingClientRect();
+
+            closed = oneEvent(el, 'sp-closed');
+            await sendKeys({ press: 'Space' });
+            await closed;
+
+            expect(firstRect).to.deep.equal(secondRect);
         });
         it('opens and selects in a single pointer button interaction', async () => {
             const el = await actionMenuFixture();

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -126,8 +126,8 @@
         "lit-html"
     ],
     "dependencies": {
-        "@floating-ui/dom": "^1.5.3",
-        "@floating-ui/utils": "^0.1.6",
+        "@floating-ui/dom": "^1.5.4",
+        "@floating-ui/utils": "^0.2.1",
         "@spectrum-web-components/action-button": "^0.40.3",
         "@spectrum-web-components/base": "^0.40.3",
         "@spectrum-web-components/reactive-controllers": "^0.40.3",

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -957,6 +957,9 @@ export class Overlay extends OverlayFeatures {
                 this.placementController.resetOverlayPosition();
             }
         }
+        if (changes.has('state') && this.state === 'closed') {
+            this.placementController.clearOverlayPosition();
+        }
     }
 
     protected renderContent(): TemplateResult {

--- a/packages/overlay/src/PlacementController.ts
+++ b/packages/overlay/src/PlacementController.ts
@@ -267,13 +267,20 @@ export class PlacementController implements ReactiveController {
         }
     }
 
-    public resetOverlayPosition = (): void => {
-        if (!this.target || !this.options) return;
-
+    public clearOverlayPosition(): void {
+        if (!this.target) {
+            return;
+        }
         this.target.style.removeProperty('max-height');
-        this.target.style.removeProperty('height');
+        this.target.style.removeProperty('max-width');
         this.initialHeight = undefined;
         this.isConstrained = false;
+    }
+
+    public resetOverlayPosition = (): void => {
+        if (!this.target || !this.options) return;
+        this.clearOverlayPosition();
+
         // force paint
         this.host.offsetHeight;
         this.computePlacement();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3724,12 +3724,12 @@
   dependencies:
     "@floating-ui/utils" "^0.1.1"
 
-"@floating-ui/core@^1.4.2":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
-  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
+"@floating-ui/core@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.3.tgz#b6aa0827708d70971c8679a16cf680a515b8a52a"
+  integrity sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==
   dependencies:
-    "@floating-ui/utils" "^0.1.3"
+    "@floating-ui/utils" "^0.2.0"
 
 "@floating-ui/dom@^1.5.1":
   version "1.5.1"
@@ -3739,13 +3739,13 @@
     "@floating-ui/core" "^1.4.1"
     "@floating-ui/utils" "^0.1.1"
 
-"@floating-ui/dom@^1.5.3":
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
-  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+"@floating-ui/dom@^1.5.4":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.4.tgz#28df1e1cb373884224a463235c218dcbd81a16bb"
+  integrity sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==
   dependencies:
-    "@floating-ui/core" "^1.4.2"
-    "@floating-ui/utils" "^0.1.3"
+    "@floating-ui/core" "^1.5.3"
+    "@floating-ui/utils" "^0.2.0"
 
 "@floating-ui/react-dom@^2.0.0":
   version "2.0.2"
@@ -3759,10 +3759,10 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.1.tgz#1a5b1959a528e374e8037c4396c3e825d6cf4a83"
   integrity sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==
 
-"@floating-ui/utils@^0.1.3", "@floating-ui/utils@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
-  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
+"@floating-ui/utils@^0.2.0", "@floating-ui/utils@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.1.tgz#16308cea045f0fc777b6ff20a9f25474dd8293d2"
+  integrity sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==
 
 "@formatjs/ecma402-abstract@1.14.3":
   version "1.14.3"


### PR DESCRIPTION
## Description
Clear styling applied when positioning after an Overlay is closed again so that previous measurements do not negatively effect subsequent positioning.

~If you can think of a non-manual test for this, I'm all ears.~

## Related issue(s)
- fixes #3955

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://repeat-placement--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--icon-only&args=align:end)
    2. Open/close the Action Menu repreatedly
    3. See that at no point does the Menu flow off the edge of the page

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.