### PR TITLE
fix: support generating random IDs outside of secure contexts

### DIFF
--- a/packages/menu/src/MenuGroup.ts
+++ b/packages/menu/src/MenuGroup.ts
@@ -19,6 +19,7 @@ import {
     queryAssignedNodes,
     state,
 } from '@spectrum-web-components/base/src/decorators.js';
+import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
 
 import { Menu } from './Menu.js';
 // Leveraged in build systems that use aliasing to prevent multiple registrations: https://github.com/adobe/spectrum-web-components/pull/3225
@@ -68,8 +69,7 @@ export class MenuGroup extends Menu {
             }
             if (headerElement) {
                 this.headerId =
-                    this.headerId ||
-                    `sp-menu-group-label-${crypto.randomUUID().slice(0, 8)}`;
+                    this.headerId || `sp-menu-group-label-${randomID()}`;
                 const headerId = headerElement.id || this.headerId;
                 if (!headerElement.id) {
                     headerElement.id = headerId;

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -20,6 +20,7 @@ import {
 import {
     ObserveSlotPresence,
     ObserveSlotText,
+    randomID,
 } from '@spectrum-web-components/shared';
 import {
     property,
@@ -372,7 +373,7 @@ export class MenuItem extends LikeAnchor(
         this.addEventListener('pointerdown', this.handlePointerdown);
         this.addEventListener('pointerenter', this.closeOverlaysForRoot);
         if (!this.hasAttribute('id')) {
-            this.id = `sp-menu-item-${crypto.randomUUID().slice(0, 8)}`;
+            this.id = `sp-menu-item-${randomID()}`;
         }
     }
 

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -34,6 +34,7 @@ import {
     StyleInfo,
     styleMap,
 } from '@spectrum-web-components/base/src/directives.js';
+import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
 
 import type {
     OpenableElement,
@@ -619,9 +620,7 @@ export class Overlay extends OverlayFeatures {
         }
 
         const longpressDescription = document.createElement('div');
-        longpressDescription.id = `longpress-describedby-descriptor-${crypto
-            .randomUUID()
-            .slice(0, 8)}`;
+        longpressDescription.id = `longpress-describedby-descriptor-${randomID()}`;
         const messageType = isIOS() || isAndroid() ? 'touch' : 'keyboard';
         longpressDescription.textContent = LONGPRESS_INSTRUCTIONS[messageType];
         longpressDescription.slot = 'longpress-describedby-descriptor';
@@ -685,9 +684,7 @@ export class Overlay extends OverlayFeatures {
             this.elementIds = this.elements.map((el) => el.id);
             const appliedIds = this.elements.map((el) => {
                 if (!el.id) {
-                    el.id = `${this.tagName.toLowerCase()}-helper-${crypto
-                        .randomUUID()
-                        .slice(0, 8)}`;
+                    el.id = `${this.tagName.toLowerCase()}-helper-${randomID()}`;
                 }
                 return el.id;
             });
@@ -911,9 +908,7 @@ export class Overlay extends OverlayFeatures {
         if (!this.hasAttribute('id')) {
             this.setAttribute(
                 'id',
-                `${this.tagName.toLowerCase()}-${crypto
-                    .randomUUID()
-                    .slice(0, 8)}`
+                `${this.tagName.toLowerCase()}-${randomID()}`
             );
         }
         if (

--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -29,6 +29,7 @@ import {
     state,
 } from '@spectrum-web-components/base/src/decorators.js';
 import { streamingListener } from '@spectrum-web-components/base/src/streaming-listener.js';
+import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
 
 import { WithSWCResizeObserver } from './types';
 
@@ -251,9 +252,7 @@ export class SplitView extends SpectrumElement {
         }
         this.controlledEl = event.target.assignedElements()[0] as HTMLElement;
         if (this.controlledEl && !this.controlledEl.id) {
-            this.controlledEl.id = `${this.tagName.toLowerCase()}-${crypto
-                .randomUUID()
-                .slice(0, 8)}`;
+            this.controlledEl.id = `${this.tagName.toLowerCase()}-${randomID()}`;
             this.controlledElIDApplied = true;
         }
         this.enoughChildren = this.children.length > 1;

--- a/tools/shared/package.json
+++ b/tools/shared/package.json
@@ -73,6 +73,10 @@
             "development": "./src/platform.dev.js",
             "default": "./src/platform.js"
         },
+        "./src/random-id.js": {
+            "development": "./src/random-id.dev.js",
+            "default": "./src/random-id.js"
+        },
         "./src/reparent-children.js": {
             "development": "./src/reparent-children.dev.js",
             "default": "./src/reparent-children.js"

--- a/tools/shared/src/random-id.ts
+++ b/tools/shared/src/random-id.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,15 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export * from './first-focusable-in.js';
-export * from './focus-visible.js';
-export * from './focusable.js';
-export * from './focusable-selectors.js';
-export * from './get-active-element.js';
-export * from './like-anchor.js';
-export * from './observe-slot-presence.js';
-export * from './observe-slot-text.js';
-export * from './platform.js';
-export * from './reparent-children.js';
-export * from './get-label-from-slot.js';
-export * from './random-id.js';
+// This gnarly-looking implementation returns the equivalent of crypto.randomUUID().slice(0, 8).
+// It uses getRandomValues() in order to be compatible with HTTP contexts.
+export function randomID(): string {
+    return Array.from(crypto.getRandomValues(new Uint8Array(4)), (b) =>
+        `0${(b & 0xff).toString(16)}`.slice(-2)
+    ).join('');
+}

--- a/tools/shared/test/random-id.test.ts
+++ b/tools/shared/test/random-id.test.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
+import { expect } from '@open-wc/testing';
+
+describe('randomID()', () => {
+    it('creates unique strings of 8 hex characters', () => {
+        const n = 1000;
+        const ids = Array.from({ length: n }, randomID);
+        const shape = ids.filter((id) => {
+            return (
+                typeof id === 'string' &&
+                id.length === 8 &&
+                id.split('').every((char) => '0123456789abcdef'.includes(char))
+            );
+        });
+        const unique = new Set(ids);
+
+        expect(shape).to.have.length(n);
+        expect(unique).to.have.length(n);
+    });
+    it('generates 100k IDs in less than a second', () => {
+        const n = 100000;
+        const sec = 1000;
+        const start = performance.now();
+        const ids = Array.from({ length: n }, randomID);
+        const time = performance.now() - start;
+
+        expect(ids).to.have.length(n);
+        expect(time).to.be.lessThan(sec);
+    });
+});


### PR DESCRIPTION
## Description

Replace HTTPS-only `crypto.randomUUID` with `crypto.getRandomValues`, generating equivalent output (an 8-character hex string).

## Motivation and context

Allows SWC to run without errors in HTTP contexts.

## How has this been tested?

- All existing tests pass
- Added a test to validate the shape of the ID
- Added a test to validate the speed of ID generation

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
