### PR TITLE
build: exclude erroneously interpreted event dispatch from CEM management

### DIFF
--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -77,6 +77,7 @@ export const strategies = {
  *
  * @fires sp-opened - announces that an overlay has completed any entry animations
  * @fires sp-closed - announce that an overlay has compelted any exit animations
+ * @fires slottable-request - requests to add or remove slottable content
  */
 export class Overlay extends OverlayFeatures {
     static override styles = [styles];
@@ -536,6 +537,9 @@ export class Overlay extends OverlayFeatures {
         if (!this.open) {
             document.body.offsetHeight;
         }
+        /**
+         * @ignore
+         */
         this.dispatchEvent(
             new SlottableRequestEvent(
                 'overlay-content',


### PR DESCRIPTION
## Description
The `SlottableRequestEvent` gets interpreted by CEM incorrectly and fails the React build when attempting to make a release. This ignores the automatic processing of the event and places it manually in the JSDocs.

## How has this been tested?
-   [ ] _Test case 1_
    1. Run `build:react`
    2. See that the process completes.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
