### PR TITLE
fix(slider): no change in background for variant filled and fill start

### DIFF
--- a/packages/slider/src/Slider.ts
+++ b/packages/slider/src/Slider.ts
@@ -101,7 +101,7 @@ export class Slider extends SizedMixin(ObserveSlotText(SliderHandle, ''), {
         if (variant === this.variant) {
             return;
         }
-        if (variants.includes(variant)) {
+        if (variants.includes(variant) && this.fillStart === undefined) {
             this.setAttribute('variant', variant);
             this._variant = variant;
         } else {

--- a/packages/slider/test/slider.test.ts
+++ b/packages/slider/test/slider.test.ts
@@ -852,6 +852,7 @@ describe('Slider', () => {
             html`
                 <sp-slider
                     max="20"
+                    variant="filled"
                     fill-start
                     min="0"
                     value="10"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a condition `this.fillStart === undefined` to the set `variant` method in order to address a specific issue. The condition ensures that the variant attribute is only set if the fillStart property is undefined, preventing unintended behavior when both variant and `fillStart` attributes are present simultaneously.

## Changes
Added a condition `this.fillStart === undefined `to the set variant method.
Updated the logic to set or remove the variant attribute based on the new condition.
<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #3973 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

```
<sp-slider
    max="20"
    variant="filled"
    fill-start
    min="0"
    value="10"
    step="1"
></sp-slider>
```

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
