### PR TITLE
docs: refactor the page load pattern

### DIFF
--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -32,7 +32,6 @@ import type {
 import type { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
-import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/link/sp-link.js';
 import '@spectrum-web-components/divider/sp-divider.js';
 import '@spectrum-web-components/toast/sp-toast.js';

--- a/projects/documentation/src/components/settings.ts
+++ b/projects/documentation/src/components/settings.ts
@@ -12,5 +12,6 @@ governing permissions and limitations under the License.
 
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/picker/sp-picker.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
 import '@spectrum-web-components/underlay/sp-underlay.js';


### PR DESCRIPTION
## Description
- clear the critical load path in mobile of as much JS as possible

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://docs-loading--spectrum-web-components.netlify.app/)
    2. In mobile
    3. See that less JS is loaded than in [latest](https://opensource.adobe.com/spectrum-web-components) or [main](https://main--spectrum-web-components.netlify.app/)
-   [ ] _Test case 2_
    1. Go [here](https://docs-loading--spectrum-web-components.netlify.app/)
    2. In mobile
    3. See that all of the page content is still accessible

## Types of changes
-   [x] Research

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.