### PR TITLE
fix(tab-overflow): improve tab navigation experience and support custom aria labels

### DIFF
--- a/packages/tabs/src/TabsOverflow.ts
+++ b/packages/tabs/src/TabsOverflow.ts
@@ -46,16 +46,16 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
     }
 
     @property({ type: Boolean, reflect: true })
-    compact = false;
+    public compact = false;
+
+    @property({ type: String, attribute: 'label-previous' })
+    public labelPrevious = 'Scroll to previous tabs';
+
+    @property({ type: String, attribute: 'label-next' })
+    public labelNext = 'Scroll to next tabs';
 
     @property({ reflect: true })
     public override dir!: 'ltr' | 'rtl';
-
-    @property({ reflect: true, type: String, attribute: 'label-previous' })
-    public labelPrevious: string | undefined;
-
-    @property({ reflect: true, type: String, attribute: 'label-next' })
-    public labelNext: string | undefined;
 
     @state()
     private overflowState: TabsOverflowState = {
@@ -138,9 +138,9 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
 
     protected override render(): TemplateResult {
         const { canScrollRight, canScrollLeft } = this.overflowState;
-        const ariaLabelPrevious =
-            this.labelPrevious || 'Scroll to previous tabs';
-        const ariaLabelNext = this.labelNext || 'Scroll to next tabs';
+        const ariaLabelPrevious = this.labelPrevious;
+        // this.labelPrevious || 'Scroll to previous tabs';
+        const ariaLabelNext = this.labelNext;
         return html`
             <div
                 class=${classMap({

--- a/packages/tabs/src/TabsOverflow.ts
+++ b/packages/tabs/src/TabsOverflow.ts
@@ -139,7 +139,6 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
     protected override render(): TemplateResult {
         const { canScrollRight, canScrollLeft } = this.overflowState;
         const ariaLabelPrevious = this.labelPrevious;
-        // this.labelPrevious || 'Scroll to previous tabs';
         const ariaLabelNext = this.labelNext;
         return html`
             <div

--- a/packages/tabs/src/TabsOverflow.ts
+++ b/packages/tabs/src/TabsOverflow.ts
@@ -51,6 +51,12 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
     @property({ reflect: true })
     public override dir!: 'ltr' | 'rtl';
 
+    @property({ reflect: true, type: String, attribute: 'label-previous' })
+    public labelPrevious: string | undefined;
+
+    @property({ reflect: true, type: String, attribute: 'label-next' })
+    public labelNext: string | undefined;
+
     @state()
     private overflowState: TabsOverflowState = {
         canScrollLeft: false,
@@ -132,6 +138,9 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
 
     protected override render(): TemplateResult {
         const { canScrollRight, canScrollLeft } = this.overflowState;
+        const ariaLabelPrevious =
+            this.labelPrevious || 'Scroll to previous tabs';
+        const ariaLabelNext = this.labelNext || 'Scroll to next tabs';
         return html`
             <div
                 class=${classMap({
@@ -145,8 +154,10 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
                         'left-scroll': true,
                         show: canScrollLeft,
                     })}
+                    aria-label=${ariaLabelPrevious}
                     quiet
                     dir="rtl"
+                    tabindex="-1"
                     @click=${this._handleScrollClick}
                 >
                     <sp-icon-chevron100
@@ -159,7 +170,9 @@ export class TabsOverflow extends SizedMixin(SpectrumElement) {
                         'right-scroll': true,
                         show: canScrollRight,
                     })}
+                    aria-label=${ariaLabelNext}
                     quiet
+                    tabindex="-1"
                     @click=${this._handleScrollClick}
                 >
                     <sp-icon-chevron100

--- a/packages/tabs/tabs-overflow.md
+++ b/packages/tabs/tabs-overflow.md
@@ -54,3 +54,7 @@ To use the `<sp-tabs-overflow>` component, simply wrap it around the `<sp-tabs>`
     </sp-tabs-overflow>
 </div>
 ```
+
+### Accessibility
+
+The `<sp-tabs-overflow>` component is not focusable via Keyboard Tab Navigation. The Tabs Overflow buttons only help visually scroll down the list of Tabs. Keyboard users can navigate through all elements inside the Tabs list using arrow keys, and Keyboard users will always initially focus on the very first Tab element, no matter how visually scrolled the Tab group might be. Therefore, the `<sp-tabs-overflow>` component is not useful for Keyboard Tab Navigation, so it is removed as to not be a hinderance.

--- a/packages/tabs/test/tabs-overflow.test.ts
+++ b/packages/tabs/test/tabs-overflow.test.ts
@@ -44,17 +44,11 @@ const renderTabsOverflow = async ({
     includeTabPanel,
     selected = 1,
     autoscroll = false,
-    labelPrev,
-    labelNext,
 }: OverflowProperties): Promise<HTMLDivElement> => {
     const tabsContainer = await fixture<HTMLDivElement>(
         html`
             <div class="container" style="width: 200px; height: 150px;">
-                <sp-tabs-overflow
-                    ?autoscroll=${autoscroll}
-                    label-previous=${labelPrev}
-                    label-next=${labelNext}
-                >
+                <sp-tabs-overflow ?autoscroll=${autoscroll}>
                     <sp-tabs size=${size} selected=${selected}>
                         ${repeat(
                             new Array(count),
@@ -249,14 +243,42 @@ describe('TabsOverflow', () => {
     });
 
     it('prev and next buttons labels overwritten via attributes', async () => {
-        const el = await renderTabsOverflow({
-            count: 20,
-            size: ElementSizes.M,
-            includeTabPanel: true,
-            labelNext: 'Go right',
-            labelPrev: 'Go left',
-        });
-        await elementUpdated(el);
+        const tabsContainer = await fixture<HTMLDivElement>(
+            html`
+                <div class="container" style="width: 200px; height: 150px;">
+                    <sp-tabs-overflow
+                        label-previous="custom label prev"
+                        label-next="custom label next"
+                    >
+                        <sp-tabs size=${ElementSizes.M} selected=${1}>
+                            ${repeat(
+                                new Array(20),
+                                (item) => item,
+                                (_item, index) =>
+                                    html`
+                                        <sp-tab
+                                            label=${`Tab Item ${index + 1}`}
+                                            value=${index + 1}
+                                        ></sp-tab>
+                                    `
+                            )}
+                            ${repeat(
+                                new Array(20),
+                                (item) => item,
+                                (_item, index) =>
+                                    html`
+                                        <sp-tab-panel value=${index + 1}>
+                                            Content for Tab Item ${index + 1}
+                                        </sp-tab-panel>
+                                    `
+                            )}
+                        </sp-tabs>
+                    </sp-tabs-overflow>
+                </div>
+            `
+        );
+        await elementUpdated(tabsContainer);
+        const el = tabsContainer;
 
         const spTabsOverflows: TabsOverflow = el.querySelector(
             'sp-tabs-overflow'
@@ -268,7 +290,11 @@ describe('TabsOverflow', () => {
             '.right-scroll'
         ) as ActionButton;
 
-        expect(leftButton?.getAttribute('aria-label')).to.equal('Go left');
-        expect(rightButton?.getAttribute('aria-label')).to.equal('Go right');
+        expect(leftButton?.getAttribute('aria-label')).to.equal(
+            'custom label prev'
+        );
+        expect(rightButton?.getAttribute('aria-label')).to.equal(
+            'custom label next'
+        );
     });
 });

--- a/packages/tabs/test/tabs-overflow.test.ts
+++ b/packages/tabs/test/tabs-overflow.test.ts
@@ -34,6 +34,8 @@ type OverflowProperties = {
     includeTabPanel: boolean;
     selected?: number;
     autoscroll?: boolean;
+    labelPrev?: string;
+    labelNext?: string;
 };
 
 const renderTabsOverflow = async ({
@@ -42,11 +44,17 @@ const renderTabsOverflow = async ({
     includeTabPanel,
     selected = 1,
     autoscroll = false,
+    labelPrev,
+    labelNext,
 }: OverflowProperties): Promise<HTMLDivElement> => {
     const tabsContainer = await fixture<HTMLDivElement>(
         html`
             <div class="container" style="width: 200px; height: 150px;">
-                <sp-tabs-overflow ?autoscroll=${autoscroll}>
+                <sp-tabs-overflow
+                    ?autoscroll=${autoscroll}
+                    label-previous=${labelPrev}
+                    label-next=${labelNext}
+                >
                     <sp-tabs size=${size} selected=${selected}>
                         ${repeat(
                             new Array(count),
@@ -212,5 +220,55 @@ describe('TabsOverflow', () => {
         const firstTab = tabsEl.querySelector(`[role="tab"][value="1"]`) as Tab;
         const firstTabPosition = firstTab.getBoundingClientRect();
         expect(firstTabPosition.left).to.be.lessThan(0);
+    });
+
+    it('prev and next buttons have default labels', async () => {
+        const el = await renderTabsOverflow({
+            count: 20,
+            size: ElementSizes.M,
+            includeTabPanel: true,
+        });
+        await elementUpdated(el);
+
+        const spTabsOverflows: TabsOverflow = el.querySelector(
+            'sp-tabs-overflow'
+        ) as TabsOverflow;
+        const leftButton = spTabsOverflows.shadowRoot.querySelector(
+            '.left-scroll'
+        ) as ActionButton;
+        const rightButton = spTabsOverflows.shadowRoot.querySelector(
+            '.right-scroll'
+        ) as ActionButton;
+
+        expect(leftButton?.getAttribute('aria-label')).to.equal(
+            'Scroll to previous tabs'
+        );
+        expect(rightButton?.getAttribute('aria-label')).to.equal(
+            'Scroll to next tabs'
+        );
+    });
+
+    it('prev and next buttons labels overwritten via attributes', async () => {
+        const el = await renderTabsOverflow({
+            count: 20,
+            size: ElementSizes.M,
+            includeTabPanel: true,
+            labelNext: 'Go right',
+            labelPrev: 'Go left',
+        });
+        await elementUpdated(el);
+
+        const spTabsOverflows: TabsOverflow = el.querySelector(
+            'sp-tabs-overflow'
+        ) as TabsOverflow;
+        const leftButton = spTabsOverflows.shadowRoot.querySelector(
+            '.left-scroll'
+        ) as ActionButton;
+        const rightButton = spTabsOverflows.shadowRoot.querySelector(
+            '.right-scroll'
+        ) as ActionButton;
+
+        expect(leftButton?.getAttribute('aria-label')).to.equal('Go left');
+        expect(rightButton?.getAttribute('aria-label')).to.equal('Go right');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<img width="835" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/162190334/a70e37f7-5b6c-4dcd-8e71-700494add6ae">

`<sp-tab-overflow>` is an optional add-on to the Tabs component that adds a [<] and [>] button to help scroll, if there are so many tabs that they overflow off the page. These buttons are currently Keyboard-Navigable, and capture tab focus before the TabGroup itself. 

These buttons should be removed from keyboard navigation for the following reasons:
- Keyboard navigators can already use their arrow keys to navigate through the entire TabGroup
- Every time keyboard navigation enters the TabGroup component, it will always initially focus the very first Tab, regardless of whether it is currently rendered on or off the page. 

Therefore, it is superfluous to have these buttons part of the tab navigation journey.

In addition, these buttons were not labeled. This PR gives them default `aria-label`s and allows overrides. These default labels are "Scroll to previous tabs" and "Scroll to next tabs" - specifically avoided left/right language in case of Right-To-Left locales.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Fixes #3270 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

- Improves Keyboard Accessibility by removing UI that is not relevant to Keyboard Navigation experience.
- Improves Screenreader Accessibility by labeling interactive components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] On Storybook and on the Docs website:
    1. Navigate to "Tabs Overflow"
    2. Observe that the Overflow buttons are no longer keyboard navigable, and arrow-key + spacebar navigation works correctly to move between tabs.
    3. Inspect the Overflow buttons and observe that they have default labels: "Scroll to previous tabs" and "Scroll to next tabs".


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
