### PR TITLE
Various Picker Fixes

### DIFF
--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -344,6 +344,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
     private handleClick(event: Event): void {
         if (this.willSynthesizeClick) {
             cancelAnimationFrame(this.willSynthesizeClick);
+            this.willSynthesizeClick = 0;
             return;
         }
         this.handlePointerBasedSelection(event);
@@ -352,6 +353,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
     private handlePointerup(event: Event): void {
         this.willSynthesizeClick = requestAnimationFrame(() => {
             event.target?.dispatchEvent(new Event('click'));
+            this.willSynthesizeClick = 0;
         });
         this.handlePointerBasedSelection(event);
     }

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -49,7 +49,7 @@ import {
     IS_MOBILE,
     MatchMediaController,
 } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
-import type { Overlay } from '@spectrum-web-components/overlay/src/Overlay.js';
+import { Overlay } from '@spectrum-web-components/overlay/src/Overlay.js';
 import type { FieldLabel } from '@spectrum-web-components/field-label';
 
 const chevronClass = {
@@ -180,17 +180,23 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
         }
         this.pointerdownState = this.open;
         this.preventNextToggle = 'maybe';
+        let cleanupAction = 0;
         const cleanup = (): void => {
-            document.removeEventListener('pointerup', cleanup);
-            document.removeEventListener('pointercancel', cleanup);
-            requestAnimationFrame(() => {
-                // Complete cleanup on the animation frame so that `click` can go first.
-                this.preventNextToggle = 'no';
+            cancelAnimationFrame(cleanupAction);
+            cleanupAction = requestAnimationFrame(async () => {
+                document.removeEventListener('pointerup', cleanup);
+                document.removeEventListener('pointercancel', cleanup);
+                this.button.removeEventListener('click', cleanup);
+                requestAnimationFrame(() => {
+                    // Complete cleanup on the second animation frame so that `click` can go first.
+                    this.preventNextToggle = 'no';
+                });
             });
         };
         // Ensure that however the pointer goes up we do `cleanup()`.
         document.addEventListener('pointerup', cleanup);
         document.addEventListener('pointercancel', cleanup);
+        this.button.addEventListener('click', cleanup);
         this.handleActivate();
     }
 
@@ -235,6 +241,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
     }
 
     public handleChange(event: Event): void {
+        this.preventNextToggle = 'no';
         const target = event.target as Menu;
         const [selected] = target.selectedItems;
         event.stopPropagation();
@@ -358,6 +365,30 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
             | undefined;
     }
 
+    protected handleBeforetoggle(
+        event: Event & {
+            target: Overlay;
+            newState: 'open' | 'closed';
+        }
+    ): void {
+        if (event.composedPath()[0] !== event.target) {
+            return;
+        }
+        if (event.newState === 'closed') {
+            if (this.preventNextToggle === 'no') {
+                this.open = false;
+            } else if (!this.pointerdownState) {
+                // Prevent browser driven closure while opening the Picker
+                // and the expected event series has not completed.
+                this.overlayElement.manuallyKeepOpen();
+            }
+        }
+        if (!this.open) {
+            this.optionsMenu.updateSelectedItemIndex();
+            this.optionsMenu.closeDescendentOverlays();
+        }
+    }
+
     protected renderLabelContent(content: Node[]): TemplateResult | Node[] {
         if (this.value && this.selectedItem) {
             return content;
@@ -454,23 +485,7 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .willPreventClose=${this.preventNextToggle !== 'no' &&
                 this.open &&
                 this.dependenciesLoaded}
-                @beforetoggle=${(
-                    event: Event & {
-                        target: Overlay;
-                        newState: 'open' | 'closed';
-                    }
-                ) => {
-                    if (event.composedPath()[0] !== event.target) {
-                        return;
-                    }
-                    if (event.newState === 'closed') {
-                        this.open = false;
-                    }
-                    if (!this.open) {
-                        this.optionsMenu.updateSelectedItemIndex();
-                        this.optionsMenu.closeDescendentOverlays();
-                    }
-                }}
+                @beforetoggle=${this.handleBeforetoggle}
             >
                 ${container}
             </sp-overlay>


### PR DESCRIPTION
## Description
- allow Picker to open/close in tabled devices
  - this is also a workaround, the longer tail work here would be to make an Interaction Strategy specifically for Picker so this was much nicer to read and reason about, however it _seems_ to correct the issue (I've only use Chrome to emulate) without changing the interaction pattern
  - also, hard to test, we need to revisit whether we can fake the mobile context in unit tests, somehow...
- Allow keyboard interaction after pointer interactions with Menu Items
  - probably could use a test? setting this for discussion first, and then can come back to that tomorrow if desired

## Related issue(s)
- fixes #4132
- fixes #4107
- fixes #4150

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://picker-tablet--spectrum-web-components.netlify.app/storybook/?path=/story/picker--default)
    2. On an tablet/emulator
    3. Try to open the Picker
    4. See that it opens
    5. Select something
    6. See that it closes
    7. Try other open/close interaction
    8. See that they work
-   [ ] _Test case 2_
    1. Go [here](https://picker-tablet--spectrum-web-components.netlify.app/storybook/?path=/story/picker--default)
    2. Choose a Menu Item with a pointing device
    3. After the Picker is closed...
    4. Select a different Menu Item with you keyboard
    5. See that the selection can be made

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)