### PR TITLE
refactor(theme): adds new system attribute to <sp-theme> and deprecates theme attribute

### DIFF
--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -631,13 +631,13 @@ export const deepNesting = (): TemplateResult => {
         ${storyStyles}
         <sp-theme
             color=${outter}
-            theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+            system=${window.__swc_hack_knobs__.defaultSystemVariant}
             scale=${window.__swc_hack_knobs__.defaultScale}
             dir=${window.__swc_hack_knobs__.defaultDirection}
         >
             <sp-theme
                 color=${color}
-                theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+                system=${window.__swc_hack_knobs__.defaultSystemVariant}
                 scale=${window.__swc_hack_knobs__.defaultScale}
                 dir=${window.__swc_hack_knobs__.defaultDirection}
             >

--- a/projects/documentation/content/guides/what-is-a-theme.md
+++ b/projects/documentation/content/guides/what-is-a-theme.md
@@ -1,0 +1,50 @@
+---
+layout: guide.njk
+title: 'What is a theme?'
+displayName: What is a theme?
+slug: what-is-a-theme
+---
+
+# Understanding "Theme" in Spectrum Web Components
+
+Theme is an overloaded term that can lead to confusion and a general thought of "What is a theme anyway?". Is it just color appearance changes for light and dark mode? Is it scale changes? Our answer historically has kind of been, "yes—all that". We've built `sp-theme` to represent these different contexts as a collective type called a "theme".
+
+```html
+<sp-theme system="spectrum" color="dark" scale="medium">
+    <sp-button>Don't Click</sp-button>
+</sp-theme>
+```
+
+This guide aims to provide an understanding of what we mean when we say "theme" in the project and how you should think about it in your projects.
+
+## What is a theme anyway?
+
+In a world where "theme" is often used to describe the look and feel of an application, we often tie the term to color alone. If we think about how a theme in a CMS (like Wordpress) works, however, it’s often much more than just color. It can affect the entire layout of the page. We don't quite have that concept to worry about but we do have multiple parameters to think about. Those are:
+
+-   **System** » The design system to use, in our case we have Spectrum and Express. This system can be spectrum itself, and as we work towards future versions of Spectrum, this system can become a way to control which version of the Design System you are using. It's also an open API which opens the door to a limited system you build for your product.
+-   **Color** » The color appearance, typically light or dark mode.
+-   **Scale** » The scale of the components as designed, often used for mobile—for example `medium`, `large`.
+-   **Direction** » The directionality of layout, this helps support right-to-left languages like Arabic.
+-   **Language** » The language of the content, such as `en-US`, `it`, `jp`, `uk`,—as defined [by mozilla](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang).
+
+## A theme is all of it
+
+All these parameters together are what we consider a "theme". Theme becomes an aggregate concept that represents the state of this collection of values. This state can be modified in some cases by the user of the application—toggling light/dark mode with the `color` attribute. It could also be modified by their browser configuration or their locale—affecting `direction`. Themes also have advanced use cases as described in the [theme guide](/tools/theme/#advanced-usage) where you could define overrides or custom subsystems that can then be exposed as new sets of `color`, `system`, etc. Finally, the theme may be dependent on future versions of the design system—for example, the `system` attribute will be the entry point for future versions of Spectrum allowing teams that need to migrate a clearer path to the new design language—which allows these parameters, like `system`, to be capable of their own beta cycle.
+
+```
+<sp-theme
+    system="spectrum"
+    color="dark"
+    scale="medium">
+    <sp-button>Don't Click</sp-button>
+</sp-theme>
+
+<!-- is a different "theme" from -->
+
+<sp-theme
+    system="express"
+    color="light"
+    scale="large">
+    <sp-button>Don't Click</sp-button>
+</sp-theme>
+```

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -26,8 +26,8 @@ import '@spectrum-web-components/theme/sp-theme.js';
 import type {
     Color,
     Scale,
+    SystemVariant,
     Theme,
-    ThemeVariant,
 } from '@spectrum-web-components/theme';
 import type { Picker } from '@spectrum-web-components/picker';
 import '@spectrum-web-components/button/sp-button.js';
@@ -53,11 +53,11 @@ import type { ActionButton } from '@spectrum-web-components/bundle';
 
 const SWC_THEME_COLOR_KEY = 'swc-docs:theme:color';
 const SWC_THEME_SCALE_KEY = 'swc-docs:theme:scale';
-const SWC_THEME_THEME_KEY = 'swc-docs:theme:theme';
+const SWC_THEME_SYSTEM_KEY = 'swc-docs:theme:system';
 const SWC_THEME_DIR_KEY = 'swc-docs:theme:dir';
 const COLOR_FALLBACK = matchMedia(DARK_MODE).matches ? 'dark' : 'light';
 const SCALE_FALLBACK = matchMedia(IS_MOBILE).matches ? 'large' : 'medium';
-const THEME_FALLBACK = 'spectrum';
+const SYSTEM_FALLBACK = 'spectrum';
 const DIR_FALLBACK = 'ltr';
 const DEFAULT_COLOR = (
     window.localStorage
@@ -69,11 +69,11 @@ const DEFAULT_SCALE = (
         ? localStorage.getItem(SWC_THEME_SCALE_KEY) || SCALE_FALLBACK
         : SCALE_FALLBACK
 ) as Scale;
-const DEFAULT_THEME = (
+const DEFAULT_SYSTEM = (
     window.localStorage
-        ? localStorage.getItem(SWC_THEME_THEME_KEY) || THEME_FALLBACK
-        : THEME_FALLBACK
-) as ThemeVariant;
+        ? localStorage.getItem(SWC_THEME_SYSTEM_KEY) || SYSTEM_FALLBACK
+        : SYSTEM_FALLBACK
+) as SystemVariant;
 const DEFAULT_DIR = (
     window.localStorage
         ? localStorage.getItem(SWC_THEME_DIR_KEY) || DIR_FALLBACK
@@ -82,8 +82,11 @@ const DEFAULT_DIR = (
 
 const isNarrowMediaQuery = matchMedia('screen and (max-width: 960px)');
 
-const lazyStyleFragment = (name: Color | Scale, flavor: ThemeVariant): void => {
-    var fragmentName = `${name}-${flavor}`;
+const lazyStyleFragment = (
+    name: Color | Scale,
+    system: SystemVariant
+): void => {
+    var fragmentName = `${name}-${system}`;
     switch (fragmentName) {
         case 'darkest-spectrum':
             import('@spectrum-web-components/theme/theme-darkest.js');
@@ -128,10 +131,10 @@ const loadDefaults = () => {
     if (
         DEFAULT_COLOR !== COLOR_FALLBACK ||
         DEFAULT_SCALE !== SCALE_FALLBACK ||
-        DEFAULT_THEME !== THEME_FALLBACK
+        DEFAULT_SYSTEM !== SYSTEM_FALLBACK
     ) {
-        lazyStyleFragment(DEFAULT_COLOR, DEFAULT_THEME);
-        lazyStyleFragment(DEFAULT_SCALE, DEFAULT_THEME);
+        lazyStyleFragment(DEFAULT_COLOR, DEFAULT_SYSTEM);
+        lazyStyleFragment(DEFAULT_SCALE, DEFAULT_SYSTEM);
     }
 };
 
@@ -174,7 +177,7 @@ export class LayoutElement extends LitElement {
     public scale: Scale = DEFAULT_SCALE;
 
     @property({ attribute: false })
-    public theme: ThemeVariant = DEFAULT_THEME;
+    public system: SystemVariant = DEFAULT_SYSTEM;
 
     @queryAsync('sp-theme')
     private themeRoot!: Theme;
@@ -226,7 +229,7 @@ export class LayoutElement extends LitElement {
     }
 
     private updateTheme(event: Event) {
-        this.theme = (event.target as Picker).value as ThemeVariant;
+        this.system = (event.target as Picker).value as SystemVariant;
     }
 
     private updateDirection(event: Event) {
@@ -369,23 +372,19 @@ export class LayoutElement extends LitElement {
         return html`
             <div class="manage-theme" role="form" aria-label="Settings">
                 <div class="theme-control">
-                    <sp-field-label for="theme-theme">Theme</sp-field-label>
+                    <sp-field-label for="theme-system">System</sp-field-label>
                     <sp-picker
-                        id="theme-theme"
+                        id="theme-system"
                         quiet
-                        value=${this.theme}
+                        value=${this.system}
                         @change=${this.updateTheme}
                     >
                         <sp-menu-item value="spectrum">Spectrum</sp-menu-item>
-                        <sp-menu-item value="express">
-                            Spectrum Express
-                        </sp-menu-item>
+                        <sp-menu-item value="express">Express</sp-menu-item>
                     </sp-picker>
                 </div>
                 <div class="theme-control">
-                    <sp-field-label for="theme-color">
-                        Color Theme
-                    </sp-field-label>
+                    <sp-field-label for="theme-color">Color</sp-field-label>
                     <sp-picker
                         id="theme-color"
                         quiet
@@ -435,7 +434,7 @@ export class LayoutElement extends LitElement {
             <sp-theme
                 .color=${this.color}
                 .scale=${this.scale}
-                .theme=${this.theme}
+                .theme=${this.system}
                 dir=${this.dir}
                 id="app"
                 @sp-track-theme=${this.handleTrackTheme}
@@ -545,11 +544,11 @@ export class LayoutElement extends LitElement {
                 loadStyleFragments = true;
             }
         }
-        if (changes.has('theme')) {
+        if (changes.has('system')) {
             if (window.localStorage) {
-                localStorage.setItem(SWC_THEME_THEME_KEY, this.theme);
+                localStorage.setItem(SWC_THEME_SYSTEM_KEY, this.system);
             }
-            if (changes.get('theme')) {
+            if (changes.get('system')) {
                 loadStyleFragments = true;
             }
         }
@@ -599,8 +598,8 @@ export class LayoutElement extends LitElement {
         }
 
         if (loadStyleFragments) {
-            lazyStyleFragment(this.color, this.theme);
-            lazyStyleFragment(this.scale, this.theme);
+            lazyStyleFragment(this.color, this.system);
+            lazyStyleFragment(this.scale, this.system);
         }
     }
 }

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -53,6 +53,7 @@ import type { ActionButton } from '@spectrum-web-components/bundle';
 
 const SWC_THEME_COLOR_KEY = 'swc-docs:theme:color';
 const SWC_THEME_SCALE_KEY = 'swc-docs:theme:scale';
+const SWC_THEME_THEME_KEY = 'swc-docs:theme:theme';
 const SWC_THEME_SYSTEM_KEY = 'swc-docs:theme:system';
 const SWC_THEME_DIR_KEY = 'swc-docs:theme:dir';
 const COLOR_FALLBACK = matchMedia(DARK_MODE).matches ? 'dark' : 'light';
@@ -71,7 +72,7 @@ const DEFAULT_SCALE = (
 ) as Scale;
 const DEFAULT_SYSTEM = (
     window.localStorage
-        ? localStorage.getItem(SWC_THEME_SYSTEM_KEY) || SYSTEM_FALLBACK
+        ? localStorage.getItem(SWC_THEME_THEME_KEY) || SYSTEM_FALLBACK
         : SYSTEM_FALLBACK
 ) as SystemVariant;
 const DEFAULT_DIR = (

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -36,8 +36,8 @@ import { Switch } from '@spectrum-web-components/switch';
 import {
     Color,
     Scale,
+    SystemVariant,
     Theme,
-    ThemeVariant,
 } from '@spectrum-web-components/theme';
 import './types.js';
 
@@ -46,8 +46,8 @@ const urlParams = new URLSearchParams(queryString);
 
 export let dir: 'ltr' | 'rtl' =
     (urlParams.get('sp_dir') as 'ltr' | 'rtl') || 'ltr';
-export let theme: ThemeVariant =
-    (urlParams.get('sp_theme') as ThemeVariant) || 'spectrum';
+export let system: SystemVariant =
+    (urlParams.get('sp_theme') as SystemVariant) || 'spectrum'; // Not sure of how this export is used, do we also need to introduce an `sp_system`?
 export let color: Color =
     (urlParams.get('sp_color') as Color) ||
     (matchMedia(DARK_MODE).matches ? 'dark' : 'light');
@@ -56,7 +56,7 @@ export let reduceMotion = urlParams.get('sp_reduceMotion') === 'true';
 export let screenshot = urlParams.get('sp_screenshot') === 'true';
 
 window.__swc_hack_knobs__ = window.__swc_hack_knobs__ || {
-    defaultThemeVariant: theme,
+    defaultSystemVariant: system,
     defaultColor: color,
     defaultScale: scale,
     defaultDirection: dir,
@@ -163,7 +163,8 @@ export class StoryDecorator extends SpectrumElement {
     }
 
     @property({ type: String })
-    public theme: ThemeVariant = window.__swc_hack_knobs__.defaultThemeVariant;
+    public system: SystemVariant =
+        window.__swc_hack_knobs__.defaultSystemVariant;
 
     @property({ type: String })
     public color: Color = window.__swc_hack_knobs__.defaultColor;
@@ -199,11 +200,11 @@ export class StoryDecorator extends SpectrumElement {
         const { value } = target as Picker;
         const { checked } = target as Switch;
         switch (id) {
-            case 'theme':
-                this.theme =
-                    theme =
-                    window.__swc_hack_knobs__.defaultThemeVariant =
-                        value as ThemeVariant;
+            case 'system':
+                this.system =
+                    system =
+                    window.__swc_hack_knobs__.defaultSystemVariant =
+                        value as SystemVariant;
                 break;
             case 'color':
                 this.color =
@@ -249,7 +250,7 @@ export class StoryDecorator extends SpectrumElement {
     protected override render(): TemplateResult {
         return html`
             <sp-theme
-                theme=${this.theme}
+                system=${this.system}
                 color=${this.color}
                 scale=${this.scale}
                 dir=${this.direction}
@@ -296,25 +297,25 @@ export class StoryDecorator extends SpectrumElement {
     private get manageTheme(): TemplateResult {
         return html`
             <div class="manage-theme" part="controls">
-                ${this.themeControl} ${this.colorControl} ${this.scaleControl}
+                ${this.systemControl} ${this.colorControl} ${this.scaleControl}
                 ${this.dirControl} ${this.reduceMotionControl}
             </div>
         `;
     }
 
-    private get themeControl(): TemplateResult {
+    private get systemControl(): TemplateResult {
         return html`
-            <sp-field-label side-aligned="start" for="theme">
-                Spectrum
+            <sp-field-label side-aligned="start" for="system">
+                System
             </sp-field-label>
             <sp-picker
-                id="theme"
+                id="system"
                 placement="top"
                 quiet
-                .value=${this.theme}
+                .value=${this.system}
                 @change=${this.updateTheme}
             >
-                <sp-menu-item value="spectrum">Classic</sp-menu-item>
+                <sp-menu-item value="spectrum">Spectrum 1</sp-menu-item>
                 <sp-menu-item value="express">Express</sp-menu-item>
             </sp-picker>
         `;
@@ -323,7 +324,7 @@ export class StoryDecorator extends SpectrumElement {
     private get colorControl(): TemplateResult {
         return html`
             <sp-field-label side-aligned="start" for="color">
-                Theme
+                Color
             </sp-field-label>
             <sp-picker
                 id="color"

--- a/projects/story-decorator/src/types.ts
+++ b/projects/story-decorator/src/types.ts
@@ -9,12 +9,12 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-import { Color, Scale, ThemeVariant } from '@spectrum-web-components/theme';
+import { Color, Scale, SystemVariant } from '@spectrum-web-components/theme';
 
 declare global {
     interface Window {
         __swc_hack_knobs__: {
-            defaultThemeVariant: ThemeVariant;
+            defaultSystemVariant: SystemVariant;
             defaultColor: Color;
             defaultScale: Scale;
             defaultDirection: 'ltr' | 'rtl';

--- a/tools/theme/core.ts
+++ b/tools/theme/core.ts
@@ -14,4 +14,7 @@ import { Theme } from './src/Theme.js';
 
 import coreStyles from './src/theme.css.js';
 
+Theme.registerThemeFragment('spectrum', 'system', coreStyles);
+
+// `theme` is deprecated in favor of `system` but maintaining `theme` as a deprecated path.
 Theme.registerThemeFragment('spectrum', 'theme', coreStyles);

--- a/tools/theme/core.ts
+++ b/tools/theme/core.ts
@@ -15,6 +15,3 @@ import { Theme } from './src/Theme.js';
 import coreStyles from './src/theme.css.js';
 
 Theme.registerThemeFragment('spectrum', 'system', coreStyles);
-
-// `theme` is deprecated in favor of `system` but maintaining `theme` as a deprecated path.
-Theme.registerThemeFragment('spectrum', 'theme', coreStyles);

--- a/tools/theme/src/express/core.ts
+++ b/tools/theme/src/express/core.ts
@@ -14,4 +14,7 @@ import { Theme } from '../Theme.js';
 
 import coreStyles from './theme.css.js';
 
+Theme.registerThemeFragment('express', 'system', coreStyles);
+
+// `theme` is deprecated in favor of `system` but maintaining `theme` as a deprecated path.
 Theme.registerThemeFragment('express', 'theme', coreStyles);

--- a/tools/theme/stories/theme.stories.ts
+++ b/tools/theme/stories/theme.stories.ts
@@ -66,7 +66,7 @@ export const Default = ({
         ${storyStyles}
         <sp-theme
             color="${color}"
-            theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+            system=${window.__swc_hack_knobs__.defaultSystemVariant}
         >
             <div id="example">
                 <div>
@@ -107,7 +107,7 @@ export const displayFlex = (): TemplateResult => html`
     <sp-theme
         id="flex-theme"
         color="dark"
-        theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+        system=${window.__swc_hack_knobs__.defaultSystemVariant}
     >
         <sp-button>Start</sp-button>
         <sp-button id="middle-button">Middle</sp-button>
@@ -147,7 +147,7 @@ export const nestedTheme = ({
         ${storyStyles}
         <sp-theme
             color="${outer}"
-            theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+            system=${window.__swc_hack_knobs__.defaultSystemVariant}
         >
             <div id="outer">
                 <div>
@@ -170,7 +170,7 @@ export const nestedTheme = ({
                 <sp-theme
                     color="${inner}"
                     dir="ltr"
-                    theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+                    system=${window.__swc_hack_knobs__.defaultSystemVariant}
                 >
                     <div id="inner">
                         <div>
@@ -225,7 +225,7 @@ export const reverseColorNestedTheme = ({
         </style>
         <sp-theme
             color="${inner}"
-            theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+            system=${window.__swc_hack_knobs__.defaultSystemVariant}
         >
             <div id="outer">
                 <div>
@@ -248,7 +248,7 @@ export const reverseColorNestedTheme = ({
                 <sp-theme
                     color="${outer}"
                     dir="rtl"
-                    theme=${window.__swc_hack_knobs__.defaultThemeVariant}
+                    system=${window.__swc_hack_knobs__.defaultSystemVariant}
                 >
                     <div id="inner">
                         <div>

--- a/tools/theme/test/theme-lazy.test.ts
+++ b/tools/theme/test/theme-lazy.test.ts
@@ -32,7 +32,7 @@ describe('Themes - lazy', () => {
             Theme as unknown as TestableThemeConstructor
         ).themeFragmentsByKind.clear();
         // Core is registered by default in `theme.ts`
-        Theme.registerThemeFragment('spectrum', 'theme', coreStyles);
+        Theme.registerThemeFragment('spectrum', 'system', coreStyles);
     });
     after(() => {
         Theme.registerThemeFragment('light', 'color', lightStyles);

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -100,7 +100,7 @@ export const packages = fs
     .concat(tools);
 
 const vrtHTML =
-    ({ themeVariant, color, scale, dir, reduceMotion, hcm }) =>
+    ({ systemVariant, color, scale, dir, reduceMotion, hcm }) =>
     (testFramework) =>
         `<!doctype html>
     <html dir=${dir}>
@@ -121,7 +121,7 @@ const vrtHTML =
         <body>
         <script>
             window.__swc_hack_knobs__ = {
-                defaultThemeVariant: "${themeVariant || ''}",
+                defaultSystemVariant: "${systemVariant || ''}",
                 defaultColor: "${color || ''}",
                 defaultScale: "${scale || ''}",
                 defaultDirection: "${dir || ''}",
@@ -134,24 +134,24 @@ const vrtHTML =
     </html>`;
 
 export let vrtGroups = [];
-const themeVariants = ['classic', 'express'];
+const systemVariants = ['spectrum', 'express'];
 const colors = ['lightest', 'light', 'dark', 'darkest'];
 const scales = ['medium', 'large'];
 const directions = ['ltr', 'rtl'];
-themeVariants.forEach((themeVariant) => {
+systemVariants.forEach((system) => {
     colors.forEach((color) => {
         scales.forEach((scale) => {
             directions.forEach((dir) => {
                 const reduceMotion = true;
                 const testHTML = vrtHTML({
-                    themeVariant,
+                    system,
                     color,
                     scale,
                     dir,
                     reduceMotion,
                 });
                 vrtGroups.push({
-                    name: `vrt-${themeVariant}-${color}-${scale}-${dir}`,
+                    name: `vrt-${system}-${color}-${scale}-${dir}`,
                     files: '(packages|tools)/*/test/*.test-vrt.js',
                     testRunnerHtml: testHTML,
                     browsers: [chromium],


### PR DESCRIPTION
Rename `theme` in `sp-theme` to use `system` instead to better describe the idea of theme as an aggregate of system, color, scale, etc.

## Description

Renames all usages of the `theme` attribute in `sp-theme` to `system` while maintaining `theme` as a deprecated option. Theme-theme has often been a confusing idea to communicate—especially with the upcoming addition of [Spectrum 2](https://s2.spectrum.adobe.com/). This PR aims to better describe a theme as a collection of values including system and color. Additionally it adds a guide that asks the question "what is a theme anyway?"

## Motivation and context

- `<sp-theme theme="spectrum">…` leads to us overloading what theme means. By updating this to system we better describe what we mean with this property. In this case `system` now talks to the design system used for design data (spectrum or express). We think this will make `sp-theme` slightly more easy to reason about as we introduce future systems like Spectrum 2.

## How has this been tested?

- Currently, minimal changes to testing as it's a refactor of existing behaviors. s/theme/system.
- Storybook has been updated to point to System as the label as has documentation pages. Also updates from "Classic" to "Spectrum 1". 
- Introduces an optional new guide to explain our reasoning about what a "theme" is. 

## Screenshots (if appropriate)

<img width="1804" alt="Screenshot 2024-03-14 at 5 43 15 PM" src="https://github.com/adobe/spectrum-web-components/assets/66142/d83c7b22-9b8c-4b3b-9da3-d6dd6c3e817f">

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [X] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [X] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [X] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [] All new and existing tests passed.
-   [X] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
