### PR TITLE
fix(table): adding missing aria-labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 686fa6e78586a47ae3fd13d4171392ca5aa5d42d
+        default: e99871d87b90a16154530b82506d8a5a6665075b
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -163,11 +163,11 @@ Event handlers for clicks and other user actions can be registered on an `<sp-ch
 Checkboxes are accessible by default, rendered in HTML using the `<input type="checkbox">` element. When the checkbox is set as `indeterminate` or
 `invalid`, the appropriate ARIA state attribute will automatically be applied.
 
-The `label` attribute value will be automatically assigned to the `aria-label` attribute of the checkbox, providing accessibility support.
+The `aria-label` attribute is useful to specify a label for a checkbox that doesn't have an explicit string label.
 
 ```html
 <sp-checkbox
     id="checkbox-with-explicit-label"
-    label="This Checkbox has a custom label"
+    aria-label="This Checkbox has a custom label"
 ></sp-checkbox>
 ```

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -162,3 +162,12 @@ Event handlers for clicks and other user actions can be registered on an `<sp-ch
 
 Checkboxes are accessible by default, rendered in HTML using the `<input type="checkbox">` element. When the checkbox is set as `indeterminate` or
 `invalid`, the appropriate ARIA state attribute will automatically be applied.
+
+The `label` attribute value will be automatically assigned to the `aria-label` attribute of the checkbox, providing accessibility support.
+
+```html
+<sp-checkbox
+    id="checkbox-with-explicit-label"
+    label="This Checkbox has a custom label"
+></sp-checkbox>
+```

--- a/packages/checkbox/src/CheckboxMixin.ts
+++ b/packages/checkbox/src/CheckboxMixin.ts
@@ -45,13 +45,6 @@ export function CheckboxMixin<T extends Constructor<ReactiveElement>>(
         @property({ type: Boolean, reflect: true })
         public readonly = false;
 
-        /**
-         * An accessible label that describes the component.
-         * It will be applied to aria-label, but not visually rendered.
-         */
-        @property({ type: String })
-        public label?: string;
-
         @query('#input')
         inputElement!: HTMLInputElement;
 
@@ -78,9 +71,7 @@ export function CheckboxMixin<T extends Constructor<ReactiveElement>>(
         protected render(): TemplateResult {
             return html`
                 <input
-                    aria-label="${ifDefined(
-                        this.label || this.ariaLabel || undefined
-                    )}"
+                    aria-label="${ifDefined(this.ariaLabel || undefined)}"
                     id="input"
                     name=${ifDefined(this.name || undefined)}
                     type="checkbox"

--- a/packages/checkbox/src/CheckboxMixin.ts
+++ b/packages/checkbox/src/CheckboxMixin.ts
@@ -45,6 +45,13 @@ export function CheckboxMixin<T extends Constructor<ReactiveElement>>(
         @property({ type: Boolean, reflect: true })
         public readonly = false;
 
+        /**
+         * An accessible label that describes the component.
+         * It will be applied to aria-label, but not visually rendered.
+         */
+        @property({ type: String })
+        public label?: string;
+
         @query('#input')
         inputElement!: HTMLInputElement;
 
@@ -71,6 +78,9 @@ export function CheckboxMixin<T extends Constructor<ReactiveElement>>(
         protected render(): TemplateResult {
             return html`
                 <input
+                    aria-label="${ifDefined(
+                        this.label || this.ariaLabel || undefined
+                    )}"
                     id="input"
                     name=${ifDefined(this.name || undefined)}
                     type="checkbox"

--- a/packages/checkbox/stories/checkbox.stories.ts
+++ b/packages/checkbox/stories/checkbox.stories.ts
@@ -30,6 +30,12 @@ export const readonly = (): TemplateResult => {
     `;
 };
 
+export const WithLabel = (): TemplateResult => {
+    return html`
+        <sp-checkbox label="Checkbox Label">Checkbox</sp-checkbox>
+    `;
+};
+
 export const Indeterminate = (): TemplateResult => {
     return html`
         <sp-checkbox indeterminate>

--- a/packages/checkbox/stories/checkbox.stories.ts
+++ b/packages/checkbox/stories/checkbox.stories.ts
@@ -32,7 +32,7 @@ export const readonly = (): TemplateResult => {
 
 export const WithLabel = (): TemplateResult => {
     return html`
-        <sp-checkbox label="Checkbox Label">Checkbox</sp-checkbox>
+        <sp-checkbox aria-label="Explicit Checkbox Label">Checkbox</sp-checkbox>
     `;
 };
 

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -75,7 +75,7 @@ describe('Checkbox', () => {
                         <sp-checkbox
                             id="checkbox6"
                             tabindex="6"
-                            label="This is checkbox6"
+                            aria-label="This is checkbox 6"
                         >
                             Check 6
                         </sp-checkbox>
@@ -265,13 +265,6 @@ describe('Checkbox', () => {
         expect(el.checked).to.be.false;
     });
 
-    it('has aria-label', async () => {
-        const el = testFixture.querySelector('#checkbox6') as Checkbox;
-        expect(el.inputElement.getAttribute('aria-label')).to.equal(
-            'This is checkbox6'
-        );
-    });
-
     it('can have `change` events cancelled', async () => {
         const el = testFixture.querySelector('#checkbox0') as Checkbox;
         await elementUpdated(el);
@@ -408,5 +401,14 @@ describe('Checkbox', () => {
         expect(getPartialCheckmarkLocalName()).to.not.equal(
             partialCheckmarkLocalname
         );
+    });
+
+    describe('aria-label', () => {
+        it('is available through aria-label on sp-checkbox component', async () => {
+            const el = testFixture.querySelector('#checkbox6') as Checkbox;
+            expect(el.inputElement.getAttribute('aria-label')).to.equal(
+                'This is checkbox 6'
+            );
+        });
     });
 });

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -72,6 +72,13 @@ describe('Checkbox', () => {
                         <sp-checkbox id="checkbox5" tabindex="-1">
                             Check 5
                         </sp-checkbox>
+                        <sp-checkbox
+                            id="checkbox6"
+                            tabindex="6"
+                            label="This is checkbox6"
+                        >
+                            Check 6
+                        </sp-checkbox>
                     </div>
                 </div>
             `
@@ -256,6 +263,13 @@ describe('Checkbox', () => {
         await elementUpdated(el);
 
         expect(el.checked).to.be.false;
+    });
+
+    it('has aria-label', async () => {
+        const el = testFixture.querySelector('#checkbox6') as Checkbox;
+        expect(el.inputElement.getAttribute('aria-label')).to.equal(
+            'This is checkbox6'
+        );
     });
 
     it('can have `change` events cancelled', async () => {

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -873,7 +873,7 @@ For each table column you want to sort, use the `sortable` attribute in its resp
             cell2.textContent = `Row Item Beta ${item.date}`;
             cell3.textContent = `Index: ${index}`;
             return [cell1, cell2, cell3];
-        }
+        };
         table.addEventListener('sorted', (event) => {
             const { sortDirection, sortKey } = event.detail;
             items = items.sort((a, b) => {
@@ -900,16 +900,16 @@ Tables can be created to allow the selection of single or multiple rows. In both
 
 The `<sp-table>` component is built to be accessible by default. The `aria-label` attribute is automatically assigned to the checkbox, providing accessibility support. The English default value for a row checkbox is 'Select'. The checkbox in the table header will have the value 'Select All'.
 
-Both strings can be customized by setting the `selectRowString` and `selectAllRowsString` attributes of the `<sp-table>` component. Providing selectRowString for the `<sp-table-row>` component will override the default value for that row. Providing selectAllRowsString for the `<sp-table>` component will override the default value for the row checkbox.
+Both strings can be customized by setting the `selectRowLabel` and `selectAllRowsLabel` attributes of the `<sp-table>` component. Providing selectRowLabel for the `<sp-table-row>` component will override the default value for that row. Providing selectAllRowsLabel for the `<sp-table>` component will override the default value for the row checkbox.
 
-### Combination of `selects`, `selectRowString` and `selectAllRowsString`
+### Combination of `selects`, `selectRowLabel` and `selectAllRowsLabel`
 
-| Component    | selectRowString | selectAllRowsString | Selects  | Result                                                                                                                                             |
-| ------------ | :-------------: | :-----------------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| sp-table     |        X        |         N/A         | single   | All row checkboxes with have an aria-label with the specified string                                                                               |
-| sp-table     |        X        |          X          | multiple | All row checkboxes with have an aria-label with the specified string. The header checkbox will have an aria-label with the specified header string |
-| sp-table-row |        X        |         N/A         | single   | The row checkbox will have an aria-label with the specified string                                                                                 |
-| sp-table-row |        X        |         N/A         | multiple | The row checkbox will have an aria-label with the specified string                                                                                 |
+| Component    | selectRowLabel | selectAllRowsLabel | Selects  | Result                                                                                                                                             |
+| ------------ | :------------: | :----------------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| sp-table     |       X        |        N/A         | single   | All row checkboxes with have an aria-label with the specified string                                                                               |
+| sp-table     |       X        |         X          | multiple | All row checkboxes with have an aria-label with the specified string. The header checkbox will have an aria-label with the specified header string |
+| sp-table-row |       X        |        N/A         | single   | The row checkbox will have an aria-label with the specified string                                                                                 |
+| sp-table-row |       X        |        N/A         | multiple | The row checkbox will have an aria-label with the specified string                                                                                 |
 
 ### Setting the Header Row Checkbox Label
 
@@ -918,7 +918,7 @@ The following example shows how to set the label for the checkbox in the header 
 ```html
 <sp-table
     selects="multiple"
-    selecteAllRowsString="Click to select all rows in the table"
+    selectAllRowsLabel="Click to select all rows in the table"
 >
     <sp-table-head>
         <sp-table-head-cell>Column Title</sp-table-head-cell>
@@ -950,7 +950,7 @@ The following example shows how to set the label for the checkbox in the header 
 The following example shows how to set the label for the checkboxes in each row. Every checkbox of each row will have an `aria-label` attribute with a value of **Click to select entire row**.
 
 ```html
-<sp-table selects="single" selecteRowString="Click to select entire row">
+<sp-table selects="single" selectRowLabel="Click to select entire row">
     <sp-table-head>
         <sp-table-head-cell>Column Title</sp-table-head-cell>
         <sp-table-head-cell>Column Title</sp-table-head-cell>
@@ -988,7 +988,7 @@ The following example shows how to set the label for the checkbox of an individu
         <sp-table-head-cell>Column Title</sp-table-head-cell>
     </sp-table-head>
     <sp-table-body>
-        <sp-table-row id="row1" value="row1" selectRowString="Select Row 1">
+        <sp-table-row id="row1" value="row1" selectRowLabel="Select Row 1">
             <sp-table-cell>Row Item Alpha</sp-table-cell>
             <sp-table-cell>Row Item Alpha</sp-table-cell>
             <sp-table-cell>Row Item Alpha</sp-table-cell>

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -904,7 +904,7 @@ Both strings can be customized by setting the `selectRowLabel` and `selectAllRow
 
 ### Combination of `selects`, `selectRowLabel` and `selectAllRowsLabel`
 
-| Component    | selectRowLabel | selectAllRowsLabel | Selects  | Result                                                                                                                                             |
+| Component    | selectRowLabel | selectAllRowsLabel | selects  | Result                                                                                                                                             |
 | ------------ | :------------: | :----------------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | sp-table     |       X        |        N/A         | single   | All row checkboxes with have an aria-label with the specified string                                                                               |
 | sp-table     |       X        |         X          | multiple | All row checkboxes with have an aria-label with the specified string. The header checkbox will have an aria-label with the specified header string |

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -893,3 +893,116 @@ For each table column you want to sort, use the `sortable` attribute in its resp
         });
     });
 </script>
+
+## Accessibility
+
+Tables can be created to allow the selection of single or multiple rows. In both cases, the checkbox in front of a row will have an `aria-label` that improves accessibility.
+
+The `<sp-table>` component is built to be accessible by default. The `aria-label` attribute is automatically assigned to the checkbox, providing accessibility support. The English default value for a row checkbox is 'Select'. The checkbox in the table header will have the value 'Select All'.
+
+Both strings can be customized by setting the `selectRowString` and `selectAllRowsString` attributes of the `<sp-table>` component. Providing selectRowString for the `<sp-table-row>` component will override the default value for that row. Providing selectAllRowsString for the `<sp-table>` component will override the default value for the row checkbox.
+
+### Combination of `selects`, `selectRowString` and `selectAllRowsString`
+
+| Component    | selectRowString | selectAllRowsString | Selects  | Result                                                                                                                                             |
+| ------------ | :-------------: | :-----------------: | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| sp-table     |        X        |         N/A         | single   | All row checkboxes with have an aria-label with the specified string                                                                               |
+| sp-table     |        X        |          X          | multiple | All row checkboxes with have an aria-label with the specified string. The header checkbox will have an aria-label with the specified header string |
+| sp-table-row |        X        |         N/A         | single   | The row checkbox will have an aria-label with the specified string                                                                                 |
+| sp-table-row |        X        |         N/A         | multiple | The row checkbox will have an aria-label with the specified string                                                                                 |
+
+### Setting the Header Row Checkbox Label
+
+The following example shows how to set the label for the checkbox in the header row. The checkbox in the header row will have an `aria-label` attribute with a value of **Click to select all rows in the table**.
+
+```html
+<sp-table
+    selects="multiple"
+    selecteAllRowsString="Click to select all rows in the table"
+>
+    <sp-table-head>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+    </sp-table-head>
+    <sp-table-body>
+        <sp-table-row value="row1">
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row value="row2">
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row value="row3">
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+        </sp-table-row>
+    </sp-table-body>
+</sp-table>
+```
+
+### Setting the Row Checkbox Label
+
+The following example shows how to set the label for the checkboxes in each row. Every checkbox of each row will have an `aria-label` attribute with a value of **Click to select entire row**.
+
+```html
+<sp-table selects="single" selecteRowString="Click to select entire row">
+    <sp-table-head>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+    </sp-table-head>
+    <sp-table-body>
+        <sp-table-row value="row1">
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row value="row2">
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row value="row3">
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+        </sp-table-row>
+    </sp-table-body>
+</sp-table>
+```
+
+### Setting the Row Checkbox Label for an individual row
+
+The following example shows how to set the label for the checkbox of an individual row. Only the checkbox of row `id="row"` row will have an `aria-label` attribute with a value of **Select Row 1**. Every other row will have the default value of **Select**.
+
+```html
+<sp-table selects="single">
+    <sp-table-head>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+        <sp-table-head-cell>Column Title</sp-table-head-cell>
+    </sp-table-head>
+    <sp-table-body>
+        <sp-table-row id="row1" value="row1" selectRowString="Select Row 1">
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+            <sp-table-cell>Row Item Alpha</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row value="row2">
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+            <sp-table-cell>Row Item Bravo</sp-table-cell>
+        </sp-table-row>
+        <sp-table-row value="row3">
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+            <sp-table-cell>Row Item Charlie</sp-table-cell>
+        </sp-table-row>
+    </sp-table-body>
+</sp-table>
+```

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -162,14 +162,14 @@ export class Table extends SizedMixin(SpectrumElement, {
      * Specify the string that is used to provide a label for a row checkbox
      */
     @property({ type: String })
-    public selectRowString = 'Select';
+    public selectRowLabel = 'Select';
 
     /**
      * Specify the string that is used to provide a label for the select all
      * checkbox in the table head
      */
     @property({ type: String })
-    public selectAllRowsString = 'Select All';
+    public selectAllRowsLabel = 'Select All';
 
     /**
      * Changes the spacing around table cell content.
@@ -344,7 +344,7 @@ export class Table extends SizedMixin(SpectrumElement, {
             ) as TableCheckboxCell;
             this.tableHeadCheckboxCell.headCell = true;
             this.tableHeadCheckboxCell.emphasized = this.emphasized;
-            this.tableHeadCheckboxCell.label = this.selectAllRowsString;
+            this.tableHeadCheckboxCell.ariaLabel = this.selectAllRowsLabel;
 
             const allSelected = this.selected.length === this.tableRows.length;
             this.manageHeadCheckbox(allSelected);
@@ -365,17 +365,19 @@ export class Table extends SizedMixin(SpectrumElement, {
                 checkbox.checked = row.selected;
 
                 // if we have a rowheader, then update the label of the checkbox
-                // Clients can specify a selectRowString attribute on the rowheader that will
+                // Clients can specify a selectRowLabel attribute on the rowheader that will
                 // be used as the label for the checkbox. If not present, the default
-                // selectRowString will be used.
+                // selectRowLabel will be used.
                 const rowHeader = row.querySelector('[role="rowheader"]');
                 if (rowHeader) {
                     const cell = rowHeader as TableCell;
-                    checkbox.label = cell.selectRowString
-                        ? cell.selectRowString
-                        : `${this.selectRowString} ${rowHeader.textContent}`;
+                    checkbox.ariaLabel = cell.selectRowLabel
+                        ? cell.selectRowLabel
+                        : `${
+                              this.selectRowLabel
+                          } ${rowHeader.textContent?.trim()}`;
                 } else {
-                    checkbox.label = this.selectRowString;
+                    checkbox.ariaLabel = this.selectRowLabel;
                 }
             });
         } else {

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -375,7 +375,7 @@ export class Table extends SizedMixin(SpectrumElement, {
                         ? cell.selectRowLabel
                         : `${
                               this.selectRowLabel
-                          } ${rowHeader.textContent?.trim()}`;
+                          } ${rowHeader.textContent?.trim()}`.trim();
                 } else {
                     checkbox.ariaLabel = this.selectRowLabel;
                 }

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -41,6 +41,7 @@ import {
     RangeChangedEvent,
     VisibilityChangedEvent,
 } from '@lit-labs/virtualizer/events.js';
+import { TableCell } from './TableCell';
 
 export enum RowType {
     ITEM = 0,
@@ -156,6 +157,19 @@ export class Table extends SizedMixin(SpectrumElement, {
      */
     @property({ type: Boolean, reflect: true })
     public quiet = false;
+
+    /**
+     * Specify the string that is used to provide a label for a row checkbox
+     */
+    @property({ type: String })
+    public selectRowString = 'Select';
+
+    /**
+     * Specify the string that is used to provide a label for the select all
+     * checkbox in the table head
+     */
+    @property({ type: String })
+    public selectAllRowsString = 'Select All';
 
     /**
      * Changes the spacing around table cell content.
@@ -330,6 +344,7 @@ export class Table extends SizedMixin(SpectrumElement, {
             ) as TableCheckboxCell;
             this.tableHeadCheckboxCell.headCell = true;
             this.tableHeadCheckboxCell.emphasized = this.emphasized;
+            this.tableHeadCheckboxCell.label = this.selectAllRowsString;
 
             const allSelected = this.selected.length === this.tableRows.length;
             this.manageHeadCheckbox(allSelected);
@@ -348,6 +363,20 @@ export class Table extends SizedMixin(SpectrumElement, {
                 row.insertAdjacentElement('afterbegin', checkbox);
                 row.selected = this.selectedSet.has(row.value);
                 checkbox.checked = row.selected;
+
+                // if we have a rowheader, then update the label of the checkbox
+                // Clients can specify a selectRowString attribute on the rowheader that will
+                // be used as the label for the checkbox. If not present, the default
+                // selectRowString will be used.
+                const rowHeader = row.querySelector('[role="rowheader"]');
+                if (rowHeader) {
+                    const cell = rowHeader as TableCell;
+                    checkbox.label = cell.selectRowString
+                        ? cell.selectRowString
+                        : `${this.selectRowString} ${rowHeader.textContent}`;
+                } else {
+                    checkbox.label = this.selectRowString;
+                }
             });
         } else {
             // Remove all checkbox cells.

--- a/packages/table/src/TableCell.ts
+++ b/packages/table/src/TableCell.ts
@@ -36,7 +36,7 @@ export class TableCell extends SpectrumElement {
     public role: 'gridcell' | 'rowheader' | 'cell';
 
     @property({ type: String })
-    public selectRowString?: string;
+    public selectRowLabel?: string;
 
     protected override render(): TemplateResult {
         return html`

--- a/packages/table/src/TableCell.ts
+++ b/packages/table/src/TableCell.ts
@@ -27,8 +27,16 @@ export class TableCell extends SpectrumElement {
         return [styles];
     }
 
+    constructor() {
+        super();
+        this.role = 'gridcell';
+    }
+
     @property({ reflect: true })
-    public role = 'gridcell';
+    public role: 'gridcell' | 'rowheader' | 'cell';
+
+    @property({ type: String })
+    public selectRowString?: string;
 
     protected override render(): TemplateResult {
         return html`

--- a/packages/table/src/TableCheckboxCell.ts
+++ b/packages/table/src/TableCheckboxCell.ts
@@ -59,6 +59,9 @@ export class TableCheckboxCell extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public emphasized = false;
 
+    @property({ type: String })
+    public label?: string;
+
     public override click(): void {
         this.checkbox.click();
     }
@@ -71,6 +74,7 @@ export class TableCheckboxCell extends SpectrumElement {
                 ?disabled=${this.disabled}
                 ?emphasized=${this.emphasized}
                 aria-hidden=${ifDefined(this.selectsSingle)}
+                aria-label=${ifDefined(this.label)}
                 class="checkbox"
             ></sp-checkbox>
         `;

--- a/packages/table/src/TableCheckboxCell.ts
+++ b/packages/table/src/TableCheckboxCell.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
+    nothing,
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -59,9 +60,6 @@ export class TableCheckboxCell extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public emphasized = false;
 
-    @property({ type: String })
-    public label?: string;
-
     public override click(): void {
         this.checkbox.click();
     }
@@ -74,7 +72,7 @@ export class TableCheckboxCell extends SpectrumElement {
                 ?disabled=${this.disabled}
                 ?emphasized=${this.emphasized}
                 aria-hidden=${ifDefined(this.selectsSingle)}
-                aria-label=${ifDefined(this.label)}
+                aria-label="${this.ariaLabel || nothing}"
                 class="checkbox"
             ></sp-checkbox>
         `;

--- a/packages/table/src/table-cell.css
+++ b/packages/table/src/table-cell.css
@@ -17,3 +17,10 @@ governing permissions and limitations under the License.
     flex: 1;
     block-size: auto;
 }
+
+:host([role='rowheader']) {
+    font-weight: var(
+        --mod-table-header-font-weight,
+        var(--spectrum-table-header-font-weight)
+    );
+}

--- a/packages/table/stories/table-elements.stories.ts
+++ b/packages/table/stories/table-elements.stories.ts
@@ -25,9 +25,25 @@ export default {
     component: 'sp-table',
     args: {
         selected: [],
-        selects: '',
+        selects: 'single',
+        selectRowString: 'Select',
+        selectAllRowsString: 'Select All',
     },
     argTypes: {
+        selectRowString: {
+            name: 'selectRowString',
+            description: 'The string to use for the select row checkbox label.',
+            control: {
+                type: 'text',
+            },
+        },
+        selectAllRowsString: {
+            name: 'selectAllRowsString',
+            description: 'The string to use for the select all checkbox label.',
+            control: {
+                type: 'text',
+            },
+        },
         selected: {
             name: 'selected',
             description: 'The value of the selected `<sp-table-row>`(s).',
@@ -171,6 +187,140 @@ export const selectsSingle = (): TemplateResult => {
                     <sp-table-cell>Row Item Echo</sp-table-cell>
                     <sp-table-cell>Row Item Echo</sp-table-cell>
                     <sp-table-cell>Row Item Echo</sp-table-cell>
+                </sp-table-row>
+            </sp-table-body>
+        </sp-table>
+        <div>Selected: ["row1"]</div>
+    `;
+};
+
+type Properties = {
+    selectedRowString: string;
+    selectedAllRowsString: string;
+    selects: string;
+};
+
+export const selectsSingleWithRowHeader = ({
+    selectedRowString,
+    selectedAllRowsString,
+    selects,
+}: Properties): TemplateResult => {
+    return html`
+        <sp-table
+            .selects=${selects}
+            .selected=${['row1']}
+            .selectedRowString=${selectedRowString}
+            .selectedAllRowStrings=${selectedAllRowsString}
+            @change=${({ target }: Event & { target: Table }) => {
+                const next = target.nextElementSibling as HTMLDivElement;
+                next.textContent = `Selected: ${JSON.stringify(
+                    target.selected
+                )}`;
+            }}
+        >
+            <sp-table-head>
+                <sp-table-head-cell>Week (Row Header)</sp-table-head-cell>
+                <sp-table-head-cell>Monday</sp-table-head-cell>
+                <sp-table-head-cell>Wednesday</sp-table-head-cell>
+                <sp-table-head-cell>Friday</sp-table-head-cell>
+            </sp-table-head>
+            <sp-table-body style="height: 120px">
+                <sp-table-row value="row0" class="row0">
+                    <sp-table-cell role="rowheader">Week 1</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row1" class="row1">
+                    <sp-table-cell role="rowheader">Week 2</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row2" class="row2">
+                    <sp-table-cell role="rowheader">Week 3</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row3" class="row3">
+                    <sp-table-cell role="rowheader">Week 4</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row4" class="row4">
+                    <sp-table-cell role="rowheader">Week 5</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row5" class="row5">
+                    <sp-table-cell role="rowheader">Week 6</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+            </sp-table-body>
+        </sp-table>
+        <div>Selected: ["row1"]</div>
+    `;
+};
+
+export const selectsMultipleWithRowHeader = (): TemplateResult => {
+    return html`
+        <sp-table
+            selects="multiple"
+            .selected=${['row1']}
+            @change=${({ target }: Event & { target: Table }) => {
+                const next = target.nextElementSibling as HTMLDivElement;
+                next.textContent = `Selected: ${JSON.stringify(
+                    target.selected
+                )}`;
+            }}
+        >
+            <sp-table-head>
+                <sp-table-head-cell>Week (Row Header)</sp-table-head-cell>
+                <sp-table-head-cell>Monday</sp-table-head-cell>
+                <sp-table-head-cell>Wednesday</sp-table-head-cell>
+                <sp-table-head-cell>Friday</sp-table-head-cell>
+            </sp-table-head>
+            <sp-table-body style="height: 120px">
+                <sp-table-row value="row0" class="row0">
+                    <sp-table-cell role="rowheader">Week 1</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row1" class="row1">
+                    <sp-table-cell role="rowheader">Week 2</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row2" class="row2">
+                    <sp-table-cell role="rowheader">Week 3</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row3" class="row3">
+                    <sp-table-cell role="rowheader">Week 4</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row4" class="row4">
+                    <sp-table-cell role="rowheader">Week 5</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
+                </sp-table-row>
+                <sp-table-row value="row5" class="row5">
+                    <sp-table-cell role="rowheader">Week 6</sp-table-cell>
+                    <sp-table-cell>Squat</sp-table-cell>
+                    <sp-table-cell>Pushup</sp-table-cell>
+                    <sp-table-cell>Deadlift</sp-table-cell>
                 </sp-table-row>
             </sp-table-body>
         </sp-table>

--- a/packages/table/stories/table-elements.stories.ts
+++ b/packages/table/stories/table-elements.stories.ts
@@ -26,19 +26,19 @@ export default {
     args: {
         selected: [],
         selects: 'single',
-        selectRowString: 'Select',
-        selectAllRowsString: 'Select All',
+        selectRowLabel: 'Select',
+        selectAllRowsLabel: 'Select All',
     },
     argTypes: {
-        selectRowString: {
-            name: 'selectRowString',
+        selectRowLabel: {
+            name: 'selectRowLabel',
             description: 'The string to use for the select row checkbox label.',
             control: {
                 type: 'text',
             },
         },
-        selectAllRowsString: {
-            name: 'selectAllRowsString',
+        selectAllRowsLabel: {
+            name: 'selectAllRowsLabel',
             description: 'The string to use for the select all checkbox label.',
             control: {
                 type: 'text',

--- a/packages/table/test/table.test.ts
+++ b/packages/table/test/table.test.ts
@@ -91,179 +91,220 @@ describe('Table', () => {
         expect(el.size).to.equal('s');
     });
 
-    it('ensure row checkbox has aria-label when no label is provided', async () => {
-        const el = await fixture<Table>(html`
-            <sp-table size="s" selects="single">
-                <sp-table-head>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                </sp-table-head>
-                <sp-table-body style="height: 120px">
-                    <sp-table-row value="row1">
-                        <sp-table-cell role="rowheader">
-                            Row Item Alpha
-                        </sp-table-cell>
-                        <sp-table-cell>Row Item Alpha</sp-table-cell>
-                        <sp-table-cell>Row Item Alpha</sp-table-cell>
-                    </sp-table-row>
-                    <sp-table-row value="row2">
-                        <sp-table-cell role="rowheader">
-                            Row Item Bravo
-                        </sp-table-cell>
-                        <sp-table-cell>Row Item Bravo</sp-table-cell>
-                        <sp-table-cell>Row Item Bravo</sp-table-cell>
-                    </sp-table-row>
-                </sp-table-body>
-            </sp-table>
-        `);
+    describe('aria-label', async () => {
+        it('ensure row checkbox has aria-label when no label is provided', async () => {
+            const el = await fixture<Table>(html`
+                <sp-table size="s" selects="single">
+                    <sp-table-head>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    </sp-table-head>
+                    <sp-table-body style="height: 120px">
+                        <sp-table-row value="row1">
+                            <sp-table-cell role="rowheader">
+                                Row Item Alpha
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        </sp-table-row>
+                        <sp-table-row value="row2">
+                            <sp-table-cell role="rowheader">
+                                Row Item Bravo
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        </sp-table-row>
+                    </sp-table-body>
+                </sp-table>
+            `);
 
-        await elementUpdated(el);
+            await elementUpdated(el);
 
-        const rowOneCheckboxCell = el.querySelector(
-            '[value="row1"] sp-table-checkbox-cell'
-        ) as TableCheckboxCell;
-        const rowTwoCheckboxCell = el.querySelector(
-            '[value="row2"] sp-table-checkbox-cell'
-        ) as TableCheckboxCell;
+            const rowOneCheckboxCell = el.querySelector(
+                '[value="row1"] sp-table-checkbox-cell'
+            ) as TableCheckboxCell;
+            const rowTwoCheckboxCell = el.querySelector(
+                '[value="row2"] sp-table-checkbox-cell'
+            ) as TableCheckboxCell;
 
-        expect(rowOneCheckboxCell).to.be.accessible();
-        expect(rowOneCheckboxCell.checkbox.getAttribute('aria-label')).to.equal(
-            'Select Row Item Alpha'
-        );
-        expect(rowTwoCheckboxCell.checkbox.getAttribute('aria-label')).to.equal(
-            'Select Row Item Bravo'
-        );
-    });
+            expect(rowOneCheckboxCell).to.be.accessible();
+            expect(
+                rowOneCheckboxCell.checkbox.getAttribute('aria-label')
+            ).to.equal('Select Row Item Alpha');
+            expect(
+                rowTwoCheckboxCell.checkbox.getAttribute('aria-label')
+            ).to.equal('Select Row Item Bravo');
+        });
 
-    it('ensure row checkbox aria-label uses the provided selectRowLabel', async () => {
-        const el = await fixture<Table>(html`
-            <sp-table size="s" selects="single" selectRowLabel="Mark the row">
-                <sp-table-head>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                </sp-table-head>
-                <sp-table-body style="height: 120px">
-                    <sp-table-row value="row1">
-                        <sp-table-cell
-                            role="rowheader"
-                            selectRowLabel="Please mark row Item Alpha"
-                        >
-                            Item Alpha
-                        </sp-table-cell>
-                        <sp-table-cell>Row Item Alpha</sp-table-cell>
-                        <sp-table-cell>Row Item Alpha</sp-table-cell>
-                    </sp-table-row>
-                    <sp-table-row value="row2">
-                        <sp-table-cell role="rowheader">
-                            Item Bravo
-                        </sp-table-cell>
-                        <sp-table-cell>Row Item Bravo</sp-table-cell>
-                        <sp-table-cell>Row Item Bravo</sp-table-cell>
-                    </sp-table-row>
-                </sp-table-body>
-            </sp-table>
-        `);
+        it('ensure row checkbox aria-label uses the provided selectRowLabel', async () => {
+            const el = await fixture<Table>(html`
+                <sp-table
+                    size="s"
+                    selects="single"
+                    selectRowLabel="Mark the row"
+                >
+                    <sp-table-head>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    </sp-table-head>
+                    <sp-table-body style="height: 120px">
+                        <sp-table-row value="row1">
+                            <sp-table-cell
+                                role="rowheader"
+                                selectRowLabel="Please mark row Item Alpha"
+                            >
+                                Item Alpha
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        </sp-table-row>
+                        <sp-table-row value="row2">
+                            <sp-table-cell role="rowheader">
+                                Item Bravo
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        </sp-table-row>
+                    </sp-table-body>
+                </sp-table>
+            `);
 
-        await elementUpdated(el);
+            await elementUpdated(el);
 
-        const rowOneCheckboxCell = el.querySelector(
-            '[value="row1"] sp-table-checkbox-cell'
-        ) as TableCheckboxCell;
-        const rowTwoCheckboxCell = el.querySelector(
-            '[value="row2"] sp-table-checkbox-cell'
-        ) as TableCheckboxCell;
+            const rowOneCheckboxCell = el.querySelector(
+                '[value="row1"] sp-table-checkbox-cell'
+            ) as TableCheckboxCell;
+            const rowTwoCheckboxCell = el.querySelector(
+                '[value="row2"] sp-table-checkbox-cell'
+            ) as TableCheckboxCell;
 
-        expect(rowOneCheckboxCell).to.be.accessible();
-        expect(rowOneCheckboxCell.checkbox.getAttribute('aria-label')).to.equal(
-            'Please mark row Item Alpha'
-        );
-        expect(rowTwoCheckboxCell.checkbox.getAttribute('aria-label')).to.equal(
-            'Mark the row Item Bravo'
-        );
-    });
+            expect(rowOneCheckboxCell).to.be.accessible();
+            expect(
+                rowOneCheckboxCell.checkbox.getAttribute('aria-label')
+            ).to.equal('Please mark row Item Alpha');
+            expect(
+                rowTwoCheckboxCell.checkbox.getAttribute('aria-label')
+            ).to.equal('Mark the row Item Bravo');
+        });
 
-    it('ensure header checkbox aria-label uses the default string', async () => {
-        const el = await fixture<Table>(html`
-            <sp-table size="s" selects="multiple">
-                <sp-table-head>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                </sp-table-head>
-                <sp-table-body style="height: 120px">
-                    <sp-table-row value="row1">
-                        <sp-table-cell role="rowheader">
-                            Item Alpha
-                        </sp-table-cell>
-                        <sp-table-cell>Row Item Alpha</sp-table-cell>
-                        <sp-table-cell>Row Item Alpha</sp-table-cell>
-                    </sp-table-row>
-                    <sp-table-row value="row2">
-                        <sp-table-cell role="rowheader">
-                            Item Bravo
-                        </sp-table-cell>
-                        <sp-table-cell>Row Item Bravo</sp-table-cell>
-                        <sp-table-cell>Row Item Bravo</sp-table-cell>
-                    </sp-table-row>
-                </sp-table-body>
-            </sp-table>
-        `);
+        it('ensure header checkbox aria-label uses the default string', async () => {
+            const el = await fixture<Table>(html`
+                <sp-table size="s" selects="multiple">
+                    <sp-table-head>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    </sp-table-head>
+                    <sp-table-body style="height: 120px">
+                        <sp-table-row value="row1">
+                            <sp-table-cell role="rowheader">
+                                Item Alpha
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        </sp-table-row>
+                        <sp-table-row value="row2">
+                            <sp-table-cell role="rowheader">
+                                Item Bravo
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        </sp-table-row>
+                    </sp-table-body>
+                </sp-table>
+            `);
 
-        await elementUpdated(el);
+            await elementUpdated(el);
 
-        const tableHeadCheckboxCell = el.querySelector(
-            'sp-table-head sp-table-checkbox-cell'
-        ) as TableCheckboxCell;
+            const tableHeadCheckboxCell = el.querySelector(
+                'sp-table-head sp-table-checkbox-cell'
+            ) as TableCheckboxCell;
 
-        expect(tableHeadCheckboxCell).to.be.accessible();
-        expect(
-            tableHeadCheckboxCell.checkbox.getAttribute('aria-label')
-        ).to.equal('Select All');
-    });
+            expect(tableHeadCheckboxCell).to.be.accessible();
+            expect(
+                tableHeadCheckboxCell.checkbox.getAttribute('aria-label')
+            ).to.equal('Select All');
+        });
 
-    it('ensure header checkbox aria-label uses the provided selectRowLabel', async () => {
-        const el = await fixture<Table>(html`
-            <sp-table
-                size="s"
-                selects="multiple"
-                selectAllRowsLabel="Select all the rows in the table"
-            >
-                <sp-table-head>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                    <sp-table-head-cell>Column Title</sp-table-head-cell>
-                </sp-table-head>
-                <sp-table-body style="height: 120px">
-                    <sp-table-row value="row1">
-                        <sp-table-cell role="rowheader">
-                            Item Alpha
-                        </sp-table-cell>
-                        <sp-table-cell>Row Item Alpha</sp-table-cell>
-                        <sp-table-cell>Row Item Alpha</sp-table-cell>
-                    </sp-table-row>
-                    <sp-table-row value="row2">
-                        <sp-table-cell role="rowheader">
-                            Item Bravo
-                        </sp-table-cell>
-                        <sp-table-cell>Row Item Bravo</sp-table-cell>
-                        <sp-table-cell>Row Item Bravo</sp-table-cell>
-                    </sp-table-row>
-                </sp-table-body>
-            </sp-table>
-        `);
+        it('ensure row checkbox aria-label uses the default string when rowheader is empty', async () => {
+            const el = await fixture<Table>(html`
+                <sp-table size="s" selects="multiple">
+                    <sp-table-head>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    </sp-table-head>
+                    <sp-table-body style="height: 120px">
+                        <sp-table-row value="row1">
+                            <sp-table-cell role="rowheader"></sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        </sp-table-row>
+                        <sp-table-row value="row2">
+                            <sp-table-cell role="rowheader">
+                                Item Bravo
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        </sp-table-row>
+                    </sp-table-body>
+                </sp-table>
+            `);
 
-        await elementUpdated(el);
+            const rowOneCheckboxCell = el.querySelector(
+                '[value="row1"] sp-table-checkbox-cell'
+            ) as TableCheckboxCell;
 
-        const tableHeadCheckboxCell = el.querySelector(
-            'sp-table-head sp-table-checkbox-cell'
-        ) as TableCheckboxCell;
+            expect(rowOneCheckboxCell).to.be.accessible();
+            expect(
+                rowOneCheckboxCell.checkbox.getAttribute('aria-label')
+            ).to.equal('Select');
+        });
 
-        expect(tableHeadCheckboxCell).to.be.accessible();
-        expect(
-            tableHeadCheckboxCell.checkbox.getAttribute('aria-label')
-        ).to.equal('Select all the rows in the table');
+        it('ensure header checkbox aria-label uses the provided selectRowLabel', async () => {
+            const el = await fixture<Table>(html`
+                <sp-table
+                    size="s"
+                    selects="multiple"
+                    selectAllRowsLabel="Select all the rows in the table"
+                >
+                    <sp-table-head>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                        <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    </sp-table-head>
+                    <sp-table-body style="height: 120px">
+                        <sp-table-row value="row1">
+                            <sp-table-cell role="rowheader">
+                                Item Alpha
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                            <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        </sp-table-row>
+                        <sp-table-row value="row2">
+                            <sp-table-cell role="rowheader">
+                                Item Bravo
+                            </sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                            <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        </sp-table-row>
+                    </sp-table-body>
+                </sp-table>
+            `);
+
+            await elementUpdated(el);
+
+            const tableHeadCheckboxCell = el.querySelector(
+                'sp-table-head sp-table-checkbox-cell'
+            ) as TableCheckboxCell;
+
+            expect(tableHeadCheckboxCell).to.be.accessible();
+            expect(
+                tableHeadCheckboxCell.checkbox.getAttribute('aria-label')
+            ).to.equal('Select all the rows in the table');
+        });
     });
 
     it('dispatches `change` events', async () => {

--- a/packages/table/test/table.test.ts
+++ b/packages/table/test/table.test.ts
@@ -136,9 +136,9 @@ describe('Table', () => {
         );
     });
 
-    it('ensure row checkbox aria-label uses the provided selectRowString', async () => {
+    it('ensure row checkbox aria-label uses the provided selectRowLabel', async () => {
         const el = await fixture<Table>(html`
-            <sp-table size="s" selects="single" selectRowString="Mark the row">
+            <sp-table size="s" selects="single" selectRowLabel="Mark the row">
                 <sp-table-head>
                     <sp-table-head-cell>Column Title</sp-table-head-cell>
                     <sp-table-head-cell>Column Title</sp-table-head-cell>
@@ -148,7 +148,7 @@ describe('Table', () => {
                     <sp-table-row value="row1">
                         <sp-table-cell
                             role="rowheader"
-                            selectRowString="Please mark row Item Alpha"
+                            selectRowLabel="Please mark row Item Alpha"
                         >
                             Item Alpha
                         </sp-table-cell>
@@ -223,12 +223,12 @@ describe('Table', () => {
         ).to.equal('Select All');
     });
 
-    it('ensure header checkbox aria-label uses the provided selectRowString', async () => {
+    it('ensure header checkbox aria-label uses the provided selectRowLabel', async () => {
         const el = await fixture<Table>(html`
             <sp-table
                 size="s"
                 selects="multiple"
-                selectAllRowsString="Select all the rows in the table"
+                selectAllRowsLabel="Select all the rows in the table"
             >
                 <sp-table-head>
                     <sp-table-head-cell>Column Title</sp-table-head-cell>

--- a/packages/table/test/table.test.ts
+++ b/packages/table/test/table.test.ts
@@ -91,6 +91,181 @@ describe('Table', () => {
         expect(el.size).to.equal('s');
     });
 
+    it('ensure row checkbox has aria-label when no label is provided', async () => {
+        const el = await fixture<Table>(html`
+            <sp-table size="s" selects="single">
+                <sp-table-head>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                </sp-table-head>
+                <sp-table-body style="height: 120px">
+                    <sp-table-row value="row1">
+                        <sp-table-cell role="rowheader">
+                            Row Item Alpha
+                        </sp-table-cell>
+                        <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        <sp-table-cell>Row Item Alpha</sp-table-cell>
+                    </sp-table-row>
+                    <sp-table-row value="row2">
+                        <sp-table-cell role="rowheader">
+                            Row Item Bravo
+                        </sp-table-cell>
+                        <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        <sp-table-cell>Row Item Bravo</sp-table-cell>
+                    </sp-table-row>
+                </sp-table-body>
+            </sp-table>
+        `);
+
+        await elementUpdated(el);
+
+        const rowOneCheckboxCell = el.querySelector(
+            '[value="row1"] sp-table-checkbox-cell'
+        ) as TableCheckboxCell;
+        const rowTwoCheckboxCell = el.querySelector(
+            '[value="row2"] sp-table-checkbox-cell'
+        ) as TableCheckboxCell;
+
+        expect(rowOneCheckboxCell).to.be.accessible();
+        expect(rowOneCheckboxCell.checkbox.getAttribute('aria-label')).to.equal(
+            'Select Row Item Alpha'
+        );
+        expect(rowTwoCheckboxCell.checkbox.getAttribute('aria-label')).to.equal(
+            'Select Row Item Bravo'
+        );
+    });
+
+    it('ensure row checkbox aria-label uses the provided selectRowString', async () => {
+        const el = await fixture<Table>(html`
+            <sp-table size="s" selects="single" selectRowString="Mark the row">
+                <sp-table-head>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                </sp-table-head>
+                <sp-table-body style="height: 120px">
+                    <sp-table-row value="row1">
+                        <sp-table-cell
+                            role="rowheader"
+                            selectRowString="Please mark row Item Alpha"
+                        >
+                            Item Alpha
+                        </sp-table-cell>
+                        <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        <sp-table-cell>Row Item Alpha</sp-table-cell>
+                    </sp-table-row>
+                    <sp-table-row value="row2">
+                        <sp-table-cell role="rowheader">
+                            Item Bravo
+                        </sp-table-cell>
+                        <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        <sp-table-cell>Row Item Bravo</sp-table-cell>
+                    </sp-table-row>
+                </sp-table-body>
+            </sp-table>
+        `);
+
+        await elementUpdated(el);
+
+        const rowOneCheckboxCell = el.querySelector(
+            '[value="row1"] sp-table-checkbox-cell'
+        ) as TableCheckboxCell;
+        const rowTwoCheckboxCell = el.querySelector(
+            '[value="row2"] sp-table-checkbox-cell'
+        ) as TableCheckboxCell;
+
+        expect(rowOneCheckboxCell).to.be.accessible();
+        expect(rowOneCheckboxCell.checkbox.getAttribute('aria-label')).to.equal(
+            'Please mark row Item Alpha'
+        );
+        expect(rowTwoCheckboxCell.checkbox.getAttribute('aria-label')).to.equal(
+            'Mark the row Item Bravo'
+        );
+    });
+
+    it('ensure header checkbox aria-label uses the default string', async () => {
+        const el = await fixture<Table>(html`
+            <sp-table size="s" selects="multiple">
+                <sp-table-head>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                </sp-table-head>
+                <sp-table-body style="height: 120px">
+                    <sp-table-row value="row1">
+                        <sp-table-cell role="rowheader">
+                            Item Alpha
+                        </sp-table-cell>
+                        <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        <sp-table-cell>Row Item Alpha</sp-table-cell>
+                    </sp-table-row>
+                    <sp-table-row value="row2">
+                        <sp-table-cell role="rowheader">
+                            Item Bravo
+                        </sp-table-cell>
+                        <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        <sp-table-cell>Row Item Bravo</sp-table-cell>
+                    </sp-table-row>
+                </sp-table-body>
+            </sp-table>
+        `);
+
+        await elementUpdated(el);
+
+        const tableHeadCheckboxCell = el.querySelector(
+            'sp-table-head sp-table-checkbox-cell'
+        ) as TableCheckboxCell;
+
+        expect(tableHeadCheckboxCell).to.be.accessible();
+        expect(
+            tableHeadCheckboxCell.checkbox.getAttribute('aria-label')
+        ).to.equal('Select All');
+    });
+
+    it('ensure header checkbox aria-label uses the provided selectRowString', async () => {
+        const el = await fixture<Table>(html`
+            <sp-table
+                size="s"
+                selects="multiple"
+                selectAllRowsString="Select all the rows in the table"
+            >
+                <sp-table-head>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                    <sp-table-head-cell>Column Title</sp-table-head-cell>
+                </sp-table-head>
+                <sp-table-body style="height: 120px">
+                    <sp-table-row value="row1">
+                        <sp-table-cell role="rowheader">
+                            Item Alpha
+                        </sp-table-cell>
+                        <sp-table-cell>Row Item Alpha</sp-table-cell>
+                        <sp-table-cell>Row Item Alpha</sp-table-cell>
+                    </sp-table-row>
+                    <sp-table-row value="row2">
+                        <sp-table-cell role="rowheader">
+                            Item Bravo
+                        </sp-table-cell>
+                        <sp-table-cell>Row Item Bravo</sp-table-cell>
+                        <sp-table-cell>Row Item Bravo</sp-table-cell>
+                    </sp-table-row>
+                </sp-table-body>
+            </sp-table>
+        `);
+
+        await elementUpdated(el);
+
+        const tableHeadCheckboxCell = el.querySelector(
+            'sp-table-head sp-table-checkbox-cell'
+        ) as TableCheckboxCell;
+
+        expect(tableHeadCheckboxCell).to.be.accessible();
+        expect(
+            tableHeadCheckboxCell.checkbox.getAttribute('aria-label')
+        ).to.equal('Select all the rows in the table');
+    });
+
     it('dispatches `change` events', async () => {
         const changeSpy = spy();
         const el = await fixture<Table>(html`


### PR DESCRIPTION
## Description

The PR implements the following changes

- add `rowheader` role for `<sp-table-cell>`
- tables with `single` or `multiple` select will now have an `aria-label` attribute for the checkboxes in the table. There is an english default string for checkboxes that select a row is **Select** and for the checkbox selecting all rows the default is **Select All**
- The string that will be used for the checkboxes can be provided for the `<sp-table>` element and `<sp-table-cell>` supports an attribute to allow an explicit override for that row. This is intended for clients to support a localized version for the checkbox
- Clients can provide a localized version for **Select All** checkbox string for `<sp-table>` component

## Related issue(s)

This fix addresses

- #3394
- #3396 

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

## Motivation and context

Screen Readers were unable to distinguish the different checkboxes for each table row

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
