### PR TITLE
chore(top-nav): clean up CSS implementation for user interactions

### DIFF
--- a/packages/top-nav/src/top-nav-item.css
+++ b/packages/top-nav/src/top-nav-item.css
@@ -42,6 +42,22 @@ a:focus {
     ); /* .spectrum-Tabs-item.focus-ring .spectrum-Icon */
 }
 
+#item-label {
+    margin-block: 0;
+    padding-block-end: var(
+        --mod-tabs-bottom-to-text,
+        var(--spectrum-tabs-bottom-to-text)
+    );
+    padding-block-start: var(
+        --mod-tabs-top-to-text,
+        var(--spectrum-tabs-top-to-text)
+    );
+}
+
+slot {
+    pointer-events: none;
+}
+
 @media (forced-colors: active) {
     :host {
         --highcontrast-tabs-focus-indicator-color: canvastext;

--- a/packages/top-nav/test/top-nav.test.ts
+++ b/packages/top-nav/test/top-nav.test.ts
@@ -16,6 +16,7 @@ import { TopNav, TopNavItem } from '@spectrum-web-components/top-nav';
 import { Default, Selected } from '../stories/top-nav.stories.js';
 import { spy } from 'sinon';
 import { testForLitDevWarnings } from '../../../test/testing-helpers';
+import { sendMouse } from '../../../test/plugins/browser.js';
 
 describe('TopNav', () => {
     testForLitDevWarnings(async () => await fixture<TopNav>(Default()));
@@ -100,6 +101,34 @@ describe('TopNavItem', () => {
         await elementUpdated(el);
 
         el.click();
+
+        expect(clickSpy.called).to.be.true;
+        expect(clickSpy.calledWith(anchor)).to.be.true;
+    });
+    it('`<a>` accepts click across full item area', async () => {
+        const clickSpy = spy();
+        const test = await fixture<TopNav>(Selected());
+        const el = test.querySelector(
+            'sp-top-nav-item:nth-of-type(4)'
+        ) as TopNavItem;
+        const anchor = el.focusElement;
+        test.addEventListener('click', (event: Event) => {
+            event.preventDefault();
+            const target = event.composedPath()[0];
+            clickSpy(target);
+        });
+        await elementUpdated(el);
+        const rect = el.getBoundingClientRect();
+
+        await sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [rect.left + rect.width / 2, rect.top + 1],
+                },
+            ],
+        });
+        await elementUpdated(test);
 
         expect(clickSpy.called).to.be.true;
         expect(clickSpy.calledWith(anchor)).to.be.true;


### PR DESCRIPTION
## Description
Swap margin for padding to allow clicks across the full area of the Top Nav Item to interact with the `<a>` element internal to its shadow DOM.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://top-nav-updates--spectrum-web-components.netlify.app/storybook/iframe.html?args=&id=top-nav--default&viewMode=story#page-4)
    2. Select any of the Top Nav Items
    3. See that the visual selection and URL change
    4. Click any of the Top Nav Items at the top and bottom extremes of the item (when the 👆🏼 first displays as the cursor)
    5. See that the visual selection and URL change

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)