### PR TITLE
fix(picker): use tray on all touch devices

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -45,10 +45,7 @@ import type {
     MenuItemChildren,
 } from '@spectrum-web-components/menu';
 import { Placement } from '@spectrum-web-components/overlay';
-import {
-    IS_MOBILE,
-    MatchMediaController,
-} from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
+import { MatchMediaController } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
 import type { Overlay } from '@spectrum-web-components/overlay/src/Overlay.js';
 import type { FieldLabel } from '@spectrum-web-components/field-label';
 
@@ -61,7 +58,10 @@ const chevronClass = {
 
 export const DESCRIPTION_ID = 'option-picker';
 export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
-    protected isMobile = new MatchMediaController(this, IS_MOBILE);
+    protected isMobile = new MatchMediaController(
+        this,
+        '(hover: none) and (pointer: coarse)'
+    );
 
     @state()
     appliedLabel?: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

What we are observing with the latest version of SWC is that on a large touch device such as an iPad pro the action menu looks to be using the sp-overlay + sp-popover. However on touch end it seems to close the Overlay and the result is the menu just flickers. On smaller devices the mobile tray implementation is triggered as expected and this doesn't happen.

Can be reproduced using the documentation and/or sandbox: https://opensource.adobe.com/spectrum-web-components/components/action-menu/, https://studio.webcomponents.dev/edit/OfeOwrikpHyrhWv6YvUI/package.json?p=stories

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #4107

## Motivation and context

The sp-action-menu should work on iPad pro and other larger touch devices. Either a mobile tray implementation should be used or the standard overlay should work.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
