### PR TITLE
test(combobox): fulfil accessibility contract

### DIFF
--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -320,7 +320,7 @@ export class Combobox extends Textfield {
                 aria-controls=${ifDefined(
                     this.open ? 'listbox-menu' : undefined
                 )}
-                aria-describedby=${this.helpTextId}
+                aria-describedby="${this.helpTextId} tooltip"
                 aria-expanded="${this.open ? 'true' : 'false'}"
                 aria-label=${ifDefined(this.label || this.appliedLabel)}
                 aria-labelledby="applied-label label"
@@ -367,7 +367,7 @@ export class Combobox extends Textfield {
             ${super.render()}
             <sp-picker-button
                 aria-controls="listbox-menu"
-                aria-describedby=${this.helpTextId}
+                aria-describedby="${this.helpTextId} tooltip"
                 aria-expanded=${this.open ? 'true' : 'false'}
                 aria-label=${ifDefined(this.label || this.appliedLabel)}
                 aria-labelledby="applied-label label"

--- a/packages/combobox/test/combobox-a11y.test.ts
+++ b/packages/combobox/test/combobox-a11y.test.ts
@@ -16,13 +16,18 @@ import '@spectrum-web-components/combobox/sp-combobox.js';
 import '@spectrum-web-components/combobox/sp-combobox-item.js';
 import { Combobox } from '..';
 import { fixture } from '../../../test/testing-helpers.js';
+import { findDescribedNode } from '../../../test/testing-helpers-a11y.js';
 import {
     a11ySnapshot,
     findAccessibilityNode,
     sendKeys,
 } from '@web/test-runner-commands';
 import { comboboxFixture, isWebKit } from './index.js';
-import { withFieldLabel, withHelpText } from '../stories/combobox.stories.js';
+import {
+    withFieldLabel,
+    withHelpText,
+    withTooltip,
+} from '../stories/combobox.stories.js';
 import { MenuItem } from '@spectrum-web-components/menu';
 
 describe('Combobox accessibility', () => {
@@ -158,6 +163,16 @@ describe('Combobox accessibility', () => {
                 '`name` is the the selected item text plus the label text'
             ).to.not.be.null;
         }
+    });
+    it('manages its "description" value with slotted <sp-tooltip>', async () => {
+        const test = await fixture<HTMLDivElement>(html`
+            <div>${withTooltip()}</div>
+        `);
+        const el = test.querySelector('sp-combobox') as unknown as Combobox;
+        const tooltipText = 'This combobox has a tooltip.';
+
+        await elementUpdated(el);
+        await findDescribedNode(el.label, tooltipText);
     });
     it('renders open', async () => {
         const el = await comboboxFixture();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fulfil the accessibility contract for a combobox with tooltip by adding the "tooltip" as something that works for `aria-describedby` and wrote a test to make sure the description is linked to the combobox's tooltip.
## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manually tested, unit tests
-   [ ] _Test case 1_
    1. Go here
    2. Turn on screen reader
    3. Tab into combobox
    4. See that the combobox is described by not only the label, but also the tooltip text.
    5. Also look at the accessibility tab and see it's got a description, too, that matches the tooltip's text.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
