### PR TITLE
fix(slider): reimplement gradient slider track application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 3f18b907cc7ccfebda57963ffe10e1c132c17761
+        default: 3c86da55c6424efb216fdabca5308d64db7ac4c6
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -417,12 +417,12 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
         ];
         const trackItems = [
             { id: 'track0', html: this.renderTrackSegment(...segments[0]) },
+            { id: 'fill', html: this.renderFillOffset() },
             { id: 'ramp', html: this.renderRamp() },
             ...segments.slice(1).map(([start, end], index) => ({
                 id: `track${index + 1}`,
                 html: this.renderTrackSegment(start, end),
             })),
-            { id: 'fill', html: this.renderFillOffset() },
         ];
 
         return html`
@@ -501,12 +501,8 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
         const size = end - start;
         const styles: StyleInfo = {
             width: `${size * 100}%`,
-            ...(this.handleController.size > 1 && {
-                '--spectrum-slider-track-background-size': `${
-                    (1 / size) * 100
-                }%`,
-                '--spectrum-slider-track-segment-position': `${start * 100}%`,
-            }),
+            '--spectrum-slider-track-background-size': `${(1 / size) * 100}%`,
+            '--spectrum-slider-track-segment-position': `${start * 100}%`,
         };
         return styles;
     }

--- a/packages/slider/src/slider.css
+++ b/packages/slider/src/slider.css
@@ -145,3 +145,7 @@ governing permissions and limitations under the License.
 :host([label-visibility='none']) #track {
     align-self: flex-end;
 }
+
+.fill {
+    z-index: 2;
+}

--- a/packages/slider/stories/slider.stories.ts
+++ b/packages/slider/stories/slider.stories.ts
@@ -499,6 +499,22 @@ hideStepper.decorators = [editableDecorator];
 
 export const Gradient = (args: StoryArgs = {}): TemplateResult => {
     return html`
+        <style>
+            sp-slider {
+                --mod-slider-track-color: linear-gradient(
+                    to right,
+                    red,
+                    green 100%
+                );
+            }
+            sp-slider[dir='rtl'] {
+                --mod-slider-track-color: linear-gradient(
+                    to left,
+                    red,
+                    green 100%
+                );
+            }
+        </style>
         <div
             style="
                 width: 500px;
@@ -506,10 +522,6 @@ export const Gradient = (args: StoryArgs = {}): TemplateResult => {
             "
         >
             <sp-slider
-                style="
-                    --spectrum-slider-track-color:linear-gradient(to right, red, green 100%);
-                    --spectrum-slider-track-color-rtl:linear-gradient(to left, red, green 100%);
-                "
                 label="Opacity"
                 max="100"
                 min="0"


### PR DESCRIPTION
## Description
Update the application of `fill-start` to ensure the delivery of "gradient" sliders.

## Related issue(s)
- fixes #3992

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://slider-gradient--spectrum-web-components.netlify.app/storybook/?path=/story/slider--gradient)
    2. See that the gradient smoothly crosses the full expanse of the slider track
-   [ ] _Test case 2_
    1. Go [here](https://slider-gradient--spectrum-web-components.netlify.app/storybook/?path=/story/slider--fill-start-with-value)
    2. Make sure the fills are visible and that they all start from expected positions along the track
-   [ ] _Test case 3_
    1. Go [here](https://slider-gradient--spectrum-web-components.netlify.app/storybook/?path=/story/slider--three-handles-complex)
    2. Make sure the fills are visible and that they all start from expected positions along the track

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.