### PR TITLE
chore: use latest Playwright

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
     node:
         docker:
-            - image: mcr.microsoft.com/playwright:v1.41.2
+            - image: mcr.microsoft.com/playwright:v1.42.1
         resource_class: large
         environment:
             NODE_ENV: development

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "@netlify/build": "^29.1.0",
         "@open-wc/dev-server-hmr": "^0.2.0",
         "@open-wc/testing": "^3.2.0",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.42.1",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",

--- a/packages/combobox/test/combobox-a11y.test.ts
+++ b/packages/combobox/test/combobox-a11y.test.ts
@@ -20,7 +20,7 @@ import {
 
 import '@spectrum-web-components/combobox/sp-combobox.js';
 import { Combobox } from '@spectrum-web-components/combobox';
-import { fixture } from '../../../test/testing-helpers.js';
+import { detectOS, fixture } from '../../../test/testing-helpers.js';
 import { findDescribedNode } from '../../../test/testing-helpers-a11y.js';
 import {
     a11ySnapshot,
@@ -72,15 +72,23 @@ describe('Combobox accessibility', () => {
         const el = test.querySelector('sp-combobox') as unknown as Combobox;
         const name = 'Pick something';
         const webkitName = 'Pick something Banana';
-        type NamedNode = { name: string; role: string; value?: string };
+        const isWebKitMacOS = isWebKit && detectOS() === 'Mac OS';
+        type NamedNode = {
+            description: string;
+            name: string;
+            role: string;
+            value?: string;
+        };
 
         await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
 
         let snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
-        let a11yNode = findAccessibilityNode<NamedNode>(
+        const a11yNode = findAccessibilityNode<NamedNode>(
             snapshot,
             (node) =>
                 node.name === name && !node.value && node.role === 'combobox'
@@ -94,18 +102,32 @@ describe('Combobox accessibility', () => {
         snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
-        // gating it this way is the only way I could get ALL the tests to pass on all browsers
-        if (isWebKit) {
-            a11yNode = findAccessibilityNode<NamedNode>(
+
+        // WebKit doesn't currently associate the `name` via the accessibility tree.
+        // Instead if lists this data in the description 🤷🏻‍♂️
+        // Give it an escape hatch for now.
+        const node = findAccessibilityNode<NamedNode>(
+            snapshot,
+            (node) =>
+                (node.name === name ||
+                    (isWebKitMacOS && node.name === webkitName)) &&
+                node.value === 'Banana' &&
+                node.role === 'combobox'
+        );
+
+        expect(
+            node,
+            `pre escape hatch node not available: ${JSON.stringify(
                 snapshot,
-                (node) =>
-                    node.name === webkitName &&
-                    node.value === 'Banana' &&
-                    node.role === 'combobox'
-            );
-            expect(a11yNode, '`name` is null on WebKit').to.not.be.null;
-        } else {
-            a11yNode = findAccessibilityNode<NamedNode>(
+                null,
+                '  '
+            )}`
+        ).to.not.be.null;
+
+        if (isWebKitMacOS) {
+            // Retest WebKit without the escape hatch, expecting it to fail.
+            // This way we get notified when the results are as expected, again.
+            const iOSNode = findAccessibilityNode<NamedNode>(
                 snapshot,
                 (node) =>
                     node.name === name &&
@@ -113,9 +135,13 @@ describe('Combobox accessibility', () => {
                     node.role === 'combobox'
             );
             expect(
-                a11yNode,
-                '`name` is the the selected item text plus the label text'
-            ).to.not.be.null;
+                iOSNode,
+                `post escape hatch node available: ${JSON.stringify(
+                    snapshot,
+                    null,
+                    '  '
+                )}`
+            ).to.be.null;
         }
     });
     it('manages its "name" value in the accessibility tree', async () => {
@@ -123,15 +149,23 @@ describe('Combobox accessibility', () => {
 
         const name = 'Combobox';
         const webkitName = 'Combobox Banana';
-        type NamedNode = { name: string; role: string; value?: string };
+        const isWebKitMacOS = isWebKit && detectOS() === 'Mac OS';
+        type NamedNode = {
+            description: string;
+            name: string;
+            role: string;
+            value?: string;
+        };
 
         await elementUpdated(el);
+        await nextFrame();
+        await nextFrame();
 
         let snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
 
-        let a11yNode = findAccessibilityNode<NamedNode>(
+        const a11yNode = findAccessibilityNode<NamedNode>(
             snapshot,
             (node) =>
                 node.name === name && !node.value && node.role === 'combobox'
@@ -145,18 +179,32 @@ describe('Combobox accessibility', () => {
         snapshot = (await a11ySnapshot({})) as unknown as NamedNode & {
             children: NamedNode[];
         };
-        // gating it this way is the only way I could get ALL the tests to pass on all browsers
-        if (isWebKit) {
-            a11yNode = findAccessibilityNode<NamedNode>(
+
+        // WebKit doesn't currently associate the `name` via the accessibility tree.
+        // Instead if lists this data in the description 🤷🏻‍♂️
+        // Give it an escape hatch for now.
+        const node = findAccessibilityNode<NamedNode>(
+            snapshot,
+            (node) =>
+                (node.name === name ||
+                    (isWebKitMacOS && node.name === webkitName)) &&
+                node.value === 'Banana' &&
+                node.role === 'combobox'
+        );
+
+        expect(
+            node,
+            `pre escape hatch node not available: ${JSON.stringify(
                 snapshot,
-                (node) =>
-                    node.name === webkitName &&
-                    node.value === 'Banana' &&
-                    node.role === 'combobox'
-            );
-            expect(a11yNode, '`name` is null on WebKit').to.not.be.null;
-        } else {
-            a11yNode = findAccessibilityNode<NamedNode>(
+                null,
+                '  '
+            )}`
+        ).to.not.be.null;
+
+        if (isWebKitMacOS) {
+            // Retest WebKit without the escape hatch, expecting it to fail.
+            // This way we get notified when the results are as expected, again.
+            const iOSNode = findAccessibilityNode<NamedNode>(
                 snapshot,
                 (node) =>
                     node.name === name &&
@@ -164,9 +212,13 @@ describe('Combobox accessibility', () => {
                     node.role === 'combobox'
             );
             expect(
-                a11yNode,
-                '`name` is the the selected item text plus the label text'
-            ).to.not.be.null;
+                iOSNode,
+                `post escape hatch node available: ${JSON.stringify(
+                    snapshot,
+                    null,
+                    '  '
+                )}`
+            ).to.be.null;
         }
     });
     it('manages its "description" value with slotted <sp-tooltip>', async () => {

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -300,3 +300,25 @@ export async function usedHeapMB(): Promise<
                 ?.bytes || 0,
     };
 }
+
+export function detectOS(): string | null {
+    const userAgent = window.navigator.userAgent;
+    const platform = window.navigator.platform;
+    const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
+    const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+    const iosPlatforms = ['iPhone', 'iPad', 'iPod'];
+
+    if (macosPlatforms.indexOf(platform) !== -1) {
+        return 'Mac OS';
+    } else if (iosPlatforms.indexOf(platform) !== -1) {
+        return 'iOS';
+    } else if (windowsPlatforms.indexOf(platform) !== -1) {
+        return 'Windows';
+    } else if (/Android/.test(userAgent)) {
+        return 'Android';
+    } else if (/Linux/.test(platform)) {
+        return 'Linux';
+    }
+
+    return null;
+}

--- a/tools/grid/src/GridController.ts
+++ b/tools/grid/src/GridController.ts
@@ -24,6 +24,14 @@ interface ItemSize {
     height: number;
 }
 
+const doCallbackAfterPaint = (cb: () => void): void => {
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            cb();
+        });
+    });
+};
+
 export class GridController<T extends HTMLElement>
     implements ReactiveController
 {
@@ -171,13 +179,6 @@ export class GridController<T extends HTMLElement>
     }
 
     protected handleFocusin = (event: FocusEvent): void => {
-        const doCallbackAfterPaint = (cb: () => void): void => {
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                    cb();
-                });
-            });
-        };
         const scrollToFirst = (): void => this.host.scrollToIndex(0);
         const focusIntoGrid = (): void => {
             this.focus();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4223,12 +4223,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@playwright/test@^1.41.2":
-  version "1.41.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.41.2.tgz#bd9db40177f8fd442e16e14e0389d23751cdfc54"
-  integrity sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==
+"@playwright/test@^1.42.1":
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.42.1.tgz#9eff7417bcaa770e9e9a00439e078284b301f31c"
+  integrity sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==
   dependencies:
-    playwright "1.41.2"
+    playwright "1.42.1"
 
 "@pnpm/network.ca-file@^1.0.1":
   version "1.0.1"
@@ -21100,17 +21100,17 @@ pkg-up@^4.0.0:
   dependencies:
     find-up "^6.2.0"
 
-playwright-core@1.41.2:
-  version "1.41.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.41.2.tgz#db22372c708926c697acc261f0ef8406606802d9"
-  integrity sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==
+playwright-core@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.42.1.tgz#13c150b93c940a3280ab1d3fbc945bc855c9459e"
+  integrity sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==
 
-playwright@1.41.2, playwright@^1.22.2:
-  version "1.41.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.41.2.tgz#4e760b1c79f33d9129a8c65cc27953be6dd35042"
-  integrity sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==
+playwright@1.42.1, playwright@^1.22.2:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.42.1.tgz#79c828b51fe3830211137550542426111dc8239f"
+  integrity sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==
   dependencies:
-    playwright-core "1.41.2"
+    playwright-core "1.42.1"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
## Description
Updates to the latest Playwright.
- moves one static method out of a class
- restructures some test processes to support catching when macOS webkit and linux webkit no longer diverge with each other or other browsers
