### PR TITLE
fix(underlay): dispatch a "close" event rather than relying naively on "click"

### DIFF
--- a/packages/dialog/src/DialogBase.ts
+++ b/packages/dialog/src/DialogBase.ts
@@ -183,7 +183,7 @@ export class DialogBase extends FocusVisiblePolyfillMixin(SpectrumElement) {
                 ? html`
                       <sp-underlay
                           ?open=${this.open}
-                          @click=${this.dismiss}
+                          @close=${this.dismiss}
                           @transitionrun=${this.handleTransitionEvent}
                           @transitionend=${this.handleUnderlayTransitionend}
                           @transitioncancel=${this.handleTransitionEvent}

--- a/packages/tray/src/Tray.ts
+++ b/packages/tray/src/Tray.ts
@@ -123,7 +123,7 @@ export class Tray extends SpectrumElement {
         return html`
             <sp-underlay
                 ?open=${this.open}
-                @click=${this.close}
+                @close=${this.close}
                 @transitionend=${this.handleUnderlayTransitionend}
             ></sp-underlay>
             <div

--- a/packages/underlay/src/Underlay.ts
+++ b/packages/underlay/src/Underlay.ts
@@ -22,16 +22,40 @@ import styles from './underlay.css.js';
 
 /**
  * @element sp-underlay
+ *
+ * @fires close - When the underlay is "clicked" and the consuming pattern should chose whether to close based on that interaction
  */
 export class Underlay extends SpectrumElement {
     public static override get styles(): CSSResultArray {
         return [styles];
     }
 
+    private canClick = false;
+
     @property({ type: Boolean, reflect: true })
     public open = false;
 
+    public override click(): void {
+        this.dispatchEvent(new Event('close'));
+    }
+
+    protected handlePointerdown(): void {
+        this.canClick = true;
+    }
+
+    protected handlePointerup(): void {
+        if (this.canClick) {
+            this.click();
+        }
+        this.canClick = false;
+    }
+
     protected override render(): TemplateResult {
         return html``;
+    }
+
+    protected override firstUpdated(): void {
+        this.addEventListener('pointerdown', this.handlePointerdown);
+        this.addEventListener('pointerup', this.handlePointerup);
     }
 }

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -341,7 +341,7 @@ export class LayoutElement extends LitElement {
                       <sp-underlay
                           class="scrim"
                           ?open=${this.settings}
-                          @click=${this.toggleSettings}
+                          @close=${this.toggleSettings}
                           ?hidden=${!this.isNarrow}
                       ></sp-underlay>
                       <aside

--- a/projects/documentation/src/components/side-nav.ts
+++ b/projects/documentation/src/components/side-nav.ts
@@ -75,7 +75,7 @@ export class SideNav extends LitElement {
         return html`
             <sp-underlay
                 class="scrim"
-                @click=${this.toggle}
+                @close=${this.toggle}
                 ?open=${this.open}
             ></sp-underlay>
             <aside>


### PR DESCRIPTION
## Description
Relying on `click` directly means that patterns that open an Overlay on `pointerdown`, like `<sp-picker>`, could inadvertently close the Overlay as part of that initial interaction.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://picker-mobile--spectrum-web-components.netlify.app/)
    2. Use a mobile device, emulator, or Dev Tools to mock the mobile context
    3. Open one of the theme Pickers
    4. See that it stays open.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.