### PR TITLE
chore(menu): support delivering submenus via directives

### DIFF
--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -406,10 +406,22 @@ export const groups = ({
 groups.decorators = [isOverlayOpen];
 
 export const directive = (): TemplateResult => {
+    const renderSubmenu = (): TemplateResult => html`
+        <sp-menu-item>Submenu Item 1</sp-menu-item>
+        <sp-menu-item>Submenu Item 2</sp-menu-item>
+        <sp-menu-item>Submenu Item 3</sp-menu-item>
+        <sp-menu-item>Submenu Item 4</sp-menu-item>
+    `;
     const renderOptions = (): TemplateResult => html`
         <sp-menu-item>Deselect</sp-menu-item>
         <sp-menu-item>Select Inverse</sp-menu-item>
-        <sp-menu-item>Feather...</sp-menu-item>
+        <sp-menu-item>
+            Feather...
+            <sp-menu
+                slot="submenu"
+                ${slottableRequest(renderSubmenu)}
+            ></sp-menu>
+        </sp-menu-item>
         <sp-menu-item>Select and Mask...</sp-menu-item>
         <sp-menu-divider></sp-menu-divider>
         <sp-menu-item>Save Selection</sp-menu-item>

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -30,89 +30,576 @@ import '@spectrum-web-components/action-menu/sp-action-menu.js';
 import '@spectrum-web-components/menu/sp-menu-group.js';
 import '@spectrum-web-components/overlay/sp-overlay.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
+import { TemplateResult } from 'lit-html';
+import { slottableRequest } from '@spectrum-web-components/overlay/src/slottable-request-directive.js';
+
+type SelectsWithKeyboardTest = {
+    dir: 'ltr' | 'rtl' | 'auto';
+    openKey: 'ArrowRight' | 'ArrowLeft';
+    closeKey: 'ArrowRight' | 'ArrowLeft';
+};
+
+const selectsWithKeyboardData = [
+    {
+        dir: 'ltr',
+        openKey: 'ArrowRight',
+        closeKey: 'ArrowLeft',
+    },
+    {
+        dir: 'rtl',
+        openKey: 'ArrowLeft',
+        closeKey: 'ArrowRight',
+    },
+] as SelectsWithKeyboardTest[];
 
 describe('Submenu', () => {
-    it('selects - pointer', async () => {
-        const rootChanged = spy();
-        const submenuChanged = spy();
-        const el = await fixture<Menu>(
-            html`
+    function selectWithPointer(): void {
+        it('with pointer', async function () {
+            const rootItemBoundingRect = this.rootItem.getBoundingClientRect();
+            expect(this.rootItem.open).to.be.false;
+
+            const opened = oneEvent(this.rootItem, 'sp-opened');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await opened;
+
+            expect(this.rootItem.open).to.be.true;
+
+            const item2 = document.querySelector('.submenu-item-2') as MenuItem;
+            const item2BoundingRect = item2.getBoundingClientRect();
+
+            const closed = oneEvent(this.rootItem, 'sp-closed');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'click',
+                        position: [
+                            item2BoundingRect.left +
+                                item2BoundingRect.width / 2,
+                            item2BoundingRect.top +
+                                item2BoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await closed;
+
+            expect(
+                this.submenuChanged.withArgs('Two').calledOnce,
+                `submenu changed ${this.submenuChanged.callCount} times`
+            ).to.be.true;
+            expect(
+                this.rootChanged.withArgs('Has submenu').calledOnce,
+                'root changed'
+            ).to.be.true;
+        });
+    }
+    function selectsWithKeyboard(testData: SelectsWithKeyboardTest): void {
+        it(`with keyboard: ${testData.dir}`, async function () {
+            this.el.parentElement.dir = testData.dir;
+
+            await elementUpdated(this.el);
+            expect(this.rootItem.open).to.be.false;
+            const input = document.createElement('input');
+            this.el.insertAdjacentElement('beforebegin', input);
+            input.focus();
+            await sendKeys({
+                press: 'Tab',
+            });
+            await sendKeys({
+                press: 'ArrowDown',
+            });
+            await elementUpdated(this.rootItem);
+
+            expect(this.rootItem.focused).to.be.true;
+
+            let opened = oneEvent(this.rootItem, 'sp-opened');
+            await sendKeys({
+                press: testData.openKey,
+            });
+            await opened;
+
+            let submenu = this.el.querySelector('[slot="submenu"]') as Menu;
+            let submenuItem = this.el.querySelector(
+                '.submenu-item-2'
+            ) as MenuItem;
+
+            expect(this.rootItem.open).to.be.true;
+            expect(
+                submenu === document.activeElement,
+                `${document.activeElement?.id}`
+            ).to.be.true;
+
+            let closed = oneEvent(this.rootItem, 'sp-closed');
+            await sendKeys({
+                press: testData.closeKey,
+            });
+            await closed;
+
+            expect(this.rootItem.open).to.be.false;
+            expect(
+                this.el === document.activeElement,
+                `${document.activeElement?.id}`
+            ).to.be.true;
+
+            opened = oneEvent(this.rootItem, 'sp-opened');
+            await sendKeys({
+                press: testData.openKey,
+            });
+            await opened;
+
+            submenu = this.el.querySelector('[slot="submenu"]') as Menu;
+            submenuItem = this.el.querySelector('.submenu-item-2') as MenuItem;
+
+            expect(this.rootItem.open).to.be.true;
+
+            await sendKeys({
+                press: 'ArrowDown',
+            });
+            await elementUpdated(submenu);
+            await elementUpdated(submenuItem);
+
+            expect(submenu.getAttribute('aria-activedescendant')).to.equal(
+                submenuItem.id
+            );
+
+            closed = oneEvent(this.rootItem, 'sp-closed');
+            await sendKeys({
+                press: 'Enter',
+            });
+            await closed;
+
+            expect(this.submenuChanged.calledWith('Two'), 'submenu changed').to
+                .be.true;
+            expect(this.rootChanged.called, 'root has changed').to.be.true;
+            expect(
+                this.rootChanged.calledWith('Has submenu'),
+                'root specifically changed'
+            ).to.be.true;
+        });
+    }
+    function returnsFocusToRootWhenClosingSubmenu(): void {
+        it('returns visible focus when submenu closed', async function () {
+            const input = document.createElement('input');
+            this.el.insertAdjacentElement('beforebegin', input);
+            input.focus();
+            await sendKeys({
+                press: 'Tab',
+            });
+            await sendKeys({
+                press: 'ArrowDown',
+            });
+            await elementUpdated(this.rootItem);
+            expect(this.rootItem.active).to.be.false;
+            expect(this.rootItem.focused).to.be.true;
+            expect(this.rootItem.open).to.be.false;
+
+            const opened = oneEvent(this.rootItem, 'sp-opened');
+            await sendKeys({
+                press: 'ArrowRight',
+            });
+            await opened;
+
+            expect(this.rootItem.active).to.be.true;
+            expect(this.rootItem.focused).to.be.false;
+            expect(this.rootItem.open).to.be.true;
+
+            await sendKeys({
+                press: 'ArrowDown',
+            });
+
+            expect(this.rootItem.active).to.be.true;
+            expect(this.rootItem.focused).to.be.false;
+            expect(this.rootItem.open).to.be.true;
+
+            const closed = oneEvent(this.rootItem, 'sp-closed');
+            await sendKeys({
+                press: 'ArrowLeft',
+            });
+            await closed;
+
+            expect(this.rootItem.active).to.be.false;
+            expect(this.rootItem.focused).to.be.true;
+            expect(this.rootItem.open).to.be.false;
+        });
+    }
+    function closesOnPointerLeave(): void {
+        it('closes on `pointerleave`', async function () {
+            const rootItemBoundingRect = this.rootItem.getBoundingClientRect();
+            expect(this.rootItem.open).to.be.false;
+
+            const opened = oneEvent(this.rootItem, 'sp-opened');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await opened;
+
+            expect(this.rootItem.open).to.be.true;
+
+            const closed = oneEvent(this.rootItem, 'sp-closed');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height * 2,
+                        ],
+                    },
+                ],
+            });
+            await closed;
+
+            expect(this.rootItem.open).to.be.false;
+        });
+    }
+    function persistsThroughMouseLeaveAndReturn(): void {
+        it('stays open when mousing off menu item and back again', async function () {
+            const rootItemBoundingRect = this.rootItem.getBoundingClientRect();
+            expect(this.rootItem.open).to.be.false;
+
+            const opened = oneEvent(this.rootItem, 'sp-opened');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height * 2,
+                        ],
+                    },
+                ],
+            });
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await opened;
+
+            expect(this.rootItem.open).to.be.true;
+
+            const closed = oneEvent(this.rootItem, 'sp-closed');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height * 2,
+                        ],
+                    },
+                ],
+            });
+            await closed;
+        });
+    }
+    function doesNotOpenWhenDisabled(): void {
+        it('does not open when disabled', async function () {
+            this.rootItem.disabled = true;
+            await elementUpdated(this.rootItem);
+
+            const rootItemBoundingRect = this.rootItem.getBoundingClientRect();
+            expect(this.rootItem.open).to.be.false;
+
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            // wait 200ms for open
+            await new Promise((r) => setTimeout(r, 200));
+
+            expect(this.rootItem.open).to.be.false;
+        });
+    }
+    function persistsWhenMovingBetweenItemAndSubmenu(): void {
+        it('stays open when mousing between menu item and submenu', async function () {
+            const rootItemBoundingRect = this.rootItem.getBoundingClientRect();
+            expect(this.rootItem.open).to.be.false;
+
+            const opened = oneEvent(this.rootItem, 'sp-opened');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await opened;
+            await nextFrame();
+            await nextFrame();
+
+            const subItem = this.el.querySelector(
+                '.submenu-item-2'
+            ) as MenuItem;
+            const clickSpy = spy();
+            subItem.addEventListener('click', () => clickSpy());
+            const subItemBoundingRect = subItem.getBoundingClientRect();
+            expect(this.rootItem.open).to.be.true;
+
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            subItemBoundingRect.left +
+                                subItemBoundingRect.width / 2,
+                            subItemBoundingRect.top +
+                                subItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            expect(this.rootItem.open).to.be.true;
+            // Ensure it _doesn't_ get closed.
+            await aTimeout(150);
+
+            expect(this.rootItem.open).to.be.true;
+
+            const closed = oneEvent(this.rootItem, 'sp-closed');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'click',
+                        position: [
+                            subItemBoundingRect.left +
+                                subItemBoundingRect.width / 2,
+                            subItemBoundingRect.top +
+                                subItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await closed;
+
+            expect(clickSpy.callCount).to.equal(1);
+        });
+    }
+    function continuesToOpenWhenMovingBetweenItemAndSubmenu(): void {
+        it('continues to open when mousing between menu item and submenu', async function () {
+            const rootItemBoundingRect = this.rootItem.getBoundingClientRect();
+            expect(this.rootItem.open).to.be.false;
+
+            const opened = oneEvent(this.rootItem, 'sp-opened');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            rootItemBoundingRect.left +
+                                rootItemBoundingRect.width / 2,
+                            rootItemBoundingRect.top +
+                                rootItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            // Wait for the overlay system to position the submenu before measuring it's position and moving to it.
+            await nextFrame();
+            await nextFrame();
+            await nextFrame();
+            await nextFrame();
+            await nextFrame();
+            await nextFrame();
+            await nextFrame();
+            await nextFrame();
+            const subItem = this.el.querySelector(
+                '.submenu-item-2'
+            ) as MenuItem;
+            const clickSpy = spy();
+            subItem.addEventListener('click', () => clickSpy());
+            const subItemBoundingRect = subItem.getBoundingClientRect();
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'move',
+                        position: [
+                            subItemBoundingRect.left +
+                                subItemBoundingRect.width / 2,
+                            subItemBoundingRect.top +
+                                subItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await opened;
+            expect(this.rootItem.open).to.be.true;
+            // Ensure it _doesn't_ get closed.
+            await aTimeout(150);
+
+            expect(this.rootItem.open).to.be.true;
+
+            const closed = oneEvent(this.rootItem, 'sp-closed');
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'click',
+                        position: [
+                            subItemBoundingRect.left +
+                                subItemBoundingRect.width / 2,
+                            subItemBoundingRect.top +
+                                subItemBoundingRect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await closed;
+
+            expect(clickSpy.callCount).to.equal(1);
+        });
+    }
+    const renderSubmenu = (): TemplateResult => html`
+        <sp-menu-item class="submenu-item-1">One</sp-menu-item>
+        <sp-menu-item class="submenu-item-2">Two</sp-menu-item>
+        <sp-menu-item class="submenu-item-3">Three</sp-menu-item>
+    `;
+    describe('static DOM', () => {
+        beforeEach(async function () {
+            this.rootChanged = spy();
+            this.submenuChanged = spy();
+            this.el = await fixture<Menu>(html`
                 <sp-menu
                     @change=${(event: Event & { target: Menu }) => {
-                        rootChanged(event.target.value);
+                        this.rootChanged(event.target.value);
                     }}
                 >
+                    <sp-menu-item>No submenu</sp-menu-item>
                     <sp-menu-item class="root">
                         Has submenu
                         <sp-menu
                             slot="submenu"
                             @change=${(event: Event & { target: Menu }) => {
-                                submenuChanged(event.target.value);
+                                this.submenuChanged(event.target.value);
                             }}
                         >
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-2">
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
+                            ${renderSubmenu()}
                         </sp-menu>
                     </sp-menu-item>
                 </sp-menu>
-            `
-        );
+            `);
+            await elementUpdated(this.el);
+            await nextFrame();
+            await nextFrame();
 
-        await elementUpdated(el);
-        await nextFrame();
-        await nextFrame();
-        const rootItem = el.querySelector('.root') as MenuItem;
-        const rootItemBoundingRect = rootItem.getBoundingClientRect();
-        expect(rootItem.open).to.be.false;
-
-        const opened = oneEvent(rootItem, 'sp-opened');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
+            this.rootItem = this.el.querySelector('.root') as MenuItem;
         });
-        await opened;
-
-        expect(rootItem.open).to.be.true;
-
-        const item2 = document.querySelector('.submenu-item-2') as MenuItem;
-        const item2BoundingRect = item2.getBoundingClientRect();
-
-        const closed = oneEvent(rootItem, 'sp-closed');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'click',
-                    position: [
-                        item2BoundingRect.left + item2BoundingRect.width / 2,
-                        item2BoundingRect.top + item2BoundingRect.height / 2,
-                    ],
-                },
-            ],
+        describe('selects', () => {
+            selectWithPointer();
+            selectsWithKeyboardData.map((testData) => {
+                selectsWithKeyboard(testData);
+            });
         });
-        await closed;
+        closesOnPointerLeave();
+        returnsFocusToRootWhenClosingSubmenu();
+        persistsThroughMouseLeaveAndReturn();
+        doesNotOpenWhenDisabled();
+        persistsWhenMovingBetweenItemAndSubmenu();
+        continuesToOpenWhenMovingBetweenItemAndSubmenu();
+    });
+    describe('directive', () => {
+        beforeEach(async function () {
+            this.rootChanged = spy();
+            this.submenuChanged = spy();
+            this.el = await fixture<Menu>(html`
+                <sp-menu
+                    @change=${(event: Event & { target: Menu }) => {
+                        this.rootChanged(event.target.value);
+                    }}
+                >
+                    <sp-menu-item>No submenu</sp-menu-item>
+                    <sp-menu-item class="root">
+                        Has submenu
+                        <sp-menu
+                            slot="submenu"
+                            @change=${(event: Event & { target: Menu }) => {
+                                this.submenuChanged(event.target.value);
+                            }}
+                            ${slottableRequest(renderSubmenu)}
+                        ></sp-menu>
+                    </sp-menu-item>
+                </sp-menu>
+            `);
+            await elementUpdated(this.el);
+            await nextFrame();
+            await nextFrame();
 
-        expect(
-            submenuChanged.withArgs('Two').calledOnce,
-            `submenu changed ${submenuChanged.callCount} times`
-        ).to.be.true;
-        expect(rootChanged.withArgs('Has submenu').calledOnce, 'root changed')
-            .to.be.true;
+            this.rootItem = this.el.querySelector('.root') as MenuItem;
+        });
+        describe('selects', () => {
+            selectWithPointer();
+            selectsWithKeyboardData.map((testData) => {
+                selectsWithKeyboard(testData);
+            });
+        });
+        closesOnPointerLeave();
+        returnsFocusToRootWhenClosingSubmenu();
+        persistsThroughMouseLeaveAndReturn();
+        doesNotOpenWhenDisabled();
+        persistsWhenMovingBetweenItemAndSubmenu();
+        continuesToOpenWhenMovingBetweenItemAndSubmenu();
     });
     it('closes deep tree on selection', async function () {
         const rootChanged = spy();
@@ -231,506 +718,9 @@ describe('Submenu', () => {
         expect(subSubmenuChanged.calledWith('C'), 'sub submenu changed').to.be
             .true;
     });
-    (
-        [
-            {
-                dir: 'ltr',
-                openKey: 'ArrowRight',
-                closeKey: 'ArrowLeft',
-            },
-            {
-                dir: 'rtl',
-                openKey: 'ArrowLeft',
-                closeKey: 'ArrowRight',
-            },
-        ] as {
-            dir: 'ltr' | 'rtl' | 'auto';
-            openKey: 'ArrowRight' | 'ArrowLeft';
-            closeKey: 'ArrowRight' | 'ArrowLeft';
-        }[]
-    ).map((testData) => {
-        it(`selects - keyboard: ${testData.dir}`, async function () {
-            const rootChanged = spy();
-            const submenuChanged = spy();
-            const el = await fixture<Menu>(
-                html`
-                    <sp-menu
-                        id="base"
-                        @change=${(event: Event & { target: Menu }) => {
-                            rootChanged(event.target.value);
-                        }}
-                    >
-                        <sp-menu-item class="root">
-                            Has submenu
-                            <sp-menu
-                                id="sub"
-                                slot="submenu"
-                                @change=${(event: Event & { target: Menu }) => {
-                                    submenuChanged(event.target.value);
-                                }}
-                            >
-                                <sp-menu-item class="submenu-item-1">
-                                    One
-                                </sp-menu-item>
-                                <sp-menu-item class="submenu-item-2">
-                                    Two
-                                </sp-menu-item>
-                                <sp-menu-item class="submenu-item-3">
-                                    Three
-                                </sp-menu-item>
-                            </sp-menu>
-                        </sp-menu-item>
-                    </sp-menu>
-                `,
-                testData.dir
-            );
-
-            await elementUpdated(el);
-            const rootItem = el.querySelector('.root') as MenuItem;
-            const submenu = el.querySelector('[slot="submenu"]') as Menu;
-            const submenuItem = el.querySelector('.submenu-item-2') as MenuItem;
-            expect(rootItem.open).to.be.false;
-            el.focus();
-            await elementUpdated(el);
-
-            let opened = oneEvent(rootItem, 'sp-opened');
-            await sendKeys({
-                press: testData.openKey,
-            });
-            await opened;
-
-            expect(rootItem.open).to.be.true;
-            expect(
-                submenu === document.activeElement,
-                `${document.activeElement?.id}`
-            ).to.be.true;
-
-            let closed = oneEvent(rootItem, 'sp-closed');
-            await sendKeys({
-                press: testData.closeKey,
-            });
-            await closed;
-
-            expect(rootItem.open).to.be.false;
-            expect(
-                el === document.activeElement,
-                `${document.activeElement?.id}`
-            ).to.be.true;
-
-            opened = oneEvent(rootItem, 'sp-opened');
-            await sendKeys({
-                press: testData.openKey,
-            });
-            await opened;
-
-            expect(rootItem.open).to.be.true;
-
-            await sendKeys({
-                press: 'ArrowDown',
-            });
-            await elementUpdated(submenu);
-            await elementUpdated(submenuItem);
-
-            expect(submenu.getAttribute('aria-activedescendant')).to.equal(
-                submenuItem.id
-            );
-
-            closed = oneEvent(rootItem, 'sp-closed');
-            await sendKeys({
-                press: 'Enter',
-            });
-            await closed;
-
-            expect(submenuChanged.calledWith('Two'), 'submenu changed').to.be
-                .true;
-            expect(rootChanged.called, 'root has changed').to.be.true;
-            expect(
-                rootChanged.calledWith('Has submenu'),
-                'root specifically changed'
-            ).to.be.true;
-        });
-    });
-    it('closes on `pointerleave`', async () => {
-        const el = await fixture<Menu>(
-            html`
-                <sp-menu>
-                    <sp-menu-item class="root">
-                        Has submenu
-                        <sp-menu slot="submenu">
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-2">
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu>
-            `
-        );
-
-        await elementUpdated(el);
-        const rootItem = el.querySelector('.root') as MenuItem;
-        const rootItemBoundingRect = rootItem.getBoundingClientRect();
-        expect(rootItem.open).to.be.false;
-
-        const opened = oneEvent(rootItem, 'sp-opened');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        await opened;
-
-        expect(rootItem.open).to.be.true;
-
-        const closed = oneEvent(rootItem, 'sp-closed');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height * 2,
-                    ],
-                },
-            ],
-        });
-        await closed;
-
-        expect(rootItem.open).to.be.false;
-    });
-    it('stays open when mousing off menu item and back again', async () => {
-        const el = await fixture<Menu>(
-            html`
-                <sp-menu>
-                    <sp-menu-item class="root">
-                        Has submenu
-                        <sp-menu slot="submenu">
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-2">
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu>
-            `
-        );
-
-        await elementUpdated(el);
-        const rootItem = el.querySelector('.root') as MenuItem;
-        const rootItemBoundingRect = rootItem.getBoundingClientRect();
-        expect(rootItem.open).to.be.false;
-
-        const opened = oneEvent(rootItem, 'sp-opened');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height * 2,
-                    ],
-                },
-            ],
-        });
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        await opened;
-
-        expect(rootItem.open).to.be.true;
-
-        const closed = oneEvent(rootItem, 'sp-closed');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height * 2,
-                    ],
-                },
-            ],
-        });
-        await closed;
-    });
-    it('continues to open when mousing between menu item and submenu', async function () {
-        const clickSpy = spy();
-        const el = await fixture<Menu>(
-            html`
-                <sp-menu>
-                    <sp-menu-item class="root">
-                        Has submenu
-                        <sp-menu slot="submenu">
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item
-                                class="submenu-item-2"
-                                @click=${() => clickSpy()}
-                            >
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu>
-            `
-        );
-
-        await elementUpdated(el);
-        const rootItem = el.querySelector('.root') as MenuItem;
-        const subItem = el.querySelector('.submenu-item-2') as MenuItem;
-        const rootItemBoundingRect = rootItem.getBoundingClientRect();
-        expect(rootItem.open).to.be.false;
-
-        const opened = oneEvent(rootItem, 'sp-opened');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        // Wait for the overlay system to position the submenu before measuring it's position and moving to it.
-        await nextFrame();
-        await nextFrame();
-        await nextFrame();
-        await nextFrame();
-        await nextFrame();
-        await nextFrame();
-        await nextFrame();
-        await nextFrame();
-        const subItemBoundingRect = subItem.getBoundingClientRect();
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        subItemBoundingRect.left +
-                            subItemBoundingRect.width / 2,
-                        subItemBoundingRect.top +
-                            subItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        await opened;
-        expect(rootItem.open).to.be.true;
-        // Ensure it _doesn't_ get closed.
-        await aTimeout(150);
-
-        expect(rootItem.open).to.be.true;
-
-        const closed = oneEvent(rootItem, 'sp-closed');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'click',
-                    position: [
-                        subItemBoundingRect.left +
-                            subItemBoundingRect.width / 2,
-                        subItemBoundingRect.top +
-                            subItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        await closed;
-
-        expect(clickSpy.callCount).to.equal(1);
-    });
-    it('stays open when mousing between menu item and submenu', async () => {
-        const clickSpy = spy();
-        const el = await fixture<Menu>(
-            html`
-                <sp-menu>
-                    <sp-menu-item class="root">
-                        Has submenu
-                        <sp-menu slot="submenu">
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item
-                                class="submenu-item-2"
-                                @click=${() => clickSpy()}
-                            >
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu>
-            `
-        );
-
-        await elementUpdated(el);
-        const rootItem = el.querySelector('.root') as MenuItem;
-        const subItem = el.querySelector('.submenu-item-2') as MenuItem;
-        const rootItemBoundingRect = rootItem.getBoundingClientRect();
-        expect(rootItem.open).to.be.false;
-
-        const opened = oneEvent(rootItem, 'sp-opened');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        await opened;
-        await nextFrame();
-        await nextFrame();
-        const subItemBoundingRect = subItem.getBoundingClientRect();
-        expect(rootItem.open).to.be.true;
-
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        subItemBoundingRect.left +
-                            subItemBoundingRect.width / 2,
-                        subItemBoundingRect.top +
-                            subItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        expect(rootItem.open).to.be.true;
-        // Ensure it _doesn't_ get closed.
-        await aTimeout(150);
-
-        expect(rootItem.open).to.be.true;
-
-        const closed = oneEvent(rootItem, 'sp-closed');
-        await sendMouse({
-            steps: [
-                {
-                    type: 'click',
-                    position: [
-                        subItemBoundingRect.left +
-                            subItemBoundingRect.width / 2,
-                        subItemBoundingRect.top +
-                            subItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        await closed;
-
-        expect(clickSpy.callCount).to.equal(1);
-    });
-    it('not opens if disabled', async () => {
-        const el = await fixture<Menu>(
-            html`
-                <sp-menu>
-                    <sp-menu-item disabled class="root">
-                        Has submenu
-                        <sp-menu slot="submenu">
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-2">
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu>
-            `
-        );
-
-        await elementUpdated(el);
-        const rootItem = el.querySelector('.root') as MenuItem;
-        const rootItemBoundingRect = rootItem.getBoundingClientRect();
-        expect(rootItem.open).to.be.false;
-
-        await sendMouse({
-            steps: [
-                {
-                    type: 'move',
-                    position: [
-                        rootItemBoundingRect.left +
-                            rootItemBoundingRect.width / 2,
-                        rootItemBoundingRect.top +
-                            rootItemBoundingRect.height / 2,
-                    ],
-                },
-            ],
-        });
-        // wait 200ms for open
-        await new Promise((r) => setTimeout(r, 200));
-
-        expect(rootItem.open).to.be.false;
-    });
     it('closes all decendent submenus when closing a ancestor menu', async () => {
         const el = await fixture<ActionMenu>(html`
-            <sp-action-menu>
+            <sp-action-menu label="Closing ancestors will close submenus">
                 <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
                 <sp-menu-group role="none" id="group">
                     <span slot="header">New York</span>
@@ -803,222 +793,166 @@ describe('Submenu', () => {
         await rootMenu1Closed;
         await rootMenu2Opened;
     });
-
-    it('closes back to the first overlay without a `root` when clicking away', async function () {
-        const el = await fixture<ActionMenu>(html`
-            <sp-action-menu>
-                <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
-                <sp-menu-group role="none">
-                    <span slot="header">New York</span>
-                    <sp-menu-item>Bronx</sp-menu-item>
-                    <sp-menu-item id="submenu-item-1">
-                        Brooklyn
-                        <sp-menu slot="submenu">
-                            <sp-menu-item id="submenu-item-2">
-                                Ft. Greene
-                                <sp-menu slot="submenu">
-                                    <sp-menu-item>S. Oxford St</sp-menu-item>
-                                    <sp-menu-item>S. Portland Ave</sp-menu-item>
-                                    <sp-menu-item>S. Elliot Pl</sp-menu-item>
-                                </sp-menu>
-                            </sp-menu-item>
-                            <sp-menu-item disabled>Park Slope</sp-menu-item>
-                            <sp-menu-item>Williamsburg</sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                    <sp-menu-item id="submenu-item-3">
-                        Manhattan
-                        <sp-menu slot="submenu">
-                            <sp-menu-item disabled>SoHo</sp-menu-item>
-                            <sp-menu-item>
-                                Union Square
-                                <sp-menu slot="submenu">
-                                    <sp-menu-item>14th St</sp-menu-item>
-                                    <sp-menu-item>Broadway</sp-menu-item>
-                                    <sp-menu-item>Park Ave</sp-menu-item>
-                                </sp-menu>
-                            </sp-menu-item>
-                            <sp-menu-item>Upper East Side</sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu-group>
-            </sp-action-menu>
-        `);
-
-        const rootMenu1 = el.querySelector('#submenu-item-1') as Menu;
-        const childMenu2 = el.querySelector('#submenu-item-2') as Menu;
-
-        expect(el.open).to.be.false;
-        let opened = oneEvent(el, 'sp-opened');
-        el.click();
-        await opened;
-        expect(el.open).to.be.true;
-
-        opened = oneEvent(rootMenu1, 'sp-opened');
-        rootMenu1.dispatchEvent(
-            new PointerEvent('pointerenter', { bubbles: true })
-        );
-        await opened;
-
-        opened = oneEvent(childMenu2, 'sp-opened');
-        childMenu2.dispatchEvent(
-            new PointerEvent('pointerenter', { bubbles: true })
-        );
-        await opened;
-        const closed = Promise.all([
-            oneEvent(childMenu2, 'sp-closed'),
-            oneEvent(rootMenu1, 'sp-closed'),
-            oneEvent(el, 'sp-closed'),
-        ]);
-        await sendMouse({
-            steps: [
-                {
-                    type: 'click',
-                    position: [600, 5],
-                },
-            ],
+    describe('deep tree', () => {
+        beforeEach(async function () {
+            this.el = await fixture<ActionMenu>(html`
+                <sp-action-menu label="Deep submenu tree">
+                    <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
+                    <sp-menu-group role="none">
+                        <span slot="header">New York</span>
+                        <sp-menu-item id="no-submenu">Bronx</sp-menu-item>
+                        <sp-menu-item id="submenu-item-1">
+                            Brooklyn
+                            <sp-menu slot="submenu">
+                                <sp-menu-item id="submenu-item-2">
+                                    Ft. Greene
+                                    <sp-menu slot="submenu">
+                                        <sp-menu-item>
+                                            S. Oxford St
+                                        </sp-menu-item>
+                                        <sp-menu-item>
+                                            S. Portland Ave
+                                        </sp-menu-item>
+                                        <sp-menu-item>
+                                            S. Elliot Pl
+                                        </sp-menu-item>
+                                    </sp-menu>
+                                </sp-menu-item>
+                                <sp-menu-item disabled>Park Slope</sp-menu-item>
+                                <sp-menu-item id="ancestor-item">
+                                    Williamsburg
+                                </sp-menu-item>
+                            </sp-menu>
+                        </sp-menu-item>
+                        <sp-menu-item id="submenu-item-3">
+                            Manhattan
+                            <sp-menu slot="submenu">
+                                <sp-menu-item disabled>SoHo</sp-menu-item>
+                                <sp-menu-item>
+                                    Union Square
+                                    <sp-menu slot="submenu">
+                                        <sp-menu-item>14th St</sp-menu-item>
+                                        <sp-menu-item>Broadway</sp-menu-item>
+                                        <sp-menu-item>Park Ave</sp-menu-item>
+                                    </sp-menu>
+                                </sp-menu-item>
+                                <sp-menu-item>Upper East Side</sp-menu-item>
+                            </sp-menu>
+                        </sp-menu-item>
+                    </sp-menu-group>
+                </sp-action-menu>
+            `);
+            await nextFrame();
+            await nextFrame();
         });
-        await closed;
-    });
+        it('closes back to the first overlay without a `root` when clicking away', async function () {
+            const rootMenu1 = this.el.querySelector('#submenu-item-1') as Menu;
+            const childMenu2 = this.el.querySelector('#submenu-item-2') as Menu;
 
-    it('closes decendent menus when Menu Item in ancestor without a submenu is pointerentered', async () => {
-        const el = await fixture<ActionMenu>(html`
-            <sp-action-menu>
-                <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
-                <sp-menu-group role="none">
-                    <span slot="header">New York</span>
-                    <sp-menu-item id="no-submenu">Bronx</sp-menu-item>
-                    <sp-menu-item id="submenu-item-1">
-                        Brooklyn
-                        <sp-menu slot="submenu">
-                            <sp-menu-item id="submenu-item-2">
-                                Ft. Greene
-                            </sp-menu-item>
-                            <sp-menu-item disabled>Park Slope</sp-menu-item>
-                            <sp-menu-item id="ancestor-item">
-                                Williamsburg
-                            </sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                    <sp-menu-item id="submenu-item-3">
-                        Manhattan
-                        <sp-menu slot="submenu">
-                            <sp-menu-item disabled>SoHo</sp-menu-item>
-                            <sp-menu-item>Union Square</sp-menu-item>
-                            <sp-menu-item>Upper East Side</sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu-group>
-            </sp-action-menu>
-        `);
+            expect(this.el.open).to.be.false;
+            let opened = oneEvent(this.el, 'sp-opened');
+            this.el.click();
+            await opened;
+            expect(this.el.open).to.be.true;
 
-        const rootMenu = el.querySelector('#submenu-item-1') as MenuItem;
-        const noSubmenu = el.querySelector('#no-submenu') as MenuItem;
+            opened = oneEvent(rootMenu1, 'sp-opened');
+            rootMenu1.dispatchEvent(
+                new PointerEvent('pointerenter', { bubbles: true })
+            );
+            await opened;
 
-        expect(el.open).to.be.false;
-        let opened = oneEvent(el, 'sp-opened');
-        el.click();
-        await opened;
-        expect(el.open).to.be.true;
-
-        opened = oneEvent(rootMenu, 'sp-opened');
-        rootMenu.dispatchEvent(
-            new PointerEvent('pointerenter', { bubbles: true })
-        );
-        await opened;
-
-        const closed = oneEvent(rootMenu, 'sp-closed');
-        noSubmenu.dispatchEvent(
-            new PointerEvent('pointerenter', { bubbles: true })
-        );
-        await closed;
-    });
-
-    it('closes decendent menus when Menu Item in ancestor is clicked', async function () {
-        const el = await fixture<ActionMenu>(html`
-            <sp-action-menu>
-                <sp-icon-show-menu slot="icon"></sp-icon-show-menu>
-                <sp-menu-group role="none">
-                    <span slot="header">New York</span>
-                    <sp-menu-item>Bronx</sp-menu-item>
-                    <sp-menu-item id="submenu-item-1">
-                        Brooklyn
-                        <sp-menu slot="submenu">
-                            <sp-menu-item id="submenu-item-2">
-                                Ft. Greene
-                                <sp-menu slot="submenu">
-                                    <sp-menu-item>S. Oxford St</sp-menu-item>
-                                    <sp-menu-item>S. Portland Ave</sp-menu-item>
-                                    <sp-menu-item>S. Elliot Pl</sp-menu-item>
-                                </sp-menu>
-                            </sp-menu-item>
-                            <sp-menu-item disabled>Park Slope</sp-menu-item>
-                            <sp-menu-item id="ancestor-item">
-                                Williamsburg
-                            </sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                    <sp-menu-item id="submenu-item-3">
-                        Manhattan
-                        <sp-menu slot="submenu">
-                            <sp-menu-item disabled>SoHo</sp-menu-item>
-                            <sp-menu-item>
-                                Union Square
-                                <sp-menu slot="submenu">
-                                    <sp-menu-item>14th St</sp-menu-item>
-                                    <sp-menu-item>Broadway</sp-menu-item>
-                                    <sp-menu-item>Park Ave</sp-menu-item>
-                                </sp-menu>
-                            </sp-menu-item>
-                            <sp-menu-item>Upper East Side</sp-menu-item>
-                        </sp-menu>
-                    </sp-menu-item>
-                </sp-menu-group>
-            </sp-action-menu>
-        `);
-        await nextFrame();
-        await nextFrame();
-
-        const rootMenu1 = el.querySelector('#submenu-item-1') as MenuItem;
-        const childMenu2 = el.querySelector('#submenu-item-2') as MenuItem;
-        const ancestorItem = el.querySelector('#ancestor-item') as MenuItem;
-
-        expect(el.open).to.be.false;
-        let opened = oneEvent(el, 'sp-opened');
-        el.click();
-        await opened;
-        expect(el.open).to.be.true;
-
-        opened = oneEvent(rootMenu1, 'sp-opened');
-        rootMenu1.dispatchEvent(
-            new PointerEvent('pointerenter', { bubbles: true })
-        );
-        await opened;
-
-        opened = oneEvent(childMenu2, 'sp-opened');
-        childMenu2.dispatchEvent(
-            new PointerEvent('pointerenter', { bubbles: true })
-        );
-        await opened;
-
-        const closed = Promise.all([
-            oneEvent(childMenu2, 'sp-closed'),
-            oneEvent(rootMenu1, 'sp-closed'),
-            oneEvent(el, 'sp-closed'),
-        ]);
-        const rect = ancestorItem.getBoundingClientRect();
-        await sendMouse({
-            steps: [
-                {
-                    type: 'click',
-                    position: [
-                        rect.left + rect.width / 2,
-                        rect.top + rect.height / 2,
-                    ],
-                },
-            ],
+            opened = oneEvent(childMenu2, 'sp-opened');
+            childMenu2.dispatchEvent(
+                new PointerEvent('pointerenter', { bubbles: true })
+            );
+            await opened;
+            const closed = Promise.all([
+                oneEvent(childMenu2, 'sp-closed'),
+                oneEvent(rootMenu1, 'sp-closed'),
+                oneEvent(this.el, 'sp-closed'),
+            ]);
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'click',
+                        position: [600, 5],
+                    },
+                ],
+            });
+            await closed;
         });
-        await closed;
+        it('closes decendent menus when Menu Item in ancestor without a submenu is pointerentered', async function () {
+            const rootMenu = this.el.querySelector(
+                '#submenu-item-1'
+            ) as MenuItem;
+            const noSubmenu = this.el.querySelector('#no-submenu') as MenuItem;
+
+            expect(this.el.open).to.be.false;
+            let opened = oneEvent(this.el, 'sp-opened');
+            this.el.click();
+            await opened;
+            expect(this.el.open).to.be.true;
+
+            opened = oneEvent(rootMenu, 'sp-opened');
+            rootMenu.dispatchEvent(
+                new PointerEvent('pointerenter', { bubbles: true })
+            );
+            await opened;
+
+            const closed = oneEvent(rootMenu, 'sp-closed');
+            noSubmenu.dispatchEvent(
+                new PointerEvent('pointerenter', { bubbles: true })
+            );
+            await closed;
+        });
+        it('closes decendent menus when Menu Item in ancestor is clicked', async function () {
+            const rootMenu1 = this.el.querySelector(
+                '#submenu-item-1'
+            ) as MenuItem;
+            const childMenu2 = this.el.querySelector(
+                '#submenu-item-2'
+            ) as MenuItem;
+            const ancestorItem = this.el.querySelector(
+                '#ancestor-item'
+            ) as MenuItem;
+
+            expect(this.el.open).to.be.false;
+            let opened = oneEvent(this.el, 'sp-opened');
+            this.el.click();
+            await opened;
+            expect(this.el.open).to.be.true;
+
+            opened = oneEvent(rootMenu1, 'sp-opened');
+            rootMenu1.dispatchEvent(
+                new PointerEvent('pointerenter', { bubbles: true })
+            );
+            await opened;
+
+            opened = oneEvent(childMenu2, 'sp-opened');
+            childMenu2.dispatchEvent(
+                new PointerEvent('pointerenter', { bubbles: true })
+            );
+            await opened;
+
+            const closed = Promise.all([
+                oneEvent(childMenu2, 'sp-closed'),
+                oneEvent(rootMenu1, 'sp-closed'),
+                oneEvent(this.el, 'sp-closed'),
+            ]);
+            const rect = ancestorItem.getBoundingClientRect();
+            await sendMouse({
+                steps: [
+                    {
+                        type: 'click',
+                        position: [
+                            rect.left + rect.width / 2,
+                            rect.top + rect.height / 2,
+                        ],
+                    },
+                ],
+            });
+            await closed;
+        });
     });
     it('cleans up submenus that close before they are "open"', async () => {
         if ('showPopover' in document.createElement('div')) {
@@ -1037,31 +971,11 @@ describe('Submenu', () => {
                 <sp-menu>
                     <sp-menu-item class="root-1">
                         Has submenu
-                        <sp-menu slot="submenu">
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-2">
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
-                        </sp-menu>
+                        <sp-menu slot="submenu">${renderSubmenu()}</sp-menu>
                     </sp-menu-item>
                     <sp-menu-item class="root-2">
                         Has submenu
-                        <sp-menu slot="submenu">
-                            <sp-menu-item class="submenu-item-1">
-                                One
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-2">
-                                Two
-                            </sp-menu-item>
-                            <sp-menu-item class="submenu-item-3">
-                                Three
-                            </sp-menu-item>
-                        </sp-menu>
+                        <sp-menu slot="submenu">${renderSubmenu()}</sp-menu>
                     </sp-menu-item>
                 </sp-menu>
             `

--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -201,6 +201,12 @@ export class Overlay extends OverlayFeatures {
     override placement?: Placement;
 
     /**
+     * The state in which the last `request-slottable` event was dispatched.
+     * Do not allow overlays from dispatching the same state twice in a row.
+     */
+    private lastRequestSlottableState = false;
+
+    /**
      * Whether to pass focus to the overlay once opened, or
      * to the appropriate value based on the "type" of the overlay
      * when set to `"auto"`.
@@ -534,6 +540,9 @@ export class Overlay extends OverlayFeatures {
     }
 
     protected override requestSlottable(): void {
+        if (this.lastRequestSlottableState === this.open) {
+            return;
+        }
         if (!this.open) {
             document.body.offsetHeight;
         }
@@ -546,6 +555,7 @@ export class Overlay extends OverlayFeatures {
                 this.open ? {} : removeSlottableRequest
             )
         );
+        this.lastRequestSlottableState = this.open;
     }
 
     override willUpdate(changes: PropertyValues): void {

--- a/packages/overlay/test/overlay-trigger-hover.test.ts
+++ b/packages/overlay/test/overlay-trigger-hover.test.ts
@@ -282,12 +282,17 @@ describe('Overlay Trigger - Hover', () => {
             `)()
         );
         await elementUpdated(el);
+        const input = document.createElement('input');
+        el.insertAdjacentElement('beforebegin', input);
 
         expect(el.open).to.be.undefined;
 
         const trigger = el.querySelector('[slot="trigger"]') as ActionButton;
         const opened = oneEvent(el, 'sp-opened');
-        trigger.focus();
+        input.focus();
+        await sendKeys({
+            press: 'Tab',
+        });
         await opened;
 
         expect(el.open).to.equal('hover');

--- a/packages/tooltip/test/tooltip-directive.test.ts
+++ b/packages/tooltip/test/tooltip-directive.test.ts
@@ -14,103 +14,111 @@ import '@spectrum-web-components/tooltip/sp-tooltip.js';
 import {
     elementUpdated,
     expect,
-    fixture,
     html,
     nextFrame,
     oneEvent,
 } from '@open-wc/testing';
-import { Button } from '@spectrum-web-components/button';
 import '@spectrum-web-components/button/sp-button.js';
 import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
 import type { Tooltip } from '@spectrum-web-components/tooltip';
+import { sendKeys } from '@web/test-runner-commands';
+import { render, TemplateResult } from '@spectrum-web-components/base';
 
 describe('Tooltip Directive', () => {
-    it('opens an Overlay that was previously not on the DOM', async function () {
-        const el = await fixture<Button>(html`
-            <sp-button
-                ${tooltip(
-                    () =>
-                        html`
-                            Tip me!
-                        `
-                )}
-            >
+    const renderTooltip = (): TemplateResult =>
+        html`
+            Tip me!
+        `;
+    function renderButton(
+        ...directiveParams: Parameters<typeof tooltip>
+    ): TemplateResult {
+        return html`
+            <sp-button ${tooltip(...directiveParams)}>
                 I'm a button...
             </sp-button>
-        `);
+        `;
+    }
+    function opensTooltip(): void {
+        it('opens tooltip not previously on DOM', async function () {
+            await elementUpdated(this.el);
 
-        await elementUpdated(el);
+            const input = document.createElement('input');
+            this.el.insertAdjacentElement('beforebegin', input);
 
-        let overlays = document.querySelectorAll('sp-overlay');
-        expect(overlays.length).to.equal(0);
+            this.overlays = document.querySelectorAll('sp-overlay');
+            expect(this.overlays.length).to.equal(0);
 
-        const opened = oneEvent(el, 'sp-opened');
-        el.focus();
-        await opened;
+            const opened = oneEvent(this.el, 'sp-opened');
+            input.focus();
+            await sendKeys({
+                press: 'Tab',
+            });
+            expect(document.activeElement === this.el).to.be.true;
+            expect(this.el.matches(':focus-visible')).to.be.true;
+            await opened;
 
-        overlays = document.querySelectorAll('sp-overlay');
-        expect(overlays.length).to.equal(1);
+            this.overlays = document.querySelectorAll('sp-overlay');
+            expect(this.overlays.length).to.equal(1);
+        });
+    }
+    function closesTooltip(): void {
+        it('closes a tooltip and removes it from the DOM', async function () {
+            // `slottable-request` comes _after_ `sp-closed` and triggers DOM cleanup
+            const closed = oneEvent(this.overlays[0], 'slottable-request');
+            this.el.blur();
+            await closed;
 
-        // `slottable-request` comes _after_ `sp-closed` and triggers DOM cleanup
-        const closed = oneEvent(overlays[0], 'slottable-request');
-        el.blur();
-        await closed;
+            // Wait for DOM clean up to complete
+            await nextFrame();
+            await nextFrame();
 
-        // Wait for DOM clean up to complete
-        await nextFrame();
-        await nextFrame();
-
-        overlays = document.querySelectorAll('sp-overlay');
-        expect(overlays.length).to.equal(0);
+            this.overlays = document.querySelectorAll('sp-overlay');
+            expect(this.overlays.length).to.equal(0);
+        });
+    }
+    describe('template only', () => {
+        before(async function () {
+            this.testEl = document.createElement('div');
+            document.body.append(this.testEl);
+            render(renderButton(renderTooltip), this.testEl);
+            this.el = this.testEl.querySelector('sp-button');
+            this.overlays = null;
+        });
+        after(function () {
+            this.testEl.remove();
+        });
+        opensTooltip();
+        closesTooltip();
     });
-
-    it('accepts `options`', async function () {
-        const variant = 'positive';
-        const offset = 10;
-        const el = await fixture<Button>(html`
-            <sp-button
-                ${tooltip(
-                    () =>
-                        html`
-                            Tip me!
-                        `,
-                    {
-                        variant,
-                        overlayOptions: {
-                            offset,
-                        },
-                    }
-                )}
-            >
-                I'm a button...
-            </sp-button>
-        `);
-
-        await elementUpdated(el);
-
-        let overlays = document.querySelectorAll('sp-overlay');
-        expect(overlays.length).to.equal(0);
-
-        const opened = oneEvent(el, 'sp-opened');
-        el.focus();
-        await opened;
-
-        overlays = document.querySelectorAll('sp-overlay');
-        expect(overlays.length).to.equal(1);
-        expect(overlays[0].offset).to.equal(offset);
-        const tooltipEl = overlays[0].querySelector('sp-tooltip') as Tooltip;
-        expect(tooltipEl.variant).to.equal(variant);
-
-        // `slottable-request` comes _after_ `sp-closed` and triggers DOM cleanup
-        const closed = oneEvent(overlays[0], 'slottable-request');
-        el.blur();
-        await closed;
-
-        // Wait for DOM clean up to complete
-        await nextFrame();
-        await nextFrame();
-
-        overlays = document.querySelectorAll('sp-overlay');
-        expect(overlays.length).to.equal(0);
+    describe('with `options`', () => {
+        before(async function () {
+            this.variant = 'positive';
+            this.offset = 10;
+            this.testEl = document.createElement('div');
+            document.body.append(this.testEl);
+            render(
+                renderButton(renderTooltip, {
+                    variant: this.variant,
+                    overlayOptions: {
+                        offset: this.offset,
+                    },
+                }),
+                this.testEl
+            );
+            this.el = this.testEl.querySelector('sp-button');
+            this.overlays = null;
+        });
+        after(function () {
+            this.testEl.remove();
+        });
+        opensTooltip();
+        it('passes `options` to the overlay', async function () {
+            expect(this.overlays[0].offset).to.equal(this.offset);
+            const tooltipEl = this.overlays[0].querySelector(
+                'sp-tooltip'
+            ) as Tooltip;
+            expect(tooltipEl.variant).to.equal(this.variant);
+        });
+        closesTooltip();
     });
 });


### PR DESCRIPTION
## Description
Expand use of `slottable-request` based laziness to support submenus.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://submenu-directive--spectrum-web-components.netlify.app/storybook/?path=/story/action-menu--directive)
    2. See that the submenu can be activated with the mouse or the keyboard
    3. When using the keyboard confirm that the "visible focus" returns to the submenu host, not the first menu item in the parent menu

## Types of changes
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)