### PR TITLE
fix(top-nav): focus loupe on :focus-visible only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: d722636bd94d3bb522dd578cfb7dc9403e093e98
+        default: 058e55ea2c05e5ab919bc7c9f9fc9ea2d5f6f816
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/top-nav/src/top-nav-item.css
+++ b/packages/top-nav/src/top-nav-item.css
@@ -14,32 +14,84 @@ a {
     color: inherit;
 }
 
-a:focus {
+a:focus,
+a:focus-visible {
     outline: none;
 }
 
-:host(:focus-within) {
-    color: var(
-        --mod-tabs-color-key-focus,
-        var(--spectrum-tabs-color-key-focus)
-    ); /* .spectrum-Tabs-item.focus-ring */
+:host a:before {
+    block-size: calc(
+        100% - var(--mod-tabs-top-to-text, var(--spectrum-tabs-top-to-text))
+    );
+    border: var(
+            --mod-tabs-focus-indicator-width,
+            var(--spectrum-tabs-focus-indicator-width)
+        )
+        solid transparent;
+    border-radius: var(
+        --mod-tabs-focus-indicator-border-radius,
+        var(--spectrum-tabs-focus-indicator-border-radius)
+    );
+    box-sizing: border-box;
+    content: '';
+    inline-size: calc(
+        100% +
+            var(
+                --mod-tabs-focus-indicator-gap,
+                var(--spectrum-tabs-focus-indicator-gap)
+            ) * 2
+    );
+    inset-block-start: calc(
+        var(--mod-tabs-top-to-text, var(--spectrum-tabs-top-to-text)) / 2
+    );
+    inset-inline-end: calc(
+        var(
+                --mod-tabs-focus-indicator-gap,
+                var(--spectrum-tabs-focus-indicator-gap)
+            ) * -1
+    );
+    inset-inline-start: calc(
+        var(
+                --mod-tabs-focus-indicator-gap,
+                var(--spectrum-tabs-focus-indicator-gap)
+            ) * -1
+    );
+    pointer-events: none;
+    position: absolute;
 }
 
-:host(:focus-within):before {
+:host a.focus-visible {
+    color: var(
+        --highcontrast-tabs-color-key-focus,
+        var(--mod-tabs-color-key-focus, var(--spectrum-tabs-color-key-focus))
+    );
+}
+
+:host a:focus-visible {
+    color: var(
+        --highcontrast-tabs-color-key-focus,
+        var(--mod-tabs-color-key-focus, var(--spectrum-tabs-color-key-focus))
+    );
+}
+
+:host a.focus-visible:before {
     border-color: var(
         --highcontrast-tabs-focus-indicator-color,
         var(
             --mod-tabs-focus-indicator-color,
             var(--spectrum-tabs-focus-indicator-color)
         )
-    ); /* .spectrum-Tabs-item.focus-ring:before */
+    );
 }
 
-:host(:focus-within) ::slotted([slot='icon']) {
-    color: var(
-        --mod-tabs-color-key-focus,
-        var(--spectrum-tabs-color-key-focus)
-    ); /* .spectrum-Tabs-item.focus-ring .spectrum-Icon */
+:host a:focus-visible:before {
+    border-color: var(
+        --highcontrast-tabs-focus-indicator-color,
+        var(
+            --mod-tabs-focus-indicator-color,
+            var(--spectrum-tabs-focus-indicator-color)
+        )
+    );
 }
 
 #item-label {
@@ -56,10 +108,4 @@ a:focus {
 
 slot {
     pointer-events: none;
-}
-
-@media (forced-colors: active) {
-    :host {
-        --highcontrast-tabs-focus-indicator-color: canvastext;
-    }
 }


### PR DESCRIPTION
## Description
Update focus loupe to trigger on `:focu-visible` on the internal `<a>` element rather that `:focus-within` of the `:host` so that the loupe only occurs on "keyboard input".

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://top-nav-focus-visible--spectrum-web-components.netlify.app/components/top-nav/#example)
    2. Click the items in the example Top Nav
    3. See that the "indicator" moves to "feature" the clicked item, but there is no "focus loupe" present
-   [ ] _Test case 2_
    1. Go [here](https://top-nav-focus-visible--spectrum-web-components.netlify.app/components/top-nav/#example)
    2. Click an item in the example Top Nav
    3. Use `Tab` or `Shift+Tab` to move focus to an alternate Item
    4. See that the "focus loupe" is present
    5. Press `Enter`
    6. See that the "indicator" move to "feature" the item and there is _still_ a "focus loupe" visible

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.