### PR TITLE
API Tables and additional VRT coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 86d27f6640a81a1c23529b40817190be2093812a
+        default: 3f18b907cc7ccfebda57963ffe10e1c132c17761
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -79,6 +79,9 @@ export class Combobox extends Textfield {
     @query('#input')
     private input!: HTMLInputElement;
 
+    /**
+     * An array of options to present in the Menu provided while typing into the input
+     */
     @property({ type: Array })
     public options?: ComboboxOption[];
 
@@ -109,6 +112,9 @@ export class Combobox extends Textfield {
     }
 
     public handleComboboxKeydown(event: KeyboardEvent): void {
+        if (this.readonly) {
+            return;
+        }
         if (event.altKey && event.code === 'ArrowDown') {
             this.open = true;
         } else if (event.code === 'ArrowDown') {
@@ -215,11 +221,8 @@ export class Combobox extends Textfield {
         );
     }
 
-    public handleComboboxInput({
-        target,
-    }: Event & { target: HTMLInputElement }): void {
-        // Element data.
-        this.value = target.value;
+    public override handleInput(event: Event): void {
+        super.handleInput(event);
         this.activeDescendant = undefined;
         this.open = true;
     }
@@ -246,6 +249,10 @@ export class Combobox extends Textfield {
     }
 
     public toggleOpen(): void {
+        if (this.readonly) {
+            this.open = false;
+            return;
+        }
         this.open = !this.open;
         this.inputElement.focus();
     }
@@ -324,7 +331,6 @@ export class Combobox extends Textfield {
                 aria-invalid=${ifDefined(this.invalid || undefined)}
                 autocomplete="off"
                 @click=${this.toggleOpen}
-                @input=${this.handleComboboxInput}
                 @keydown=${this.handleComboboxKeydown}
                 id="input"
                 class="input"
@@ -334,7 +340,6 @@ export class Combobox extends Textfield {
                 tabindex="0"
                 @sp-closed=${this.handleClosed}
                 @sp-opened=${this.handleOpened}
-                type=${this.type}
                 maxlength=${ifDefined(
                     this.maxlength > -1 ? this.maxlength : undefined
                 )}
@@ -372,6 +377,7 @@ export class Combobox extends Textfield {
                 class="button ${this.focused
                     ? 'focus-visible is-keyboardFocused'
                     : ''}"
+                ?disabled=${this.disabled}
                 ?focused=${this.focused}
                 size=${this.size}
             ></sp-picker-button>

--- a/packages/combobox/src/combobox.css
+++ b/packages/combobox/src/combobox.css
@@ -21,6 +21,11 @@ governing permissions and limitations under the License.
     flex-wrap: nowrap;
 }
 
+:host([readonly]) sp-picker-button {
+    visibility: hidden;
+    pointer-events: none;
+}
+
 sp-field-label {
     display: block;
     width: 100%;

--- a/packages/combobox/stories/combobox.stories.ts
+++ b/packages/combobox/stories/combobox.stories.ts
@@ -39,6 +39,34 @@ export const Default = (): TemplateResult => {
     `;
 };
 
+export const disabled = (): TemplateResult => {
+    return html`
+        <sp-field-label for="combobox-disabled">
+            Where do you live?
+        </sp-field-label>
+        <sp-combobox
+            disabled
+            id="combobox-disabled"
+            .options=${countries}
+            value="Azerbaijan"
+        ></sp-combobox>
+    `;
+};
+
+export const readonly = (): TemplateResult => {
+    return html`
+        <sp-field-label for="combobox-readonly">
+            Where do you live?
+        </sp-field-label>
+        <sp-combobox
+            readonly
+            id="combobox-readonly"
+            .options=${countries}
+            value="Solomon Islands"
+        ></sp-combobox>
+    `;
+};
+
 export const listAutocomplete = (): TemplateResult => {
     return html`
         <sp-field-label for="combobox-2">Where do you live?</sp-field-label>

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -55,65 +55,114 @@ export class TextfieldBase extends ManageHelpText(
     @state()
     protected appliedLabel?: string;
 
+    /**
+     * A regular expression outlining the keys that will be allowed to update the value of the form control.
+     */
     @property({ attribute: 'allowed-keys' })
     allowedKeys = '';
 
+    /**
+     * @private
+     */
     @property({ type: Boolean, reflect: true })
     public focused = false;
 
     @query('.input:not(#sizer)')
     protected inputElement!: HTMLInputElement | HTMLTextAreaElement;
 
+    /**
+     * Whether the `value` held by the form control is invalid.
+     */
     @property({ type: Boolean, reflect: true })
     public invalid = false;
 
+    /**
+     * A string applied via `aria-label` to the form control when a user visible label is not provided.
+     */
     @property()
     public label = '';
 
+    /**
+     * Name of the form control.
+     */
     @property({ type: String, reflect: true })
     public name: string | undefined;
 
+    /**
+     * Text that appears in the form control when it has no value set
+     */
     @property()
     public placeholder = '';
 
-    @property({ attribute: 'type', reflect: true })
-    private _type: TextfieldType = 'text';
-
     @state()
-    get type(): TextfieldType {
-        return textfieldTypes.find((t) => t === this._type) ?? 'text';
-    }
-
     set type(val: TextfieldType) {
         const prev = this._type;
         this._type = val;
         this.requestUpdate('type', prev);
     }
 
+    get type(): TextfieldType {
+        return textfieldTypes.find((t) => t === this._type) ?? 'text';
+    }
+
+    /**
+     * @private
+     * This binding allows for invalid value for `type` to still be reflected to the DOM
+     */
+    @property({ attribute: 'type', reflect: true })
+    private _type: TextfieldType = 'text';
+
+    /**
+     * Pattern the `value` must match to be valid
+     */
     @property()
     public pattern?: string;
 
+    /**
+     * Whether a form control delivered with the `multiline` attribute will change size to accomodate longer input
+     */
     @property({ type: Boolean, reflect: true })
     public grows = false;
 
+    /**
+     * Defines the maximum string length that the user can enter
+     */
     @property({ type: Number })
     public maxlength = -1;
 
+    /**
+     * Defines the minimum string length that the user can enter
+     */
     @property({ type: Number })
     public minlength = -1;
 
+    /**
+     * Whether the form control should accept a value longer than one line
+     */
     @property({ type: Boolean, reflect: true })
     public multiline = false;
 
+    /**
+     * Whether a user can interact with the value of the form control
+     */
     @property({ type: Boolean, reflect: true })
     public readonly = false;
 
+    /**
+     * The specific number of rows the form control should provide in the user interface
+     */
     @property({ type: Number })
     public rows = -1;
 
+    /**
+     * Whether the `value` held by the form control is valid.
+     */
     @property({ type: Boolean, reflect: true })
     public valid = false;
 
+    /**
+     * The value held by the form control
+     */
     @property({ type: String })
     public set value(value: string | number) {
         if (value === this.value) {
@@ -130,12 +179,21 @@ export class TextfieldBase extends ManageHelpText(
 
     protected _value: string | number = '';
 
+    /**
+     * Whether to display the form control with no visible background
+     */
     @property({ type: Boolean, reflect: true })
     public quiet = false;
 
+    /**
+     * Whether the form control will be found to be invalid when it holds no `value`
+     */
     @property({ type: Boolean, reflect: true })
     public required = false;
 
+    /**
+     * What form of assistance should be provided when attempting to supply a value to the form control
+     */
     @property({ type: String, reflect: true })
     public autocomplete?:
         | HTMLInputElement['autocomplete']

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -26,6 +26,10 @@ governing permissions and limitations under the License.
     resize: none;
 }
 
+:host([disabled]:focus-visible) {
+    outline: none;
+}
+
 #textfield {
     inline-size: 100%;
 }

--- a/projects/documentation/scripts/component-template-parts.js
+++ b/projects/documentation/scripts/component-template-parts.js
@@ -119,10 +119,24 @@ tags:
 - ${componentName}
 ---
 ${
-    tag.attributes && tag.attributes.length
+    tag.attributes &&
+    tag.attributes.length &&
+    tag.members &&
+    tag.members.length &&
+    tag.attributes.filter((attribute) => {
+        const member = tag.members.find((member) => {
+            return member.name === attribute.name;
+        });
+        return member?.privacy === 'public';
+    }).length
         ? buildTable(
               'Attributes and Properties',
-              tag.attributes,
+              tag.attributes.filter((attribute) => {
+                  const member = tag.members.find((member) => {
+                      return member.name === attribute.name;
+                  });
+                  return member?.privacy === 'public';
+              }),
               ['Property', 'Attribute', 'Type', 'Default', 'Description'],
               [
                   (attribute) => `<code>${attribute.fieldName || ''}</code>`,


### PR DESCRIPTION
## Description
- expand on API descriptions in Textfield
- add support for `[disabled]` and `[readonly]
- cover these states in Storybook
  - [x] Add a `value` to the `readonly` demo

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://combobox-api-table--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--disabled)
    2. See what a `disabled` Combobox looks like
-   [ ] _Test case 2_
    1. Go [here](https://combobox-api-table--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--readonly)
    2. See what a `readonly`

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.