### PR TITLE
Selection management fixes

### DIFF
--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -170,13 +170,12 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
     }
 
     private deselectSelectedButtons(): void {
-        const selected = [
-            ...this.querySelectorAll('[selected]'),
-        ] as ActionButton[];
-        selected.forEach((el) => {
-            el.selected = false;
-            el.tabIndex = -1;
-            el.setAttribute(
+        this.buttons.forEach((button) => {
+            if (!button.selected) return;
+
+            button.selected = false;
+            button.tabIndex = -1;
+            button.setAttribute(
                 this.selects ? 'aria-checked' : /* c8 ignore */ 'aria-pressed',
                 'false'
             );

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -699,7 +699,7 @@ describe('ActionGroup', () => {
         expect(secondButton.selected, 'second button selected').to.be.true;
     });
 
-    it('does not allow interaction with child content to interupt the selection mechanism', async () => {
+    it('does not allow interaction with child content to interrupt the selection mechanism', async () => {
         const el = await singleSelectedActionGroup([]);
         await elementUpdated(el);
         expect(el.selected.length).to.equal(0);
@@ -723,8 +723,8 @@ describe('ActionGroup', () => {
 
         expect(el.selected.length).to.equal(1);
         expect(el.selected).to.deep.equal(['first']);
-        expect(firstButton.selected, 'first button not selected').to.be.true;
-        expect(secondButton.selected, 'second button selected').to.be.false;
+        expect(firstButton.selected, 'first button selected').to.be.true;
+        expect(secondButton.selected, 'second button not selected').to.be.false;
 
         const rect = icon.getBoundingClientRect();
         await sendMouse({

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -82,6 +82,7 @@ async function singleSelectedActionGroup(
                     First
                 </sp-action-button>
                 <sp-action-button value="second" class="second">
+                    <div slot="icon" style="width: 10px; height: 10px;"></div>
                     Second
                 </sp-action-button>
             </sp-action-group>
@@ -655,6 +656,54 @@ describe('ActionGroup', () => {
         await elementUpdated(el);
 
         expect(el.selected.length).to.equal(1);
+        expect(firstButton.selected, 'first button not selected').to.be.false;
+        expect(secondButton.selected, 'second button selected').to.be.true;
+    });
+
+    it('does not allow interaction with child content to interupt the selection mechanism', async () => {
+        const el = await singleSelectedActionGroup([]);
+        await elementUpdated(el);
+        expect(el.selected.length).to.equal(0);
+
+        const firstButton = el.querySelector('.first') as ActionButton;
+        const secondButton = el.querySelector('.second') as ActionButton;
+        const icon = secondButton.querySelector('[slot=icon]') as HTMLElement;
+        expect(firstButton.selected, 'first button selected').to.be.false;
+        expect(secondButton.selected, 'second button not selected').to.be.false;
+
+        secondButton.click();
+        await elementUpdated(el);
+
+        expect(el.selected.length).to.equal(1);
+        expect(el.selected).to.deep.equal(['second']);
+        expect(firstButton.selected, 'first button not selected').to.be.false;
+        expect(secondButton.selected, 'second button selected').to.be.true;
+
+        firstButton.click();
+        await elementUpdated(el);
+
+        expect(el.selected.length).to.equal(1);
+        expect(el.selected).to.deep.equal(['first']);
+        expect(firstButton.selected, 'first button not selected').to.be.true;
+        expect(secondButton.selected, 'second button selected').to.be.false;
+
+        const rect = icon.getBoundingClientRect();
+        await sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [
+                        rect.left + rect.width / 2,
+                        rect.top + rect.height / 2,
+                    ],
+                },
+            ],
+        });
+        icon.click();
+        await elementUpdated(el);
+
+        expect(el.selected.length).to.equal(1);
+        expect(el.selected).to.deep.equal(['second']);
         expect(firstButton.selected, 'first button not selected').to.be.false;
         expect(secondButton.selected, 'second button selected').to.be.true;
     });

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -423,6 +423,45 @@ describe('ActionGroup', () => {
 
         expect(el.selected, '"Third" selected').to.deep.equal(['Third']);
     });
+    it('manages [selects="single"] selection through multiple slots', async () => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <div>
+                    <sp-action-button>First</sp-action-button>
+                    <sp-action-button>Second</sp-action-button>
+                    <sp-action-button selected>Third</sp-action-button>
+                </div>
+            `
+        );
+
+        const firstItem = test.querySelector(
+            'sp-action-button'
+        ) as ActionButton;
+        const thirdItem = test.querySelector(
+            'sp-action-button[selected]'
+        ) as ActionButton;
+
+        const shadowRoot = test.attachShadow({ mode: 'open' });
+        shadowRoot.innerHTML = `
+            <sp-action-group label="Selects Single Group" selects="single">
+                <slot></slot>
+            </sp-action-group>
+        `;
+
+        const el = shadowRoot.querySelector('sp-action-group') as ActionGroup;
+        await elementUpdated(el);
+
+        expect(el.selected, '"Third" selected').to.deep.equal(['Third']);
+        expect(firstItem.selected).to.be.false;
+        expect(thirdItem.selected).to.be.true;
+
+        firstItem.click();
+        await elementUpdated(el);
+
+        expect(el.selected, '"First" selected').to.deep.equal(['First']);
+        expect(firstItem.selected).to.be.true;
+        expect(thirdItem.selected).to.be.false;
+    });
     it('surfaces [selects="multiple"] selection', async () => {
         const el = await fixture<ActionGroup>(
             html`

--- a/packages/button/src/button-base.css
+++ b/packages/button/src/button-base.css
@@ -47,6 +47,10 @@ governing permissions and limitations under the License.
     pointer-events: none;
 }
 
+::slotted(*) {
+    pointer-events: none;
+}
+
 slot[name='icon']::slotted(svg),
 slot[name='icon']::slotted(img) {
     fill: currentcolor;


### PR DESCRIPTION
## Description
- force Button content to be `pointer-events: none` so that the host can be the target for all click interactions, particularly ones leading to selection
- ensure the Action Group can manage selection state through multiple slots

## How has this been tested?
-   [ ] _Test case 1_
    1. See that added Action Group tests handle "icons" that are not managed by SWC and therefor do not prevent their own `pointer-events`
-   [ ] _Test case 2_
    1. See that added Action Group tests handle selection through multiple slots; on of their own and own of their parent's

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.