### PR TITLE
chore(overlay): add "slottable-request" events to the very beginning/end of the Overlay lifecycle

### DIFF
--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -507,8 +507,11 @@ export class Combobox extends Textfield {
             this.open = false;
         }
         if (changed.has('activeDescendant')) {
-            if (changed.get('activeDescendant')) {
-                (changed.get('activeDescendant') as MenuItem).focused = false;
+            const previouslyActiveDescendant = changed.get(
+                'activeDescendant'
+            ) as unknown as MenuItem;
+            if (previouslyActiveDescendant) {
+                previouslyActiveDescendant.focused = false;
             }
             if (
                 this.activeDescendant &&

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -103,6 +103,10 @@
             "default": "./src/overlay-types.js"
         },
         "./src/overlay.css.js": "./src/overlay.css.js",
+        "./src/slottable-request-event.js": {
+            "development": "./src/slottable-request-event.dev.js",
+            "default": "./src/slottable-request-event.js"
+        },
         "./active-overlay.js": {
             "development": "./active-overlay.dev.js",
             "default": "./active-overlay.js"

--- a/packages/overlay/src/AbstractOverlay.ts
+++ b/packages/overlay/src/AbstractOverlay.ts
@@ -236,6 +236,7 @@ export class AbstractOverlay extends SpectrumElement {
     placement?: Placement;
     protected placementController!: PlacementController;
     receivesFocus!: 'true' | 'false' | 'auto';
+    protected requestSlottable(): void {}
     /* c8 ignore next 6 */
     get state(): OverlayState {
         return 'closed';

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -50,6 +50,10 @@ import { LongpressController } from './LongpressController.js';
 export { LONGPRESS_INSTRUCTIONS } from './LongpressController.js';
 
 import styles from './overlay.css.js';
+import {
+    removeSlottableRequest,
+    SlottableRequestEvent,
+} from './slottable-request-event.js';
 
 const supportsPopover = 'showPopover' in document.createElement('div');
 
@@ -172,6 +176,9 @@ export class Overlay extends OverlayFeatures {
             Overlay.openCount += 1;
         }
         this.requestUpdate('open', !this.open);
+        if (this.open) {
+            this.requestSlottable();
+        }
     }
 
     private _open = false;
@@ -512,6 +519,18 @@ export class Overlay extends OverlayFeatures {
         const shouldPreventClose = this.willPreventClose;
         this.willPreventClose = false;
         return shouldPreventClose;
+    }
+
+    protected override requestSlottable(): void {
+        if (!this.open) {
+            document.body.offsetHeight;
+        }
+        this.dispatchEvent(
+            new SlottableRequestEvent(
+                'overlay-content',
+                this.open ? {} : removeSlottableRequest
+            )
+        );
     }
 
     override willUpdate(changes: PropertyValues): void {

--- a/packages/overlay/src/OverlayDialog.ts
+++ b/packages/overlay/src/OverlayDialog.ts
@@ -20,6 +20,7 @@ import {
     BeforetoggleClosedEvent,
     BeforetoggleOpenEvent,
     guaranteedAllTransitionend,
+    nextFrame,
     OverlayStateEvent,
 } from './AbstractOverlay.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
@@ -107,7 +108,7 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
                     // The browser will error in this case.
                     return;
                 }
-                const reportChange = (): void => {
+                const reportChange = async (): Promise<void> => {
                     const hasVirtualTrigger =
                         this.triggerElement instanceof VirtualTrigger;
                     this.dispatchEvent(
@@ -131,6 +132,15 @@ export function OverlayDialog<T extends Constructor<AbstractOverlay>>(
                         );
                     }
                     this.state = targetOpenState ? 'opened' : 'closed';
+                    // Ensure layout and paint are done and the Overlay is still closed before removing the slottable request.
+                    await nextFrame();
+                    await nextFrame();
+                    if (
+                        targetOpenState === this.open &&
+                        targetOpenState === false
+                    ) {
+                        this.requestSlottable();
+                    }
                 };
                 if (!targetOpenState && this.dialogEl.open) {
                     this.dialogEl.addEventListener(

--- a/packages/overlay/src/OverlayNoPopover.ts
+++ b/packages/overlay/src/OverlayNoPopover.ts
@@ -20,6 +20,7 @@ import {
     BeforetoggleClosedEvent,
     BeforetoggleOpenEvent,
     guaranteedAllTransitionend,
+    nextFrame,
     OverlayStateEvent,
     overlayTimer,
 } from './AbstractOverlay.js';
@@ -91,37 +92,50 @@ export function OverlayNoPopover<T extends Constructor<AbstractOverlay>>(
                     }
                 });
             };
-            const finish = (el: OpenableElement, index: number) => (): void => {
-                if (this.open !== targetOpenState) {
-                    return;
-                }
-                const eventName = targetOpenState ? 'sp-opened' : 'sp-closed';
-                el.dispatchEvent(
-                    new OverlayStateEvent(eventName, this, {
-                        interaction: this.type,
-                    })
-                );
-                if (index > 0) {
-                    return;
-                }
-                const hasVirtualTrigger =
-                    this.triggerElement instanceof VirtualTrigger;
-                this.dispatchEvent(
-                    new OverlayStateEvent(eventName, this, {
-                        interaction: this.type,
-                        publish: hasVirtualTrigger,
-                    })
-                );
-                if (this.triggerElement && !hasVirtualTrigger) {
-                    (this.triggerElement as HTMLElement).dispatchEvent(
+            const finish =
+                (el: OpenableElement, index: number) =>
+                async (): Promise<void> => {
+                    if (this.open !== targetOpenState) {
+                        return;
+                    }
+                    const eventName = targetOpenState
+                        ? 'sp-opened'
+                        : 'sp-closed';
+                    el.dispatchEvent(
                         new OverlayStateEvent(eventName, this, {
                             interaction: this.type,
-                            publish: true,
                         })
                     );
-                }
-                this.state = targetOpenState ? 'opened' : 'closed';
-            };
+                    if (index > 0) {
+                        return;
+                    }
+                    const hasVirtualTrigger =
+                        this.triggerElement instanceof VirtualTrigger;
+                    this.dispatchEvent(
+                        new OverlayStateEvent(eventName, this, {
+                            interaction: this.type,
+                            publish: hasVirtualTrigger,
+                        })
+                    );
+                    if (this.triggerElement && !hasVirtualTrigger) {
+                        (this.triggerElement as HTMLElement).dispatchEvent(
+                            new OverlayStateEvent(eventName, this, {
+                                interaction: this.type,
+                                publish: true,
+                            })
+                        );
+                    }
+                    this.state = targetOpenState ? 'opened' : 'closed';
+                    // Ensure layout and paint are done and the Overlay is still closed before removing the slottable request.
+                    await nextFrame();
+                    await nextFrame();
+                    if (
+                        targetOpenState === this.open &&
+                        targetOpenState === false
+                    ) {
+                        this.requestSlottable();
+                    }
+                };
             this.elements.forEach((el, index) => {
                 guaranteedAllTransitionend(
                     el,

--- a/packages/overlay/src/OverlayPopover.ts
+++ b/packages/overlay/src/OverlayPopover.ts
@@ -205,6 +205,15 @@ export function OverlayPopover<T extends Constructor<AbstractOverlay>>(
                             );
                         }
                         this.state = targetOpenState ? 'opened' : 'closed';
+                        // Ensure layout and paint are done and the Overlay is still closed before removing the slottable request.
+                        await nextFrame();
+                        await nextFrame();
+                        if (
+                            targetOpenState === this.open &&
+                            targetOpenState === false
+                        ) {
+                            this.requestSlottable();
+                        }
                     };
                     if (this.open !== targetOpenState) {
                         return;

--- a/packages/overlay/src/slottable-request-event.ts
+++ b/packages/overlay/src/slottable-request-event.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+export class SlottableRequestEvent extends Event {
+    readonly data: unknown;
+    readonly name: string;
+    readonly slotName: string;
+    constructor(name: string, data: unknown, key?: string) {
+        super('slottable-request', {
+            bubbles: false,
+            cancelable: true,
+            composed: false,
+        });
+        this.name = name;
+        this.data = data;
+        this.slotName = key !== undefined ? `${name}.${key}` : name;
+        if (window.__swc.DEBUG) {
+            window.__swc.warn(
+                undefined,
+                `⚠️  WARNING ⚠️ : \`slottable-request\` events are experimental and there is no guarantees behind usage of them in an application!! Their shape and presence within the library could be changed at anytime.
+                
+Learn more about the protocol these events are based on below:`,
+                'https://github.com/webcomponents-cg/community-protocols/pull/45',
+                {
+                    level: 'high',
+                    type: 'api',
+                }
+            );
+        }
+    }
+}
+
+export const removeSlottableRequest = Symbol('remove-slottable-request');

--- a/packages/overlay/test/overlay-element.test.ts
+++ b/packages/overlay/test/overlay-element.test.ts
@@ -18,7 +18,7 @@ import {
     nextFrame,
     oneEvent,
 } from '@open-wc/testing';
-import type { Overlay } from '@spectrum-web-components/overlay/src/Overlay.js';
+import { Overlay } from '@spectrum-web-components/overlay/src/Overlay.js';
 import '@spectrum-web-components/overlay/sp-overlay.js';
 import { Tooltip } from '@spectrum-web-components/tooltip';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
@@ -33,6 +33,11 @@ import { sendMouse } from '../../../test/plugins/browser.js';
 import { Button } from '@spectrum-web-components/button';
 import { sendKeys } from '@web/test-runner-commands';
 import { click, receivesFocus } from '../stories/overlay-element.stories.js';
+import {
+    removeSlottableRequest,
+    SlottableRequestEvent,
+} from '../src/slottable-request-event.js';
+import { stub } from 'sinon';
 
 const OVERLAY_TYPES = ['modal', 'page', 'hint', 'auto', 'manual'] as const;
 type OverlayTypes = typeof OVERLAY_TYPES[number];
@@ -73,6 +78,143 @@ describe('sp-overlay', () => {
             expect(content.open).to.be.true;
         });
     }
+
+    describe('`slottable-request` event', () => {
+        it('dispatched before `sp-opened`', async function () {
+            this.retries(0);
+            let slottableRequestTime = 0;
+            let openedTime = 0;
+            const el = await fixture<Overlay>(html`
+                <sp-overlay
+                    @slottable-request=${() =>
+                        (slottableRequestTime = performance.now())}
+                    @sp-opened=${() => (openedTime = performance.now())}
+                >
+                    <sp-popover>test</sp-popover>
+                </sp-overlay>
+            `);
+
+            await elementUpdated(el);
+
+            const opened = oneEvent(el, 'sp-opened');
+            el.open = true;
+            await opened;
+
+            expect(slottableRequestTime).to.be.lt(openedTime);
+        });
+        it('dispatched after `sp-closed`', async function () {
+            this.retries(0);
+            let slottableRequestTime = 0;
+            let closedTime = 0;
+            const el = await fixture<Overlay>(html`
+                <sp-overlay
+                    @sp-closed=${() => (closedTime = performance.now())}
+                    @slottable-request=${() =>
+                        (slottableRequestTime = performance.now())}
+                >
+                    <sp-popover>test</sp-popover>
+                </sp-overlay>
+            `);
+
+            await elementUpdated(el);
+
+            const opened = oneEvent(el, 'sp-opened');
+            el.open = true;
+            await opened;
+
+            await nextFrame();
+            await nextFrame();
+
+            const closed = oneEvent(el, 'sp-closed');
+            el.open = false;
+            await closed;
+
+            await nextFrame();
+            await nextFrame();
+
+            expect(
+                slottableRequestTime,
+                `slottable-request: ${slottableRequestTime}, sp-closed: ${closedTime}`
+            ).to.be.gt(closedTime);
+        });
+        it('follows transition timing from lazily added children', async function () {
+            this.retries(0);
+            let slottableRequestTime = 0;
+            let openedTime = 0;
+            const popover = document.createElement('sp-popover');
+            popover.textContent = 'Test';
+            const el = await fixture<Overlay>(html`
+                <sp-overlay
+                    @slottable-request=${(event: SlottableRequestEvent) => {
+                        slottableRequestTime = performance.now();
+                        if (event.data !== removeSlottableRequest) {
+                            (event.target as HTMLElement).append(popover);
+                        } else {
+                            popover.remove();
+                        }
+                    }}
+                    @sp-opened=${() => (openedTime = performance.now())}
+                ></sp-overlay>
+            `);
+
+            await elementUpdated(el);
+
+            const opened = oneEvent(el, 'sp-opened');
+            el.open = true;
+            await opened;
+
+            expect(slottableRequestTime).to.be.lte(openedTime);
+            expect(openedTime - slottableRequestTime).to.be.gt(130);
+        });
+
+        describe('dev mode', () => {
+            let consoleWarnStub!: ReturnType<typeof stub>;
+            before(() => {
+                window.__swc.verbose = true;
+                consoleWarnStub = stub(console, 'warn');
+            });
+            afterEach(() => {
+                consoleWarnStub.resetHistory();
+            });
+            after(() => {
+                window.__swc.verbose = false;
+                consoleWarnStub.restore();
+            });
+
+            it('warns that `variant` is deprecated', async () => {
+                const el = await fixture<Overlay>(html`
+                    <sp-overlay>
+                        <sp-popover>test</sp-popover>
+                    </sp-overlay>
+                `);
+
+                await elementUpdated(el);
+
+                const opened = oneEvent(el, 'sp-opened');
+                el.open = true;
+                await opened;
+
+                expect(consoleWarnStub.called).to.be.true;
+                const spyCall = consoleWarnStub.getCall(0);
+                expect(
+                    (spyCall.args.at(0) as string).includes(
+                        '`slottable-request` events are experimental'
+                    ),
+                    '`slottable-request`-centric message'
+                ).to.be.true;
+                expect(
+                    spyCall.args.at(-1),
+                    'confirm `data` shape'
+                ).to.deep.equal({
+                    data: {
+                        localName: 'base',
+                        type: 'api',
+                        level: 'high',
+                    },
+                });
+            });
+        });
+    });
 
     describe('[type="modal"]', () => {
         opensDeclaratively('modal');


### PR DESCRIPTION
## Description
Surface as yet unused `slottable-request` event infrastructure to unlock in situ testing of some theoretical performance optimizations. Use `chore` in the commit so that this change doesn't appear on the change log.

## Related issue(s)
- refs #3549 

## How has this been tested?
-   [ ] _Test case 1_
    1. Namely checkout the tests that run, but know this is an experimental feature that could be removed or changed at any time.

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
