### PR TITLE
fix(picker): correctly process the CSS for the quiet hover effect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 3ac2a24425678f3fbe475bee63696d063a4c3331
+        default: c9a42ab4bc05206cb7db4a34c45bd7747813c5ae
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/picker/src/spectrum-config.js
+++ b/packages/picker/src/spectrum-config.js
@@ -103,6 +103,19 @@ const config = {
                         },
                     ],
                 },
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'not',
+                        selectors: [[builder.class('spectrum-Picker--quiet')]],
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'not',
+                        selectors: [[builder.attribute('quiet')]],
+                    },
+                    hoist: true,
+                },
             ],
         },
     ],

--- a/packages/picker/src/spectrum-picker.css
+++ b/packages/picker/src/spectrum-picker.css
@@ -713,7 +713,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([open]) #button:not(.spectrum-Picker--quiet) {
+:host([open]:not([quiet])) #button {
     color: var(
         --highcontrast-picker-content-color-default,
         var(
@@ -737,7 +737,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([open]) #button:not(.spectrum-Picker--quiet) .picker {
+:host([open]:not([quiet])) #button .picker {
     color: var(
         --highcontrast-picker-content-color-default,
         var(
@@ -969,7 +969,7 @@ governing permissions and limitations under the License.
         );
     }
 
-    :host([open]) #button:not(.spectrum-Picker--quiet):hover .picker {
+    :host([open]:not([quiet])) #button:hover .picker {
         color: var(
             --highcontrast-picker-content-color-default,
             var(
@@ -1013,7 +1013,7 @@ governing permissions and limitations under the License.
         );
     }
 
-    :host([open]) #button:not(.spectrum-Picker--quiet):hover {
+    :host([open]:not([quiet])) #button:hover {
         color: var(
             --highcontrast-picker-content-color-default,
             var(

--- a/packages/picker/stories/picker.stories.ts
+++ b/packages/picker/stories/picker.stories.ts
@@ -26,6 +26,7 @@ import { isOverlayOpen } from '../../overlay/stories/index.js';
 import '../../overlay/stories/index.js';
 import { handleChange, StoryArgs, Template } from './template.js';
 import { argTypes } from './args.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export default {
     title: 'Picker',
@@ -66,7 +67,9 @@ export default {
 
 export const Default = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label for="picker-1">Where do you live?</sp-field-label>
+        <sp-field-label for="picker-1" size=${ifDefined(args.size)}>
+            Where do you live?
+        </sp-field-label>
         <sp-picker
             id="picker-1"
             @change=${handleChange(args)}
@@ -105,7 +108,9 @@ invalid.args = {
 export const tooltip = (args: StoryArgs): TemplateResult => {
     const { open, ...rest } = args;
     return html`
-        <sp-field-label for="picker-1">Where do you live?</sp-field-label>
+        <sp-field-label for="picker-1" size=${ifDefined(args.size)}>
+            Where do you live?
+        </sp-field-label>
         <sp-picker
             id="picker-1"
             @change=${handleChange(args)}
@@ -145,7 +150,11 @@ tooltip.decorators = [isOverlayOpen];
 
 export const leftSideLabel = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label side-aligned="start" for="picker-1">
+        <sp-field-label
+            side-aligned="start"
+            for="picker-1"
+            size=${ifDefined(args.size)}
+        >
             Where do you live?
         </sp-field-label>
         <sp-picker
@@ -224,7 +233,9 @@ export const slottedLabel = (args: StoryArgs): TemplateResult => {
 
 export const quiet = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label for="picker-quiet">Where do you live?</sp-field-label>
+        <sp-field-label for="picker-quiet" size=${ifDefined(args.size)}>
+            Where do you live?
+        </sp-field-label>
         <sp-picker
             ${spreadProps(args)}
             id="picker-quiet"
@@ -251,7 +262,11 @@ quiet.args = {
 
 export const quietSideLabel = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label side-aligned="start" for="picker-quiet-sidelabel">
+        <sp-field-label
+            side-aligned="start"
+            for="picker-quiet-sidelabel"
+            size=${ifDefined(args.size)}
+        >
             Where do you live?
         </sp-field-label>
         <sp-picker
@@ -280,7 +295,7 @@ quietSideLabel.args = {
 
 export const icons = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label for="picker-quiet">
+        <sp-field-label for="picker-quiet" size=${ifDefined(args.size)}>
             Choose an action type...
         </sp-field-label>
         <sp-picker
@@ -308,7 +323,7 @@ export const icons = (args: StoryArgs): TemplateResult => {
 
 export const iconsNone = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label for="picker-quiet">
+        <sp-field-label for="picker-quiet" size=${ifDefined(args.size)}>
             Choose an action type...
         </sp-field-label>
         <sp-picker
@@ -341,7 +356,7 @@ iconsNone.decorators = [isOverlayOpen];
 
 export const iconValue = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label for="picker-quiet">
+        <sp-field-label for="picker-quiet" size=${ifDefined(args.size)}>
             Choose an action type...
         </sp-field-label>
         <sp-picker
@@ -371,7 +386,7 @@ export const iconValue = (args: StoryArgs): TemplateResult => {
 
 export const iconsOnly = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label for="picker-quiet">
+        <sp-field-label for="picker-quiet" size=${ifDefined(args.size)}>
             Choose an action type...
         </sp-field-label>
         <sp-picker
@@ -409,7 +424,7 @@ export const Open = (args: StoryArgs): TemplateResult => {
             }
         </style>
         <fieldset class="backdrop-filter-test">
-            <sp-field-label for="picker-open">
+            <sp-field-label for="picker-open" size=${ifDefined(args.size)}>
                 Where do you live?
             </sp-field-label>
             <sp-picker
@@ -430,7 +445,7 @@ export const Open = (args: StoryArgs): TemplateResult => {
             </sp-picker>
         </fieldset>
         <fieldset>
-            <sp-field-label for="picker-closed">
+            <sp-field-label for="picker-closed" size=${ifDefined(args.size)}>
                 Where do you live?
             </sp-field-label>
             <sp-picker
@@ -490,7 +505,7 @@ export const OpenShowingEdgeCase = (args: StoryArgs): TemplateResult => {
             .
         </p>
         <fieldset class="backdrop-filter-test">
-            <sp-field-label for="picker-open">
+            <sp-field-label for="picker-open" size=${ifDefined(args.size)}>
                 Where do you live?
             </sp-field-label>
             <sp-picker
@@ -511,7 +526,7 @@ export const OpenShowingEdgeCase = (args: StoryArgs): TemplateResult => {
             </sp-picker>
         </fieldset>
         <fieldset>
-            <sp-field-label for="picker-closed">
+            <sp-field-label for="picker-closed" size=${ifDefined(args.size)}>
                 Where do you live?
             </sp-field-label>
             <sp-picker
@@ -537,7 +552,9 @@ OpenShowingEdgeCase.swc_vrt = {
 
 export const initialValue = (args: StoryArgs): TemplateResult => {
     return html`
-        <sp-field-label for="picker-initial">Where do you live?</sp-field-label>
+        <sp-field-label for="picker-initial" size=${ifDefined(args.size)}>
+            Where do you live?
+        </sp-field-label>
         <sp-picker
             id="picker-initial"
             @change=${handleChange(args)}
@@ -581,7 +598,7 @@ export const readonly = (args: StoryArgs): TemplateResult => {
 export const custom = (args: StoryArgs): TemplateResult => {
     const initialState = 'lb1-mo';
     return html`
-        <sp-field-label for="picker-state">
+        <sp-field-label for="picker-state" size=${ifDefined(args.size)}>
             What state do you live in?
         </sp-field-label>
         <sp-picker

--- a/packages/picker/stories/template.ts
+++ b/packages/picker/stories/template.ts
@@ -10,13 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { html, type TemplateResult } from '@spectrum-web-components/base';
+import {
+    ElementSize,
+    html,
+    type TemplateResult,
+} from '@spectrum-web-components/base';
 import type { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 
 import { spreadProps } from '../../../test/lit-helpers.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
 
 export interface StoryArgs {
     disabled?: boolean;
@@ -27,6 +32,7 @@ export interface StoryArgs {
     showText?: boolean;
     onChange?: (val: string) => void;
     [prop: string]: unknown;
+    size?: ElementSize;
 }
 
 export const handleChange =
@@ -37,7 +43,9 @@ export const handleChange =
     };
 
 export const Template = (args: StoryArgs): TemplateResult => html`
-    <sp-field-label for="picker-1">Where do you live?</sp-field-label>
+    <sp-field-label for="picker-1" size=${ifDefined(args.size)}>
+        Where do you live?
+    </sp-field-label>
     <sp-picker
         id="picker-1"
         @change=${handleChange(args)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Seems like the problem is that the CSS for the quiet variant of the `sp-picker` was not correctly processed:
```
:host([open]) #button:not(.spectrum-Picker--quiet) {
```
observe the `spectrum-Picker--quiet` class which should be translated to the HTML quiet attribute.

I added some more processing rules in the `spectrum-config` which should take care of that. Let me know if there is a better config to use for this.

Also, in the storybook, the `sp-label-field` should have the same size as the `sp-picker`, or else it looks weird and the `sp-picker` climbs over the `sp-label-field`. I adjusted the stories to pass the `size` attribute to the `sp-label-field` as well, if present.

## Related issue(s)

- fixes https://github.com/adobe/spectrum-web-components/issues/4166

## Motivation and context

Solves a CSS bug in the `Picker` component when using the `quiet` variant and hovering over the component.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] Hover effect is no longer present on the `<sp-picker quiet..... />`
    1. Go here: https://rocss-picker-quiet-hover--spectrum-web-components.netlify.app/components/picker/
    2. Click and hover on the Picker. You can also test the controllers for the theme and scale too since those are quiet pickers as well.
    3. Observe there is no hover effect present anymore.
-   [x] `sp-picker` no longer overlaps with the `sp-label-field`
    1. Go here: https://rocss-picker-quiet-hover--spectrum-web-components.netlify.app/components/picker/
    2. Adjust the size of the picker to L or XL
    3. Inspect the button and the label
    4. Observe that the button no longer overlaps the picker:
![Screenshot 2024-03-12 at 12 07 36](https://github.com/adobe/spectrum-web-components/assets/13311865/3d7e9fe5-7a3b-4c03-975f-e645b5ec4f2e)

-   [x] In storybook, you can not change the size of the Picker from the Controls addon panel
    1. Go here: https://rocss-picker-quiet-hover--spectrum-web-components.netlify.app/storybook/?path=/story/picker--quiet
    2. Open the Controls addon panel
    3. Observe there is a dropdown now for the `size` attribute
    4. Observe that the size of the `sp-label-field` changes too when interacting with this dropdown

## Screenshots (if appropriate)
![Screenshot 2024-03-12 at 11 26 08](https://github.com/adobe/spectrum-web-components/assets/13311865/1f145973-0b1a-420c-b44f-addfbde39450)

![Screenshot 2024-03-12 at 12 07 13](https://github.com/adobe/spectrum-web-components/assets/13311865/82145c3f-672b-4a21-a603-381984329837)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
