### PR TITLE
Truncated element

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c70f3ed57c4e3536313872fd3d23510caa801a44
+        default: a3a63503e5584396e8b34ec0b02e8a1a26ebc1ae
     wireit_cache_name:
         type: string
         default: wireit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ For e.g: Be descriptive after the /, like `john-doe/123-fix-bug`.
 
 ### Commitlint
 
-We use [Commitlint](https://github.com/conventional-changelog/commitlint/#what-is-commitlint) to help manage the semantic versions across the various packages in this library. Please be sure that you take this into concideration when submitting PRs to this repositiory. Generally, your commits should look like the following:
+We use [Commitlint](https://github.com/conventional-changelog/commitlint/#what-is-commitlint) to help manage the semantic versions across the various packages in this library. Please be sure that you take this into consideration when submitting PRs to this repository. Generally, your commits should look like the following:
 
 ```bash
 type(scope?): subject #scope is optional, but should reference the package you are updating

--- a/tools/bundle/package.json
+++ b/tools/bundle/package.json
@@ -131,6 +131,7 @@
         "@spectrum-web-components/tooltip": "^0.41.2",
         "@spectrum-web-components/top-nav": "^0.41.2",
         "@spectrum-web-components/tray": "^0.41.2",
+        "@spectrum-web-components/truncated": "^0.0.1",
         "@spectrum-web-components/underlay": "^0.41.2"
     },
     "types": "./src/index.d.ts",

--- a/tools/bundle/tsconfig.json
+++ b/tools/bundle/tsconfig.json
@@ -65,6 +65,7 @@
         { "path": "../../packages/tags" },
         { "path": "../../packages/textfield" },
         { "path": "../theme" },
+        { "path": "../truncated" },
         { "path": "../../packages/thumbnail" },
         { "path": "../../packages/toast" },
         { "path": "../../packages/tooltip" },

--- a/tools/truncated/.npmignore
+++ b/tools/truncated/.npmignore
@@ -1,0 +1,2 @@
+stories
+test

--- a/tools/truncated/README.md
+++ b/tools/truncated/README.md
@@ -1,6 +1,10 @@
 ## Description
 
+`<sp-truncated>` renders a line of text, truncating it if it overflows its container. When overflowing, a tooltip is automatically created
+that renders the entire non-truncated content.
 
+It is used like a `<span>` to contain potentially-long strings that are important for users to see, even when in small containers, like full
+names and email addresses.
 
 ### Usage
 
@@ -23,8 +27,20 @@ When looking to leverage the `Truncated` base class as a type and/or for extensi
 import { Truncated } from '@spectrum-web-components/truncated';
 ```
 
+
 ## Example
 
-```html
-<sp-truncated></sp-truncated>
+```
+<sp-truncated>This will truncate into a tooltip if there isn't enough space for it.</sp-truncated>
+```
+
+### With specific overflow content
+
+By default, tooltip text will be extracted from overflowing content. To provide your own overflow content, slot it into "overflow":
+
+```
+<sp-truncated placement="right">
+    This is the inline content
+    <span slot="overflow">And this overflow content will go into the tooltip, on the right</span>
+</sp-truncated>
 ```

--- a/tools/truncated/README.md
+++ b/tools/truncated/README.md
@@ -1,0 +1,30 @@
+## Description
+
+
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/truncated?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/truncated)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/truncated?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/truncated)
+
+```
+yarn add @spectrum-web-components/truncated
+```
+
+Import the side effectful registration of `<sp-truncated>` via:
+
+```
+import '@spectrum-web-components/truncated/sp-truncated.js';
+```
+
+When looking to leverage the `Truncated` base class as a type and/or for extension purposes, do so via:
+
+```
+import { Truncated } from '@spectrum-web-components/truncated';
+```
+
+## Example
+
+```html
+<sp-truncated></sp-truncated>
+```

--- a/tools/truncated/README.md
+++ b/tools/truncated/README.md
@@ -27,20 +27,23 @@ When looking to leverage the `Truncated` base class as a type and/or for extensi
 import { Truncated } from '@spectrum-web-components/truncated';
 ```
 
-
 ## Example
 
-```
-<sp-truncated>This will truncate into a tooltip if there isn't enough space for it.</sp-truncated>
+```html
+<sp-truncated>
+    This will truncate into a tooltip if there isn't enough space for it.
+</sp-truncated>
 ```
 
 ### With specific overflow content
 
 By default, tooltip text will be extracted from overflowing content. To provide your own overflow content, slot it into "overflow":
 
-```
+```html
 <sp-truncated placement="right">
     This is the inline content
-    <span slot="overflow">And this overflow content will go into the tooltip, on the right</span>
+    <span slot="overflow">
+        And this overflow content will go into the tooltip, on the right
+    </span>
 </sp-truncated>
 ```

--- a/tools/truncated/exports.json
+++ b/tools/truncated/exports.json
@@ -1,0 +1,4 @@
+{
+    "./src/*": "./src/*.js",
+    "./sp-truncated.js": "./sp-truncated.js"
+}

--- a/tools/truncated/exports.json
+++ b/tools/truncated/exports.json
@@ -1,4 +1,5 @@
 {
     "./src/*": "./src/*.js",
+    "./sp-truncated": "./sp-truncated.js",
     "./sp-truncated.js": "./sp-truncated.js"
 }

--- a/tools/truncated/package.json
+++ b/tools/truncated/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spectrum-web-components/truncated",
-    "version": "0.41.1",
+    "version": "0.0.1",
     "publishConfig": {
         "access": "public"
     },
@@ -9,7 +9,7 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/adobe/spectrum-web-components.git",
-        "directory": "packages/truncated"
+        "directory": "tools/truncated"
     },
     "author": "",
     "homepage": "https://adobe.github.io/spectrum-web-components/components/truncated",
@@ -34,6 +34,7 @@
             "default": "./src/index.js"
         },
         "./src/truncated.css.js": "./src/truncated.css.js",
+        "./sp-truncated": "./sp-truncated.js",
         "./sp-truncated.js": {
             "development": "./sp-truncated.dev.js",
             "default": "./sp-truncated.js"
@@ -62,15 +63,10 @@
         "@spectrum-web-components/styles": "^0.41.0",
         "@spectrum-web-components/tooltip": "^0.41.0"
     },
-    "devDependencies": {
-        "@open-wc/testing": "^3.2.0",
-        "@web/test-runner-commands": "^0.9.0"
-    },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js",
-        "./**/*.dev.js",
         "./**/*.dev.js"
     ]
 }

--- a/tools/truncated/package.json
+++ b/tools/truncated/package.json
@@ -1,0 +1,76 @@
+{
+    "name": "@spectrum-web-components/truncated",
+    "version": "0.41.1",
+    "publishConfig": {
+        "access": "public"
+    },
+    "description": "Web component implementation of a Spectrum design Truncated",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adobe/spectrum-web-components.git",
+        "directory": "packages/truncated"
+    },
+    "author": "",
+    "homepage": "https://adobe.github.io/spectrum-web-components/components/truncated",
+    "bugs": {
+        "url": "https://github.com/adobe/spectrum-web-components/issues"
+    },
+    "main": "src/index.js",
+    "module": "src/index.js",
+    "type": "module",
+    "exports": {
+        ".": {
+            "development": "./src/index.dev.js",
+            "default": "./src/index.js"
+        },
+        "./package.json": "./package.json",
+        "./src/Truncated.js": {
+            "development": "./src/Truncated.dev.js",
+            "default": "./src/Truncated.js"
+        },
+        "./src/index.js": {
+            "development": "./src/index.dev.js",
+            "default": "./src/index.js"
+        },
+        "./src/truncated.css.js": "./src/truncated.css.js",
+        "./sp-truncated.js": {
+            "development": "./sp-truncated.dev.js",
+            "default": "./sp-truncated.js"
+        }
+    },
+    "scripts": {
+        "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
+    },
+    "files": [
+        "**/*.d.ts",
+        "**/*.js",
+        "**/*.js.map",
+        "custom-elements.json",
+        "!stories/",
+        "!test/"
+    ],
+    "keywords": [
+        "spectrum css",
+        "web components",
+        "lit-element",
+        "lit-html"
+    ],
+    "dependencies": {
+        "@spectrum-web-components/base": "^0.41.0",
+        "@spectrum-web-components/overlay": "^0.41.0",
+        "@spectrum-web-components/styles": "^0.41.0",
+        "@spectrum-web-components/tooltip": "^0.41.0"
+    },
+    "devDependencies": {
+        "@open-wc/testing": "^3.2.0",
+        "@web/test-runner-commands": "^0.9.0"
+    },
+    "types": "./src/index.d.ts",
+    "customElements": "custom-elements.json",
+    "sideEffects": [
+        "./sp-*.js",
+        "./**/*.dev.js",
+        "./**/*.dev.js"
+    ]
+}

--- a/tools/truncated/sp-truncated.ts
+++ b/tools/truncated/sp-truncated.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { Truncated } from './src/Truncated.js';
+
+customElements.define('sp-truncated', Truncated);
+
+declare global {
+    interface HTMLElementTagNameMap {
+        'sp-truncated': Truncated;
+    }
+}

--- a/tools/truncated/src/Truncated.ts
+++ b/tools/truncated/src/Truncated.ts
@@ -1,0 +1,194 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import {
+    CSSResultArray,
+    html,
+    PropertyValueMap,
+    SpectrumElement,
+    TemplateResult,
+} from '@spectrum-web-components/base';
+import type { Overlay, Placement } from '@spectrum-web-components/overlay';
+import '@spectrum-web-components/overlay/sp-overlay.js';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import {
+    property,
+    query,
+    queryAssignedElements,
+    queryAssignedNodes,
+    state,
+} from '@spectrum-web-components/base/src/decorators.js';
+
+import styles from './truncated.css.js';
+
+/**
+ * @element sp-truncated
+ */
+export class Truncated extends SpectrumElement {
+    public static override get styles(): CSSResultArray {
+        return [styles];
+    }
+
+    /**
+     * @type {"top" | "top-start" | "top-end" | "right" | "right-start" | "right-end" | "bottom" | "bottom-start" | "bottom-end" | "left" | "left-start" | "left-end"}
+     */
+    @property()
+    placement: Placement = 'top-start';
+
+    /*
+     * @type {String}
+     * @attr success-message
+     * @description The message to display when the text is copied to the clipboard after clicking on the truncated text
+     */
+    @property({ type: String, attribute: 'success-message' })
+    successMessage = 'Copied to clipboard';
+
+    @state()
+    hasCopied = false;
+
+    @state()
+    private fullText = '';
+
+    @state()
+    private overflowing = false;
+
+    @query('#content')
+    private content!: HTMLElement;
+
+    @query('#overlay')
+    private overlayEl?: Overlay;
+
+    @queryAssignedNodes({ flatten: true })
+    private slottedContent!: Node[];
+
+    // elements instead of nodes because, according to spec,
+    // flattened assignedNodes will return a slot's *children* if there are no assigned nodes.
+    // ¯\_(ツ)_/¯
+    @queryAssignedElements({ slot: 'overflow', flatten: true })
+    private slottedOverflow!: HTMLElement[];
+
+    get hasCustomOverflow(): boolean {
+        return this.slottedOverflow.length > 0;
+    }
+
+    private resizeObserver = new ResizeObserver(() => {
+        this.measureOverflow();
+    });
+
+    private mutationObserver = new MutationObserver(() => {
+        this.copyText();
+    });
+
+    override render(): TemplateResult {
+        /* eslint-disable lit-a11y/click-events-have-key-events */
+        return html`
+            <span id="content" @click=${this.handleClick}>
+                <slot></slot>
+            </span>
+            ${this.renderTooltip()}
+        `;
+        /* eslint-enable lit-a11y/click-events-have-key-events */
+    }
+
+    private renderTooltip(): TemplateResult | undefined {
+        if (!this.overflowing) {
+            return html`
+                <slot
+                    name="overflow"
+                    style="display: none"
+                    @slotchange=${this.handleOverflowSlotchange}
+                ></slot>
+            `;
+        }
+        return html`
+            <sp-overlay
+                id="overlay"
+                .triggerElement=${this as HTMLElement}
+                .triggerInteraction=${'hover'}
+                type="hint"
+                placement=${this.placement}
+            >
+                <sp-tooltip name="tooltip">
+                    ${!this.hasCopied
+                        ? html`
+                              <slot
+                                  name="overflow"
+                                  @slotchange=${this.handleOverflowSlotchange}
+                              >
+                                  ${this.fullText}
+                              </slot>
+                          `
+                        : this.successMessage}
+                </sp-tooltip>
+            </sp-overlay>
+        `;
+    }
+
+    protected override firstUpdated(
+        _changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>
+    ): void {
+        this.resizeObserver.observe(this);
+        this.resizeObserver.observe(this.content);
+        this.copyText();
+        this.measureOverflow();
+    }
+
+    protected override updated(changedProperties: PropertyValueMap<any>): void {
+        super.updated(changedProperties);
+        if (
+            changedProperties.has('hasCopied') &&
+            this.hasCopied &&
+            this.overlayEl
+        ) {
+            // we know overlayEl exists because it couldn't copy the text otherwise
+            this.overlayEl.open = true;
+        }
+    }
+
+    private handleOverflowSlotchange(): void {
+        this.mutationObserver.disconnect();
+        if (!this.hasCustomOverflow) {
+            this.mutationObserver.observe(this.content, {
+                subtree: true,
+                childList: true,
+                characterData: true,
+            });
+        }
+    }
+
+    private handleClick(): void {
+        if (!this.overflowing) return;
+
+        const textToCopy = this.slottedContent
+            .map((node) => node.textContent ?? '')
+            .join('')
+            .trim();
+        navigator.clipboard.writeText(textToCopy);
+        this.hasCopied = true;
+        setTimeout(() => {
+            this.hasCopied = false;
+        }, 6000);
+    }
+
+    private measureOverflow(): void {
+        // Add 1 because Safari sometimes rounds by 1px, breaking the calculation otherwise
+        this.overflowing = this.content.offsetWidth > this.clientWidth + 1;
+    }
+
+    // Copies just the textContent of slotted nodes into the tooltip to avoid duplicating the user's DOM
+    private copyText(): void {
+        if (this.hasCustomOverflow) return;
+        this.fullText = this.slottedContent
+            .map((node) => node.textContent ?? '')
+            .join('');
+    }
+}

--- a/tools/truncated/src/Truncated.ts
+++ b/tools/truncated/src/Truncated.ts
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
-    PropertyValueMap,
+    PropertyValues,
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -134,7 +134,7 @@ export class Truncated extends SpectrumElement {
     }
 
     protected override firstUpdated(
-        _changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>
+        _changedProperties: PropertyValues<this>
     ): void {
         this.resizeObserver.observe(this);
         this.resizeObserver.observe(this.content);
@@ -142,7 +142,7 @@ export class Truncated extends SpectrumElement {
         this.measureOverflow();
     }
 
-    protected override updated(changedProperties: PropertyValueMap<any>): void {
+    protected override updated(changedProperties: PropertyValues<this>): void {
         super.updated(changedProperties);
         if (
             changedProperties.has('hasCopied') &&

--- a/tools/truncated/src/Truncated.ts
+++ b/tools/truncated/src/Truncated.ts
@@ -157,6 +157,7 @@ export class Truncated extends SpectrumElement {
     private handleOverflowSlotchange(): void {
         this.mutationObserver.disconnect();
         if (!this.hasCustomOverflow) {
+            /* c8 ignore next 5 */
             this.mutationObserver.observe(this.content, {
                 subtree: true,
                 childList: true,

--- a/tools/truncated/src/index.ts
+++ b/tools/truncated/src/index.ts
@@ -1,0 +1,12 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+export * from './Truncated.js';

--- a/tools/truncated/src/truncated.css
+++ b/tools/truncated/src/truncated.css
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+:host {
+    display: inline-block;
+    min-width: 0;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/tools/truncated/stories/truncated.stories.ts
+++ b/tools/truncated/stories/truncated.stories.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import '../sp-truncated.js';
+
+const Dog =
+    'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAspBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAAyADIDASIAAhEBAxEB/8QAHAAAAgIDAQEAAAAAAAAAAAAAAAcFCAMEBgIJ/8QAMhAAAgEDBAEBBgYABwAAAAAAAQIDBAURAAYSITEHEyJBUWGBFBUjMnGhCCU1QmKisf/EABkBAAMBAQEAAAAAAAAAAAAAAAMEBQIGAf/EACoRAAICAAMHAwUBAAAAAAAAAAECAAMRITEEBRITQVGhYXHwFBUiY5Gx/9oADAMBAAIRAxEAPwD6b0VwFTIQYXUD4ka3I5AwOAcZ+OldD6+2H9BI6iB5JDjgHGdbq+uu3BKEkqUhfOG5Hr7agV7y2XTmgwmUZI4YyM68kjj40urr6x0dMjR0UXt5mAKs59zB7z0e9chQ+sNw3JE1TR1oSBWZAY4woYqxBODk+R/WriVs6gjrF3uRNY8SyY94gfLUfcHqWXjTFQR5JOk5UeodfDVwQT1rNLNyaMMAOZAyQCB5x3j6H5HUpat5x3J5va1M6zAAcSfOktqFlKliPx6nHT3m67UsyE7Vqq8cjhofPz0a5bpuxLLg9/u0ag/WHv5Ea4ZQikrWRwp5lR2so850xdpx1W6kelt9FNWPGAZJQAFQH5kkDvB0+H9JtjQXmko5LVSrBURlIVpmaWRpBkkcRk/tBOdRV1itu09wT2Gx0wpKdCG4FChZiikswPee/j8tC2bcvOs4LXAHprErEapOIyGhtlzsdqSavRVSCMqEMisx49qDg9fL7DUf6dR7leulWte2pt38HCtIkEbrUe2x+oXJ6IJ7GPuNTu9Krlt2WBWPAg8j8SfnquHqr6j3Cr9OKiw2i/z7c3BTVUZWoWQQfiU97EaOWGchSSAcjA6xrr0I2QrSxJUDIn/IBU5q5DOPu60u6KbclTNWVdDUWIVdM9vjjhIniXBEwd84OQTjrwT3qauddFty2fjTdaeGWSXlxYgnj4A/n4/fS/8A8PW723lZ9t22a8/ntVZqflc62QiZal2DoqlgSGwQxJBP7QM+dO+qoLHUk/mEdCIU7VhTGQr9cYznUfeattlTU1vgpw8fPEapqy9RFg3rv7NihKkqcZD+dGmSLPsgj/U6P7286Nc19m/b8/sZ4LO/iKfe3qLda+hobpctwpZZaCYGGSiZVLAkF0CIFyWUYyfGT9cwB3pPeLvTbgaeOZKvOFSYSEJxwrE58kf+DSGX1hsF6UwVEtWY2BAQK+CMd8hnBH9d60rBVWKCy0tue5vMKX3I2elOeAPuAgPjIAUZ+mddTSbFIYYY9YV0BUqZcO6UEl920gpalIZZIlZHftSx8D+8arts66xbv3beLFUpBFVUE0sdX7dVxD7NirZJOMch0frrjbhvK5VE8Iot61Vtio0RY6aCjVlXjkoSpYYx5HWNczW2e3124btfpd03SnrbpwNU9FBGgbgFxhWZgP2g+PPeqL31vmwz94pXsrpkDr6S59o29Y9p2eoijlgo5qoiNZKciKVip59Fck4yTj/l9dRz7krbWGSpm/NqRcKs0aFahBjsuv8Av/le/pqtm0tx0ez7cYjuK83andhKkdUqHDAceWfJJHnJ7+wxmuvrbSqrLHBUP0R2qdfXsHU67F2xXACNV1FBhmY85fU7bcUro13iRlYgqzEEHPgg9jRqsTeuKcm/y1z35Pse/wDro0vwt3ENyz2iltrt+EzyPw+Op+2uzA5YnKjOT/OjRoo0jXWbZRVZiAAWPZA86xVk8kdSeMjr+zwxHnlnRo1hpoaTetsryUhDOzAeATnUTe2IY9nyR5/nRo0NZ71kYigqCQPHy0aNGgxif//Z';
+
+export default {
+    title: 'Truncated',
+    component: 'sp-truncated',
+};
+
+export const Default = (): TemplateResult => {
+    return html`
+        <p
+            style="width: 200px; color: #000; border: solid 1px #ccc; overflow: hidden; resize: both;"
+        >
+            <sp-truncated>
+                This is a
+                <strong>very long</strong>
+                🦋 sentence that 🦋 should be truncated
+            </sp-truncated>
+            <sp-truncated>
+                ThisIsAVeryLongWordThatShouldBeTruncated
+            </sp-truncated>
+            <sp-truncated>
+                We can even
+                <img src=${Dog} alt="kitten" />
+                truncate around a picture
+            </sp-truncated>
+            <sp-truncated>
+                Custom overflow content can also be provided for the tooltip
+                <span slot="overflow">
+                    <span style="font-size: 24px;">Like this!</span>
+                </span>
+            </sp-truncated>
+            <sp-truncated placement="right">
+                Alternative placements can be specified
+            </sp-truncated>
+            <sp-truncated>Should have no tooltip</sp-truncated>
+        </p>
+    `;
+};

--- a/tools/truncated/test/benchmark/basic-test.ts
+++ b/tools/truncated/test/benchmark/basic-test.ts
@@ -14,5 +14,10 @@ import { html } from '@spectrum-web-components/base';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
-    <sp-truncated></sp-truncated>
+    <p style="width: 200px">
+        <sp-truncated>
+            This is a very long text that will overflow into a tooltip with the
+            help of sp-truncated.
+        </sp-truncated>
+    </p>
 `);

--- a/tools/truncated/test/benchmark/basic-test.ts
+++ b/tools/truncated/test/benchmark/basic-test.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import '@spectrum-web-components/truncated/sp-truncated.js';
+import { html } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+measureFixtureCreation(html`
+    <sp-truncated></sp-truncated>
+`);

--- a/tools/truncated/test/truncated.test.ts
+++ b/tools/truncated/test/truncated.test.ts
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { Tooltip } from '@spectrum-web-components/tooltip/src/Tooltip.js';
+import { sendMouse } from '@web/test-runner-commands';
+
+import { Truncated } from '../src/index.js';
+import '../sp-truncated.js';
+
+describe('Truncated', () => {
+    it('loads default truncated accessibly', async () => {
+        const el = await fixture<Truncated>(
+            html`
+                <ue-truncated></ue-truncated>
+            `
+        );
+
+        await expect(el).to.be.accessible();
+    });
+    it('renders a tooltip when overflowing', async () => {
+        const p = await fixture(html`
+            <p style="width: 200px">
+                <sp-truncated>This will overflow into a tooltip</sp-truncated>
+            </p>
+        `);
+        const el = p.querySelector('sp-truncated') as Truncated;
+        const tooltip = el.shadowRoot!.querySelector('sp-tooltip') as Tooltip;
+        const rect = el.getBoundingClientRect();
+
+        const opened = oneEvent(el, 'sp-opened');
+
+        await sendMouse({
+            type: 'move',
+            position: [Math.round(rect.left + 2), Math.round(rect.top + 2)],
+        });
+
+        await opened;
+
+        expect(tooltip.open).to.be.true;
+    });
+    it('does not render a tooltip when content fits', async () => {
+        const p = await fixture(html`
+            <p style="width: 200px">
+                <sp-truncated>Short</sp-truncated>
+            </p>
+        `);
+        const el = p.querySelector('sp-truncated') as Truncated;
+        const tooltip = el.shadowRoot!.querySelector(
+            'sp-tooltip'
+        ) as Tooltip | null;
+        const rect = el.getBoundingClientRect();
+        await sendMouse({
+            type: 'move',
+            position: [Math.round(rect.left + 2), Math.round(rect.top + 2)],
+        });
+
+        expect(tooltip).to.be.null;
+    });
+    it('detects whether or not custom overflow is specified for optimization', async () => {
+        const defaultOverflow = await fixture<Truncated>(
+            html`
+                <sp-truncated>This will overflow into a tooltip</sp-truncated>
+            `
+        );
+        const customOverflow = await fixture<Truncated>(
+            html`
+                <sp-truncated>
+                    Default
+                    <span slot="overflow">Custom</span>
+                </sp-truncated>
+            `
+        );
+
+        expect(defaultOverflow.hasCustomOverflow).to.be.false;
+        expect(customOverflow.hasCustomOverflow).to.be.true;
+    });
+});

--- a/tools/truncated/test/truncated.test.ts
+++ b/tools/truncated/test/truncated.test.ts
@@ -20,7 +20,7 @@ describe('Truncated', () => {
     it('loads default truncated accessibly', async () => {
         const el = await fixture<Truncated>(
             html`
-                <ue-truncated></ue-truncated>
+                <sp-truncated></sp-truncated>
             `
         );
 
@@ -28,7 +28,7 @@ describe('Truncated', () => {
     });
     it('renders a tooltip when overflowing', async () => {
         const p = await fixture(html`
-            <p style="width: 200px">
+            <p style="width: 20px">
                 <sp-truncated>This will overflow into a tooltip</sp-truncated>
             </p>
         `);
@@ -36,15 +36,13 @@ describe('Truncated', () => {
         const tooltip = el.shadowRoot!.querySelector('sp-tooltip') as Tooltip;
         const rect = el.getBoundingClientRect();
 
-        const opened = oneEvent(el, 'sp-opened');
-
         await sendMouse({
             type: 'move',
             position: [Math.round(rect.left + 2), Math.round(rect.top + 2)],
         });
+        const opened = oneEvent(el, 'sp-opened');
 
         await opened;
-
         expect(tooltip.open).to.be.true;
     });
     it('does not render a tooltip when content fits', async () => {
@@ -82,5 +80,24 @@ describe('Truncated', () => {
 
         expect(defaultOverflow.hasCustomOverflow).to.be.false;
         expect(customOverflow.hasCustomOverflow).to.be.true;
+    });
+    it('copies the text when clicked', async () => {
+        const text =
+            'This will overflow into a  tooltiptooltiptooltiptooltipmtooltipv tooltip tooltiptooltip';
+
+        const defaultOverflow = await fixture<Truncated>(
+            html`
+                <p style="width: 200px">
+                    <sp-truncated>${text}</sp-truncated>
+                </p>
+            `
+        );
+
+        const truncated = defaultOverflow.querySelector('sp-truncated');
+        const content = truncated?.shadowRoot.querySelector(
+            '#content'
+        ) as Truncated;
+        content.click();
+        expect(truncated?.hasCopied).to.be.true;
     });
 });

--- a/tools/truncated/tsconfig.json
+++ b/tools/truncated/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "./"
+    },
+    "include": ["*.ts", "src/*.ts"],
+    "exclude": ["test/*.ts", "stories/*.ts"],
+    "references": [
+        { "path": "../base" }
+    ]
+}

--- a/tsconfig-all.json
+++ b/tsconfig-all.json
@@ -90,6 +90,7 @@
         { "path": "tools/reactive-controllers" },
         { "path": "tools/shared" },
         { "path": "tools/styles" },
-        { "path": "tools/theme" }
+        { "path": "tools/theme" },
+        { "path": "tools/truncated" }
     ]
 }


### PR DESCRIPTION
To succesfully implement the [Breadcrumbs](https://github.com/adobe/spectrum-web-components/discussions/4100) component we would require the truncated element from UEC. We copied the component in SWC so we do not create a new dependency to UEC. 

## Related issue(s)

https://github.com/adobe/spectrum-web-components/discussions/4100

## How has this been tested?

-   [x] _Test case 1_
    1. Opened storybook 
    2. Hover over truncated elements
    3. The tooltip appears.
-   [x] _Test case 2_
    1.  Opened storybook 
    2. Hover over non-truncated elements
    3. The tooltip should not appear

## Screenshots (if appropriate)

![image](https://github.com/adobe/spectrum-web-components/assets/56998711/e8c5685c-b700-408e-840f-f9f14e09fd6a)

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
