### PR TITLE
refactor: prefer native :active when possible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: fbac3bdcdee3a5e52972b9aa87e52b2cf5b82bfe
+        default: 862fed6296aa9e1a69e901ed053555705c92b320
     wireit_cache_name:
         type: string
         default: wireit

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
         "alex": "^11.0.1",
         "cem-plugin-module-file-extensions": "^0.0.5",
         "chalk": "^5.0.1",
-        "chromedriver": "^121.0.2",
+        "chromedriver": "^122.0.0",
         "common-tags": "^1.8.2",
         "custom-elements-manifest": "^2.0.0",
         "debounce": "^2.0.0",

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -483,7 +483,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) {
+:host(:is(:active, [active])) {
     background-color: var(
         --highcontrast-actionbutton-background-color-down,
         var(

--- a/packages/action-button/src/spectrum-config.js
+++ b/packages/action-button/src/spectrum-config.js
@@ -44,7 +44,31 @@ const config = {
                 converter.classToAttribute('is-disabled', 'disabled'),
                 converter.pseudoToAttribute('disabled', 'disabled'),
                 converter.classToAttribute('is-selected', 'selected'),
-                converter.pseudoToAttribute('active', 'active'),
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
+                    hoist: true,
+                },
                 converter.classToAttribute('is-active', 'active'),
                 converter.classToAttribute('spectrum-ActionButton--emphasized'),
                 ...converter.enumerateAttributes(

--- a/packages/button/src/ButtonBase.ts
+++ b/packages/button/src/ButtonBase.ts
@@ -180,14 +180,6 @@ export class ButtonBase extends ObserveSlotText(LikeAnchor(Focusable), '', [
         }
     }
 
-    private handleRemoveActive(): void {
-        this.active = false;
-    }
-
-    private handlePointerdown(): void {
-        this.active = true;
-    }
-
     private manageAnchor(): void {
         if (this.href && this.href.length > 0) {
             if (
@@ -216,7 +208,6 @@ export class ButtonBase extends ObserveSlotText(LikeAnchor(Focusable), '', [
         this.manageAnchor();
         this.addEventListener('keydown', this.handleKeydown);
         this.addEventListener('keypress', this.handleKeypress);
-        this.addEventListener('pointerdown', this.handlePointerdown);
     }
 
     protected override updated(changed: PropertyValues): void {
@@ -226,25 +217,6 @@ export class ButtonBase extends ObserveSlotText(LikeAnchor(Focusable), '', [
         }
         if (changed.has('label')) {
             this.setAttribute('aria-label', this.label || '');
-        }
-        if (changed.has('active')) {
-            if (this.active) {
-                this.addEventListener('focusout', this.handleRemoveActive);
-                this.addEventListener('pointerup', this.handleRemoveActive);
-                this.addEventListener('pointercancel', this.handleRemoveActive);
-                this.addEventListener('pointerleave', this.handleRemoveActive);
-            } else {
-                this.removeEventListener('focusout', this.handleRemoveActive);
-                this.removeEventListener('pointerup', this.handleRemoveActive);
-                this.removeEventListener(
-                    'pointercancel',
-                    this.handleRemoveActive
-                );
-                this.removeEventListener(
-                    'pointerleave',
-                    this.handleRemoveActive
-                );
-            }
         }
         if (this.anchorElement) {
             this.anchorElement.addEventListener('focus', this.proxyFocus);

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -362,7 +362,7 @@ governing permissions and limitations under the License.
     position: relative;
 }
 
-:host([active]) {
+:host(:is(:active, [active])) {
     box-shadow: none;
 }
 
@@ -594,7 +594,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) {
+:host(:is(:active, [active])) {
     background-color: var(
         --highcontrast-button-background-color-down,
         var(

--- a/packages/button/src/spectrum-config.js
+++ b/packages/button/src/spectrum-config.js
@@ -74,7 +74,31 @@ const config = {
                 converter.classToAttribute('is-focused', 'focused'),
                 converter.classToAttribute('is-pending', 'pending'),
                 converter.pseudoToAttribute('disabled', 'disabled'),
-                converter.pseudoToAttribute('active', 'active'),
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
+                    hoist: true,
+                },
                 converter.classToAttribute(
                     'spectrum-Button--iconOnly',
                     'icon-only'

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -150,7 +150,7 @@ governing permissions and limitations under the License.
     position: relative;
 }
 
-:host:active #box:before {
+:host(:is(:active, [active])) #box:before {
     border-color: var(
         --highcontrast-checkbox-highlight-color-down,
         var(
@@ -160,7 +160,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host:active #input:checked + #box:before {
+:host(:is(:active, [active])) #input:checked + #box:before {
     border-color: var(
         --highcontrast-checkbox-highlight-color-down,
         var(
@@ -170,7 +170,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host:active #label {
+:host(:is(:active, [active])) #label {
     color: var(
         --highcontrast-checkbox-content-color-down,
         var(
@@ -212,7 +212,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([readonly]):active #box:before {
+:host([readonly]:is(:active, [active])) #box:before {
     border-color: var(
         --highcontrast-checkbox-selected-color-default,
         var(
@@ -453,9 +453,11 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([emphasized][indeterminate]):active #box:before,
-:host([emphasized][indeterminate]):active #input:checked + #box:before,
-:host([emphasized]):active #input:checked + #box:before {
+:host([emphasized]:is(:active, [active])[indeterminate]) #box:before,
+:host([emphasized]:is(:active, [active])[indeterminate])
+    #input:checked
+    + #box:before,
+:host([emphasized]:is(:active, [active])) #input:checked + #box:before {
     border-color: var(
         --highcontrast-checkbox-highlight-color-default,
         var(
@@ -465,8 +467,10 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([emphasized][invalid][invalid]):active #input:checked + #box:before,
-:host([emphasized][invalid][invalid]):active #box:before {
+:host([emphasized][invalid][invalid]:is(:active, [active]))
+    #input:checked
+    + #box:before,
+:host([emphasized][invalid][invalid]:is(:active, [active])) #box:before {
     border-color: var(
         --highcontrast-checkbox-highlight-color-default,
         var(

--- a/packages/checkbox/src/spectrum-config.js
+++ b/packages/checkbox/src/spectrum-config.js
@@ -27,7 +27,31 @@ const config = {
             components: [
                 converter.classToHost(),
                 converter.classToAttribute('is-indeterminate', 'indeterminate'),
-                // converter.classToAttribute('is-invalid', 'invalid'),
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
+                    hoist: true,
+                },
                 converter.classToAttribute('is-readOnly', 'readonly'),
                 converter.classToAttribute('spectrum-Checkbox--emphasized'),
                 // Default to `size='m'` without needing the attribute

--- a/packages/clear-button/src/spectrum-clear-button.css
+++ b/packages/clear-button/src/spectrum-clear-button.css
@@ -169,14 +169,14 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([active]) {
+:host(:is(:active, [active])) {
     color: var(
         --mod-clear-button-icon-color-down,
         var(--spectrum-clear-button-icon-color-down)
     );
 }
 
-:host([active]) .fill {
+:host(:is(:active, [active])) .fill {
     background-color: var(
         --mod-clear-button-background-color-down,
         var(--spectrum-clear-button-background-color-down)

--- a/packages/clear-button/src/spectrum-config.js
+++ b/packages/clear-button/src/spectrum-config.js
@@ -26,7 +26,31 @@ const config = {
             fileName: 'clear-button',
             components: [
                 converter.classToHost(),
-                converter.pseudoToAttribute('active', 'active'),
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
+                    hoist: true,
+                },
                 converter.pseudoToAttribute('disabled', 'disabled'),
                 converter.classToAttribute('is-disabled', 'disabled'),
                 ...converter.enumerateAttributes(

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -333,14 +333,14 @@ governing permissions and limitations under the License.
     );
 }
 
-:host(:not([disabled])[active]) {
+:host(:not([disabled]):is(:active, [active])) {
     background-color: var(
         --mod-closebutton-background-color-down,
         var(--spectrum-closebutton-background-color-down)
     );
 }
 
-:host(:not([disabled])[active]) .icon {
+:host(:not([disabled]):is(:active, [active])) .icon {
     color: var(
         --highcontrast-closebutton-icon-color-down,
         var(
@@ -456,8 +456,8 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([static='black']:not([disabled])[active]),
-:host([static='white']:not([disabled])[active]) {
+:host([static='black']:not([disabled]):is(:active, [active])),
+:host([static='white']:not([disabled]):is(:active, [active])) {
     background-color: var(
         --highcontrast-closebutton-static-background-color-down,
         var(
@@ -467,8 +467,8 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black']:not([disabled])[active]) .icon,
-:host([static='white']:not([disabled])[active]) .icon {
+:host([static='black']:not([disabled]):is(:active, [active])) .icon,
+:host([static='white']:not([disabled]):is(:active, [active])) .icon {
     color: var(
         --highcontrast-closebutton-icon-color-default,
         var(

--- a/packages/close-button/src/spectrum-config.js
+++ b/packages/close-button/src/spectrum-config.js
@@ -26,7 +26,31 @@ const config = {
             fileName: 'close-button',
             components: [
                 converter.classToHost(),
-                converter.pseudoToAttribute('active', 'active'),
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
+                    hoist: true,
+                },
                 converter.pseudoToAttribute('disabled', 'disabled'),
                 converter.classToAttribute('is-disabled', 'disabled'),
                 converter.classToAttribute('is-focused', 'focused'),

--- a/packages/infield-button/src/spectrum-config.js
+++ b/packages/infield-button/src/spectrum-config.js
@@ -48,6 +48,31 @@ const config = {
                     ],
                     'block'
                 ),
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
+                    hoist: true,
+                },
                 converter.classToAttribute('spectrum-InfieldButton--quiet'),
                 converter.pseudoToAttribute('disabled', 'disabled'),
                 converter.classToClass('spectrum-InfieldButton-fill', 'fill'),

--- a/packages/infield-button/src/spectrum-infield-button.css
+++ b/packages/infield-button/src/spectrum-infield-button.css
@@ -200,7 +200,7 @@ governing permissions and limitations under the License.
 }
 
 @media (forced-colors: active) {
-    :host:active:not(:disabled),
+    :host(:is(:active, [active])):not(:disabled),
     :host(:focus-visible):not(:disabled) {
         --highcontrast-infield-button-border-color: Highlight;
     }
@@ -323,14 +323,14 @@ governing permissions and limitations under the License.
     }
 }
 
-:host:active .fill {
+:host(:is(:active, [active])) .fill {
     background-color: var(
         --mod-infield-button-background-color-down,
         var(--spectrum-infield-button-background-color-down)
     );
 }
 
-:host:active ::slotted(*) {
+:host(:is(:active, [active])) ::slotted(*) {
     color: var(
         --mod-infield-button-icon-color-down,
         var(--spectrum-infield-button-icon-color-down)

--- a/packages/menu/src/MenuItem.ts
+++ b/packages/menu/src/MenuItem.ts
@@ -96,8 +96,6 @@ export class MenuItem extends LikeAnchor(
         return [menuItemStyles, checkmarkStyles, chevronStyles];
     }
 
-    abortControllerPointer!: AbortController;
-
     abortControllerSubmenu!: AbortController;
 
     @property({ type: Boolean, reflect: true })
@@ -282,7 +280,7 @@ export class MenuItem extends LikeAnchor(
                 ?disabled=${!this.hasSubmenu}
                 ?open=${this.hasSubmenu && this.open}
                 .placement=${this.isLTR ? 'right-start' : 'left-start'}
-                .offset=${[-10, -4] as [number, number]}
+                .offset=${[-10, -5] as [number, number]}
                 .type=${'auto'}
                 @close=${(event: Event) => event.stopPropagation()}
             >
@@ -347,15 +345,7 @@ export class MenuItem extends LikeAnchor(
         }
     }
 
-    private handleRemoveActive(): void {
-        if (this.open) {
-            return;
-        }
-        this.active = false;
-    }
-
     private handlePointerdown(event: PointerEvent): void {
-        this.active = true;
         if (event.target === this && this.hasSubmenu && this.open) {
             this.addEventListener('focus', this.handleSubmenuFocus, {
                 once: true,
@@ -510,25 +500,6 @@ export class MenuItem extends LikeAnchor(
         ) {
             if (this.active) {
                 this.menuData.selectionRoot?.closeDescendentOverlays();
-                this.abortControllerPointer = new AbortController();
-                const options = { signal: this.abortControllerPointer.signal };
-                this.addEventListener(
-                    'pointerup',
-                    this.handleRemoveActive,
-                    options
-                );
-                this.addEventListener(
-                    'pointerleave',
-                    this.handleRemoveActive,
-                    options
-                );
-                this.addEventListener(
-                    'pointercancel',
-                    this.handleRemoveActive,
-                    options
-                );
-            } else {
-                this.abortControllerPointer?.abort();
             }
         }
         if (this.anchorElement) {

--- a/packages/menu/src/spectrum-config.js
+++ b/packages/menu/src/spectrum-config.js
@@ -83,7 +83,31 @@ const config = {
                 converter.classToHost('spectrum-Menu-item'),
                 converter.classToAttribute('is-disabled', 'disabled'),
                 converter.classToAttribute('is-active', 'active'),
-                converter.pseudoToAttribute('active', 'active'),
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
+                    hoist: true,
+                },
                 converter.classToAttribute('is-focused', 'focused'),
                 converter.classToAttribute('is-selected', 'selected'),
                 converter.classToId('spectrum-Menu-itemLabel', 'label'),

--- a/packages/menu/src/spectrum-menu-item.css
+++ b/packages/menu/src/spectrum-menu-item.css
@@ -255,7 +255,7 @@ governing permissions and limitations under the License.
     --spectrum-menu-item-focus-indicator-direction-scalar: -1;
 }
 
-:host([active]) {
+:host(:is(:active, [active])) {
     background-color: var(
         --highcontrast-menu-item-background-color-focus,
         var(
@@ -265,7 +265,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) > #label {
+:host(:is(:active, [active])) > #label {
     color: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -275,7 +275,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) > [name='description']::slotted(*) {
+:host(:is(:active, [active])) > [name='description']::slotted(*) {
     color: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -285,7 +285,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) > ::slotted([slot='value']) {
+:host(:is(:active, [active])) > ::slotted([slot='value']) {
     color: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -295,7 +295,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) > .icon:not(.chevron, .checkmark) {
+:host(:is(:active, [active])) > .icon:not(.chevron, .checkmark) {
     fill: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -312,7 +312,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) > .chevron {
+:host(:is(:active, [active])) > .chevron {
     fill: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -329,7 +329,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) > .checkmark {
+:host(:is(:active, [active])) > .checkmark {
     fill: var(
         --highcontrast-menu-item-color-focus,
         var(
@@ -531,7 +531,7 @@ governing permissions and limitations under the License.
     transform: rotate(90deg);
 }
 
-:host([active]) .spectrum-Menu-item--collapsible.is-open,
+:host(:is(:active, [active])) .spectrum-Menu-item--collapsible.is-open,
 .spectrum-Menu-item--collapsible.is-open:focus,
 :host([focused]) .spectrum-Menu-item--collapsible.is-open {
     background-color: var(
@@ -665,7 +665,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([has-submenu][active]) .chevron {
+:host([has-submenu]:is(:active, [active])) .chevron {
     fill: var(
         --highcontrast-menu-item-color-focus,
         var(

--- a/packages/picker-button/src/spectrum-config.js
+++ b/packages/picker-button/src/spectrum-config.js
@@ -195,7 +195,31 @@ const config = {
                     },
                     hoist: true,
                 },
-                converter.pseudoToAttribute('active', 'active'),
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
+                    hoist: true,
+                },
                 converter.classToAttribute('is-invalid', 'invalid'),
                 converter.notToAttribute('is-invalid', 'invalid'),
                 ...converter.enumerateAttributes(

--- a/packages/picker-button/src/spectrum-picker-button.css
+++ b/packages/picker-button/src/spectrum-picker-button.css
@@ -199,7 +199,7 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([active]) .root .spectrum-PickerButton-fill,
+:host(:is(:active, [active])) .root .spectrum-PickerButton-fill,
 :host([open]) .root .spectrum-PickerButton-fill {
     background-color: var(
         --mod-picker-button-background-color-down,
@@ -207,7 +207,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) .root .spectrum-PickerButton-label,
+:host(:is(:active, [active])) .root .spectrum-PickerButton-label,
 :host([open]) .root .spectrum-PickerButton-label {
     color: var(
         --mod-picker-button-font-color-down,
@@ -215,7 +215,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([active]) .root .spectrum-PickerButton-icon,
+:host(:is(:active, [active])) .root .spectrum-PickerButton-icon,
 :host([open]) .root .spectrum-PickerButton-icon {
     color: var(
         --mod-picker-button-icon-color-down,

--- a/packages/tags/src/spectrum-config.js
+++ b/packages/tags/src/spectrum-config.js
@@ -49,7 +49,28 @@ const config = {
             fileName: 'tag',
             components: [
                 {
-                    find: builder.pseudoClass('active'),
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'active',
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'is',
+                        selectors: [
+                            [
+                                {
+                                    type: 'pseudo-class',
+                                    kind: 'active',
+                                },
+                            ],
+                            [
+                                {
+                                    type: 'attribute',
+                                    name: 'active',
+                                },
+                            ],
+                        ],
+                    },
                     hoist: true,
                 },
                 {

--- a/packages/tags/src/spectrum-tag.css
+++ b/packages/tags/src/spectrum-tag.css
@@ -446,7 +446,7 @@ governing permissions and limitations under the License.
     overflow: hidden;
 }
 
-:host(:active) {
+:host(:is(:active, [active])) {
     border-color: var(
         --highcontrast-tag-border-color-active,
         var(
@@ -573,7 +573,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([selected]:active) {
+:host([selected]:is(:active, [active])) {
     border-color: var(
         --highcontrast-tag-border-color-selected-active,
         var(
@@ -625,7 +625,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([invalid]:active) {
+:host([invalid]:is(:active, [active])) {
     border-color: var(
         --highcontrast-tag-border-color-invalid-active,
         var(
@@ -684,7 +684,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([invalid][selected]:active) {
+:host([invalid][selected]:is(:active, [active])) {
     border-color: var(
         --highcontrast-tag-border-color-invalid-selected-active,
         var(
@@ -858,7 +858,7 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([emphasized]:active) {
+:host([emphasized]:is(:active, [active])) {
     border-color: var(
         --highcontrast-tag-border-color-emphasized-active,
         var(

--- a/packages/tags/src/tag.css
+++ b/packages/tags/src/tag.css
@@ -40,7 +40,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([invalid]):active .clear-button {
+:host([invalid]:is(:active, [active])) .clear-button {
     --spectrum-clearbutton-medium-icon-color: var(
         --spectrum-tag-icon-color-error-hover,
         var(--spectrum-red-600)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5971,6 +5971,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@tootallnate/quickjs-emscripten@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
+  integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
+
 "@toycode/markdown-it-class@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@toycode/markdown-it-class/-/markdown-it-class-1.2.4.tgz#6d9bc162d0b980695a2e6b2622f49eb1c3f349c8"
@@ -8460,6 +8465,13 @@ ast-module-types@^5.0.0:
   resolved "https://registry.yarnpkg.com/ast-module-types/-/ast-module-types-5.0.0.tgz#32b2b05c56067ff38e95df66f11d6afd6c9ba16b"
   integrity sha512-JvqziE0Wc0rXQfma0HZC/aY7URXHFuZV84fJRtP8u+lhp0JYCNd5wJzVXP45t0PH0Mej3ynlzvdyITYIu0G4LQ==
 
+ast-types@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
+  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
+  dependencies:
+    tslib "^2.0.1"
+
 ast-types@^0.16.1:
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.16.1.tgz#7a9da1617c9081bc121faafe91711b4c8bb81da2"
@@ -8557,12 +8569,21 @@ axe-core@^4.2.0, axe-core@^4.3.3:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
-axios@^1.0.0, axios@^1.1.3, axios@^1.6.5:
+axios@^1.0.0, axios@^1.1.3:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
   integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
   dependencies:
     follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
+axios@^1.6.7:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
+  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
+  dependencies:
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -8721,6 +8742,11 @@ basic-auth@^2.0.1:
   integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
   dependencies:
     safe-buffer "5.1.2"
+
+basic-ftp@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.0.5.tgz#14a474f5fffecca1f4f406f1c26b18f800225ac0"
+  integrity sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==
 
 batch@0.6.1:
   version "0.6.1"
@@ -9566,16 +9592,16 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^121.0.2:
-  version "121.0.2"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-121.0.2.tgz#208909a61e9d510913107ea6faf34bcdd72cdced"
-  integrity sha512-58MUSCEE3oB3G3Y/Jo3URJ2Oa1VLHcVBufyYt7vNfGrABSJm7ienQLF9IQ8LPDlPVgLUXt2OBfggK3p2/SlEBg==
+chromedriver@^122.0.0:
+  version "122.0.6"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-122.0.6.tgz#d5b2922416ba1b5e09d8da1c8fa95b370d10cd6f"
+  integrity sha512-Q0r+QlUtiJWMQ5HdYaFa0CtBmLFq3n5JWfmq9mOC00UMBvWxku09gUkvBt457QnYfTM/XHqY/HTFOxHvATnTmA==
   dependencies:
     "@testim/chrome-version" "^1.1.4"
-    axios "^1.6.5"
+    axios "^1.6.7"
     compare-versions "^6.1.0"
     extract-zip "^2.0.1"
-    https-proxy-agent "^5.0.1"
+    proxy-agent "^6.4.0"
     proxy-from-env "^1.1.0"
     tcp-port-used "^1.0.2"
 
@@ -10799,6 +10825,11 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
   integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
 
+data-uri-to-buffer@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
+  integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -11082,6 +11113,15 @@ defu@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.2.tgz#1217cba167410a1765ba93893c6dbac9ed9d9e5c"
   integrity sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==
+
+degenerator@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-5.0.1.tgz#9403bf297c6dad9a1ece409b37db27954f91f2f5"
+  integrity sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==
+  dependencies:
+    ast-types "^0.13.4"
+    escodegen "^2.1.0"
+    esprima "^4.0.1"
 
 del@^4.1.1:
   version "4.1.1"
@@ -12017,6 +12057,17 @@ escodegen@^2.0.0:
     estraverse "^5.2.0"
     esutils "^2.0.2"
     optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
+escodegen@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
+  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
   optionalDependencies:
     source-map "~0.6.1"
 
@@ -13178,7 +13229,7 @@ folder-walker@3.2.0:
   dependencies:
     from2 "^2.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.4:
+follow-redirects@^1.0.0, follow-redirects@^1.15.4, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -13315,6 +13366,15 @@ fs-extra@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+fs-extra@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
+  integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -13591,6 +13651,16 @@ get-symbol-description@^1.0.2:
     call-bind "^1.0.5"
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
+
+get-uri@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-6.0.3.tgz#0d26697bc13cf91092e519aa63aa60ee5b6f385a"
+  integrity sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==
+  dependencies:
+    basic-ftp "^5.0.2"
+    data-uri-to-buffer "^6.0.2"
+    debug "^4.3.4"
+    fs-extra "^11.2.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -14606,6 +14676,14 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+http-proxy-agent@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
 http-proxy-middleware@2.0.6, http-proxy-middleware@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
@@ -14681,6 +14759,14 @@ https-proxy-agent@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz#e2645b846b90e96c6e6f347fb5b2e41f1590b09b"
   integrity sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==
+  dependencies:
+    agent-base "^7.0.2"
+    debug "4"
+
+https-proxy-agent@^7.0.3:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168"
+  integrity sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==
   dependencies:
     agent-base "^7.0.2"
     debug "4"
@@ -17663,6 +17749,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.14.1:
+  version "7.18.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
+  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+
 lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.0.tgz#21be64954a4680e303a09e9468f880b98a0b3c7f"
@@ -19343,6 +19434,11 @@ netlify@13.1.10, netlify@^13.1.10:
     p-wait-for "^4.0.0"
     qs "^6.9.6"
 
+netmask@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
+  integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
+
 next@^14:
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/next/-/next-14.1.0.tgz#b31c0261ff9caa6b4a17c5af019ed77387174b69"
@@ -20472,6 +20568,28 @@ p-waterfall@2.1.1:
   integrity sha512-RRTnDb2TBG/epPRI2yYXsimO0v3BXC8Yd3ogr1545IaqKK17VGhbWVeGGN+XfCm/08OK8635nH31c8bATkHuSw==
   dependencies:
     p-reduce "^2.0.0"
+
+pac-proxy-agent@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz#6b9ddc002ec3ff0ba5fdf4a8a21d363bcc612d75"
+  integrity sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==
+  dependencies:
+    "@tootallnate/quickjs-emscripten" "^0.23.0"
+    agent-base "^7.0.2"
+    debug "^4.3.4"
+    get-uri "^6.0.1"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.2"
+    pac-resolver "^7.0.0"
+    socks-proxy-agent "^8.0.2"
+
+pac-resolver@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-7.0.1.tgz#54675558ea368b64d210fd9c92a640b5f3b8abb6"
+  integrity sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==
+  dependencies:
+    degenerator "^5.0.0"
+    netmask "^2.0.2"
 
 package-json@^8.1.0:
   version "8.1.0"
@@ -21746,6 +21864,20 @@ proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-agent@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-6.4.0.tgz#b4e2dd51dee2b377748aef8d45604c2d7608652d"
+  integrity sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==
+  dependencies:
+    agent-base "^7.0.2"
+    debug "^4.3.4"
+    http-proxy-agent "^7.0.1"
+    https-proxy-agent "^7.0.3"
+    lru-cache "^7.14.1"
+    pac-proxy-agent "^7.0.1"
+    proxy-from-env "^1.1.0"
+    socks-proxy-agent "^8.0.2"
 
 proxy-from-env@1.1.0, proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
@@ -23604,6 +23736,15 @@ socks-proxy-agent@^7.0.0:
     agent-base "^6.0.2"
     debug "^4.3.3"
     socks "^2.6.2"
+
+socks-proxy-agent@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz#5acbd7be7baf18c46a3f293a840109a430a640ad"
+  integrity sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==
+  dependencies:
+    agent-base "^7.0.2"
+    debug "^4.3.4"
+    socks "^2.7.1"
 
 socks@^2.6.2, socks@^2.7.1:
   version "2.7.1"


### PR DESCRIPTION
## Description
Use natively applied `:active` when possible.
- this should not change the end user behavior in any way
- a small (though likely not noticeable) KB and runtime benefit will be present

## Related issue(s)
- refs #4007

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://native-active--spectrum-web-components.netlify.app/storybook/?path=/story/menu-submenu--submenu)
    2. See that the synthetic `[active]` continues to be applied
-   [ ] _Test case 2_
    1. Go [here](https://native-active--spectrum-web-components.netlify.app/storybook/?path=/story/button-accent-fill--default)
    2. In a non-`:hover` supporting context
    3. See that pressing the button applies the `:active` state

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)