### PR TITLE
fix(progress-bar, progress-circle): remove aria-label only if set by label and label is empty

### DIFF
--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -139,7 +139,9 @@ export class ProgressBar extends SizedMixin(
         if (changes.has('label')) {
             if (this.label.length) {
                 this.setAttribute('aria-label', this.label);
-            } else {
+            } else if (
+                changes.get('label') === this.getAttribute('aria-label')
+            ) {
                 this.removeAttribute('aria-label');
             }
         }

--- a/packages/progress-bar/test/progress-bar.test.ts
+++ b/packages/progress-bar/test/progress-bar.test.ts
@@ -173,4 +173,35 @@ describe('ProgressBar', () => {
         ) as HTMLElement;
         expect(percentage.textContent?.search('٪')).to.not.equal(-1);
     });
+
+    it('accepts `aria-label`', async () => {
+        const el = await fixture<ProgressBar>(html`
+            <sp-progress-bar aria-label="Loading"></sp-progress-bar>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.hasAttribute('aria-label')).to.be.true;
+        expect(el.getAttribute('aria-label')).to.equal('Loading');
+    });
+    it('sets `aria-label` to equal `label` if `label` is set', async () => {
+        const el = await fixture<ProgressBar>(html`
+            <sp-progress-bar label="Loading"></sp-progress-bar>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.hasAttribute('aria-label')).to.be.true;
+        expect(el.getAttribute('aria-label')).to.equal('Loading');
+    });
+    it('does not remove `aria-label` if set independently of `label`', async () => {
+        const el = await fixture<ProgressBar>(html`
+            <sp-progress-bar label="" aria-label="Loading"></sp-progress-bar>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.hasAttribute('aria-label')).to.be.true;
+        expect(el.getAttribute('aria-label')).to.equal('Loading');
+    });
 });

--- a/packages/progress-circle/src/ProgressCircle.ts
+++ b/packages/progress-circle/src/ProgressCircle.ts
@@ -133,7 +133,9 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
         if (changes.has('label')) {
             if (this.label.length) {
                 this.setAttribute('aria-label', this.label);
-            } else {
+            } else if (
+                changes.get('label') === this.getAttribute('aria-label')
+            ) {
                 this.removeAttribute('aria-label');
             }
         }

--- a/packages/progress-circle/test/progress-circle.test.ts
+++ b/packages/progress-circle/test/progress-circle.test.ts
@@ -112,4 +112,37 @@ describe('ProgressCircle', () => {
         });
         consoleWarnStub.restore();
     });
+    it('accepts `aria-label`', async () => {
+        const el = await fixture<ProgressCircle>(html`
+            <sp-progress-circle aria-label="Loading"></sp-progress-circle>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.hasAttribute('aria-label')).to.be.true;
+        expect(el.getAttribute('aria-label')).to.equal('Loading');
+    });
+    it('sets `aria-label` to equal `label` if `label` is set', async () => {
+        const el = await fixture<ProgressCircle>(html`
+            <sp-progress-circle label="Loading"></sp-progress-circle>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.hasAttribute('aria-label')).to.be.true;
+        expect(el.getAttribute('aria-label')).to.equal('Loading');
+    });
+    it('does not remove `aria-label` if set independently of `label`', async () => {
+        const el = await fixture<ProgressCircle>(html`
+            <sp-progress-circle
+                label=""
+                aria-label="Loading"
+            ></sp-progress-circle>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.hasAttribute('aria-label')).to.be.true;
+        expect(el.getAttribute('aria-label')).to.equal('Loading');
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Following @Westbrook's suggestion, remove `aria-label` when it matches the previously set (and now empty) `label`. This allows an `aria-label` to remain when it is set independently of the label, but correctly removes an `aria-label` when its corresponding `label` is removed.

## Related issue(s)

- fixes https://github.com/adobe/spectrum-web-components/issues/4151

## Motivation and context

We are unable to set an `aria-label` for `sp-progress-bar` or `sp-progress-circle` because it gets removed when `label` is not set. This lets us set an `aria-label` appropriately to meet accessibility standards.

## How has this been tested?

I tested adding and removing `label` and `aria-label` attributes in the storybooks for the affected components:

-   [ ] Component should support `aria-label`
    1. Add `aria-label` to component without `label`
    2. Observe `aria-label` in DOM as expected
-   [ ] Component should support `label` that sets `aria-label` and removes `aria-label` when `label` is removed
    1. Add `label` to component without `aria-label`
    2. Observe `label` and `aria-label` in DOM as expected
    3. Remove `label` from the DOM and observe `aria-label` is also removed as expected

I also added a few unit tests.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
