### PR TITLE
fix(combobox): correct value to itemText interchange when something is "selected"

### DIFF
--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -79,6 +79,8 @@ export class Combobox extends Textfield {
     @query('#input')
     private input!: HTMLInputElement;
 
+    private itemValue = '';
+
     /**
      * An array of options to present in the Menu provided while typing into the input
      */
@@ -215,8 +217,8 @@ export class Combobox extends Textfield {
         const valueLowerCase = this.value.toLowerCase();
         this.availableOptions = (this.options || this.optionEls).filter(
             (descendant) => {
-                const descendantValueLowerCase = descendant.value.toLowerCase();
-                return descendantValueLowerCase.startsWith(valueLowerCase);
+                const itemTextLowerCase = descendant.itemText.toLowerCase();
+                return itemTextLowerCase.startsWith(valueLowerCase);
             }
         );
     }
@@ -265,6 +267,10 @@ export class Combobox extends Textfield {
         }
         if (changed.has('value')) {
             this.filterAvailableOptions();
+            this.itemValue =
+                this.availableOptions.find(
+                    (option) => option.itemText === this.value
+                )?.value ?? '';
         }
         return super.shouldUpdate(changed);
     }
@@ -405,8 +411,9 @@ export class Combobox extends Textfield {
                         selects=${ifDefined(
                             this.autocomplete === 'none' ? 'single' : undefined
                         )}
-                        .selected=${this.autocomplete === 'none'
-                            ? [this.value]
+                        .selected=${this.autocomplete === 'none' &&
+                        this.itemValue
+                            ? [this.itemValue]
                             : []}
                         style="min-width: ${width}px;"
                         size=${this.size}

--- a/packages/combobox/test/combobox.test.ts
+++ b/packages/combobox/test/combobox.test.ts
@@ -34,6 +34,7 @@ import { sendMouse } from '../../../test/plugins/browser.js';
 import { withTooltip } from '../stories/combobox.stories.js';
 import type { Tooltip } from '@spectrum-web-components/tooltip';
 import { MenuItem } from '@spectrum-web-components/menu';
+import { countries } from '../stories/index.js';
 
 describe('Combobox', () => {
     describe('manages focus', () => {
@@ -594,6 +595,31 @@ describe('Combobox', () => {
         });
     });
     describe('responds to value changes', () => {
+        it('applies a visible selection based on `itemText`', async () => {
+            const el = await comboboxFixture();
+            el.autocomplete = 'none';
+            el.options = countries;
+            await elementUpdated(el);
+
+            let selected = el.shadowRoot.querySelector('[selected]');
+            expect(selected).to.be.null;
+
+            el.value = 'af';
+            await elementUpdated(el);
+
+            const opened = oneEvent(el, 'sp-opened');
+            el.open = true;
+            await opened;
+
+            selected = el.shadowRoot.querySelector('[selected]');
+            expect(selected).to.be.null;
+
+            el.value = 'Algeria';
+            await elementUpdated(el);
+
+            selected = el.shadowRoot.querySelector('[selected]');
+            expect(selected).to.not.be.null;
+        });
         it('sets the value when descendent is active and `enter` is pressed', async () => {
             const el = await comboboxFixture();
 

--- a/packages/combobox/test/index.ts
+++ b/packages/combobox/test/index.ts
@@ -276,6 +276,7 @@ export const benchmarkOptions = countryList.map((value, index) => ({
 
 export type TestableCombobox = HTMLElement & {
     activeDescendant: ComboboxOption;
+    autocomplete: 'none' | 'list';
     availableOptions: ComboboxOption[];
     focused: boolean;
     focusElement: HTMLInputElement;


### PR DESCRIPTION
## Description
correct value to itemText interchange when something is "selected"

## How has this been tested?

-   [ ] _Test case 1_
    1. Go [here](https://combobox-types--spectrum-web-components.netlify.app/storybook/index.html?path=/story/combobox--default)
    2. Type `al` into the Combobox
    3. See that "Albania" does not get selected
-   [ ] _Test case 2_
    1. Go [here](https://combobox-types--spectrum-web-components.netlify.app/storybook/index.html?path=/story/combobox--default)
    2. Type `Afghanistan` into the Combobox
    3. See that "Afghanistan" is selected

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
