### PR TITLE
feat(dialog-wrapper): add dismiss-label attribute for the close button's label

### DIFF
--- a/packages/dialog/dialog-wrapper.md
+++ b/packages/dialog/dialog-wrapper.md
@@ -1,6 +1,6 @@
 ## Description
 
-`sp-dialog-wrapper` supplies an attribute based interface for the managed custmization of an `sp-dialog` element and the light DOM supplied to it. This is paired it with an `underlay` attribute that opts-in to the use of an `sp-underlay` element between your page content and the `sp-dialog` that opens over it.
+`sp-dialog-wrapper` supplies an attribute based interface for the managed customization of an `sp-dialog` element and the light DOM supplied to it. This is paired it with an `underlay` attribute that opts-in to the use of an `sp-underlay` element between your page content and the `sp-dialog` that opens over it.
 
 ### Usage
 
@@ -34,6 +34,7 @@ import { DialogWrapper } from '@spectrum-web-components/dialog';
         slot="click-content"
         headline="Dialog title"
         dismissable
+        dismiss-label="Close"
         underlay
         footer="Content for footer"
     >

--- a/packages/dialog/src/Dialog.ts
+++ b/packages/dialog/src/Dialog.ts
@@ -61,6 +61,9 @@ export class Dialog extends ObserveSlotPresence(AlertDialog, [
     @property({ type: Boolean, reflect: true })
     public dismissable = false;
 
+    @property({ type: String, reflect: true, attribute: 'dismiss-label' })
+    public dismissLabel = '';
+
     protected get hasFooter(): boolean {
         return this.getSlotContentPresence('[slot="footer"]');
     }
@@ -123,7 +126,7 @@ export class Dialog extends ObserveSlotPresence(AlertDialog, [
         return html`
             <sp-close-button
                 class="close-button"
-                label="Close"
+                label=${this.dismissLabel}
                 quiet
                 size="m"
                 @click=${this.close}

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -50,6 +50,9 @@ export class DialogWrapper extends DialogBase {
     @property({ attribute: 'confirm-label' })
     public confirmLabel = '';
 
+    @property({ attribute: 'dismiss-label' })
+    public dismissLabel = '';
+
     @property()
     public footer = '';
 
@@ -192,6 +195,19 @@ export class DialogWrapper extends DialogBase {
                           >
                               ${this.confirmLabel}
                           </sp-button>
+                      `
+                    : nothing}
+                ${this.dismissable && this.dismissLabel
+                    ? html`
+                          <sp-close-button
+                              class="close-button"
+                              label="Close"
+                              quiet
+                              size="m"
+                              @click=${this.close}
+                          >
+                              ${this.dismissLabel}
+                          </sp-close-button>
                       `
                     : nothing}
             </sp-dialog>

--- a/packages/dialog/src/DialogWrapper.ts
+++ b/packages/dialog/src/DialogWrapper.ts
@@ -127,6 +127,7 @@ export class DialogWrapper extends DialogBase {
         return html`
             <sp-dialog
                 ?dismissable=${this.dismissable}
+                dismiss-label=${this.dismissLabel}
                 ?no-divider=${hideDivider}
                 ?error=${this.error}
                 mode=${ifDefined(this.mode)}
@@ -195,19 +196,6 @@ export class DialogWrapper extends DialogBase {
                           >
                               ${this.confirmLabel}
                           </sp-button>
-                      `
-                    : nothing}
-                ${this.dismissable && this.dismissLabel
-                    ? html`
-                          <sp-close-button
-                              class="close-button"
-                              label="Close"
-                              quiet
-                              size="m"
-                              @click=${this.close}
-                          >
-                              ${this.dismissLabel}
-                          </sp-close-button>
                       `
                     : nothing}
             </sp-dialog>

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -86,6 +86,7 @@ export const wrapperLabeledHero = (
             hero=${landscape}
             hero-label="Hero Image Alt Text"
             dismissable
+            dismiss-label="Close"
             headline="Wrapped Dialog w/ Hero Image"
             @close=${handleClose(args)}
             size="s"
@@ -116,6 +117,7 @@ export const wrapperDismissable = (
             ?open=${open}
             .hero=${landscape}
             dismissable
+            dismiss-label="Close"
             headline="Wrapped Dialog w/ Hero Image"
             @close=${handleClose(args)}
             size="s"
@@ -147,6 +149,7 @@ export const wrapperDismissableUnderlay = (
             ?open=${open}
             hero=${landscape}
             dismissable
+            dismiss-label="Close"
             headline="Wrapped Dialog w/ Hero Image"
             underlay
             @close=${handleClose(args)}
@@ -272,6 +275,7 @@ export const longContent = (
                 slot="click-content"
                 headline="Dialog title"
                 dismissable
+                dismiss-label="Close"
                 underlay
                 size="s"
             >
@@ -386,6 +390,7 @@ export const wrapperDismissableUnderlayError = (
                 ?open=${open}
                 hero=${landscape}
                 dismissable
+                dismiss-label="Close"
                 error
                 headline="Wrapped Dialog w/ Hero Image"
                 underlay
@@ -549,6 +554,7 @@ export const tooltips = (
                 slot="click-content"
                 headline="Dialog title"
                 dismissable
+                dismiss-label="Close"
                 underlay
                 size="s"
             >

--- a/packages/dialog/stories/dialog-wrapper.stories.ts
+++ b/packages/dialog/stories/dialog-wrapper.stories.ts
@@ -27,7 +27,7 @@ import '../../overlay/stories/index.js';
 import type { DialogWrapper } from '@spectrum-web-components/dialog';
 
 export default {
-    title: 'Dialog Wrapped',
+    title: 'Dialog Wrapper',
     component: 'sp-dialog-wrapper',
     argTypes: {
         onClose: { action: 'close' },

--- a/packages/dialog/stories/dialog.stories.ts
+++ b/packages/dialog/stories/dialog.stories.ts
@@ -80,7 +80,7 @@ export const large = (): TemplateResult => {
 
 export const dismissable = (): TemplateResult => {
     return html`
-        <sp-dialog size="m" dismissable>
+        <sp-dialog size="m" dismissable dismiss-label="Close">
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
@@ -99,7 +99,7 @@ export const dismissable = (): TemplateResult => {
 
 export const noDivider = (): TemplateResult => {
     return html`
-        <sp-dialog size="m" dismissable no-divider>
+        <sp-dialog size="m" dismissable dismiss-label="Close" no-divider>
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua. Auctor
@@ -118,7 +118,7 @@ export const noDivider = (): TemplateResult => {
 
 export const hero = (): TemplateResult => {
     return html`
-        <sp-dialog size="m" dismissable no-divider>
+        <sp-dialog size="m" dismissable dismiss-label="Close" no-divider>
             <div slot="hero" style="background-image: url(${landscape})"></div>
             <h2 slot="heading">Disclaimer</h2>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
@@ -214,7 +214,7 @@ export const alertErrorWithLongTitle = (): TemplateResult => {
 
 export const fullscreen = (): TemplateResult => {
     return html`
-        <sp-dialog mode="fullscreen" dismissable>
+        <sp-dialog mode="fullscreen" dismissable dismiss-label="Close">
             <h2 slot="heading">Enable Smart Filters?</h2>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do

--- a/packages/dialog/test/dialog-wrapper.test.ts
+++ b/packages/dialog/test/dialog-wrapper.test.ts
@@ -217,6 +217,7 @@ describe('Dialog Wrapper', () => {
         const dismissButton = dialogRoot.querySelector(
             '.close-button'
         ) as HTMLButtonElement;
+        expect(dismissButton.ariaLabel).to.be.equals('Close');
         dismissButton.click();
 
         await elementUpdated(el);

--- a/packages/dialog/test/dialog.test.ts
+++ b/packages/dialog/test/dialog.test.ts
@@ -135,6 +135,8 @@ describe('Dialog', () => {
                 : el.querySelector('.close-button ')
         ) as HTMLElement;
 
+        expect(closeButton.ariaLabel).to.be.equals('Close');
+
         closeButton.click();
 
         await elementUpdated(el);


### PR DESCRIPTION
dialog-wrapper has several labels for customization. This PR introduces a new attribute `dismiss-label` for `dialog-wrapper` and `dialog`. It allows the string passed in to be used as the `label` for `dialog-wrapper` and `dialog`.

## Description

- Added new property `dismissLabel` and attribute `dismiss-label` to `dialog-wrapper` and `dialog`. Default is ``.
- `dismiss-label` will be used as the `sp-close-button`'s `label` prop. 
- Updated all related `dialog-wrapper` and `dialog` stories to pass in `dismiss-label = 'Close'`.
- Updated 2 unit tests to check that the `dismiss-label` set in the stories trickles down to the `aria-label` of the components.
- Updated `dialog-wrapper` readme with new `dismiss-label`.

## Related issue(s)
https://github.com/adobe/spectrum-web-components/issues/3375

## Motivation and context
https://github.com/adobe/spectrum-web-components/issues/1975

## How has this been tested?

DialogWrapper 

1. Navigate to storybook
2. In the components sidebar, select and expand `Dialog Wrapper`.
3. Select any story that uses a dismissable dialog. For e.g., `Wrapper Dismissable`.
4. In DevTools, use the select tool to inspect the close ( x ) button.
5. Verify that the `sp-close-button` has `label = 'Close'`
6. Verify the parent `sp-dialog` and `sp-dialog-wrapper` has `dismiss-label = 'Close'`

Dialog 
1. Navigate to storybook
2. In the components sidebar, select and expand `Dialog`.
3. Select any story that uses a dismissable dialog. For e.g., `Dismissable`.
4. In DevTools, use the select tool to inspect the close ( x ) button.
5. Verify that the `sp-close-button` has `label = 'Close'`
6. Verify the parent `sp-dialog` has `dismiss-label = 'Close'`

## Screenshots (if appropriate)
### Dialog Wrapper

<img width="1440" alt="DialogWrapper" src="https://github.com/adobe/spectrum-web-components/assets/21351513/007faf7e-a9e3-4474-93bd-9ea95a297517">
<img width="1440" alt="DialogWrapper - property, attribute" src="https://github.com/adobe/spectrum-web-components/assets/21351513/697ba0a0-4217-415d-ac0e-486dd2109bde">


### Dialog

<img width="1437" alt="Dialog" src="https://github.com/adobe/spectrum-web-components/assets/21351513/27694bc4-ad33-432d-9eeb-ae404c2d7591">
<img width="1440" alt="Dialog - Property" src="https://github.com/adobe/spectrum-web-components/assets/21351513/2ea27d1e-9e09-44b8-9b43-461cc881ea97">
<img width="1440" alt="Dialog - Attribute" src="https://github.com/adobe/spectrum-web-components/assets/21351513/ea97cd59-e276-452d-a943-9b238660fa6b">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
