### PR TITLE
fix: [split-view]: update label attribute to be customizable

### DIFF
--- a/packages/split-view/src/SplitView.ts
+++ b/packages/split-view/src/SplitView.ts
@@ -184,8 +184,9 @@ export class SplitView extends SpectrumElement {
                         this.viewSize - this.splitterSize
                     )) as boolean,
         };
-        const label =
-            this.label || (this.resizable ? 'Resize the panels' : undefined);
+        const label = this.resizable
+            ? this.label || 'Resize the panels'
+            : undefined;
 
         return html`
             <slot

--- a/packages/split-view/test/split-view.test.ts
+++ b/packages/split-view/test/split-view.test.ts
@@ -972,12 +972,13 @@ describe('SplitView', () => {
         expect(testPanel).to.be.null;
     });
 
-    it('allows a custom label', async () => {
+    it('allows a custom label when resizable if specified', async () => {
+        const customLabel = 'Resizable Split View Custom Label';
         const el = await fixture<SplitView>(
             html`
                 <sp-split-view
                     resizable
-                    label="Resizable Split View Custom Label"
+                    label=${customLabel}
                     primary-min="50"
                     secondary-min="50"
                 >
@@ -986,7 +987,7 @@ describe('SplitView', () => {
                 </sp-split-view>
             `
         );
-        expect(el.label).to.equal('Resizable Split View Custom Label');
+        expect(el.label).to.equal(customLabel);
     });
     it('keeps the splitter pos when removing and re-adding a panel', async () => {
         let pointerId = -1;

--- a/packages/split-view/test/split-view.test.ts
+++ b/packages/split-view/test/split-view.test.ts
@@ -972,6 +972,22 @@ describe('SplitView', () => {
         expect(testPanel).to.be.null;
     });
 
+    it('allows a custom label', async () => {
+        const el = await fixture<SplitView>(
+            html`
+                <sp-split-view
+                    resizable
+                    label="Resizable Split View Custom Label"
+                    primary-min="50"
+                    secondary-min="50"
+                >
+                    <div>First panel</div>
+                    <div>Second panel</div>
+                </sp-split-view>
+            `
+        );
+        expect(el.label).to.equal('Resizable Split View Custom Label');
+    });
     it('keeps the splitter pos when removing and re-adding a panel', async () => {
         let pointerId = -1;
         const el = await fixture<SplitView>(

--- a/packages/split-view/test/split-view.test.ts
+++ b/packages/split-view/test/split-view.test.ts
@@ -989,6 +989,7 @@ describe('SplitView', () => {
         );
         expect(el.label).to.equal(customLabel);
     });
+
     it('keeps the splitter pos when removing and re-adding a panel', async () => {
         let pointerId = -1;
         const el = await fixture<SplitView>(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bug: https://github.com/adobe/spectrum-web-components/issues/3811
Adjusting the logic such that the label allows for a custom label, if it is defined

<!--- Describe your changes in detail -->
I have updated the label constant to consider `this.label` if it is defined. To test this out, I gave `label` the value of `Resizable Split View Custom Label` and ran on Storybook to verify that if label is defined, it overrides the default. See video:

https://github.com/adobe/spectrum-web-components/assets/55859693/6cace4bf-fd28-4a16-bab3-a266ebb34486



## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
