### PR TITLE
ci: expand lighthouse usage and reporting

### DIFF
--- a/.github/lighthouse/lighthouse-config.js
+++ b/.github/lighthouse/lighthouse-config.js
@@ -2,12 +2,11 @@ export default {
     extends: 'lighthouse:default',
     settings: {
         onlyCategories: [
-            // Excluded categories do not currently pass
-            // "accessibility",
-            // "best-practices",
+            'accessibility',
+            'best-practices',
             'performance',
-            // "pwa",
-            // "seo"
+            'pwa',
+            'seo',
         ],
         // Excluded audits do not currently pass
         // metrics/first-contentful-paint', 'metrics/largest-contentful-paint','metrics/first-meaningful-paint', 'metrics/speed-index', 'screenshot-thumbnails',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
                         repo: context.repo.repo,
                         issue_number: context.issue.number,
                       }).then(({data}) => {
-                        const priorComment = data.find(comment => comment.body.startsWith('# Branch Preview'));
+                        const priorComment = data.find(comment => comment.body.startsWith('## Branch preview') || comment.body.startsWith('# Branch Preview'));
                         if (priorComment) {
                           github.rest.issues.updateComment({
                             owner: context.repo.owner,
@@ -87,12 +87,43 @@ jobs:
               id: lighthouse
               uses: treosh/lighthouse-ci-action@v11
               with:
-                  urls: |
-                      https://${{ steps.extract_branch.outputs.branch }}--spectrum-web-components.netlify.app/
-                      https://main--spectrum-web-components.netlify.app/
                   configPath: '.github/lighthouse/lighthouserc.json'
-                  uploadArtifacts: true
+                  runs: 3
                   temporaryPublicStorage: true
+                  uploadArtifacts: true
+                  urls: |
+                      https://opensource.adobe.com/spectrum-web-components/
+                      https://main--spectrum-web-components.netlify.app/
+                      https://${{ steps.extract_branch.outputs.branch }}--spectrum-web-components.netlify.app/
+
+            - name: Post Results
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const { buildLighthouseComment } = await import('${{ github.workspace }}/tasks/build-lighthouse-comment.js');
+                      const body = buildLighthouseComment(${{ steps.lighthouse.outputs.links }}, ${{ steps.lighthouse.outputs.manifest }});
+                      github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                      }).then(({data}) => {
+                        const priorComment = data.find(comment => comment.body.startsWith('## Lighthouse scores') || comment.body.startsWith('# Lighthouse Results'));
+                        if (priorComment) {
+                          github.rest.issues.updateComment({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            comment_id: priorComment.id,
+                            body
+                          });
+                        } else {
+                          github.rest.issues.createComment({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: context.issue.number,
+                            body
+                          });
+                        }
+                      });
     compare-firefox:
         name: Compare performance to latest release on Firefox
 
@@ -215,7 +246,7 @@ jobs:
                         repo: context.repo.repo,
                         issue_number: context.issue.number,
                       }).then(({data}) => {
-                        const priorComment = data.find(comment => comment.body.startsWith('# Tachometer results'));
+                        const priorComment = data.find(comment => comment.body.startsWith('## Tachometer results') || comment.body.startsWith('# Tachometer results'));
                         if (priorComment) {
                           github.rest.issues.updateComment({
                             owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,24 +78,18 @@ jobs:
             - name: Install dependencies
               run: yarn --frozen-lockfile
 
-            - name: Generate docs URL
-              id: docsURL
-              uses: actions/github-script@v6
-              with:
-                  script: |
-                      const { buildPreviewURLComment } = await import('${{ github.workspace }}/tasks/build-preview-urls-comment.js');
-                      const body = buildPreviewURLComment(process.env.GITHUB_HEAD_REF);
-                      const urlRegex = /(https?:\/\/[^\s]+)/g;
-
-                      const docsURL = body.match(urlRegex)?.[0];
-                      core.setOutput('docsURL', docsURL);
+            - name: Extract branch name
+              shell: bash
+              run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+              id: extract_branch
 
             - name: Lighthouse CI Action
               id: lighthouse
               uses: treosh/lighthouse-ci-action@v11
               with:
                   urls: |
-                      ${{ steps.docsURL.outputs.docsURL }}
+                      https://${{ steps.extract_branch.outputs.branch }}--spectrum-web-components.netlify.app/
+                      https://main--spectrum-web-components.netlify.app/
                   configPath: '.github/lighthouse/lighthouserc.json'
                   uploadArtifacts: true
                   temporaryPublicStorage: true

--- a/tasks/build-lighthouse-comment.js
+++ b/tasks/build-lighthouse-comment.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const latestURL = 'https://opensource.adobe.com/spectrum-web-components/';
+const mainURL = 'https://main--spectrum-web-components.netlify.app/';
+
+export const buildLighthouseComment = (links, manifest) => {
+    const report = {};
+    Object.keys(links).forEach((key) => {
+        if (key === mainURL) {
+            report.main = links[key];
+        } else if (key === latestURL) {
+            report.latest = links[key];
+        } else {
+            report.branch = links[key];
+        }
+    });
+    const branch = manifest.find(
+        (result) =>
+            result.isRepresentativeRun &&
+            result.url !== mainURL &&
+            result.url !== latestURL
+    );
+    const latest = manifest.find(
+        (result) => result.isRepresentativeRun && result.url === latestURL
+    );
+    const main = manifest.find(
+        (result) => result.isRepresentativeRun && result.url === mainURL
+    );
+
+    const comment = `## Lighthouse scores
+
+| Category | Latest ([report](${report.latest})) | Main ([report](${report.main})) | Branch ([report](${report.branch})) |
+|---|---|---|---|
+| Performance | ${latest.summary.performance} | ${main.summary.performance} | ${branch.summary.performance} |
+| Accessibility | ${latest.summary.accessibility} | ${main.summary.accessibility} | ${branch.summary.accessibility} |
+| Best Practices | ${latest.summary['best-practices']} | ${main.summary['best-practices']} | ${branch.summary['best-practices']} |
+| SEO | ${latest.summary.seo} | ${main.summary.seo} | ${branch.summary.seo} |
+| PWA | ${latest.summary.pwa} | ${main.summary.pwa} | ${branch.summary.pwa} |
+
+[Lighthouse](https://github.com/GoogleChrome/lighthouse) scores comparing the documentation site built from the PR ("Branch") to that of the production documentation site ("Latest") and the build currently on <code>main</code> ("Main"). Higher scores are better, but *note that the SEO scores on Netlify URLs are artifically constrained to 0.92.*
+`;
+
+    return comment;
+};

--- a/tasks/build-preview-urls-comment.js
+++ b/tasks/build-preview-urls-comment.js
@@ -76,7 +76,7 @@ export const buildPreviewURLComment = (ref) => {
             )
         )
     );
-    let comment = `# Branch Preview
+    let comment = `## Branch preview
 
 - [Documentation Site](https://${branchSlug}--spectrum-web-components.netlify.app/)
 - [Storybook](https://${branchSlug}--spectrum-web-components.netlify.app/storybook/)`;

--- a/tasks/build-tachometer-comment.js
+++ b/tasks/build-tachometer-comment.js
@@ -140,7 +140,7 @@ export const buildTachometerComment = () => {
 
 `)
         : '';
-    let comment = `# Tachometer results
+    let comment = `## Tachometer results
 `;
     if (firefoxBody) {
         [


### PR DESCRIPTION
## Description
- build the test URL, rather than extract it from other functionality
- add a comparison to `main`
- [x] report the results into the PR
- [x] possibly compare to `latest`
- go from there

## How has this been tested?
-   [ ] _Test case 1_
    1. At some point the lighthouse results pre/post a PR should display in a comment below...

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.