### PR TITLE
fix(button): use larger icons in Close Button

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 0d9023ac47ee41236bef6ce3431f0159a1f8c3e8
+        default: 072516e18cdabf5c159ea72b6cfcc8c7f95843ed
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/button/src/CloseButton.ts
+++ b/packages/button/src/CloseButton.ts
@@ -19,37 +19,37 @@ import {
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { StyledButton } from './StyledButton.js';
 import buttonStyles from '@spectrum-web-components/close-button/src/close-button.css.js';
-import '@spectrum-web-components/icons-ui/icons/sp-icon-cross75.js';
-import '@spectrum-web-components/icons-ui/icons/sp-icon-cross100.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-cross200.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-cross300.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross400.js';
+import '@spectrum-web-components/icons-ui/icons/sp-icon-cross500.js';
 import crossMediumStyles from '@spectrum-web-components/icon/src/spectrum-icon-cross.css.js';
 import type { ButtonStatics } from './Button.js';
 
 const crossIcon: Record<string, () => TemplateResult> = {
     s: () => html`
-        <sp-icon-cross75
-            slot="icon"
-            class="icon spectrum-UIIcon-Cross75"
-        ></sp-icon-cross75>
-    `,
-    m: () => html`
-        <sp-icon-cross100
-            slot="icon"
-            class="icon spectrum-UIIcon-Cross100"
-        ></sp-icon-cross100>
-    `,
-    l: () => html`
         <sp-icon-cross200
             slot="icon"
             class="icon spectrum-UIIcon-Cross200"
         ></sp-icon-cross200>
     `,
-    xl: () => html`
+    m: () => html`
         <sp-icon-cross300
             slot="icon"
             class="icon spectrum-UIIcon-Cross300"
         ></sp-icon-cross300>
+    `,
+    l: () => html`
+        <sp-icon-cross400
+            slot="icon"
+            class="icon spectrum-UIIcon-Cross400"
+        ></sp-icon-cross400>
+    `,
+    xl: () => html`
+        <sp-icon-cross500
+            slot="icon"
+            class="icon spectrum-UIIcon-Cross500"
+        ></sp-icon-cross500>
     `,
 };
 


### PR DESCRIPTION
## Description
Implement _only_ the `large` Close Button instead of only the `default` Close button in support of usage in Dialog elements and in preparation for S2 where there will ONLY be "large", which kind of makes it default, right? 😉 

## Related issue(s)
- fixes #3939

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://4cd0782161a090690773055cd29cdfde--spectrum-web-components.netlify.app/review/)
    2. See all the patterns this updates: Action Bar, Dialog, Toast

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.