### PR TITLE
chore(overlay, tooltip): v0 directive for Overlay v2 testing

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -97,6 +97,10 @@
             "development": "./src/overlay-timer.dev.js",
             "default": "./src/overlay-timer.js"
         },
+        "./src/overlay-trigger-directive.js": {
+            "development": "./src/overlay-trigger-directive.dev.js",
+            "default": "./src/overlay-trigger-directive.js"
+        },
         "./src/overlay-trigger.css.js": "./src/overlay-trigger.css.js",
         "./src/overlay-types.js": {
             "development": "./src/overlay-types.dev.js",

--- a/packages/overlay/src/ClickController.ts
+++ b/packages/overlay/src/ClickController.ts
@@ -10,9 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { InteractionController } from './InteractionController.js';
+import {
+    InteractionController,
+    InteractionTypes,
+} from './InteractionController.js';
 
 export class ClickController extends InteractionController {
+    override type = InteractionTypes.click;
+
     /**
      * An overlay with a `click` interaction should not close on click `triggerElement`.
      * When a click is initiated (`pointerdown`), apply `preventNextToggle` when the

--- a/packages/overlay/src/HoverController.ts
+++ b/packages/overlay/src/HoverController.ts
@@ -13,12 +13,14 @@ governing permissions and limitations under the License.
 import { conditionAttributeWithId } from '@spectrum-web-components/base/src/condition-attribute-with-id.js';
 import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
 
-import { InteractionController } from './InteractionController.js';
+import { InteractionController, InteractionTypes } from './InteractionController.js';
 import { noop } from './AbstractOverlay.js';
 
 const HOVER_DELAY = 300;
 
 export class HoverController extends InteractionController {
+    override type = InteractionTypes.hover;
+
     private elementIds: string[] = [];
 
     focusedin = false;

--- a/packages/overlay/src/InteractionController.ts
+++ b/packages/overlay/src/InteractionController.ts
@@ -13,6 +13,12 @@ governing permissions and limitations under the License.
 import type { ReactiveController } from 'lit';
 import { AbstractOverlay } from './AbstractOverlay.js';
 
+export enum InteractionTypes {
+    'click',
+    'hover',
+    'longpress',
+}
+
 export class InteractionController implements ReactiveController {
     abortController!: AbortController;
 
@@ -20,9 +26,14 @@ export class InteractionController implements ReactiveController {
         return false;
     }
 
-    constructor(public host: AbstractOverlay, public target: HTMLElement) {
+    type!: InteractionTypes;
+
+    constructor(public host: AbstractOverlay, public target: HTMLElement, private isPersistent = false) {
         this.host.addController(this);
         this.prepareDescription(this.target);
+        if (this.isPersistent) {
+            this.init();
+        }
     }
 
     prepareDescription(_: HTMLElement): void {}
@@ -46,6 +57,8 @@ export class InteractionController implements ReactiveController {
     }
 
     hostDisconnected(): void {
-        this.abort();
+        if (!this.isPersistent) {
+            this.abort();
+        }
     }
 }

--- a/packages/overlay/src/LongpressController.ts
+++ b/packages/overlay/src/LongpressController.ts
@@ -18,7 +18,7 @@ import { conditionAttributeWithId } from '@spectrum-web-components/base/src/cond
 import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
 
 import { noop } from './AbstractOverlay.js';
-import { InteractionController } from './InteractionController.js';
+import { InteractionController, InteractionTypes } from './InteractionController.js';
 
 const LONGPRESS_DURATION = 300;
 export const LONGPRESS_INSTRUCTIONS = {
@@ -32,6 +32,8 @@ type LongpressEvent = {
 };
 
 export class LongpressController extends InteractionController {
+    override type = InteractionTypes.longpress;
+
     override get activelyOpening(): boolean {
         return (
             this.longpressState === 'opening' ||

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -36,6 +36,7 @@ import type {
     OverlayState,
     OverlayTypes,
     Placement,
+    TriggerInteraction,
 } from './overlay-types.js';
 import { AbstractOverlay, nextFrame } from './AbstractOverlay.js';
 import { OverlayDialog } from './OverlayDialog.js';
@@ -251,7 +252,7 @@ export class Overlay extends OverlayFeatures {
      * The specific interaction to listen for on the `triggerElement` to open the overlay.
      */
     @property({ attribute: false })
-    triggerInteraction?: 'click' | 'longpress' | 'hover';
+    triggerInteraction?: TriggerInteraction;
 
     /**
      * Configures the open/close heuristics of the Overlay.

--- a/packages/overlay/src/index.ts
+++ b/packages/overlay/src/index.ts
@@ -14,3 +14,4 @@ export * from './OverlayTrigger.js';
 export * from './overlay-types.js';
 export * from './VirtualTrigger.js';
 export * from './loader.js';
+export * from './overlay-trigger-directive.js';

--- a/packages/overlay/src/overlay-trigger-directive.ts
+++ b/packages/overlay/src/overlay-trigger-directive.ts
@@ -1,0 +1,200 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { ElementPart, nothing, render, TemplateResult } from 'lit';
+import { AsyncDirective, directive } from 'lit/async-directive.js';
+import { Overlay } from './overlay.js';
+import { OverlayContentTypes } from './OverlayTrigger.js';
+import {
+    OverlayOpenCloseDetail,
+    OverlayTriggerInteractions,
+    Placement,
+} from './overlay-types.js';
+
+export type OverlayTriggerOptions = {
+    triggerOn: OverlayContentTypes;
+    placement: Placement;
+    type: OverlayTriggerInteractions;
+    offset: number;
+};
+
+export class OverlayTriggerDirective extends AsyncDirective {
+    private template?: TemplateResult;
+    private target?: HTMLElement;
+
+    protected defaultOptions: OverlayTriggerOptions = {
+        triggerOn: 'hover',
+        placement: 'top-start',
+        type: 'inline',
+        offset: 0,
+    };
+    protected options: OverlayTriggerOptions = { ...this.defaultOptions };
+
+    private open = false;
+    private overlaidContent?: HTMLElement;
+    private closeOverlay?: Promise<() => void>;
+    private abortOverlay?: (value: boolean) => void;
+
+    render(
+        _template: TemplateResult,
+        _options?: Partial<OverlayTriggerOptions>
+    ): unknown {
+        // render function here just defines the interface to the update call later
+        // we don't have anything to render since this is tintended to be an ElementPart directive
+        // so will be used on an element and is not itself rendered
+        return nothing;
+    }
+
+    override update(
+        part: ElementPart,
+        [template, options]: Parameters<this['render']>
+    ): void {
+        if (this.target !== part.element) {
+            this.removeListeners();
+        }
+        this.options = {
+            ...this.defaultOptions,
+            ...options,
+        };
+        this.template = template;
+
+        this.target = part.element as HTMLElement;
+        // start listening for trigger events
+        this.addListeners();
+    }
+
+    private async handleOpen(): Promise<void> {
+        if (this.open) {
+            return;
+        }
+        if (!this.template || !this.target) {
+            return;
+        }
+        this.open = true;
+        // render the template into an empty span (we'll discard later)
+        const fragment = document.createElement('span');
+        render(this.template, fragment);
+        // create an abort promise to exit overlay show early if we're rapidly closing
+        const abortPromise: Promise<boolean> = new Promise((res) => {
+            this.abortOverlay = res;
+        });
+        // we're going to capture the child of the span, since thats the content we actually want
+        this.overlaidContent = fragment.children[0] as HTMLElement;
+        // actually open the overlay with this content
+        this.closeOverlay = Overlay.open(
+            this.target,
+            this.options.triggerOn,
+            this.overlaidContent,
+            {
+                placement: this.options.placement,
+                offset: this.options.offset,
+                abortPromise,
+            }
+        );
+    }
+
+    private handleClosed = (
+        event: CustomEvent<OverlayOpenCloseDetail>
+    ): void => {
+        // closed outside of our control?
+        if (event?.detail.interaction === this.options.triggerOn) {
+            this.open = false;
+        }
+    };
+
+    private async doClose(): Promise<void> {
+        if (this.abortOverlay) {
+            this.abortOverlay(true);
+            this.abortOverlay = undefined;
+        }
+        if (this.closeOverlay) {
+            const closeOverlay = this.closeOverlay;
+            this.closeOverlay = undefined;
+            (await closeOverlay)();
+        }
+        this.overlaidContent = undefined;
+        this.open = false;
+    }
+
+    private removeListeners(): void {
+        if (!this.target) {
+            return;
+        }
+        this.target.removeEventListener('mouseenter', this.activate);
+        this.target.removeEventListener('focusin', this.activate);
+        this.target.removeEventListener('mouseleave', this.deactivate);
+        this.target.removeEventListener('focusout', this.deactivate);
+        this.target.removeEventListener('click', this.activate);
+        this.target.removeEventListener('longpress', this.activate);
+        this.target.removeEventListener('sp-closed', this.handleClosed);
+    }
+
+    private addListeners(): void {
+        if (!this.template || !this.target) {
+            return;
+        }
+        this.target.addEventListener('sp-closed', this.handleClosed);
+
+        switch (this.options.triggerOn) {
+            case 'hover': {
+                this.target.addEventListener('mouseenter', this.activate);
+                this.target.addEventListener('focusin', this.activate);
+                this.target.addEventListener('mouseleave', this.deactivate);
+                this.target.addEventListener('focusout', this.deactivate);
+                break;
+            }
+            case 'click': {
+                this.target.addEventListener('click', this.activate);
+                break;
+            }
+            case 'longpress': {
+                this.target.addEventListener('longpress', this.activate);
+            }
+        }
+    }
+
+    private deactivate = (event: Event): void => {
+        const mouseIsEnteringHoverContent =
+            event.type === 'mouseleave' &&
+            this.options.triggerOn === 'hover' &&
+            this.open &&
+            (event as unknown as MouseEvent).relatedTarget ===
+                this.overlaidContent;
+        if (mouseIsEnteringHoverContent && this.overlaidContent) {
+            // mouse is moving from the trigger to the hover content
+            // start listening on the overlay to see if we leave it
+            this.overlaidContent.addEventListener(
+                'mouseleave',
+                (event: MouseEvent) => {
+                    // did the mouse exit back onto the trigger?
+                    const mouseIsEnteringTrigger =
+                        event.relatedTarget === this.target;
+                    if (mouseIsEnteringTrigger) {
+                        // then do nothing
+                        return;
+                    }
+                    // otherwise let the overlay close with the regular mouse leave behavior
+                    this.deactivate(event);
+                },
+                { once: true }
+            );
+            return;
+        }
+        this.doClose();
+    };
+
+    private activate = (_event: Event): void => {
+        if (!this.target) return;
+        this.handleOpen();
+    };
+}
+
+export const trigger = directive(OverlayTriggerDirective);

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -69,6 +69,13 @@ export type OverlayOptionsV1 = {
     virtualTrigger?: VirtualTrigger;
 };
 
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'sp-opened': CustomEvent<OverlayOpenCloseDetail>;
+        'sp-closed': CustomEvent<OverlayOpenCloseDetail>;
+    }
+}
+
 export type OpenableElement = HTMLElement & {
     open: boolean;
     tipElement?: HTMLElement;

--- a/packages/overlay/src/overlay-types.ts
+++ b/packages/overlay/src/overlay-types.ts
@@ -23,6 +23,8 @@ export { Placement };
 
 export type OverlayTypes = 'auto' | 'hint' | 'manual' | 'modal' | 'page';
 
+export type TriggerInteraction = 'click' | 'longpress' | 'hover';
+
 export type TriggerInteractions = OverlayTypes;
 
 export type TriggerInteractionsV1 =

--- a/packages/overlay/stories/overlay-directive.stories.ts
+++ b/packages/overlay/stories/overlay-directive.stories.ts
@@ -123,17 +123,22 @@ export default {
         placement: 'bottom',
         offset: 0,
         colorStop: 'light',
+        triggerOn: 'click',
     },
 };
 
 interface Properties {
     placement: Placement;
     offset: number;
-    open?: OverlayContentTypes;
+    triggerOn?: OverlayContentTypes;
     type?: Extract<TriggerInteractions, 'inline' | 'modal' | 'replace'>;
 }
 
-const template = ({ placement, offset, open }: Properties): TemplateResult => {
+const template = ({
+    placement,
+    offset,
+    triggerOn,
+}: Properties): TemplateResult => {
     return html`
         ${storyStyles}
         <sp-button
@@ -186,7 +191,7 @@ const template = ({ placement, offset, open }: Properties): TemplateResult => {
                 `,
                 {
                     placement,
-                    triggerOn: open,
+                    triggerOn,
                     offset,
                 }
             )}

--- a/packages/overlay/stories/overlay-directive.stories.ts
+++ b/packages/overlay/stories/overlay-directive.stories.ts
@@ -1,0 +1,199 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import {
+    OverlayContentTypes,
+    Placement,
+    TriggerInteractions,
+} from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/action-group/sp-action-group.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/dialog/sp-dialog-wrapper.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-open-in.js';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import { trigger } from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
+
+import '@spectrum-web-components/picker/sp-picker.js';
+import '@spectrum-web-components/menu/sp-menu.js';
+import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/menu/sp-menu-divider.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/slider/sp-slider.js';
+import '@spectrum-web-components/radio/sp-radio.js';
+import '@spectrum-web-components/radio/sp-radio-group.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/theme/src/themes.js';
+import '@spectrum-web-components/accordion/sp-accordion.js';
+import '@spectrum-web-components/accordion/sp-accordion-item.js';
+import '../../../projects/story-decorator/src/types.js';
+
+import './overlay-story-components.js';
+import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
+
+const storyStyles = html`
+    <style>
+        html,
+        body,
+        #root,
+        #root-inner,
+        sp-story-decorator {
+            height: 100%;
+            margin: 0;
+        }
+
+        sp-story-decorator::part(container) {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            height: 100%;
+            align-items: center;
+            justify-content: center;
+        }
+
+        overlay-trigger {
+            flex: none;
+        }
+
+        #styled-div {
+            background-color: var(--styled-div-background-color, blue);
+            color: white;
+            padding: 4px 10px;
+            margin-bottom: 10px;
+        }
+
+        #inner-trigger {
+            display: inline-block;
+        }
+    </style>
+`;
+
+export default {
+    title: 'Overlay Directive',
+    argTypes: {
+        offset: { control: 'number' },
+        placement: {
+            control: {
+                type: 'inline-radio',
+                options: [
+                    'top',
+                    'top-start',
+                    'top-end',
+                    'bottom',
+                    'bottom-start',
+                    'bottom-end',
+                    'left',
+                    'left-start',
+                    'left-end',
+                    'right',
+                    'right-start',
+                    'right-end',
+                    'auto',
+                    'auto-start',
+                    'auto-end',
+                    'none',
+                ],
+            },
+        },
+        type: {
+            control: {
+                type: 'inline-radio',
+                options: ['modal', 'replace', 'inline'],
+            },
+        },
+        colorStop: {
+            control: {
+                type: 'inline-radio',
+                options: ['light', 'dark'],
+            },
+        },
+    },
+    args: {
+        placement: 'bottom',
+        offset: 0,
+        colorStop: 'light',
+    },
+};
+
+interface Properties {
+    placement: Placement;
+    offset: number;
+    open?: OverlayContentTypes;
+    type?: Extract<TriggerInteractions, 'inline' | 'modal' | 'replace'>;
+}
+
+const template = ({ placement, offset, open }: Properties): TemplateResult => {
+    return html`
+        ${storyStyles}
+        <sp-button
+            variant="primary"
+            ${tooltip('Click to open a popover.')}
+            ${trigger(
+                html`
+                    <sp-popover placement="${placement}" tip>
+                        <sp-dialog no-divider>
+                            <div class="options-popover-content">
+                                <sp-slider
+                                    value="5"
+                                    step="0.5"
+                                    min="0"
+                                    max="20"
+                                    label="Awesomeness"
+                                ></sp-slider>
+                                <div id="styled-div">
+                                    The background of this div should be blue
+                                </div>
+                                <sp-button
+                                    ${tooltip('Click to open another popover.')}
+                                    ${trigger(
+                                        html`
+                                            <sp-popover
+                                                placement="bottom"
+                                                tip
+                                                open
+                                            >
+                                                <sp-dialog size="s" no-divider>
+                                                    <div
+                                                        class="options-popover-content"
+                                                    >
+                                                        Another Popover
+                                                    </div>
+                                                </sp-dialog>
+                                            </sp-popover>
+                                        `,
+                                        {
+                                            placement: 'bottom',
+                                            triggerOn: 'click',
+                                        }
+                                    )}
+                                >
+                                    Press Me
+                                </sp-button>
+                            </div>
+                        </sp-dialog>
+                    </sp-popover>
+                `,
+                {
+                    placement,
+                    triggerOn: open,
+                    offset,
+                }
+            )}
+        >
+            Show Popover
+        </sp-button>
+    `;
+};
+
+export const Default = (args: Properties): TemplateResult => template(args);

--- a/packages/overlay/stories/overlay-directive.stories.ts
+++ b/packages/overlay/stories/overlay-directive.stories.ts
@@ -22,7 +22,10 @@ import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-open-in.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
-import { trigger } from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
+import {
+    InsertionOptions,
+    trigger,
+} from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
 
 import '@spectrum-web-components/dialog/sp-dialog.js';
 import '@spectrum-web-components/picker/sp-picker.js';
@@ -42,6 +45,7 @@ import '../../../projects/story-decorator/src/types.js';
 
 import './overlay-story-components.js';
 import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
+import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 
 const storyStyles = html`
     <style>
@@ -129,87 +133,80 @@ export default {
 };
 
 interface Properties {
-    placement: Placement;
-    offset: number;
+    placement?: Placement;
+    offset?: number;
     triggerOn?: OverlayContentTypes;
     type?: Extract<TriggerInteractions, 'inline' | 'modal' | 'replace'>;
+    insertionOptions?: InsertionOptions;
 }
 
 const template = ({
     placement,
     offset,
     triggerOn,
+    insertionOptions,
 }: Properties): TemplateResult => {
+    const renderTooltip = (): TemplateResult => html`
+        Click to open a popover.
+    `;
+    const renderPopover = (): TemplateResult => html`
+        <sp-popover placement="${ifDefined(placement)}" tip>
+            <sp-dialog no-divider>
+                <div class="options-popover-content">
+                    <sp-slider
+                        value="5"
+                        step="0.5"
+                        min="0"
+                        max="20"
+                        label="Awesomeness"
+                    ></sp-slider>
+                    <div id="styled-div">
+                        The background of this div should be blue
+                    </div>
+                    <sp-button
+                        ${tooltip(
+                            () =>
+                                html`
+                                    Click to open another popover.
+                                `
+                        )}
+                        ${trigger(
+                            () => html`
+                                <sp-popover placement="bottom" tip open>
+                                    <sp-dialog size="s" no-divider>
+                                        <div class="options-popover-content">
+                                            Another Popover
+                                        </div>
+                                    </sp-dialog>
+                                </sp-popover>
+                            `,
+                            {
+                                triggerInteraction: 'click',
+                                overlayOptions: {
+                                    placement: 'bottom',
+                                },
+                            }
+                        )}
+                    >
+                        Press Me
+                    </sp-button>
+                </div>
+            </sp-dialog>
+        </sp-popover>
+    `;
     return html`
         ${storyStyles}
         <sp-button
             variant="primary"
-            ${tooltip(
-                () =>
-                    html`
-                        Click to open a popover.
-                    `
-            )}
-            ${trigger(
-                () => html`
-                    <sp-popover placement="${placement}" tip>
-                        <sp-dialog no-divider>
-                            <div class="options-popover-content">
-                                <sp-slider
-                                    value="5"
-                                    step="0.5"
-                                    min="0"
-                                    max="20"
-                                    label="Awesomeness"
-                                ></sp-slider>
-                                <div id="styled-div">
-                                    The background of this div should be blue
-                                </div>
-                                <sp-button
-                                    ${tooltip(
-                                        () =>
-                                            html`
-                                                Click to open another popover.
-                                            `
-                                    )}
-                                    ${trigger(
-                                        () => html`
-                                            <sp-popover
-                                                placement="bottom"
-                                                tip
-                                                open
-                                            >
-                                                <sp-dialog size="s" no-divider>
-                                                    <div
-                                                        class="options-popover-content"
-                                                    >
-                                                        Another Popover
-                                                    </div>
-                                                </sp-dialog>
-                                            </sp-popover>
-                                        `,
-                                        {
-                                            triggerInteraction: 'click',
-                                            overlayOptions: {
-                                                placement: 'bottom',
-                                            },
-                                        }
-                                    )}
-                                >
-                                    Press Me
-                                </sp-button>
-                            </div>
-                        </sp-dialog>
-                    </sp-popover>
-                `,
-                {
-                    triggerInteraction: triggerOn,
-                    overlayOptions: {
-                        placement,
-                        offset,
-                    },
-                }
-            )}
+            ${tooltip(renderTooltip)}
+            ${trigger(renderPopover, {
+                triggerInteraction: triggerOn,
+                overlayOptions: {
+                    placement,
+                    offset,
+                },
+                insertionOptions: insertionOptions,
+            })}
         >
             Show Popover
         </sp-button>
@@ -219,5 +216,21 @@ const template = ({
 export const Default = (args: Properties): TemplateResult => template(args);
 
 Default.swc_vrt = {
+    skip: true,
+};
+
+export const elsewhere = (args: Properties = {}): TemplateResult => html`
+    ${template(args)}
+    <div id="other-element"></div>
+`;
+
+elsewhere.args = {
+    insertionOptions: {
+        el: () => document.querySelector('#other-element'),
+        where: 'afterbegin',
+    },
+} as Properties;
+
+elsewhere.swc_vrt = {
     skip: true,
 };

--- a/packages/overlay/stories/overlay-directive.stories.ts
+++ b/packages/overlay/stories/overlay-directive.stories.ts
@@ -24,6 +24,7 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-open-in.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
 import { trigger } from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
 
+import '@spectrum-web-components/dialog/sp-dialog.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/menu/sp-menu.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
@@ -143,9 +144,14 @@ const template = ({
         ${storyStyles}
         <sp-button
             variant="primary"
-            ${tooltip('Click to open a popover.')}
+            ${tooltip(
+                () =>
+                    html`
+                        Click to open a popover.
+                    `
+            )}
             ${trigger(
-                html`
+                () => html`
                     <sp-popover placement="${placement}" tip>
                         <sp-dialog no-divider>
                             <div class="options-popover-content">
@@ -160,9 +166,14 @@ const template = ({
                                     The background of this div should be blue
                                 </div>
                                 <sp-button
-                                    ${tooltip('Click to open another popover.')}
+                                    ${tooltip(
+                                        () =>
+                                            html`
+                                                Click to open another popover.
+                                            `
+                                    )}
                                     ${trigger(
-                                        html`
+                                        () => html`
                                             <sp-popover
                                                 placement="bottom"
                                                 tip
@@ -178,8 +189,10 @@ const template = ({
                                             </sp-popover>
                                         `,
                                         {
-                                            placement: 'bottom',
-                                            triggerOn: 'click',
+                                            triggerInteraction: 'click',
+                                            overlayOptions: {
+                                                placement: 'bottom',
+                                            },
                                         }
                                     )}
                                 >
@@ -190,9 +203,11 @@ const template = ({
                     </sp-popover>
                 `,
                 {
-                    placement,
-                    triggerOn,
-                    offset,
+                    triggerInteraction: triggerOn,
+                    overlayOptions: {
+                        placement,
+                        offset,
+                    },
                 }
             )}
         >
@@ -202,3 +217,7 @@ const template = ({
 };
 
 export const Default = (args: Properties): TemplateResult => template(args);
+
+Default.swc_vrt = {
+    skip: true,
+};

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -9,7 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import { html, render, TemplateResult } from '@spectrum-web-components/base';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import '@spectrum-web-components/dialog/sp-dialog.js';
 import '@spectrum-web-components/overlay/sp-overlay.js';
@@ -22,6 +22,7 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/link/sp-link.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import '@spectrum-web-components/slider/sp-slider.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-anchor-select.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-polygon-select.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-rect-select.js';
@@ -29,6 +30,10 @@ import { Placement } from '@floating-ui/dom';
 import { OverlayTypes } from '../src/overlay-types.js';
 import { notAgain } from '../../dialog/stories/dialog-base.stories.js';
 import './overlay-story-components.js';
+import {
+    removeSlottableRequest,
+    SlottableRequestEvent,
+} from '../src/slottable-request-event.js';
 
 export default {
     title: 'Overlay Element',
@@ -653,5 +658,49 @@ export const transientHover = (): TemplateResult => html`
     <transient-hover></transient-hover>
 `;
 transientHover.swc_vrt = {
+    skip: true,
+};
+
+export const lazyElements = (): TemplateResult => {
+    const handleSlottableRequest = (event: SlottableRequestEvent): void => {
+        const template =
+            event.data === removeSlottableRequest
+                ? undefined
+                : html`
+                      <sp-popover>
+                          <sp-dialog no-divider>
+                              <sp-slider
+                                  value="5"
+                                  step="0.5"
+                                  min="0"
+                                  max="20"
+                                  label="Awesomeness"
+                              ></sp-slider>
+                              <div id="styled-div">
+                                  The background of this div should be blue
+                              </div>
+                              <sp-button>
+                                  Press Me
+                                  <sp-tooltip self-managed delayed>
+                                      Click to open another popover.
+                                  </sp-tooltip>
+                              </sp-button>
+                          </sp-dialog>
+                      </sp-popover>
+                  `;
+        render(template, event.target as HTMLElement);
+    };
+    return html`
+        <sp-button id="button">Trigger</sp-button>
+        <sp-overlay
+            placement="bottom"
+            type="auto"
+            trigger="button@click"
+            @slottable-request=${handleSlottableRequest}
+        ></sp-overlay>
+    `;
+};
+
+lazyElements.swc_vrt = {
     skip: true,
 };

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -29,6 +29,7 @@ import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-magnify.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-open-in.js';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
+
 import { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/overlay/sp-overlay.js';

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -191,15 +191,14 @@ const template = ({
                             </sp-dialog>
                         </sp-popover>
 
-                            <sp-tooltip
-                                slot="hover-content"
-                                delayed
-                                tip="bottom"
-                            >
-                                Click to open another popover.
-                            </sp-tooltip>
-                        </overlay-trigger>
-                    </div>
+                        <sp-tooltip
+                            slot="hover-content"
+                            delayed
+                            tip="bottom"
+                        >
+                            Click to open another popover.
+                        </sp-tooltip>
+                    </overlay-trigger>
                 </sp-dialog>
             </sp-popover>
             <sp-tooltip

--- a/packages/overlay/test/benchmark/directive-test.ts
+++ b/packages/overlay/test/benchmark/directive-test.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+import * as overlayTools from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import { html } from 'lit';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+if ('trigger' in overlayTools) {
+    const trigger = overlayTools.trigger;
+    measureFixtureCreation(
+        html`
+            <sp-button
+                ${trigger(html`
+                    <sp-popover>
+                        <p>This is the content.</p>
+                    </sp-popover>
+                `)}
+            >
+                Trigger
+            </sp-button>
+        `
+    );
+} else {
+    // TODO: Remove this hackery once we land an official version of the directive approach
+    measureFixtureCreation(
+        html`
+            <overlay-trigger>
+                <sp-button slot="trigger">Trigger</sp-button>
+                <sp-popover slot="content">
+                    <p>This is the content.</p>
+                </sp-popover>
+            </overlay-trigger>
+        `
+    );
+}

--- a/packages/overlay/test/benchmark/directive-test.ts
+++ b/packages/overlay/test/benchmark/directive-test.ts
@@ -10,38 +10,45 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '@spectrum-web-components/overlay/overlay-trigger.js';
-import * as overlayTools from '@spectrum-web-components/overlay';
+import { trigger } from '@spectrum-web-components/overlay';
 import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/popover/sp-popover.js';
-import { html } from 'lit';
+import '@spectrum-web-components/dialog/sp-dialog.js';
+import '@spectrum-web-components/slider/sp-slider.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import { html, TemplateResult } from 'lit';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
-if ('trigger' in overlayTools) {
-    const trigger = overlayTools.trigger;
-    measureFixtureCreation(
-        html`
-            <sp-button
-                ${trigger(html`
-                    <sp-popover>
-                        <p>This is the content.</p>
-                    </sp-popover>
-                `)}
-            >
-                Trigger
+const popover = (): TemplateResult => html`
+    <sp-popover>
+        <sp-dialog no-divider>
+            <sp-slider
+                value="5"
+                step="0.5"
+                min="0"
+                max="20"
+                label="Awesomeness"
+            ></sp-slider>
+            <div id="styled-div">
+                The background of this div should be blue
+            </div>
+            <sp-button>
+                Press Me
+                <sp-tooltip
+                    self-managed
+                    delayed
+                >
+                    Click to open another popover.
+                </sp-tooltip>
             </sp-button>
-        `
-    );
-} else {
-    // TODO: Remove this hackery once we land an official version of the directive approach
-    measureFixtureCreation(
-        html`
-            <overlay-trigger>
-                <sp-button slot="trigger">Trigger</sp-button>
-                <sp-popover slot="content">
-                    <p>This is the content.</p>
-                </sp-popover>
-            </overlay-trigger>
-        `
-    );
-}
+        </sp-dialog>
+    </sp-popover>
+`;
+
+measureFixtureCreation(
+    html`
+        <sp-button ${trigger(popover)}>
+            Trigger
+        </sp-button>
+    `
+);

--- a/packages/overlay/test/benchmark/element-test.ts
+++ b/packages/overlay/test/benchmark/element-test.ts
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '@spectrum-web-components/overlay/overlay-trigger.js';
+import '@spectrum-web-components/overlay/sp-overlay.js';
 import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/popover/sp-popover.js';
 import '@spectrum-web-components/dialog/sp-dialog.js';
@@ -21,9 +21,9 @@ import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(
     html`
-        <overlay-trigger content="click">
-            <sp-button slot="trigger">Trigger</sp-button>
-            <sp-popover slot="click-content">
+        <sp-button id="button">Trigger</sp-button>
+        <sp-overlay trigger="button@click">
+            <sp-popover>
                 <sp-dialog no-divider>
                     <sp-slider
                         value="5"
@@ -46,6 +46,6 @@ measureFixtureCreation(
                     </sp-button>
                 </sp-dialog>
             </sp-popover>
-        </overlay-trigger>
+        </sp-overlay>
     `
 );

--- a/packages/overlay/test/benchmark/lazy-test.ts
+++ b/packages/overlay/test/benchmark/lazy-test.ts
@@ -1,0 +1,64 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/overlay/sp-overlay.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/dialog/sp-dialog.js';
+import '@spectrum-web-components/slider/sp-slider.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import {
+    removeSlottableRequest,
+    type SlottableRequestEvent,
+} from '@spectrum-web-components/overlay/src/slottable-request-event.js';
+import { html, render } from 'lit';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+const handleSlottableRequest = (event: SlottableRequestEvent): void => {
+    const template =
+        event.data === removeSlottableRequest
+            ? undefined
+            : html`
+                  <sp-popover>
+                      <sp-dialog no-divider>
+                          <sp-slider
+                              value="5"
+                              step="0.5"
+                              min="0"
+                              max="20"
+                              label="Awesomeness"
+                          ></sp-slider>
+                          <div id="styled-div">
+                              The background of this div should be blue
+                          </div>
+                          <sp-button>
+                              Press Me
+                              <sp-tooltip self-managed delayed>
+                                  Click to open another popover.
+                              </sp-tooltip>
+                          </sp-button>
+                      </sp-dialog>
+                  </sp-popover>
+              `;
+    render(template, event.target as HTMLElement);
+};
+
+measureFixtureCreation(
+    html`
+        <sp-button id="button">Trigger</sp-button>
+        <sp-overlay
+            trigger="button"
+            .triggerInteraction=${'click'}
+            @slottable-request=${handleSlottableRequest}
+        ></sp-overlay>
+    `
+);

--- a/packages/overlay/test/overlay-directive.test.ts
+++ b/packages/overlay/test/overlay-directive.test.ts
@@ -1,0 +1,184 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import { html } from '@spectrum-web-components/base';
+import {
+    elementUpdated,
+    expect,
+    nextFrame,
+    oneEvent,
+    waitUntil,
+} from '@open-wc/testing';
+import { Button } from '@spectrum-web-components/button';
+import '@spectrum-web-components/button/sp-button.js';
+import { elsewhere } from '../stories/overlay-directive.stories.js';
+import { sendMouse } from '../../../test/plugins/browser.js';
+import { fixture } from '../../../test/testing-helpers.js';
+
+describe('Overlay Directive', () => {
+    it('opens an Overlay after the trigger', async function () {
+        const test = await fixture<HTMLElement>(html`
+            <div
+                style="width: 100%; height: 100vh; display: grid; place-content: center;"
+            >
+                ${elsewhere()}
+            </div>
+        `);
+
+        const el = test.querySelector('sp-button') as Button;
+
+        await elementUpdated(el);
+        let overlays = document.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(0);
+
+        const rect = el.getBoundingClientRect();
+        let opened = oneEvent(el, 'sp-opened');
+        // Open the Tooltip via "hover"
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await opened;
+
+        opened = oneEvent(el, 'sp-opened');
+        // Open the Popover via "click"
+        await sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                },
+                {
+                    type: 'move',
+                    position: [
+                        rect.left - rect.width / 2,
+                        rect.top - rect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await opened;
+
+        overlays = document.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.be.gt(0);
+        expect(overlays[0].previousElementSibling).to.equal(el);
+
+        // `slottable-request` comes _after_ `sp-closed` and triggers DOM cleanup
+        const closed = oneEvent(overlays[0], 'slottable-request');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [
+                        rect.left - rect.width / 2,
+                        rect.top - rect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await closed;
+
+        await waitUntil(() => {
+            overlays = document.querySelectorAll('sp-overlay');
+            return overlays.length === 0;
+        }, 'not all overlays were cleaned up');
+
+        expect(overlays.length).to.equal(0);
+    });
+
+    it('opens an Overlay in a specific part of the DOM', async function () {
+        const test = await fixture<HTMLElement>(html`
+            <div
+                style="width: 100%; height: 100vh; display: grid; place-content: center;"
+            >
+                ${elsewhere(elsewhere.args)}
+            </div>
+        `);
+
+        const el = test.querySelector('sp-button') as Button;
+
+        await elementUpdated(el);
+
+        const otherElement = test.querySelector(
+            '#other-element'
+        ) as HTMLElement;
+        let overlays = otherElement.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(0);
+
+        const rect = el.getBoundingClientRect();
+        let opened = oneEvent(el, 'sp-opened');
+        // Open the Tooltip via "hover"
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await opened;
+
+        opened = oneEvent(el, 'sp-opened');
+        // Open the Popover via "click"
+        await sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await opened;
+
+        overlays = otherElement.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(1);
+
+        // `slottable-request` comes _after_ `sp-closed` and triggers DOM cleanup
+        const closed = oneEvent(overlays[0], 'slottable-request');
+        await sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [
+                        rect.left - rect.width / 2,
+                        rect.top - rect.height / 2,
+                    ],
+                },
+            ],
+        });
+        await closed;
+
+        // Wait for DOM clean up to complete
+        await nextFrame();
+        await nextFrame();
+
+        overlays = otherElement.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(0);
+    });
+});

--- a/packages/overlay/test/overlay-element.test.ts
+++ b/packages/overlay/test/overlay-element.test.ts
@@ -181,7 +181,7 @@ describe('sp-overlay', () => {
                 consoleWarnStub.restore();
             });
 
-            it('warns that `variant` is deprecated', async () => {
+            it('warns that `slottable-request` events are experimental', async () => {
                 const el = await fixture<Overlay>(html`
                     <sp-overlay>
                         <sp-popover>test</sp-popover>

--- a/packages/overlay/test/overlay-trigger-directive.test.ts
+++ b/packages/overlay/test/overlay-trigger-directive.test.ts
@@ -1,0 +1,91 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { elementUpdated, expect, fixture, oneEvent } from '@open-wc/testing';
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import { stub } from 'sinon';
+import { trigger } from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/popover/sp-popover.js';
+import '@spectrum-web-components/dialog/sp-dialog.js';
+import '@spectrum-web-components/slider/sp-slider.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import { Overlay } from '@spectrum-web-components/overlay/src/Overlay.js';
+
+describe('Overlay trigger directive', () => {
+    describe('dev mode', () => {
+        let consoleWarnStub!: ReturnType<typeof stub>;
+        before(() => {
+            window.__swc.verbose = true;
+            consoleWarnStub = stub(console, 'warn');
+        });
+        afterEach(() => {
+            consoleWarnStub.resetHistory();
+        });
+        after(() => {
+            window.__swc.verbose = false;
+            consoleWarnStub.restore();
+        });
+
+        it('warns that the trigger directive is experimental', async () => {
+            const popover = (): TemplateResult => html`
+                <sp-popover>
+                    <sp-dialog no-divider>
+                        <sp-slider
+                            value="5"
+                            step="0.5"
+                            min="0"
+                            max="20"
+                            label="Awesomeness"
+                        ></sp-slider>
+                        <div id="styled-div">
+                            The background of this div should be blue
+                        </div>
+                        <sp-button>
+                            Press Me
+                            <sp-tooltip self-managed delayed>
+                                Click to open another popover.
+                            </sp-tooltip>
+                        </sp-button>
+                    </sp-dialog>
+                </sp-popover>
+            `;
+            const el = await fixture<Overlay>(html`
+                <sp-button ${trigger(popover, { triggerInteraction: 'click' })}>
+                    Trigger
+                </sp-button>
+            `);
+
+            await elementUpdated(el);
+
+            const opened = oneEvent(el, 'sp-opened');
+            el.click();
+            await opened;
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes(
+                    'The Overlay Trigger Directive is experimental'
+                ),
+                'Overlay Trigger Directive-centric message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'base',
+                    type: 'api',
+                    level: 'high',
+                },
+            });
+        });
+    });
+});

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -33,6 +33,10 @@
             "development": "./src/index.dev.js",
             "default": "./src/index.js"
         },
+        "./src/tooltip-directive.js": {
+            "development": "./src/tooltip-directive.dev.js",
+            "default": "./src/tooltip-directive.js"
+        },
         "./src/tooltip.css.js": "./src/tooltip.css.js",
         "./sp-tooltip.js": {
             "development": "./sp-tooltip.dev.js",

--- a/packages/tooltip/src/tooltip-directive.ts
+++ b/packages/tooltip/src/tooltip-directive.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import {
+    OverlayTriggerOptions,
+    trigger,
+} from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
+import { html } from 'lit';
+import '../sp-tooltip.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+export const tooltip = function tooltip(
+    tooltipText: string,
+    options?: Partial<OverlayTriggerOptions & { variant: string }>
+): ReturnType<typeof trigger> {
+    return trigger(
+        html`
+            <sp-tooltip variant=${ifDefined(options?.variant)}>
+                ${tooltipText}
+            </sp-tooltip>
+        `,
+        options
+    );
+};

--- a/packages/tooltip/src/tooltip-directive.ts
+++ b/packages/tooltip/src/tooltip-directive.ts
@@ -20,12 +20,21 @@ export const tooltip = function tooltip(
     tooltipContent: () => TemplateResult,
     options?: Partial<OverlayTriggerOptions & { variant: string }>
 ): ReturnType<typeof trigger> {
-    return trigger(() => {
-        import('@spectrum-web-components/tooltip/sp-tooltip.js');
-        return html`
-            <sp-tooltip variant=${ifDefined(options?.variant)}>
-                ${tooltipContent()}
-            </sp-tooltip>
-        `;
-    }, options);
+    return trigger(
+        () => {
+            import('@spectrum-web-components/tooltip/sp-tooltip.js');
+            return html`
+                <sp-tooltip variant=${ifDefined(options?.variant)}>
+                    ${tooltipContent()}
+                </sp-tooltip>
+            `;
+        },
+        {
+            ...options,
+            overlayOptions: {
+                type: 'hint',
+                ...options?.overlayOptions,
+            },
+        }
+    );
 };

--- a/packages/tooltip/src/tooltip-directive.ts
+++ b/packages/tooltip/src/tooltip-directive.ts
@@ -9,24 +9,23 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import {
     OverlayTriggerOptions,
     trigger,
 } from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
-import { html } from 'lit';
-import '../sp-tooltip.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 
 export const tooltip = function tooltip(
-    tooltipText: string,
+    tooltipContent: () => TemplateResult,
     options?: Partial<OverlayTriggerOptions & { variant: string }>
 ): ReturnType<typeof trigger> {
-    return trigger(
-        html`
+    return trigger(() => {
+        import('@spectrum-web-components/tooltip/sp-tooltip.js');
+        return html`
             <sp-tooltip variant=${ifDefined(options?.variant)}>
-                ${tooltipText}
+                ${tooltipContent()}
             </sp-tooltip>
-        `,
-        options
-    );
+        `;
+    }, options);
 };

--- a/packages/tooltip/stories/tooltip-directive.stories.ts
+++ b/packages/tooltip/stories/tooltip-directive.stories.ts
@@ -1,0 +1,119 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-alert.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-checkmark.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-info.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-edit.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import { Placement } from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/overlay/overlay-trigger.js';
+
+export default {
+    component: 'sp-tooltip',
+    title: 'Tooltip Directive',
+};
+
+interface Properties {
+    open?: boolean;
+    placement?: Placement;
+    text?: string;
+    variant?: string;
+    offset?: number;
+    delayed?: boolean;
+}
+
+export const Default = ({
+    placement,
+    text,
+    variant,
+}: Properties): TemplateResult => {
+    return html`
+        <sp-button ${tooltip(text || 'Tooltip', { placement, variant })}>
+            Hover me
+        </sp-button>
+    `;
+};
+Default.args = {
+    open: true,
+    placement: 'top',
+    variant: '',
+    text: 'Tooltip',
+};
+Default.argTypes = {
+    open: {
+        name: 'open',
+        type: { name: 'boolean', required: false },
+        description: 'Whether the tooltip is open.',
+        table: {
+            type: { summary: 'boolean' },
+            defaultValue: { summary: false },
+        },
+        control: {
+            type: 'boolean',
+        },
+    },
+    placement: {
+        name: 'placement',
+        type: { name: 'string', required: false },
+        description: 'The placement of the tooltip in relation to its parent',
+        table: {
+            type: { summary: 'string' },
+            defaultValue: { summary: 'top' },
+        },
+        control: {
+            type: 'inline-radio',
+            options: [
+                'auto',
+                'auto-start',
+                'auto-end',
+                'top',
+                'bottom',
+                'right',
+                'left',
+                'top-start',
+                'top-end',
+                'bottom-start',
+                'bottom-end',
+                'right-start',
+                'right-end',
+                'left-start',
+                'left-end',
+                'none',
+            ],
+        },
+    },
+    text: {
+        name: 'text',
+        type: { name: 'string', required: false },
+        table: {
+            type: { summary: 'string' },
+            defaultValue: { summary: '' },
+        },
+        control: 'text',
+    },
+    variant: {
+        name: 'variant',
+        type: { name: 'string', required: false },
+        description: 'The style of the tooltip.',
+        table: {
+            type: { summary: 'string' },
+            defaultValue: { summary: '' },
+        },
+        control: {
+            type: 'inline-radio',
+            options: ['info', 'positive', 'negative', ''],
+        },
+    },
+};

--- a/packages/tooltip/stories/tooltip-directive.stories.ts
+++ b/packages/tooltip/stories/tooltip-directive.stories.ts
@@ -40,7 +40,18 @@ export const Default = ({
     variant,
 }: Properties): TemplateResult => {
     return html`
-        <sp-button ${tooltip(text || 'Tooltip', { placement, variant })}>
+        <sp-button
+            ${tooltip(
+                () =>
+                    html`
+                        ${text || 'Tooltip'}
+                    `,
+                {
+                    overlayOptions: { placement },
+                    variant,
+                }
+            )}
+        >
             Hover me
         </sp-button>
     `;
@@ -116,4 +127,7 @@ Default.argTypes = {
             options: ['info', 'positive', 'negative', ''],
         },
     },
+};
+Default.swc_vrt = {
+    skip: true,
 };

--- a/packages/tooltip/test/benchmark/test-directive.ts
+++ b/packages/tooltip/test/benchmark/test-directive.ts
@@ -10,15 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
-import '@spectrum-web-components/overlay/sp-overlay.js';
 import { html } from 'lit';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
-    <sp-action-button>
+    <sp-action-button
+        ${tooltip(() => html`Tip me!`)}
+    >
         I'm a button...
-        <sp-tooltip self-managed>Tip me!</sp-tooltip>
     </sp-action-button>
 `);

--- a/packages/tooltip/test/tooltip-directive.test.ts
+++ b/packages/tooltip/test/tooltip-directive.test.ts
@@ -1,0 +1,116 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    html,
+    nextFrame,
+    oneEvent,
+} from '@open-wc/testing';
+import { Button } from '@spectrum-web-components/button';
+import '@spectrum-web-components/button/sp-button.js';
+import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
+import type { Tooltip } from '@spectrum-web-components/tooltip';
+
+describe('Tooltip Directive', () => {
+    it('opens an Overlay that was previously not on the DOM', async function () {
+        const el = await fixture<Button>(html`
+            <sp-button
+                ${tooltip(
+                    () =>
+                        html`
+                            Tip me!
+                        `
+                )}
+            >
+                I'm a button...
+            </sp-button>
+        `);
+
+        await elementUpdated(el);
+
+        let overlays = document.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(0);
+
+        const opened = oneEvent(el, 'sp-opened');
+        el.focus();
+        await opened;
+
+        overlays = document.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(1);
+
+        // `slottable-request` comes _after_ `sp-closed` and triggers DOM cleanup
+        const closed = oneEvent(overlays[0], 'slottable-request');
+        el.blur();
+        await closed;
+
+        // Wait for DOM clean up to complete
+        await nextFrame();
+        await nextFrame();
+
+        overlays = document.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(0);
+    });
+
+    it('accepts `options`', async function () {
+        const variant = 'positive';
+        const offset = 10;
+        const el = await fixture<Button>(html`
+            <sp-button
+                ${tooltip(
+                    () =>
+                        html`
+                            Tip me!
+                        `,
+                    {
+                        variant,
+                        overlayOptions: {
+                            offset,
+                        },
+                    }
+                )}
+            >
+                I'm a button...
+            </sp-button>
+        `);
+
+        await elementUpdated(el);
+
+        let overlays = document.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(0);
+
+        const opened = oneEvent(el, 'sp-opened');
+        el.focus();
+        await opened;
+
+        overlays = document.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(1);
+        expect(overlays[0].offset).to.equal(offset);
+        const tooltipEl = overlays[0].querySelector('sp-tooltip') as Tooltip;
+        expect(tooltipEl.variant).to.equal(variant);
+
+        // `slottable-request` comes _after_ `sp-closed` and triggers DOM cleanup
+        const closed = oneEvent(overlays[0], 'slottable-request');
+        el.blur();
+        await closed;
+
+        // Wait for DOM clean up to complete
+        await nextFrame();
+        await nextFrame();
+
+        overlays = document.querySelectorAll('sp-overlay');
+        expect(overlays.length).to.equal(0);
+    });
+});

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -53,6 +53,7 @@ export let color: Color =
     (matchMedia(DARK_MODE).matches ? 'dark' : 'light');
 export let scale: Scale = (urlParams.get('sp_scale') as Scale) || 'medium';
 export let reduceMotion = urlParams.get('sp_reduceMotion') === 'true';
+export let screenshot = urlParams.get('sp_screenshot') === 'true';
 
 window.__swc_hack_knobs__ = window.__swc_hack_knobs__ || {
     defaultThemeVariant: theme,
@@ -187,7 +188,7 @@ export class StoryDecorator extends SpectrumElement {
     public reduceMotion = window.__swc_hack_knobs__.defaultReduceMotion;
 
     @property({ type: Boolean, reflect: true })
-    public screenshot = false;
+    public screenshot = screenshot;
 
     @queryAsync('sp-theme')
     private themeRoot!: Theme;


### PR DESCRIPTION
## Description
Directives, demos, and tests for lazily rendering Overlay content.

This prepares for an initial pre-release for use in major consuming clients for testing purposes.

*EVERYTHING HERE IS EXPERIMENTAL!*

We're looking at pre-releasing this to `latest` and then revisit after some testing for documentation/announcement.

_Known issues:_
- directives do not orchestrate with each other, so using more than one on the same trigger is not currently suggested
- lazily populating an `<sp-overlay>` should be _roughly_ as performant as the directive, but not currently sure why there's a performance delta between the two (this lead to some gaming of the class structure that could technically be reverted)
- I'm not super happy with this argument shape or the defaults it represents:
  ```
        triggerInteraction: 'hover',
        overlayOptions: {
            placement: 'top-start',
            type: 'auto',
            offset: 0,
        },
  ```
  further pre-release experimentation will likely smooth that out.
- there are additional DEV MODE warnings included for the experimental nature of this code
- there's not a lot of tests of the directive

## Related issue(s)
- refs #3549

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://overlay-directive-v2--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-directive--default)
    2. See the tooltip and the popover related to the button

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.