### PR TITLE
Dependency Manager reactive controller

### DIFF
--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -63,6 +63,7 @@
     "dependencies": {
         "@spectrum-web-components/base": "^0.42.0",
         "@spectrum-web-components/overlay": "^0.42.0",
+        "@spectrum-web-components/reactive-controllers": "^0.42.0",
         "@spectrum-web-components/shared": "^0.42.0"
     },
     "devDependencies": {

--- a/packages/tooltip/src/Tooltip.ts
+++ b/packages/tooltip/src/Tooltip.ts
@@ -19,7 +19,6 @@ import {
 import {
     property,
     query,
-    state,
 } from '@spectrum-web-components/base/src/decorators.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import type {
@@ -30,6 +29,7 @@ import type {
 
 import tooltipStyles from './tooltip.css.js';
 import { focusableSelector } from '@spectrum-web-components/shared/src/focusable-selectors.js';
+import { DependencyManagerController } from '@spectrum-web-components/reactive-controllers/src/DependencyManger.js';
 
 class TooltipOpenable extends HTMLElement {
     constructor() {
@@ -129,6 +129,8 @@ export class Tooltip extends SpectrumElement {
      */
     @property({ type: Boolean })
     delayed = false;
+
+    private dependencyManager = new DependencyManagerController(this);
 
     /**
      * Whether to prevent a self-managed Tooltip from responding to user input.
@@ -250,29 +252,6 @@ export class Tooltip extends SpectrumElement {
         return triggerElement;
     }
 
-    @state()
-    private dependenciesLoaded = false;
-    private dependenciesToLoad: Record<string, boolean> = {};
-
-    private trackDependency(dependency: string, flag?: boolean): void {
-        const loaded =
-            !!customElements.get(dependency) ||
-            this.dependenciesToLoad[dependency] ||
-            !!flag;
-        if (!loaded) {
-            customElements.whenDefined(dependency).then(() => {
-                this.trackDependency(dependency, true);
-            });
-        }
-        this.dependenciesToLoad = {
-            ...this.dependenciesToLoad,
-            [dependency]: loaded,
-        };
-        this.dependenciesLoaded = Object.values(this.dependenciesToLoad).every(
-            (loaded) => loaded
-        );
-    }
-
     override render(): TemplateResult {
         const tooltip = html`
             <sp-tooltip-openable
@@ -288,13 +267,13 @@ export class Tooltip extends SpectrumElement {
             </sp-tooltip-openable>
         `;
         if (this.selfManaged) {
-            this.trackDependency('sp-overlay');
+            this.dependencyManager.add('sp-overlay');
             import('@spectrum-web-components/overlay/sp-overlay.js');
             return html`
                 <sp-overlay
                     ?open=${this.open &&
                     !this.disabled &&
-                    this.dependenciesLoaded}
+                    this.dependencyManager.loaded}
                     ?delayed=${this.delayed}
                     ?disabled=${this.disabled}
                     offset=${this.offset}

--- a/tools/reactive-controllers/dependency-manager.md
+++ b/tools/reactive-controllers/dependency-manager.md
@@ -1,0 +1,66 @@
+## Description
+
+In cases where you choose to lazily register custom element definitions across the lifecycle of your application, delaying certain functionality until that registration is complete can be beneficial. To normalize management of this process, a `DependencyManagerController` can be added to your custom element.
+
+Use the `add()` method to inform the manager which custom element tag names you need to be defined before doing some action. When the elements you have provided to the manager are available, the controller will request an update to your host element and surface a `loaded` boolean to clarify the current load state of the managed dependencies.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/reactive-controllers?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/reactive-controllers)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/reactive-controllers?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/reactive-controllers)
+
+```
+yarn add @spectrum-web-components/reactive-controllers
+```
+
+Import the `DependencyManagerController` via:
+
+```
+import { DependencyManagerController } from '@spectrum-web-components/reactive-controllers/DependencyManager.js';
+```
+
+## Example
+
+A `Host` element that renders a different message depending on the `loaded` state of the `<some-heavy-element>` dependency in the following custom element definition:
+
+```js
+import { html, LitElement } from 'lit';
+import { DependencyManagerController } from '@spectrum-web-components/reactive-controllers/DependencyManager.js';
+import '@spectrum-web-components/button/sp-button.js';
+
+class Host extends LitElement {
+    dependencyManager = new DependencyManagerController(this);
+
+    state = 'initial';
+
+    forwardState() {
+        this.state = 'heavy';
+    }
+
+    render() {
+        const isInitialState = this.state === 'initial';
+        if (isInitialState || !this.dependencyManager.loaded) {
+            if (!isInitialState) {
+                // When not in the initial state, this element depends on <some-heavy-element>
+                this.dependencyManager.add('some-heavy-element');
+                // Lazily load that element
+                import('path/to/register/some-heavy-element.js');
+            }
+            return html`
+                <sp-button
+                    @click=${this.forwardState}
+                    ?pending=${!isInitialState &&
+                    !this.dependencyManager.loaded}
+                >
+                    Go to next state
+                </sp-button>
+            `;
+        } else {
+            // <some-heavy-element> has now been loaded and can be rendered
+            return html`
+                <some-heavy-element></some-heavy-element>
+            `;
+        }
+    }
+}
+```

--- a/tools/reactive-controllers/match-media.md
+++ b/tools/reactive-controllers/match-media.md
@@ -16,7 +16,7 @@ yarn add @spectrum-web-components/reactive-controllers
 Import the `MatchMediaController` via:
 
 ```
-import { MatchMediaController } from '@spectrum-web-components/reactive-controllers/MatchMediaController.js';
+import { MatchMediaController } from '@spectrum-web-components/reactive-controllers/MatchMedia.js';
 ```
 
 ## Example
@@ -25,7 +25,7 @@ A `Host` element that renders a different message depending on the "orientation"
 
 ```js
 import { html, LitElement } from 'lit';
-import { MatchMediaController } from '@spectrum-web-components/reactive-controllers/MatchMediaController.js';
+import { MatchMediaController } from '@spectrum-web-components/reactive-controllers/MatchMedia.js';
 
 class Host extends LitElement {
     orientationLandscape = new MatchMediaController(

--- a/tools/reactive-controllers/package.json
+++ b/tools/reactive-controllers/package.json
@@ -29,6 +29,10 @@
             "development": "./src/Color.dev.js",
             "default": "./src/Color.js"
         },
+        "./src/DependencyManger.js": {
+            "development": "./src/DependencyManger.dev.js",
+            "default": "./src/DependencyManger.js"
+        },
         "./src/ElementResolution.js": {
             "development": "./src/ElementResolution.dev.js",
             "default": "./src/ElementResolution.js"

--- a/tools/reactive-controllers/src/DependencyManger.ts
+++ b/tools/reactive-controllers/src/DependencyManger.ts
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import type { ReactiveElement } from 'lit';
+export const dependencyManagerLoadedSymbol = Symbol(
+    'dependency manager loaded'
+);
+
+/**
+ * Manage the availability of custom element dependencies of a host element
+ * to gate render and functional behavior before and after their presence
+ */
+export class DependencyManagerController {
+    private dependencies: Record<string, boolean> = {};
+
+    private host!: ReactiveElement;
+
+    /**
+     * Whether all of the provided dependencies have been registered.
+     * This will be `false` when no dependencies have been listed for management.
+     * Changes to this value will trigger `requestUpdate()` on the host.
+     */
+    public get loaded(): boolean {
+        return this._loaded;
+    }
+
+    private set loaded(loaded: boolean) {
+        if (loaded === this.loaded) return;
+        this._loaded = loaded;
+        this.host.requestUpdate(dependencyManagerLoadedSymbol, !this.loaded);
+    }
+
+    private _loaded = false;
+
+    constructor(host: ReactiveElement) {
+        this.host = host;
+    }
+
+    /**
+     * Submit a custom element tag name to be managed as a dependency.
+     *
+     * @param dependency {string} - the custom element tag to manage
+     * @param alreadyLoaded {boolean} - force the managemented custom element to be listed as loaded
+     */
+    public add(dependency: string, alreadyLoaded?: boolean): void {
+        const loaded =
+            !!alreadyLoaded ||
+            !!customElements.get(dependency) ||
+            this.dependencies[dependency];
+        if (!loaded) {
+            customElements.whenDefined(dependency).then(() => {
+                this.add(dependency, true);
+            });
+        }
+        this.dependencies = {
+            ...this.dependencies,
+            [dependency]: loaded,
+        };
+        // Update the loaded property based on the new loaded state of all dependencies
+        this.loaded = Object.values(this.dependencies).every(
+            (loaded) => loaded
+        );
+    }
+}

--- a/tools/reactive-controllers/test/dependency-manager.test.ts
+++ b/tools/reactive-controllers/test/dependency-manager.test.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { ReactiveElement } from 'lit';
+import { expect, nextFrame } from '@open-wc/testing';
+import { DependencyManagerController } from '@spectrum-web-components/reactive-controllers/src/DependencyManger.js';
+import { spy } from 'sinon';
+
+describe('Dependency Manager', () => {
+    it('manages dependencies', async function () {
+        this.retries(0);
+        const tagName = 'some-heavy-element';
+        const requestUpdateSpy = spy();
+        const manager = new DependencyManagerController({
+            requestUpdate: () => requestUpdateSpy(),
+        } as unknown as ReactiveElement);
+        expect(manager.loaded).to.be.false;
+        manager.add(tagName);
+        expect(manager.loaded).to.be.false;
+        expect(requestUpdateSpy.notCalled).to.be.true;
+        customElements.define(tagName, class extends HTMLElement {});
+        // Allow time for the registration to propagate.
+        await nextFrame();
+        expect(manager.loaded).to.be.true;
+        expect(requestUpdateSpy.notCalled).to.be.false;
+    });
+});


### PR DESCRIPTION
## Description
Add, document, and test the `DependencyManagerController` which tracks when supplied custom elements are fully registered to the page.

Refactor Picker and Tooltip to use the `DependencyManagerController` to manage their dependencies.

## Related issue(s)
- fixes #3900

## Motivation and context
Deduplication.

## How has this been tested?
-   [ ] _Test case 1_
    1. See the test
-   [ ] _Test case 2_
    1. See that Picker and Tooltip work as expected in storybook

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.