### PR TITLE
fix: expose version property on theme

### DIFF
--- a/tools/theme/src/Theme.ts
+++ b/tools/theme/src/Theme.ts
@@ -15,6 +15,7 @@ import {
     CSSResultGroup,
     supportsAdoptingStyleSheets,
 } from '@spectrum-web-components/base';
+import { version } from '@spectrum-web-components/base/src/version.js';
 
 declare global {
     interface Window {
@@ -95,6 +96,7 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
     private static defaultFragments: Set<FragmentName> = new Set(['spectrum']);
     private static templateElement?: HTMLTemplateElement;
     private static instances: Set<Theme> = new Set();
+    static VERSION = version;
 
     static get observedAttributes(): string[] {
         return ['color', 'scale', 'theme', 'lang', 'dir'];

--- a/tools/theme/test/theme.test.ts
+++ b/tools/theme/test/theme.test.ts
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { Theme } from '@spectrum-web-components/theme';
+import { expect } from '@open-wc/testing';
+import { version } from '@spectrum-web-components/base/src/version.js';
+
+class DirElement extends Theme {}
+
+customElements.define('dir-element', DirElement);
+
+describe('Theme', () => {
+    it('has a static VERSION property', () => {
+        expect(DirElement.VERSION).to.equal(version);
+    });
+});


### PR DESCRIPTION
## Description

In https://github.com/adobe/spectrum-web-components/issues/3574 most components were updated to expose a static property for the version number. However, theme doesn't extend the same base so this value isn't available in that case. This PR addresses that by using the same approach for Theme.

## Related issue(s)

- fixes #3976 

## Motivation and context

To align theme with other components

## How has this been tested?

Tested in Storybook and unit test.

## Screenshots (if appropriate)

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
