### PR TITLE
refactor(menu): leverage dependency management in Menu Item for submenus

### DIFF
--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -92,6 +92,7 @@
         "@spectrum-web-components/icons-ui": "^0.42.0",
         "@spectrum-web-components/overlay": "^0.42.0",
         "@spectrum-web-components/popover": "^0.42.0",
+        "@spectrum-web-components/reactive-controllers": "^0.42.0",
         "@spectrum-web-components/shared": "^0.42.0"
     },
     "devDependencies": {

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -32,6 +32,7 @@ import { LikeAnchor } from '@spectrum-web-components/shared/src/like-anchor.js';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron100.js';
 import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
+import { DependencyManagerController } from '@spectrum-web-components/reactive-controllers/src/DependencyManger.js';
 
 import menuItemStyles from './menu-item.css.js';
 import checkmarkStyles from '@spectrum-web-components/icon/src/spectrum-icon-checkmark.css.js';
@@ -100,6 +101,8 @@ export class MenuItem extends LikeAnchor(
 
     @property({ type: Boolean, reflect: true })
     public active = false;
+
+    private dependencyManager = new DependencyManagerController(this);
 
     @property({ type: Boolean, reflect: true })
     public focused = false;
@@ -272,13 +275,17 @@ export class MenuItem extends LikeAnchor(
         if (!this.hasSubmenu) {
             return slot;
         }
+        this.dependencyManager.add('sp-overlay');
+        this.dependencyManager.add('sp-popover');
         import('@spectrum-web-components/overlay/sp-overlay.js');
         import('@spectrum-web-components/popover/sp-popover.js');
         return html`
             <sp-overlay
                 .triggerElement=${this as HTMLElement}
                 ?disabled=${!this.hasSubmenu}
-                ?open=${this.hasSubmenu && this.open}
+                ?open=${this.hasSubmenu &&
+                this.open &&
+                this.dependencyManager.loaded}
                 .placement=${this.isLTR ? 'right-start' : 'left-start'}
                 .offset=${[-10, -5] as [number, number]}
                 .type=${'auto'}

--- a/packages/menu/test/menu.test.ts
+++ b/packages/menu/test/menu.test.ts
@@ -17,7 +17,6 @@ import { Menu, MenuItem } from '@spectrum-web-components/menu';
 import {
     elementUpdated,
     expect,
-    fixture,
     html,
     nextFrame,
     waitUntil,
@@ -25,6 +24,7 @@ import {
 import {
     arrowDownEvent,
     arrowUpEvent,
+    fixture,
     tabEvent,
     testForLitDevWarnings,
     tEvent,
@@ -191,7 +191,15 @@ describe('Menu', () => {
         await elementUpdated(el);
 
         const otherItem = el.querySelector('#other') as MenuItem;
-        otherItem.click();
+        otherItem.focus();
+        await elementUpdated(el);
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        await elementUpdated(el);
+        await sendKeys({
+            press: 'Enter',
+        });
 
         await elementUpdated(el);
 
@@ -566,13 +574,17 @@ describe('Menu', () => {
                 </sp-menu>
             `
         );
+        await nextFrame();
+        await nextFrame();
         expect(el.selected).to.deep.equal([]);
 
-        const items = [...el.querySelectorAll('[value]')] as MenuItem[];
+        const items = [...el.children] as MenuItem[];
+        await Promise.all(items.map((child) => child.updateComplete));
 
         items[0].click();
         await nextFrame();
         await nextFrame();
+        expect(el.selected).to.deep.equal(['1']);
 
         items[0].click();
         await nextFrame();


### PR DESCRIPTION
## Description
Use Dependency Manager Controller in Menu Item to prevent early opening of submenus.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://manage-menu-item--spectrum-web-components.netlify.app/storybook/index.html?path=/story/menu-submenu--submenu)
    2. See that the submenus open as expected

## Types of changes
-   [x] Refactor to shared code

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.