### PR TITLE
fix(textfield): clearly mark/support "multiline" as a requirement of "grows"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 7d1cdc603b1afb11c62f9b716f97e859b929c279
+        default: c3df2b2da5c455e279b0a4396c2b15ee164dd246
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -119,7 +119,8 @@ export class TextfieldBase extends ManageHelpText(
     public pattern?: string;
 
     /**
-     * Whether a form control delivered with the `multiline` attribute will change size to accomodate longer input
+     * Whether a form control delivered with the `multiline` attribute will change size
+     * vertically to accomodate longer input
      */
     @property({ type: Boolean, reflect: true })
     public grows = false;
@@ -289,7 +290,7 @@ export class TextfieldBase extends ManageHelpText(
 
     private get renderMultiline(): TemplateResult {
         return html`
-            ${this.grows && this.rows === -1
+            ${this.multiline && this.grows && this.rows === -1
                 ? html`
                       <div id="sizer" class="input" aria-hidden="true">
                           ${this.value}&#8203;

--- a/packages/textfield/src/textfield.css
+++ b/packages/textfield/src/textfield.css
@@ -48,20 +48,6 @@ textarea {
     forced-color-adjust: var(--swc-test-forced-color-adjust);
 }
 
-:host([grows]:not([quiet])) #textfield:after {
-    grid-area: unset;
-    min-block-size: calc(
-        var(
-                --mod-text-area-min-block-size,
-                var(--spectrum-text-area-min-block-size)
-            ) +
-            var(
-                --mod-textfield-focus-indicator-gap,
-                var(--spectrum-textfield-focus-indicator-gap)
-            ) * 2
-    );
-}
-
 #sizer {
     block-size: auto;
     word-break: break-word;
@@ -97,15 +83,6 @@ textarea {
     min-block-size: auto;
 }
 
-:host([grows]:not([rows])) .input:not(#sizer) {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    resize: none;
-    overflow: hidden;
-}
-
 /* restore specificity from the original Spectrum CSS */
 
 :host([disabled][quiet]) #textfield .input,
@@ -135,4 +112,27 @@ textarea {
             var(--spectrum-textfield-text-color-disabled)
         )
     );
+}
+
+:host([multiline][grows]:not([quiet])) #textfield:after {
+    grid-area: unset;
+    min-block-size: calc(
+        var(
+                --mod-text-area-min-block-size,
+                var(--spectrum-text-area-min-block-size)
+            ) +
+            var(
+                --mod-textfield-focus-indicator-gap,
+                var(--spectrum-textfield-focus-indicator-gap)
+            ) * 2
+    );
+}
+
+:host([multiline][grows]:not([rows])) .input:not(#sizer) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    resize: none;
+    overflow: hidden;
 }

--- a/packages/textfield/stories/textfield.stories.ts
+++ b/packages/textfield/stories/textfield.stories.ts
@@ -52,6 +52,20 @@ export const Default = (): TemplateResult => {
     `;
 };
 
+export const growsOnly = (): TemplateResult => {
+    return html`
+        <sp-field-label for="grows-only">
+            This Textfield has the "grows" attribute without the "multiline"
+            attribute
+        </sp-field-label>
+        <sp-textfield
+            grows
+            id="grows-only"
+            placeholder="Does not grow or display incorrectly"
+        ></sp-textfield>
+    `;
+};
+
 export const quiet = (): TemplateResult => {
     return html`
         <sp-field-label for="name">Enter your name</sp-field-label>


### PR DESCRIPTION
## Description
Prevent negative outcomes for used that leverage `grows` but not `multiline`.

`multiline` was previously document as a requirement, but clarify the effect _both_ attributes as having only vertical sizing effects.

## Related issue(s)
- fixed #2862

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://textfield-grows-only--spectrum-web-components.netlify.app/storybook/?path=/story/textfield--grows-only)
    2. See the magic in action

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.