### PR TITLE
fix: added checks before building a theme

### DIFF
--- a/scripts/spectrum-tokens.js
+++ b/scripts/spectrum-tokens.js
@@ -137,35 +137,42 @@ const processPackages = async (srcPath, index) => {
     const packageName = tokenPackages[index];
     const expressPath = path.join(srcPath, 'express.css');
     const spectrumPath = path.join(srcPath, 'spectrum.css');
-    let express = fs.readFileSync(expressPath, 'utf8');
-    let spectrum = fs.readFileSync(spectrumPath, 'utf8');
-    express = removeImporantComments(targetHost(express));
-    spectrum = removeImporantComments(targetHost(spectrum));
 
-    fs.appendFileSync(
-        path.join(
-            __dirname,
-            '..',
-            'tools',
-            'styles',
-            'tokens',
-            'express',
-            'global-vars.css'
-        ),
-        express
-    );
-    fs.appendFileSync(
-        path.join(
-            __dirname,
-            '..',
-            'tools',
-            'styles',
-            'tokens',
-            'spectrum',
-            'global-vars.css'
-        ),
-        spectrum
-    );
+    // check if expressPath exists
+    if (fs.existsSync(expressPath)) {
+        let express = fs.readFileSync(expressPath, 'utf8');
+        express = removeImporantComments(targetHost(express));
+        fs.appendFileSync(
+            path.join(
+                __dirname,
+                '..',
+                'tools',
+                'styles',
+                'tokens',
+                'express',
+                'global-vars.css'
+            ),
+            express
+        );
+    }
+
+    // check if spectrumPath exists
+    if (fs.existsSync(spectrumPath)) {
+        let spectrum = fs.readFileSync(spectrumPath, 'utf8');
+        spectrum = removeImporantComments(targetHost(spectrum));
+        fs.appendFileSync(
+            path.join(
+                __dirname,
+                '..',
+                'tools',
+                'styles',
+                'tokens',
+                'spectrum',
+                'global-vars.css'
+            ),
+            spectrum
+        );
+    }
 
     const varsPaths = path.join(
         __dirname,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Spectrum-css have removed the empty css theme files from their project and thus during our css-build step we cannot always expect to get all the theme files. 

## Description

All I did is simply add a check if the corresponding theme file exists or not in our `spectrum-tokens.js` script

<!--- Describe your changes in detail -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. All existing tests are passing and we are able to build the project without any errors

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
