### PR TITLE
fix(combobox): correct package.json listings

### DIFF
--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -4,7 +4,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "description": "",
+    "description": "Web component implementation of a Spectrum design Combobox",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
@@ -43,11 +43,12 @@
         "test": "echo \"Error: run tests from mono-repo root.\" && exit 1"
     },
     "files": [
-        "*.d.ts",
-        "*.js",
-        "*.js.map",
-        "/src/",
-        "custom-elements.json"
+        "**/*.d.ts",
+        "**/*.js",
+        "**/*.js.map",
+        "custom-elements.json",
+        "!stories/",
+        "!test/"
     ],
     "keywords": [
         "spectrum css",
@@ -73,6 +74,6 @@
     "customElements": "custom-elements.json",
     "sideEffects": [
         "./sp-*.js",
-        "./sp-*.ts"
+        "./**/*.dev.js"
     ]
 }


### PR DESCRIPTION
## Description
Normalize `package.json` in Combobox to ensure the correct files are published to NPM and that the correct files are listed as "sideeffectful" in bundles.

## Related issue(s)
- fixes #4243

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://github.com/adobe/spectrum-web-components/blob/main/packages/color-field/package.json)
    2. See the `package.json` of one of our most recently generated packages
    3. Compare that to the file changed in the PR
    4. See if there is anything missing

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.