### PR TITLE
chore(picker): update event bind timing

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -63,7 +63,9 @@ export class ActionMenu extends ObserveSlotPresence(
         return this.slotContentIsPresent;
     }
 
-    private handleSlottableRequest = (event: SlottableRequestEvent): void => {
+    protected override handleSlottableRequest = (
+        event: SlottableRequestEvent
+    ): void => {
         this.dispatchEvent(new SlottableRequestEvent(event.name, event.data));
     };
 
@@ -130,15 +132,5 @@ export class ActionMenu extends ObserveSlotPresence(
             this.invalid = false;
         }
         super.update(changedProperties);
-    }
-
-    protected override updated(changes: PropertyValues<this>): void {
-        super.updated(changes);
-        if (this.hasRenderedOverlay) {
-            this.overlayElement.addEventListener(
-                'slottable-request',
-                this.handleSlottableRequest
-            );
-        }
     }
 }

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -22,13 +22,12 @@ import { slottableRequest } from '@spectrum-web-components/overlay/src/slottable
 import { ActionMenuMarkup } from './';
 import { makeOverBackground } from '../../button/stories/index.js';
 import { isOverlayOpen } from '../../overlay/stories/index.js';
-import '../../overlay/stories/index.js';
 
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import type { MenuItem } from '@spectrum-web-components/menu/src/MenuItem.js';
 import { Placement } from '@spectrum-web-components/overlay/src/overlay-types.js';
 import { Menu } from '@spectrum-web-components/menu';
-import { ActionMenu } from '../src/ActionMenu';
+import type { ActionMenu } from '@spectrum-web-components/action-menu';
 
 export default {
     component: 'sp-action-menu',

--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -52,6 +52,7 @@ import {
 } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
 import { DependencyManagerController } from '@spectrum-web-components/reactive-controllers/src/DependencyManger.js';
 import { Overlay } from '@spectrum-web-components/overlay/src/Overlay.js';
+import type { SlottableRequestEvent } from '@spectrum-web-components/overlay/src/slottable-request-event.js';
 import type { FieldLabel } from '@spectrum-web-components/field-label';
 
 const chevronClass = {
@@ -401,6 +402,10 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
         }
     }
 
+    protected handleSlottableRequest = (
+        _event: SlottableRequestEvent
+    ): void => {};
+
     protected renderLabelContent(content: Node[]): TemplateResult | Node[] {
         if (this.value && this.selectedItem) {
             return content;
@@ -503,6 +508,8 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
         import('@spectrum-web-components/overlay/sp-overlay.js');
         return html`
             <sp-overlay
+                @slottable-request=${this.handleSlottableRequest}
+                @beforetoggle=${this.handleBeforetoggle}
                 .triggerElement=${this as HTMLElement}
                 .offset=${0}
                 ?open=${this.open && this.dependencyManager.loaded}
@@ -512,7 +519,6 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                 .willPreventClose=${this.preventNextToggle !== 'no' &&
                 this.open &&
                 this.dependencyManager.loaded}
-                @beforetoggle=${this.handleBeforetoggle}
             >
                 ${container}
             </sp-overlay>


### PR DESCRIPTION
## Description
Bind `slottable-request` events before properties that could trigger them.

## How has this been tested?
-   [ ] _Test case 1_
    1. I've not been able to recreate this in library, but toggling `open` to `true` will trigger a `slottable-request`, and if the event binding for that hasn't already been made ancestor elements that should dispatch the same will not be informed.

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.