### PR TITLE
fix(overlay): leverage "transition-behavior" to persist top-layer content while closing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 686fa6e78586a47ae3fd13d4171392ca5aa5d42d
+        default: 824fb67e89d53a25416b315fc8dda02aa83e5482
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/overlay/src/AbstractOverlay.ts
+++ b/packages/overlay/src/AbstractOverlay.ts
@@ -237,6 +237,9 @@ export class AbstractOverlay extends SpectrumElement {
     protected placementController!: PlacementController;
     receivesFocus!: 'true' | 'false' | 'auto';
     protected requestSlottable(): void {}
+    protected returnFocus(): void {
+        return;
+    }
     /* c8 ignore next 6 */
     get state(): OverlayState {
         return 'closed';

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -354,6 +354,45 @@ export class Overlay extends OverlayFeatures {
         focusEl?.focus();
     }
 
+    protected override returnFocus(): void {
+        if (this.open || this.type === 'hint') return;
+
+        // If the focus remains inside of the overlay or
+        // a slotted descendent of the overlay you need to return
+        // focus back to the trigger.
+        const getAncestors = (): HTMLElement[] => {
+            const ancestors: HTMLElement[] = [];
+            // eslint-disable-next-line @spectrum-web-components/document-active-element
+            let currentNode = document.activeElement;
+            while (
+                currentNode?.shadowRoot &&
+                currentNode.shadowRoot.activeElement
+            ) {
+                currentNode = currentNode.shadowRoot.activeElement;
+            }
+            while (currentNode) {
+                const ancestor =
+                    currentNode.assignedSlot ||
+                    currentNode.parentElement ||
+                    (currentNode.getRootNode() as ShadowRoot)?.host;
+                if (ancestor) {
+                    ancestors.push(ancestor as HTMLElement);
+                }
+                currentNode = ancestor;
+            }
+            return ancestors;
+        };
+        if (
+            (this.triggerElement as HTMLElement)?.focus &&
+            (this.contains((this.getRootNode() as Document).activeElement) ||
+                getAncestors().includes(this) ||
+                // eslint-disable-next-line @spectrum-web-components/document-active-element
+                document.activeElement === document.body)
+        ) {
+            (this.triggerElement as HTMLElement).focus();
+        }
+    }
+
     private closeOnFocusOut = (event: FocusEvent): void => {
         // If you don't know where the focus went, we can't do anyting here.
         if (!event.relatedTarget) {
@@ -434,42 +473,6 @@ export class Overlay extends OverlayFeatures {
                     this.closeOnFocusOut,
                     { capture: true }
                 );
-            }
-        }
-        if (!this.open && this.type !== 'hint') {
-            // If the focus remains inside of the overlay or
-            // a slotted descendent of the overlay you need to return
-            // focus back to the trigger.
-            const getAncestors = (): HTMLElement[] => {
-                const ancestors: HTMLElement[] = [];
-                // eslint-disable-next-line @spectrum-web-components/document-active-element
-                let currentNode = document.activeElement;
-                while (
-                    currentNode?.shadowRoot &&
-                    currentNode.shadowRoot.activeElement
-                ) {
-                    currentNode = currentNode.shadowRoot.activeElement;
-                }
-                while (currentNode) {
-                    const ancestor =
-                        currentNode.assignedSlot ||
-                        currentNode.parentElement ||
-                        (currentNode.getRootNode() as ShadowRoot)?.host;
-                    if (ancestor) {
-                        ancestors.push(ancestor as HTMLElement);
-                    }
-                    currentNode = ancestor;
-                }
-                return ancestors;
-            };
-            if (
-                (this.triggerElement as HTMLElement)?.focus &&
-                (this.contains(
-                    (this.getRootNode() as Document).activeElement
-                ) ||
-                    getAncestors().includes(this))
-            ) {
-                (this.triggerElement as HTMLElement).focus();
             }
         }
     }

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -364,10 +364,7 @@ export class Overlay extends OverlayFeatures {
             const ancestors: HTMLElement[] = [];
             // eslint-disable-next-line @spectrum-web-components/document-active-element
             let currentNode = document.activeElement;
-            while (
-                currentNode?.shadowRoot &&
-                currentNode.shadowRoot.activeElement
-            ) {
+            while (currentNode?.shadowRoot?.activeElement) {
                 currentNode = currentNode.shadowRoot.activeElement;
             }
             while (currentNode) {

--- a/packages/overlay/src/OverlayDialog.ts
+++ b/packages/overlay/src/OverlayDialog.ts
@@ -132,6 +132,7 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
                         );
                     }
                     this.state = targetOpenState ? 'opened' : 'closed';
+                    this.returnFocus();
                     // Ensure layout and paint are done and the Overlay is still closed before removing the slottable request.
                     await nextFrame();
                     await nextFrame();

--- a/packages/overlay/src/OverlayNoPopover.ts
+++ b/packages/overlay/src/OverlayNoPopover.ts
@@ -126,6 +126,7 @@ export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
                         );
                     }
                     this.state = targetOpenState ? 'opened' : 'closed';
+                    this.returnFocus();
                     // Ensure layout and paint are done and the Overlay is still closed before removing the slottable request.
                     await nextFrame();
                     await nextFrame();

--- a/packages/overlay/src/OverlayPopover.ts
+++ b/packages/overlay/src/OverlayPopover.ts
@@ -27,6 +27,8 @@ import {
 import type { AbstractOverlay } from './AbstractOverlay.js';
 import { userFocusableSelector } from '@spectrum-web-components/shared';
 
+const supportsOverlayAuto = CSS.supports('(overlay: auto)');
+
 function isOpen(el: HTMLElement): boolean {
     let popoverOpen = false;
     try {
@@ -122,7 +124,9 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
             targetOpenState: boolean
         ): Promise<void> {
             await nextFrame();
-            await this.shouldHidePopover(targetOpenState);
+            if (!supportsOverlayAuto) {
+                await this.shouldHidePopover(targetOpenState);
+            }
             await this.shouldShowPopover(targetOpenState);
             await nextFrame();
         }
@@ -205,6 +209,7 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
                             );
                         }
                         this.state = targetOpenState ? 'opened' : 'closed';
+                        this.returnFocus();
                         // Ensure layout and paint are done and the Overlay is still closed before removing the slottable request.
                         await nextFrame();
                         await nextFrame();

--- a/packages/overlay/src/overlay.css
+++ b/packages/overlay/src/overlay.css
@@ -177,6 +177,29 @@ slot[name='longpress-describedby-descriptor'] {
     }
 }
 
+@supports (overlay: auto) {
+    .dialog {
+        display: none;
+        transition: all
+                var(
+                    --mod-overlay-animation-duration,
+                    var(--spectrum-animation-duration-100, 0.13s)
+                ),
+            translate 0s,
+            display
+                var(
+                    --mod-overlay-animation-duration,
+                    var(--spectrum-animation-duration-100, 0.13s)
+                );
+        transition-behavior: allow-discrete;
+    }
+
+    .dialog:popover-open,
+    .dialog:modal {
+        display: flex;
+    }
+}
+
 @supports (not selector(:open)) and (not selector(:popover-open)) {
     :host:not([open]) .dialog {
         pointer-events: none;

--- a/packages/overlay/test/overlay-trigger-extended.test.ts
+++ b/packages/overlay/test/overlay-trigger-extended.test.ts
@@ -141,8 +141,8 @@ describe('Overlay Trigger - extended', () => {
         expect(popover.placement).to.equal('bottom');
     });
 
-    xit('occludes content behind the overlay', async () => {
-        // currently fails for no reason in Firefox locally, and most browsers in CI.
+    it('occludes content behind the overlay', async () => {
+        // currently fails most browsers in CI.
         ({ overlayTrigger, button, popover } = await initTest());
         const textfield = document.createElement('sp-textfield');
         overlayTrigger.insertAdjacentElement('afterend', textfield);

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import { html, TemplateResult } from '@spectrum-web-components/base';
 
+import '@spectrum-web-components/link/sp-link.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
@@ -389,15 +390,6 @@ export const Open = (args: StoryArgs): TemplateResult => {
                 clear: left;
                 margin-bottom: 15px;
             }
-            /* Enforce CSS stacking to test "transition-behavior: allow-discrete" */
-            /* Breaks the story in non-[popover] supporting browsers */
-            fieldset:nth-of-type(2) {
-                position: relative;
-                z-index: 2;
-            }
-            .backdrop-filter-test {
-                backdrop-filter: saturate(80%);
-            }
         </style>
         <fieldset class="backdrop-filter-test">
             <sp-field-label for="picker-open">
@@ -441,6 +433,90 @@ Open.args = {
     open: true,
 };
 Open.decorators = [isOverlayOpen];
+
+export const OpenShowingEdgeCase = (args: StoryArgs): TemplateResult => {
+    return html`
+        <style>
+            fieldset {
+                float: left;
+                clear: left;
+                margin-bottom: 15px;
+            }
+            /* Enforce CSS stacking to test "transition-behavior: allow-discrete" */
+            /* Breaks the story in non-[popover] supporting browsers */
+            fieldset:nth-of-type(2) {
+                position: relative;
+                z-index: 2;
+            }
+            .backdrop-filter-test {
+                backdrop-filter: saturate(80%);
+            }
+        </style>
+        <p>
+            In browser that do not support
+            <code>[popover]</code>
+            , the following "open"
+            <code>sp-picker</code>
+            will display behind both the closed
+            <code>sp-picker</code>
+            as well as the
+            <code>fieldset</code>
+            that contains it.
+        </p>
+        <p>
+            Learn more about this situation in our
+            <sp-link
+                href="https://opensource.adobe.com/spectrum-web-components/components/overlay/#fallback-support"
+            >
+                documentation site
+            </sp-link>
+            .
+        </p>
+        <fieldset class="backdrop-filter-test">
+            <sp-field-label for="picker-open">
+                Where do you live?
+            </sp-field-label>
+            <sp-picker
+                id="picker-open"
+                label="Open picker"
+                ${spreadProps(args)}
+                @change=${handleChange(args)}
+            >
+                <span slot="label">
+                    Select a Country with a very long label, too long, in fact
+                </span>
+                <sp-menu-item>Deselect</sp-menu-item>
+                <sp-menu-item>Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-picker>
+        </fieldset>
+        <fieldset>
+            <sp-field-label for="picker-closed">
+                Where do you live?
+            </sp-field-label>
+            <sp-picker
+                id="picker-closed"
+                label="Picker that displays below the options"
+                @change=${handleChange(args)}
+            >
+                <span slot="label">
+                    Other menu that goes behind the open one
+                </span>
+                <sp-menu-item>Not so many options...</sp-menu-item>
+            </sp-picker>
+        </fieldset>
+    `;
+};
+OpenShowingEdgeCase.args = {
+    open: true,
+};
+OpenShowingEdgeCase.decorators = [isOverlayOpen];
+OpenShowingEdgeCase.swc_vrt = {
+    skip: true,
+};
 
 export const initialValue = (args: StoryArgs): TemplateResult => {
     return html`

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -389,6 +389,12 @@ export const Open = (args: StoryArgs): TemplateResult => {
                 clear: left;
                 margin-bottom: 15px;
             }
+            /* Enforce CSS stacking to test "transition-behavior: allow-discrete" */
+            /* Breaks the story in non-[popover] supporting browsers */
+            fieldset:nth-of-type(2) {
+                position: relative;
+                z-index: 2;
+            }
             .backdrop-filter-test {
                 backdrop-filter: saturate(80%);
             }

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -155,40 +155,44 @@ export async function isOnTopLayer(element: HTMLElement): Promise<boolean> {
         composed: true,
         bubbles: true,
     });
-    element.addEventListener(queryEvent.type, (event: Event) => {
-        const closestDialog = ([...event.composedPath()] as HTMLElement[]).find(
-            (el) => {
+    element.addEventListener(
+        queryEvent.type,
+        (event: Event) => {
+            const closestDialog = (
+                [...event.composedPath()] as HTMLElement[]
+            ).find((el) => {
                 return (
                     el.classList?.contains('dialog') &&
                     el.part?.contains('dialog')
                 );
+            });
+            if (!closestDialog) {
+                resolve(false);
+                return;
             }
-        );
-        if (!closestDialog) {
-            resolve(false);
-            return;
-        }
-        let popoverOpen = false;
-        try {
-            popoverOpen = closestDialog.matches(':popover-open');
-        } catch (error) {}
-        let open = false;
-        try {
-            open = closestDialog.matches(':open');
-        } catch (error) {}
-        let modal = false;
-        try {
-            modal = closestDialog.matches(':modal');
-        } catch (error) {}
-        let polyfill = false;
-        if (!popoverOpen && !open && !modal) {
-            const style = getComputedStyle(closestDialog);
-            polyfill =
-                style.getPropertyValue('--sp-overlay-open') === 'true' &&
-                style.getPropertyValue('position') === 'fixed';
-        }
-        resolve(popoverOpen || open || modal || polyfill);
-    });
+            let popoverOpen = false;
+            try {
+                popoverOpen = closestDialog.matches(':popover-open');
+            } catch (error) {}
+            let open = false;
+            try {
+                open = closestDialog.matches(':open');
+            } catch (error) {}
+            let modal = false;
+            try {
+                modal = closestDialog.matches(':modal');
+            } catch (error) {}
+            let polyfill = false;
+            if (!popoverOpen && !open && !modal) {
+                const style = getComputedStyle(closestDialog);
+                polyfill =
+                    style.getPropertyValue('--sp-overlay-open') === 'true' &&
+                    style.getPropertyValue('position') === 'fixed';
+            }
+            resolve(popoverOpen || open || modal || polyfill);
+        },
+        { once: true }
+    );
     element.dispatchEvent(queryEvent);
     return found;
 }


### PR DESCRIPTION
## Description
Currently when the browser closers an Overlay for us, it will fall off of the `#top-layer` immediately and allow the Overlay content to paint behind standard page content while its close animation is playing.

`transition-behavior`, in association with the `overlay` property, allows the content to stay on the `#top-layer` through the course of the animation.

*TO DO*
- [x] decide whether the [open Picker demo](https://transition-behavior--spectrum-web-components.netlify.app/storybook/?path=/story/picker--open) should continue to be forward facing and test this specific feature, while being broken in Firefox/WebKit, or whether it should be normalized for "working as expected" everywhere

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://transition-behavior--spectrum-web-components.netlify.app/storybook/?path=/story/picker--open) (Currently Chromium only, [more info](https://developer.mozilla.org/en-US/docs/Web/CSS/overlay))
    2. Open the Picker (it should be by default)
    3. Click away from the Menu, so the Picker closes
    4. See that the Menu does not appear "behind" the second Picker while its close animation plays

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.