### PR TITLE
Expand `slottable-request` usage and APIs

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -25,6 +25,7 @@ import { ObserveSlotPresence } from '@spectrum-web-components/shared/src/observe
 import { ObserveSlotText } from '@spectrum-web-components/shared/src/observe-slot-text.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-more.js';
 import actionMenuStyles from './action-menu.css.js';
+import { SlottableRequestEvent } from '@spectrum-web-components/overlay/src/slottable-request-event.js';
 
 /**
  * @element sp-action-menu
@@ -61,6 +62,10 @@ export class ActionMenu extends ObserveSlotPresence(
     private get labelOnly(): boolean {
         return this.slotContentIsPresent;
     }
+
+    private handleSlottableRequest = (event: SlottableRequestEvent): void => {
+        this.dispatchEvent(new SlottableRequestEvent(event.name, event.data));
+    };
 
     protected override get buttonContent(): TemplateResult[] {
         return [
@@ -125,5 +130,15 @@ export class ActionMenu extends ObserveSlotPresence(
             this.invalid = false;
         }
         super.update(changedProperties);
+    }
+
+    protected override updated(changes: PropertyValues<this>): void {
+        super.updated(changes);
+        if (this.hasRenderedOverlay) {
+            this.overlayElement.addEventListener(
+                'slottable-request',
+                this.handleSlottableRequest
+            );
+        }
     }
 }

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -18,6 +18,7 @@ import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/menu/sp-menu-divider.js';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import { slottableRequest } from '@spectrum-web-components/overlay/src/slottable-request-directive.js';
 import { ActionMenuMarkup } from './';
 import { makeOverBackground } from '../../button/stories/index.js';
 import { isOverlayOpen } from '../../overlay/stories/index.js';
@@ -403,3 +404,26 @@ export const groups = ({
 `;
 
 groups.decorators = [isOverlayOpen];
+
+export const directive = (): TemplateResult => {
+    const renderOptions = (): TemplateResult => html`
+        <sp-menu-item>Deselect</sp-menu-item>
+        <sp-menu-item>Select Inverse</sp-menu-item>
+        <sp-menu-item>Feather...</sp-menu-item>
+        <sp-menu-item>Select and Mask...</sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>Save Selection</sp-menu-item>
+        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+    `;
+    return html`
+        <sp-action-menu ${slottableRequest(renderOptions)}>
+            <span slot="label">
+                Select a Country with a very long label, too long in fact
+            </span>
+        </sp-action-menu>
+    `;
+};
+
+directive.swc_vrt = {
+    skip: true,
+};

--- a/packages/action-menu/test/action-menu-directive.test.ts
+++ b/packages/action-menu/test/action-menu-directive.test.ts
@@ -20,7 +20,6 @@ import { nextFrame } from '@spectrum-web-components/overlay/src/AbstractOverlay.
 
 describe('Slottable Request Directive', () => {
     it('Action Menu requests for options rendering when opening and closing', async function () {
-        this.retries(0);
         const el = await fixture<ActionMenu>(directive());
         const initialNodeLength = el.children.length;
         expect(el.open).to.be.false;

--- a/packages/action-menu/test/action-menu-directive.test.ts
+++ b/packages/action-menu/test/action-menu-directive.test.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { expect, oneEvent } from '@open-wc/testing';
+import { ActionMenu } from '@spectrum-web-components/action-menu';
+import { sendKeys } from '@web/test-runner-commands';
+
+import { directive } from '../stories/action-menu.stories.js';
+import { fixture } from '../../../test/testing-helpers.js';
+import { nextFrame } from '@spectrum-web-components/overlay/src/AbstractOverlay.js';
+
+describe('Slottable Request Directive', () => {
+    it('Action Menu requests for options rendering when opening and closing', async function () {
+        this.retries(0);
+        const el = await fixture<ActionMenu>(directive());
+        const initialNodeLength = el.children.length;
+        expect(el.open).to.be.false;
+        expect(el.children.length).to.equal(initialNodeLength);
+
+        const opened = oneEvent(el, 'sp-opened');
+        el.click();
+        await opened;
+
+        expect(el.open).to.be.true;
+        expect(el.children.length).to.be.gt(initialNodeLength);
+
+        const closed = oneEvent(el, 'sp-closed');
+        await sendKeys({
+            press: 'Escape',
+        });
+        await closed;
+        await nextFrame();
+        await nextFrame();
+
+        expect(el.open).to.be.false;
+        expect(el.children.length).to.equal(initialNodeLength);
+    });
+});

--- a/packages/action-menu/test/benchmark/test-directive.ts
+++ b/packages/action-menu/test/benchmark/test-directive.ts
@@ -10,16 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import '@spectrum-web-components/action-menu/sp-action-menu.js';
-import '@spectrum-web-components/menu/sp-menu-item.js';
-import '@spectrum-web-components/menu/sp-menu-divider.js';
-import { html } from 'lit';
+import { html, TemplateResult } from '@spectrum-web-components/base';
+import { slottableRequest } from '@spectrum-web-components/overlay/src/slottable-request-directive.js';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
-measureFixtureCreation(html`
-    <sp-action-menu>
-        <span slot="label">
-            Select a Country with a very long label, too long in fact
-        </span>
+const renderOptions = (): TemplateResult => {
+    import('@spectrum-web-components/menu/sp-menu-item.js');
+    import('@spectrum-web-components/menu/sp-menu-divider.js');
+    return html`
         <sp-menu-item>Deselect</sp-menu-item>
         <sp-menu-item>Select Inverse</sp-menu-item>
         <sp-menu-item>Feather...</sp-menu-item>
@@ -27,5 +25,13 @@ measureFixtureCreation(html`
         <sp-menu-divider></sp-menu-divider>
         <sp-menu-item>Save Selection</sp-menu-item>
         <sp-menu-item disabled>Make Work Path</sp-menu-item>
+    `;
+};
+
+measureFixtureCreation(html`
+    <sp-action-menu ${slottableRequest(renderOptions)}>
+        <span slot="label">
+            Select a Country with a very long label, too long in fact
+        </span>
     </sp-action-menu>
 `);

--- a/packages/action-menu/test/benchmark/test-lazy.ts
+++ b/packages/action-menu/test/benchmark/test-lazy.ts
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import '@spectrum-web-components/action-menu/sp-action-menu.js';
+import { html, render } from '@spectrum-web-components/base';
+import {
+    removeSlottableRequest,
+    type SlottableRequestEvent,
+} from '@spectrum-web-components/overlay/src/slottable-request-event.js';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+const handleSlottableRequest = (event: SlottableRequestEvent): void => {
+    import('@spectrum-web-components/menu/sp-menu-item.js');
+    import('@spectrum-web-components/menu/sp-menu-divider.js');
+    const label = html`
+        <span slot="label">
+            Select a Country with a very long label, too long in fact
+        </span>
+    `;
+    const template =
+        event.data === removeSlottableRequest
+            ? label
+            : html`
+                  ${label}
+                  <sp-menu-item>Deselect</sp-menu-item>
+                  <sp-menu-item>Select Inverse</sp-menu-item>
+                  <sp-menu-item>Feather...</sp-menu-item>
+                  <sp-menu-item>Select and Mask...</sp-menu-item>
+                  <sp-menu-divider></sp-menu-divider>
+                  <sp-menu-item>Save Selection</sp-menu-item>
+                  <sp-menu-item disabled>Make Work Path</sp-menu-item>
+              `;
+    render(template, event.target as HTMLElement);
+};
+
+measureFixtureCreation(html`
+    <sp-action-menu @slottable-request=${handleSlottableRequest}>
+        <span slot="label">
+            Select a Country with a very long label, too long in fact
+        </span>
+    </sp-action-menu>
+`);

--- a/packages/action-menu/test/benchmark/test-open-close-directive.ts
+++ b/packages/action-menu/test/benchmark/test-open-close-directive.ts
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/action-menu/sp-action-menu.js';
+import type { ActionMenu } from '@spectrum-web-components/action-menu';
+import { slottableRequest } from '@spectrum-web-components/overlay/src/slottable-request-directive.js';
+import { html, TemplateResult } from 'lit';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+import { SpectrumElement } from '@spectrum-web-components/base';
+
+const renderOptions = (): TemplateResult => {
+    import('@spectrum-web-components/menu/sp-menu-item.js');
+    import('@spectrum-web-components/menu/sp-menu-divider.js');
+    return html`
+        <sp-menu-item>Deselect</sp-menu-item>
+        <sp-menu-item>Select Inverse</sp-menu-item>
+        <sp-menu-item>Feather...</sp-menu-item>
+        <sp-menu-item>Select and Mask...</sp-menu-item>
+        <sp-menu-divider></sp-menu-divider>
+        <sp-menu-item>Save Selection</sp-menu-item>
+        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+    `;
+};
+
+class ActionMenuWorkflow extends HTMLElement {
+    ready!: (value: boolean | PromiseLike<boolean>) => void;
+    target!: ActionMenu;
+    count = 0;
+
+    constructor() {
+        super();
+        this.readyPromise = new Promise((res) => {
+            this.ready = res;
+            this.setup();
+        });
+    }
+
+    async setup(): Promise<void> {
+        this.target = this.nextElementSibling as ActionMenu;
+        const childPromises = [] as Promise<boolean>[];
+        [...this.target.children].forEach((child) => {
+            if ('updateComplete' in child) {
+                childPromises.push((child as SpectrumElement).updateComplete);
+            }
+        });
+        await Promise.all([this.target.updateComplete, ...childPromises]);
+        this.target.addEventListener('sp-opened', () => {
+            requestAnimationFrame(() => (this.target.open = false));
+        });
+        this.target.addEventListener('sp-closed', () => {
+            this.count += 1;
+            if (this.count >= 5) {
+                this.ready(true);
+                return;
+            }
+            requestAnimationFrame(() => (this.target.open = true));
+        });
+        requestAnimationFrame(() => (this.target.open = true));
+    }
+
+    private readyPromise: Promise<boolean> = Promise.resolve(false);
+
+    get updateComplete(): Promise<boolean> {
+        return this.readyPromise;
+    }
+}
+
+customElements.define('action-menu-workflow', ActionMenuWorkflow);
+
+measureFixtureCreation(
+    html`
+        <action-menu-workflow></action-menu-workflow>
+        <sp-action-menu ${slottableRequest(renderOptions)}>
+            <span slot="label">
+                Select a Country with a very long label, too long in fact
+            </span>
+        </sp-action-menu>
+    `,
+    { numRenders: 1 }
+);

--- a/packages/action-menu/test/benchmark/test-open-close.ts
+++ b/packages/action-menu/test/benchmark/test-open-close.ts
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/action-menu/sp-action-menu.js';
+import type { ActionMenu } from '@spectrum-web-components/action-menu';
+import '@spectrum-web-components/menu/sp-menu-item.js';
+import '@spectrum-web-components/menu/sp-menu-divider.js';
+import { html } from 'lit';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+import { SpectrumElement } from '@spectrum-web-components/base';
+
+class ActionMenuWorkflow extends HTMLElement {
+    ready!: (value: boolean | PromiseLike<boolean>) => void;
+    target!: ActionMenu;
+    count = 0;
+
+    constructor() {
+        super();
+        this.readyPromise = new Promise((res) => {
+            this.ready = res;
+            this.setup();
+        });
+    }
+
+    async setup(): Promise<void> {
+        this.target = this.nextElementSibling as ActionMenu;
+        const childPromises = [] as Promise<boolean>[];
+        [...this.target.children].forEach((child) => {
+            if ('updateComplete' in child) {
+                childPromises.push((child as SpectrumElement).updateComplete);
+            }
+        });
+        await Promise.all([this.target.updateComplete, ...childPromises]);
+        this.target.addEventListener('sp-opened', () => {
+            requestAnimationFrame(() => (this.target.open = false));
+        });
+        this.target.addEventListener('sp-closed', () => {
+            this.count += 1;
+            if (this.count >= 5) {
+                this.ready(true);
+                return;
+            }
+            requestAnimationFrame(() => (this.target.open = true));
+        });
+        requestAnimationFrame(() => (this.target.open = true));
+    }
+
+    private readyPromise: Promise<boolean> = Promise.resolve(false);
+
+    get updateComplete(): Promise<boolean> {
+        return this.readyPromise;
+    }
+}
+
+customElements.define('action-menu-workflow', ActionMenuWorkflow);
+
+measureFixtureCreation(
+    html`
+        <action-menu-workflow></action-menu-workflow>
+        <sp-action-menu>
+            <span slot="label">
+                Select a Country with a very long label, too long in fact
+            </span>
+            <sp-menu-item>Deselect</sp-menu-item>
+            <sp-menu-item>Select Inverse</sp-menu-item>
+            <sp-menu-item>Feather...</sp-menu-item>
+            <sp-menu-item>Select and Mask...</sp-menu-item>
+            <sp-menu-divider></sp-menu-divider>
+            <sp-menu-item>Save Selection</sp-menu-item>
+            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+        </sp-action-menu>
+    `,
+    { numRenders: 1 }
+);

--- a/packages/action-menu/test/index.ts
+++ b/packages/action-menu/test/index.ts
@@ -661,7 +661,6 @@ export const testActionMenu = (mode: 'sync' | 'async'): void => {
             expect(openSpy.callCount).to.equal(1);
         });
         it('opens, then closes, on subsequent clicks', async function () {
-            this.retries(0);
             const el = await actionMenuFixture();
             const rect = el.getBoundingClientRect();
 

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -107,6 +107,10 @@
             "default": "./src/overlay-types.js"
         },
         "./src/overlay.css.js": "./src/overlay.css.js",
+        "./src/slottable-request-directive.js": {
+            "development": "./src/slottable-request-directive.dev.js",
+            "default": "./src/slottable-request-directive.js"
+        },
         "./src/slottable-request-event.js": {
             "development": "./src/slottable-request-event.dev.js",
             "default": "./src/slottable-request-event.js"

--- a/packages/overlay/src/HoverController.ts
+++ b/packages/overlay/src/HoverController.ts
@@ -13,7 +13,10 @@ governing permissions and limitations under the License.
 import { conditionAttributeWithId } from '@spectrum-web-components/base/src/condition-attribute-with-id.js';
 import { randomID } from '@spectrum-web-components/shared/src/random-id.js';
 
-import { InteractionController, InteractionTypes } from './InteractionController.js';
+import {
+    InteractionController,
+    InteractionTypes,
+} from './InteractionController.js';
 import { noop } from './AbstractOverlay.js';
 
 const HOVER_DELAY = 300;
@@ -30,6 +33,10 @@ export class HoverController extends InteractionController {
     pointerentered = false;
 
     handleTargetFocusin(): void {
+        // eslint-disable-next-line @spectrum-web-components/document-active-element
+        if (!document.activeElement?.matches(':focus-visible')) {
+            return;
+        }
         this.host.open = true;
         this.focusedin = true;
     }

--- a/packages/overlay/src/OverlayStack.ts
+++ b/packages/overlay/src/OverlayStack.ts
@@ -180,14 +180,14 @@ class OverlayStack {
             );
             overlay.dispatchEvent(queryPathEvent);
         } else if (overlay.type === 'hint') {
-            const previous = this.stack.find((overlayEl) => {
+            const hasPrevious = this.stack.some((overlayEl) => {
                 return (
                     overlayEl.type !== 'manual' &&
                     overlayEl.triggerElement &&
                     overlayEl.triggerElement === overlay.triggerElement
                 );
             });
-            if (previous) {
+            if (hasPrevious) {
                 overlay.open = false;
                 return;
             }

--- a/packages/overlay/src/OverlayStack.ts
+++ b/packages/overlay/src/OverlayStack.ts
@@ -141,9 +141,9 @@ class OverlayStack {
      * When overlays are added manage the open state of exisiting overlays appropriately:
      * - 'modal': should close other overlays
      * - 'page': should close other overlays
-     * - 'hint': shouldn't close other overlays
      * - 'auto': should close other 'auto' overlays and other 'hint' overlays, but not 'manual' overlays
      * - 'manual': shouldn't close other overlays
+     * - 'hint': shouldn't close other overlays and give way to all other overlays on a trigger
      */
     add(overlay: Overlay): void {
         if (this.stack.includes(overlay)) {
@@ -180,6 +180,17 @@ class OverlayStack {
             );
             overlay.dispatchEvent(queryPathEvent);
         } else if (overlay.type === 'hint') {
+            const previous = this.stack.find((overlayEl) => {
+                return (
+                    overlayEl.type !== 'manual' &&
+                    overlayEl.triggerElement &&
+                    overlayEl.triggerElement === overlay.triggerElement
+                );
+            });
+            if (previous) {
+                overlay.open = false;
+                return;
+            }
             this.stack.forEach((overlayEl) => {
                 if (overlayEl.type === 'hint') {
                     this.closeOverlay(overlayEl);

--- a/packages/overlay/src/slottable-request-directive.ts
+++ b/packages/overlay/src/slottable-request-directive.ts
@@ -1,0 +1,97 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import {
+    ElementPart,
+    nothing,
+    render,
+    TemplateResult,
+} from '@spectrum-web-components/base';
+import { AsyncDirective, directive } from 'lit/async-directive.js';
+import {
+    removeSlottableRequest,
+    SlottableRequestEvent,
+} from './slottable-request-event.js';
+
+export class SlottableRequestDirective extends AsyncDirective {
+    protected template!: () => TemplateResult;
+    protected target!: HTMLElement;
+    private renderBefore: HTMLElement | undefined;
+    protected listenerHost!: HTMLElement;
+    protected listeners!: AbortController;
+
+    /* c8 ignore next 9 */
+    render(_template: () => TemplateResult): unknown {
+        // render function here just defines the interface to the update call later
+        // we don't have anything to render since this is intended to be an ElementPart directive
+        // so will be used on an element and is not itself rendered
+        return nothing;
+    }
+
+    override update(
+        part: ElementPart,
+        [template]: Parameters<this['render']>
+    ): void {
+        this.template = template;
+        if (this.target !== part.element) {
+            this.target = part.element as HTMLElement;
+            this.renderBefore = this.target.children[0] as HTMLElement;
+        }
+        this.listenerHost = this.target;
+        this.init();
+    }
+
+    handleSlottableRequest(event: SlottableRequestEvent): void {
+        /* c8 ignore next 1 */
+        if (event.target !== event.currentTarget) return;
+
+        const willRemoveSlottable = event.data === removeSlottableRequest;
+
+        render(willRemoveSlottable ? undefined : this.template(), this.target, {
+            renderBefore: this.renderBefore,
+        });
+    }
+
+    init(): void {
+        this.listeners?.abort();
+        this.listeners = new AbortController();
+        const { signal } = this.listeners;
+        this.listenerHost.addEventListener(
+            'slottable-request',
+            (event: Event) =>
+                this.handleSlottableRequest(event as SlottableRequestEvent),
+            { signal }
+        );
+
+        if (window.__swc.DEBUG) {
+            window.__swc.warn(
+                undefined,
+                `⚠️  WARNING ⚠️ : The Overlay Trigger Directive is experimental and there is no guarantees behind its usage in an application!! Its API and presence within the library could be changed at anytime. See "sp-overlay" or "Overlay.open()" for a stable API for overlaying content on your application.`,
+                'https://opensource.adobe.com/spectrum-web-components/components/overlay',
+                {
+                    level: 'high',
+                    type: 'api',
+                }
+            );
+        }
+    }
+
+    override disconnected(): void {
+        this.listeners.abort();
+    }
+
+    /* c8 ignore next 3 */
+    override reconnected(): void {
+        this.init();
+    }
+}
+
+export const slottableRequest = directive(SlottableRequestDirective);

--- a/packages/overlay/src/slottable-request-event.ts
+++ b/packages/overlay/src/slottable-request-event.ts
@@ -39,3 +39,9 @@ Learn more about the protocol these events are based on below:`,
 }
 
 export const removeSlottableRequest = Symbol('remove-slottable-request');
+
+declare global {
+    interface GlobalEventHandlersEventMap {
+        'slottable-request': SlottableRequestEvent;
+    }
+}

--- a/packages/overlay/stories/overlay-directive.stories.ts
+++ b/packages/overlay/stories/overlay-directive.stories.ts
@@ -232,16 +232,12 @@ const template = ({
 export const Default = ({ open }: Properties = {}): TemplateResult => {
     const renderPopover = (): TemplateResult => html`
         <sp-popover>
-            <p>Popover content goes here</p>
+            <sp-dialog no-divider>Popover content goes here</sp-dialog>
         </sp-popover>
     `;
-    const options = typeof open !== 'undefined'
-        ? { open }
-        : undefined;
+    const options = typeof open !== 'undefined' ? { open } : undefined;
     return html`
-        <sp-button
-            ${trigger(renderPopover, options)}
-        >Open Popover</sp-button>
+        <sp-button ${trigger(renderPopover, options)}>Open Popover</sp-button>
     `;
 };
 

--- a/packages/overlay/stories/overlay-directive.stories.ts
+++ b/packages/overlay/stories/overlay-directive.stories.ts
@@ -123,12 +123,25 @@ export default {
                 options: ['light', 'dark'],
             },
         },
+        open: {
+            name: 'open',
+            type: { name: 'boolean', required: false },
+            description: 'Whether the second accordion item is open.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
     },
     args: {
         placement: 'bottom',
         offset: 0,
         colorStop: 'light',
         triggerOn: 'click',
+        open: false,
     },
 };
 
@@ -138,11 +151,13 @@ interface Properties {
     triggerOn?: OverlayContentTypes;
     type?: Extract<TriggerInteractions, 'inline' | 'modal' | 'replace'>;
     insertionOptions?: InsertionOptions;
+    open?: boolean;
 }
 
 const template = ({
     placement,
     offset,
+    open,
     triggerOn,
     insertionOptions,
 }: Properties): TemplateResult => {
@@ -200,6 +215,7 @@ const template = ({
             variant="primary"
             ${tooltip(renderTooltip)}
             ${trigger(renderPopover, {
+                open,
                 triggerInteraction: triggerOn,
                 overlayOptions: {
                     placement,
@@ -213,24 +229,44 @@ const template = ({
     `;
 };
 
-export const Default = (args: Properties): TemplateResult => template(args);
+export const Default = ({ open }: Properties = {}): TemplateResult => {
+    const renderPopover = (): TemplateResult => html`
+        <sp-popover>
+            <p>Popover content goes here</p>
+        </sp-popover>
+    `;
+    const options = typeof open !== 'undefined'
+        ? { open }
+        : undefined;
+    return html`
+        <sp-button
+            ${trigger(renderPopover, options)}
+        >Open Popover</sp-button>
+    `;
+};
 
 Default.swc_vrt = {
     skip: true,
 };
 
-export const elsewhere = (args: Properties = {}): TemplateResult => html`
+export const congifured = (args: Properties): TemplateResult => template(args);
+
+congifured.swc_vrt = {
+    skip: true,
+};
+
+export const insertionOptions = (args: Properties = {}): TemplateResult => html`
     ${template(args)}
     <div id="other-element"></div>
 `;
 
-elsewhere.args = {
+insertionOptions.args = {
     insertionOptions: {
         el: () => document.querySelector('#other-element'),
         where: 'afterbegin',
     },
 } as Properties;
 
-elsewhere.swc_vrt = {
+insertionOptions.swc_vrt = {
     skip: true,
 };

--- a/packages/overlay/test/benchmark/directive-test.ts
+++ b/packages/overlay/test/benchmark/directive-test.ts
@@ -19,36 +19,37 @@ import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import { html, TemplateResult } from 'lit';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
-const popover = (): TemplateResult => html`
-    <sp-popover>
-        <sp-dialog no-divider>
-            <sp-slider
-                value="5"
-                step="0.5"
-                min="0"
-                max="20"
-                label="Awesomeness"
-            ></sp-slider>
-            <div id="styled-div">
-                The background of this div should be blue
-            </div>
-            <sp-button>
-                Press Me
-                <sp-tooltip
-                    self-managed
-                    delayed
-                >
-                    Click to open another popover.
-                </sp-tooltip>
-            </sp-button>
-        </sp-dialog>
-    </sp-popover>
-`;
+const renderPopover = (): TemplateResult => {
+    import('@spectrum-web-components/popover/sp-popover.js');
+    import('@spectrum-web-components/dialog/sp-dialog.js');
+    import('@spectrum-web-components/slider/sp-slider.js');
+    import('@spectrum-web-components/tooltip/sp-tooltip.js');
+    return html`
+        <sp-popover>
+            <sp-dialog no-divider>
+                <sp-slider
+                    value="5"
+                    step="0.5"
+                    min="0"
+                    max="20"
+                    label="Awesomeness"
+                ></sp-slider>
+                <div id="styled-div">
+                    The background of this div should be blue
+                </div>
+                <sp-button>
+                    Press Me
+                    <sp-tooltip self-managed delayed>
+                        Click to open another popover.
+                    </sp-tooltip>
+                </sp-button>
+            </sp-dialog>
+        </sp-popover>
+    `;
+};
 
 measureFixtureCreation(
     html`
-        <sp-button ${trigger(popover)}>
-            Trigger
-        </sp-button>
+        <sp-button ${trigger(renderPopover)}>Trigger</sp-button>
     `
 );

--- a/packages/overlay/test/benchmark/lazy-test.ts
+++ b/packages/overlay/test/benchmark/lazy-test.ts
@@ -12,18 +12,18 @@ governing permissions and limitations under the License.
 
 import '@spectrum-web-components/overlay/sp-overlay.js';
 import '@spectrum-web-components/button/sp-button.js';
-import '@spectrum-web-components/popover/sp-popover.js';
-import '@spectrum-web-components/dialog/sp-dialog.js';
-import '@spectrum-web-components/slider/sp-slider.js';
-import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import {
     removeSlottableRequest,
     type SlottableRequestEvent,
 } from '@spectrum-web-components/overlay/src/slottable-request-event.js';
-import { html, render } from 'lit';
+import { html, render } from '@spectrum-web-components/base';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 const handleSlottableRequest = (event: SlottableRequestEvent): void => {
+    import('@spectrum-web-components/popover/sp-popover.js');
+    import('@spectrum-web-components/dialog/sp-dialog.js');
+    import('@spectrum-web-components/slider/sp-slider.js');
+    import('@spectrum-web-components/tooltip/sp-tooltip.js');
     const template =
         event.data === removeSlottableRequest
             ? undefined
@@ -56,8 +56,7 @@ measureFixtureCreation(
     html`
         <sp-button id="button">Trigger</sp-button>
         <sp-overlay
-            trigger="button"
-            .triggerInteraction=${'click'}
+            trigger="button@click"
             @slottable-request=${handleSlottableRequest}
         ></sp-overlay>
     `

--- a/packages/overlay/test/overlay-directive.test.ts
+++ b/packages/overlay/test/overlay-directive.test.ts
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import { html } from '@spectrum-web-components/base';
 import {
     elementUpdated,
@@ -20,18 +19,36 @@ import {
     waitUntil,
 } from '@open-wc/testing';
 import { Button } from '@spectrum-web-components/button';
-import '@spectrum-web-components/button/sp-button.js';
-import { elsewhere } from '../stories/overlay-directive.stories.js';
+import { Overlay } from '@spectrum-web-components/overlay';
+import { Default, insertionOptions } from '../stories/overlay-directive.stories.js';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import { fixture } from '../../../test/testing-helpers.js';
 
 describe('Overlay Directive', () => {
+    it('opens declaratively', async function() {
+        const test = await fixture<Button>(Default({ open: true }));
+        await oneEvent(test, 'sp-opened');
+
+        const el = test.nextElementSibling as Overlay;
+        
+        expect(el.open).to.be.true;
+    });
+    it('opens without options', async function() {
+        const test = await fixture<Button>(Default());
+        const opened = oneEvent(test, 'sp-opened');
+        test.click();
+        await opened;
+
+        const el = test.nextElementSibling as Overlay;
+        
+        expect(el.open).to.be.true;
+    });
     it('opens an Overlay after the trigger', async function () {
         const test = await fixture<HTMLElement>(html`
             <div
                 style="width: 100%; height: 100vh; display: grid; place-content: center;"
             >
-                ${elsewhere()}
+                ${insertionOptions()}
             </div>
         `);
 
@@ -111,7 +128,7 @@ describe('Overlay Directive', () => {
             <div
                 style="width: 100%; height: 100vh; display: grid; place-content: center;"
             >
-                ${elsewhere(elsewhere.args)}
+                ${insertionOptions(insertionOptions.args)}
             </div>
         `);
 

--- a/packages/overlay/test/overlay-element.test.ts
+++ b/packages/overlay/test/overlay-element.test.ts
@@ -81,7 +81,6 @@ describe('sp-overlay', () => {
 
     describe('`slottable-request` event', () => {
         it('dispatched before `sp-opened`', async function () {
-            this.retries(0);
             let slottableRequestTime = 0;
             let openedTime = 0;
             const el = await fixture<Overlay>(html`
@@ -103,7 +102,6 @@ describe('sp-overlay', () => {
             expect(slottableRequestTime).to.be.lt(openedTime);
         });
         it('dispatched after `sp-closed`', async function () {
-            this.retries(0);
             let slottableRequestTime = 0;
             let closedTime = 0;
             const el = await fixture<Overlay>(html`
@@ -138,7 +136,6 @@ describe('sp-overlay', () => {
             ).to.be.gt(closedTime);
         });
         it('follows transition timing from lazily added children', async function () {
-            this.retries(0);
             let slottableRequestTime = 0;
             let openedTime = 0;
             const popover = document.createElement('sp-popover');

--- a/packages/overlay/test/overlay-lifecycle.test.ts
+++ b/packages/overlay/test/overlay-lifecycle.test.ts
@@ -22,7 +22,11 @@ import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import { OverlayTrigger } from '@spectrum-web-components/overlay';
 import '@spectrum-web-components/overlay/overlay-trigger.js';
-import { a11ySnapshot, findAccessibilityNode } from '@web/test-runner-commands';
+import {
+    a11ySnapshot,
+    findAccessibilityNode,
+    sendKeys,
+} from '@web/test-runner-commands';
 import { Tooltip } from '@spectrum-web-components/tooltip';
 
 describe('Overlay Trigger - accessible hover content management', () => {
@@ -158,10 +162,15 @@ describe('Overlay Trigger - accessible hover content management', () => {
         expect(trigger.getAttribute('aria-describedby')).to.equal(tooltip.id);
         expect(el.open).to.be.undefined;
 
+        // For `:focus-visible` heuristic.
+        const input = document.createElement('input');
+        el.insertAdjacentElement('afterbegin', input);
+        input.focus();
+
         const opened = oneEvent(el, 'sp-opened');
-        trigger.dispatchEvent(
-            new FocusEvent('focusin', { bubbles: true, composed: true })
-        );
+        await sendKeys({
+            press: 'Tab',
+        });
         await opened;
 
         expect(trigger.getAttribute('aria-describedby')).to.equal(tooltip.id);

--- a/packages/overlay/test/overlay-trigger-hover-click.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover-click.test.ts
@@ -31,6 +31,8 @@ import { sendMouse } from '../../../test/plugins/browser.js';
 import { clickAndHoverTargets, deep } from '../stories/overlay.stories.js';
 import { ignoreResizeObserverLoopError } from '../../../test/testing-helpers.js';
 import { Tooltip } from '@spectrum-web-components/tooltip/src/Tooltip.js';
+import { sendKeys } from '@web/test-runner-commands';
+import { Button } from '@spectrum-web-components/button';
 
 ignoreResizeObserverLoopError(before, after);
 
@@ -209,6 +211,7 @@ describe('Overlay Trigger - Hover and Click', () => {
             <div>${deep()}</div>
         `);
         const el = test.querySelector('overlay-trigger') as OverlayTrigger;
+        const trigger = test.querySelector('sp-button') as Button;
         const button = el.querySelector('sp-action-button') as ActionButton;
         const button2 = el.querySelector(
             'sp-action-button:nth-of-type(2)'
@@ -219,10 +222,18 @@ describe('Overlay Trigger - Hover and Click', () => {
         expect(tooltip.open).to.be.false;
 
         const opened = oneEvent(el, 'sp-opened');
-        const tooltipOpen = oneEvent(button, 'sp-opened');
-        el.open = 'click';
+        trigger.focus();
+        // For `:focus-visible` heuristic.
+        await sendKeys({
+            press: 'Tab',
+        });
+        await sendKeys({
+            press: 'Shift+Tab',
+        });
+        await sendKeys({
+            press: 'Space',
+        });
         await opened;
-        await tooltipOpen;
 
         expect(el.open).to.equal('click');
         expect(tooltip.open).to.be.true;
@@ -235,7 +246,11 @@ describe('Overlay Trigger - Hover and Click', () => {
         expect(tooltip.open).to.be.true;
 
         let closed = oneEvent(button, 'sp-closed');
-        button2.focus();
+        expect(document.activeElement === button, `button focused`).to.be.true;
+        await sendKeys({
+            press: 'Tab',
+        });
+        expect(document.activeElement === button2, `button focused`).to.be.true;
         await closed;
 
         expect(el.open).to.equal('click');

--- a/packages/overlay/test/overlay-trigger-longpress.test.ts
+++ b/packages/overlay/test/overlay-trigger-longpress.test.ts
@@ -56,8 +56,15 @@ describe('Overlay Trigger - Longpress', () => {
             expect(this.content).to.not.be.null;
             expect(this.content.open).to.be.false;
 
+            // For `:focus-visible` heuristic.
+            const input = document.createElement('input');
+            this.el.insertAdjacentElement('beforebegin', input);
+            input.focus();
+
             const open = oneEvent(this.el, 'sp-opened');
-            this.trigger.focus();
+            await sendKeys({
+                press: 'Tab',
+            });
             await open;
         });
         it('opens/closes for `Space`', async function () {

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -78,6 +78,7 @@ class TooltipOpenable extends HTMLElement {
         }
         tooltip.open = open;
     }
+    /* c8 ignore next 3 */
     get open(): boolean {
         return this._open;
     }
@@ -221,6 +222,7 @@ export class Tooltip extends SpectrumElement {
         }
         let triggerElement = (start.parentElement ||
             (root as ShadowRoot).host ||
+            /* c8 ignore next 1 */
             root) as HTMLElement;
         while (!triggerElement?.matches?.(focusableSelector)) {
             start =
@@ -242,6 +244,7 @@ export class Tooltip extends SpectrumElement {
             }
             triggerElement = (start.parentElement ||
                 (root as ShadowRoot).host ||
+                /* c8 ignore next 1 */
                 root) as HTMLElement;
         }
         return triggerElement;

--- a/packages/tooltip/src/tooltip-directive.ts
+++ b/packages/tooltip/src/tooltip-directive.ts
@@ -31,6 +31,7 @@ export const tooltip = function tooltip(
         },
         {
             ...options,
+            triggerInteraction: 'hover',
             overlayOptions: {
                 type: 'hint',
                 ...options?.overlayOptions,

--- a/packages/tooltip/stories/tooltip-directive.stories.ts
+++ b/packages/tooltip/stories/tooltip-directive.stories.ts
@@ -35,6 +35,7 @@ interface Properties {
 }
 
 export const Default = ({
+    open,
     placement,
     text,
     variant,
@@ -47,6 +48,7 @@ export const Default = ({
                         ${text || 'Tooltip'}
                     `,
                 {
+                    open,
                     overlayOptions: { placement },
                     variant,
                 }

--- a/packages/tooltip/test/benchmark/test-element.ts
+++ b/packages/tooltip/test/benchmark/test-element.ts
@@ -12,12 +12,13 @@ governing permissions and limitations under the License.
 
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/overlay/sp-overlay.js';
 import { html } from 'lit';
 import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
 
 measureFixtureCreation(html`
-    <sp-action-button>
-        I'm a button...
-        <sp-tooltip self-managed>Tip me!</sp-tooltip>
-    </sp-action-button>
+    <sp-action-button id="button">I'm a button...</sp-action-button>
+    <sp-overlay trigger="button@hover" type="hint">
+        <sp-tooltip>Tip me!</sp-tooltip>
+    </sp-overlay>
 `);

--- a/packages/tooltip/test/benchmark/test-lazy.ts
+++ b/packages/tooltip/test/benchmark/test-lazy.ts
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import '@spectrum-web-components/action-button/sp-action-button.js';
+import '@spectrum-web-components/overlay/sp-overlay.js';
+import {
+    removeSlottableRequest,
+    type SlottableRequestEvent,
+} from '@spectrum-web-components/overlay/src/slottable-request-event.js';
+import { html, render } from '@spectrum-web-components/base';
+import { measureFixtureCreation } from '../../../../test/benchmark/helpers.js';
+
+const handleSlottableRequest = (event: SlottableRequestEvent): void => {
+    import('@spectrum-web-components/tooltip/sp-tooltip.js');
+    const template =
+        event.data === removeSlottableRequest
+            ? undefined
+            : html`
+                  <sp-tooltip>Tip me!</sp-tooltip>
+              `;
+    render(template, event.target as HTMLElement);
+};
+
+measureFixtureCreation(html`
+    <sp-action-button id="button">I'm a button...</sp-action-button>
+    <sp-overlay
+        trigger="button@hover"
+        type="hint"
+        @slottable-request=${handleSlottableRequest}
+    ></sp-overlay>
+`);

--- a/test/benchmark/cli.ts
+++ b/test/benchmark/cli.ts
@@ -34,6 +34,16 @@ const optionDefinitions: commandLineUsage.OptionDefinition[] = [
         defaultValue: [],
     },
     {
+        name: 'filter',
+        description:
+            'A filter for tests in a package to benchmark.\ne.g.' +
+            ' "-f test-open-close".\n(default runs all)',
+        alias: 'f',
+        type: String,
+        multiple: true,
+        defaultValue: [],
+    },
+    {
         name: 'remote',
         description:
             'Remote location to point tachometer.\ne.g. if running' +
@@ -97,6 +107,7 @@ const optionDefinitions: commandLineUsage.OptionDefinition[] = [
 interface Options {
     help: boolean;
     package: string[];
+    filter: string[];
     remote: string;
     'sample-size': string;
     timeout: string;
@@ -190,7 +201,13 @@ $ node test/benchmark/cli -n 20
             { withFileTypes: true }
         )
             .filter(
-                (dirEntry) => dirEntry.isFile() && dirEntry.name.endsWith('.js')
+                (dirEntry) =>
+                    dirEntry.isFile() &&
+                    dirEntry.name.endsWith('.js') &&
+                    (!opts.filter.length ||
+                        opts.filter.find(
+                            (filter) => dirEntry.name.search(filter) > -1
+                        ))
             )
             .map((dirEntry) => dirEntry.name.replace(/\.js$/, ''));
 
@@ -243,7 +260,7 @@ $ node test/benchmark/cli -n 20
             }
             config.benchmarks.push({
                 name: `${packageName}:${benchmark}`,
-                url: `bench-runner.html?bench=${benchmark}&package=${packageName}&dir=${monorepoDir}`,
+                url: `bench-runner.html?bench=${benchmark}&package=${packageName}&start=${start}&dir=${monorepoDir}`,
                 measurement: 'global',
                 browser: {
                     name: opts.browser,

--- a/test/benchmark/cli.ts
+++ b/test/benchmark/cli.ts
@@ -205,8 +205,8 @@ $ node test/benchmark/cli -n 20
                     dirEntry.isFile() &&
                     dirEntry.name.endsWith('.js') &&
                     (!opts.filter.length ||
-                        opts.filter.find(
-                            (filter) => dirEntry.name.search(filter) > -1
+                        opts.filter.find((filter) =>
+                            dirEntry.name.includes(filter)
                         ))
             )
             .map((dirEntry) => dirEntry.name.replace(/\.js$/, ''));


### PR DESCRIPTION
## Description
- allow `open` as a flag in the Overlay directives
- abstract `slottable-request` down for use with non-Overlay elements
- prioritize non-`type="hint"` Overlays on the same trigger
- expand options for performance testing specific files
- clean up performance test files
- add `slottable-request` and associated testing to the Action Menu

### To Dos:
- [x] test the new directive
- [x] test the `open` flag
- [x] meet coverage levels
- [x] confirm story names and update VRT cache

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://slottable-action-menu--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--decorated)
    2. Open and close the menu
    3. See that it works roughly like it did before
-   [ ] _Test case 2_
    1. Go [here](https://slottable-action-menu--spectrum-web-components.netlify.app/storybook/?path=/story/overlay-directive--default)
    2. See that toggling `open` in the Controls pane opens and closes the Popover
-   [ ] _Test case 3_
    1. Go [here](https://slottable-action-menu--spectrum-web-components.netlify.app/storybook/?path=/story/tooltip-directive--default)
    2. See that toggling `open` in the Controls pane opens and closes the Tooltip

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.