### PR TITLE
switch: added change event listener to api

### DIFF
--- a/packages/switch/src/Switch.ts
+++ b/packages/switch/src/Switch.ts
@@ -26,6 +26,7 @@ import legacyStyles from './switch-legacy.css.js';
  * @element sp-switch
  *
  * @slot - text label of the Switch
+ * @fires change - Announces a change in the `checked` property of a Switch
  */
 export class Switch extends SizedMixin(CheckboxBase) {
     public static override get styles(): CSSResultArray {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Expect Switch component onChange to trigger an event

## Description

<!--- Describe your changes in detail -->

added change event listener to api

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3970 

## Motivation and context

OnChange does not trigger an event after migrating from SWC 0.11.11 to 0.40.2 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   I have verified the change by building react-swc components using `yarn build:react`

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
