### PR TITLE
docs(action-menu): include action menu label in stories and READMEs

### DIFF
--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -107,7 +107,12 @@ Cards can be supplied an `actions` via a names slot.
         alt="Demo Image"
     />
     <div slot="footer">Footer</div>
-    <sp-action-menu slot="actions" placement="bottom-end" quiet>
+    <sp-action-menu
+        label="More Actions"
+        slot="actions"
+        placement="bottom-end"
+        quiet
+    >
         <sp-menu-item>Deselect</sp-menu-item>
         <sp-menu-item>Select Inverse</sp-menu-item>
         <sp-menu-item>Feather...</sp-menu-item>
@@ -181,7 +186,12 @@ Quiet cards will also accept `actions` via a named slot.
     <sp-card variant="quiet" heading="Card Heading" subheading="JPG Photo">
         <img alt="" slot="preview" src="https://picsum.photos/200/300" />
         <div slot="description">10/15/18</div>
-        <sp-action-menu slot="actions" placement="bottom-end" quiet>
+        <sp-action-menu
+            label="More Actions"
+            slot="actions"
+            placement="bottom-end"
+            quiet
+        >
             <sp-menu-item>Deselect</sp-menu-item>
             <sp-menu-item>Select Inverse</sp-menu-item>
             <sp-menu-item>Feather...</sp-menu-item>
@@ -262,7 +272,12 @@ Or a `quiet` card:
     >
         <img src="https://picsum.photos/110" alt="Demo Image" slot="preview" />
         <div slot="footer">Footer</div>
-        <sp-action-menu slot="actions" placement="bottom-end" quiet>
+        <sp-action-menu
+            label="More Actions"
+            slot="actions"
+            placement="bottom-end"
+            quiet
+        >
             <sp-menu-item>Deselect</sp-menu-item>
             <sp-menu-item>Select Inverse</sp-menu-item>
             <sp-menu-item>Feather...</sp-menu-item>

--- a/packages/card/stories/card.stories.ts
+++ b/packages/card/stories/card.stories.ts
@@ -85,7 +85,12 @@ export const href = (args: StoryArgs): TemplateResult => {
                 Footer with a
                 <sp-link href="https://google.com">link to Google</sp-link>
             </div>
-            <sp-action-menu slot="actions" placement="bottom-end" quiet>
+            <sp-action-menu
+                label="More Actions"
+                slot="actions"
+                placement="bottom-end"
+                quiet
+            >
                 <sp-menu-item>Deselect</sp-menu-item>
                 <sp-menu-item>Select Inverse</sp-menu-item>
                 <sp-menu-item>Feather...</sp-menu-item>
@@ -112,7 +117,12 @@ export const actions = (args: StoryArgs): TemplateResult => {
         >
             <img slot="cover-photo" src=${portrait} alt="Demo Graphic" />
             <div slot="footer">Footer</div>
-            <sp-action-menu slot="actions" placement="bottom-end" quiet>
+            <sp-action-menu
+                label="More Actions"
+                slot="actions"
+                placement="bottom-end"
+                quiet
+            >
                 <sp-menu-item>Deselect</sp-menu-item>
                 <sp-menu-item>Select Inverse</sp-menu-item>
                 <sp-menu-item>Feather...</sp-menu-item>
@@ -222,7 +232,12 @@ export const quietActions = (args: StoryArgs): TemplateResult => {
             >
                 <img src=${portrait} alt="Demo Graphic" slot="preview" />
                 <div slot="description">10/15/18</div>
-                <sp-action-menu slot="actions" placement="bottom-end" quiet>
+                <sp-action-menu
+                    label="More Actions"
+                    slot="actions"
+                    placement="bottom-end"
+                    quiet
+                >
                     <sp-menu-item>Deselect</sp-menu-item>
                     <sp-menu-item>Select Inverse</sp-menu-item>
                     <sp-menu-item>Feather...</sp-menu-item>
@@ -289,7 +304,12 @@ export const smallQuiet = (args: StoryArgs): TemplateResult => {
             >
                 <img src=${portrait} alt="Demo Graphic" slot="preview" />
                 <div slot="footer">Footer</div>
-                <sp-action-menu slot="actions" placement="bottom-end" quiet>
+                <sp-action-menu
+                    label="More Actions"
+                    slot="actions"
+                    placement="bottom-end"
+                    quiet
+                >
                     <sp-menu-item>Deselect</sp-menu-item>
                     <sp-menu-item>Select Inverse</sp-menu-item>
                     <sp-menu-item>Feather...</sp-menu-item>
@@ -331,7 +351,12 @@ export const SlottedHeading = (args: StoryArgs): TemplateResult => {
                 quiet
             ></sp-textfield>
             <div slot="subheading">Last modified on 6/17/2020, 3:37 PM</div>
-            <sp-action-menu slot="actions" placement="bottom-end" quiet>
+            <sp-action-menu
+                label="More Actions"
+                slot="actions"
+                placement="bottom-end"
+                quiet
+            >
                 <sp-menu-item>Deselect</sp-menu-item>
                 <sp-menu-item>Select Inverse</sp-menu-item>
                 <sp-menu-item>Feather...</sp-menu-item>

--- a/packages/coachmark/README.md
+++ b/packages/coachmark/README.md
@@ -56,7 +56,12 @@ Coach marks can include an `<sp-action-menu>`, which appears at the top right of
     <div slot="content">
         This is a Coachmark with nothing but text in it. Kind of lonely in here.
     </div>
-    <sp-action-menu placement="bottom-end" quiet slot="actions">
+    <sp-action-menu
+        label="More Actions"
+        placement="bottom-end"
+        quiet
+        slot="actions"
+    >
         <sp-menu-item>Skip tour</sp-menu-item>
         <sp-menu-item>Restart tour</sp-menu-item>
     </sp-action-menu>
@@ -86,7 +91,7 @@ The primary and secondary CTA buttons within the coachmark popover can be config
     <div slot="content">
         This is a Coachmark with nothing but text in it. Kind of lonely in here.
     </div>
-    <sp-action-menu placement="bottom-end" quiet slot="actions">
+    <sp-action-menu label="More Actions" placement="bottom-end" quiet slot="actions">
         <sp-menu-item>Skip tour</sp-menu-item>
         <sp-menu-item>Restart tour</sp-menu-item>
     </sp-action-menu>
@@ -137,7 +142,12 @@ Media Types allowed: `Images & Gifs`
 >
     <div slot="title">Coachmark with 16:9 image</div>
     <div slot="content">This is a Coachmark with some description</div>
-    <sp-action-menu placement="bottom-end" quiet slot="actions">
+    <sp-action-menu
+        label="More Actions"
+        placement="bottom-end"
+        quiet
+        slot="actions"
+    >
         <sp-menu-item>Skip tour</sp-menu-item>
         <sp-menu-item>Restart tour</sp-menu-item>
     </sp-action-menu>
@@ -159,7 +169,12 @@ A custom media can also be added via `<slot name="cover-photo"></slot>`
     <div slot="title">Coachmark with 16:9 image</div>
     <div slot="content">This is a Coachmark with some description</div>
     <img slot="asset" src="https://picsum.photos/id/237/200/300" alt="" />
-    <sp-action-menu placement="bottom-end" quiet slot="actions">
+    <sp-action-menu
+        label="More Actions"
+        placement="bottom-end"
+        quiet
+        slot="actions"
+    >
         <sp-menu-item>Skip tour</sp-menu-item>
         <sp-menu-item>Restart tour</sp-menu-item>
     </sp-action-menu>
@@ -182,7 +197,7 @@ The `shortcutKey` is the primary key used to trigger an interaction and are typi
         secondary-cta="Previous"
         id="coachmark-keys"
     >
-        <sp-action-menu placement="bottom-end" quiet slot="actions">
+        <sp-action-menu label="More Actions" placement="bottom-end" quiet slot="actions">
             <sp-menu-item>Skip tour</sp-menu-item>
             <sp-menu-item>Restart tour</sp-menu-item>
         </sp-action-menu>

--- a/packages/menu/stories/submenu.stories.ts
+++ b/packages/menu/stories/submenu.stories.ts
@@ -159,7 +159,11 @@ export const submenu = (): TemplateResult => {
         valueEls.second.textContent = event.target.selected[0] || '';
     };
     return html`
-        <sp-action-menu @change=${handleRootChange} @sp-opened=${clearValues}>
+        <sp-action-menu
+            label="More Actions"
+            @change=${handleRootChange}
+            @sp-opened=${clearValues}
+        >
             <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
             <sp-menu-group
                 @change=${() => console.log('group change')}

--- a/packages/overlay/stories/overlay-element.stories.ts
+++ b/packages/overlay/stories/overlay-element.stories.ts
@@ -346,7 +346,7 @@ export const actionGroup = ({ delayed }: Properties): TemplateResult => {
                 <sp-action-button id="trigger-3" hold-affordance>
                     <sp-icon-rect-select slot="icon"></sp-icon-rect-select>
                 </sp-action-button>
-                <sp-action-menu placement="left">
+                <sp-action-menu label="More Actions" placement="left">
                     <sp-menu-group id="cms">
                         <span slot="header">cms</span>
                         <sp-menu-item value="updateAllSiteContent">
@@ -557,7 +557,7 @@ export const actionGroupWithFilters = ({
                         Hover
                     </sp-tooltip>
                 </sp-action-button>
-                <sp-action-menu>
+                <sp-action-menu label="More Actions">
                     <sp-menu-group id="cms">
                         <span slot="header">cms</span>
                         <sp-menu-item value="updateAllSiteContent">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated SWC component READMEs and stories that include the action menu as part of examples with an expected action menu label to demonstrate accessible examples [aligning with existing SWC action menu documentation:](https://opensource.adobe.com/spectrum-web-components/components/action-menu/#no-visible-label)

> "The visible label that is be provided via the default <slot> interface can be ommitted in preference of an icon only interface. In this context be sure that the <sp-action-menu> continued to be accessible to screen readers by applying the label attribute. This will apply an aria-label attribute of the same value to the <button> element that toggles the menu list.".

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes https://github.com/adobe/spectrum-web-components/issues/3388

## Motivation and context

Provides consumers of SWC with accessible usage examples of the Action Menu across different SWC components such as the Card and Overlay.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] Run Storybook locally (`yarn storybook`)
    1. Go to each story modified in this PR
    2. Enable VoiceOver in Settings-->Accessibility
    3. Tab to the Action Menu button
    4. Observe that VoiceOver gives a label to the Action Menu button now, typically "More Actions"
-   [ ] View Remote Storybook to see original behavior
    1. Go to each story modified in this PR
    2. Enable VoiceOver in Settings-->Accessibility
    3. Tab to the Action Menu button
    4. Observe that VoiceOver does not provide a label to the Action Menu, making it unclear what the purpose of the action menu

## Screenshots (if appropriate)

Before:

https://github.com/adobe/spectrum-web-components/assets/24359834/ef93e080-502b-47dd-890a-fd2f31594b07

After:

https://github.com/adobe/spectrum-web-components/assets/24359834/b5244ea2-3f29-48e2-837f-78d5dee3447f

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
