### PR TITLE
ci: ensure that gh-pages deployment has both .nojekyll and no preceeding __ in filenames

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,6 @@ jobs:
             - name: Deploy to GitHub Pages
               run: |
                   git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-                  npx gh-pages -d projects/documentation/dist -m "[skip ci] update demonstration site" -t -u "github-actions-bot <support+actions@github.com>"
+                  npx gh-pages -d projects/documentation/dist -m "[skip ci] update demonstration site" -t -u "github-actions-bot <support+actions@github.com>" --nojekyll
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/projects/documentation/rollup.config.js
+++ b/projects/documentation/rollup.config.js
@@ -126,7 +126,10 @@ export default async () => {
             extractAssets: false,
         })
     );
-    mpaConfig.output.assetFileNames = '[hash][extname]';
+    mpaConfig.output.assetFileNames = 'swc.[hash].[ext]';
+    mpaConfig.output.chunkFileNames = 'swc.[hash].js';
+    mpaConfig.output.entryFileNames = 'swc.[hash].js';
+    mpaConfig.output.sourcemapFileNames = 'swc.[hash].js.map';
     mpaConfig.output.sourcemap = true;
 
     mpaConfig.moduleContext = {


### PR DESCRIPTION
## Description
I swear we used to publish a `.nojekyll` manually, but apparently not for sometime. Add the flag to do so from `gh-pages`.

Also, prevent file hash output from allowing files that start with `_` which also seems to trigger [this issue](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/), somehow.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://opensource.adobe.com/spectrum-web-components/components/color-field/)
    2. See that the docs site works.
    3. NOTE: I manually ran this code locally after the docs site broke during the most recent publication

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.