### PR TITLE
fix(popover): correct tip delivery size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 8db475da1be22d52a739b89fe6ec3317d7a51f25
+        default: f0b23861090807cce5d78a70ed43391f367dc3dc
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/popover/src/popover.css
+++ b/packages/popover/src/popover.css
@@ -12,8 +12,6 @@ governing permissions and limitations under the License.
 @import url('./spectrum-popover.css');
 
 :host {
-    --sp-popover-tip-size: 24px;
-
     min-width: min-content;
     max-height: 100%;
     max-width: 100%;
@@ -36,14 +34,9 @@ governing permissions and limitations under the License.
     right: auto;
 }
 
-.block {
-    width: 100%;
-    height: 50%;
-    display: block;
-}
-
+.block,
 .inline {
-    width: 50%;
+    width: 100%;
     height: 100%;
     display: block;
 }


### PR DESCRIPTION
## Description
Correct the tip size for the Popover element when positioned to the left/right of something

## Related issue(s)
- fix #4011

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://popover-tip--spectrum-web-components.netlify.app/storybook/?path=/story/popover--dialog-right)
    2. See the tip be correctly sized
-   [ ] _Test case 2_
    1. Go [here](https://popover-tip--spectrum-web-components.netlify.app/storybook/?path=/story/popover--overlaid-left)
    2. See the tip be correctly sized

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.