### PR TITLE
chore: take latest CSS dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 072516e18cdabf5c159ea72b6cfcc8c7f95843ed
+        default: 15e9cb73f536a5f74d7978a8ae3fdef174935f6f
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -73,7 +73,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/accordion": "^4.1.1"
+        "@spectrum-css/accordion": "^4.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/accordion/src/spectrum-accordion-item.css
+++ b/packages/accordion/src/spectrum-accordion-item.css
@@ -213,22 +213,6 @@ governing permissions and limitations under the License.
         var(--spectrum-accordion-item-header-color-default)
     );
 }
-#header:hover {
-    background-color: var(
-        --mod-accordion-background-color-hover,
-        var(--spectrum-accordion-background-color-hover)
-    );
-    color: var(
-        --mod-accordion-item-header-color-hover,
-        var(--spectrum-accordion-item-header-color-hover)
-    );
-}
-#header:hover + .iconContainer {
-    color: var(
-        --mod-accordion-item-header-color-hover,
-        var(--spectrum-accordion-item-header-color-hover)
-    );
-}
 #header.focus-visible {
     background-color: var(
         --mod-accordion-background-color-key-focus,
@@ -297,15 +281,8 @@ governing permissions and limitations under the License.
         var(--spectrum-accordion-item-header-color-down)
     );
 }
-:host([open]) #header:hover {
-    background-color: var(
-        --mod-accordion-background-color-hover,
-        var(--spectrum-accordion-background-color-hover)
-    );
-}
 :host([disabled]) #header,
-:host([disabled]) #header.focus-visible,
-:host([disabled]) #header:hover {
+:host([disabled]) #header.focus-visible {
     background-color: #0000;
     color: var(
         --mod-accordion-item-header-disabled-color,
@@ -313,13 +290,43 @@ governing permissions and limitations under the License.
     );
 }
 :host([disabled]) #header,
-:host([disabled]) #header:focus-visible,
-:host([disabled]) #header:hover {
+:host([disabled]) #header:focus-visible {
     background-color: #0000;
     color: var(
         --mod-accordion-item-header-disabled-color,
         var(--spectrum-accordion-item-header-disabled-color)
     );
+}
+@media (hover: hover) {
+    #header:hover {
+        background-color: var(
+            --mod-accordion-background-color-hover,
+            var(--spectrum-accordion-background-color-hover)
+        );
+        color: var(
+            --mod-accordion-item-header-color-hover,
+            var(--spectrum-accordion-item-header-color-hover)
+        );
+    }
+    #header:hover + .iconContainer {
+        color: var(
+            --mod-accordion-item-header-color-hover,
+            var(--spectrum-accordion-item-header-color-hover)
+        );
+    }
+    :host([open]) #header:hover {
+        background-color: var(
+            --mod-accordion-background-color-hover,
+            var(--spectrum-accordion-background-color-hover)
+        );
+    }
+    :host([disabled]) #header:hover {
+        background-color: #0000;
+        color: var(
+            --mod-accordion-item-header-disabled-color,
+            var(--spectrum-accordion-item-header-disabled-color)
+        );
+    }
 }
 :host([disabled]) #header + .iconContainer {
     color: var(

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^5.1.0"
+        "@spectrum-css/actionbutton": "^5.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -411,28 +411,30 @@ governing permissions and limitations under the License.
     );
     position: relative;
 }
-:host(:hover) {
-    background-color: var(
-        --highcontrast-actionbutton-background-color-hover,
-        var(
-            --mod-actionbutton-background-color-hover,
-            var(--spectrum-actionbutton-background-color-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-actionbutton-border-color-hover,
-        var(
-            --mod-actionbutton-border-color-hover,
-            var(--spectrum-actionbutton-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-actionbutton-content-color-hover,
-        var(
-            --mod-actionbutton-content-color-hover,
-            var(--spectrum-actionbutton-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        background-color: var(
+            --highcontrast-actionbutton-background-color-hover,
+            var(
+                --mod-actionbutton-background-color-hover,
+                var(--spectrum-actionbutton-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-actionbutton-border-color-hover,
+            var(
+                --mod-actionbutton-border-color-hover,
+                var(--spectrum-actionbutton-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-actionbutton-content-color-hover,
+            var(
+                --mod-actionbutton-content-color-hover,
+                var(--spectrum-actionbutton-content-color-hover)
+            )
+        );
+    }
 }
 :host(.focus-visible) {
     background-color: var(

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/reactive-controllers": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/actiongroup": "^4.1.10"
+        "@spectrum-css/actiongroup": "^4.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-group/src/spectrum-action-group.css
+++ b/packages/action-group/src/spectrum-action-group.css
@@ -143,8 +143,10 @@ governing permissions and limitations under the License.
 :host([compact]:not([quiet])) ::slotted([selected]) {
     z-index: 1;
 }
-:host([compact]:not([quiet])) ::slotted(:hover) {
-    z-index: 2;
+@media (hover: hover) {
+    :host([compact]:not([quiet])) ::slotted(:hover) {
+        z-index: 2;
+    }
 }
 :host([compact]:not([quiet])) ::slotted(.focus-visible) {
     z-index: 3;

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -90,7 +90,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/button": "^11.1.0"
+        "@spectrum-css/button": "^11.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -299,7 +299,6 @@ governing permissions and limitations under the License.
     );
     position: relative;
 }
-:host(:hover),
 :host([active]) {
     box-shadow: none;
 }
@@ -474,28 +473,33 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:hover) {
-    background-color: var(
-        --highcontrast-button-background-color-hover,
-        var(
-            --mod-button-background-color-hover,
-            var(--spectrum-button-background-color-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-button-border-color-hover,
-        var(
-            --mod-button-border-color-hover,
-            var(--spectrum-button-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-button-content-color-hover,
-        var(
-            --mod-button-content-color-hover,
-            var(--spectrum-button-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        box-shadow: none;
+    }
+    :host(:hover) {
+        background-color: var(
+            --highcontrast-button-background-color-hover,
+            var(
+                --mod-button-background-color-hover,
+                var(--spectrum-button-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-button-border-color-hover,
+            var(
+                --mod-button-border-color-hover,
+                var(--spectrum-button-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-button-content-color-hover,
+            var(
+                --mod-button-content-color-hover,
+                var(--spectrum-button-content-color-hover)
+            )
+        );
+    }
 }
 :host(.focus-visible) {
     background-color: var(

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -67,7 +67,7 @@
         "@spectrum-web-components/styles": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/card": "^6.3.1"
+        "@spectrum-css/card": "^6.4.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/card/src/spectrum-card.css
+++ b/packages/card/src/spectrum-card.css
@@ -217,15 +217,6 @@ governing permissions and limitations under the License.
             )
     );
 }
-:host(:hover) {
-    border-color: var(
-        --highcontrast-card-border-color-hover,
-        var(
-            --mod-card-border-color-hover,
-            var(--spectrum-card-border-color-hover)
-        )
-    );
-}
 :host([selected]) {
     border-color: var(
         --highcontrast-card-border-color-selected,
@@ -274,8 +265,6 @@ governing permissions and limitations under the License.
 }
 :host(:focus) .actions,
 :host(:focus) .quick-actions,
-:host(:hover) .actions,
-:host(:hover) .quick-actions,
 :host([focused]) .actions,
 :host([focused]) .quick-actions,
 :host([selected]) .actions,
@@ -681,17 +670,6 @@ governing permissions and limitations under the License.
     );
     position: absolute;
 }
-:host([variant='gallery']:hover),
-:host([variant='quiet']:hover) {
-    border-color: #0000;
-}
-:host([variant='gallery']:hover) #preview,
-:host([variant='quiet']:hover) #preview {
-    background-color: var(
-        --mod-card-background-color-hover,
-        var(--spectrum-card-background-color-hover)
-    );
-}
 :host([variant='gallery'][drop-target]),
 :host([variant='quiet'][drop-target]) {
     background-color: #0000;
@@ -746,11 +724,39 @@ governing permissions and limitations under the License.
 :host([horizontal]) {
     flex-direction: row;
 }
-:host([horizontal]:hover) #preview {
-    border-color: var(
-        --mod-card-border-color-hover,
-        var(--spectrum-card-border-color-hover)
-    );
+@media (hover: hover) {
+    :host(:hover) .actions,
+    :host(:hover) .quick-actions {
+        opacity: 1;
+        pointer-events: all;
+        visibility: visible;
+    }
+    :host(:hover) {
+        border-color: var(
+            --highcontrast-card-border-color-hover,
+            var(
+                --mod-card-border-color-hover,
+                var(--spectrum-card-border-color-hover)
+            )
+        );
+    }
+    :host([variant='gallery']:hover),
+    :host([variant='quiet']:hover) {
+        border-color: #0000;
+    }
+    :host([variant='gallery']:hover) #preview,
+    :host([variant='quiet']:hover) #preview {
+        background-color: var(
+            --mod-card-background-color-hover,
+            var(--spectrum-card-background-color-hover)
+        );
+    }
+    :host([horizontal]:hover) #preview {
+        border-color: var(
+            --mod-card-border-color-hover,
+            var(--spectrum-card-border-color-hover)
+        );
+    }
 }
 :host([horizontal]) #preview {
     align-items: center;

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -71,7 +71,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/checkbox": "^8.0.6"
+        "@spectrum-css/checkbox": "^8.1.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -136,33 +136,6 @@ governing permissions and limitations under the License.
     position: relative;
     vertical-align: top;
 }
-:host(:hover) #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-hover,
-        var(
-            --mod-checkbox-control-color-hover,
-            var(--spectrum-checkbox-control-color-hover)
-        )
-    );
-}
-:host(:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-hover,
-        var(
-            --mod-checkbox-control-selected-color-hover,
-            var(--spectrum-checkbox-control-selected-color-hover)
-        )
-    );
-}
-:host(:hover) #label {
-    color: var(
-        --highcontrast-checkbox-content-color-hover,
-        var(
-            --mod-checkbox-content-color-hover,
-            var(--spectrum-checkbox-content-color-hover)
-        )
-    );
-}
 :host:active #box:before {
     border-color: var(
         --highcontrast-checkbox-highlight-color-down,
@@ -220,26 +193,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid][invalid]:hover) #box:before,
-:host([invalid][invalid]:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-hover,
-        var(
-            --mod-checkbox-invalid-color-hover,
-            var(--spectrum-checkbox-invalid-color-hover)
-        )
-    );
-}
 :host([readonly]) {
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-control-selected-color-default,
-            var(--spectrum-checkbox-control-selected-color-default)
-        )
-    );
-}
-:host([readonly]:hover) #box:before {
     border-color: var(
         --highcontrast-checkbox-color-default,
         var(
@@ -327,16 +281,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([indeterminate]:hover) #box:before,
-:host([indeterminate]:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-hover,
-        var(
-            --mod-checkbox-control-selected-color-hover,
-            var(--spectrum-checkbox-control-selected-color-hover)
-        )
-    );
-}
 :host([invalid][invalid][indeterminate]) #box:before,
 :host([invalid][invalid][indeterminate]) #input:checked + #box:before {
     border-color: var(
@@ -351,25 +295,6 @@ governing permissions and limitations under the License.
         var(--spectrum-checkbox-selected-border-width)
     );
 }
-:host([invalid][invalid][indeterminate]:hover) #box:before,
-:host([invalid][invalid][indeterminate]:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-default,
-        var(
-            --mod-checkbox-invalid-color-hover,
-            var(--spectrum-checkbox-invalid-color-hover)
-        )
-    );
-}
-:host([invalid][invalid][indeterminate]:hover) #label {
-    color: var(
-        --highcontrast-checkbox-content-color-hover,
-        var(
-            --mod-checkbox-content-color-hover,
-            var(--spectrum-checkbox-content-color-hover)
-        )
-    );
-}
 :host([emphasized]) #input:checked + #box:before,
 :host([emphasized][indeterminate]) #box:before,
 :host([emphasized][indeterminate]) #input:checked + #box:before {
@@ -378,17 +303,6 @@ governing permissions and limitations under the License.
         var(
             --mod-checkbox-emphasized-color-default,
             var(--spectrum-checkbox-emphasized-color-default)
-        )
-    );
-}
-:host([emphasized]:hover) #input:checked + #box:before,
-:host([emphasized][indeterminate]:hover) #box:before,
-:host([emphasized][indeterminate]:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-hover,
-        var(
-            --mod-checkbox-emphasized-color-hover,
-            var(--spectrum-checkbox-emphasized-color-hover)
         )
     );
 }
@@ -434,29 +348,111 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([emphasized][invalid][invalid]:hover) #input:checked + #box:before,
-:host([emphasized][invalid][invalid][indeterminate]:hover) #box:before,
-:host([emphasized][invalid][invalid][indeterminate]:hover)
-    #input:checked
-    + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-color-hover,
-        var(
-            --mod-checkbox-invalid-color-hover,
-            var(--spectrum-checkbox-invalid-color-hover)
-        )
-    );
-}
-:host([emphasized]:hover) #input:checked + #box:before,
-:host([emphasized][indeterminate]:hover) #box:before,
-:host([emphasized][indeterminate]:hover) #input:checked + #box:before {
-    border-color: var(
-        --highcontrast-checkbox-highlight-color-hover,
-        var(
-            --mod-checkbox-emphasized-color-hover,
-            var(--spectrum-checkbox-emphasized-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid][invalid]:hover) #box:before,
+    :host([invalid][invalid]:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-hover,
+            var(
+                --mod-checkbox-invalid-color-hover,
+                var(--spectrum-checkbox-invalid-color-hover)
+            )
+        );
+    }
+    :host([readonly]:hover) #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-default,
+            var(
+                --mod-checkbox-control-selected-color-default,
+                var(--spectrum-checkbox-control-selected-color-default)
+            )
+        );
+    }
+    :host([indeterminate]:hover) #box:before,
+    :host([indeterminate]:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-control-selected-color-hover,
+                var(--spectrum-checkbox-control-selected-color-hover)
+            )
+        );
+    }
+    :host([invalid][invalid][indeterminate]:hover) #box:before,
+    :host([invalid][invalid][indeterminate]:hover)
+        #input:checked
+        + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-default,
+            var(
+                --mod-checkbox-invalid-color-hover,
+                var(--spectrum-checkbox-invalid-color-hover)
+            )
+        );
+    }
+    :host(:hover) #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-control-color-hover,
+                var(--spectrum-checkbox-control-color-hover)
+            )
+        );
+    }
+    :host(:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-control-selected-color-hover,
+                var(--spectrum-checkbox-control-selected-color-hover)
+            )
+        );
+    }
+    :host(:hover) #label,
+    :host([invalid][invalid][indeterminate]:hover) #label {
+        color: var(
+            --highcontrast-checkbox-content-color-hover,
+            var(
+                --mod-checkbox-content-color-hover,
+                var(--spectrum-checkbox-content-color-hover)
+            )
+        );
+    }
+    :host([emphasized]:hover) #input:checked + #box:before,
+    :host([emphasized][indeterminate]:hover) #box:before,
+    :host([emphasized][indeterminate]:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-hover,
+            var(
+                --mod-checkbox-emphasized-color-hover,
+                var(--spectrum-checkbox-emphasized-color-hover)
+            )
+        );
+    }
+    :host([emphasized][invalid][invalid]:hover) #input:checked + #box:before,
+    :host([emphasized][invalid][invalid][indeterminate]:hover) #box:before,
+    :host([emphasized][invalid][invalid][indeterminate]:hover)
+        #input:checked
+        + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-color-hover,
+            var(
+                --mod-checkbox-invalid-color-hover,
+                var(--spectrum-checkbox-invalid-color-hover)
+            )
+        );
+    }
+    :host([emphasized]:hover) #input:checked + #box:before,
+    :host([emphasized][indeterminate]:hover) #box:before,
+    :host([emphasized][indeterminate]:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-emphasized-color-hover,
+                var(--spectrum-checkbox-emphasized-color-hover)
+            )
+        );
+    }
 }
 :host([emphasized]):active #input:checked + #box:before,
 :host([emphasized][indeterminate]):active #box:before,

--- a/packages/clear-button/package.json
+++ b/packages/clear-button/package.json
@@ -45,7 +45,7 @@
         "@spectrum-web-components/base": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/clearbutton": "^5.0.16"
+        "@spectrum-css/clearbutton": "^5.1.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/clear-button/src/spectrum-clear-button.css
+++ b/packages/clear-button/src/spectrum-clear-button.css
@@ -139,20 +139,22 @@ governing permissions and limitations under the License.
     margin-block: 0;
     margin-inline: auto;
 }
-:host(:hover) {
-    color: var(
-        --highcontrast-clear-button-icon-color-hover,
-        var(
-            --mod-clear-button-icon-color-hover,
-            var(--spectrum-clear-button-icon-color-hover)
-        )
-    );
-}
-:host(:hover) .fill {
-    background-color: var(
-        --mod-clear-button-background-color-hover,
-        var(--spectrum-clear-button-background-color-hover)
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        color: var(
+            --highcontrast-clear-button-icon-color-hover,
+            var(
+                --mod-clear-button-icon-color-hover,
+                var(--spectrum-clear-button-icon-color-hover)
+            )
+        );
+    }
+    :host(:hover) .fill {
+        background-color: var(
+            --mod-clear-button-background-color-hover,
+            var(--spectrum-clear-button-background-color-hover)
+        );
+    }
 }
 :host([active]) {
     color: var(

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -45,7 +45,7 @@
         "@spectrum-web-components/base": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/closebutton": "^4.1.0"
+        "@spectrum-css/closebutton": "^4.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -341,21 +341,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:not([disabled]):hover) {
-    background-color: var(
-        --mod-closebutton-background-color-hover,
-        var(--spectrum-closebutton-background-color-hover)
-    );
-}
-:host(:not([disabled]):hover) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-hover,
-        var(
-            --mod-closebutton-icon-color-hover,
-            var(--spectrum-closebutton-icon-color-hover)
-        )
-    );
-}
 :host(:not([disabled])[active]) {
     background-color: var(
         --mod-closebutton-background-color-down,
@@ -446,25 +431,42 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([static='black']:not([disabled]):hover),
-:host([static='white']:not([disabled]):hover) {
-    background-color: var(
-        --highcontrast-closebutton-static-background-color-hover,
-        var(
-            --mod-closebutton-static-background-color-hover,
-            var(--spectrum-closebutton-static-background-color-hover)
-        )
-    );
-}
-:host([static='black']:not([disabled]):hover) .icon,
-:host([static='white']:not([disabled]):hover) .icon {
-    color: var(
-        --highcontrast-closebutton-icon-color-default,
-        var(
-            --mod-closebutton-icon-color-default,
-            var(--spectrum-closebutton-icon-color-default)
-        )
-    );
+@media (hover: hover) {
+    :host(:not([disabled]):hover) .icon {
+        color: var(
+            --highcontrast-closebutton-icon-color-hover,
+            var(
+                --mod-closebutton-icon-color-hover,
+                var(--spectrum-closebutton-icon-color-hover)
+            )
+        );
+    }
+    :host(:not([disabled]):hover) {
+        background-color: var(
+            --mod-closebutton-background-color-hover,
+            var(--spectrum-closebutton-background-color-hover)
+        );
+    }
+    :host([static='black']:not([disabled]):hover),
+    :host([static='white']:not([disabled]):hover) {
+        background-color: var(
+            --highcontrast-closebutton-static-background-color-hover,
+            var(
+                --mod-closebutton-static-background-color-hover,
+                var(--spectrum-closebutton-static-background-color-hover)
+            )
+        );
+    }
+    :host([static='black']:not([disabled]):hover) .icon,
+    :host([static='white']:not([disabled]):hover) .icon {
+        color: var(
+            --highcontrast-closebutton-icon-color-default,
+            var(
+                --mod-closebutton-icon-color-default,
+                var(--spectrum-closebutton-icon-color-default)
+            )
+        );
+    }
 }
 :host([static='black']:not([disabled])[active]),
 :host([static='white']:not([disabled])[active]) {

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -67,7 +67,7 @@
         "@spectrum-web-components/textfield": "^0.40.1"
     },
     "devDependencies": {
-        "@spectrum-css/combobox": "^2.0.48"
+        "@spectrum-css/combobox": "^2.1.0"
     },
     "types": "./src/index.d.ts",
     "sideEffects": [

--- a/packages/combobox/src/spectrum-combobox.css
+++ b/packages/combobox/src/spectrum-combobox.css
@@ -279,8 +279,6 @@ governing permissions and limitations under the License.
             var(--mod-combobox-icon-size, var(--spectrum-combobox-icon-size)) /
             2
     );
-    --mod-picker-button-background-color-quiet: transparent;
-    --mod-picker-button-border-color-quiet: transparent;
 }
 :host([quiet][size='s']) {
     --spectrum-combobox-spacing-label-to-combobox: var(
@@ -301,6 +299,10 @@ governing permissions and limitations under the License.
     --spectrum-combobox-spacing-label-to-combobox: var(
         --spectrum-field-label-to-component-quiet-extra-large
     );
+}
+:host([quiet]) {
+    --mod-picker-button-background-color-quiet: transparent;
+    --mod-picker-button-border-color-quiet: transparent;
 }
 @media (forced-colors: active) {
     :host {
@@ -426,9 +428,6 @@ governing permissions and limitations under the License.
     );
 }
 .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet):active,
-.button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet):hover,
-:host(:hover)
-    .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet),
 :host:has(:active)
     .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet) {
     --mod-picker-button-border-color: var(
@@ -436,21 +435,6 @@ governing permissions and limitations under the License.
         var(
             --mod-combobox-border-color-hover,
             var(--spectrum-combobox-border-color-hover)
-        )
-    );
-}
-.button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet):focus:hover,
-:host(:hover):has(:focus)
-    .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet),
-:host([focused])
-    .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet):hover,
-:host([focused]:hover)
-    .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet) {
-    --mod-picker-button-border-color: var(
-        --highcontrast-combobox-border-color-highlight,
-        var(
-            --mod-combobox-border-color-focus-hover,
-            var(--spectrum-combobox-border-color-focus-hover)
         )
     );
 }
@@ -506,31 +490,13 @@ governing permissions and limitations under the License.
     );
 }
 :host([invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet):active,
-:host([invalid]) .button:not(:disabled, .spectrum-PickerButton--quiet):hover,
 :host([invalid]):has(:active)
-    .button:not(:disabled, .spectrum-PickerButton--quiet),
-:host([invalid]:hover) .button:not(:disabled, .spectrum-PickerButton--quiet) {
+    .button:not(:disabled, .spectrum-PickerButton--quiet) {
     --mod-picker-button-border-color: var(
         --highcontrast-combobox-border-color-invalid,
         var(
             --mod-combobox-border-color-invalid-hover,
             var(--spectrum-combobox-border-color-invalid-hover)
-        )
-    );
-}
-:host([focused][invalid]:hover)
-    .button:not(:disabled, .spectrum-PickerButton--quiet),
-:host([invalid])
-    .button:not(:disabled, .spectrum-PickerButton--quiet):focus:hover,
-:host([invalid]:hover):has(:focus)
-    .button:not(:disabled, .spectrum-PickerButton--quiet),
-:host([invalid][focused])
-    .button:not(:disabled, .spectrum-PickerButton--quiet):hover {
-    --mod-picker-button-border-color: var(
-        --highcontrast-combobox-border-color-invalid,
-        var(
-            --mod-combobox-border-color-invalid-focus-hover,
-            var(--spectrum-combobox-border-color-invalid-focus-hover)
         )
     );
 }
@@ -598,9 +564,7 @@ governing permissions and limitations under the License.
         --mod-combobox-font-color-placeholder
     );
 }
-#input:active,
-#input:hover,
-.spectrum-Combobox-textfield #input {
+#input:active {
     --mod-textfield-background-color: var(
         --mod-combobox-background-color-hover
     );
@@ -611,11 +575,73 @@ governing permissions and limitations under the License.
         --mod-combobox-background-color-focus
     );
 }
-#input:focus:hover,
-.spectrum-Combobox-textfield #input:hover {
-    --mod-textfield-background-color: var(
-        --mod-combobox-background-color-focus-hover
-    );
+@media (hover: hover) {
+    .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet):hover,
+    :host(:hover)
+        .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet) {
+        --mod-picker-button-border-color: var(
+            --highcontrast-combobox-border-color-highlight,
+            var(
+                --mod-combobox-border-color-hover,
+                var(--spectrum-combobox-border-color-hover)
+            )
+        );
+    }
+    .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet):focus:hover,
+    :host(:hover):has(:focus)
+        .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet),
+    :host([focused])
+        .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet):hover,
+    :host([focused]:hover)
+        .button:not(:disabled, .is-invalid, .spectrum-PickerButton--quiet) {
+        --mod-picker-button-border-color: var(
+            --highcontrast-combobox-border-color-highlight,
+            var(
+                --mod-combobox-border-color-focus-hover,
+                var(--spectrum-combobox-border-color-focus-hover)
+            )
+        );
+    }
+    :host([invalid])
+        .button:not(:disabled, .spectrum-PickerButton--quiet):hover,
+    :host([invalid]:hover)
+        .button:not(:disabled, .spectrum-PickerButton--quiet) {
+        --mod-picker-button-border-color: var(
+            --highcontrast-combobox-border-color-invalid,
+            var(
+                --mod-combobox-border-color-invalid-hover,
+                var(--spectrum-combobox-border-color-invalid-hover)
+            )
+        );
+    }
+    :host([focused][invalid]:hover)
+        .button:not(:disabled, .spectrum-PickerButton--quiet),
+    :host([invalid])
+        .button:not(:disabled, .spectrum-PickerButton--quiet):focus:hover,
+    :host([invalid]:hover):has(:focus)
+        .button:not(:disabled, .spectrum-PickerButton--quiet),
+    :host([invalid][focused])
+        .button:not(:disabled, .spectrum-PickerButton--quiet):hover {
+        --mod-picker-button-border-color: var(
+            --highcontrast-combobox-border-color-invalid,
+            var(
+                --mod-combobox-border-color-invalid-focus-hover,
+                var(--spectrum-combobox-border-color-invalid-focus-hover)
+            )
+        );
+    }
+    #input:hover,
+    .spectrum-Combobox-textfield #input {
+        --mod-textfield-background-color: var(
+            --mod-combobox-background-color-hover
+        );
+    }
+    #input:focus:hover,
+    .spectrum-Combobox-textfield #input:hover {
+        --mod-textfield-background-color: var(
+            --mod-combobox-background-color-focus-hover
+        );
+    }
 }
 .spectrum-Combobox-textfield #input {
     --mod-textfield-background-color: var(

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/dropzone": "^5.1.0"
+        "@spectrum-css/dropzone": "^5.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dropzone/src/spectrum-dropzone.css
+++ b/packages/dropzone/src/spectrum-dropzone.css
@@ -306,12 +306,19 @@ governing permissions and limitations under the License.
         var(--spectrum-drop-zone-content-top-to-text)
     );
 }
-.spectrum-DropZone-button:focus,
-.spectrum-DropZone-button:hover {
+.spectrum-DropZone-button:focus {
     background-color: var(
         --mod-drop-zone-content-background-color,
         var(--spectrum-drop-zone-content-background-color)
     );
+}
+@media (hover: hover) {
+    .spectrum-DropZone-button:hover {
+        background-color: var(
+            --mod-drop-zone-content-background-color,
+            var(--spectrum-drop-zone-content-background-color)
+        );
+    }
 }
 @media (forced-colors: active) {
     :host {

--- a/packages/infield-button/package.json
+++ b/packages/infield-button/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/button": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/infieldbutton": "^4.1.0"
+        "@spectrum-css/infieldbutton": "^4.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/infield-button/src/spectrum-infield-button.css
+++ b/packages/infield-button/src/spectrum-infield-button.css
@@ -189,14 +189,17 @@ governing permissions and limitations under the License.
 }
 @media (forced-colors: active) {
     :host(.focus-visible):not(:disabled),
-    :host(:hover):not(:disabled),
     :host:active:not(:disabled) {
         --highcontrast-infield-button-border-color: Highlight;
     }
     :host(:focus-visible):not(:disabled),
-    :host(:hover):not(:disabled),
     :host:active:not(:disabled) {
         --highcontrast-infield-button-border-color: Highlight;
+    }
+    @media (hover: hover) {
+        :host(:hover):not(:disabled) {
+            --highcontrast-infield-button-border-color: Highlight;
+        }
     }
 }
 :host {
@@ -288,17 +291,19 @@ governing permissions and limitations under the License.
 :host([disabled]) {
     cursor: auto;
 }
-:host(:hover) .fill {
-    background-color: var(
-        --mod-infield-button-background-color-hover,
-        var(--spectrum-infield-button-background-color-hover)
-    );
-}
-:host(:hover) ::slotted(*) {
-    color: var(
-        --mod-infield-button-icon-color-hover,
-        var(--spectrum-infield-button-icon-color-hover)
-    );
+@media (hover: hover) {
+    :host(:hover) .fill {
+        background-color: var(
+            --mod-infield-button-background-color-hover,
+            var(--spectrum-infield-button-background-color-hover)
+        );
+    }
+    :host(:hover) ::slotted(*) {
+        color: var(
+            --mod-infield-button-icon-color-hover,
+            var(--spectrum-infield-button-icon-color-hover)
+        );
+    }
 }
 :host:active .fill {
     background-color: var(

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/link": "^4.1.0"
+        "@spectrum-css/link": "^4.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/link/src/spectrum-link.css
+++ b/packages/link/src/spectrum-link.css
@@ -75,15 +75,6 @@ a {
         )
         ease-in-out;
 }
-a:hover {
-    color: var(
-        --highcontrast-link-text-color-primary-hover,
-        var(
-            --mod-link-text-color-primary-hover,
-            var(--spectrum-link-text-color-primary-hover)
-        )
-    );
-}
 a:active {
     color: var(
         --highcontrast-link-text-color-primary-active,
@@ -101,10 +92,10 @@ a.focus-visible {
             var(--spectrum-link-text-color-primary-focus)
         )
     );
-    -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration: underline double;
+    text-decoration: underline double;
     text-decoration-color: var(--highcontrast-link-focus-color, inherit);
-    text-decoration-style: double;
 }
 a:focus-visible {
     color: var(
@@ -114,10 +105,10 @@ a:focus-visible {
             var(--spectrum-link-text-color-primary-focus)
         )
     );
-    -webkit-text-decoration: underline;
     text-decoration: underline;
+    -webkit-text-decoration: underline double;
+    text-decoration: underline double;
     text-decoration-color: var(--highcontrast-link-focus-color, inherit);
-    text-decoration-style: double;
 }
 :host([variant='secondary']) a {
     color: var(
@@ -125,15 +116,6 @@ a:focus-visible {
         var(
             --mod-link-text-color-secondary-default,
             var(--spectrum-link-text-color-secondary-default)
-        )
-    );
-}
-:host([variant='secondary']) a:hover {
-    color: var(
-        --highcontrast-link-text-color-secondary-hover,
-        var(
-            --mod-link-text-color-secondary-hover,
-            var(--spectrum-link-text-color-secondary-hover)
         )
     );
 }
@@ -159,10 +141,6 @@ a:focus-visible {
     -webkit-text-decoration: none;
     text-decoration: none;
 }
-:host([quiet]) a:hover {
-    -webkit-text-decoration: underline;
-    text-decoration: underline;
-}
 :host([static='white']) a {
     color: var(
         --highcontrast-link-text-color-white,
@@ -170,8 +148,7 @@ a:focus-visible {
     );
 }
 :host([static='white']) a:active,
-:host([static='white']) a:focus,
-:host([static='white']) a:hover {
+:host([static='white']) a:focus {
     color: var(
         --highcontrast-link-text-color-white,
         var(--mod-link-text-color-white, var(--spectrum-link-text-color-white))
@@ -184,10 +161,51 @@ a:focus-visible {
     );
 }
 :host([static='black']) a:active,
-:host([static='black']) a:focus,
-:host([static='black']) a:hover {
+:host([static='black']) a:focus {
     color: var(
         --highcontrast-link-text-color-black,
         var(--mod-link-text-color-black, var(--spectrum-link-text-color-black))
     );
+}
+@media (hover: hover) {
+    a:hover {
+        color: var(
+            --highcontrast-link-text-color-primary-hover,
+            var(
+                --mod-link-text-color-primary-hover,
+                var(--spectrum-link-text-color-primary-hover)
+            )
+        );
+    }
+    :host([variant='secondary']) a:hover {
+        color: var(
+            --highcontrast-link-text-color-secondary-hover,
+            var(
+                --mod-link-text-color-secondary-hover,
+                var(--spectrum-link-text-color-secondary-hover)
+            )
+        );
+    }
+    :host([quiet]) a:hover {
+        -webkit-text-decoration: underline;
+        text-decoration: underline;
+    }
+    :host([static='white']) a:hover {
+        color: var(
+            --highcontrast-link-text-color-white,
+            var(
+                --mod-link-text-color-white,
+                var(--spectrum-link-text-color-white)
+            )
+        );
+    }
+    :host([static='black']) a:hover {
+        color: var(
+            --highcontrast-link-text-color-black,
+            var(
+                --mod-link-text-color-black,
+                var(--spectrum-link-text-color-black)
+            )
+        );
+    }
 }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -95,7 +95,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/menu": "^6.0.0"
+        "@spectrum-css/menu": "^6.1.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -76,6 +76,7 @@ const config = {
                 converter.classToHost('spectrum-Menu-item'),
                 converter.classToAttribute('is-disabled', 'disabled'),
                 converter.classToAttribute('is-active', 'active'),
+                converter.pseudoToAttribute('active', 'active'),
                 converter.classToAttribute('is-focused', 'focused'),
                 converter.classToAttribute('is-selected', 'selected'),
                 converter.classToId('spectrum-Menu-itemLabel', 'label'),

--- a/packages/menu/src/spectrum-menu-divider.css
+++ b/packages/menu/src/spectrum-menu-divider.css
@@ -13,6 +13,8 @@ governing permissions and limitations under the License.
 /* THIS FILE IS MACHINE GENERATED. DO NOT EDIT */
 :host {
     --spectrum-menu-divider-thickness: var(--spectrum-divider-thickness-medium);
+}
+:host {
     inline-size: auto;
     margin-block: var(
         --mod-menu-section-divider-margin-block,

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -235,90 +235,6 @@ governing permissions and limitations under the License.
 :host([dir='rtl']) {
     --spectrum-menu-item-focus-indicator-direction-scalar: -1;
 }
-:host(:hover) {
-    background-color: var(
-        --highcontrast-menu-item-background-color-focus,
-        var(
-            --mod-menu-item-background-color-hover,
-            var(--spectrum-menu-item-background-color-hover)
-        )
-    );
-}
-:host(:hover) > #label {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-content-color-hover,
-            var(--spectrum-menu-item-label-content-color-hover)
-        )
-    );
-}
-:host(:hover) > [name='description']::slotted(*) {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-description-color-hover,
-            var(--spectrum-menu-item-description-color-hover)
-        )
-    );
-}
-:host(:hover) > ::slotted([slot='value']) {
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-value-color-hover,
-            var(--spectrum-menu-item-value-color-hover)
-        )
-    );
-}
-:host(:hover) > .icon:not(.chevron, .checkmark) {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-icon-color-hover,
-            var(--spectrum-menu-item-label-icon-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-item-label-icon-color-hover,
-            var(--spectrum-menu-item-label-icon-color-hover)
-        )
-    );
-}
-:host(:hover) > .chevron {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-collapsible-icon-color,
-            var(--spectrum-menu-collapsible-icon-color)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-collapsible-icon-color,
-            var(--spectrum-menu-collapsible-icon-color)
-        )
-    );
-}
-:host(:hover) > .checkmark {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-checkmark-icon-color-hover,
-            var(--spectrum-menu-checkmark-icon-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-checkmark-icon-color-hover,
-            var(--spectrum-menu-checkmark-icon-color-hover)
-        )
-    );
-}
 :host:active {
     background-color: var(
         --highcontrast-menu-item-background-color-focus,
@@ -567,7 +483,6 @@ governing permissions and limitations under the License.
 }
 .spectrum-Menu-item--collapsible.is-open:active,
 .spectrum-Menu-item--collapsible.is-open:focus,
-.spectrum-Menu-item--collapsible.is-open:hover,
 :host([focused]) .spectrum-Menu-item--collapsible.is-open {
     background-color: var(
         --highcontrast-menu-item-background-color-default,
@@ -674,22 +589,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([has-submenu]:hover) .chevron {
-    fill: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-drillin-icon-color-hover,
-            var(--spectrum-menu-drillin-icon-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-focus,
-        var(
-            --mod-menu-drillin-icon-color-hover,
-            var(--spectrum-menu-drillin-icon-color-hover)
-        )
-    );
-}
 :host([has-submenu]:focus) .chevron,
 :host([has-submenu][focused]) .chevron {
     fill: var(
@@ -764,26 +663,158 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([aria-disabled='true']:hover),
-:host([disabled]:hover) {
-    cursor: default;
-}
-:host([aria-disabled='true']:hover) ::slotted([slot='icon']),
-:host([disabled]:hover) ::slotted([slot='icon']) {
-    fill: var(
-        --highcontrast-menu-item-color-disabled,
-        var(
-            --mod-menu-item-label-icon-color-disabled,
-            var(--spectrum-menu-item-label-icon-color-disabled)
-        )
-    );
-    color: var(
-        --highcontrast-menu-item-color-disabled,
-        var(
-            --mod-menu-item-label-icon-color-disabled,
-            var(--spectrum-menu-item-label-icon-color-disabled)
-        )
-    );
+@media (hover: hover) {
+    :host([has-submenu]:hover) .chevron {
+        fill: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-drillin-icon-color-hover,
+                var(--spectrum-menu-drillin-icon-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-drillin-icon-color-hover,
+                var(--spectrum-menu-drillin-icon-color-hover)
+            )
+        );
+    }
+    :host(:hover) {
+        background-color: var(
+            --highcontrast-menu-item-background-color-focus,
+            var(
+                --mod-menu-item-background-color-hover,
+                var(--spectrum-menu-item-background-color-hover)
+            )
+        );
+    }
+    :host(:hover) > #label {
+        color: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-item-label-content-color-hover,
+                var(--spectrum-menu-item-label-content-color-hover)
+            )
+        );
+    }
+    :host(:hover) > [name='description']::slotted(*) {
+        color: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-item-description-color-hover,
+                var(--spectrum-menu-item-description-color-hover)
+            )
+        );
+    }
+    :host(:hover) > ::slotted([slot='value']) {
+        color: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-item-value-color-hover,
+                var(--spectrum-menu-item-value-color-hover)
+            )
+        );
+    }
+    :host(:hover) > .icon:not(.chevron, .checkmark) {
+        fill: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-item-label-icon-color-hover,
+                var(--spectrum-menu-item-label-icon-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-item-label-icon-color-hover,
+                var(--spectrum-menu-item-label-icon-color-hover)
+            )
+        );
+    }
+    :host(:hover) > .chevron {
+        fill: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-collapsible-icon-color,
+                var(--spectrum-menu-collapsible-icon-color)
+            )
+        );
+        color: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-collapsible-icon-color,
+                var(--spectrum-menu-collapsible-icon-color)
+            )
+        );
+    }
+    :host(:hover) > .checkmark {
+        fill: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-checkmark-icon-color-hover,
+                var(--spectrum-menu-checkmark-icon-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-menu-item-color-focus,
+            var(
+                --mod-menu-checkmark-icon-color-hover,
+                var(--spectrum-menu-checkmark-icon-color-hover)
+            )
+        );
+    }
+    .spectrum-Menu-item--collapsible.is-open:hover {
+        background-color: var(
+            --highcontrast-menu-item-background-color-default,
+            var(
+                --mod-menu-item-background-color-default,
+                var(--spectrum-menu-item-background-color-default)
+            )
+        );
+    }
+    :host([aria-disabled='true']:hover),
+    :host([disabled]:hover) {
+        background-color: #0000;
+        cursor: default;
+    }
+    :host([aria-disabled='true']:hover) #label,
+    :host([disabled]:hover) #label {
+        color: var(
+            --highcontrast-menu-item-color-disabled,
+            var(
+                --mod-menu-item-label-content-color-disabled,
+                var(--spectrum-menu-item-label-content-color-disabled)
+            )
+        );
+    }
+    :host([aria-disabled='true']:hover) [name='description']::slotted(*),
+    :host([disabled]:hover) [name='description']::slotted(*) {
+        color: var(
+            --highcontrast-menu-item-color-disabled,
+            var(
+                --mod-menu-item-description-color-disabled,
+                var(--spectrum-menu-item-description-color-disabled)
+            )
+        );
+    }
+    :host([aria-disabled='true']:hover) ::slotted([slot='icon']),
+    :host([disabled]:hover) ::slotted([slot='icon']) {
+        fill: var(
+            --highcontrast-menu-item-color-disabled,
+            var(
+                --mod-menu-item-label-icon-color-disabled,
+                var(--spectrum-menu-item-label-icon-color-disabled)
+            )
+        );
+        color: var(
+            --highcontrast-menu-item-color-disabled,
+            var(
+                --mod-menu-item-label-icon-color-disabled,
+                var(--spectrum-menu-item-label-icon-color-disabled)
+            )
+        );
+    }
 }
 .spectrum-Menu-back {
     align-items: center;

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -235,7 +235,7 @@ governing permissions and limitations under the License.
 :host([dir='rtl']) {
     --spectrum-menu-item-focus-indicator-direction-scalar: -1;
 }
-:host:active {
+:host([active]) {
     background-color: var(
         --highcontrast-menu-item-background-color-focus,
         var(
@@ -244,7 +244,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host:active > #label {
+:host([active]) > #label {
     color: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -253,7 +253,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host:active > [name='description']::slotted(*) {
+:host([active]) > [name='description']::slotted(*) {
     color: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -262,7 +262,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host:active > ::slotted([slot='value']) {
+:host([active]) > ::slotted([slot='value']) {
     color: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -271,7 +271,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host:active > .icon:not(.chevron, .checkmark) {
+:host([active]) > .icon:not(.chevron, .checkmark) {
     fill: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -287,7 +287,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host:active > .chevron {
+:host([active]) > .chevron {
     fill: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -303,7 +303,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host:active > .checkmark {
+:host([active]) > .checkmark {
     fill: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -481,8 +481,8 @@ governing permissions and limitations under the License.
 .spectrum-Menu-item--collapsible.is-open .chevron {
     transform: rotate(90deg);
 }
-.spectrum-Menu-item--collapsible.is-open:active,
 .spectrum-Menu-item--collapsible.is-open:focus,
+:host([active]) .spectrum-Menu-item--collapsible.is-open,
 :host([focused]) .spectrum-Menu-item--collapsible.is-open {
     background-color: var(
         --highcontrast-menu-item-background-color-default,
@@ -606,7 +606,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([has-submenu]):active .chevron {
+:host([has-submenu][active]) .chevron {
     fill: var(
         --highcontrast-menu-item-color-focus,
         var(

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -68,7 +68,7 @@
     },
     "devDependencies": {
         "@formatjs/intl-numberformat": "^8.3.5",
-        "@spectrum-css/stepper": "^5.0.7"
+        "@spectrum-css/stepper": "^5.1.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/number-field/src/spectrum-number-field.css
+++ b/packages/number-field/src/spectrum-number-field.css
@@ -121,24 +121,11 @@ governing permissions and limitations under the License.
     );
     --mod-textfield-icon-spacing-inline-start-invalid: 0;
 }
-:host([invalid]:hover) #textfield {
-    --mod-infield-button-border-color: var(
-        --mod-stepper-border-color-hover-invalid,
-        var(--spectrum-negative-border-color-hover)
-    );
-}
 :host([invalid]) #textfield:focus,
 :host([invalid][focused]) #textfield {
     --mod-infield-button-border-color: var(
         --mod-stepper-border-color-focus-invalid,
         var(--spectrum-stepper-border-color-focus-invalid)
-    );
-}
-:host([invalid]:hover) #textfield:focus,
-:host([invalid][focused]:hover) #textfield {
-    --mod-infield-button-border-color: var(
-        --mod-stepper-border-color-focus-hover-invalid,
-        var(--spectrum-stepper-border-color-focus-hover-invalid)
     );
 }
 :host([invalid]) #textfield.focus-visible,
@@ -181,25 +168,6 @@ governing permissions and limitations under the License.
     border-inline-end-width: 0;
     border-start-end-radius: 0;
 }
-:host(:hover) #textfield:not(.is-disabled, .is-invalid) {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color-hover,
-        var(
-            --mod-stepper-buttons-border-color-hover,
-            var(--spectrum-stepper-buttons-border-color-hover)
-        )
-    );
-}
-:host(:hover:not([disabled])) #textfield .buttons,
-:host(:hover:not([disabled])) #textfield .input {
-    border-color: var(
-        --highcontrast-stepper-border-color-hover,
-        var(
-            --mod-stepper-border-color-hover,
-            var(--spectrum-stepper-border-color-hover)
-        )
-    );
-}
 #textfield:focus,
 :host([focused]) #textfield {
     --mod-infield-button-border-color: var(
@@ -223,28 +191,6 @@ governing permissions and limitations under the License.
         var(
             --mod-stepper-border-color-focus,
             var(--spectrum-stepper-border-color-focus)
-        )
-    );
-}
-:host(:hover) #textfield:focus,
-:host([focused]:hover) #textfield {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color-focus-hover,
-        var(
-            --mod-stepper-buttons-border-color-focus-hover,
-            var(--spectrum-stepper-buttons-border-color-focus-hover)
-        )
-    );
-}
-:host(:hover) #textfield:focus .buttons,
-:host(:hover) #textfield:focus .input,
-:host([focused]:hover) #textfield .buttons,
-:host([focused]:hover) #textfield .input {
-    border-color: var(
-        --highcontrast-stepper-border-color-focus-hover,
-        var(
-            --mod-stepper-border-color-focus-hover,
-            var(--spectrum-stepper-border-color-focus-hover)
         )
     );
 }
@@ -389,18 +335,6 @@ governing permissions and limitations under the License.
 :host([quiet]) #textfield .input {
     background-color: #0000;
 }
-:host([quiet]:hover:not([disabled])) #textfield {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color-hover,
-        var(
-            --mod-stepper-border-color-hover,
-            var(--spectrum-stepper-border-color-hover)
-        )
-    );
-}
-:host([quiet]:hover:not([disabled])) #textfield .buttons {
-    background-color: #0000;
-}
 :host([quiet]) #textfield:focus,
 :host([quiet][focused]) #textfield {
     --mod-infield-button-border-color: var(
@@ -408,16 +342,6 @@ governing permissions and limitations under the License.
         var(
             --mod-stepper-border-color-focus,
             var(--spectrum-stepper-border-color-focus)
-        )
-    );
-}
-:host([quiet]:hover) #textfield:focus,
-:host([quiet][focused]:hover) #textfield {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color-focus-hover,
-        var(
-            --mod-stepper-border-color-focus-hover,
-            var(--spectrum-stepper-border-color-focus-hover)
         )
     );
 }
@@ -440,14 +364,92 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([quiet][keyboard-focused]:hover) #textfield {
-    --mod-infield-button-border-color: var(
-        --highcontrast-stepper-border-color-hover,
-        var(
-            --mod-stepper-border-color-hover,
-            var(--spectrum-stepper-border-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid]:hover) #textfield:focus,
+    :host([invalid][focused]:hover) #textfield {
+        --mod-infield-button-border-color: var(
+            --mod-stepper-border-color-focus-hover-invalid,
+            var(--spectrum-stepper-border-color-focus-hover-invalid)
+        );
+    }
+    :host(:hover) #textfield:focus .buttons,
+    :host(:hover) #textfield:focus .input,
+    :host([focused]:hover) #textfield .buttons,
+    :host([focused]:hover) #textfield .input {
+        border-color: var(
+            --highcontrast-stepper-border-color-focus-hover,
+            var(
+                --mod-stepper-border-color-focus-hover,
+                var(--spectrum-stepper-border-color-focus-hover)
+            )
+        );
+    }
+    :host([invalid]:hover) #textfield {
+        --mod-infield-button-border-color: var(
+            --mod-stepper-border-color-hover-invalid,
+            var(--spectrum-negative-border-color-hover)
+        );
+    }
+    :host(:hover:not([disabled])) #textfield .buttons,
+    :host(:hover:not([disabled])) #textfield .input {
+        border-color: var(
+            --highcontrast-stepper-border-color-hover,
+            var(
+                --mod-stepper-border-color-hover,
+                var(--spectrum-stepper-border-color-hover)
+            )
+        );
+    }
+    :host(:hover) #textfield:focus,
+    :host([focused]:hover) #textfield {
+        --mod-infield-button-border-color: var(
+            --highcontrast-stepper-border-color-focus-hover,
+            var(
+                --mod-stepper-buttons-border-color-focus-hover,
+                var(--spectrum-stepper-buttons-border-color-focus-hover)
+            )
+        );
+    }
+    :host(:hover) #textfield:not(.is-disabled, .is-invalid) {
+        --mod-infield-button-border-color: var(
+            --highcontrast-stepper-border-color-hover,
+            var(
+                --mod-stepper-buttons-border-color-hover,
+                var(--spectrum-stepper-buttons-border-color-hover)
+            )
+        );
+    }
+    :host([quiet]:hover:not([disabled])) #textfield {
+        --mod-infield-button-border-color: var(
+            --highcontrast-stepper-border-color-hover,
+            var(
+                --mod-stepper-border-color-hover,
+                var(--spectrum-stepper-border-color-hover)
+            )
+        );
+    }
+    :host([quiet]:hover:not([disabled])) #textfield .buttons {
+        background-color: #0000;
+    }
+    :host([quiet]:hover) #textfield:focus,
+    :host([quiet][focused]:hover) #textfield {
+        --mod-infield-button-border-color: var(
+            --highcontrast-stepper-border-color-focus-hover,
+            var(
+                --mod-stepper-border-color-focus-hover,
+                var(--spectrum-stepper-border-color-focus-hover)
+            )
+        );
+    }
+    :host([quiet][keyboard-focused]:hover) #textfield {
+        --mod-infield-button-border-color: var(
+            --highcontrast-stepper-border-color-hover,
+            var(
+                --mod-stepper-border-color-hover,
+                var(--spectrum-stepper-border-color-hover)
+            )
+        );
+    }
 }
 #textfield:before {
     content: '';

--- a/packages/picker-button/package.json
+++ b/packages/picker-button/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/pickerbutton": "^4.0.23"
+        "@spectrum-css/pickerbutton": "^4.1.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker-button/src/spectrum-picker-button.css
+++ b/packages/picker-button/src/spectrum-picker-button.css
@@ -168,23 +168,25 @@ governing permissions and limitations under the License.
         var(--spectrum-picker-button-padding)
     );
 }
-.root:hover .spectrum-PickerButton-fill {
-    background-color: var(
-        --mod-picker-button-background-color-hover,
-        var(--spectrum-picker-button-background-color-hover)
-    );
-}
-.root:hover .spectrum-PickerButton-label {
-    color: var(
-        --mod-picker-button-font-color-hover,
-        var(--spectrum-picker-button-font-color-hover)
-    );
-}
-.root:hover .spectrum-PickerButton-icon {
-    color: var(
-        --mod-picker-button-icon-color-hover,
-        var(--spectrum-picker-button-icon-color-hover)
-    );
+@media (hover: hover) {
+    .root:hover .spectrum-PickerButton-fill {
+        background-color: var(
+            --mod-picker-button-background-color-hover,
+            var(--spectrum-picker-button-background-color-hover)
+        );
+    }
+    .root:hover .spectrum-PickerButton-label {
+        color: var(
+            --mod-picker-button-font-color-hover,
+            var(--spectrum-picker-button-font-color-hover)
+        );
+    }
+    .root:hover .spectrum-PickerButton-icon {
+        color: var(
+            --mod-picker-button-icon-color-hover,
+            var(--spectrum-picker-button-icon-color-hover)
+        );
+    }
 }
 :host([active]) .root .spectrum-PickerButton-fill,
 :host([open]) .root .spectrum-PickerButton-fill {

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -79,7 +79,7 @@
         "@spectrum-web-components/tray": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/picker": "^7.1.0"
+        "@spectrum-css/picker": "^7.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -497,38 +497,6 @@ governing permissions and limitations under the License.
     pointer-events: none;
     position: absolute;
 }
-#button:hover {
-    background-color: var(
-        --highcontrast-picker-background-color,
-        var(
-            --mod-picker-background-color-hover,
-            var(--spectrum-picker-background-color-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-picker-border-color-hover,
-        var(
-            --mod-picker-border-color-hover,
-            var(--spectrum-picker-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-hover,
-            var(--spectrum-picker-font-color-hover)
-        )
-    );
-}
-#button:hover .picker {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-icon-color-hover,
-            var(--spectrum-picker-icon-color-hover)
-        )
-    );
-}
 #button:active {
     background-color: var(
         --highcontrast-picker-background-color,
@@ -685,15 +653,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid]) #button:not(:disabled, .is-disabled):hover {
-    border-color: var(
-        --highcontrast-picker-border-color-hover,
-        var(
-            --mod-picker-border-color-error-hover,
-            var(--spectrum-picker-border-color-error-hover)
-        )
-    );
-}
 :host([invalid]) #button:not(:disabled, .is-disabled):active {
     border-color: var(
         --highcontrast-picker-border-color-default,
@@ -709,15 +668,6 @@ governing permissions and limitations under the License.
         var(
             --mod-picker-border-color-error-default-open,
             var(--spectrum-picker-border-color-error-default-open)
-        )
-    );
-}
-:host([invalid][open]) #button:not(:disabled, .is-disabled):hover {
-    border-color: var(
-        --highcontrast-picker-border-color-hover,
-        var(
-            --mod-picker-border-color-error-hover-open,
-            var(--spectrum-picker-border-color-error-hover-open)
         )
     );
 }
@@ -823,38 +773,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([open]) #button:not(.spectrum-Picker--quiet):hover {
-    background-color: var(
-        --highcontrast-picker-background-color,
-        var(
-            --mod-picker-background-color-hover-open,
-            var(--spectrum-picker-background-color-hover-open)
-        )
-    );
-    border-color: var(
-        --highcontrast-picker-border-color-hover,
-        var(
-            --mod-picker-border-color-hover-open,
-            var(--spectrum-picker-border-color-hover-open)
-        )
-    );
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-hover-open,
-            var(--spectrum-picker-font-color-hover-open)
-        )
-    );
-}
-:host([open]) #button:not(.spectrum-Picker--quiet):hover .picker {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-icon-color-hover-open,
-            var(--spectrum-picker-icon-color-hover-open)
-        )
-    );
-}
 :host([open]) #button:not(.spectrum-Picker--quiet) .picker {
     color: var(
         --highcontrast-picker-content-color-default,
@@ -913,15 +831,6 @@ governing permissions and limitations under the License.
             var(--spectrum-picker-animation-duration)
         )
         ease-in-out;
-}
-.label.placeholder:hover {
-    color: var(
-        --highcontrast-picker-content-color-default,
-        var(
-            --mod-picker-font-color-hover,
-            var(--spectrum-picker-font-color-hover)
-        )
-    );
 }
 .label.placeholder:active {
     color: var(
@@ -1053,8 +962,104 @@ governing permissions and limitations under the License.
     border: none;
     inline-size: auto;
 }
-:host([quiet]) #button:hover {
-    background-color: var(--highcontrast-picker-background-color, transparent);
+@media (hover: hover) {
+    #button:hover .picker {
+        color: var(
+            --highcontrast-picker-content-color-default,
+            var(
+                --mod-picker-icon-color-hover,
+                var(--spectrum-picker-icon-color-hover)
+            )
+        );
+    }
+    :host([invalid]) #button:not(:disabled, .is-disabled):hover {
+        border-color: var(
+            --highcontrast-picker-border-color-hover,
+            var(
+                --mod-picker-border-color-error-hover,
+                var(--spectrum-picker-border-color-error-hover)
+            )
+        );
+    }
+    :host([invalid][open]) #button:not(:disabled, .is-disabled):hover {
+        border-color: var(
+            --highcontrast-picker-border-color-hover,
+            var(
+                --mod-picker-border-color-error-hover-open,
+                var(--spectrum-picker-border-color-error-hover-open)
+            )
+        );
+    }
+    :host([open]) #button:not(.spectrum-Picker--quiet):hover .picker {
+        color: var(
+            --highcontrast-picker-content-color-default,
+            var(
+                --mod-picker-icon-color-hover-open,
+                var(--spectrum-picker-icon-color-hover-open)
+            )
+        );
+    }
+    .label.placeholder:hover {
+        color: var(
+            --highcontrast-picker-content-color-default,
+            var(
+                --mod-picker-font-color-hover,
+                var(--spectrum-picker-font-color-hover)
+            )
+        );
+    }
+    #button:hover {
+        background-color: var(
+            --highcontrast-picker-background-color,
+            var(
+                --mod-picker-background-color-hover,
+                var(--spectrum-picker-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-picker-border-color-hover,
+            var(
+                --mod-picker-border-color-hover,
+                var(--spectrum-picker-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-picker-content-color-default,
+            var(
+                --mod-picker-font-color-hover,
+                var(--spectrum-picker-font-color-hover)
+            )
+        );
+    }
+    :host([open]) #button:not(.spectrum-Picker--quiet):hover {
+        background-color: var(
+            --highcontrast-picker-background-color,
+            var(
+                --mod-picker-background-color-hover-open,
+                var(--spectrum-picker-background-color-hover-open)
+            )
+        );
+        border-color: var(
+            --highcontrast-picker-border-color-hover,
+            var(
+                --mod-picker-border-color-hover-open,
+                var(--spectrum-picker-border-color-hover-open)
+            )
+        );
+        color: var(
+            --highcontrast-picker-content-color-default,
+            var(
+                --mod-picker-font-color-hover-open,
+                var(--spectrum-picker-font-color-hover-open)
+            )
+        );
+    }
+    :host([quiet]) #button:hover {
+        background-color: var(
+            --highcontrast-picker-background-color,
+            transparent
+        );
+    }
 }
 :host([quiet]) #button.focus-visible,
 :host([quiet]) #button.is-keyboardFocused {

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -72,7 +72,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/radio": "^8.0.19"
+        "@spectrum-css/radio": "^8.1.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/radio/src/spectrum-radio.css
+++ b/packages/radio/src/spectrum-radio.css
@@ -171,33 +171,6 @@ governing permissions and limitations under the License.
     position: relative;
     vertical-align: top;
 }
-:host(:hover) #button:before {
-    border-color: var(
-        --highcontrast-radio-button-border-color-hover,
-        var(
-            --mod-radio-button-border-color-hover,
-            var(--spectrum-radio-button-border-color-hover)
-        )
-    );
-}
-:host([checked]:hover) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-button-checked-border-color-hover,
-        var(
-            --mod-radio-button-checked-border-color-hover,
-            var(--spectrum-radio-button-checked-border-color-hover)
-        )
-    );
-}
-:host(:hover) #label {
-    color: var(
-        --highcontrast-radio-neutral-content-color-hover,
-        var(
-            --mod-radio-neutral-content-color-hover,
-            var(--spectrum-radio-neutral-content-color-hover)
-        )
-    );
-}
 :host(:active) #button:before {
     border-color: var(
         --highcontrast-radio-button-border-color-down,
@@ -348,14 +321,43 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([emphasized][checked]:hover) #input + #button:before {
-    border-color: var(
-        --highcontrast-radio-emphasized-accent-color-hover,
-        var(
-            --mod-radio-emphasized-accent-color-hover,
-            var(--spectrum-radio-emphasized-accent-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host(:hover) #button:before {
+        border-color: var(
+            --highcontrast-radio-button-border-color-hover,
+            var(
+                --mod-radio-button-border-color-hover,
+                var(--spectrum-radio-button-border-color-hover)
+            )
+        );
+    }
+    :host([checked]:hover) #input + #button:before {
+        border-color: var(
+            --highcontrast-radio-button-checked-border-color-hover,
+            var(
+                --mod-radio-button-checked-border-color-hover,
+                var(--spectrum-radio-button-checked-border-color-hover)
+            )
+        );
+    }
+    :host(:hover) #label {
+        color: var(
+            --highcontrast-radio-neutral-content-color-hover,
+            var(
+                --mod-radio-neutral-content-color-hover,
+                var(--spectrum-radio-neutral-content-color-hover)
+            )
+        );
+    }
+    :host([emphasized][checked]:hover) #input + #button:before {
+        border-color: var(
+            --highcontrast-radio-emphasized-accent-color-hover,
+            var(
+                --mod-radio-emphasized-accent-color-hover,
+                var(--spectrum-radio-emphasized-accent-color-hover)
+            )
+        );
+    }
 }
 :host([emphasized]:active[checked]) #input + #button:before {
     border-color: var(

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/textfield": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/search": "^6.1.0"
+        "@spectrum-css/search": "^6.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/search/src/spectrum-search.css
+++ b/packages/search/src/spectrum-search.css
@@ -237,25 +237,10 @@ governing permissions and limitations under the License.
     margin-block: auto;
     position: absolute;
 }
-#textfield:hover .icon-search {
-    --spectrum-search-color: var(
-        --highcontrast-search-color-hover,
-        var(--mod-search-color-hover, var(--spectrum-search-color-hover))
-    );
-}
 #textfield.is-focused .icon-search {
     --spectrum-search-color: var(
         --highcontrast-search-color-focus,
         var(--mod-search-color-focus, var(--spectrum-search-color-focus))
-    );
-}
-#textfield.is-focused:hover .icon-search {
-    --spectrum-search-color: var(
-        --highcontrast-search-color-focus,
-        var(
-            --mod-search-color-focus-hover,
-            var(--spectrum-search-color-focus-hover)
-        )
     );
 }
 #textfield.is-keyboardFocused .icon-search {
@@ -267,15 +252,46 @@ governing permissions and limitations under the License.
         )
     );
 }
-#textfield.is-disabled .icon-search,
-#textfield.is-disabled:hover .icon-search {
+#textfield.is-disabled .icon-search {
     --spectrum-search-color: var(
         --highcontrast-search-color-disabled,
         var(--mod-search-color-disabled, var(--spectrum-search-color-disabled))
     );
 }
+@media (hover: hover) {
+    #textfield:hover .icon-search {
+        --spectrum-search-color: var(
+            --highcontrast-search-color-hover,
+            var(--mod-search-color-hover, var(--spectrum-search-color-hover))
+        );
+    }
+    #textfield.is-focused:hover .icon-search {
+        --spectrum-search-color: var(
+            --highcontrast-search-color-focus,
+            var(
+                --mod-search-color-focus-hover,
+                var(--spectrum-search-color-focus-hover)
+            )
+        );
+    }
+    #textfield.is-disabled:hover .icon-search {
+        --spectrum-search-color: var(
+            --highcontrast-search-color-disabled,
+            var(
+                --mod-search-color-disabled,
+                var(--spectrum-search-color-disabled)
+            )
+        );
+    }
+}
 .input {
     -webkit-appearance: none;
+}
+.input::-webkit-search-cancel-button,
+.input::-webkit-search-decoration {
+    -webkit-appearance: none;
+}
+.input {
     block-size: var(--mod-search-block-size, var(--spectrum-search-block-size));
     font-style: var(--mod-search-font-style, var(--spectrum-search-font-style));
     line-height: var(
@@ -290,10 +306,6 @@ governing permissions and limitations under the License.
         var(--mod-search-top-to-text, var(--spectrum-search-top-to-text)) -
             var(--mod-search-border-width, var(--spectrum-search-border-width))
     );
-}
-.input::-webkit-search-cancel-button,
-.input::-webkit-search-decoration {
-    -webkit-appearance: none;
 }
 :host(:not([quiet])) #textfield .icon-search {
     inset-inline-start: var(

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -80,7 +80,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/sidenav": "^4.1.0"
+        "@spectrum-css/sidenav": "^4.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/sidenav/src/spectrum-sidenav-heading.css
+++ b/packages/sidenav/src/spectrum-sidenav-heading.css
@@ -97,6 +97,13 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-text-font-style: var(--spectrum-default-font-style);
     --spectrum-sidenav-text-font-size: var(--spectrum-font-size-100);
     --spectrum-sidenav-text-line-height: var(--spectrum-line-height-100);
+}
+#list:lang(ja),
+#list:lang(ko),
+#list:lang(zh) {
+    --spectrum-sidenav-text-line-height: var(--spectrum-cjk-line-height-100);
+}
+#list {
     --spectrum-sidenav-top-level-font-family: var(
         --spectrum-sans-font-family-stack
     );
@@ -104,18 +111,6 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-top-level-font-style: var(--spectrum-default-font-style);
     --spectrum-sidenav-top-level-font-size: var(--spectrum-font-size-100);
     --spectrum-sidenav-top-level-line-height: var(--spectrum-line-height-100);
-    --spectrum-sidenav-header-font-family: var(
-        --spectrum-sans-font-family-stack
-    );
-    --spectrum-sidenav-header-font-weight: var(--spectrum-medium-font-weight);
-    --spectrum-sidenav-header-font-style: var(--spectrum-default-font-style);
-    --spectrum-sidenav-header-font-size: var(--spectrum-font-size-75);
-    --spectrum-sidenav-header-line-height: var(--spectrum-line-height-100);
-}
-#list:lang(ja),
-#list:lang(ko),
-#list:lang(zh) {
-    --spectrum-sidenav-text-line-height: var(--spectrum-cjk-line-height-100);
 }
 #list:lang(ja),
 #list:lang(ko),
@@ -123,6 +118,15 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-top-level-line-height: var(
         --spectrum-cjk-line-height-100
     );
+}
+#list {
+    --spectrum-sidenav-header-font-family: var(
+        --spectrum-sans-font-family-stack
+    );
+    --spectrum-sidenav-header-font-weight: var(--spectrum-medium-font-weight);
+    --spectrum-sidenav-header-font-style: var(--spectrum-default-font-style);
+    --spectrum-sidenav-header-font-size: var(--spectrum-font-size-75);
+    --spectrum-sidenav-header-line-height: var(--spectrum-line-height-100);
 }
 #list:lang(ja),
 #list:lang(ko),

--- a/packages/sidenav/src/spectrum-sidenav-item.css
+++ b/packages/sidenav/src/spectrum-sidenav-item.css
@@ -97,6 +97,13 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-text-font-style: var(--spectrum-default-font-style);
     --spectrum-sidenav-text-font-size: var(--spectrum-font-size-100);
     --spectrum-sidenav-text-line-height: var(--spectrum-line-height-100);
+}
+#list:lang(ja),
+#list:lang(ko),
+#list:lang(zh) {
+    --spectrum-sidenav-text-line-height: var(--spectrum-cjk-line-height-100);
+}
+#list {
     --spectrum-sidenav-top-level-font-family: var(
         --spectrum-sans-font-family-stack
     );
@@ -104,18 +111,6 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-top-level-font-style: var(--spectrum-default-font-style);
     --spectrum-sidenav-top-level-font-size: var(--spectrum-font-size-100);
     --spectrum-sidenav-top-level-line-height: var(--spectrum-line-height-100);
-    --spectrum-sidenav-header-font-family: var(
-        --spectrum-sans-font-family-stack
-    );
-    --spectrum-sidenav-header-font-weight: var(--spectrum-medium-font-weight);
-    --spectrum-sidenav-header-font-style: var(--spectrum-default-font-style);
-    --spectrum-sidenav-header-font-size: var(--spectrum-font-size-75);
-    --spectrum-sidenav-header-line-height: var(--spectrum-line-height-100);
-}
-#list:lang(ja),
-#list:lang(ko),
-#list:lang(zh) {
-    --spectrum-sidenav-text-line-height: var(--spectrum-cjk-line-height-100);
 }
 #list:lang(ja),
 #list:lang(ko),
@@ -123,6 +118,15 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-top-level-line-height: var(
         --spectrum-cjk-line-height-100
     );
+}
+#list {
+    --spectrum-sidenav-header-font-family: var(
+        --spectrum-sans-font-family-stack
+    );
+    --spectrum-sidenav-header-font-weight: var(--spectrum-medium-font-weight);
+    --spectrum-sidenav-header-font-style: var(--spectrum-default-font-style);
+    --spectrum-sidenav-header-font-size: var(--spectrum-font-size-75);
+    --spectrum-sidenav-header-line-height: var(--spectrum-line-height-100);
 }
 #list:lang(ja),
 #list:lang(ko),
@@ -172,19 +176,6 @@ governing permissions and limitations under the License.
             --mod-sidenav-content-color-default-selected,
             var(--spectrum-sidenav-content-color-default-selected)
         )
-    );
-}
-:host([selected]) #item-link:hover {
-    background-color: var(
-        --highcontrast-sidenav-background-hover-selected,
-        var(
-            --mod-sidenav-background-hover-selected,
-            var(--spectrum-sidenav-background-hover-selected)
-        )
-    );
-    color: var(
-        --mod-sidenav-content-color-hover-selected,
-        var(--spectrum-sidenav-content-color-hover-selected)
     );
 }
 :host([selected]) #item-link:active {
@@ -323,21 +314,36 @@ governing permissions and limitations under the License.
         var(--spectrum-sidenav-icon-spacing)
     );
 }
-#item-link:hover {
-    background-color: var(
-        --highcontrast-sidenav-background-hover,
-        var(
-            --mod-sidenav-background-hover,
-            var(--spectrum-sidenav-background-hover)
-        )
-    );
-    color: var(
-        --highcontrast-sidenav-content-color-hover,
-        var(
-            --mod-sidenav-content-color-hover,
-            var(--spectrum-sidenav-content-color-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([selected]) #item-link:hover {
+        background-color: var(
+            --highcontrast-sidenav-background-hover-selected,
+            var(
+                --mod-sidenav-background-hover-selected,
+                var(--spectrum-sidenav-background-hover-selected)
+            )
+        );
+        color: var(
+            --mod-sidenav-content-color-hover-selected,
+            var(--spectrum-sidenav-content-color-hover-selected)
+        );
+    }
+    #item-link:hover {
+        background-color: var(
+            --highcontrast-sidenav-background-hover,
+            var(
+                --mod-sidenav-background-hover,
+                var(--spectrum-sidenav-background-hover)
+            )
+        );
+        color: var(
+            --highcontrast-sidenav-content-color-hover,
+            var(
+                --mod-sidenav-content-color-hover,
+                var(--spectrum-sidenav-content-color-hover)
+            )
+        );
+    }
 }
 #item-link:active {
     background-color: var(

--- a/packages/sidenav/src/spectrum-sidenav.css
+++ b/packages/sidenav/src/spectrum-sidenav.css
@@ -97,6 +97,13 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-text-font-style: var(--spectrum-default-font-style);
     --spectrum-sidenav-text-font-size: var(--spectrum-font-size-100);
     --spectrum-sidenav-text-line-height: var(--spectrum-line-height-100);
+}
+:host:lang(ja),
+:host:lang(ko),
+:host:lang(zh) {
+    --spectrum-sidenav-text-line-height: var(--spectrum-cjk-line-height-100);
+}
+:host {
     --spectrum-sidenav-top-level-font-family: var(
         --spectrum-sans-font-family-stack
     );
@@ -104,18 +111,6 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-top-level-font-style: var(--spectrum-default-font-style);
     --spectrum-sidenav-top-level-font-size: var(--spectrum-font-size-100);
     --spectrum-sidenav-top-level-line-height: var(--spectrum-line-height-100);
-    --spectrum-sidenav-header-font-family: var(
-        --spectrum-sans-font-family-stack
-    );
-    --spectrum-sidenav-header-font-weight: var(--spectrum-medium-font-weight);
-    --spectrum-sidenav-header-font-style: var(--spectrum-default-font-style);
-    --spectrum-sidenav-header-font-size: var(--spectrum-font-size-75);
-    --spectrum-sidenav-header-line-height: var(--spectrum-line-height-100);
-}
-:host:lang(ja),
-:host:lang(ko),
-:host:lang(zh) {
-    --spectrum-sidenav-text-line-height: var(--spectrum-cjk-line-height-100);
 }
 :host:lang(ja),
 :host:lang(ko),
@@ -123,6 +118,15 @@ governing permissions and limitations under the License.
     --spectrum-sidenav-top-level-line-height: var(
         --spectrum-cjk-line-height-100
     );
+}
+:host {
+    --spectrum-sidenav-header-font-family: var(
+        --spectrum-sans-font-family-stack
+    );
+    --spectrum-sidenav-header-font-weight: var(--spectrum-medium-font-weight);
+    --spectrum-sidenav-header-font-style: var(--spectrum-default-font-style);
+    --spectrum-sidenav-header-font-size: var(--spectrum-font-size-75);
+    --spectrum-sidenav-header-line-height: var(--spectrum-line-height-100);
 }
 :host:lang(ja),
 :host:lang(ko),

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -83,7 +83,7 @@
         "@spectrum-web-components/theme": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^4.2.1"
+        "@spectrum-css/slider": "^4.3.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/slider/src/spectrum-slider.css
+++ b/packages/slider/src/spectrum-slider.css
@@ -773,15 +773,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-.handle:hover {
-    border-color: var(
-        --highcontrast-slider-handle-border-color-hover,
-        var(
-            --mod-slider-handle-border-color-hover,
-            var(--spectrum-slider-handle-border-color-hover)
-        )
-    );
-}
 .handle.handle-highlight {
     border-color: var(
         --highcontrast-slider-handle-border-color-key-focus,
@@ -899,8 +890,7 @@ governing permissions and limitations under the License.
     cursor: default;
     pointer-events: none;
 }
-:host([disabled]) .handle:active,
-:host([disabled]) .handle:hover {
+:host([disabled]) .handle:active {
     background: var(
         --highcontrast-slider-handle-background-color-disabled,
         var(
@@ -912,6 +902,33 @@ governing permissions and limitations under the License.
         --highcontrast-disabled-border-color,
         var(--mod-disabled-border-color, var(--spectrum-disabled-border-color))
     );
+}
+@media (hover: hover) {
+    .handle:hover {
+        border-color: var(
+            --highcontrast-slider-handle-border-color-hover,
+            var(
+                --mod-slider-handle-border-color-hover,
+                var(--spectrum-slider-handle-border-color-hover)
+            )
+        );
+    }
+    :host([disabled]) .handle:hover {
+        background: var(
+            --highcontrast-slider-handle-background-color-disabled,
+            var(
+                --mod-slider-handle-background-color-disabled,
+                var(--spectrum-slider-handle-background-color-disabled)
+            )
+        );
+        border-color: var(
+            --highcontrast-disabled-border-color,
+            var(
+                --mod-disabled-border-color,
+                var(--spectrum-disabled-border-color)
+            )
+        );
+    }
 }
 :host([disabled]) .track:before {
     background: var(
@@ -1012,13 +1029,21 @@ governing permissions and limitations under the License.
     }
     :host:not(.is-disabled) #controls.handle-highlight,
     :host:not(.is-disabled) #controls:active,
-    :host:not(.is-disabled) #controls:focus-within,
-    :host:not(.is-disabled) #controls:hover {
+    :host:not(.is-disabled) #controls:focus-within {
         --highcontrast-slider-track-fill-color: Highlight;
         --highcontrast-slider-track-color: Highlight;
         --highcontrast-slider-handle-border-color: Highlight;
         --highcontrast-slider-ramp-track-color: Highlight;
         --highcontrast-slider-tick-mark-color: Highlight;
+    }
+    @media (hover: hover) {
+        :host:not(.is-disabled) #controls:hover {
+            --highcontrast-slider-track-fill-color: Highlight;
+            --highcontrast-slider-track-color: Highlight;
+            --highcontrast-slider-handle-border-color: Highlight;
+            --highcontrast-slider-ramp-track-color: Highlight;
+            --highcontrast-slider-tick-mark-color: Highlight;
+        }
     }
     :host([disabled]) #ramp + .handle {
         fill: ButtonFace;

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/base": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/splitview": "^4.1.0"
+        "@spectrum-css/splitview": "^4.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/split-view/src/spectrum-split-view.css
+++ b/packages/split-view/src/spectrum-split-view.css
@@ -84,10 +84,15 @@ governing permissions and limitations under the License.
                 var(
                         --mod-splitview-gripper-width,
                         var(--spectrum-splitview-gripper-width)
-                    ) + 2 *
-                    var(
-                        --mod-splitview-gripper-border-width-vertical,
-                        var(--spectrum-splitview-gripper-border-width-vertical)
+                    ) +
+                    (
+                        2 *
+                            var(
+                                --mod-splitview-gripper-border-width-vertical,
+                                var(
+                                    --spectrum-splitview-gripper-border-width-vertical
+                                )
+                            )
                     ) -
                     var(
                         --mod-splitview-gripper-width,
@@ -150,8 +155,7 @@ governing permissions and limitations under the License.
 #splitter.is-collapsed-end #gripper {
     inset-inline: auto 0;
 }
-:host([resizable]) #splitter.is-hovered,
-:host([resizable]) #splitter:hover {
+:host([resizable]) #splitter.is-hovered {
     background-color: var(
         --highcontrast-splitview-handle-background-color-hover,
         var(
@@ -160,8 +164,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([resizable]) #splitter.is-hovered #gripper,
-:host([resizable]) #splitter:hover #gripper {
+:host([resizable]) #splitter.is-hovered #gripper {
     border-color: var(
         --highcontrast-splitview-handle-background-color-hover,
         var(
@@ -170,8 +173,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([resizable]) #splitter.is-hovered #gripper:before,
-:host([resizable]) #splitter:hover #gripper:before {
+:host([resizable]) #splitter.is-hovered #gripper:before {
     background-color: var(
         --highcontrast-splitview-handle-background-color-hover,
         var(
@@ -179,6 +181,35 @@ governing permissions and limitations under the License.
             var(--spectrum-splitview-handle-background-color-hover)
         )
     );
+}
+@media (hover: hover) {
+    :host([resizable]) #splitter:hover {
+        background-color: var(
+            --highcontrast-splitview-handle-background-color-hover,
+            var(
+                --mod-splitview-handle-background-color-hover,
+                var(--spectrum-splitview-handle-background-color-hover)
+            )
+        );
+    }
+    :host([resizable]) #splitter:hover #gripper {
+        border-color: var(
+            --highcontrast-splitview-handle-background-color-hover,
+            var(
+                --mod-splitview-handle-background-color-hover,
+                var(--spectrum-splitview-handle-background-color-hover)
+            )
+        );
+    }
+    :host([resizable]) #splitter:hover #gripper:before {
+        background-color: var(
+            --highcontrast-splitview-handle-background-color-hover,
+            var(
+                --mod-splitview-handle-background-color-hover,
+                var(--spectrum-splitview-handle-background-color-hover)
+            )
+        );
+    }
 }
 :host([resizable]) #splitter.is-active,
 :host([resizable]) #splitter:active {
@@ -317,10 +348,15 @@ governing permissions and limitations under the License.
                 var(
                         --mod-splitview-gripper-width,
                         var(--spectrum-splitview-gripper-width)
-                    ) + 2 *
-                    var(
-                        --mod-splitview-gripper-border-width-vertical,
-                        var(--spectrum-splitview-gripper-border-width-vertical)
+                    ) +
+                    (
+                        2 *
+                            var(
+                                --mod-splitview-gripper-border-width-vertical,
+                                var(
+                                    --spectrum-splitview-gripper-border-width-vertical
+                                )
+                            )
                     ) -
                     var(
                         --mod-splitview-gripper-width,

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/checkbox": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/switch": "^4.1.0"
+        "@spectrum-css/switch": "^4.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/switch/src/spectrum-switch.css
+++ b/packages/switch/src/spectrum-switch.css
@@ -334,8 +334,10 @@ governing permissions and limitations under the License.
 }
 #switch:after {
     border-radius: calc(
-        var(--mod-switch-control-height, var(--spectrum-switch-control-height)) +
-            var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap))
+        var(--mod-switch-control-height, var(--spectrum-switch-control-height)) /
+            2 +
+            var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) *
+            2
     );
     content: '';
     display: block;
@@ -381,97 +383,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host(:hover) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-hover,
-        var(
-            --mod-switch-handle-border-color-hover,
-            var(--spectrum-switch-handle-border-color-hover)
-        )
-    );
-    box-shadow: none;
-}
-:host(:hover) #input ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-hover,
-        var(
-            --mod-switch-label-color-hover,
-            var(--spectrum-switch-label-color-hover)
-        )
-    );
-}
-:host([checked]:hover) #input:enabled + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-selected-hover,
-        var(
-            --mod-switch-background-color-selected-hover,
-            var(--spectrum-switch-background-color-selected-hover)
-        )
-    );
-}
-:host([checked]:hover) #input:enabled + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-selected-hover,
-        var(
-            --mod-switch-handle-border-color-selected-hover,
-            var(--spectrum-switch-handle-border-color-selected-hover)
-        )
-    );
-}
-:host([disabled]:hover) #input + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-disabled,
-        var(
-            --mod-switch-background-color-disabled,
-            var(--spectrum-switch-background-color-disabled)
-        )
-    );
-}
-:host([disabled]:hover) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-disabled,
-        var(
-            --mod-switch-handle-border-color-disabled,
-            var(--spectrum-switch-handle-border-color-disabled)
-        )
-    );
-}
-:host([disabled]:hover) #input ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-disabled,
-        var(
-            --mod-switch-label-color-disabled,
-            var(--spectrum-switch-label-color-disabled)
-        )
-    );
-}
-:host([disabled][checked]:hover) #input + #switch {
-    background-color: var(
-        --highcontrast-switch-background-color-selected-disabled,
-        var(
-            --mod-switch-background-color-selected-disabled,
-            var(--spectrum-switch-background-color-selected-disabled)
-        )
-    );
-}
-:host([disabled][checked]:hover) #input + #switch:before {
-    border-color: var(
-        --highcontrast-switch-handle-border-color-disabled,
-        var(
-            --mod-switch-handle-border-color-disabled,
-            var(--spectrum-switch-handle-border-color-disabled)
-        )
-    );
-}
-:host([disabled][checked]:hover) #input ~ #label {
-    color: var(
-        --highcontrast-switch-label-color-disabled,
-        var(
-            --mod-switch-label-color-disabled,
-            var(--spectrum-switch-label-color-disabled)
-        )
-    );
-}
 :host(:active) #input + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-down,
@@ -508,8 +419,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-#input.focus-visible + #switch:after,
-:host(:hover) #input.focus-visible + #switch:after {
+#input.focus-visible + #switch:after {
     box-shadow: 0 0 0
         var(
             --mod-switch-focus-indicator-thickness,
@@ -523,8 +433,7 @@ governing permissions and limitations under the License.
             )
         );
 }
-#input:focus-visible + #switch:after,
-:host(:hover) #input:focus-visible + #switch:after {
+#input:focus-visible + #switch:after {
     box-shadow: 0 0 0
         var(
             --mod-switch-focus-indicator-thickness,
@@ -538,8 +447,7 @@ governing permissions and limitations under the License.
             )
         );
 }
-#input.focus-visible + #switch:before,
-:host(:hover) #input.focus-visible + #switch:before {
+#input.focus-visible + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-focus,
         var(
@@ -548,8 +456,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-#input:focus-visible + #switch:before,
-:host(:hover) #input:focus-visible + #switch:before {
+#input:focus-visible + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-focus,
         var(
@@ -558,8 +465,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([checked]) #input.focus-visible + #switch,
-:host([checked]:hover) #input.focus-visible + #switch {
+:host([checked]) #input.focus-visible + #switch {
     background-color: var(
         --highcontrast-switch-background-color-selected-focus,
         var(
@@ -568,8 +474,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([checked]) #input:focus-visible + #switch,
-:host([checked]:hover) #input:focus-visible + #switch {
+:host([checked]) #input:focus-visible + #switch {
     background-color: var(
         --highcontrast-switch-background-color-selected-focus,
         var(
@@ -578,8 +483,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([checked]) #input.focus-visible + #switch:before,
-:host([checked]:hover) #input.focus-visible + #switch:before {
+:host([checked]) #input.focus-visible + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-selected-focus,
         var(
@@ -588,8 +492,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([checked]) #input:focus-visible + #switch:before,
-:host([checked]:hover) #input:focus-visible + #switch:before {
+:host([checked]) #input:focus-visible + #switch:before {
     border-color: var(
         --highcontrast-switch-handle-border-color-selected-focus,
         var(
@@ -598,8 +501,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-#input.focus-visible ~ #label,
-:host(:hover) #input.focus-visible ~ #label {
+#input.focus-visible ~ #label {
     color: var(
         --highcontrast-switch-label-color-focus,
         var(
@@ -608,8 +510,7 @@ governing permissions and limitations under the License.
         )
     );
 }
-#input:focus-visible ~ #label,
-:host(:hover) #input:focus-visible ~ #label {
+#input:focus-visible ~ #label {
     color: var(
         --highcontrast-switch-label-color-focus,
         var(
@@ -617,6 +518,199 @@ governing permissions and limitations under the License.
             var(--spectrum-switch-label-color-focus)
         )
     );
+}
+@media (hover: hover) {
+    :host([disabled][checked]:hover) #input + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-disabled,
+            var(
+                --mod-switch-handle-border-color-disabled,
+                var(--spectrum-switch-handle-border-color-disabled)
+            )
+        );
+    }
+    :host([disabled]:hover) #input + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-disabled,
+            var(
+                --mod-switch-handle-border-color-disabled,
+                var(--spectrum-switch-handle-border-color-disabled)
+            )
+        );
+    }
+    :host([disabled][checked]:hover) #input + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-selected-disabled,
+            var(
+                --mod-switch-background-color-selected-disabled,
+                var(--spectrum-switch-background-color-selected-disabled)
+            )
+        );
+    }
+    :host([disabled][checked]:hover) #input ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-disabled,
+            var(
+                --mod-switch-label-color-disabled,
+                var(--spectrum-switch-label-color-disabled)
+            )
+        );
+    }
+    :host([checked]:hover) #input.focus-visible + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-selected-focus,
+            var(
+                --mod-switch-handle-border-color-selected-focus,
+                var(--spectrum-switch-handle-border-color-selected-focus)
+            )
+        );
+    }
+    :host([checked]:hover) #input:focus-visible + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-selected-focus,
+            var(
+                --mod-switch-handle-border-color-selected-focus,
+                var(--spectrum-switch-handle-border-color-selected-focus)
+            )
+        );
+    }
+    :host(:hover) #input + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-hover,
+            var(
+                --mod-switch-handle-border-color-hover,
+                var(--spectrum-switch-handle-border-color-hover)
+            )
+        );
+        box-shadow: none;
+    }
+    :host([checked]:hover) #input:enabled + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-selected-hover,
+            var(
+                --mod-switch-handle-border-color-selected-hover,
+                var(--spectrum-switch-handle-border-color-selected-hover)
+            )
+        );
+    }
+    :host([disabled]:hover) #input + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-disabled,
+            var(
+                --mod-switch-background-color-disabled,
+                var(--spectrum-switch-background-color-disabled)
+            )
+        );
+    }
+    :host([disabled]:hover) #input ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-disabled,
+            var(
+                --mod-switch-label-color-disabled,
+                var(--spectrum-switch-label-color-disabled)
+            )
+        );
+    }
+    :host(:hover) #input.focus-visible + #switch:after {
+        box-shadow: 0 0 0
+            var(
+                --mod-switch-focus-indicator-thickness,
+                var(--spectrum-switch-focus-indicator-thickness)
+            )
+            var(
+                --highcontrast-switch-focus-indicator-color,
+                var(
+                    --mod-switch-focus-indicator-color,
+                    var(--spectrum-switch-focus-indicator-color)
+                )
+            );
+    }
+    :host(:hover) #input:focus-visible + #switch:after {
+        box-shadow: 0 0 0
+            var(
+                --mod-switch-focus-indicator-thickness,
+                var(--spectrum-switch-focus-indicator-thickness)
+            )
+            var(
+                --highcontrast-switch-focus-indicator-color,
+                var(
+                    --mod-switch-focus-indicator-color,
+                    var(--spectrum-switch-focus-indicator-color)
+                )
+            );
+    }
+    :host(:hover) #input.focus-visible + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-focus,
+            var(
+                --mod-switch-handle-border-color-focus,
+                var(--spectrum-switch-handle-border-color-focus)
+            )
+        );
+    }
+    :host(:hover) #input:focus-visible + #switch:before {
+        border-color: var(
+            --highcontrast-switch-handle-border-color-focus,
+            var(
+                --mod-switch-handle-border-color-focus,
+                var(--spectrum-switch-handle-border-color-focus)
+            )
+        );
+    }
+    :host([checked]:hover) #input.focus-visible + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-selected-focus,
+            var(
+                --mod-switch-background-color-selected-focus,
+                var(--spectrum-switch-background-color-selected-focus)
+            )
+        );
+    }
+    :host([checked]:hover) #input:focus-visible + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-selected-focus,
+            var(
+                --mod-switch-background-color-selected-focus,
+                var(--spectrum-switch-background-color-selected-focus)
+            )
+        );
+    }
+    :host(:hover) #input ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-hover,
+            var(
+                --mod-switch-label-color-hover,
+                var(--spectrum-switch-label-color-hover)
+            )
+        );
+    }
+    :host([checked]:hover) #input:enabled + #switch {
+        background-color: var(
+            --highcontrast-switch-background-color-selected-hover,
+            var(
+                --mod-switch-background-color-selected-hover,
+                var(--spectrum-switch-background-color-selected-hover)
+            )
+        );
+    }
+    :host(:hover) #input.focus-visible ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-focus,
+            var(
+                --mod-switch-label-color-focus,
+                var(--spectrum-switch-label-color-focus)
+            )
+        );
+    }
+    :host(:hover) #input:focus-visible ~ #label {
+        color: var(
+            --highcontrast-switch-label-color-focus,
+            var(
+                --mod-switch-label-color-focus,
+                var(--spectrum-switch-label-color-focus)
+            )
+        );
+    }
 }
 :host([checked]) #input + #switch {
     background-color: var(
@@ -710,16 +804,18 @@ governing permissions and limitations under the License.
     #input:not(:checked) + #switch {
         box-shadow: inset 0 0 0 1px ButtonText;
     }
-    :host(:hover) #input:not(:checked) + #switch {
-        box-shadow: inset 0 0 0 1px Highlight;
-    }
-    :host([disabled][checked]:hover) #input + #switch {
-        background-color: GrayText;
-        box-shadow: inset 0 0 0 1px GrayText;
-    }
-    :host([disabled][checked]:hover) #input + #switch:before {
-        background-color: ButtonFace;
-        border-color: GrayText;
+    @media (hover: hover) {
+        :host(:hover) #input:not(:checked) + #switch {
+            box-shadow: inset 0 0 0 1px Highlight;
+        }
+        :host([disabled][checked]:hover) #input + #switch {
+            background-color: GrayText;
+            box-shadow: inset 0 0 0 1px GrayText;
+        }
+        :host([disabled][checked]:hover) #input + #switch:before {
+            background-color: ButtonFace;
+            border-color: GrayText;
+        }
     }
     :host([disabled]) #input:not(:checked) + #switch {
         background-color: ButtonFace;

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -123,7 +123,7 @@
         "@spectrum-web-components/icons-ui": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/table": "^5.1.1"
+        "@spectrum-css/table": "^5.2.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/table/src/spectrum-table-head-cell.css
+++ b/packages/table/src/spectrum-table-head-cell.css
@@ -104,15 +104,6 @@ governing permissions and limitations under the License.
 :host([sortable]) {
     cursor: var(--mod-table-cursor-header-sortable, pointer);
 }
-:host([sortable]:hover) {
-    --spectrum-table-icon-color: var(
-        --highcontrast-table-icon-color-focus,
-        var(
-            --mod-table-icon-color-hover,
-            var(--spectrum-table-icon-color-hover)
-        )
-    );
-}
 :host([sortable][active]) {
     --spectrum-table-icon-color: var(
         --highcontrast-table-icon-color-focus,
@@ -128,15 +119,6 @@ governing permissions and limitations under the License.
         var(
             --mod-table-icon-color-focus,
             var(--spectrum-table-icon-color-focus)
-        )
-    );
-}
-:host([sortable]:focus):hover {
-    --spectrum-table-icon-color: var(
-        --highcontrast-table-icon-color-focus,
-        var(
-            --mod-table-icon-color-focus-hover,
-            var(--spectrum-table-icon-color-focus-hover)
         )
     );
 }
@@ -244,4 +226,24 @@ governing permissions and limitations under the License.
             --highcontrast-table-border-color,
             var(--mod-table-border-color, var(--spectrum-table-border-color))
         );
+}
+@media (hover: hover) {
+    :host([sortable]:hover) {
+        --spectrum-table-icon-color: var(
+            --highcontrast-table-icon-color-focus,
+            var(
+                --mod-table-icon-color-hover,
+                var(--spectrum-table-icon-color-hover)
+            )
+        );
+    }
+    :host([sortable]:focus):hover {
+        --spectrum-table-icon-color: var(
+            --highcontrast-table-icon-color-focus,
+            var(
+                --mod-table-icon-color-focus-hover,
+                var(--spectrum-table-icon-color-focus-hover)
+            )
+        );
+    }
 }

--- a/packages/table/src/spectrum-table-row.css
+++ b/packages/table/src/spectrum-table-row.css
@@ -15,16 +15,19 @@ governing permissions and limitations under the License.
     :host(.focus-visible)
         .spectrum-Table-checkbox
         .spectrum-Checkbox-box:before,
-    :host(:hover) .spectrum-Table-checkbox .spectrum-Checkbox-box:before,
     :host([focused]) .spectrum-Table-checkbox .spectrum-Checkbox-box:before {
         outline: var(--highcontrast-table-row-text-color-hover) 1px solid;
     }
     :host(:focus-visible)
         .spectrum-Table-checkbox
         .spectrum-Checkbox-box:before,
-    :host(:hover) .spectrum-Table-checkbox .spectrum-Checkbox-box:before,
     :host([focused]) .spectrum-Table-checkbox .spectrum-Checkbox-box:before {
         outline: var(--highcontrast-table-row-text-color-hover) 1px solid;
+    }
+    @media (hover: hover) {
+        :host(:hover) .spectrum-Table-checkbox .spectrum-Checkbox-box:before {
+            outline: var(--highcontrast-table-row-text-color-hover) 1px solid;
+        }
     }
     :host([drop-target]),
     :host([drop-target]) .spectrum-Table-body,
@@ -149,7 +152,6 @@ governing permissions and limitations under the License.
     outline: 0;
 }
 :host(.focus-visible),
-:host(:hover),
 :host([focused]) {
     --highcontrast-table-row-text-color: var(
         --highcontrast-table-row-text-color-hover
@@ -166,7 +168,6 @@ governing permissions and limitations under the License.
     );
 }
 :host(:focus-visible),
-:host(:hover),
 :host([focused]) {
     --highcontrast-table-row-text-color: var(
         --highcontrast-table-row-text-color-hover
@@ -209,7 +210,6 @@ governing permissions and limitations under the License.
     );
 }
 :host([selected].focus-visible),
-:host([selected]:hover),
 :host([selected][focused]) {
     --highcontrast-table-row-text-color: var(
         --highcontrast-table-selected-row-text-color-focus
@@ -222,7 +222,6 @@ governing permissions and limitations under the License.
     );
 }
 :host([selected]:focus-visible),
-:host([selected]:hover),
 :host([selected][focused]) {
     --highcontrast-table-row-text-color: var(
         --highcontrast-table-selected-row-text-color-focus
@@ -379,18 +378,6 @@ governing permissions and limitations under the License.
     );
     text-align: start;
 }
-.spectrum-Table-row--sectionHeader:hover {
-    --highcontrast-table-row-text-color: var(
-        --highcontrast-table-section-header-text-color
-    );
-    --spectrum-table-cell-background-color: var(
-        --highcontrast-table-section-header-background-color,
-        var(
-            --mod-table-section-header-background-color,
-            var(--spectrum-table-section-header-background-color)
-        )
-    );
-}
 :host {
     display: table-row;
 }
@@ -473,6 +460,46 @@ governing permissions and limitations under the License.
 }
 :host([hidden]) .spectrum-Table-row--collapsible {
     display: none;
+}
+@media (hover: hover) {
+    :host([selected]:hover) {
+        --highcontrast-table-row-text-color: var(
+            --highcontrast-table-selected-row-text-color-focus
+        );
+        --highcontrast-table-icon-color: var(
+            --highcontrast-table-selected-row-text-color-focus
+        );
+        --spectrum-table-cell-background-color: var(
+            --spectrum-table-selected-cell-background-color-focus
+        );
+    }
+    :host(:hover) {
+        --highcontrast-table-row-text-color: var(
+            --highcontrast-table-row-text-color-hover
+        );
+        --highcontrast-table-icon-color: var(
+            --highcontrast-table-row-text-color-hover
+        );
+        --spectrum-table-cell-background-color: var(
+            --highcontrast-table-row-background-color-hover,
+            var(
+                --mod-table-row-background-color-hover,
+                var(--spectrum-table-row-background-color-hover)
+            )
+        );
+    }
+    .spectrum-Table-row--sectionHeader:hover {
+        --highcontrast-table-row-text-color: var(
+            --highcontrast-table-section-header-text-color
+        );
+        --spectrum-table-cell-background-color: var(
+            --highcontrast-table-section-header-background-color,
+            var(
+                --mod-table-section-header-background-color,
+                var(--spectrum-table-section-header-background-color)
+            )
+        );
+    }
 }
 .spectrum-Table-row--thumbnail {
     --table-thumbnail-cell-block-spacing: var(

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -93,7 +93,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/tabs": "^4.0.28"
+        "@spectrum-css/tabs": "^4.1.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tabs/src/spectrum-tab.css
+++ b/packages/tabs/src/spectrum-tab.css
@@ -89,11 +89,13 @@ governing permissions and limitations under the License.
     pointer-events: none;
     position: absolute;
 }
-:host(:hover) {
-    color: var(
-        --highcontrast-tabs-color-hover,
-        var(--mod-tabs-color-hover, var(--spectrum-tabs-color-hover))
-    );
+@media (hover: hover) {
+    :host(:hover) {
+        color: var(
+            --highcontrast-tabs-color-hover,
+            var(--mod-tabs-color-hover, var(--spectrum-tabs-color-hover))
+        );
+    }
 }
 :host([selected]) {
     color: var(

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -72,7 +72,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/tag": "^8.0.17",
+        "@spectrum-css/tag": "^8.1.0",
         "@spectrum-css/taggroup": "^4.1.0"
     },
     "types": "./src/index.d.ts",

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -407,29 +407,6 @@ governing permissions and limitations under the License.
     text-overflow: ellipsis;
     white-space: nowrap;
 }
-:host(:hover) {
-    background-color: var(
-        --highcontrast-tag-background-color-hover,
-        var(
-            --mod-tag-background-color-hover,
-            var(--spectrum-tag-background-color-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-tag-border-color-hover,
-        var(
-            --mod-tag-border-color-hover,
-            var(--spectrum-tag-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-hover,
-        var(
-            --mod-tag-content-color-hover,
-            var(--spectrum-tag-content-color-hover)
-        )
-    );
-}
 :host(:active) {
     background-color: var(
         --highcontrast-tag-background-color-active,
@@ -630,22 +607,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([selected]:hover) {
-    background-color: var(
-        --highcontrast-tag-background-color-selected-hover,
-        var(
-            --mod-tag-background-color-selected-hover,
-            var(--spectrum-tag-background-color-selected-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-tag-border-color-selected-hover,
-        var(
-            --mod-tag-border-color-selected-hover,
-            var(--spectrum-tag-border-color-selected-hover)
-        )
-    );
-}
 :host([selected]:active) {
     background-color: var(
         --highcontrast-tag-background-color-selected-active,
@@ -709,22 +670,6 @@ governing permissions and limitations under the License.
         var(
             --mod-tag-content-color-invalid,
             var(--spectrum-tag-content-color-invalid)
-        )
-    );
-}
-:host([invalid]:hover) {
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-hover,
-        var(
-            --mod-tag-border-color-invalid-hover,
-            var(--spectrum-tag-border-color-invalid-hover)
-        )
-    );
-    color: var(
-        --highcontrast-tag-content-color-invalid-hover,
-        var(
-            --mod-tag-content-color-invalid-hover,
-            var(--spectrum-tag-content-color-invalid-hover)
         )
     );
 }
@@ -801,22 +746,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([invalid][selected]:hover) {
-    background-color: var(
-        --highcontrast-tag-background-color-invalid-selected-hover,
-        var(
-            --mod-tag-background-color-invalid-selected-hover,
-            var(--spectrum-tag-background-color-invalid-selected-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-tag-border-color-invalid-selected-hover,
-        var(
-            --mod-tag-border-color-invalid-selected-hover,
-            var(--spectrum-tag-border-color-invalid-selected-hover)
-        )
-    );
-}
 :host([invalid][selected]:active) {
     background-color: var(
         --highcontrast-tag-background-color-invalid-selected-active,
@@ -890,21 +819,115 @@ governing permissions and limitations under the License.
         )
     );
 }
-:host([emphasized]:hover) {
-    background-color: var(
-        --highcontrast-tag-background-color-emphasized-hover,
-        var(
-            --mod-tag-background-color-emphasized-hover,
-            var(--spectrum-tag-background-color-emphasized-hover)
-        )
-    );
-    border-color: var(
-        --highcontrast-tag-border-color-emphasized-hover,
-        var(
-            --mod-tag-border-color-emphasized-hover,
-            var(--spectrum-tag-border-color-emphasized-hover)
-        )
-    );
+@media (hover: hover) {
+    :host([invalid][selected]:hover) {
+        background-color: var(
+            --highcontrast-tag-background-color-invalid-selected-hover,
+            var(
+                --mod-tag-background-color-invalid-selected-hover,
+                var(--spectrum-tag-background-color-invalid-selected-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-tag-border-color-invalid-selected-hover,
+            var(
+                --mod-tag-border-color-invalid-selected-hover,
+                var(--spectrum-tag-border-color-invalid-selected-hover)
+            )
+        );
+        color: var(
+            --highcontrast-tag-content-color-invalid-selected,
+            var(
+                --mod-tag-content-color-invalid-selected,
+                var(--spectrum-tag-content-color-invalid-selected)
+            )
+        );
+    }
+    :host(:hover) {
+        background-color: var(
+            --highcontrast-tag-background-color-hover,
+            var(
+                --mod-tag-background-color-hover,
+                var(--spectrum-tag-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-tag-border-color-hover,
+            var(
+                --mod-tag-border-color-hover,
+                var(--spectrum-tag-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-tag-content-color-hover,
+            var(
+                --mod-tag-content-color-hover,
+                var(--spectrum-tag-content-color-hover)
+            )
+        );
+    }
+    :host([selected]:hover) {
+        background-color: var(
+            --highcontrast-tag-background-color-selected-hover,
+            var(
+                --mod-tag-background-color-selected-hover,
+                var(--spectrum-tag-background-color-selected-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-tag-border-color-selected-hover,
+            var(
+                --mod-tag-border-color-selected-hover,
+                var(--spectrum-tag-border-color-selected-hover)
+            )
+        );
+        color: var(
+            --highcontrast-tag-content-color-selected,
+            var(
+                --mod-tag-content-color-selected,
+                var(--spectrum-tag-content-color-selected)
+            )
+        );
+    }
+    :host([invalid]:hover) {
+        border-color: var(
+            --highcontrast-tag-border-color-invalid-hover,
+            var(
+                --mod-tag-border-color-invalid-hover,
+                var(--spectrum-tag-border-color-invalid-hover)
+            )
+        );
+        color: var(
+            --highcontrast-tag-content-color-invalid-hover,
+            var(
+                --mod-tag-content-color-invalid-hover,
+                var(--spectrum-tag-content-color-invalid-hover)
+            )
+        );
+    }
+    :host([emphasized]:hover) {
+        background-color: var(
+            --highcontrast-tag-background-color-emphasized-hover,
+            var(
+                --mod-tag-background-color-emphasized-hover,
+                var(--spectrum-tag-background-color-emphasized-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-tag-border-color-emphasized-hover,
+            var(
+                --mod-tag-border-color-emphasized-hover,
+                var(--spectrum-tag-border-color-emphasized-hover)
+            )
+        );
+        color: var(
+            --highcontrast-tag-content-color-emphasized,
+            var(
+                --mod-tag-content-color-emphasized,
+                var(--spectrum-tag-content-color-emphasized)
+            )
+        );
+    }
 }
 :host([emphasized]:active) {
     background-color: var(

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -65,7 +65,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/textfield": "^6.0.31"
+        "@spectrum-css/textfield": "^6.1.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/textfield/src/spectrum-textfield.css
+++ b/packages/textfield/src/spectrum-textfield.css
@@ -712,33 +712,6 @@ governing permissions and limitations under the License.
 .input:lang(zh)::-moz-placeholder {
     font-style: normal;
 }
-#textfield:hover .input,
-.input:hover {
-    border-color: var(
-        --highcontrast-textfield-border-color-hover,
-        var(
-            --mod-textfield-border-color-hover,
-            var(--spectrum-textfield-border-color-hover)
-        )
-    );
-    color: var(
-        --highcontrast-textfield-text-color-hover,
-        var(
-            --mod-textfield-text-color-hover,
-            var(--spectrum-textfield-text-color-hover)
-        )
-    );
-}
-#textfield:hover .input::placeholder,
-.input:hover::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-hover,
-        var(
-            --mod-textfield-text-color-hover,
-            var(--spectrum-textfield-text-color-hover)
-        )
-    );
-}
 .input:focus,
 :host([focused]) .input {
     border-color: var(
@@ -766,33 +739,6 @@ governing permissions and limitations under the License.
         )
     );
 }
-.input:focus:hover,
-:host([focused]) .input:hover {
-    border-color: var(
-        --highcontrast-textfield-border-color-focus-hover,
-        var(
-            --mod-textfield-border-color-focus-hover,
-            var(--spectrum-textfield-border-color-focus-hover)
-        )
-    );
-    color: var(
-        --highcontrast-textfield-text-color-focus-hover,
-        var(
-            --mod-textfield-text-color-focus-hover,
-            var(--spectrum-textfield-text-color-focus-hover)
-        )
-    );
-}
-.input:focus:hover::placeholder,
-:host([focused]) .input:hover::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-focus-hover,
-        var(
-            --mod-textfield-text-color-focus-hover,
-            var(--spectrum-textfield-text-color-focus-hover)
-        )
-    );
-}
 :host([focused]) .input {
     border-color: var(
         --highcontrast-textfield-border-color-keyboard-focus,
@@ -808,6 +754,17 @@ governing permissions and limitations under the License.
             var(--spectrum-textfield-text-color-keyboard-focus)
         )
     );
+}
+:host([focused]) .input::placeholder {
+    color: var(
+        --highcontrast-textfield-text-color-keyboard-focus,
+        var(
+            --mod-textfield-text-color-keyboard-focus,
+            var(--spectrum-textfield-text-color-keyboard-focus)
+        )
+    );
+}
+:host([focused]) .input {
     outline: var(
             --mod-textfield-focus-indicator-width,
             var(--spectrum-textfield-focus-indicator-width)
@@ -823,15 +780,6 @@ governing permissions and limitations under the License.
     outline-offset: var(
         --mod-textfield-focus-indicator-gap,
         var(--spectrum-textfield-focus-indicator-gap)
-    );
-}
-:host([focused]) .input::placeholder {
-    color: var(
-        --highcontrast-textfield-text-color-keyboard-focus,
-        var(
-            --mod-textfield-text-color-keyboard-focus,
-            var(--spectrum-textfield-text-color-keyboard-focus)
-        )
     );
 }
 :host([valid]) .input {
@@ -895,16 +843,6 @@ governing permissions and limitations under the License.
             )
     );
 }
-:host([invalid]) .input:hover,
-:host([invalid]:hover) .input {
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-hover,
-        var(
-            --mod-textfield-border-color-invalid-hover,
-            var(--spectrum-textfield-border-color-invalid-hover)
-        )
-    );
-}
 :host([invalid]) .input:focus,
 :host([invalid]:focus) .input,
 :host([invalid][focused]) .input {
@@ -913,17 +851,6 @@ governing permissions and limitations under the License.
         var(
             --mod-textfield-border-color-invalid-focus,
             var(--spectrum-textfield-border-color-invalid-focus)
-        )
-    );
-}
-:host([invalid]) .input:focus:hover,
-:host([invalid]:focus) .input:hover,
-:host([invalid][focused]) .input:hover {
-    border-color: var(
-        --highcontrast-textfield-border-color-invalid-focus-hover,
-        var(
-            --mod-textfield-border-color-invalid-focus-hover,
-            var(--spectrum-textfield-border-color-invalid-focus-hover)
         )
     );
 }
@@ -948,8 +875,7 @@ governing permissions and limitations under the License.
     );
 }
 .input:disabled,
-:host([disabled]) #textfield .input,
-:host([disabled]) #textfield:hover .input {
+:host([disabled]) #textfield .input {
     -webkit-text-fill-color: var(
         --highcontrast-textfield-text-color-disabled,
         var(
@@ -973,8 +899,7 @@ governing permissions and limitations under the License.
     resize: none;
 }
 .input:disabled::placeholder,
-:host([disabled]) #textfield .input::placeholder,
-:host([disabled]) #textfield:hover .input::placeholder {
+:host([disabled]) #textfield .input::placeholder {
     color: var(
         --highcontrast-textfield-text-color-disabled,
         var(
@@ -1005,8 +930,7 @@ governing permissions and limitations under the License.
     resize: none;
 }
 .input:disabled,
-:host([quiet][disabled]) .input,
-:host([quiet][disabled]:hover) .input {
+:host([quiet][disabled]) .input {
     background-color: #0000;
     border-color: var(
         --mod-textfield-border-color-disabled,
@@ -1021,8 +945,7 @@ governing permissions and limitations under the License.
     );
 }
 .input:disabled::placeholder,
-:host([quiet][disabled]) .input::placeholder,
-:host([quiet][disabled]:hover) .input::placeholder {
+:host([quiet][disabled]) .input::placeholder {
     color: var(
         --highcontrast-textfield-text-color-disabled,
         var(
@@ -1032,8 +955,7 @@ governing permissions and limitations under the License.
     );
 }
 .input:read-only,
-:host([readonly]) #textfield .input,
-:host([readonly]) #textfield:hover .input {
+:host([readonly]) #textfield .input {
     background-color: #0000;
     border-color: #0000;
     color: var(
@@ -1046,8 +968,7 @@ governing permissions and limitations under the License.
     outline: none;
 }
 .input:read-only::placeholder,
-:host([readonly]) #textfield .input::placeholder,
-:host([readonly]) #textfield:hover .input::placeholder {
+:host([readonly]) #textfield .input::placeholder {
     background-color: #0000;
     color: var(
         --highcontrast-textfield-text-color-readonly,
@@ -1056,6 +977,160 @@ governing permissions and limitations under the License.
             var(--spectrum-textfield-text-color-readonly)
         )
     );
+}
+@media (hover: hover) {
+    #textfield:hover .input::placeholder,
+    .input:hover::placeholder {
+        color: var(
+            --highcontrast-textfield-text-color-hover,
+            var(
+                --mod-textfield-text-color-hover,
+                var(--spectrum-textfield-text-color-hover)
+            )
+        );
+    }
+    .input:focus:hover,
+    :host([focused]) .input:hover {
+        border-color: var(
+            --highcontrast-textfield-border-color-focus-hover,
+            var(
+                --mod-textfield-border-color-focus-hover,
+                var(--spectrum-textfield-border-color-focus-hover)
+            )
+        );
+        color: var(
+            --highcontrast-textfield-text-color-focus-hover,
+            var(
+                --mod-textfield-text-color-focus-hover,
+                var(--spectrum-textfield-text-color-focus-hover)
+            )
+        );
+    }
+    .input:focus:hover::placeholder,
+    :host([focused]) .input:hover::placeholder {
+        color: var(
+            --highcontrast-textfield-text-color-focus-hover,
+            var(
+                --mod-textfield-text-color-focus-hover,
+                var(--spectrum-textfield-text-color-focus-hover)
+            )
+        );
+    }
+    :host([invalid]) .input:focus:hover,
+    :host([invalid]:focus) .input:hover,
+    :host([invalid][focused]) .input:hover {
+        border-color: var(
+            --highcontrast-textfield-border-color-invalid-focus-hover,
+            var(
+                --mod-textfield-border-color-invalid-focus-hover,
+                var(--spectrum-textfield-border-color-invalid-focus-hover)
+            )
+        );
+    }
+    :host([disabled]) #textfield:hover .input::placeholder {
+        color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+    }
+    :host([quiet][disabled]:hover) .input::placeholder {
+        color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+    }
+    #textfield:hover .input,
+    .input:hover {
+        border-color: var(
+            --highcontrast-textfield-border-color-hover,
+            var(
+                --mod-textfield-border-color-hover,
+                var(--spectrum-textfield-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-textfield-text-color-hover,
+            var(
+                --mod-textfield-text-color-hover,
+                var(--spectrum-textfield-text-color-hover)
+            )
+        );
+    }
+    :host([invalid]) .input:hover,
+    :host([invalid]:hover) .input {
+        border-color: var(
+            --highcontrast-textfield-border-color-invalid-hover,
+            var(
+                --mod-textfield-border-color-invalid-hover,
+                var(--spectrum-textfield-border-color-invalid-hover)
+            )
+        );
+    }
+    :host([disabled]) #textfield:hover .input {
+        -webkit-text-fill-color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+        background-color: var(
+            --mod-textfield-background-color-disabled,
+            var(--spectrum-textfield-background-color-disabled)
+        );
+        border-color: #0000;
+        color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+        opacity: 1;
+        resize: none;
+    }
+    :host([quiet][disabled]:hover) .input {
+        background-color: #0000;
+        border-color: var(
+            --mod-textfield-border-color-disabled,
+            var(--spectrum-textfield-border-color-disabled)
+        );
+        color: var(
+            --highcontrast-textfield-text-color-disabled,
+            var(
+                --mod-textfield-text-color-disabled,
+                var(--spectrum-textfield-text-color-disabled)
+            )
+        );
+    }
+    :host([readonly]) #textfield:hover .input {
+        background-color: #0000;
+        border-color: #0000;
+        color: var(
+            --highcontrast-textfield-text-color-readonly,
+            var(
+                --mod-textfield-text-color-readonly,
+                var(--spectrum-textfield-text-color-readonly)
+            )
+        );
+        outline: none;
+    }
+    :host([readonly]) #textfield:hover .input::placeholder {
+        background-color: #0000;
+        color: var(
+            --highcontrast-textfield-text-color-readonly,
+            var(
+                --mod-textfield-text-color-readonly,
+                var(--spectrum-textfield-text-color-readonly)
+            )
+        );
+    }
 }
 .spectrum-Textfield--sideLabel {
     grid-template-columns: auto auto auto;

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/shared": "^0.40.4"
     },
     "devDependencies": {
-        "@spectrum-css/tooltip": "^5.2.0"
+        "@spectrum-css/tooltip": "^5.3.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/tools/styles/package.json
+++ b/tools/styles/package.json
@@ -109,7 +109,7 @@
     "devDependencies": {
         "@spectrum-css/commons": "^9.1.0",
         "@spectrum-css/expressvars": "^3.0.9",
-        "@spectrum-css/tokens": "^13.0.9",
+        "@spectrum-css/tokens": "^13.1.0",
         "@spectrum-css/typography": "^5.1.0",
         "@spectrum-css/vars": "^9.0.8"
     },

--- a/tools/styles/tokens/spectrum/custom-large-vars.css
+++ b/tools/styles/tokens/spectrum/custom-large-vars.css
@@ -66,6 +66,9 @@
     --spectrum-well-border-radius: 5px;
 
     --spectrum-icon-chevron-size-50: 8px;
+    /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+    --spectrum-workflow-icon-size-xxl: 40px;
+    --spectrum-workflow-icon-size-xxs: 15px;
 
     --spectrum-treeview-item-indentation-medium: 20px;
     --spectrum-treeview-item-indentation-small: 15px;
@@ -111,4 +114,7 @@
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-xs);
 
     --spectrum-tooltip-animation-distance: 5px;
+
+    --spectrum-ui-icon-medium-display: none;
+    --spectrum-ui-icon-large-display: block;
 }

--- a/tools/styles/tokens/spectrum/custom-medium-vars.css
+++ b/tools/styles/tokens/spectrum/custom-medium-vars.css
@@ -65,6 +65,9 @@
     --spectrum-well-border-radius: var(--spectrum-spacing-75);
 
     --spectrum-icon-chevron-size-50: 6px;
+    /* XXL and XXS icon sizes are not within the design spec and are planned to be deprecated in Spectrum 2. */
+    --spectrum-workflow-icon-size-xxl: 32px;
+    --spectrum-workflow-icon-size-xxs: 12px;
 
     --spectrum-treeview-item-indentation-medium: var(--spectrum-spacing-300);
     --spectrum-treeview-item-indentation-small: var(--spectrum-spacing-200);
@@ -112,4 +115,7 @@
     --spectrum-assetcard-content-font-size: var(--spectrum-body-size-s);
 
     --spectrum-tooltip-animation-distance: var(--spectrum-spacing-75);
+
+    --spectrum-ui-icon-medium-display: block;
+    --spectrum-ui-icon-large-display: none;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6633,25 +6633,25 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
-"@spectrum-css/accordion@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-4.1.1.tgz#68f7b4878831fc80b023ac972d8c8da23085acc9"
-  integrity sha512-5ImV5252fS3lUec/1WnuZS6rAgKJPqxsgnUCQ4PkNs4kCzVnkhde4zcuqDcUw8cwSBJ0WopW1hHXZz0NKbuiLw==
+"@spectrum-css/accordion@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-4.2.0.tgz#d36ddc80b1dbaaa00dad53ef69fd11010540071c"
+  integrity sha512-eKjqiQrdUCAkl1B29isbgeE4YKM8VPM31Gs8oB1Q/Okmw4ybliSQgC4fSTPfXv0Yg6nNHjJuNl5ez+vWlT32Dg==
 
 "@spectrum-css/actionbar@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-7.1.0.tgz#b515d66b00512a8d4345124d50adab352fca4686"
   integrity sha512-D/uFkP8Nb4+XNZSQckwKnKoWC8jc4qiEzJgeCe+k+CswJgEQFU3PK4ZO3/vfVycxr9xfDe+nUimM4FYl26ebSg==
 
-"@spectrum-css/actionbutton@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-5.1.0.tgz#2c15c02201e295728ed92f79c362fcf75f363824"
-  integrity sha512-wc2Bsu+FF0N/lONB/GNNwfd2ANvE1vMQ4eVt+2AyYMrZfsBFCwtYsKr3+tAamZ6hNptpPWxlicoma6Nmy30YBQ==
+"@spectrum-css/actionbutton@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-5.2.0.tgz#ee9cce7a8fd0e882a15002da7b813d6b483017c5"
+  integrity sha512-b0ZANN9Fg4r7ONQ86gVaZjiACUkEhDiKC27Zw5F93hSE5863T+jfK9utHhSPn7isEhTQmNeBisjEr/RwuXLCiA==
 
-"@spectrum-css/actiongroup@^4.1.10":
-  version "4.1.10"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-4.1.10.tgz#faa6b9f9720ab18e9c015c63a56399ead5605913"
-  integrity sha512-x3Xhu9VUZQ34RTPAkOybY78XgIinoWM9RFLzNSLRzWIFp2TvHz7q/tjKcdTNCSdJxwtMgw6sEnFuJJR+xOHpEw==
+"@spectrum-css/actiongroup@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-4.2.0.tgz#3c514b95332ba988f08a360f5eb6ad2acf199e96"
+  integrity sha512-S5syz8+CQKYmulX9lPa7aeuo+Xua2rLrpAka4O3AyaWADV7rXKKmqva7gZ0B5HR+3wNgfb3mU0dX5Rx+D1B56A==
 
 "@spectrum-css/actionmenu@^5.1.0":
   version "5.1.0"
@@ -6683,35 +6683,35 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/banner/-/banner-3.0.0-beta.2.tgz#df448a3dcb8ac63448bd628843a2895cec305780"
   integrity sha512-NqrT03ItWzj+L0dtqjedhop6wKOspBmaowzp9IOY/2kL561kRqYTLKR9vTteZ3cEDVD3ajKA8y+bKIW0eN+X7A==
 
-"@spectrum-css/button@^11.1.0":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-11.1.0.tgz#8ac167fcd8b0d24f72c4669776664658f49a19a4"
-  integrity sha512-GtLkLo219AaQsNZWO2+UHPN6S4tAUhv11DKv4uQeW0O1bTCOpbC9/GOZcv5CYKXNKIxCr+e8G2lxij4y7xfjtQ==
+"@spectrum-css/button@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-11.2.0.tgz#f4086c2cbe58d719f559f0a528b7e970e4e126a5"
+  integrity sha512-Au8VXM6la88P4VQv4RhWdJBLFJgOx5MnUHxaXMOAzhM6HK3R+KqkxQi+kCRm/f/zfAlCSwHIZHxup4Pwnvz66A==
 
 "@spectrum-css/buttongroup@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-6.2.0.tgz#bd105d28af994afb64bd892e11193bd8059fe932"
   integrity sha512-puxAw6gY7zWLpcS75PsJX/pjnpOWnSmTiraBOLL20U7S4M/a9Zc6Jbhq5SAqxn3hQ2TOYyWo9xyGiXUmde6EcQ==
 
-"@spectrum-css/card@^6.3.1":
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-6.3.1.tgz#703f3f14079447ef91774f422b700b287dd89942"
-  integrity sha512-Us//7m6q1OrYgFFWl9G6CXUvPc9+P2Ggzei0M1EW4lEftTzsaVV39spLTI8PzdS1xN8PCiOkrd1wlwtwqip0cA==
+"@spectrum-css/card@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-6.4.0.tgz#f088d186809941dbe19b17f7966ddc4ca4bd8cd7"
+  integrity sha512-LT3C82IadHiHkQY+IrOYoAPyDzzb2zDmkAKJl6lKZe0BUsGRVK3cqS7KIyrA3+kpkpC+0EJ0pUPmyQrdt2WbMw==
 
-"@spectrum-css/checkbox@^8.0.6":
-  version "8.0.6"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-8.0.6.tgz#eba3e7f0c607c297db624916ae0d76c78c2960bf"
-  integrity sha512-G8Qw40R+IuLNEsy3NsFOsBA6CyM4h0F0BgWECPDZ4cJGADa1G1W+yjNsOuPWGvl/qgcjm5Rjo5g6zTYPq4Mjhg==
+"@spectrum-css/checkbox@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-8.1.0.tgz#174b2c69c4d7ee2d919a38a9acbae6f259c6543f"
+  integrity sha512-42ryCfUpUg3Br54nr0Ti3yjkkjTWeSIQbkaxcL8mmvgOE7/RKElZ7Dav6atWau2jZyTMOhv/EhkvlMWuNgk9CQ==
 
-"@spectrum-css/clearbutton@^5.0.16":
-  version "5.0.16"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-5.0.16.tgz#861e28c38a381e1cd001f4b646d8007a5319bc9b"
-  integrity sha512-b0gKgIHdKxiyqsKybjk+gw/hQ6VSlHNw71C8rwP/otgmOKm3ZV3O1PI7ukRWQ7USKvOPlKPxyWgQFXhuvV/wwQ==
+"@spectrum-css/clearbutton@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-5.1.0.tgz#cea931cf0676e1031ee0cbd6143e934b32f43c98"
+  integrity sha512-cU4do5Iue8K0PbG5za7HuLV+1WLmZJLFNfsqtUsKAtCLD/F3kO0g5En+rSyoLlXLuW6qv9Ro6SGGW1pPH5iaXQ==
 
-"@spectrum-css/closebutton@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-4.1.0.tgz#1272ec65be320e547cf1ddcc59990ae768a6464f"
-  integrity sha512-ZZEO0SGeZwwbfuAhZQnk28rxplf3AiTdLxowTjSgoBivyZygQK12lBIEk5PM7X+Wiv6cOXMRuQ1xOYOfr9x5MA==
+"@spectrum-css/closebutton@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-4.2.0.tgz#8ea4e797fa402487e10b03ca10577e02f3aa7402"
+  integrity sha512-5qGNq+yBaPQdfaFkqTPGVhtCnsrl4OTkGjj1I5minP4XTsmHQBNBr0oW4zYlCzxP1pM5qPp7ipaUU1VgPBB9Ag==
 
 "@spectrum-css/coachmark@^5.0.75":
   version "5.0.75"
@@ -6743,10 +6743,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-3.1.0.tgz#c765fa896eaad6e446e859f045df43c0586d31af"
   integrity sha512-vPSy6FiCc5oMQ9QDjSgXUwATZfgCog97zaB+w1M/urBwKNsXWXeZe4p+jENVC5g0TKq6uZwYaLFrDP2ot5yIdw==
 
-"@spectrum-css/combobox@^2.0.48":
-  version "2.0.48"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/combobox/-/combobox-2.0.48.tgz#60b9e49d126f2fa8f2a42e04e49094743026f1d0"
-  integrity sha512-61+XrmlVl5HPcm3Ws3WVrJcJtrWF1ANIJ7gELSuJ/42gL4X1n18Kd38N//oLh66vIOTVbnOv7UF4opo03cvecA==
+"@spectrum-css/combobox@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/combobox/-/combobox-2.1.0.tgz#593a4ed56f6b4ccbbd25cc734c433ca69a86d1bd"
+  integrity sha512-1W3tE0+4/TR9GL+WGcSDIp0nNrSrG4Yl+NDm/4Th0sTuUeU9vR09/ehW837lLJj9FblecDiXVbuRw/AJmX5kUw==
 
 "@spectrum-css/commons@^9.1.0":
   version "9.1.0"
@@ -6763,10 +6763,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-2.2.0.tgz#e9c4c0e7cc97ae45528483f5ee0bbdaee1c09844"
   integrity sha512-Bpe+UN2rX8fUNzPieZY/9y5S3TjcsOds7Z6Sw42pEyrB7+iCcLZmTNDFF/uupinUFgvNEVdsHBuw8yEjnURU0w==
 
-"@spectrum-css/dropzone@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-5.1.0.tgz#4afeba96e3dbba4e9981ba0e9404fb81756c089d"
-  integrity sha512-p8nqjDsoho8YijOazesXaCVTBjoWPPHW7qR9a1j247qRtw6tRfwnq2iKju91wh9sM0AulIqPX0mzhWm8HIi/DQ==
+"@spectrum-css/dropzone@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-5.2.0.tgz#c515d802a5d30659a3a49656501c62b009627bf9"
+  integrity sha512-S7JYw5TDlg8+MLfXMBHJuJG9ELnKkvFi/HdqJ0Y5xJKlMn43qulFz12Chn+B1eJ7VhchO71uE+NzstztZtU5rg==
 
 "@spectrum-css/expressvars@^3.0.9":
   version "3.0.9"
@@ -6798,20 +6798,20 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-6.1.0.tgz#299daaae621bda731757e529a20eba555fb0d07a"
   integrity sha512-oJWjLg6jViSKzQWOY8sFxLIdQac1QYUdBDm1IJ+JvDZo00C2nz3MP3RyJLCxuCt+MZLIAeaA3iDujuq2jhT6Aw==
 
-"@spectrum-css/infieldbutton@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/infieldbutton/-/infieldbutton-4.1.0.tgz#64b4cbc4e78240dfc34a65b0b2a17a63317d686e"
-  integrity sha512-1UOJSvJ9ZUdCsk0h6oOIPO9uv2wbVSMKcRBhCg0/aAlJMcEyVL2KG0OioczNVCCQHlgizmdn3xQYDJItg3DM6A==
+"@spectrum-css/infieldbutton@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/infieldbutton/-/infieldbutton-4.2.0.tgz#c57baaee49318ee96f0367de1414fe80e9be883e"
+  integrity sha512-NclDtCAeqXfY2WFdqkvrXdIhoYFEV97jRaZPi964bqwf0w+idX7D0+5JlI4leT5rliHkt2B9ssiosLTWBvIqhQ==
 
-"@spectrum-css/link@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-4.1.0.tgz#0e53381bd5623477b3a600b9a0c8c274180b7bfe"
-  integrity sha512-sFkqTOCzHMRSZ4pl+Opv+fryQHvYDomCNH+y9Rjs2RrDc1lKFL0QUUu331vbb4ebzhKaORkc95ktnvqvzvcCEg==
+"@spectrum-css/link@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-4.2.0.tgz#0e776de795adb1f3afd10bbd7ddf80ec39ca4019"
+  integrity sha512-tJtm+CBCdU1p6yik5WnEpzXsabZSODJEConzcoRGjcNT/FPiSqbqVtWtnMlCTJIjmY5OYjq5pu2a5HZ7yVRQGg==
 
-"@spectrum-css/menu@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-6.0.0.tgz#b914e1439cae893a628437ffa9f2bb8802a94850"
-  integrity sha512-2swuwQBRjR519skPbt0Yr4dPonw58nOMz02TEc+Dk768r/AI0kLD9QKSa//6sbh3V9TaWjQ+aSbV+PXI2NBGjg==
+"@spectrum-css/menu@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-6.1.0.tgz#68e0e057652d2eb96437fbd55b60431c2c246f8b"
+  integrity sha512-wPzcn5yLEtoNyqTxHSTgUy3hj87A9VaDrAzx0fcpUud9FV84ad6M8lEUTVyYC8Gjr4mGyIYnetZuXTZn+Uwdgg==
 
 "@spectrum-css/modal@^4.2.0":
   version "4.2.0"
@@ -6823,15 +6823,15 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/opacitycheckerboard/-/opacitycheckerboard-1.1.1.tgz#0b86256cde20091182e4632ea3ffab4e54525418"
   integrity sha512-rhr27YQUSsW9B0MO8LqMYUGQ7hBu5UmouvA6FEdRJr+DgFKZOB2W/bFZv69w9sbi3kdrH0WmsUFXQmpWLGDDMw==
 
-"@spectrum-css/picker@^7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-7.1.0.tgz#7d01603787a66abcadb61860c6ad6c3445af309d"
-  integrity sha512-ZQFHqkZ8eOZ6nyr1+6KIM91Q0qLZH0FssuGz2ovwO7YU0j+o+avjNbhXpxKV9i+Ht6AENQXDs5SyijV9f1Bwtw==
+"@spectrum-css/picker@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-7.2.0.tgz#0c9823b2d589a880eb61ce4c66924d6f763a41f2"
+  integrity sha512-CE6hVrDWy93vNAakfMD4KnmJOS8bZaJ+3ekRlU50eoO/ybhEQj7TzH6Htj0CQ5S5JN4/lWbbX2wMFm4CkDMtbg==
 
-"@spectrum-css/pickerbutton@^4.0.23":
-  version "4.0.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/pickerbutton/-/pickerbutton-4.0.23.tgz#ccce20cf42d8722817565f4b9e072ee9020e6a93"
-  integrity sha512-lI/8nQKNODkTR3DJ+o8IYFFdKnivv16PbvpH13H2GXB9oKf4oMhrWmdyAQdXBW51Afb3QjZOS9IMUv8YKe0Nag==
+"@spectrum-css/pickerbutton@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/pickerbutton/-/pickerbutton-4.1.0.tgz#4b5df72edd113000263a96516ec03c9647b23f67"
+  integrity sha512-4HNjxsRlrui9WzGBpAMohwBSQEjfpt+S3UX03nF3U/I6r21qGqOs4RnnMtrCPcijZqgKu3K+SwmON9JT/mCiAw==
 
 "@spectrum-css/popover@^6.2.0":
   version "6.2.0"
@@ -6853,45 +6853,45 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.1.0.tgz#e135d005d6d5c9ea3eb64923b47395f099c357b5"
   integrity sha512-P9gZ1RjSMjeMFNOK6Z/9ch+LmUdp08CVPCWa3nnwd6yVcBG0eVjIuX/xVaN1STsi7zfuhyAlRXzmEes7cduOgg==
 
-"@spectrum-css/radio@^8.0.19":
-  version "8.0.19"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-8.0.19.tgz#dd9acbbb11cfe7f02aa63f239b72d490f8b6261d"
-  integrity sha512-89clj47w4j4H57uQPJDA8h0Dva38EdxQGSh28HXfFmxL1DZJwLD/Be2OZ/9s7h01CfsOPEvAUtjpsEZcvm9dsQ==
+"@spectrum-css/radio@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-8.1.0.tgz#68993e9952c377fdcdb903d4c5962a789fe142b8"
+  integrity sha512-JcUHqCDUhHZYscZN69Qh5P1TgtLzDXtJKEUUk0v6yTAdrc47DPxCEgtlHyDQL6iiLAqaFGBJILaG3hC7sYBbIQ==
 
-"@spectrum-css/search@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-6.1.0.tgz#c06931f92f6fd25d49f3b9f5b6ece7dcf73a6cf2"
-  integrity sha512-ooNs4Q1ypsjOrvFydMOOvJlqjKzOZi1Bn4MB0QHvcdXjC0QXHI32VViuBHoD81RjvU+W3aoFm8YLJDcBDmE5aA==
+"@spectrum-css/search@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-6.2.0.tgz#f3841e4c671739c42b3c5948e8b7262151adf5ce"
+  integrity sha512-+nC5osxRN7avO58jHaCesjjIUDKWhVczwl+kdnH0E7Bj2yc+8RbgBXANi6JE4d4rAk4KHcEz6qaKxJIoHNYsIQ==
 
-"@spectrum-css/sidenav@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-4.1.0.tgz#954e449f56366bbdf1f3e409c03d460415080c2a"
-  integrity sha512-RStY34CB6GpY/iyQi69dYPuHuWFj7cR0fuX3AY5B7gbUT7+RKKxcycC1haYClKAH8PqXV7AUFFzCRJaUYeXphg==
+"@spectrum-css/sidenav@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-4.2.0.tgz#078cafc2788f5f43ac070f28ccc70e58fd07fec7"
+  integrity sha512-OTykAnooYpSVJRyeQi/pprcS/A2q8jqp+dlQOfHqkw5Zmyij3Qsv5qIjwzPwscfxwChuhla/hEI5aqyIuH3MYQ==
 
-"@spectrum-css/slider@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.2.1.tgz#a6a31f4a4273cc5f2dbb9518ac04020df8fc49cb"
-  integrity sha512-oPrHBUtkPThqTrsaXskf9NBA4ZXmGWKRUlRkhDkuYM6BejIse4Ur7AtvTfxSFNdkl0IC9BULbeRpOQ63VCLHoA==
+"@spectrum-css/slider@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.3.0.tgz#5e0cbcadcb2981ff24790d513e69e97f550cfea4"
+  integrity sha512-Z5VD8IF8BOtYlMU9HdoOrQclHf72Ju1XC0QBnbxmWdQLM8hdawJd/wiNcVt3sCAaktBkcjlASWtnMm5jQoIT8Q==
 
 "@spectrum-css/splitbutton@^8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-8.1.0.tgz#893de1f076b5c90939f90f7ab5485f6d3bae3757"
   integrity sha512-OBH16iACINSd+I5oepokZ8JO/843zu0UrnTQjP5WQtmPN17uQOduxkqgYWJpG66DhQy0aAuB8acIGF+X4r8yfw==
 
-"@spectrum-css/splitview@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-4.1.0.tgz#ff5c493652817c0aba1434abaa9fa1875b8c3654"
-  integrity sha512-/FxzVA+xOLxwS80LFoxQYTb6Ms8ZMrK9p1hT9JVkCvNm8hYty8sb2s7pZ9geP3cca4SW4D7IbLT7ADh++Duk7Q==
+"@spectrum-css/splitview@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-4.2.0.tgz#25f14b73f5a012c4b5f8a500cd2ec6d89849d167"
+  integrity sha512-9dqyE58du06MNyiswTzopcvVlkabA8uJOwE4kVaa/7hkQrb1xzx+meQhfgrFFcSq79u58PKqHEJJT2uB27b0Pw==
 
 "@spectrum-css/statuslight@^6.1.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-6.1.0.tgz#e3c2be949ddfbfe472503681fa422b5d99b983c0"
   integrity sha512-cnzfaic+WKMqr2KOXhMgO05dx+zrJHAKzxSYArcpWKSbi27covI1GsphNPn5X6wUcRM5Fy9byLU6K2wkhk3ICA==
 
-"@spectrum-css/stepper@^5.0.7":
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-5.0.7.tgz#833d05d5dac067a879c9a9e24825b336fbb1ee95"
-  integrity sha512-aoIbGAHDNen5cfkrSi8L2kWFd5USPvp7dglsEXbI5SFXBgQsPjpZhwOzoYWhAd6etrsVoPYbw3rPMgqX1XDTOw==
+"@spectrum-css/stepper@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-5.1.0.tgz#1a76a49c90bd553dd38f9612ec2abc782a10a730"
+  integrity sha512-xNdbwvGmlu26WpAadfjh2QwxWc8wjN0vxHVZEjgxRmxybljlIFHriRNZypNzl20oTp+a0vVwS/JWg5WxVqQivQ==
 
 "@spectrum-css/swatch@^5.1.0":
   version "5.1.0"
@@ -6903,35 +6903,35 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/swatchgroup/-/swatchgroup-2.1.0.tgz#ea24c5214291dcbceb400d1f6235148d9c1eca01"
   integrity sha512-zPFJs2M6lgPjBrgLd9xAfG1DzQK9ITYaDf6ERX4CiB8pCRLzEAEOp7Iq8q+l2fcAgG9B6xPlVPk/vcN2TzrNjg==
 
-"@spectrum-css/switch@^4.1.0":
+"@spectrum-css/switch@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-4.2.0.tgz#88a8bff8072f32658847b93536f2ce0c2cca9120"
+  integrity sha512-QClCkaNas6vFbEfROxdFIG8VTN/ee/J7mWvW5mK/Pnv5ZajGrq33glv8HpocFfokc+CAoEVyxn1ZUA4lTXA5ow==
+
+"@spectrum-css/table@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-5.2.0.tgz#48327bbea84238ea2a45e3a0af59091b21d14848"
+  integrity sha512-JU2dJ8HNfBXQOu6y0wUgI6jpc5JewIBPiEIxdcm6nNMlOzwrMUPb7sH9Bf9tV+HQMGnpzKOkcEF9prf8YS82NA==
+
+"@spectrum-css/tabs@^4.1.0":
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-4.1.0.tgz#4c4c8b49328bdbdd365d03270e62445af1d01260"
-  integrity sha512-P/N2Jk3eYII//InZzFzCDisR11tAEZLAmcNU9LlM6amomX+avj+jZaRYY07J6HdH57unhWTVl6UsdM2p7hO+gg==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-4.1.0.tgz#424aef1f40119690168d76062fccf124d758ed12"
+  integrity sha512-XAA+rQIh1SoIVEKoGgmD4zuvKem+ZdZhkRt+xhgP/JuSEibLnxRG41B9buglxdnDvz/kdP6KzyWrtpNf4fL74A==
 
-"@spectrum-css/table@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-5.1.1.tgz#bb20813472ce2d0194d627bd13d505d4e40729a9"
-  integrity sha512-AVatPc8/WZfACLqvx6mpVBLvG/iLIo0q1LqYSmHCL1Lra8muVWvTcSyfX2WNe3Eyp4aCrzbk9+flYBDlNLZ4kw==
-
-"@spectrum-css/tabs@^4.0.28":
-  version "4.0.28"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-4.0.28.tgz#21719326a042ffe03e749c01c6b3d8b798f8f25a"
-  integrity sha512-NcuD1LaIv4zO+fsJihY8BcvIrHm6/YO4vfrk/Z4GWaIZmjtSIdBrQUNgicrUGXywC4/1HHcumRe2TopqHjjtxw==
-
-"@spectrum-css/tag@^8.0.17":
-  version "8.0.17"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-8.0.17.tgz#ed604466184b5bfe33f014951cb0126e9812d630"
-  integrity sha512-ZAtY7w83FJvzYxzrUocVfuW7ZVvlPZKK4XBW/3ihoZY6jksLBc4RrhWvw9P4FXndNo2BaKIFkbYUuVDy4uLM+A==
+"@spectrum-css/tag@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-8.1.0.tgz#b8ee13f11733f9e6e286be980e3c3649f328695c"
+  integrity sha512-nw88UZ5kZbeNuapt3mEZUYFy8DU06ge1GQVPYDjxeR7IxmtxTw06TxzkS1+BsOFWBpOtvG+l+iDauKI6L65NwA==
 
 "@spectrum-css/taggroup@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-4.1.0.tgz#5242cb0bab32d163a2b22ec1f21cf954ecc00b46"
   integrity sha512-HsF3p1cbyAf+2PetEAhrudOQRjSmUSBvUABz/bKk4blgUW3rDpTW0kGEosgW1RirIHJK4VLPxOZJF5eefLRfTA==
 
-"@spectrum-css/textfield@^6.0.31":
-  version "6.0.31"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-6.0.31.tgz#5e4d0176ff02a05f1cd9510215c7f112e59024e9"
-  integrity sha512-ntUp7ljSOd5ExWte5bXAgeunjpk1kYbkpTKwca3SVoyLq3zbh/hnagxHiPnWK3XHgZmTuoeRtpZUIvWGUii1jg==
+"@spectrum-css/textfield@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-6.1.0.tgz#987af6006e948ec408ea0ec303453f097c708702"
+  integrity sha512-xIukc0RGINNmMxxRgKNP/DgzHe+a18GKH/XF9zqXDfVOLspaLDUWuGXQegKxcBqlqtJPg/8O3GfPK3DzEnFJmA==
 
 "@spectrum-css/thumbnail@^5.2.0":
   version "5.2.0"
@@ -6943,15 +6943,15 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-9.1.20.tgz#dd2f472a4ef1e0f1016e9312bb62e878b2479ed9"
   integrity sha512-GgX8NZXxRUbPJK+WDj16g769XB2yIHUYLOazIFhUauT7+WsqC7EBjNcg6ALa/ibt/93epb4VX6yqjjyA0K4zRw==
 
-"@spectrum-css/tokens@^13.0.9":
-  version "13.0.9"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-13.0.9.tgz#52f232bd3fd81982ae465e91ae398fd8975d36e5"
-  integrity sha512-IPzkiweUw/LiUYGYxMKtSkAVTG5cKdN5NAKYCBBGDAZCMkPvaFSztvC4CjZlUBYaGKrk5YHsmDVAMqGKUoHy7g==
+"@spectrum-css/tokens@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-13.1.0.tgz#41a90d7df4218ab6503f61231b2e895f12954384"
+  integrity sha512-vbgsawUmxp8/lxz7NmVnJm4DEx0QT72CFox7Ut1pfk64GcANZpyP2e1/P4MPx6+nMQK62V0lH6LLD88KIHpKXQ==
 
-"@spectrum-css/tooltip@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-5.2.0.tgz#a57bffe22fec8e1097e09e9509b5327f13123040"
-  integrity sha512-UY8zP+BAn1FhAUOngbLrdpuulvbqBNzR3cVTnS16Ug0UF7Ec8Tq4EXCaqtxuWohgDluD42mAMdTOBveLls+suw==
+"@spectrum-css/tooltip@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-5.3.0.tgz#7ecfa206de67513ba1d0460e1d7437c861a6555c"
+  integrity sha512-s46+m/1tXSqPjSFDSEpZGLvm0+Buvwg38K7eZA/g0ooz+RvMzLLKYgX2wc/ZFnZ0jgTPqKb9ja8gm9limk0B4g==
 
 "@spectrum-css/tray@^2.2.0":
   version "2.2.0"


### PR DESCRIPTION
## Description
Take CSS update the sequesters `:hover` styles within the `@media (hover: hover) {}` media query, which prevents it in the _majority_ of mobile/touch-only contexts.

## Related issue(s)
- fixes #2598

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://spectrum-css--spectrum-web-components.netlify.app/storybook/index.html?path=/story/menu--default)
    2. In a mobile or touch-only context (can be triggered with Chrome Dev Tools)
    3. Click on of the Menu Items
    4. See that the "hover" state is not triggered
-  [ ] _Test case 2_
    1. Go [here](https://73874bdaecee6ea6d7a506b37d5d256d--spectrum-web-components.netlify.app/review/)
    2. See the accepted VRT updates

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)