### PR TITLE
docs: refactor navigation and settings UI to leverage trigger directive

### DIFF
--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -77,6 +77,10 @@
             "development": "./src/VirtualTrigger.dev.js",
             "default": "./src/VirtualTrigger.js"
         },
+        "./src/events.js": {
+            "development": "./src/events.dev.js",
+            "default": "./src/events.js"
+        },
         "./src/fullSizePlugin.js": {
             "development": "./src/fullSizePlugin.dev.js",
             "default": "./src/fullSizePlugin.js"

--- a/packages/overlay/src/AbstractOverlay.ts
+++ b/packages/overlay/src/AbstractOverlay.ts
@@ -19,7 +19,6 @@ import type {
     OverlayState,
     OverlayTypes,
     Placement,
-    TriggerInteractions,
     TriggerInteractionsV1,
 } from './overlay-types.js';
 import type { Overlay } from './Overlay.js';
@@ -33,65 +32,6 @@ export const overlayTimer = new OverlayTimer();
 export const noop = (): void => {
     return;
 };
-
-export class BeforetoggleClosedEvent extends Event {
-    currentState = 'open';
-    newState = 'closed';
-    constructor() {
-        super('beforetoggle', {
-            bubbles: false,
-            composed: false,
-        });
-    }
-}
-
-export class BeforetoggleOpenEvent extends Event {
-    currentState = 'closed';
-    newState = 'open';
-    constructor() {
-        super('beforetoggle', {
-            bubbles: false,
-            composed: false,
-        });
-    }
-}
-
-export class OverlayStateEvent extends Event {
-    detail!: {
-        interaction: string;
-        reason?: 'external-click';
-    };
-
-    constructor(
-        type: string,
-        public overlay: HTMLElement,
-        {
-            publish,
-            interaction,
-            reason,
-        }: {
-            publish?: boolean;
-            interaction: TriggerInteractions;
-            reason?: 'external-click';
-        }
-    ) {
-        super(type, {
-            bubbles: publish,
-            composed: publish,
-        });
-        this.detail = {
-            interaction,
-            reason,
-        };
-    }
-}
-
-declare global {
-    interface GlobalEventHandlersEventMap {
-        'sp-open': OverlayStateEvent;
-        'sp-close': OverlayStateEvent;
-    }
-}
 
 /**
  * Apply a "transitionend" listener to an element that may not transition but

--- a/packages/overlay/src/OverlayDialog.ts
+++ b/packages/overlay/src/OverlayDialog.ts
@@ -16,13 +16,12 @@ import {
 } from '@spectrum-web-components/shared/src/first-focusable-in.js';
 import { VirtualTrigger } from './VirtualTrigger.js';
 import { Constructor, OpenableElement } from './overlay-types.js';
+import { guaranteedAllTransitionend, nextFrame } from './AbstractOverlay.js';
 import {
     BeforetoggleClosedEvent,
     BeforetoggleOpenEvent,
-    guaranteedAllTransitionend,
-    nextFrame,
     OverlayStateEvent,
-} from './AbstractOverlay.js';
+} from './events.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
 import { userFocusableSelector } from '@spectrum-web-components/shared';
 

--- a/packages/overlay/src/OverlayNoPopover.ts
+++ b/packages/overlay/src/OverlayNoPopover.ts
@@ -17,13 +17,15 @@ import type { SpectrumElement } from '@spectrum-web-components/base';
 import { VirtualTrigger } from './VirtualTrigger.js';
 import { Constructor, OpenableElement } from './overlay-types.js';
 import {
-    BeforetoggleClosedEvent,
-    BeforetoggleOpenEvent,
     guaranteedAllTransitionend,
     nextFrame,
-    OverlayStateEvent,
     overlayTimer,
 } from './AbstractOverlay.js';
+import {
+    BeforetoggleClosedEvent,
+    BeforetoggleOpenEvent,
+    OverlayStateEvent,
+} from './events.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
 import { userFocusableSelector } from '@spectrum-web-components/shared';
 

--- a/packages/overlay/src/OverlayPopover.ts
+++ b/packages/overlay/src/OverlayPopover.ts
@@ -17,13 +17,15 @@ import type { SpectrumElement } from '@spectrum-web-components/base';
 import { VirtualTrigger } from './VirtualTrigger.js';
 import { Constructor, OpenableElement } from './overlay-types.js';
 import {
-    BeforetoggleClosedEvent,
-    BeforetoggleOpenEvent,
     guaranteedAllTransitionend,
     nextFrame,
-    OverlayStateEvent,
     overlayTimer,
 } from './AbstractOverlay.js';
+import {
+    BeforetoggleClosedEvent,
+    BeforetoggleOpenEvent,
+    OverlayStateEvent,
+} from './events.js';
 import type { AbstractOverlay } from './AbstractOverlay.js';
 import { userFocusableSelector } from '@spectrum-web-components/shared';
 

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -24,7 +24,7 @@ import {
 } from '@spectrum-web-components/base/src/decorators.js';
 import type { Placement } from '@floating-ui/dom';
 
-import type { BeforetoggleOpenEvent } from './AbstractOverlay.js';
+import type { BeforetoggleOpenEvent } from './events.js';
 import type { Overlay } from './Overlay.js';
 import type { OverlayTriggerInteractions } from './overlay-types';
 

--- a/packages/overlay/src/events.ts
+++ b/packages/overlay/src/events.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import type { TriggerInteractions } from './overlay-types.js';
+
+export class BeforetoggleClosedEvent extends Event {
+    currentState = 'open';
+    newState = 'closed';
+    constructor() {
+        super('beforetoggle', {
+            bubbles: false,
+            composed: false,
+        });
+    }
+}
+
+export class BeforetoggleOpenEvent extends Event {
+    currentState = 'closed';
+    newState = 'open';
+    constructor() {
+        super('beforetoggle', {
+            bubbles: false,
+            composed: false,
+        });
+    }
+}
+
+export class OverlayStateEvent extends Event {
+    detail!: {
+        interaction: string;
+        reason?: 'external-click';
+    };
+
+    constructor(
+        type: string,
+        public overlay: HTMLElement,
+        {
+            publish,
+            interaction,
+            reason,
+        }: {
+            publish?: boolean;
+            interaction: TriggerInteractions;
+            reason?: 'external-click';
+        }
+    ) {
+        super(type, {
+            bubbles: publish,
+            composed: publish,
+        });
+        this.detail = {
+            interaction,
+            reason,
+        };
+    }
+}

--- a/packages/overlay/src/overlay-trigger-directive.ts
+++ b/packages/overlay/src/overlay-trigger-directive.ts
@@ -47,7 +47,6 @@ export class OverlayTriggerDirective extends SlottableRequestDirective {
     protected defaultOptions: OverlayTriggerOptions = {
         triggerInteraction: 'click',
         overlayOptions: {
-            placement: 'top-start',
             type: 'auto',
             offset: 0,
         },

--- a/packages/overlay/src/overlay-trigger-directive.ts
+++ b/packages/overlay/src/overlay-trigger-directive.ts
@@ -17,13 +17,13 @@ import {
 } from '@spectrum-web-components/base';
 import { directive } from 'lit/async-directive.js';
 import { strategies } from './strategies.js';
-import { OverlayOptions, TriggerInteraction } from './overlay-types.js';
-import { ClickController } from './ClickController.js';
-import { HoverController } from './HoverController.js';
-import { LongpressController } from './LongpressController.js';
+import type { OverlayOptions, TriggerInteraction } from './overlay-types.js';
+import type { ClickController } from './ClickController.js';
+import type { HoverController } from './HoverController.js';
+import type { LongpressController } from './LongpressController.js';
 import {
     removeSlottableRequest,
-    SlottableRequestEvent,
+    type SlottableRequestEvent,
 } from './slottable-request-event.js';
 import { SlottableRequestDirective } from './slottable-request-directive.js';
 import { AbstractOverlay } from './AbstractOverlay.js';

--- a/projects/documentation/src/components/layout.css
+++ b/projects/documentation/src/components/layout.css
@@ -262,6 +262,7 @@ aside .manage-theme {
     flex-direction: column;
     display: flex;
     padding: 0px 24px 24px;
+    order: 1;
 }
 
 .scrim {
@@ -281,12 +282,12 @@ aside .theme-control {
     margin: 0 0 calc(var(--swc-scale-factor) * 24px);
 }
 
-aside.show {
+sp-underlay[open] + aside {
     transition-delay: 0ms, 0ms;
     visibility: visible;
 }
 
-aside:not(.show) {
+sp-underlay:not([open]) + aside {
     transform: translateX(100%);
     visibility: hidden;
 }

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -301,7 +301,9 @@ export class LayoutElement extends LitElement {
         `;
         import('./side-nav.js');
         return html`
-            <docs-side-nav id="side-nav">${navContent}</docs-side-nav>
+            <docs-side-nav id="side-nav" .isNarrow=${this.isNarrow}>
+                ${navContent}
+            </docs-side-nav>
         `;
     }
 
@@ -435,7 +437,6 @@ export class LayoutElement extends LitElement {
                 ${this.isNarrow ? this.header : html``}
                 <div id="body">
                     ${this.isNarrow ? html`` : this.sideNav}
-                    ${this.isNarrow ? html`` : this.settingsContent}
                     <div
                         id="page"
                         @alert=${this.addAlert}

--- a/projects/documentation/src/components/layout.ts
+++ b/projects/documentation/src/components/layout.ts
@@ -35,11 +35,10 @@ import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/action-button/sp-action-button.js';
 import '@spectrum-web-components/link/sp-link.js';
 import '@spectrum-web-components/divider/sp-divider.js';
-import '@spectrum-web-components/toast/sp-toast.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import {
-    OverlayTriggerOptions,
+    type OverlayTriggerOptions,
     trigger,
 } from '@spectrum-web-components/overlay/src/overlay-trigger-directive.js';
 
@@ -264,16 +263,19 @@ export class LayoutElement extends LitElement {
                  * every additional alert.
                  */
 
-                element: (count: number, message: string) => html`
-                    <sp-toast
-                        .timeout=${count}
-                        variant="info"
-                        @close=${close}
-                        open
-                    >
-                        ${message} ${count > 1 ? `(${count} alerts)` : ''}
-                    </sp-toast>
-                `,
+                element: (count: number, message: string) => {
+                    import('@spectrum-web-components/toast/sp-toast.js');
+                    return html`
+                        <sp-toast
+                            .timeout=${count}
+                            variant="info"
+                            @close=${close}
+                            open
+                        >
+                            ${message} ${count > 1 ? `(${count} alerts)` : ''}
+                        </sp-toast>
+                    `;
+                },
             });
         }
         const alert = this.alerts.get(target);
@@ -308,7 +310,7 @@ export class LayoutElement extends LitElement {
     }
 
     private get settingsContent(): TemplateResult {
-        import('./settings.js');
+        import('@spectrum-web-components/underlay/sp-underlay.js');
         return html`
             <sp-underlay
                 class="scrim"
@@ -331,6 +333,7 @@ export class LayoutElement extends LitElement {
     }
 
     private get manageTheme(): TemplateResult {
+        import('./settings.js');
         return html`
             <div class="manage-theme" role="form" aria-label="Settings">
                 <div class="theme-control">

--- a/projects/documentation/src/components/settings.ts
+++ b/projects/documentation/src/components/settings.ts
@@ -14,4 +14,3 @@ import '@spectrum-web-components/field-label/sp-field-label.js';
 import '@spectrum-web-components/picker/sp-picker.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
-import '@spectrum-web-components/underlay/sp-underlay.js';

--- a/projects/documentation/src/components/side-nav.ts
+++ b/projects/documentation/src/components/side-nav.ts
@@ -40,6 +40,9 @@ export class SideNav extends LitElement {
         this.open = !this.open;
     }
 
+    @property({ type: Boolean })
+    public isNarrow = false;
+
     public override focus() {
         const target = document.querySelector(
             '[slot="logo"]'
@@ -59,14 +62,18 @@ export class SideNav extends LitElement {
 
     override render(): TemplateResult {
         return html`
-            <sp-underlay
-                class="scrim"
-                @close=${this.toggle}
-                ?open=${this.open}
-                @transitionrun=${this.handleTransitionEvent}
-                @transitionend=${this.handleTransitionEvent}
-                @transitioncancel=${this.handleTransitionEvent}
-            ></sp-underlay>
+            ${this.isNarrow
+                ? html`
+                      <sp-underlay
+                          class="scrim"
+                          @close=${this.toggle}
+                          ?open=${this.open}
+                          @transitionrun=${this.handleTransitionEvent}
+                          @transitionend=${this.handleTransitionEvent}
+                          @transitioncancel=${this.handleTransitionEvent}
+                      ></sp-underlay>
+                  `
+                : html``}
             <aside
                 @transitionrun=${this.handleTransitionEvent}
                 @transitionend=${this.handleTransitionEvent}

--- a/projects/documentation/src/components/side-nav.ts
+++ b/projects/documentation/src/components/side-nav.ts
@@ -53,14 +53,25 @@ export class SideNav extends LitElement {
         target.focus();
     }
 
+    handleTransitionEvent(event: TransitionEvent): void {
+        this.dispatchEvent(new TransitionEvent(event.type));
+    }
+
     override render(): TemplateResult {
         return html`
             <sp-underlay
                 class="scrim"
                 @close=${this.toggle}
                 ?open=${this.open}
+                @transitionrun=${this.handleTransitionEvent}
+                @transitionend=${this.handleTransitionEvent}
+                @transitioncancel=${this.handleTransitionEvent}
             ></sp-underlay>
-            <aside>
+            <aside
+                @transitionrun=${this.handleTransitionEvent}
+                @transitionend=${this.handleTransitionEvent}
+                @transitioncancel=${this.handleTransitionEvent}
+            >
                 <div id="nav-header">
                     <div id="logo-container">
                         <slot name="logo"></slot>

--- a/projects/documentation/src/components/side-nav.ts
+++ b/projects/documentation/src/components/side-nav.ts
@@ -36,27 +36,9 @@ export class SideNav extends LitElement {
     @property({ type: Boolean, reflect: true })
     public open = false;
 
-    public toggle(event: MouseEvent | KeyboardEvent) {
-        if (
-            event.type === 'keydown' &&
-            (event as KeyboardEvent).code !== 'Enter' &&
-            (event as KeyboardEvent).code !== 'Space'
-        ) {
-            return;
-        }
+    public toggle() {
         this.open = !this.open;
     }
-
-    handleKeydown = (event: KeyboardEvent) => {
-        if (
-            event.code === 'Escape' &&
-            (event.target! as Element).closest(
-                '[role="listbox"],[role="menu"]'
-            ) === null
-        ) {
-            this.open = false;
-        }
-    };
 
     public override focus() {
         const target = document.querySelector(
@@ -83,14 +65,7 @@ export class SideNav extends LitElement {
                     <div id="logo-container">
                         <slot name="logo"></slot>
                     </div>
-                    <docs-search
-                        tabindex=${ifDefined(
-                            !this.open &&
-                                matchMedia('(max-width: 960px)').matches
-                                ? -1
-                                : undefined
-                        )}
-                    ></docs-search>
+                    <docs-search></docs-search>
                 </div>
                 <div class="navigation">
                     <slot></slot>
@@ -102,18 +77,7 @@ export class SideNav extends LitElement {
     override updated(changes: PropertyValues) {
         if (changes.has('open')) {
             if (!this.open && changes.get('open')) {
-                this.dispatchEvent(new Event('close'));
-                this.ownerDocument.removeEventListener(
-                    'keydown',
-                    this.handleKeydown,
-                    true
-                );
-            } else if (this.open && !changes.get('open')) {
-                this.ownerDocument.addEventListener(
-                    'keydown',
-                    this.handleKeydown,
-                    true
-                );
+                this.dispatchEvent(new Event('close', { bubbles: true }));
             }
         }
     }


### PR DESCRIPTION
## Description
1. Move from custom `inert` based left/right navigation UI to use the trigger directive

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://docs-with-overlay--spectrum-web-components.netlify.app/)
    3. In mobile screen sizes (less than `960px`)
    4. See that the left hand navigation opens/closes
    5. See that the right hand options panel opens/closes
-   [ ] _Test case 2_
    1. Go [here](https://docs-with-overlay--spectrum-web-components.netlify.app/)
    3. In mobile screen sizes (less than `960px`)
    4. See that the Overlay code is only loaded when opening the settings panel, side nav, or Picker.

## Types of changes
-   [x] Refactor

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)