### PR TITLE
refactor(overlay): move interaction management to a strategy pattern

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -29,6 +29,22 @@
             "development": "./src/AbstractOverlay.dev.js",
             "default": "./src/AbstractOverlay.js"
         },
+        "./src/ClickController.js": {
+            "development": "./src/ClickController.dev.js",
+            "default": "./src/ClickController.js"
+        },
+        "./src/HoverController.js": {
+            "development": "./src/HoverController.dev.js",
+            "default": "./src/HoverController.js"
+        },
+        "./src/InteractionController.js": {
+            "development": "./src/InteractionController.dev.js",
+            "default": "./src/InteractionController.js"
+        },
+        "./src/LongpressController.js": {
+            "development": "./src/LongpressController.dev.js",
+            "default": "./src/LongpressController.js"
+        },
         "./src/Overlay.js": {
             "development": "./src/Overlay.dev.js",
             "default": "./src/Overlay.js"

--- a/packages/overlay/src/AbstractOverlay.ts
+++ b/packages/overlay/src/AbstractOverlay.ts
@@ -169,11 +169,6 @@ export function nextFrame(): Promise<void> {
     return new Promise((res) => requestAnimationFrame(() => res()));
 }
 
-export function forcePaint(): void {
-    // force the browser to paint
-    document.body.offsetHeight;
-}
-
 /**
  * Abstract Overlay base class so that property tyings and imperative API
  * interfaces can be held separate from the actual class definition.
@@ -185,6 +180,7 @@ export class AbstractOverlay extends SpectrumElement {
     ): Promise<void> {
         return;
     }
+    /* c8 ignore next 6 */
     get delayed(): boolean {
         return false;
     }
@@ -195,11 +191,20 @@ export class AbstractOverlay extends SpectrumElement {
         showPopover(): void;
         hidePopover(): void;
     };
+    /* c8 ignore next 6 */
+    get disabled(): boolean {
+        return false;
+    }
+    set disabled(_disabled: boolean) {
+        return;
+    }
     dispose = noop;
+    /* c8 ignore next 3 */
     protected async ensureOnDOM(_targetOpenState: boolean): Promise<void> {
         return;
     }
     elements!: OpenableElement[];
+    /* c8 ignore next 5 */
     protected async makeTransition(
         _targetOpenState: boolean
     ): Promise<HTMLElement | null> {
@@ -208,16 +213,20 @@ export class AbstractOverlay extends SpectrumElement {
     protected async manageDelay(_targetOpenState: boolean): Promise<void> {
         return;
     }
+    /* c8 ignore next 3 */
     protected async manageDialogOpen(): Promise<void> {
         return;
     }
+    /* c8 ignore next 3 */
     protected async managePopoverOpen(): Promise<void> {
         return;
     }
+    /* c8 ignore next 3 */
     protected managePosition(): void {
         return;
     }
-    protected offset: number | [number, number] = 6;
+    protected offset: number | [number, number] = 0;
+    /* c8 ignore next 6 */
     get open(): boolean {
         return false;
     }
@@ -227,6 +236,7 @@ export class AbstractOverlay extends SpectrumElement {
     placement?: Placement;
     protected placementController!: PlacementController;
     receivesFocus!: 'true' | 'false' | 'auto';
+    /* c8 ignore next 6 */
     get state(): OverlayState {
         return 'closed';
     }
@@ -237,7 +247,7 @@ export class AbstractOverlay extends SpectrumElement {
     triggerElement!: HTMLElement | VirtualTrigger | null;
     type!: OverlayTypes;
     willPreventClose = false;
-
+    /* c8 ignore next 3 */
     public manuallyKeepOpen(): void {
         return;
     }

--- a/packages/overlay/src/ClickController.ts
+++ b/packages/overlay/src/ClickController.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { InteractionController } from './InteractionController.js';
+
+export class ClickController extends InteractionController {
+    /**
+     * An overlay with a `click` interaction should not close on click `triggerElement`.
+     * When a click is initiated (`pointerdown`), apply `preventNextToggle` when the
+     * overlay is `open` to prevent from toggling the overlay when the click event
+     * propagates later in the interaction.
+     */
+    private preventNextToggle = false;
+
+    handleClick(): void {
+        if (!this.preventNextToggle) {
+            this.host.open = !this.host.open;
+        }
+        this.preventNextToggle = false;
+    }
+
+    handlePointerdown(): void {
+        this.preventNextToggle = this.host.open;
+    }
+
+    override init(): void {
+        // Clean up listeners if they've already been bound
+        this.abortController?.abort();
+        this.abortController = new AbortController();
+        const { signal } = this.abortController;
+        this.target.addEventListener('click', () => this.handleClick(), {
+            signal,
+        });
+        this.target.addEventListener(
+            'pointerdown',
+            () => this.handlePointerdown(),
+            { signal }
+        );
+    }
+}

--- a/packages/overlay/src/HoverController.ts
+++ b/packages/overlay/src/HoverController.ts
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { conditionAttributeWithId } from '@spectrum-web-components/base/src/condition-attribute-with-id.js';
+import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
+
+import { InteractionController } from './InteractionController.js';
+import { noop } from './AbstractOverlay.js';
+
+const HOVER_DELAY = 300;
+
+export class HoverController extends InteractionController {
+    private elementIds: string[] = [];
+
+    focusedin = false;
+
+    private hoverTimeout?: ReturnType<typeof setTimeout>;
+
+    pointerentered = false;
+
+    handleTargetFocusin(): void {
+        this.host.open = true;
+        this.focusedin = true;
+    }
+
+    handleTargetFocusout(): void {
+        this.focusedin = false;
+        if (this.pointerentered) return;
+        this.host.open = false;
+    }
+
+    handleTargetPointerenter(): void {
+        if (this.hoverTimeout) {
+            clearTimeout(this.hoverTimeout);
+            this.hoverTimeout = undefined;
+        }
+        if (this.host.disabled) return;
+        this.host.open = true;
+        this.pointerentered = true;
+    }
+
+    handleTargetPointerleave(): void {
+        this.doPointerleave();
+    }
+
+    // set a timeout once the pointer enters and the overlay is shown
+    // give the user time to enter the overlay
+    handleHostPointerenter(): void {
+        if (this.hoverTimeout) {
+            clearTimeout(this.hoverTimeout);
+            this.hoverTimeout = undefined;
+        }
+    }
+
+    handleHostPointerleave(): void {
+        this.doPointerleave();
+    }
+
+    override prepareDescription(): void {
+        // require "content" to apply relationship
+        if (!this.host.elements.length) return;
+
+        const triggerRoot = this.target.getRootNode();
+        const contentRoot = this.host.elements[0].getRootNode();
+        const overlayRoot = this.host.getRootNode();
+        if (triggerRoot === overlayRoot) {
+            this.prepareOverlayRelativeDescription();
+        } else if (triggerRoot === contentRoot) {
+            this.prepareContentRelativeDescription();
+        }
+    }
+
+    private prepareOverlayRelativeDescription(): void {
+        const releaseDescription = conditionAttributeWithId(
+            this.target,
+            'aria-describedby',
+            [this.host.id]
+        );
+        this.releaseDescription = () => {
+            releaseDescription();
+            this.releaseDescription = noop;
+        };
+    }
+
+    private prepareContentRelativeDescription(): void {
+        const elementIds: string[] = [];
+        const appliedIds = this.host.elements.map((el) => {
+            elementIds.push(el.id);
+            if (!el.id) {
+                el.id = `${this.host.tagName.toLowerCase()}-helper-${randomID()}`;
+            }
+            return el.id;
+        });
+        this.elementIds = elementIds;
+        const releaseDescription = conditionAttributeWithId(
+            this.target,
+            'aria-describedby',
+            appliedIds
+        );
+        this.releaseDescription = () => {
+            releaseDescription();
+            this.host.elements.map((el, index) => {
+                el.id = this.elementIds[index];
+            });
+            this.releaseDescription = noop;
+        };
+    }
+
+    protected doPointerleave(): void {
+        this.pointerentered = false;
+        const triggerElement = this.target as HTMLElement;
+        if (this.focusedin && triggerElement.matches(':focus-visible')) return;
+
+        this.hoverTimeout = setTimeout(() => {
+            this.host.open = false;
+        }, HOVER_DELAY);
+    }
+
+    override init(): void {
+        // Clean up listeners if they've already been bound
+        this.abortController?.abort();
+        this.abortController = new AbortController();
+        const { signal } = this.abortController;
+        this.target.addEventListener(
+            'focusin',
+            () => this.handleTargetFocusin(),
+            { signal }
+        );
+        this.target.addEventListener(
+            'focusout',
+            () => this.handleTargetFocusout(),
+            { signal }
+        );
+        this.target.addEventListener(
+            'pointerenter',
+            () => this.handleTargetPointerenter(),
+            { signal }
+        );
+        this.target.addEventListener(
+            'pointerleave',
+            () => this.handleTargetPointerleave(),
+            { signal }
+        );
+        this.host.addEventListener(
+            'pointerenter',
+            () => this.handleHostPointerenter(),
+            { signal }
+        );
+        this.host.addEventListener(
+            'pointerleave',
+            () => this.handleHostPointerleave(),
+            { signal }
+        );
+    }
+}

--- a/packages/overlay/src/InteractionController.ts
+++ b/packages/overlay/src/InteractionController.ts
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import type { ReactiveController } from 'lit';
+import { AbstractOverlay } from './AbstractOverlay.js';
+
+export class InteractionController implements ReactiveController {
+    abortController!: AbortController;
+
+    get activelyOpening(): boolean {
+        return false;
+    }
+
+    constructor(public host: AbstractOverlay, public target: HTMLElement) {
+        this.host.addController(this);
+        this.prepareDescription(this.target);
+    }
+
+    prepareDescription(_: HTMLElement): void {}
+
+    releaseDescription(): void {}
+
+    shouldCompleteOpen(): void {}
+
+    /* c8 ignore next 3 */
+    init(): void {
+        // Abstract init() method.
+    }
+
+    abort(): void {
+        this.releaseDescription();
+        this.abortController?.abort();
+    }
+
+    hostConnected(): void {
+        this.init();
+    }
+
+    hostDisconnected(): void {
+        this.abort();
+    }
+}

--- a/packages/overlay/src/LongpressController.ts
+++ b/packages/overlay/src/LongpressController.ts
@@ -1,0 +1,206 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    isAndroid,
+    isIOS,
+} from '@spectrum-web-components/shared/src/platform.js';
+import { conditionAttributeWithId } from '@spectrum-web-components/base/src/condition-attribute-with-id.js';
+import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
+
+import { noop } from './AbstractOverlay.js';
+import { InteractionController } from './InteractionController.js';
+
+const LONGPRESS_DURATION = 300;
+export const LONGPRESS_INSTRUCTIONS = {
+    touch: 'Double tap and long press for additional options',
+    keyboard: 'Press Space or Alt+Down Arrow for additional options',
+    mouse: 'Click and hold for additional options',
+};
+
+type LongpressEvent = {
+    source: 'pointer' | 'keyboard';
+};
+
+export class LongpressController extends InteractionController {
+    override get activelyOpening(): boolean {
+        return (
+            this.longpressState === 'opening' ||
+            this.longpressState === 'pressed'
+        );
+    }
+
+    protected longpressState: null | 'potential' | 'opening' | 'pressed' = null;
+
+    override releaseDescription = noop;
+
+    private timeout!: ReturnType<typeof setTimeout>;
+
+    handleLongpress(): void {
+        this.host.open = true;
+        this.longpressState =
+            this.longpressState === 'potential' ? 'opening' : 'pressed';
+    }
+
+    handlePointerdown(event: PointerEvent): void {
+        if (!this.target) return;
+        if (event.button !== 0) return;
+        this.longpressState = 'potential';
+        document.addEventListener('pointerup', this.handlePointerup);
+        document.addEventListener('pointercancel', this.handlePointerup);
+        // Only dispatch longpress event if the trigger element isn't doing it for us.
+        const triggerHandlesLongpress = 'holdAffordance' in this.target;
+        if (triggerHandlesLongpress) return;
+        this.timeout = setTimeout(() => {
+            if (!this.target) return;
+            this.target.dispatchEvent(
+                new CustomEvent<LongpressEvent>('longpress', {
+                    bubbles: true,
+                    composed: true,
+                    detail: {
+                        source: 'pointer',
+                    },
+                })
+            );
+        }, LONGPRESS_DURATION);
+    }
+
+    private handlePointerup = (): void => {
+        clearTimeout(this.timeout);
+        if (!this.target) return;
+        // When triggered by the pointer, the last of `opened`
+        // or `pointerup` should move the `longpressState` to
+        // `null` so that the earlier event can void the "light
+        // dismiss" and keep the Overlay open.
+        this.longpressState = this.host.state === 'opening' ? 'pressed' : null;
+        document.removeEventListener('pointerup', this.handlePointerup);
+        document.removeEventListener('pointercancel', this.handlePointerup);
+    };
+
+    private handleKeydown(event: KeyboardEvent): void {
+        const { code, altKey } = event;
+        if (altKey && code === 'ArrowDown') {
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+        }
+    }
+
+    private handleKeyup(event: KeyboardEvent): void {
+        const { code, altKey } = event;
+        if (code === 'Space' || (altKey && code === 'ArrowDown')) {
+            if (!this.target) {
+                return;
+            }
+            event.stopPropagation();
+            this.target.dispatchEvent(
+                new CustomEvent<LongpressEvent>('longpress', {
+                    bubbles: true,
+                    composed: true,
+                    detail: {
+                        source: 'keyboard',
+                    },
+                })
+            );
+            setTimeout(() => {
+                this.longpressState = null;
+            });
+        }
+    }
+
+    override prepareDescription(trigger: HTMLElement): void {
+        if (
+            // do not reapply until target is recycled
+            this.releaseDescription !== noop ||
+            // require "longpress content" to apply relationship
+            !this.host.elements.length
+        ) {
+            return;
+        }
+
+        const longpressDescription = document.createElement('div');
+        longpressDescription.id = `longpress-describedby-descriptor-${randomID()}`;
+        const messageType = isIOS() || isAndroid() ? 'touch' : 'keyboard';
+        longpressDescription.textContent = LONGPRESS_INSTRUCTIONS[messageType];
+        longpressDescription.slot = 'longpress-describedby-descriptor';
+        const triggerParent = trigger.getRootNode() as HTMLElement;
+        const overlayParent = this.host.getRootNode() as HTMLElement;
+        // Manage the placement of the helper element in an accessible place with
+        // the lowest chance of negatively affecting the layout of the page.
+        if (triggerParent === overlayParent) {
+            // Trigger and Overlay in same DOM tree...
+            // Append helper element to Overlay.
+            this.host.append(longpressDescription);
+        } else {
+            // If Trigger in <body>, hide helper
+            longpressDescription.hidden = !('host' in triggerParent);
+            // Trigger and Overlay in different DOM tree, Trigger in shadow tree...
+            // Insert helper element after Trigger.
+            trigger.insertAdjacentElement('afterend', longpressDescription);
+        }
+
+        const releaseDescription = conditionAttributeWithId(
+            trigger,
+            'aria-describedby',
+            [longpressDescription.id]
+        );
+        this.releaseDescription = () => {
+            releaseDescription();
+            longpressDescription.remove();
+            this.releaseDescription = noop;
+        };
+    }
+
+    override shouldCompleteOpen(): void {
+        // When triggered by the pointer, the last of `opened`
+        // or `pointerup` should move the `longpressState` to
+        // `null` so that the earlier event can void the "light
+        // dismiss" and keep the Overlay open.
+        this.longpressState =
+            this.longpressState === 'pressed' ? null : this.longpressState;
+    }
+
+    override init(): void {
+        // Clean up listeners if they've already been bound
+        this.abortController?.abort();
+        this.abortController = new AbortController();
+        const { signal } = this.abortController;
+        this.target.addEventListener(
+            'longpress',
+            () => this.handleLongpress(),
+            { signal }
+        );
+        this.target.addEventListener(
+            'pointerdown',
+            (event: PointerEvent) => this.handlePointerdown(event),
+            { signal }
+        );
+
+        this.prepareDescription(this.target);
+        if (
+            (this.target as HTMLElement & { holdAffordance: boolean })
+                .holdAffordance
+        ) {
+            // Only bind keyboard events when the trigger element isn't doing it for us.
+            return;
+        }
+        this.target.addEventListener(
+            'keydown',
+            (event: KeyboardEvent) => this.handleKeydown(event),
+            { signal }
+        );
+        this.target.addEventListener(
+            'keyup',
+            (event: KeyboardEvent) => this.handleKeyup(event),
+            { signal }
+        );
+    }
+}

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -21,14 +21,9 @@ import {
     state,
 } from '@spectrum-web-components/base/src/decorators.js';
 import {
-    isAndroid,
-    isIOS,
-} from '@spectrum-web-components/shared/src/platform.js';
-import {
     ElementResolutionController,
     elementResolverUpdatedSymbol,
 } from '@spectrum-web-components/reactive-controllers/src/ElementResolution.js';
-import { conditionAttributeWithId } from '@spectrum-web-components/base/src/condition-attribute-with-id.js';
 import {
     ifDefined,
     StyleInfo,
@@ -47,24 +42,14 @@ import { OverlayDialog } from './OverlayDialog.js';
 import { OverlayPopover } from './OverlayPopover.js';
 import { OverlayNoPopover } from './OverlayNoPopover.js';
 import { overlayStack } from './OverlayStack.js';
-import { noop } from './AbstractOverlay.js';
 import { VirtualTrigger } from './VirtualTrigger.js';
 import { PlacementController } from './PlacementController.js';
+import { ClickController } from './ClickController.js';
+import { HoverController } from './HoverController.js';
+import { LongpressController } from './LongpressController.js';
+export { LONGPRESS_INSTRUCTIONS } from './LongpressController.js';
 
 import styles from './overlay.css.js';
-
-const LONGPRESS_DURATION = 300;
-const HOVER_DELAY = 300;
-
-type LongpressEvent = {
-    source: 'pointer' | 'keyboard';
-};
-
-export const LONGPRESS_INSTRUCTIONS = {
-    touch: 'Double tap and long press for additional options',
-    keyboard: 'Press Space or Alt+Down Arrow for additional options',
-    mouse: 'Click and hold for additional options',
-};
 
 const supportsPopover = 'showPopover' in document.createElement('div');
 
@@ -76,6 +61,12 @@ if (supportsPopover) {
     OverlayFeatures = OverlayNoPopover(OverlayFeatures);
 }
 
+const strategies = {
+    click: ClickController,
+    longpress: LongpressController,
+    hover: HoverController,
+};
+
 /**
  * @element sp-overlay
  *
@@ -84,8 +75,6 @@ if (supportsPopover) {
  */
 export class Overlay extends OverlayFeatures {
     static override styles = [styles];
-
-    abortController!: AbortController;
 
     /**
      * An Overlay that is `delayed` will wait until a warm-up period of 1000ms
@@ -116,16 +105,14 @@ export class Overlay extends OverlayFeatures {
      * Whether the overlay is currently functional or not
      */
     @property({ type: Boolean })
-    get disabled(): boolean {
+    override get disabled(): boolean {
         return this._disabled;
     }
 
-    set disabled(disabled: boolean) {
+    override set disabled(disabled: boolean) {
         this._disabled = disabled;
         if (disabled) {
-            if (this.hasNonVirtualTrigger) {
-                this.unbindEvents();
-            }
+            this.strategy?.abort();
             this.wasOpen = this.open;
             this.open = false;
         } else {
@@ -151,12 +138,6 @@ export class Overlay extends OverlayFeatures {
             !(this.triggerElement instanceof VirtualTrigger)
         );
     }
-
-    protected longpressState: 'null' | 'potential' | 'opening' | 'pressed' =
-        'null';
-
-    private longressTimeout!: ReturnType<typeof setTimeout>;
-    private hoverTimeout?: ReturnType<typeof setTimeout>;
 
     /**
      * The `offset` property accepts either a single number, to
@@ -185,12 +166,7 @@ export class Overlay extends OverlayFeatures {
         if (open === this.open) return;
         // Don't respond when you're in the shadow on a longpress
         // Shadow occurs when the first "click" would normally close the popover
-        if (
-            (this.longpressState === 'opening' ||
-                this.longpressState === 'pressed') &&
-            !open
-        )
-            return;
+        if (this.strategy?.activelyOpening && !open) return;
         this._open = open;
         if (this.open) {
             Overlay.openCount += 1;
@@ -219,9 +195,6 @@ export class Overlay extends OverlayFeatures {
     @property({ attribute: 'receives-focus' })
     override receivesFocus: 'true' | 'false' | 'auto' = 'auto';
 
-    private releaseAriaDescribedby = noop;
-    private releaseLongpressDescribedby = noop;
-
     @query('slot')
     slotEl!: HTMLSlotElement;
 
@@ -235,19 +208,14 @@ export class Overlay extends OverlayFeatures {
         const oldState = this.state;
         this._state = state;
         if (this.state === 'opened' || this.state === 'closed') {
-            // When triggered by the pointer, the last of `opened`
-            // or `pointerup` should move the `longpressState` to
-            // `null` so that the earlier event can void the "light
-            // dismiss" and keep the Overlay open.
-            this.longpressState =
-                this.longpressState === 'pressed'
-                    ? 'null'
-                    : this.longpressState;
+            this.strategy?.shouldCompleteOpen();
         }
         this.requestUpdate('state', oldState);
     }
 
     override _state: OverlayState = 'closed';
+
+    private strategy?: ClickController | HoverController | LongpressController;
 
     @property({ type: Number, attribute: 'tip-padding' })
     tipPadding?: number;
@@ -499,368 +467,16 @@ export class Overlay extends OverlayFeatures {
         }
     }
 
-    protected unbindEvents(): void {
-        this.abortController?.abort();
-    }
-
     protected bindEvents(): void {
+        this.strategy?.abort();
+        this.strategy = undefined;
         if (!this.hasNonVirtualTrigger) return;
-        // Clean up listeners if they've already been bound
-        this.abortController?.abort();
-        this.abortController = new AbortController();
-        const nextTriggerElement = this.triggerElement as HTMLElement;
-        switch (this.triggerInteraction) {
-            case 'click':
-                this.bindClickEvents(nextTriggerElement);
-                return;
-            case 'longpress':
-                this.bindLongpressEvents(nextTriggerElement);
-                return;
-            case 'hover':
-                this.bindHoverEvents(nextTriggerElement);
-                return;
-        }
-    }
-
-    protected bindClickEvents(triggerElement: HTMLElement): void {
-        const options = { signal: this.abortController.signal };
-        triggerElement.addEventListener('click', this.handleClick, options);
-        triggerElement.addEventListener(
-            'pointerdown',
-            this.handlePointerdownForClick,
-            options
+        if (!this.triggerInteraction) return;
+        this.strategy = new strategies[this.triggerInteraction](
+            this,
+            this.triggerElement as HTMLElement
         );
     }
-
-    protected bindLongpressEvents(triggerElement: HTMLElement): void {
-        const options = { signal: this.abortController.signal };
-        triggerElement.addEventListener(
-            'longpress',
-            this.handleLongpress,
-            options
-        );
-        triggerElement.addEventListener(
-            'pointerdown',
-            this.handlePointerdown,
-            options
-        );
-        this.prepareLongpressDescription(triggerElement);
-        if (
-            (triggerElement as HTMLElement & { holdAffordance: boolean })
-                .holdAffordance
-        ) {
-            // Only bind keyboard events when the trigger element isn't doing it for us.
-            return;
-        }
-        triggerElement.addEventListener('keydown', this.handleKeydown, options);
-        triggerElement.addEventListener('keyup', this.handleKeyup, options);
-    }
-
-    protected bindHoverEvents(triggerElement: HTMLElement): void {
-        const options = { signal: this.abortController.signal };
-        triggerElement.addEventListener('focusin', this.handleFocusin, options);
-        triggerElement.addEventListener(
-            'focusout',
-            this.handleFocusout,
-            options
-        );
-        triggerElement.addEventListener(
-            'pointerenter',
-            this.handlePointerenter,
-            options
-        );
-        triggerElement.addEventListener(
-            'pointerleave',
-            this.handlePointerleave,
-            options
-        );
-        this.addEventListener(
-            'pointerenter',
-            this.handleOverlayPointerenter,
-            options
-        );
-        this.addEventListener(
-            'pointerleave',
-            this.handleOverlayPointerleave,
-            options
-        );
-    }
-
-    protected manageTriggerElement(
-        triggerElement: HTMLElement | undefined
-    ): void {
-        if (triggerElement) {
-            this.unbindEvents();
-            this.releaseAriaDescribedby();
-        }
-        const missingOrVirtual =
-            !this.triggerElement ||
-            this.triggerElement instanceof VirtualTrigger;
-        if (missingOrVirtual) {
-            return;
-        }
-        this.bindEvents();
-        if (this.receivesFocus === 'true') return;
-
-        this.prepareAriaDescribedby();
-    }
-
-    private elementIds: string[] = [];
-
-    private prepareLongpressDescription(trigger: HTMLElement): void {
-        if (
-            // only "longpress" relationships are described this way
-            this.triggerInteraction !== 'longpress' ||
-            // do not reapply until target it recycled
-            this.releaseLongpressDescribedby !== noop ||
-            // require "longpress content" to apply relationship
-            !this.elements.length
-        ) {
-            return;
-        }
-
-        const longpressDescription = document.createElement('div');
-        longpressDescription.id = `longpress-describedby-descriptor-${randomID()}`;
-        const messageType = isIOS() || isAndroid() ? 'touch' : 'keyboard';
-        longpressDescription.textContent = LONGPRESS_INSTRUCTIONS[messageType];
-        longpressDescription.slot = 'longpress-describedby-descriptor';
-        const triggerParent = trigger.getRootNode() as HTMLElement;
-        const overlayParent = this.getRootNode() as HTMLElement;
-        // Manage the placement of the helper element in an accessible place with
-        // the lowest chance of negatively affecting the layout of the page.
-        if (triggerParent === overlayParent) {
-            // Trigger and Overlay in same DOM tree...
-            // Append helper element to Overlay.
-            this.append(longpressDescription);
-        } else {
-            // If Trigger in <body>, hide helper
-            longpressDescription.hidden = !('host' in triggerParent);
-            // Trigger and Overlay in different DOM tree, Trigger in shadow tree...
-            // Insert helper element after Trigger.
-            trigger.insertAdjacentElement('afterend', longpressDescription);
-        }
-
-        const releaseLongpressDescribedby = conditionAttributeWithId(
-            trigger,
-            'aria-describedby',
-            [longpressDescription.id]
-        );
-        this.releaseLongpressDescribedby = () => {
-            releaseLongpressDescribedby();
-            longpressDescription.remove();
-            this.releaseLongpressDescribedby = noop;
-        };
-    }
-
-    private prepareAriaDescribedby(): void {
-        if (
-            // only "hover" relationships establed described by content
-            this.triggerInteraction !== 'hover' ||
-            // do not reapply until target is recycled
-            this.releaseAriaDescribedby !== noop ||
-            // require "hover content" to apply relationship
-            !this.elements.length ||
-            // Virtual triggers can have no aria content
-            !this.hasNonVirtualTrigger
-        ) {
-            return;
-        }
-
-        const trigger = this.triggerElement as HTMLElement;
-        const triggerRoot = trigger.getRootNode();
-        const contentRoot = this.elements[0].getRootNode();
-        const overlayRoot = this.getRootNode();
-        if (triggerRoot == overlayRoot) {
-            const releaseAriaDescribedby = conditionAttributeWithId(
-                trigger,
-                'aria-describedby',
-                [this.id]
-            );
-            this.releaseAriaDescribedby = () => {
-                releaseAriaDescribedby();
-                this.releaseAriaDescribedby = noop;
-            };
-        } else if (triggerRoot === contentRoot) {
-            this.elementIds = this.elements.map((el) => el.id);
-            const appliedIds = this.elements.map((el) => {
-                if (!el.id) {
-                    el.id = `${this.tagName.toLowerCase()}-helper-${randomID()}`;
-                }
-                return el.id;
-            });
-            const releaseAriaDescribedby = conditionAttributeWithId(
-                trigger,
-                'aria-describedby',
-                appliedIds
-            );
-            this.releaseAriaDescribedby = () => {
-                releaseAriaDescribedby();
-                this.elements.map((el, index) => {
-                    el.id = this.elementIds[index];
-                });
-                this.releaseAriaDescribedby = noop;
-            };
-        }
-    }
-
-    private handlePointerdown = (event: PointerEvent): void => {
-        if (!this.triggerElement) return;
-        if (event.button !== 0) return;
-        const triggerElement = this.triggerElement as HTMLElement;
-        this.longpressState = 'potential';
-        document.addEventListener('pointerup', this.handlePointerup);
-        document.addEventListener('pointercancel', this.handlePointerup);
-        if (
-            (triggerElement as HTMLElement & { holdAffordance: boolean })
-                .holdAffordance
-        ) {
-            // Only dispatch longpress event if the trigger element isn't doing it for us.
-            return;
-        }
-        this.longressTimeout = setTimeout(() => {
-            if (!triggerElement) return;
-            triggerElement.dispatchEvent(
-                new CustomEvent<LongpressEvent>('longpress', {
-                    bubbles: true,
-                    composed: true,
-                    detail: {
-                        source: 'pointer',
-                    },
-                })
-            );
-        }, LONGPRESS_DURATION);
-    };
-
-    private handlePointerup = (): void => {
-        clearTimeout(this.longressTimeout);
-        if (!this.triggerElement) return;
-        // When triggered by the pointer, the last of `opened`
-        // or `pointerup` should move the `longpressState` to
-        // `null` so that the earlier event can void the "light
-        // dismiss" and keep the Overlay open.
-        this.longpressState = this.state === 'opening' ? 'pressed' : 'null';
-        document.removeEventListener('pointerup', this.handlePointerup);
-        document.removeEventListener('pointercancel', this.handlePointerup);
-    };
-
-    /**
-     * @private
-     */
-    protected handleKeydown = (event: KeyboardEvent): void => {
-        const { code, altKey } = event;
-        if (code === 'Space' || (altKey && code === 'ArrowDown')) {
-            if (code === 'ArrowDown') {
-                event.stopPropagation();
-                event.stopImmediatePropagation();
-            }
-        }
-    };
-
-    protected handleKeyup = (event: KeyboardEvent): void => {
-        const { code, altKey } = event;
-        if (code === 'Space' || (altKey && code === 'ArrowDown')) {
-            if (!this.triggerElement || !this.hasNonVirtualTrigger) {
-                return;
-            }
-            event.stopPropagation();
-            (this.triggerElement as HTMLElement).dispatchEvent(
-                new CustomEvent<LongpressEvent>('longpress', {
-                    bubbles: true,
-                    composed: true,
-                    detail: {
-                        source: 'keyboard',
-                    },
-                })
-            );
-            setTimeout(() => {
-                this.longpressState = 'null';
-            });
-        }
-    };
-
-    /**
-     * An overlay with a `click` interaction should not close on click `triggerElement`.
-     * When a click is initiated (`pointerdown`), apply `preventNextToggle` when the
-     * overlay is `open` to prevent from toggling the overlay when the click event
-     * propagates later in the interaction.
-     */
-    private preventNextToggle = false;
-
-    protected handlePointerdownForClick = (): void => {
-        this.preventNextToggle = this.open;
-    };
-
-    protected handleClick = (): void => {
-        if (
-            this.longpressState === 'opening' ||
-            this.longpressState === 'pressed'
-        ) {
-            return;
-        }
-        if (!this.preventNextToggle) {
-            this.open = !this.open;
-        }
-        this.preventNextToggle = false;
-    };
-
-    private focusedin = false;
-
-    protected handleFocusin = (): void => {
-        this.open = true;
-        this.focusedin = true;
-    };
-
-    protected handleFocusout = (): void => {
-        this.focusedin = false;
-        if (this.pointerentered) return;
-        this.open = false;
-    };
-
-    private pointerentered = false;
-
-    protected handlePointerenter = (): void => {
-        if (this.hoverTimeout) {
-            clearTimeout(this.hoverTimeout);
-            delete this.hoverTimeout;
-        }
-        if (this.disabled) return;
-        this.open = true;
-        this.pointerentered = true;
-    };
-
-    // set a timeout once the pointer enters and the overlay is shown
-    // give the user time to enter the overlay
-
-    protected handleOverlayPointerenter = (): void => {
-        if (this.hoverTimeout) {
-            clearTimeout(this.hoverTimeout);
-            delete this.hoverTimeout;
-        }
-    };
-
-    protected handlePointerleave = (): void => {
-        this.doPointerleave();
-    };
-
-    protected handleOverlayPointerleave = (): void => {
-        this.doPointerleave();
-    };
-
-    protected doPointerleave(): void {
-        this.pointerentered = false;
-        const triggerElement = this.triggerElement as HTMLElement;
-        if (this.focusedin && triggerElement.matches(':focus-visible')) return;
-
-        this.hoverTimeout = setTimeout(() => {
-            this.open = false;
-        }, HOVER_DELAY);
-    }
-
-    protected handleLongpress = (): void => {
-        this.open = true;
-        this.longpressState =
-            this.longpressState === 'potential' ? 'opening' : 'pressed';
-    };
 
     protected handleBeforetoggle(event: Event & { newState: string }): void {
         if (event.newState !== 'open') {
@@ -869,10 +485,7 @@ export class Overlay extends OverlayFeatures {
     }
 
     protected handleBrowserClose(): void {
-        if (
-            this.longpressState !== 'opening' &&
-            this.longpressState !== 'pressed'
-        ) {
+        if (!this.strategy?.activelyOpening) {
             this.open = false;
             return;
         }
@@ -886,13 +499,10 @@ export class Overlay extends OverlayFeatures {
     }
 
     protected handleSlotchange(): void {
-        if (this.triggerElement) {
-            this.prepareAriaDescribedby();
-        }
         if (!this.elements.length) {
-            this.releaseLongpressDescribedby();
+            this.strategy?.releaseDescription();
         } else if (this.hasNonVirtualTrigger) {
-            this.prepareLongpressDescription(
+            this.strategy?.prepareDescription(
                 this.triggerElement as HTMLElement
             );
         }
@@ -926,7 +536,7 @@ export class Overlay extends OverlayFeatures {
                 | 'hover'
                 | undefined;
         }
-        // Merge multiple possible calls to manageTriggerElement().
+        // Merge multiple possible calls to `bindEvents()`.
         let oldTrigger: HTMLElement | false | undefined = false;
         if (changes.has(elementResolverUpdatedSymbol)) {
             oldTrigger = this.triggerElement as HTMLElement;
@@ -936,7 +546,7 @@ export class Overlay extends OverlayFeatures {
             oldTrigger = changes.get('triggerElement');
         }
         if (oldTrigger !== false) {
-            this.manageTriggerElement(oldTrigger);
+            this.bindEvents();
         }
     }
 
@@ -1042,17 +652,11 @@ export class Overlay extends OverlayFeatures {
         this.addEventListener('close', () => {
             this.open = false;
         });
-        if (this.hasNonVirtualTrigger) {
-            this.bindEvents();
-        }
+        this.bindEvents();
     }
 
     override disconnectedCallback(): void {
-        if (this.hasNonVirtualTrigger) {
-            this.unbindEvents();
-        }
-        this.releaseAriaDescribedby();
-        this.releaseLongpressDescribedby();
+        this.strategy?.releaseDescription();
         this.open = false;
         super.disconnectedCallback();
     }

--- a/packages/overlay/src/OverlayNoPopover.ts
+++ b/packages/overlay/src/OverlayNoPopover.ts
@@ -19,7 +19,6 @@ import { Constructor, OpenableElement } from './overlay-types.js';
 import {
     BeforetoggleClosedEvent,
     BeforetoggleOpenEvent,
-    forcePaint,
     guaranteedAllTransitionend,
     OverlayStateEvent,
     overlayTimer,
@@ -53,7 +52,8 @@ export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
         protected override async ensureOnDOM(
             _targetOpenState: boolean
         ): Promise<void> {
-            forcePaint();
+            // force the browser to paint
+            document.body.offsetHeight;
         }
 
         protected override async makeTransition(


### PR DESCRIPTION
## Description
Refactor Overlay interactions into strategies. This could reduce the negatives in #3550 in that it duplicated so much brittle/nuanced code.

## Related issue(s)
- refs #3549 
- fixes #4088 

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://overlay-strategy--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-element--modal)
    2. Test the actual interaction with each of the Overlay Element types
    3. See that they work the same as before

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.