### PR TITLE
chore(picker): return "click" listening

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -105,6 +105,7 @@ export class ActionMenu extends ObserveSlotPresence(
                 class="button"
                 size=${this.size}
                 @blur=${this.handleButtonBlur}
+                @click=${this.handleActivate}
                 @pointerdown=${this.handleButtonPointerdown}
                 @focus=${this.handleButtonFocus}
                 @keydown=${{

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -19,10 +19,12 @@ import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import { Placement } from '@spectrum-web-components/overlay/src/overlay-types.js';
+import type { ActionMenu } from '@spectrum-web-components/action-menu';
 
 export const ActionMenuMarkup = ({
     ariaLabel = 'More Actions',
-    changeHandler = (() => undefined) as (event: Event) => void,
+    onChange = (() => undefined) as (value: string) => void,
+    changeHandler = (() => undefined) as (value: string) => void,
     disabled = false,
     open = false,
     quiet = false,
@@ -47,7 +49,10 @@ export const ActionMenuMarkup = ({
                     : (staticValue as 'black' | 'white')
             )}
             size=${size}
-            @change="${changeHandler}"
+            @change=${(event: Event & { target: ActionMenu }) => {
+                changeHandler(event.target.value);
+                onChange(event.target.value);
+            }}
             .selects=${selects ? selects : undefined}
             value=${selected ? 'Select Inverse' : ''}
         >

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -652,6 +652,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
                 childItem &&
                 childItem.menuData.selectionRoot === event.target
             ) {
+                event.preventDefault();
                 childItem.click();
             }
             return;

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -500,6 +500,45 @@ export function runPickerTests(): void {
                 'finally, not visually focused'
             );
         });
+        it('opens with visible focus on a menu item on `Space`', async function () {
+            const firstItem = el.querySelector('sp-menu-item') as MenuItem;
+
+            await elementUpdated(el);
+
+            expect(firstItem.focused, 'should not visually focused').to.be
+                .false;
+
+            el.focus();
+            await elementUpdated(el);
+            const opened = oneEvent(el, 'sp-opened');
+            await sendKeys({ press: 'ArrowRight' });
+            await sendKeys({ press: 'ArrowLeft' });
+            await sendKeys({ press: 'Space' });
+            await opened;
+
+            expect(el.open).to.be.true;
+            expect(firstItem.focused, 'should be visually focused').to.be.true;
+
+            const closed = oneEvent(el, 'sp-closed');
+            await sendKeys({
+                press: 'Escape',
+            });
+            await closed;
+
+            expect(el.open).to.be.false;
+            expect(
+                document.activeElement === el,
+                `focused ${document.activeElement?.localName} instead of back on Picker`
+            ).to.be.true;
+            expect(
+                el.shadowRoot.activeElement === el.button,
+                `focused ${el.shadowRoot.activeElement?.localName} instead of back on button`
+            ).to.be.true;
+            await waitUntil(
+                () => !firstItem.focused,
+                'finally, not visually focused'
+            );
+        });
         it('opens, on click, without visible focus on a menu item', async () => {
             await nextFrame();
             await nextFrame();

--- a/packages/split-button/src/SplitButton.ts
+++ b/packages/split-button/src/SplitButton.ts
@@ -146,6 +146,7 @@ export class SplitButton extends SizedMixin(PickerBase) {
                     aria-controls=${ifDefined(this.open ? 'menu' : undefined)}
                     class="button trigger ${this.variant}"
                     @blur=${this.handleButtonBlur}
+                    @click=${this.handleActivate}
                     @pointerdown=${this.handleButtonPointerdown}
                     @focus=${this.handleButtonFocus}
                     @keydown=${{

--- a/projects/documentation/package.json
+++ b/projects/documentation/package.json
@@ -95,10 +95,12 @@
         "build:eleventy": {
             "command": "eleventy --config=.eleventy.cjs --incremental --quiet",
             "dependencies": [
-                "copy-docs"
+                {
+                    "script": "copy-docs"
+                }
             ],
             "files": [
-                "./content/**/*.md",
+                "./content/**/*",
                 "./.eleventy.cjs"
             ],
             "clean": "if-file-deleted",
@@ -205,8 +207,9 @@
             "command": "node scripts/copy-component-docs.js",
             "files": [
                 "../../packages/**/*.md",
+                "../../packages/**/*.ts",
                 "../../tools/**/*.md",
-                "custom-elements.json",
+                "../../tools/**/*.ts",
                 "scripts/copy-component-docs.js",
                 "scripts/component-template-parts.js"
             ],


### PR DESCRIPTION
## Description
While #3935 updated the interaction model of Picker, Action Menu, and Split Button, it accidentally disabled interaction with the keyboard and screen reader. This adds them back with a test to support.

Side benefits:
- clean up doc site build config so that it doesn't loop so often
- add some event tracking to the Action Menu storybook
- `preventDefault()` the `Arrow*` events that open `<sp-picker>`
- `preventDefault()` the `Space` events that select Menu Items
- refactor some naming for clarity

**Note:**
Listed as a `chore(picker):` as it corrects a `fix(picker):` that has yet to be released.

## Related issue(s)
- refs #3956

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://picker-spacebar--spectrum-web-components.netlify.app/storybook/index.html?path=/story/action-menu--default)
    2. Tab to the Action Menu
    3. Press `Space`
    4. See that the Action Menu opens
    5. Select a Menu Item with the arrow keys
    6. Press `Space`
    7. See that that items was "selected" (Action Menus don't hold a selection but it will be reported in the Actions tab)
    8. See that the Action Menu is closed
-   [ ] _Test case 2_
    1. Go [here](https://picker-spacebar--spectrum-web-components.netlify.app/storybook/index.html?path=/story/action-menu--default)
    2. Repeat above with the screen reader controls


## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)