### PR TITLE
fix(progress-circle): ensure size can be applied to non-"size" attribute bearing elements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c3df2b2da5c455e279b0a4396c2b15ee164dd246
+        default: d722636bd94d3bb522dd578cfb7dc9403e093e98
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/button/stories/index.ts
+++ b/packages/button/stories/index.ts
@@ -116,35 +116,21 @@ export const makeOverBackground =
     };
 
 export function renderButton(properties: Properties): TemplateResult {
-    if (properties.variant) {
-        return html`
-            <sp-button
-                variant="${properties.variant}"
-                treatment="${properties.treatment}"
-                ?quiet="${!!properties.quiet}"
-                ?disabled=${!!properties.disabled}
-                size=${properties.size || 'm'}
-                href=${ifDefined(properties.href)}
-                target=${ifDefined(properties.target)}
-                ?warning=${properties.warning}
-                ?pending=${!!properties.pending}
-                ?icon-only=${properties.iconOnly}
-            >
-                ${properties.content || 'Click Me'}
-            </sp-button>
-        `;
-    } else {
-        return html`
-            <sp-button
-                ?quiet="${!!properties.quiet}"
-                ?disabled=${!!properties.disabled}
-                size=${properties.size}
-                ?pending=${!!properties.pending}
-            >
-                ${properties.content || 'Click Me'}
-            </sp-button>
-        `;
-    }
+    return html`
+        <sp-button
+            ?disabled=${!!properties.disabled}
+            href=${ifDefined(properties.href)}
+            ?icon-only=${properties.iconOnly}
+            ?pending=${!!properties.pending}
+            ?quiet="${!!properties.quiet}"
+            size=${properties.size}
+            target=${ifDefined(properties.target)}
+            treatment=${ifDefined(properties.treatment)}
+            variant=${ifDefined(properties.variant)}
+        >
+            ${properties.content || 'Click Me'}
+        </sp-button>
+    `;
 }
 
 export function renderButtonSet(properties: Properties): TemplateResult {

--- a/packages/button/stories/template.ts
+++ b/packages/button/stories/template.ts
@@ -27,7 +27,6 @@ export interface Properties {
     size?: 's' | 'm' | 'l' | 'xl';
     href?: string;
     target?: '_blank' | '_parent' | '_self' | '_top';
-    warning?: boolean;
     iconOnly?: boolean;
 }
 

--- a/packages/progress-circle/src/progress-circle.css
+++ b/packages/progress-circle/src/progress-circle.css
@@ -22,6 +22,7 @@ governing permissions and limitations under the License.
         var(--_spectrum-progress-circle-size)
     );
 
+    --spectrum-progress-circle-size: inherit;
     --spectrum-progresscircle-m-over-background-track-fill-color: var(
         --spectrum-alias-track-fill-color-overbackground
     );
@@ -78,3 +79,11 @@ slot {
         var(--_spectrum-progress-circle-size)
     );
 }
+
+/* stylelint-disable */
+:host([indeterminate]) .fills,
+:host([indeterminate]) .fillSubMask1,
+:host([indeterminate]) .fillSubMask2 {
+    animation-duration: var(--spectrum-animation-duration-2000);
+}
+/* stylelint-enable */

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -89,6 +89,7 @@ const reduceMotionProperties = css`
     --spectrum-animation-duration-2000: 0ms;
     --spectrum-animation-duration-4000: 0ms;
     --spectrum-animation-duration-6000: 0ms;
+    --pending-delay: 0s;
     --spectrum-coachmark-animation-indicator-ring-duration: 0ms;
     --swc-test-duration: 1ms;
 `;


### PR DESCRIPTION
## Description
At some point (likely with the new Core Tokens for Icon) the sizing of the Progress Circle for pending Buttons was broken.
- correct sizing
- update Progress Circle to leverage animation tokens
- move progress button custom property into "Reduce Motion" override at story time so it can be included in VRTs
- update VRTs

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://progress-circle-size--spectrum-web-components.netlify.app/storybook/?path=/story/button-accent-fill-pending--m)
    2. See that the Progress Circle displays after 1 second
    3. Switch on "Reduce Motion"
    4. Navigate to the "L" size story for these pending buttons
    5. See that the Progress Circle display immediately
    6. See that all Progress Circles are contains _within_ their respective Buttons

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.