### PR TITLE
fix(shared): ensure the "updateComplete" in Focusable is stable

### DIFF
--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -770,6 +770,8 @@ describe('ActionGroup', () => {
 
         await elementUpdated(el);
 
+        await Promise.all(el.buttons.map((button) => elementUpdated(button)));
+
         const firstButton = el.querySelector('.first') as ActionButton;
         const secondButton = el.querySelector('.second') as ActionButton;
         const thirdButton = el.querySelector('.third') as ActionButton;
@@ -818,6 +820,8 @@ describe('ActionGroup', () => {
         );
 
         await elementUpdated(el);
+
+        await Promise.all(el.buttons.map((button) => elementUpdated(button)));
 
         const firstButton = el.querySelector('.first') as ActionButton;
         const secondButton = el.querySelector('.second') as ActionButton;

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -97,6 +97,41 @@ describe('Button', () => {
         expect(el).to.not.be.undefined;
         await expect(el).to.be.accessible();
     });
+    it('has a stable/predictable `updateComplete`', async () => {
+        const test = await fixture<HTMLDivElement>(
+            html`
+                <div></div>
+            `
+        );
+
+        let keydownTime = -1;
+        let updateComplete1 = -1;
+        let updateComplete2 = -1;
+
+        const el = document.createElement('sp-button');
+        el.autofocus = true;
+        el.addEventListener('keydown', () => {
+            keydownTime = performance.now();
+        });
+        el.updateComplete.then(() => {
+            updateComplete1 = performance.now();
+        });
+        el.updateComplete.then(() => {
+            updateComplete2 = performance.now();
+        });
+        test.append(el);
+        // don't use elementUpdated(), as it is under test...
+        await nextFrame();
+        await nextFrame();
+        await nextFrame();
+        await nextFrame();
+
+        expect(keydownTime, 'keydown happened').to.not.eq(-1);
+        expect(updateComplete1, 'first update complete happened').to.not.eq(-1);
+        expect(updateComplete2, 'first update complete happened').to.not.eq(-1);
+        expect(updateComplete1).lte(updateComplete2);
+        expect(updateComplete2).lte(keydownTime);
+    });
     it('manages "role"', async () => {
         const el = await fixture<Button>(
             html`

--- a/packages/top-nav/test/top-nav.test.ts
+++ b/packages/top-nav/test/top-nav.test.ts
@@ -47,10 +47,13 @@ describe('TopNav', () => {
 
         await expect(el).to.be.accessible();
     });
-    it('updates indicator size when Nav Item conten changes', async () => {
+    it('updates indicator size when Nav Item content changes', async () => {
         const el = await fixture<TopNav>(Selected());
 
         await elementUpdated(el);
+
+        const items = [...el.querySelectorAll('sp-top-nav-item')];
+        await Promise.all(items.map((item) => elementUpdated(item)));
 
         const indicator = el.shadowRoot.querySelector(
             '#selection-indicator'
@@ -64,10 +67,14 @@ describe('TopNav', () => {
 
         // Wait for slotchange time before continuing the test.
         await nextFrame();
+        await nextFrame();
 
         const { width: widthEnd } = indicator.getBoundingClientRect();
 
-        expect(widthStart).to.be.greaterThan(widthEnd);
+        expect(
+            widthStart,
+            `${widthStart} is not greater than ${widthEnd}`
+        ).to.be.greaterThan(widthEnd);
     });
     it('can have an item removed', async () => {
         const el = await fixture<TopNav>(Selected());

--- a/test/benchmark/bench-runner.html
+++ b/test/benchmark/bench-runner.html
@@ -18,6 +18,7 @@
             const bench = params.get('bench');
             const dir = params.get('dir');
             window.tachometerStart = params.get('start');
+            window.tachometerEnd = params.get('end');
             import(`../../${dir}/${pack}/test/benchmark/${bench}.js`);
         </script>
     </body>

--- a/test/benchmark/cli.ts
+++ b/test/benchmark/cli.ts
@@ -96,6 +96,15 @@ const optionDefinitions: commandLineUsage.OptionDefinition[] = [
         defaultValue: 'element',
     },
     {
+        name: 'end',
+        description:
+            'Test until "updateComplete" for all elements in the text (only includes the work included required to update) or "paint" (wait for the paint after the update has completed).' +
+            '\n(default updateComplete)',
+        alias: 'e',
+        type: String,
+        defaultValue: 'updateComplete',
+    },
+    {
         name: 'json',
         description: 'Save output to json.',
         alias: 'j',
@@ -114,6 +123,7 @@ interface Options {
     browser: 'chrome' | 'firefox';
     compare: string;
     start: string;
+    end: string;
     json: boolean;
 }
 
@@ -162,6 +172,7 @@ $ node test/benchmark/cli -n 20
             .map((dirEntry) => dirEntry.name);
     }
     const start = opts.start;
+    const end = opts.end;
 
     const printResults: string[] = [];
     for (const packageName of packages) {
@@ -238,7 +249,7 @@ $ node test/benchmark/cli -n 20
             if (opts.compare !== 'none') {
                 config.benchmarks.push({
                     name: `${packageName}:${benchmark}`,
-                    url: `bench-runner.html?bench=${benchmark}&package=${packageName}&start=${start}&dir=${monorepoDir}`,
+                    url: `bench-runner.html?bench=${benchmark}&package=${packageName}&start=${start}&end=${end}&dir=${monorepoDir}`,
                     packageVersions: {
                         label: 'remote',
                         dependencies: {
@@ -260,7 +271,7 @@ $ node test/benchmark/cli -n 20
             }
             config.benchmarks.push({
                 name: `${packageName}:${benchmark}`,
-                url: `bench-runner.html?bench=${benchmark}&package=${packageName}&start=${start}&dir=${monorepoDir}`,
+                url: `bench-runner.html?bench=${benchmark}&package=${packageName}&start=${start}&end=${end}&dir=${monorepoDir}`,
                 measurement: 'global',
                 browser: {
                     name: opts.browser,

--- a/test/benchmark/helpers.ts
+++ b/test/benchmark/helpers.ts
@@ -26,6 +26,10 @@ declare global {
 
 /**
  * Runs `callback` shortly after the next browser Frame is produced.
+ *
+ * Adopted from https://webperf.tips/tip/measuring-paint-time/ but possibly replaceable by
+ * a performance observer with additional work:
+ * https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/PerformanceObserver
  */
 function runAfterFramePaint(callback: () => void) {
     // Queue a "before Render Steps" callback via requestAnimationFrame.

--- a/tools/shared/src/focusable.ts
+++ b/tools/shared/src/focusable.ts
@@ -270,29 +270,31 @@ export class Focusable extends FocusVisiblePolyfillMixin(SpectrumElement) {
 
     protected override async getUpdateComplete(): Promise<boolean> {
         const complete = (await super.getUpdateComplete()) as boolean;
-        if (this._recentlyConnected) {
-            this._recentlyConnected = false;
-            // If at connect time the [autofocus] content is placed within
-            // content that needs to be "hidden" by default, it would need to wait
-            // two rAFs for animations to be triggered on that content in
-            // order for the [autofocus] to become "visisble" and have its
-            // focus() capabilities enabled.
-            //
-            // Await this with `getUpdateComplete` so that the element cannot
-            // become "ready" until `manageFocus` has occured.
-            await nextFrame();
-            await nextFrame();
-        }
+        await this.autofocusReady;
         return complete;
     }
 
-    private _recentlyConnected = false;
+    private autofocusReady = Promise.resolve();
 
     public override connectedCallback(): void {
         super.connectedCallback();
-        this._recentlyConnected = true;
-        this.updateComplete.then(() => {
-            this.manageAutoFocus();
-        });
+        if (this.autofocus) {
+            this.autofocusReady = new Promise(async (res) => {
+                // If at connect time the [autofocus] content is placed within
+                // content that needs to be "hidden" by default, it would need to wait
+                // two rAFs for animations to be triggered on that content in
+                // order for the [autofocus] to become "visisble" and have its
+                // focus() capabilities enabled.
+                //
+                // Await this with `getUpdateComplete` so that the element cannot
+                // become "ready" until `manageFocus` has occured.
+                await nextFrame();
+                await nextFrame();
+                res();
+            });
+            this.updateComplete.then(() => {
+                this.manageAutoFocus();
+            });
+        }
     }
 }


### PR DESCRIPTION
## Description
- Leveraging non-static promises can cause faulty timing in `updateComplete` callbacks.
- Only delaying `updateComplete` when `autofocus` is true accelerated the render of the majority of focusable elements
- add the `end` or `-e` flag to the benchmark suite that accepts `updateComplete` (the default) or `paint` which waits till the browser paints before ending the performance measurement

## Motivation and context
The `paint` timing of `focusable` element can be pushed back for the active `requestAnimationFrame`, we shouldn't charge every element that fee at render time.

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://perf-refactor--spectrum-web-components.netlify.app/storybook/?path=/story/button-accent-fill--default)
    2. See that the element renders as expected
-   [ ] _Test case 2_
    1. Review the timing of the tests

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
