### PR TITLE
docs(badge): updated non semantics docs for mod override

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: a3a63503e5584396e8b34ec0b02e8a1a26ebc1ae
+        default: d95e1f5e29f6a847ce8190ad6ad6028456707b71
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -97,6 +97,7 @@ The `<sp-badge>` can be customized with either semantic or non-semantic variants
     <sp-badge variant="informative">Informative</sp-badge>
     <sp-badge variant="positive">Positive</sp-badge>
     <sp-badge variant="negative">Negative</sp-badge>
+    <sp-badge variant="notice">Notice</sp-badge>
 </div>
 ```
 
@@ -105,51 +106,21 @@ The `<sp-badge>` can be customized with either semantic or non-semantic variants
 Non-semantic badge colors are no longer supported directly by Spectrum and Spectrum Web Components. You can mimic their delivery via the following CSS Custom Properties. These values for the `variant` attribute/property have not been marked as deprecated, but will no longer achieve the results you may have relied on in the past.
 
 ```html demo
-<div style="display: flex; gap: var(--spectrum-spacing-75);">
-    <sp-badge
-        variant="seafoam"
-        static="black"
-        style="--mod-badge-background-color-seafoam: var(--spectrum-seafoam-background-color-default)"
-    >
-        Seafoam
-    </sp-badge>
-    <sp-badge
-        variant="indigo"
-        static="black"
-        style="--mod-badge-background-color-indigo: var(--spectrum-indigo-background-color-default)"
-    >
-        Indigo
-    </sp-badge>
-    <sp-badge
-        variant="purple"
-        static="black"
-        style="--mod-badge-background-color-purple: var(--spectrum-purple-background-color-default)"
-    >
-        Purple
-    </sp-badge>
-    <sp-badge
-        variant="fuchsia"
-        static="black"
-        style="--mod-badge-background-color-fuchsia: var(--spectrum-fuchsia-background-color-default)"
-    >
-        Fuchsia
-    </sp-badge>
-    <sp-badge
-        variant="magenta"
-        static="black"
-        style="--mod-badge-background-color-magenta: var(--spectrum-magenta-background-color-default)"
-    >
-        Magenta
-    </sp-badge>
-    <sp-badge
-        variant="yellow"
-        static="black"
-        style="
-            --mod-badge-background-color-yellow: var(--spectrum-yellow-background-color-default); --mod-badge-label-icon-color-white: var(--spectrum-black);
-        "
-    >
-        Yellow
-    </sp-badge>
+<div style="display: flex; gap: var(--spectrum-spacing-75); flex-wrap:wrap;">
+    <sp-badge variant="seafoam" static="black">Seafoam</sp-badge>
+    <sp-badge variant="indigo" static="black">Indigo</sp-badge>
+    <sp-badge variant="purple" static="black">Purple</sp-badge>
+    <sp-badge variant="fuchsia" static="black">Fuchsia</sp-badge>
+    <sp-badge variant="magenta" static="black">Magenta</sp-badge>
+    <sp-badge variant="yellow" static="black">Yellow</sp-badge>
+    <sp-badge variant="gray" static="black">Gray</sp-badge>
+    <sp-badge variant="red" static="black">Red</sp-badge>
+    <sp-badge variant="orange" static="black">Orange</sp-badge>
+    <sp-badge variant="chartreuse" static="black">Chartreuse</sp-badge>
+    <sp-badge variant="celery" static="black">Celery</sp-badge>
+    <sp-badge variant="green" static="black">Green</sp-badge>
+    <sp-badge variant="cyan" static="black">Cyan</sp-badge>
+    <sp-badge variant="blue" static="black">Blue</sp-badge>
 </div>
 ```
 

--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -109,35 +109,35 @@ Non-semantic badge colors are no longer supported directly by Spectrum and Spect
     <sp-badge
         variant="seafoam"
         static="black"
-        style="--mod-badge-background-color-default: var(--spectrum-seafoam-background-color-default)"
+        style="--mod-badge-background-color-seafoam: var(--spectrum-seafoam-background-color-default)"
     >
         Seafoam
     </sp-badge>
     <sp-badge
         variant="indigo"
         static="black"
-        style="--mod-badge-background-color-default: var(--spectrum-indigo-background-color-default)"
+        style="--mod-badge-background-color-indigo: var(--spectrum-indigo-background-color-default)"
     >
         Indigo
     </sp-badge>
     <sp-badge
         variant="purple"
         static="black"
-        style="--mod-badge-background-color-default: var(--spectrum-purple-background-color-default)"
+        style="--mod-badge-background-color-purple: var(--spectrum-purple-background-color-default)"
     >
         Purple
     </sp-badge>
     <sp-badge
         variant="fuchsia"
         static="black"
-        style="--mod-badge-background-color-default: var(--spectrum-fuchsia-background-color-default)"
+        style="--mod-badge-background-color-fuchsia: var(--spectrum-fuchsia-background-color-default)"
     >
         Fuchsia
     </sp-badge>
     <sp-badge
         variant="magenta"
         static="black"
-        style="--mod-badge-background-color-default: var(--spectrum-magenta-background-color-default)"
+        style="--mod-badge-background-color-magenta: var(--spectrum-magenta-background-color-default)"
     >
         Magenta
     </sp-badge>
@@ -145,7 +145,7 @@ Non-semantic badge colors are no longer supported directly by Spectrum and Spect
         variant="yellow"
         static="black"
         style="
-            --mod-badge-background-color-default: var(--spectrum-yellow-background-color-default); --mod-badge-label-icon-color-white: var(--spectrum-black);
+            --mod-badge-background-color-yellow: var(--spectrum-yellow-background-color-default); --mod-badge-label-icon-color-white: var(--spectrum-black);
         "
     >
         Yellow

--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -93,6 +93,7 @@ The `<sp-badge>` can be customized with either semantic or non-semantic variants
 
 ```html demo
 <div style="display: flex; gap: var(--spectrum-spacing-75);">
+    <sp-badge variant="accent">Informative</sp-badge>
     <sp-badge variant="neutral">Neutral</sp-badge>
     <sp-badge variant="informative">Informative</sp-badge>
     <sp-badge variant="positive">Positive</sp-badge>
@@ -107,20 +108,20 @@ Non-semantic badge colors are no longer supported directly by Spectrum and Spect
 
 ```html demo
 <div style="display: flex; gap: var(--spectrum-spacing-75); flex-wrap:wrap;">
-    <sp-badge variant="seafoam" static="black">Seafoam</sp-badge>
-    <sp-badge variant="indigo" static="black">Indigo</sp-badge>
-    <sp-badge variant="purple" static="black">Purple</sp-badge>
-    <sp-badge variant="fuchsia" static="black">Fuchsia</sp-badge>
-    <sp-badge variant="magenta" static="black">Magenta</sp-badge>
-    <sp-badge variant="yellow" static="black">Yellow</sp-badge>
-    <sp-badge variant="gray" static="black">Gray</sp-badge>
-    <sp-badge variant="red" static="black">Red</sp-badge>
-    <sp-badge variant="orange" static="black">Orange</sp-badge>
-    <sp-badge variant="chartreuse" static="black">Chartreuse</sp-badge>
-    <sp-badge variant="celery" static="black">Celery</sp-badge>
-    <sp-badge variant="green" static="black">Green</sp-badge>
-    <sp-badge variant="cyan" static="black">Cyan</sp-badge>
-    <sp-badge variant="blue" static="black">Blue</sp-badge>
+    <sp-badge variant="seafoam">Seafoam</sp-badge>
+    <sp-badge variant="indigo">Indigo</sp-badge>
+    <sp-badge variant="purple">Purple</sp-badge>
+    <sp-badge variant="fuchsia">Fuchsia</sp-badge>
+    <sp-badge variant="magenta">Magenta</sp-badge>
+    <sp-badge variant="yellow">Yellow</sp-badge>
+    <sp-badge variant="gray">Gray</sp-badge>
+    <sp-badge variant="red">Red</sp-badge>
+    <sp-badge variant="orange">Orange</sp-badge>
+    <sp-badge variant="chartreuse">Chartreuse</sp-badge>
+    <sp-badge variant="celery">Celery</sp-badge>
+    <sp-badge variant="green">Green</sp-badge>
+    <sp-badge variant="cyan">Cyan</sp-badge>
+    <sp-badge variant="blue">Blue</sp-badge>
 </div>
 ```
 

--- a/packages/badge/src/Badge.ts
+++ b/packages/badge/src/Badge.ts
@@ -30,12 +30,21 @@ export const BADGE_VARIANTS = [
     'informative',
     'positive',
     'negative',
+    'notice',
     'fuchsia',
     'indigo',
     'magenta',
     'purple',
     'seafoam',
     'yellow',
+    'gray',
+    'red',
+    'orange',
+    'chartreuse',
+    'celery',
+    'green',
+    'cyan',
+    'blue',
 ] as const;
 export type BadgeVariant = typeof BADGE_VARIANTS[number];
 export const FIXED_VALUES_DEPRECATED = ['top', 'bottom', 'left', 'right'];

--- a/packages/badge/src/spectrum-badge.css
+++ b/packages/badge/src/spectrum-badge.css
@@ -19,19 +19,19 @@ governing permissions and limitations under the License.
     --spectrum-badge-label-icon-color: var(--spectrum-white);
 }
 
-.spectrum-Badge--orange,
+:host([variant='orange']),
 :host([variant='yellow']),
-.spectrum-Badge--chartreuse,
-.spectrum-Badge--celery {
+:host([variant='chartreuse']),
+:host([variant='celery']) {
     --spectrum-badge-label-icon-color: var(--spectrum-black);
 }
 
-.spectrum-Badge--gray,
-.spectrum-Badge--red,
-.spectrum-Badge--green,
+:host([variant='gray']),
+:host([variant='red']),
+:host([variant='green']),
 :host([variant='seafoam']),
-.spectrum-Badge--cyan,
-.spectrum-Badge--blue,
+:host([variant='cyan']),
+:host([variant='blue']),
 :host([variant='indigo']),
 :host([variant='purple']),
 :host([variant='fuchsia']),
@@ -266,28 +266,28 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Badge--notice {
+:host([variant='notice']) {
     background: var(
         --mod-badge-background-color-notice,
         var(--spectrum-badge-background-color-notice)
     );
 }
 
-.spectrum-Badge--gray {
+:host([variant='gray']) {
     background: var(
         --mod-badge-background-color-gray,
         var(--spectrum-badge-background-color-gray)
     );
 }
 
-.spectrum-Badge--red {
+:host([variant='red']) {
     background: var(
         --mod-badge-background-color-red,
         var(--spectrum-badge-background-color-red)
     );
 }
 
-.spectrum-Badge--orange {
+:host([variant='orange']) {
     background: var(
         --mod-badge-background-color-orange,
         var(--spectrum-badge-background-color-orange)
@@ -301,21 +301,21 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Badge--chartreuse {
+:host([variant='chartreuse']) {
     background: var(
         --mod-badge-background-color-chartreuse,
         var(--spectrum-badge-background-color-chartreuse)
     );
 }
 
-.spectrum-Badge--celery {
+:host([variant='celery']) {
     background: var(
         --mod-badge-background-color-celery,
         var(--spectrum-badge-background-color-celery)
     );
 }
 
-.spectrum-Badge--green {
+:host([variant='green']) {
     background: var(
         --mod-badge-background-color-green,
         var(--spectrum-badge-background-color-green)
@@ -329,14 +329,14 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Badge--cyan {
+:host([variant='cyan']) {
     background: var(
         --mod-badge-background-color-cyan,
         var(--spectrum-badge-background-color-cyan)
     );
 }
 
-.spectrum-Badge--blue {
+:host([variant='blue']) {
     background: var(
         --mod-badge-background-color-blue,
         var(--spectrum-badge-background-color-blue)

--- a/packages/badge/src/spectrum-config.js
+++ b/packages/badge/src/spectrum-config.js
@@ -50,6 +50,7 @@ const config = {
                         ['spectrum-Badge--informative'],
                         ['spectrum-Badge--negative'],
                         ['spectrum-Badge--neutral'],
+                        ['spectrum-Badge--notice'],
                         // non-semantic
                         ['spectrum-Badge--seafoam'],
                         ['spectrum-Badge--indigo'],
@@ -57,6 +58,14 @@ const config = {
                         ['spectrum-Badge--fuchsia'],
                         ['spectrum-Badge--magenta'],
                         ['spectrum-Badge--yellow'],
+                        ['spectrum-Badge--gray'],
+                        ['spectrum-Badge--red'],
+                        ['spectrum-Badge--orange'],
+                        ['spectrum-Badge--chartreuse'],
+                        ['spectrum-Badge--celery'],
+                        ['spectrum-Badge--green'],
+                        ['spectrum-Badge--cyan'],
+                        ['spectrum-Badge--blue'],
                     ],
                     'variant'
                 ),

--- a/packages/badge/stories/badge.stories.ts
+++ b/packages/badge/stories/badge.stories.ts
@@ -85,48 +85,26 @@ export const Semantic = (): TemplateResult => {
         <sp-badge variant="informative">Informative</sp-badge>
         <sp-badge variant="negative">Negative</sp-badge>
         <sp-badge variant="neutral">Neutral</sp-badge>
+        <sp-badge variant="notice">Notice</sp-badge>
     `;
 };
 
 export const NonSemantic = (): TemplateResult => {
     return html`
-        <sp-badge
-            variant="seafoam"
-            style="--mod-badge-background-color-default: var(--spectrum-global-color-static-seafoam-600)"
-        >
-            Seafoam
-        </sp-badge>
-        <sp-badge
-            variant="indigo"
-            style="--mod-badge-background-color-default: var(--spectrum-global-color-static-indigo-600)"
-        >
-            Indigo
-        </sp-badge>
-        <sp-badge
-            variant="purple"
-            style="--mod-badge-background-color-default: var(--spectrum-global-color-static-purple-600)"
-        >
-            Purple
-        </sp-badge>
-        <sp-badge
-            variant="fuchsia"
-            style="--mod-badge-background-color-default: var(--spectrum-global-color-static-fuchsia-600)"
-        >
-            Fuchsia
-        </sp-badge>
-        <sp-badge
-            variant="magenta"
-            style="--mod-badge-background-color-default: var(--spectrum-global-color-static-magenta-600)"
-        >
-            Magenta
-        </sp-badge>
-        <sp-badge
-            variant="yellow"
-            static="black"
-            style="--mod-badge-background-color-default: var(--spectrum-alias-background-color-yellow-default)"
-        >
-            Yellow
-        </sp-badge>
+        <sp-badge variant="seafoam">Seafoam</sp-badge>
+        <sp-badge variant="indigo">Indigo</sp-badge>
+        <sp-badge variant="purple">Purple</sp-badge>
+        <sp-badge variant="fuchsia">Fuchsia</sp-badge>
+        <sp-badge variant="magenta">Magenta</sp-badge>
+        <sp-badge variant="yellow">Yellow</sp-badge>
+        <sp-badge variant="gray">Gray</sp-badge>
+        <sp-badge variant="red">Red</sp-badge>
+        <sp-badge variant="orange">Orange</sp-badge>
+        <sp-badge variant="chartreuse">Chartreuse</sp-badge>
+        <sp-badge variant="celery">Celery</sp-badge>
+        <sp-badge variant="green">Green</sp-badge>
+        <sp-badge variant="cyan">Cyan</sp-badge>
+        <sp-badge variant="blue">Blue</sp-badge>
     `;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated the `--mod-badge-background-color-default` override for `seafoam,indigo,purple,fuchsia,magenta,yellow` non semantic variants property which should be
```
--mod-badge-background-color-seafoam
--mod-badge-background-color-indigo
--mod-badge-background-color-purple
--mod-badge-background-color-fuchsia
--mod-badge-background-color-magenta
--mod-badge-background-color-yellow
```

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
