### PR TITLE
feat(tabs): adds optional property to bring selected tab into view when first rendered

### DIFF
--- a/packages/tabs/src/Tabs.ts
+++ b/packages/tabs/src/Tabs.ts
@@ -229,7 +229,9 @@ export class Tabs extends SizedMixin(Focusable, { noDefaultSize: true }) {
         return {};
     }
 
-    private _waitForChildrenToUpdate(): Promise<boolean[]> {
+    override async getUpdateComplete(): Promise<boolean> {
+        const complete = await super.getUpdateComplete();
+
         const tabs = [...this.children] as Tab[];
         const tabUpdateCompletes = tabs.map((tab) => {
             if (typeof tab.updateComplete !== 'undefined') {
@@ -237,30 +239,9 @@ export class Tabs extends SizedMixin(Focusable, { noDefaultSize: true }) {
             }
             return Promise.resolve(true);
         });
-        return Promise.all(tabUpdateCompletes);
-    }
 
-    protected override manageAutoFocus(): void {
-        this._waitForChildrenToUpdate().then(() => super.manageAutoFocus());
-    }
-
-    public scrollToSelected(): void {
-        this._waitForChildrenToUpdate().then(() => {
-            const selectedTab = this.querySelector(
-                `[role="tab"][value="${this.selected}"]`
-            ) as Tab;
-
-            // only if the selected tab is not visible
-            if (selectedTab && selectedTab.offsetLeft > this.clientWidth) {
-                // scroll it to the center of the container
-                this.scrollTabs(
-                    selectedTab.offsetLeft -
-                        this.clientWidth / 2 +
-                        selectedTab.clientWidth / 2,
-                    'instant'
-                );
-            }
-        });
+        await Promise.all(tabUpdateCompletes);
+        return complete;
     }
 
     protected managePanels({

--- a/packages/tabs/src/TabsOverflow.ts
+++ b/packages/tabs/src/TabsOverflow.ts
@@ -27,6 +27,7 @@ import {
 import { classMap } from '@spectrum-web-components/base/src/directives.js';
 import { ResizeController } from '@lit-labs/observers/resize-controller.js';
 import { Tabs } from './Tabs.js';
+import { Tab } from './Tab.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron100.js';
 import chevronIconStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
@@ -78,9 +79,7 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
         });
     }
 
-    protected override async firstUpdated(
-        changes: PropertyValues
-    ): Promise<void> {
+    protected override firstUpdated(changes: PropertyValues): void {
         super.firstUpdated(changes);
         // enable scroll event
         const [tabs] = this.scrollContent;
@@ -89,8 +88,13 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
         }
         this.resizeController.observe(this.overflowContainer);
 
-        if (this.autoscroll) {
-            tabs.scrollToSelected();
+        if (this.autoscroll && tabs?.selected) {
+            tabs.updateComplete.then(() => {
+                const selectedTab = this.querySelector(
+                    `[role="tab"][value="${tabs.selected}"]`
+                ) as Tab;
+                selectedTab.scrollIntoView({ inline: 'center' });
+            });
         }
     }
 

--- a/packages/tabs/src/TabsOverflow.ts
+++ b/packages/tabs/src/TabsOverflow.ts
@@ -48,6 +48,9 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
     @property({ type: Boolean, reflect: true })
     compact = false;
 
+    @property({ type: Boolean, reflect: true })
+    autoscroll = false;
+
     @property({ reflect: true })
     public override dir!: 'ltr' | 'rtl';
 
@@ -75,7 +78,9 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
         });
     }
 
-    protected override firstUpdated(changes: PropertyValues): void {
+    protected override async firstUpdated(
+        changes: PropertyValues
+    ): Promise<void> {
         super.firstUpdated(changes);
         // enable scroll event
         const [tabs] = this.scrollContent;
@@ -83,6 +88,10 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
             tabs.enableTabsScroll = true;
         }
         this.resizeController.observe(this.overflowContainer);
+
+        if (this.autoscroll) {
+            tabs.scrollToSelected();
+        }
     }
 
     private async _handleSlotChange(): Promise<void> {

--- a/packages/tabs/stories/index.ts
+++ b/packages/tabs/stories/index.ts
@@ -23,6 +23,7 @@ export interface OverflowProperties {
     size?: string;
     includeTabPanel?: boolean;
     compact?: boolean;
+    autoscroll?: boolean;
 }
 
 export const renderTabsOverflowExample = ({
@@ -31,6 +32,7 @@ export const renderTabsOverflowExample = ({
     size = 'm',
     includeTabPanel,
     compact,
+    autoscroll,
 }: OverflowProperties): TemplateResult => {
     return html`
         <style>
@@ -42,7 +44,11 @@ export const renderTabsOverflowExample = ({
             }
         </style>
         <div class="container">
-            <sp-tabs-overflow size=${size} ?compact=${compact}>
+            <sp-tabs-overflow
+                size=${size}
+                ?compact=${compact}
+                ?autoscroll=${autoscroll}
+            >
                 <sp-tabs size=${size} selected=${selected} ?compact=${compact}>
                     ${repeat(
                         new Array(count),

--- a/packages/tabs/stories/index.ts
+++ b/packages/tabs/stories/index.ts
@@ -18,6 +18,7 @@ import { html, nothing, TemplateResult } from '@spectrum-web-components/base';
 import { repeat } from '@spectrum-web-components/base/src/directives.js';
 
 export interface OverflowProperties {
+    selected?: number;
     count?: number;
     size?: string;
     includeTabPanel?: boolean;
@@ -25,6 +26,7 @@ export interface OverflowProperties {
 }
 
 export const renderTabsOverflowExample = ({
+    selected = 1,
     count = 20,
     size = 'm',
     includeTabPanel,
@@ -41,7 +43,7 @@ export const renderTabsOverflowExample = ({
         </style>
         <div class="container">
             <sp-tabs-overflow size=${size} ?compact=${compact}>
-                <sp-tabs size=${size} selected="1" ?compact=${compact}>
+                <sp-tabs size=${size} selected=${selected} ?compact=${compact}>
                     ${repeat(
                         new Array(count),
                         (item) => item,

--- a/packages/tabs/stories/tabs-overflow.stories.ts
+++ b/packages/tabs/stories/tabs-overflow.stories.ts
@@ -23,3 +23,11 @@ export const compact = (args: OverflowProperties): TemplateResult => {
 compact.args = {
     compact: true,
 };
+
+export const autoscroll = (args: OverflowProperties): TemplateResult => {
+    return renderTabsOverflowExample(args);
+};
+autoscroll.args = {
+    selected: 10,
+    autoscroll: true,
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

 If the default selected tab is out of view, the tabs overflow component does not ensure that tab is scrolled into view.

## Related issue(s)

See https://github.com/adobe/spectrum-web-components/issues/3987

## Motivation and context

As a user, I can easily see what tab is selected without having to scroll to discover it.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)


https://github.com/adobe/spectrum-web-components/assets/13311865/3de0a2be-07af-4e55-8da9-5f3355aec6b3


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
