### PR TITLE
fix(theme): include custom Spectrum color tokens in Express color tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 057302188600caa67ec4920171362cca7420d2a5
+        default: 33f99dcd1189f71edd93a803bbcb133dc5539fde
     wireit_cache_name:
         type: string
         default: wireit

--- a/tools/theme/src/express/theme-dark.css
+++ b/tools/theme/src/express/theme-dark.css
@@ -12,4 +12,5 @@ governing permissions and limitations under the License.
 
 @import url('@spectrum-web-components/styles/express/theme-dark.css');
 @import url('@spectrum-web-components/styles/tokens/dark-vars.css');
+@import url('@spectrum-web-components/styles/tokens/spectrum/custom-dark-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/custom-dark-vars.css');

--- a/tools/theme/src/express/theme-light.css
+++ b/tools/theme/src/express/theme-light.css
@@ -12,4 +12,5 @@ governing permissions and limitations under the License.
 
 @import url('@spectrum-web-components/styles/express/theme-light.css');
 @import url('@spectrum-web-components/styles/tokens/light-vars.css');
+@import url('@spectrum-web-components/styles/tokens/spectrum/custom-light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/custom-light-vars.css');


### PR DESCRIPTION
## Description
Custom Spectrum Tokens are required as a baseline for Express to be delivered correctly.
- prepend Custom Spectrum Tokens to the light and dark colors stops in the Express theme.

## Related issue(s)
- fixes #3933


## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://express-custom-tokens--spectrum-web-components.netlify.app/storybook/?path=/story/menu--default&sp_theme=express)
    2. Confirm the page loaded in the Express theme
    3. See that when hovered the Menu Item background color changes

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.