### PR TITLE
docs: use capo.js to tune header content order

### DIFF
--- a/projects/documentation/content/_includes/layout.njk
+++ b/projects/documentation/content/_includes/layout.njk
@@ -1,17 +1,20 @@
 <!doctype html>
 <html lang="en">
   <head>
-    {% include "partials/meta-info.njk" %}
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
     <link rel="preconnect" href="https://use.typekit.net">
-    <link rel="dns-prefetch" href="https://use.typekit.net">
     <link rel="stylesheet" href="/styles.css">
     <link rel="stylesheet" href="/medium.css" media="screen and (min-width: 701px) and (min-height: 701px), (hover: hover), (pointer: fine)">
     <link rel="stylesheet" href="/large.css" media="screen and (max-width: 700px) and (hover: none) and (pointer: coarse), (max-height: 700px) and (hover: none) and (pointer: coarse)">
     <link rel="stylesheet" href="/dark.css" media="screen and (prefers-color-scheme: dark)">
     <link rel="stylesheet" href="/light.css" media="screen and (prefers-color-scheme: light)">
     <link rel="preload" href="/styles.css" as="style">
+    <link rel="dns-prefetch" href="https://use.typekit.net">
     {% block head %}
     {% endblock %}
+    {% include "partials/meta-info.njk" %}
   </head>
   <body>
     {% block content %}

--- a/projects/documentation/content/_includes/partials/meta-info.njk
+++ b/projects/documentation/content/_includes/partials/meta-info.njk
@@ -15,9 +15,6 @@
   {% set pageDesc = metaDesc %}
 {% endif %}
 
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{{ title }}</title>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
 <link


### PR DESCRIPTION
Update content order in the docs site's header for performance suggestion from https://rviscomi.github.io/capo.js/