### PR TITLE
fix(menu): correct disabled menu item's chevron to appropriate colour

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: d0c3962bea4786d21761102249fa2506fb6f4965
+        default: 7d1cdc603b1afb11c62f9b716f97e859b929c279
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/menu/src/menu-item.css
+++ b/packages/menu/src/menu-item.css
@@ -23,6 +23,16 @@ governing permissions and limitations under the License.
     pointer-events: none;
 }
 
+:host([has-submenu][disabled]) .chevron {
+    color: var(
+        --highcontrast-menu-item-color-disabled,
+        var(
+            --mod-menu-item-label-icon-color-disabled,
+            var(--spectrum-menu-item-label-icon-color-disabled)
+        )
+    );
+}
+
 #button {
     position: absolute;
     inset: 0;

--- a/packages/menu/stories/submenu.stories.ts
+++ b/packages/menu/stories/submenu.stories.ts
@@ -209,6 +209,16 @@ export const submenu = (): TemplateResult => {
                         <sp-menu-item>Upper East Side</sp-menu-item>
                     </sp-menu>
                 </sp-menu-item>
+                <sp-menu-item disabled>
+                    Queens
+                    <sp-menu disabled slot="submenu">
+                        <sp-menu-item>
+                            You shouldn't be able to see this!
+                        </sp-menu-item>
+                        <sp-menu-item>Forest Hills</sp-menu-item>
+                        <sp-menu-item>Jamaica</sp-menu-item>
+                    </sp-menu>
+                </sp-menu-item>
             </sp-menu-group>
         </sp-action-menu>
         <div>

--- a/packages/menu/stories/submenu.stories.ts
+++ b/packages/menu/stories/submenu.stories.ts
@@ -211,7 +211,7 @@ export const submenu = (): TemplateResult => {
                 </sp-menu-item>
                 <sp-menu-item disabled>
                     Queens
-                    <sp-menu disabled slot="submenu">
+                    <sp-menu slot="submenu">
                         <sp-menu-item>
                             You shouldn't be able to see this!
                         </sp-menu-item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
A local fix for this visual bug until Spectrum CSS is able to get back to fixing this for us. The chevron wasn't turning to the disabled colour if its menu item is disabled. Now, it does! 

## Related issue(s)

fixes #3659

## Motivation and context

PSWeb fix request

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   VRTs

## Screenshots (if appropriate)
Before: 
![image](https://github.com/adobe/spectrum-web-components/assets/44980010/92204059-a228-473b-ac2f-49d290e059f2)

After (see Queens):
![image](https://github.com/adobe/spectrum-web-components/assets/44980010/f1c71feb-800a-4834-99d0-4a384652243d)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
