### PR TITLE
ci: slugify URLs in lighthouse testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
 
             - name: Extract branch name
               shell: bash
-              run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+              run: echo "branch=$(npx slugify-cli ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}})" >> $GITHUB_OUTPUT
               id: extract_branch
 
             - name: Lighthouse CI Action


### PR DESCRIPTION
Process branch to slug, so that more branch names can be tested.

We'll want to expand to some level of support for the super long branches (which get hashed) at some point, but baby steps.