### PR TITLE
feat(asset): use core tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: b7e5c09d7b9eb5384d503cd9a4409f757a549115
+        default: c70f3ed57c4e3536313872fd3d23510caa801a44
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -73,7 +73,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/accordion": "^4.2.4"
+        "@spectrum-css/accordion": "^4.2.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-bar/package.json
+++ b/packages/action-bar/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/popover": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/actionbar": "^7.2.2"
+        "@spectrum-css/actionbar": "^7.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-button/package.json
+++ b/packages/action-button/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/actionbutton": "^5.2.4"
+        "@spectrum-css/actionbutton": "^5.2.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-group/package.json
+++ b/packages/action-group/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/reactive-controllers": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/actiongroup": "^4.2.3"
+        "@spectrum-css/actiongroup": "^4.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/action-menu/package.json
+++ b/packages/action-menu/package.json
@@ -69,7 +69,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/actionmenu": "^5.1.1"
+        "@spectrum-css/actionmenu": "^5.1.2"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -66,7 +66,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/alertdialog": "^1.2.2"
+        "@spectrum-css/alertdialog": "^1.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/asset/package.json
+++ b/packages/asset/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/asset": "^3.1.2"
+        "@spectrum-css/asset": "^4.0.0"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/asset/src/spectrum-asset.css
+++ b/packages/asset/src/spectrum-asset.css
@@ -22,55 +22,39 @@ governing permissions and limitations under the License.
 
 ::slotted(*) {
     object-fit: contain;
-    transition: opacity var(--spectrum-global-animation-duration-100, 0.13s);
+    transition: opacity var(--spectrum-animation-duration-100);
     max-block-size: 100%;
     max-inline-size: 100%;
 }
 
 .folder,
 .file {
-    min-inline-size: var(
-        --spectrum-asset-icon-min-width,
-        var(--spectrum-global-dimension-size-600)
+    inline-size: clamp(
+        var(--mod-asset-icon-min-width, 48px),
+        100%,
+        var(--mod-asset-icon-max-width, 80px)
     );
-    max-inline-size: var(
-        --spectrum-asset-icon-max-width,
-        var(--spectrum-global-dimension-static-size-1000)
-    );
-    margin: var(
-        --spectrum-asset-icon-margin,
-        var(--spectrum-global-dimension-size-250)
-    );
+    margin: var(--mod-asset-icon-margin, 20px);
     block-size: 100%;
-    inline-size: 100%;
 }
 
 .folderBackground {
     fill: var(
         --highcontrast-asset-folder-background-color,
-        var(
-            --spectrum-asset-folder-background-color,
-            var(--spectrum-global-color-gray-300)
-        )
+        var(--mod-asset-folder-background-color, var(--spectrum-gray-300))
     );
 }
 
 .fileBackground {
     fill: var(
         --highcontrast-asset-file-background-color,
-        var(
-            --spectrum-asset-file-background-color,
-            var(--spectrum-global-color-gray-50)
-        )
+        var(--mod-asset-file-background-color, var(--spectrum-gray-50))
     );
 }
 
 .folderOutline,
 .fileOutline {
-    fill: var(
-        --spectrum-asset-icon-outline-color,
-        var(--spectrum-global-color-gray-500)
-    );
+    fill: var(--mod-asset-icon-outline-color, var(--spectrum-gray-500));
 }
 
 @media (forced-colors: active) {

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/avatar": "^6.1.3"
+        "@spectrum-css/avatar": "^6.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/badge": "^3.2.3"
+        "@spectrum-css/badge": "^3.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/button-group/package.json
+++ b/packages/button-group/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/button": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/buttongroup": "^6.2.3"
+        "@spectrum-css/buttongroup": "^6.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -67,7 +67,7 @@
         "@spectrum-web-components/styles": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/card": "^7.0.0"
+        "@spectrum-css/card": "^7.0.1"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -71,7 +71,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/checkbox": "^8.1.3"
+        "@spectrum-css/checkbox": "^8.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/clear-button/package.json
+++ b/packages/clear-button/package.json
@@ -45,7 +45,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/clearbutton": "^5.1.2"
+        "@spectrum-css/clearbutton": "^5.1.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/close-button/package.json
+++ b/packages/close-button/package.json
@@ -45,7 +45,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/closebutton": "^4.2.3"
+        "@spectrum-css/closebutton": "^4.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/coachmark/package.json
+++ b/packages/coachmark/package.json
@@ -81,8 +81,8 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/coachindicator": "^1.1.3",
-        "@spectrum-css/coachmark": "^6.1.3"
+        "@spectrum-css/coachindicator": "^1.1.4",
+        "@spectrum-css/coachmark": "^6.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-area/package.json
+++ b/packages/color-area/package.json
@@ -69,7 +69,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/colorarea": "^4.1.3"
+        "@spectrum-css/colorarea": "^4.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-handle/package.json
+++ b/packages/color-handle/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/opacity-checkerboard": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/colorhandle": "^7.1.2"
+        "@spectrum-css/colorhandle": "^7.1.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-loupe/package.json
+++ b/packages/color-loupe/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/opacity-checkerboard": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/colorloupe": "^4.2.2"
+        "@spectrum-css/colorloupe": "^4.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-slider/package.json
+++ b/packages/color-slider/package.json
@@ -69,7 +69,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/colorslider": "^5.1.3"
+        "@spectrum-css/colorslider": "^5.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/color-wheel/package.json
+++ b/packages/color-wheel/package.json
@@ -68,7 +68,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/colorwheel": "^3.1.3"
+        "@spectrum-css/colorwheel": "^3.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -67,7 +67,7 @@
         "@spectrum-web-components/textfield": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/combobox": "^2.1.4"
+        "@spectrum-css/combobox": "^2.1.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -84,7 +84,7 @@
         "@spectrum-web-components/underlay": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/dialog": "^9.2.2"
+        "@spectrum-css/dialog": "^9.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/divider": "^2.2.3"
+        "@spectrum-css/divider": "^2.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/dropzone": "^5.2.3"
+        "@spectrum-css/dropzone": "^5.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-group/package.json
+++ b/packages/field-group/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/help-text": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/fieldgroup": "^4.2.2"
+        "@spectrum-css/fieldgroup": "^4.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/field-label/package.json
+++ b/packages/field-label/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/fieldlabel": "^7.3.4"
+        "@spectrum-css/fieldlabel": "^7.3.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/help-text/package.json
+++ b/packages/help-text/package.json
@@ -81,7 +81,7 @@
         "@spectrum-web-components/icons-workflow": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/helptext": "^4.1.3"
+        "@spectrum-css/helptext": "^4.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -75,7 +75,7 @@
         "@spectrum-web-components/iconset": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/icon": "^6.0.3"
+        "@spectrum-css/icon": "^6.0.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/icons-workflow/package.json
+++ b/packages/icons-workflow/package.json
@@ -49,7 +49,7 @@
     },
     "devDependencies": {
         "@adobe/spectrum-css-workflow-icons": "^1.5.4",
-        "@spectrum-css/icon": "^6.0.3",
+        "@spectrum-css/icon": "^6.0.4",
         "case": "^1.6.1",
         "cheerio": "^1.0.0-rc.2",
         "fast-glob": "^3.2.12",

--- a/packages/illustrated-message/package.json
+++ b/packages/illustrated-message/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/styles": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/illustratedmessage": "^6.1.3"
+        "@spectrum-css/illustratedmessage": "^6.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/infield-button/package.json
+++ b/packages/infield-button/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/button": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/infieldbutton": "^4.2.2"
+        "@spectrum-css/infieldbutton": "^4.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/link": "^4.2.3"
+        "@spectrum-css/link": "^4.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -95,7 +95,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/menu": "^6.1.3"
+        "@spectrum-css/menu": "^6.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/meter/package.json
+++ b/packages/meter/package.json
@@ -63,7 +63,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^3.1.3"
+        "@spectrum-css/progressbar": "^3.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -46,7 +46,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/modal": "^4.2.4"
+        "@spectrum-css/modal": "^4.2.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/number-field/package.json
+++ b/packages/number-field/package.json
@@ -68,7 +68,7 @@
     },
     "devDependencies": {
         "@formatjs/intl-numberformat": "^8.3.5",
-        "@spectrum-css/stepper": "^5.1.3"
+        "@spectrum-css/stepper": "^5.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker-button/package.json
+++ b/packages/picker-button/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/pickerbutton": "^4.1.3"
+        "@spectrum-css/pickerbutton": "^4.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/picker/package.json
+++ b/packages/picker/package.json
@@ -80,7 +80,7 @@
         "@spectrum-web-components/tray": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/picker": "^7.2.5"
+        "@spectrum-css/picker": "^7.2.6"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/overlay": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/popover": "^6.2.3"
+        "@spectrum-css/popover": "^6.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -63,7 +63,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/progressbar": "^3.1.3"
+        "@spectrum-css/progressbar": "^3.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/progress-circle/package.json
+++ b/packages/progress-circle/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/progresscircle": "^2.2.1"
+        "@spectrum-css/progresscircle": "^2.2.2"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -72,7 +72,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/radio": "^8.1.3"
+        "@spectrum-css/radio": "^8.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/textfield": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/search": "^6.2.2"
+        "@spectrum-css/search": "^6.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/sidenav/package.json
+++ b/packages/sidenav/package.json
@@ -80,7 +80,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/sidenav": "^4.2.2"
+        "@spectrum-css/sidenav": "^4.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -83,7 +83,7 @@
         "@spectrum-web-components/theme": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/slider": "^4.3.3"
+        "@spectrum-css/slider": "^4.3.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/split-view/package.json
+++ b/packages/split-view/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/splitview": "^4.2.2"
+        "@spectrum-css/splitview": "^4.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/status-light/package.json
+++ b/packages/status-light/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/statuslight": "^6.1.4"
+        "@spectrum-css/statuslight": "^6.1.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/swatch/package.json
+++ b/packages/swatch/package.json
@@ -75,8 +75,8 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/swatch": "^5.1.3",
-        "@spectrum-css/swatchgroup": "^2.1.3"
+        "@spectrum-css/swatch": "^5.1.4",
+        "@spectrum-css/swatchgroup": "^2.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -62,7 +62,7 @@
         "@spectrum-web-components/checkbox": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/switch": "^4.2.3"
+        "@spectrum-css/switch": "^4.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -123,7 +123,7 @@
         "@spectrum-web-components/icons-ui": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/table": "^5.2.3"
+        "@spectrum-css/table": "^5.2.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -93,7 +93,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/tabs": "^4.1.2"
+        "@spectrum-css/tabs": "^4.1.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -72,8 +72,8 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/tag": "^8.1.3",
-        "@spectrum-css/taggroup": "^4.1.3"
+        "@spectrum-css/tag": "^8.1.4",
+        "@spectrum-css/taggroup": "^4.1.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -65,7 +65,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/textfield": "^6.1.4"
+        "@spectrum-css/textfield": "^6.1.5"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/thumbnail/package.json
+++ b/packages/thumbnail/package.json
@@ -61,7 +61,7 @@
         "@spectrum-web-components/opacity-checkerboard": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/thumbnail": "^5.2.2"
+        "@spectrum-css/thumbnail": "^5.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/toast": "^9.1.23"
+        "@spectrum-css/toast": "^9.1.24"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -66,7 +66,7 @@
         "@spectrum-web-components/shared": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/tooltip": "^5.3.3"
+        "@spectrum-css/tooltip": "^5.3.4"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/tray/package.json
+++ b/packages/tray/package.json
@@ -64,7 +64,7 @@
         "@spectrum-web-components/underlay": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/tray": "^2.2.5"
+        "@spectrum-css/tray": "^2.2.6"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/underlay/package.json
+++ b/packages/underlay/package.json
@@ -60,7 +60,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/underlay": "^3.2.2"
+        "@spectrum-css/underlay": "^3.2.3"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/tools/opacity-checkerboard/package.json
+++ b/tools/opacity-checkerboard/package.json
@@ -46,7 +46,7 @@
         "@spectrum-web-components/base": "^0.41.2"
     },
     "devDependencies": {
-        "@spectrum-css/opacitycheckerboard": "^1.1.3"
+        "@spectrum-css/opacitycheckerboard": "^1.1.4"
     },
     "types": "./src/opacity-checkerboard.d.ts",
     "sideEffects": [

--- a/tools/styles/package.json
+++ b/tools/styles/package.json
@@ -110,7 +110,7 @@
         "@spectrum-css/commons": "^9.1.2",
         "@spectrum-css/expressvars": "^3.0.9",
         "@spectrum-css/tokens": "^13.2.0",
-        "@spectrum-css/typography": "^5.1.3",
+        "@spectrum-css/typography": "^5.1.4",
         "@spectrum-css/vars": "^9.0.8"
     },
     "customElements": "custom-elements.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5016,50 +5016,50 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
 
-"@spectrum-css/accordion@^4.2.4":
+"@spectrum-css/accordion@^4.2.5":
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/@spectrum-css/accordion/-/accordion-4.2.5.tgz#d64ee314ed35514bc3fec5eecc0c634ab8164db1"
   integrity sha512-E//tNAEiqsJzCQp0CyjFHWx88l1lCN/qWn3QLOaQzed2hUytsOdHYn3oTyC5GBXz9109Egg7raYhECfiuE4CEA==
 
-"@spectrum-css/actionbar@^7.2.2":
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-7.2.2.tgz#c308357c1d1dd8406167762bfbb4774d83f652c5"
-  integrity sha512-JernY9LceAksYQNif/0WDBq4lLZGZlkpRBsvFXug4V9qrhcbw8dCb1g5y+vtgjfgW0Llv7cDRzge3srH1tyeMg==
+"@spectrum-css/actionbar@^7.2.3":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbar/-/actionbar-7.2.3.tgz#9b57dac6b5e166a95c41aa5e853f44ff2a75f6ce"
+  integrity sha512-tU3ObiKPzVWwK0+l6QOV928VrUrEyaBPtEoiBtu3V8vq4o5UO/jN++0RbpCHN/KtQZrqOCqCRN0hkXayj8MlFw==
 
-"@spectrum-css/actionbutton@^5.2.4":
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-5.2.4.tgz#d8137c28a7eb187ee69bd48148f9fafee20547c5"
-  integrity sha512-7jTy50zABHKmBULKv5YCb/X7oGbYGCCRxjY8OcsLejWE+lVd8mZvORcpTvakNsGFgfLAP2xue7sFj6FJCAyscw==
+"@spectrum-css/actionbutton@^5.2.5":
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionbutton/-/actionbutton-5.2.5.tgz#618464dfae859435e1fa738fc7a37577975f7f52"
+  integrity sha512-wXxdgaE6v5P5/+BUnQGNtuY7k4NV3dFnOqPDTd4Yx/yLO8Zbmmbqfd5iILX4yPiaXCgcsx6gul53eqLKh7uc8A==
 
-"@spectrum-css/actiongroup@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-4.2.3.tgz#84485028b608502789a84d44e017a8ad4fcbb521"
-  integrity sha512-6fi94OanA4b1rHwRtuGfWHbMZ/UTFfWAFt6BSpSPVHfzWy8SIru0bBTSHvgUw/plpFJf/ulF4WihN0H1VVNLPg==
+"@spectrum-css/actiongroup@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actiongroup/-/actiongroup-4.2.4.tgz#954d12c92c6c82edfabe26794d62e3f5090e8dda"
+  integrity sha512-jtAi/cGUXLH1Ji3QdtPG8f945pt8Uhu0J5wwa5xMURN2rEXiHgWGkAC5OCePMWv3BbEo9SyH4eZaWIErdRyN8Q==
 
-"@spectrum-css/actionmenu@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-5.1.1.tgz#805b03ff7a39a0f5c1c648b59212459b5c4a87a3"
-  integrity sha512-cOMyydFkAetawsVLguu64D2NpntQX8fOCdI6cXVu0V866O1Kk6dxTci7cBJT+Z6reITq+hyFJCYjUJocL3QKPQ==
+"@spectrum-css/actionmenu@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/actionmenu/-/actionmenu-5.1.2.tgz#37f30c7ae196b7df61f7e2ed2acc260138369ee2"
+  integrity sha512-3miBH5uQ5VcQXzcEUMHcS0v4MFQYClPss+Yw9dAgDp7NKDvNQKmmWqsluYl6eOhJ6DbuOwAOy/UQe92O7UwRZQ==
 
-"@spectrum-css/alertdialog@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/alertdialog/-/alertdialog-1.2.2.tgz#58bcc68adef4534e65146b0754a28c89419d163f"
-  integrity sha512-9ilCvS0ccqmZpVEGxOhZur5sMKvePYGQ8tlMynOIaCu1sxStmkozsg7gdAX3aG2pbf8+m6PwdN98Y4We9WU/8A==
+"@spectrum-css/alertdialog@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/alertdialog/-/alertdialog-1.2.3.tgz#bdc5852716916fd05e8ab1837d215769996a157f"
+  integrity sha512-eec1AnoNCdGq2s8IhFf+3qnfBiogXf1HGLUz1WIvRUSjf5yAbBAq2POTO5ZCE6jAiybK7jF7nK1aIgHymlsXFg==
 
-"@spectrum-css/asset@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-3.1.2.tgz#8ee755739f83d0b39ba81906e54fdcb693baa1b7"
-  integrity sha512-u8Wx9Sar/g1juz51kpPbuocQNYDxkgmq+3oHF1QUxvGJ8NrhWJV9FvMpZX/m1v+C9DlrNOfC30lUjNzhwZxgAg==
+"@spectrum-css/asset@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/asset/-/asset-4.0.0.tgz#0214eb0fddf4dcf66e2c62a929884ae1198a4e34"
+  integrity sha512-t9PIRZbftzlwmCxvAoAYY/ha3s7DU27885dm9UT6bTbZ4KGPA2Da3Pk8nmqU+uukDNclNmEbCbOPYxiNJvp1jA==
 
-"@spectrum-css/avatar@^6.1.3":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-6.1.3.tgz#d1db852bf855ea8cf0d5e49b80c3a4abbc434f38"
-  integrity sha512-ihcySq+/m+oZ7SO23o3kj+mJ5F1j0gFfFFKV/9ZsPJk0KvcgK4giMNDZ/2RDDrMTIzCzDRVtxy/rxcwQZeO0wQ==
+"@spectrum-css/avatar@^6.1.4":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/avatar/-/avatar-6.1.4.tgz#eaf39341497426360d8493887cee73ccdc0dcfda"
+  integrity sha512-2fIjFXNvtcS8Rn7Eef1obGRiGBOC/pAx1kaBbKnCgcH/88pUDQMrwViJH9kAhrs+qAfJR9us/PE9MGg+WXfiGQ==
 
-"@spectrum-css/badge@^3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/badge/-/badge-3.2.3.tgz#2a7e1783eacf2fe68bdd7c090c5f128e785a1791"
-  integrity sha512-uDuKWXFKZq6z8qjzJkW2GA91yJ3bX1CcmSHY5ZDfc/eTxlrO5Qg8P2uz06ISNNLtz7/HIMLfo6x0eLpW/VY3YA==
+"@spectrum-css/badge@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/badge/-/badge-3.2.4.tgz#fd78f5affb62af27e0eada3d65b6768163400ab4"
+  integrity sha512-xvCiLFdy9cFxv6wrR/2nTJsgQSJnu7L6n5VDDOO3hjhAR0/PYxxMDNgjPrLiTudYvLn3HNR2OatebsMgAmVpFg==
 
 "@spectrum-css/banner@3.0.0-beta.2":
   version "3.0.0-beta.2"
@@ -5071,67 +5071,67 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/button/-/button-12.0.1.tgz#544031febb19985e90736abf0de99212ddc5ad4c"
   integrity sha512-emXx9cC/kDiEoiUthx1CGUUiNg6bJGnPKWEL5vX8QR3weouyL0Os7giUl2T/gKO/yC/4amfl7jgsMwcBtD1SbQ==
 
-"@spectrum-css/buttongroup@^6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-6.2.3.tgz#16f766d04d94766b04ecb95e119a55b4acf4e802"
-  integrity sha512-lswlCZ6us6RN4EXeFH+1juIYleNdvONU+f67IouYhpStOZFcRcLgH3xGkOBV/rdqdKqCtdIY2FIb2ab7NjKDqg==
+"@spectrum-css/buttongroup@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/buttongroup/-/buttongroup-6.2.4.tgz#9331c3fb3b570f0e42a93a5cf206933d1984202b"
+  integrity sha512-qth055QTs31x/9XVnjFHiOsvNpYAquSqr20mwYXEOOcjjayl5QTtLnsOEnPH5lffo14k2P/Egg3AYV3Q+leo8g==
 
-"@spectrum-css/card@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-7.0.0.tgz#f029d71f82aa74eb9bca154df0d18755367eaa09"
-  integrity sha512-qcr+uZb80jfW7fwkngSNaMV9fknO9bDnMy2mtvNKrDTJXhFmqgy/zeRx2r4qJF+t81IWu0vDVEofD55qhwe7ZA==
+"@spectrum-css/card@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-7.0.1.tgz#4ec52b00adc0a2ac8476777d12a7b9c37d92006b"
+  integrity sha512-6r3q+BPToG7q+vrZ5OrgjS8183CCYUwIulj5Bcj0m8Iu0e9Zog0L2V1iIiB9lcxLOaOBDFgsb6L9U4Wa2vs9cQ==
 
-"@spectrum-css/checkbox@^8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-8.1.3.tgz#bd93f7f38672106a9838fafc0d3f727bad0c29d0"
-  integrity sha512-PJZwebTLsS1NvdpulxC1O/iVZc3TJYDj0Gk4toNY+NKwFyHfCCAX8Lm+OwUijWX/UZFK5BTmHGVfuHJckGFxDg==
+"@spectrum-css/checkbox@^8.1.4":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-8.1.4.tgz#fe7b7f975f2dbce22576ff7da06e58e73442012d"
+  integrity sha512-BYpVfY5fgE7n4QRdomDpqApdCwDlnQYAdIaxWY4KrtuaB1hILcv6vJj9le8W8YuShBC90uyTSvnjOj1ZoHd/xA==
 
-"@spectrum-css/clearbutton@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-5.1.2.tgz#f343bd28b583af33161fa6ccbc18615bbda102f3"
-  integrity sha512-FtChNsW1d7WVmVL28x+vTqj1KBmKyvikz6bLVoPSQv9bdJ61S3KOcYOuJFnPmtZInzq/+oCVnm3+crQfb4cn2A==
-
-"@spectrum-css/closebutton@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-4.2.3.tgz#6ee18d724e114eb86807b1fa2360f97203fb98a5"
-  integrity sha512-jAajndG6N+Nz/Tivo9iaPxkYMj+UTNUgl0DYlQcrdyHqGCsEGWjidDjdDW+V1DscHcOIegJFv4rdTFi/GSje7w==
-
-"@spectrum-css/coachindicator@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/coachindicator/-/coachindicator-1.1.3.tgz#d5855f8029bf62914b339f48af27a47d69dc0231"
-  integrity sha512-wUuK+FMxv5g8xV3lIJ4agVHoDDH1PHLFEeuxlLMj+oVT8uYUaqGS180jtyyFeObuWe14s6851VmN+koxQJfbMQ==
-
-"@spectrum-css/coachmark@^6.1.3":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-6.1.3.tgz#10c7de23e3e1632eaec30dc1991089f745b3d6e9"
-  integrity sha512-u93ApxEbZkNX6dcUGewQcrdYn6dgATaJAt6mmYK9jlHGdcDCwxovxjnwJCd41lMrevj3VPh6SGlqtsZIEXbbbg==
-
-"@spectrum-css/colorarea@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-4.1.3.tgz#e250a1fbb98bbd36ddf191e07a4a367969370c98"
-  integrity sha512-yqoqeQJ4HaAllfhJP80nsQ+TGhbkZsjn9NXs4nrGWfgw3W8Fnleio2mcbfCC/c+bwiqMWzvBhstEA5ew269Q5Q==
-
-"@spectrum-css/colorhandle@^7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-7.1.2.tgz#6d34224013446e902f416c247ed819cd730e2abe"
-  integrity sha512-gi8KSyH1bPzWorT640CduuAPwqUftL1mAk89+tbdIo3oCgqfdVkRSuizP+JSH5NMz8qxzlaqHMISkz1dHwVknA==
-
-"@spectrum-css/colorloupe@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-4.2.2.tgz#5df39632557d86b1125b135d25b278cf3c197043"
-  integrity sha512-RG9aW/inhnqCpkJvERCQFF8nUPPAo53ijQkTR7JNFEEX9EOYeY0cFmzHc1Eo4RR0JPhKNgORcsPtlcPUFcSb+Q==
-
-"@spectrum-css/colorslider@^5.1.3":
+"@spectrum-css/clearbutton@^5.1.3":
   version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-5.1.3.tgz#7f3de83ad3754b167974c7dc6fb269a862974a17"
-  integrity sha512-5i8yijtsxvo+Rs2i7gYR+vjeptkhWkclRTdzsJrDz7ZlwxoGBhUW0Sio/iTfrAMEpyipcxEAahgI0iJLK2ZjNQ==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/clearbutton/-/clearbutton-5.1.3.tgz#bc4d89b84ea6dc01a7739441465e3daa5292a9e9"
+  integrity sha512-+FoaOkzLOOOPbYIlMuGvNcJ4gDWThtB91Tqawu8ac0n/5FOWyXGuHrdi9z4ofGBT82+XsCW+B4hNUsDhlalUKQ==
 
-"@spectrum-css/colorwheel@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-3.1.3.tgz#6edc288e56bafa2f718ccc2c148360e0e09bd9f6"
-  integrity sha512-RYntyg8eZsiW5Hq9tVO6qS/0TpDVT1Ivb0oIXAfuaieb+uIO6ZeqtRPhLuzpDhv+OZgVpE7+kyAoXWFuyUvdUg==
+"@spectrum-css/closebutton@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/closebutton/-/closebutton-4.2.4.tgz#ea6cf1e62aabaa60122faa07898a50518637867d"
+  integrity sha512-jtYkU6soWKKXZxvcAfcnoXLeLt2PNCilkl7JCwX9ldjxb7ngSeFPMJx6x1DMlzd3jc45Ec0jZDkiqi4u5Ccyqg==
 
-"@spectrum-css/combobox@^2.1.4":
+"@spectrum-css/coachindicator@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/coachindicator/-/coachindicator-1.1.4.tgz#634f157cbad10090e796c4243b635cb258e7b1b1"
+  integrity sha512-ULDgsdIy9h12VKUcPrjLcm5QTFvxAVMZOLOmVYJ3dGNDgu0EYuuwLwow9ewOAPBTtWg6gKbFQV1PIzBKNBo1qw==
+
+"@spectrum-css/coachmark@^6.1.4":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/coachmark/-/coachmark-6.1.4.tgz#a71b3b4a9b4820868b3d1d484af4856936616f97"
+  integrity sha512-cwo2pCjpRMqzKvyU4yJx4aWgbYjDx52+xKdzKO/H0mVBOeRSx84M7z6CtXSkz7pVwVD27bDZn+rdsKo/u7Y+BA==
+
+"@spectrum-css/colorarea@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorarea/-/colorarea-4.1.4.tgz#ee8f04e9ae8542ac8ace0b2ac5e0a0243b00a351"
+  integrity sha512-s4/18f2/OOhGcbj7cx4jvX74wXU0OcAgzHRLhcRtUUTAOtvHAMIuZYVppKkUTDimDZFG4Sub4IOBwdomZbNngA==
+
+"@spectrum-css/colorhandle@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorhandle/-/colorhandle-7.1.3.tgz#51c21aac6cb16d7fec4deb0b64c5282ebe06b5aa"
+  integrity sha512-9q0FCgNaAzk5OzB7GocSkSfUnaaoKtkq/HoJZ9dN4qDlaHm0H/rzHghK8JEHUFRwZXdUPrKtINez97ISplNyqQ==
+
+"@spectrum-css/colorloupe@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorloupe/-/colorloupe-4.2.3.tgz#09deb815fb3dd7c50cb2ca56a54c37edbaced5c0"
+  integrity sha512-rRqbiM5xZwQO2wnH9tCH7GNNCsi1U41Uh/sdkEbFNWK4gTMkidYPe0i7CPqd/B58UsSTj7hh+aFcOrsQKX5kzw==
+
+"@spectrum-css/colorslider@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorslider/-/colorslider-5.1.4.tgz#aad2e659ba075164a7d6bf89e2d49c5d41dd0972"
+  integrity sha512-ST4JWSm+aVsZqOjUezCNRbsKyNrCCBCFvLi6X52oW4SOdkYfAqwaqEVKirMRzMcQK9DrdNyrqc21T67EBzpy6g==
+
+"@spectrum-css/colorwheel@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/colorwheel/-/colorwheel-3.1.4.tgz#79fd0aefc16fba8a8c831e07079ce92744bba08c"
+  integrity sha512-nNn8CXP5FUzO84hEO33DLxfHp+3XTTvozC2pyepVQgEAan6QEhGCoYiV+9/tMqmELWOuTsecONWgMZ8tcBaZzw==
+
+"@spectrum-css/combobox@^2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@spectrum-css/combobox/-/combobox-2.1.5.tgz#b8a62e5094f9eb973eb6cab7079b4fcf96d1afc5"
   integrity sha512-wmgqaUmWmtLc0fZqjubMiRA3jv6y2yK+lqX0GUvqoFQjAn4DIdgtwu+GK8XHbIOF2N/i+U3BExT0NRAmaOPEGw==
@@ -5141,225 +5141,225 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/commons/-/commons-9.1.2.tgz#bd696269642846b4131a45395f8ae68d90346c4f"
   integrity sha512-bX3u6kIcJr19GuyezJ82GEZS1BZZhDorvVDRq81mvesFo5xJhGhJ1fZPAC7humgmTDPEhqgbfXMQR5gJZMS8tw==
 
-"@spectrum-css/dialog@^9.2.2":
+"@spectrum-css/dialog@^9.2.3":
   version "9.2.3"
   resolved "https://registry.yarnpkg.com/@spectrum-css/dialog/-/dialog-9.2.3.tgz#ed3b8e9167ae1e85de91ff19af5f87c2b7db7668"
   integrity sha512-f0IeXXsTg4E6gDosPXh6xoRrG0RmXSTtxwnIPER8K72UijTohA8fUJYXTdLncZopEPGaG3Dwrpzlke1aR2ZLuw==
 
-"@spectrum-css/divider@^2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-2.2.3.tgz#bc42a2450d5e3409a6d6d572187521e9b47cb935"
-  integrity sha512-Zhe2Mrs8v7gOsKyEfeu9a8HF8Lhfitsavovw23xo4OdqrQZYPIpgk+ky+SAAH0n5x/Mm2hhmu60w81ys5EK16Q==
+"@spectrum-css/divider@^2.2.4":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/divider/-/divider-2.2.4.tgz#219101f425704d00abbf8900b382038db84b6fee"
+  integrity sha512-Te3tR/AcCaro3T47RoVvxoR0HqSelEGnyOX/vuxa2edXDVFPVmIKvOzYkd7/+etCzpYg3+EbyxS0h8LMK8hgBA==
 
-"@spectrum-css/dropzone@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-5.2.3.tgz#2eee899214a7ca45238ea7024896a3c48807d327"
-  integrity sha512-ujiJgaIG2KE14iBNdasUKoaTY2dRfDPRBk05ouRVHTBemLwuySTpGFXBr69Z2ASyVgJS2dsG6iZlaPdVJhRfmg==
+"@spectrum-css/dropzone@^5.2.4":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/dropzone/-/dropzone-5.2.4.tgz#12a9e0bf58965aec34613dab4ba4c22bdbc46ca5"
+  integrity sha512-smNmkIVfJwX01xeikbgahW5kjw3tn7WXV+ee19LrMqUBHuqQIfvo6Qi5xPJmJsmPIT6DoMj/aYVOdXNG0AjwXA==
 
 "@spectrum-css/expressvars@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@spectrum-css/expressvars/-/expressvars-3.0.9.tgz#72678e0845c240bc9cb6b4d828f20806810f4cab"
   integrity sha512-mnxdnF2NGNdba+3OomwFURPG0XqNRD+S2cmX0ARYnia9lv84HpzhbSoGuqmQO4+4+dXe46zYjnKRe2L8oJM/zw==
 
-"@spectrum-css/fieldgroup@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-4.2.2.tgz#37630e483c2ba2b20a422d122a732b5af9c336b5"
-  integrity sha512-hHomsvdofIogXHsFJt5VsKrF+PRKWosWFmJEafRJtYBNb0Y2qEMexmEMd8ccj02XyRp2AbgIwl68PlaWmRwfcg==
-
-"@spectrum-css/fieldlabel@^7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-7.3.4.tgz#62462633460f12b934d6aa50a452ccb9809ba83b"
-  integrity sha512-hPs3SUCeAu3nwVD286GY4tiPJvc9MGdlS4xkhsCxAJWMEOYxu1j59yXJQkbaIKZojHPz+9qKplrGERigosTTuw==
-
-"@spectrum-css/helptext@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-4.1.3.tgz#ab333d78910e6b65c20e12304ae366dd8e740d2e"
-  integrity sha512-ep+FwIeoi5Xy11RAlJMWhrnuUIE7cyLGTxyhMoDVkQbAKjtsdhOtFHPnbl2AdQDnSm19Bsbh5114zir7+Ld5qQ==
-
-"@spectrum-css/icon@^6.0.3":
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-6.0.3.tgz#b14dd7bc7a01bba60651e4e4b364105015a43ccb"
-  integrity sha512-BC4VwXW4+cqKK0KAtiIc2KOHkjDsV6frWxGCa1zgZSpKfUpo43Qqy24XaW01Q6P8jk3mm25bKcih+bnkOjU5lg==
-
-"@spectrum-css/illustratedmessage@^6.1.3":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-6.1.3.tgz#af40c86f3cf956b05992f88ebaf5ff0c31452711"
-  integrity sha512-rQtlRP197VkFsv8PS9vPjsiTRUTFI3yr2huEIcoo5RgcIbm+yfuOc1+DMl0a39jmAsFoeaOb2QkLPR0BmvBB9A==
-
-"@spectrum-css/infieldbutton@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/infieldbutton/-/infieldbutton-4.2.2.tgz#4513fcfa5abc955852b7aa3ed5c05c9140596edd"
-  integrity sha512-nZ8oIV42mWrLSffjWeekyROh3ub+5A5Ud+kXLnHEge6SNveb9h7GTYcfhLiYtYFd2C05aceRLY6KRGjyNqEcbw==
-
-"@spectrum-css/link@^4.2.3":
+"@spectrum-css/fieldgroup@^4.2.3":
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-4.2.3.tgz#0d9d2147d6aadb7f7ee8ed62c54f751c73e77df3"
-  integrity sha512-TjRo0tWhcXSr7Oqmi4qJD0sxBfIJ6uErbhl45qg9Yxee39Dxmcgfne7DxyZZHGLBfWjHEJZsyMsvcHumlcXkWQ==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldgroup/-/fieldgroup-4.2.3.tgz#8578fffbd82ca4b7071e471ead77aa59ee2d6887"
+  integrity sha512-nRQ0AAUfFF2qv9vqLljSQyTY0p1VrMq5xe60XLcZdlQmAbGdHo39YSsiBZGd6MCgk+n5RESqY6S71X1KFznioQ==
 
-"@spectrum-css/menu@^6.1.3":
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-6.1.3.tgz#78fcf7822dec407a6b7ec938a9b1a2bae01adc6e"
-  integrity sha512-CfmqhMyRgCCZ1iSN4tBetUFIiDM3dGFwaOgiVVVtU6pRaUSP5x6KVDjAgiQQPn1oczRFk4wRqDmwhS7zua/JmA==
+"@spectrum-css/fieldlabel@^7.3.5":
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/fieldlabel/-/fieldlabel-7.3.5.tgz#e595a626d99c76d3d4c323c8b1fe46250a615024"
+  integrity sha512-SPBW1lKqLcFBrvFuja3mLnaAcDSmTGd7wDlqeyyEDK1ino7SBftDk38YA/xStt59QT4Rs1oT/Yev5IiUT2lGVg==
 
-"@spectrum-css/modal@^4.2.4":
+"@spectrum-css/helptext@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/helptext/-/helptext-4.1.4.tgz#302dc35b83bd2ebafbeb22ce61ec4fdfe5c774a9"
+  integrity sha512-gxgzH3svB9p9hFhW7Ff06poOcf+blSlkgIATpZzFWEkoTNI1uTuJhm9MW1I8MFRwQ4CJ0uv3O4gRyN0BpqTU+w==
+
+"@spectrum-css/icon@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/icon/-/icon-6.0.4.tgz#9c2d0ef45df7ae17d652d4fa774bd30e441ceea4"
+  integrity sha512-JDU9y1pEbUsNnJe6CyxCrxoklGQeECG5kmXu22ixPpzYwQBYQANV/AdoH77GD+bNbJZunyVjJVdySmaeNQkTiw==
+
+"@spectrum-css/illustratedmessage@^6.1.4":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/illustratedmessage/-/illustratedmessage-6.1.4.tgz#e806ab82e13ec6195745ab1320ced3ec3e6de324"
+  integrity sha512-KQv6dJlo+xTHi/aASey8u7JAixK8PzQQ+LeYi6eIZsvUrNpGoAqd4zW+5diGIrfC0k2ygxBRtLlZpexCxgg7+w==
+
+"@spectrum-css/infieldbutton@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/infieldbutton/-/infieldbutton-4.2.3.tgz#0a8cd02f19da0e208ffa6d274e67f4860e47f89a"
+  integrity sha512-yxOLsMFKCQZ3rVPdDpIKoPqDHpQBUUtNu8iC0DQuAhiWAe9EKS6m2gpOhhgHrYoKGrvfXUyswNrLeokBToq6+w==
+
+"@spectrum-css/link@^4.2.4":
   version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-4.2.4.tgz#abf846ccd5b9b5ac4c942e21c0c2f7573f0cfb3d"
-  integrity sha512-Tn0NAjRvXFgY/NKYmNFpL8DXKTxmtbfkgadylntQ9AMhilqrG+8rVqXVj+kSuT7Pt/9Fj+iqIIpoz0t3TuRFgw==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/link/-/link-4.2.4.tgz#63266932e3fc9dad19bde4eb52c4a122ac085075"
+  integrity sha512-nzzXDP29r6RaNR/eZLjQvf3UGHzzUSYeam/jde/Jzei0h+YFMHtGPfm/LoF+lh0Jz4DQBtFBxWCkY7+MsGEZfw==
 
-"@spectrum-css/opacitycheckerboard@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/opacitycheckerboard/-/opacitycheckerboard-1.1.3.tgz#8c9a9a11435be2131186ce5b00b4bd05358ebe53"
-  integrity sha512-59mtvOKN54SNwp/Q/ItaPaBs7IuRkLngyFIgt72Mp96xl7sn2973IaGYkq05YuEPOunAYaWMK/tvZcJRRBFkFg==
+"@spectrum-css/menu@^6.1.4":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/menu/-/menu-6.1.4.tgz#98e9b5f52613f2ce9db02e6fa17b67fd190b0708"
+  integrity sha512-2JAh+/g49QZ7+GDVLU5kbfPn34U7t7Q+E+akSgoVtGvzay9gC2XVzOxS05da1LJB2/1YJk0mu8GmlIlD6Kyw4w==
 
-"@spectrum-css/picker@^7.2.5":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-7.2.5.tgz#7204812d49695328b5e0be2c3bebed9ed9dad271"
-  integrity sha512-ZEr4Bn2iwbTdIfZ/X20bm8RgF02RR20wVQ47qvGMMS669nO/bNezhHUZIsj7EgcnLeiUoXNYSGNPJS/pbQoKjA==
+"@spectrum-css/modal@^4.2.5":
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/modal/-/modal-4.2.5.tgz#aadf0546faf96dfcd3004aed4614c72cb6f8fa43"
+  integrity sha512-mggvg34OiYMO9mvMlzEvrU0mMgK+U2V0wVjLSe8IO3pcxKbHQqzodRyJyUTLuDzgSKDMK4BMmaAhuUZtasSSKw==
 
-"@spectrum-css/pickerbutton@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/pickerbutton/-/pickerbutton-4.1.3.tgz#99d15e8f37321f45f4e12cbc56d07020c9cb1235"
-  integrity sha512-W4nH9fccisD0ABG7sMyIBClczPOAMRHa3P08Pv2oHFoCU0bDUzrdEjEvS46l5QP9EWR4iTNxSilJZqMZuzq5kg==
+"@spectrum-css/opacitycheckerboard@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/opacitycheckerboard/-/opacitycheckerboard-1.1.4.tgz#cef7aeb8509e8f1728aac9c2bc6c5548f01dc0c3"
+  integrity sha512-5M2lS0EK3FXGPYQx5U+IZhkodu8ogj9p2VXGFolkFsUG1an5BbbPyKG5Bf8SVq/QKZ8BXUtBsvWLSL5Ra+9CXQ==
 
-"@spectrum-css/popover@^6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-6.2.3.tgz#aaafbbc330c0675778e0b43abf1fe6768b60d571"
-  integrity sha512-H9AEYhca7xk2yw1S1ZwgSAydZflE/JD4En+FAA4SFG7/GOu+woz2K7vmMudalvhk/DdcsdTKE3NSptf7sFyJTA==
+"@spectrum-css/picker@^7.2.6":
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/picker/-/picker-7.2.6.tgz#1f911a04fb4794e08b0a7c1b71f98b0f7395a78e"
+  integrity sha512-EIzJCYGlobZCNsuwJGzZ1o0oiQh+DclJeIJjFCXNFm7b6mxWkO1VNbV06WOmRXujVmoUomkUJlRYAd2Km46zGQ==
 
-"@spectrum-css/progressbar@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-3.1.3.tgz#b29118b362c6fb08d01f6ed73c2961d3c0b34b20"
-  integrity sha512-F4xwGAa1/NvrwtCypxSBS3INBSxQu0P8vtadVUbT0Vmb/Bme8FdFleAV5NppFNY5pot7ZFeZYSmJS709gnhFyQ==
+"@spectrum-css/pickerbutton@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/pickerbutton/-/pickerbutton-4.1.4.tgz#f74055ac187166afeb5caebabe4ab2079b8a81ff"
+  integrity sha512-H10lb/eNv66sqxlmaMfZrvOmtnTQ47kipGi9lsM4bEJirVK3AMMdnlr9d2f6oIsV1sm2Jop+bBcz7Kn3gOq2Rg==
 
-"@spectrum-css/progresscircle@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-2.2.1.tgz#4c97a244b65e2269a855694929db1f04e8e10a8d"
-  integrity sha512-wqEnuZGstGGzG5Ilx9jRtZtq6JB2f7Odo/7u7cbYoVd6mijL1pGLVjujxmRa3RnxxccEswSRD6mWZlurciDGfA==
+"@spectrum-css/popover@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/popover/-/popover-6.2.4.tgz#ee528621bbe46371ab8347ddd1bf6edd4eb468cd"
+  integrity sha512-k3UUuIV6MGk7pCJYIa3bmFlP9bUilsZjVJvVO1Sxrrf5VzckHQf6y+vDKn+KKbGqluU0dZTXq3CyzyhBX6OfMw==
+
+"@spectrum-css/progressbar@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progressbar/-/progressbar-3.1.4.tgz#6ddefad16bd91afd21f30448308c70821a3decbc"
+  integrity sha512-MtIyTd2CBuYPt4vaixkyIT8WUvBMuU3dnQR3LUHCoRZgsAs94nMc/6OsrRd6yRFhD4c77vOdOa0sfyrqLfZhFg==
+
+"@spectrum-css/progresscircle@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/progresscircle/-/progresscircle-2.2.2.tgz#2d4fed36fd3fe71be5e48f7e5aabfe78f029b88b"
+  integrity sha512-X5lml85Jv3nZ9oagnxKERiA2N0HRxXl+kSiMvvwyeKcUk/4fOtukhkuPllLvtbZxDXLU5Qy8maiWJ/P3rivovA==
 
 "@spectrum-css/quickaction@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@spectrum-css/quickaction/-/quickaction-3.1.1.tgz#1095cc68b6e182721aa141d490b79f6ed6ca1d6d"
   integrity sha512-PCp/83ctAWrYlDYjZU+9vRMLte2GBaxiKOBvm1g9UH0XqTvocjlyVRNIvVbE0ywdefVtbKGFr30x+Yk9HTdaRQ==
 
-"@spectrum-css/radio@^8.1.3":
+"@spectrum-css/radio@^8.1.4":
   version "8.1.4"
   resolved "https://registry.yarnpkg.com/@spectrum-css/radio/-/radio-8.1.4.tgz#f41bf9a50841e36cc344dd44b80227c228c8b9b0"
   integrity sha512-2j2mMm3VPKr/ayFUMtjuQKrcaJikwW86w8RAkax4KVppuOc3DUng+lYfYTJkd5b6i02ohhJx7n65/dicoOiTdw==
 
-"@spectrum-css/search@^6.2.2":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-6.2.2.tgz#4524c137123d40f0ba2427100e122fa3002dacfd"
-  integrity sha512-ftgywv+h1IVlF9V6/P5iDMNVN9Ya6pNz7HoWYI4Ma4Vg4LJeG1pTuSuDzhntzwK5S/n7/8MEn/yCsDSgSPk3RQ==
+"@spectrum-css/search@^6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/search/-/search-6.2.3.tgz#4f7e5cf5ed5ab231a41331c6731d230c543be2ae"
+  integrity sha512-9qPrVWqnWcmfefhJdOP5YetwEriJj6OHQIfxQy103st2DCz92RpXGj6wZ4g6iH36I16qO+hqRZqyuc8D/IqYMA==
 
-"@spectrum-css/sidenav@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-4.2.2.tgz#66ad7e64e2915e1e9047f10dae798297e8293d1c"
-  integrity sha512-OltxkBOjJXPl8PmCwDUp4EKsjhBgl8+iG8smQkatPnJejcVwn32whZMOkc5ZGl9Hf9imRcZopubbyYh4kbYGNQ==
+"@spectrum-css/sidenav@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/sidenav/-/sidenav-4.2.3.tgz#67006138077886eef74779643446ecd37629a70a"
+  integrity sha512-L3VSoslDJI+LEsjoATuN8B/jLL5tEgAsjHY3OdjbOcOltO2dj+dNvkx+5Kf9u3Fzer57jN14ybdIFfoQZgfwSw==
 
-"@spectrum-css/slider@^4.3.3":
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.3.3.tgz#5eb8b8e762b4cd6ed46e0e585af2dc7a40ca32db"
-  integrity sha512-jlm6kuTtXi+XH9F1ia5y5jzYAyYBCsitIxmHsfPRKJAAKb0KfO4O3IFl6g+Sy5f/ujES2j7UStAJrqjWFMcudg==
+"@spectrum-css/slider@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/slider/-/slider-4.3.4.tgz#397b680230ace9d86e4be71063ea69356aa9407c"
+  integrity sha512-tumGbh+iOKk/2IpKPVn5YBKfWubeCOTNY12sSrMU1KvCQkKrQfHuVtb4TxbZweMmTIsnkTKLpmbKd5rje7mfSA==
 
 "@spectrum-css/splitbutton@^8.1.2":
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/splitbutton/-/splitbutton-8.1.2.tgz#149d9e98094cd035f6f348f8cf50d72ce8f17f19"
   integrity sha512-hUsqhEhgm8PfKvwKPSACPU+Jqt0NaovD53gOp9QRa4jU9G3q8RpE5uJbs+pGZ9vyI6ocsm5lbs0zYtA082axzQ==
 
-"@spectrum-css/splitview@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-4.2.2.tgz#90b7f182a22dc60751dd13d857b88a63ff0729cb"
-  integrity sha512-TnjY7+FUi7ayErxZsZf+GnBto8aBsGxPuBt1D6X9E4GoSgtLvJAOyryrLRNFt3sW8z4ukJQ1C0AjxPh2K+ig0Q==
-
-"@spectrum-css/statuslight@^6.1.4":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-6.1.4.tgz#764c40db1167b14e01ce39660db2ac8a01a2caa9"
-  integrity sha512-ingEVSPsPVxYRpyBWXlVvCBMCpGboNShYuRYv6FmSjJpri8R059EH69T1WAKvA3Z/GDG1c+KF4Nm89LhXCnbBg==
-
-"@spectrum-css/stepper@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-5.1.3.tgz#102cbc4b9296054dd32b201e2e8da3ad4904b596"
-  integrity sha512-hyvbMxc5Px9FBJjq2kNWpSqRHy6R8PqoSA/ez4LhRaNnoakIKuQ9sJKNj0dXWLB1OBtMnzbWgj7Dn41lE4xzgg==
-
-"@spectrum-css/swatch@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/swatch/-/swatch-5.1.3.tgz#dddfdfff3ceecf941d51660c048d5fdcf98652b3"
-  integrity sha512-LWwTsi3eZoI1x4+HpyCu+IpZ08zjebhDFSzAVNZ2Irp2zmcI6xd/6l4HYlHUCEl2ojEYVhj7w75YkSiO3TibWw==
-
-"@spectrum-css/swatchgroup@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/swatchgroup/-/swatchgroup-2.1.3.tgz#e68093a76863ee2bebb115234c8558cfbd34aa96"
-  integrity sha512-iH+9iOlMv2hOueNJFGPm7Xm/sw1nj6MW8YjaF/5SqyDjDwwDozBsiX6NiqiCuWqRbuZVQ6ab4w78SUBJbfMnFQ==
-
-"@spectrum-css/switch@^4.2.3":
+"@spectrum-css/splitview@^4.2.3":
   version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-4.2.3.tgz#aeab1c21ba41c1f3bcf410d989c6de67e4482882"
-  integrity sha512-lqOKLHB/0zGOLsNUOEhsom5eahiOTidOiAXIEastG25xw5oeGHSv4UuRsSIwGKx8kaVBHyOyoAUDBNq2W4b0LQ==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/splitview/-/splitview-4.2.3.tgz#667a3b4bb335f2645a2b8b4f536626675a564065"
+  integrity sha512-EoKbfgmjnKFe88IsWWBFb3C5Ilc1WZKADadyIG6gZfF2MDERKi+NEiYltcZkNOcb/A/KYN7eN+Eu2UYWDz3BqQ==
 
-"@spectrum-css/table@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-5.2.3.tgz#4702506274af95511bc168b95d3ec9eb93a1588f"
-  integrity sha512-nE0tmU9MRgKrKtk97gPXCv2ZpnkBuvh1UCiBe08g4aURUeTCH9xcRH6g95WCTOyIhUuvaTTcJM5Jwlaanctmwg==
+"@spectrum-css/statuslight@^6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/statuslight/-/statuslight-6.1.5.tgz#0910878e5a73ba8213aca527b0a4d4a9a0efa0ef"
+  integrity sha512-FHPYHKsA6O11NHk9sOstPSHNEPcxS/qs+ZkRaxNnRnDhPkC148lqU8O8EDvkTcD9OBnvuLB1ik5m4ksCV6nwpQ==
 
-"@spectrum-css/tabs@^4.1.2":
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-4.1.2.tgz#6a24ad6dfd0e4915f589674447d5da71d61ecdb4"
-  integrity sha512-TAYMlzv7+tJ31d23G59T1Pqw6wXy0VgMDXCqjUEpwI4R/OO6tbTl7ZJYl7ldwSe+yuNTIe3aoSvI8zmjg0G6bQ==
+"@spectrum-css/stepper@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/stepper/-/stepper-5.1.4.tgz#00d4cd552a5273a8b5a985839bcfae106593ce25"
+  integrity sha512-MBp+GiroBdDYA1QcqkQotBi7hihT/UFVHeFPiMPHZsEt/gHNKsBNmvN2QU2ElNY1Bl+tPZ9dKLyqOCmAla1TrA==
 
-"@spectrum-css/tag@^8.1.3":
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-8.1.3.tgz#834676f95490ad73bb13b3232651df78c9743777"
-  integrity sha512-MAAbOvaL9SvIJjbkIXN6Wex9tdrxh5VtjHzHGjJBKRFk6gOiVverbYkmfKqqmpP1XdoaIVz+BqKotUY/fMj0Kg==
+"@spectrum-css/swatch@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/swatch/-/swatch-5.1.4.tgz#c3d4b10c1247c8475f5cebc2ac4377b4cffaa351"
+  integrity sha512-cGlBcWmnucH99cDEnz8BAsnDbmO/H2MUWXqRuUpqvkb/GEIfTg/XDflmIJndTvAcUe7Yf00WR7YG7Pow4BT2dg==
 
-"@spectrum-css/taggroup@^4.1.3":
+"@spectrum-css/swatchgroup@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/swatchgroup/-/swatchgroup-2.1.4.tgz#7166b23e4cf70f63e6915b74e14cdea21a3e75bc"
+  integrity sha512-w7U6yZ8aS+MHBQ8bVFq/ZsnVSgRDXbNn6GoXnSUWNQ0ClO+WjsfXcXcgNtwG/vQlpv79uZxMVebBmsvu1xWYMw==
+
+"@spectrum-css/switch@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/switch/-/switch-4.2.4.tgz#a0638d437ad71c94ecd5f5a43e9d347a232d5ead"
+  integrity sha512-z9bnVUJJ5Q7C4U+EbdpSbcQlAp4ixnBHfF/6NbhsWDrTpm81QMDncoxporosCRcbSqK46oHCHgZT2EM2WGgAnA==
+
+"@spectrum-css/table@^5.2.4":
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/table/-/table-5.2.4.tgz#6213922a8968cc095693fb1eb42696f27b9780aa"
+  integrity sha512-TxR3lbSgwqI+zDIRivkGjx0r/c81KNyMRUqCSlJUs1+3gya4m+w+qx1gNEKbk7VzMLM06UomqGnSQIvBiWpBUw==
+
+"@spectrum-css/tabs@^4.1.3":
   version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-4.1.3.tgz#ac71d71505f6b6e9630e32515093f205880c20d4"
-  integrity sha512-PBH6gGDOGhADbYe3h3mavgo8dqAhLd3Ci1wuk0XUyZUvgxLYnY/FnSj4HKyihKfO1IDaWL5FAJdSgOljen0Mcw==
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tabs/-/tabs-4.1.3.tgz#0be90f57ad782831117b869d02dd1a643dd2035d"
+  integrity sha512-Pg3vmN/Bq3yfph7l/QlMqnxjweZQJZ5dqVpXE9HC34cbCfKBxGJRyzKcn283XgUWYtyFbn5y6UXL2r9V/MEzwg==
 
-"@spectrum-css/textfield@^6.1.4":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-6.1.4.tgz#386541c6a90b55a23a49479eb1f1afd5793f8e42"
-  integrity sha512-HZAW4fpMIZCwBvq3ZAQ9t6ZnnEWHrDYAKscDe+MPe5a59VARSqUJ1zmnIkLWnmdA87eEMs0V22EUPrlXnbefMg==
+"@spectrum-css/tag@^8.1.4":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tag/-/tag-8.1.4.tgz#7981c77157fe3dcade58c902b0c2cd0d798f4984"
+  integrity sha512-4ABunHk/gmJCpc2Ob5XYFU+fP5G28nMsEj5oZsFVcN7XXZFOVaAkLuqhVoODF13CYLz92WOtx7cIujeuioL9MQ==
 
-"@spectrum-css/thumbnail@^5.2.2":
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-5.2.2.tgz#fb763eb6b02f5d3cee6e7ab1d7363a3df125063c"
-  integrity sha512-CWtW2iFI082UdQfWlFKaDo28Mpc0a1bhXzq+Ipaftq3JLJJXXRgQmeuYmTR5IQ2jVY8fRh2SWP/wJL2hVliw3A==
+"@spectrum-css/taggroup@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/taggroup/-/taggroup-4.1.4.tgz#ced8a2ec1ce06e0e6181e8a89fa20cb87eb2a124"
+  integrity sha512-sxwymZq4QUvkTgKhljzApxMm+KIlRh0EIxl1q/xfe9Z5yOD5npukW2LXiAJi94/nGEe+vxJssuY2QBLo7UeWLA==
 
-"@spectrum-css/toast@^9.1.23":
-  version "9.1.23"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-9.1.23.tgz#9790d9aec0e44b2913094162e1176203a1384cf7"
-  integrity sha512-aNtg8YpSLaAaHt1FjxxIUU7JHq5ru3/p4aRVXJgqXk+sJJMmkH6Fna5HW39X5eafwS779OXuxcXPJF0A1W6lew==
+"@spectrum-css/textfield@^6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/textfield/-/textfield-6.1.5.tgz#7e35023bd14c342fdeb425b5b69086fee55b10e4"
+  integrity sha512-FT79IlHeMlZoxUlD+MxdvrvnfzI0sZZ63sT5c7HDuFFZAToxrZe1fDWVxRVmowMEYv0Yj30YyamYEdoqAOojOQ==
+
+"@spectrum-css/thumbnail@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/thumbnail/-/thumbnail-5.2.3.tgz#ca9eaaf05d8b8b8306ca9dc861c2c2949017be69"
+  integrity sha512-KOncjjy3q0kBAffb3M3MdP7PpTlTlxWv8ccGfT37aTmFmT52rqssKsJN3lI0bLdF6PpsR7S/aFP6DZUyNP4Dwg==
+
+"@spectrum-css/toast@^9.1.24":
+  version "9.1.24"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/toast/-/toast-9.1.24.tgz#43125bb1030a9456e4c957c5fb992beea86ec7c1"
+  integrity sha512-AFJXkTNhNpcBb/rKvftWWa5fLhIQIsBtNUVOCZPZ9e4E41zPs5IgtI84ARZGFyC66a+ySTAt6Gp4unLyR2cAug==
 
 "@spectrum-css/tokens@^13.2.0":
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/@spectrum-css/tokens/-/tokens-13.2.0.tgz#db41a16ae5554b9cdef591aba0df6ad7f75e74da"
   integrity sha512-w1JJbbYkIeQjvsogOO1rdePuikmLaOs69+bBBL80Nb3deZUssrZE9cWOrLTv1iNzditKtn4pgrtdVXv3+Wp6SA==
 
-"@spectrum-css/tooltip@^5.3.3":
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-5.3.3.tgz#33699a60c2085705d8c6c50ed7b2b25f562df3ba"
-  integrity sha512-hph/ugc8H5fAdUYj+CpDQBil0VPjOqmf0Tx4+6F5b9K8iuzeGulaorroHARPQMxbuTfD8d1qLKonnf+Wb9J+3Q==
+"@spectrum-css/tooltip@^5.3.4":
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tooltip/-/tooltip-5.3.4.tgz#1190b86dc9ef355f06bc0da520752124070bc7cf"
+  integrity sha512-xJsn+ix7Jd2VcRsRIRQd7wLf9F4p1XEgF8fsZcjYt4FeuGetSlz0+GuFdhb9ocQbWTUIa0jYayLFxM3Dle0+SQ==
 
-"@spectrum-css/tray@^2.2.5":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-2.2.5.tgz#02a28e8206a30fc48b01478ca0b06d454425b50e"
-  integrity sha512-E+I+8xj4Ebo9cN3wGYAX4bsGi1afKDxe+j7Utj5NdThlrbGErqCghbHxNtAPBxkmcuR1zbHA3xLDBH0HNW/Yjg==
+"@spectrum-css/tray@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/tray/-/tray-2.2.6.tgz#4467e493dc46501cf42c0b288e19659738fd3abc"
+  integrity sha512-k+uu7M6Y1cuuq7E71uWx2d3+QqYUqVLRXgf+Ai67B8vQzffzkRyzFUaqWf5FXiIvhjs1wgYsKgFW/rKcwUPgOg==
 
-"@spectrum-css/typography@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-5.1.3.tgz#1ef3e0743bc09bcefa5ca1f01d691c2df8049979"
-  integrity sha512-rOlqSemH++xQoigvQ7lm9DN4TXBGGDBgozS9DQQ3tHStzYp5KbDbae6ZDxfJjfFyzLpcoLr8Sx8CBn3ii0Fwtw==
+"@spectrum-css/typography@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/typography/-/typography-5.1.4.tgz#293305027368f39a366ee77c9a8f9fa990f5ccfe"
+  integrity sha512-09qn4n933GLPjO1G3dGhhA780wfbR4+k0/ktpZQDJRwQxpSwA3BINILnYYKXP5uuXWPr2o8FH1LYg7psj2caWg==
 
 "@spectrum-css/ui-icons@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@spectrum-css/ui-icons/-/ui-icons-1.1.2.tgz#596e10c662de2b3a2142277998be5e11faf6aff4"
   integrity sha512-rD0EOdabyUJ6pjfvh9eiGlvhk2huhaah+AG8Utzqh/+YgMCn+NQEUz2zxRo9Jva8GXxORLGLDtISafHguOtiOA==
 
-"@spectrum-css/underlay@^3.2.2":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-3.2.2.tgz#c711f63691bfb905c53e9ce6991819a9a78a057b"
-  integrity sha512-haOfpO9Cq4PJUF8Pk0r173beHGQtpoE/MbXpjTP6lDtmXCYRm//BQye9JpfAWpIksUvPAZel7n6VOKSp8JZdIA==
+"@spectrum-css/underlay@^3.2.3":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/underlay/-/underlay-3.2.3.tgz#e30beb2463cc22ec2440835ed71bf2ef4e80f4ae"
+  integrity sha512-TgCtNp+FKyPrOm+Lrw1doZZ/2OfgHIEZ9nHQDodTgHuwerV+lBKSkY0WN0dP059Kk2kG/bSPGqyQ0FX3zYXRoQ==
 
 "@spectrum-css/vars@^9.0.8":
   version "9.0.8"
@@ -5367,7 +5367,7 @@
   integrity sha512-rGfd7jqXOdR69bEjrRP58ynuIeJU0czPfwQvzhtCzg7jKVukV+efNHqrs086sC6xutB3W4TF71K/dZMr3oyTyg==
 
 "@spectrum-web-components/eslint-plugin@file:./linters/eslint":
-  version "0.41.1"
+  version "0.41.2"
 
 "@storybook/addon-a11y@^7.5.0":
   version "7.6.17"


### PR DESCRIPTION
## Description
Upgrade `<sp-asset>` to leverage Core Tokens.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://spectrum-css--spectrum-web-components.netlify.app/components/asset/)
    2. See that Assets displays nicely
-   [ ] _Test case 2_
    1. Go [here](https://75cd930ee90b08032bd8a1c934b3cb65--spectrum-web-components.netlify.app/review/#CardStories/quietFile.png) (and other `large` results)
    2. See that there is minimal position updates and color updates depending on theme settings
    3. Specifically the overall visual delivery of Card (where Asset is leveraged) is no changed

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.