### PR TITLE
fix: Mitigate Safari memory leak for input element

### DIFF
--- a/packages/textfield/src/Textfield.ts
+++ b/packages/textfield/src/Textfield.ts
@@ -464,9 +464,6 @@ export class TextfieldBase extends ManageHelpText(
  * @slot negative-help-text - negative help text to associate to your form element when `invalid`
  */
 export class Textfield extends TextfieldBase {
-    @query('#form')
-    public form!: HTMLFormElement;
-
     @property({ type: String })
     public override set value(value: string) {
         if (value === this.value) {
@@ -482,46 +479,4 @@ export class Textfield extends TextfieldBase {
     }
 
     protected override _value = '';
-
-    private handleSubmit(event: Event): void {
-        event.preventDefault();
-        this.dispatchEvent(
-            new Event('submit', {
-                cancelable: true,
-                bubbles: true,
-            })
-        );
-    }
-
-    protected override renderField(): TemplateResult {
-        return html`
-            <form id="form">${super.renderField()}</form>
-        `;
-    }
-
-    public override connectedCallback(): void {
-        super.connectedCallback();
-        this._firstUpdateAfterConnected = true;
-        this.requestUpdate();
-    }
-
-    public override disconnectedCallback(): void {
-        // Cleanup form event listener and remove form element from DOM
-        this.form.removeEventListener('submit', this.handleSubmit.bind(this));
-        this.form.remove();
-        super.disconnectedCallback();
-    }
-
-    protected override firstUpdateAfterConnected(): void {
-        super.firstUpdateAfterConnected();
-        this.form.addEventListener('submit', this.handleSubmit.bind(this));
-    }
-
-    protected override updated(changes: PropertyValues<this>): void {
-        super.updated(changes);
-        if (this._firstUpdateAfterConnected) {
-            this._firstUpdateAfterConnected = false;
-            this.firstUpdateAfterConnected();
-        }
-    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is an attempt to reduce the memory leak impact caused by the [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=262219) with HTML input elements that aren't properly garbage collected.  

- input event listeners are added using `addEventListener` API instead of the lit declarative way
- event listeners and form element are removed on `disconnectedCallback`

The PR should be treated as POC to showcase the changes we need in SWC and to confirm the fix works as expected on our side.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- [https://github.com/adobe/spectrum-web-components/discussions/4197](https://github.com/adobe/spectrum-web-components/discussions/4197)

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

Here's a screenshot that compares DOM trees that use `sp-search`; left one is current SWC behavior, right one is patched using the changes in this PR.  After detaching child nodes from their parent element, the ones in red are garbage collected, while the remaining ones are retained.

<img width="1462" alt="compare-patches" src="https://github.com/adobe/spectrum-web-components/assets/37333191/c73e3f6f-7e4e-4890-a12e-cea5ca7f6b16">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
