### PR TITLE
fix(table): Add aria-rowcount to virtualized tables

### DIFF
--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -507,6 +507,9 @@ export class Table extends SizedMixin(SpectrumElement, {
                 }
             );
         }
+        if (this.items.length) {
+            this.setAttribute('aria-rowcount', `${this.items.length}`);
+        }
         const config: VirtualizeDirectiveConfig<Record<string, unknown>> = {
             items: this.items,
             renderItem: this.renderItem,

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -508,6 +508,8 @@ export class Table extends SizedMixin(SpectrumElement, {
             );
         }
         if (this.items.length) {
+            // Ensures screenreaders can announce the true size of the table
+            // despite virtualization only rendering a subset.
             this.setAttribute('aria-rowcount', `${this.items.length}`);
         }
         const config: VirtualizeDirectiveConfig<Record<string, unknown>> = {

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -507,11 +507,11 @@ export class Table extends SizedMixin(SpectrumElement, {
                 }
             );
         }
-        if (this.items.length) {
-            // Ensures screenreaders can announce the true size of the table
-            // despite virtualization only rendering a subset.
-            this.setAttribute('aria-rowcount', `${this.items.length}`);
-        }
+
+        // Ensures screenreaders can announce the true size of the table
+        // despite virtualization only rendering a subset of rows.
+        this.setAttribute('aria-rowcount', `${this.items.length}`);
+
         const config: VirtualizeDirectiveConfig<Record<string, unknown>> = {
             items: this.items,
             renderItem: this.renderItem,

--- a/packages/table/src/Table.ts
+++ b/packages/table/src/Table.ts
@@ -471,6 +471,8 @@ export class Table extends SizedMixin(SpectrumElement, {
     protected override updated(): void {
         if (this.items.length) {
             this.renderVirtualizedItems();
+        } else {
+            this.removeAttribute('aria-rowcount');
         }
     }
 

--- a/packages/table/stories/table-virtualized.stories.ts
+++ b/packages/table/stories/table-virtualized.stories.ts
@@ -97,7 +97,6 @@ class VirtualTable extends SpectrumElement {
     protected override render(): TemplateResult {
         return html`
             <sp-table
-                aria-rowcount="50"
                 .items=${this.items}
                 .renderItem=${renderItem}
                 size="m"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

The `sp-table` component can be virtualized, which only renders table rows that are currently visible in the viewport, which helps with performance on large tables. However, this can trip up screenreaders, which only detect and announce the rendered rows, and not the true size of the table. `aria-rowcount` is a screenreader attribute which announces the true unvirtualized size of the table.

This PR implements the automatic application of `aria-rowcount` for virtualized tables. 

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes #3393 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Accuracy and efficacy of screenreader accessibility.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] Run storybook - Table > Virtualized > [Any of these]
    1. Inspect the `sp-table` element
    2. Observe that the `aria-rowcount` value is correct.
-   [x] Visit docs site - Table > Virtualized
    1. Inspect the `sp-table` element
    2. Observe that the `aria-rowcount` value is correct.

## Screenshots (if appropriate)

<img width="1364" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/162190334/41f0cf47-6208-4a83-9d62-422a829574cf">

<img width="1149" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/162190334/35ebffea-8243-4e6e-8e0e-98981536f7fe">

Before my changes
<img width="1442" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/162190334/2207b1bd-c982-4ddb-8ade-5f4586b72fa7">

After my changes
<img width="1079" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/162190334/8bb1acb8-c8f7-4b32-8319-2c4056dbf172">



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
