### PR TITLE
fix(overlay): ensure "manual" Overlays ignore "light dismiss" when [popover] is not supported

### DIFF
--- a/packages/overlay/src/OverlayStack.ts
+++ b/packages/overlay/src/OverlayStack.ts
@@ -116,6 +116,10 @@ class OverlayStack {
             return;
         }
         if (supportsPopover) return;
+        if (last?.type === 'manual') {
+            // Manual Overlays should not close on "light dismiss".
+            return;
+        }
 
         if (!last) return;
         this.closeOverlay(last);

--- a/packages/overlay/test/overlay-element.test.ts
+++ b/packages/overlay/test/overlay-element.test.ts
@@ -793,7 +793,7 @@ describe('sp-overlay', () => {
                 expect(this.manual.open).to.be.true;
             });
         });
-        describe('only close when mnually closed', function () {
+        describe('only close when manually closed', function () {
             it('does not close when clicking away', async () => {
                 const test = await fixture(html`
                     <div>
@@ -823,6 +823,43 @@ describe('sp-overlay', () => {
                             position: [50, 400],
                         },
                     ],
+                });
+
+                await aTimeout(200);
+
+                expect(el.open).to.be.true;
+
+                const closed = oneEvent(el, 'sp-closed');
+                el.open = false;
+                ({ overlay } = await closed);
+                expect(el === overlay).to.be.true;
+
+                expect(el.open).to.be.false;
+            });
+            it('does not close when pressing `Escape`', async () => {
+                const test = await fixture(html`
+                    <div>
+                        ${click({
+                            ...click.args,
+                            interaction: 'click',
+                            placement: 'bottom',
+                            type: 'manual',
+                            delayed: false,
+                            receivesFocus: 'auto',
+                        })}
+                    </div>
+                `);
+                const el = test.querySelector('sp-overlay') as Overlay;
+
+                expect(el.open).to.be.false;
+
+                const opened = oneEvent(el, 'sp-opened');
+                el.open = true;
+                let { overlay } = await opened;
+                expect(el === overlay).to.be.true;
+
+                await sendKeys({
+                    press: 'Escape',
                 });
 
                 await aTimeout(200);


### PR DESCRIPTION
## Description
Polyfill the behavior of `popover="manual"` for browsers that do not yet support it.

## Related issue(s)
- fixes #4119

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://manual-overlay--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-element--click&args=type:manual)
    2. See that the `type` is actually set at "manual", if not reapply it in the Storybook Controls
    3. Open the Overlay
    4. See that clicking away from the Overlay does not close it
    5. See that pressing escape does not close the Overlay

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.