### PR TITLE
chore: added memory tests for missing packages

### DIFF
--- a/packages/accordion/test/accordion-memory.test.ts
+++ b/packages/accordion/test/accordion-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/accordion.stories.js';
-import { Accordion } from '@spectrum-web-components/accordion';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Accordion>(Default()));
+testForMemoryLeaks(Default());

--- a/packages/action-bar/test/action-bar-memory.test.ts
+++ b/packages/action-bar/test/action-bar-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/action-bar.stories.js';
-import { ActionBar } from '@spectrum-web-components/action-bar';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<ActionBar>(Default()));
+testForMemoryLeaks(Default());

--- a/packages/action-button/test/action-button-memory.test.ts
+++ b/packages/action-button/test/action-button-memory.test.ts
@@ -9,12 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { m as BlackActionButton } from '../stories/action-button-black.stories.js';
-import { ActionButton } from '@spectrum-web-components/action-button';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ActionButton>(BlackActionButton(BlackActionButton.args))
-);
+testForMemoryLeaks(BlackActionButton(BlackActionButton.args));

--- a/packages/action-button/test/action-button-memory.test.ts
+++ b/packages/action-button/test/action-button-memory.test.ts
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { m as BlackActionButton } from '../stories/action-button-black.stories.js';
+import { ActionButton } from '@spectrum-web-components/action-button';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ActionButton>(BlackActionButton(BlackActionButton.args))
+);

--- a/packages/action-group/test/action-group-memory.test.ts
+++ b/packages/action-group/test/action-group-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/action-group.stories.js';
-import { ActionGroup } from '@spectrum-web-components/action-group';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<ActionGroup>(Default({})));
+testForMemoryLeaks(Default({}));

--- a/packages/action-menu/test/action-menu-memory.test.ts
+++ b/packages/action-menu/test/action-menu-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/action-menu.stories.js';
-import { ActionMenu } from '@spectrum-web-components/action-menu';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<ActionMenu>(Default({})));
+testForMemoryLeaks(Default({}));

--- a/packages/alert-dialog/test/alert-dialog-memory.test.ts
+++ b/packages/alert-dialog/test/alert-dialog-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { confirmation } from '../stories/alert-dialog.stories.js';
-import { AlertDialog } from '@spectrum-web-components/alert-dialog';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<AlertDialog>(confirmation()));
+testForMemoryLeaks(confirmation());

--- a/packages/asset/test/asset-memory.test.ts
+++ b/packages/asset/test/asset-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/asset.stories.js';
-import { Asset } from '@spectrum-web-components/asset';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Asset>(Default()));
+testForMemoryLeaks(Default());

--- a/packages/avatar/test/avatar-memory.test.ts
+++ b/packages/avatar/test/avatar-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { linked } from '../stories/avatar.stories.js';
-import { Avatar } from '@spectrum-web-components/avatar';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Avatar>(linked()));
+testForMemoryLeaks(linked());

--- a/packages/badge/test/badge-memory.test.ts
+++ b/packages/badge/test/badge-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/badge.stories.js';
-import { Badge } from '@spectrum-web-components/badge';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Badge>(Default()));
+testForMemoryLeaks(Default());

--- a/packages/banner/test/banner-memory.test.ts
+++ b/packages/banner/test/banner-memory.test.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { Default } from '../stories/banner.stories.js';
+import { Banner } from '@spectrum-web-components/banner';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(async () => await fixture<Banner>(Default({})));

--- a/packages/banner/test/banner-memory.test.ts
+++ b/packages/banner/test/banner-memory.test.ts
@@ -9,9 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/banner.stories.js';
-import { Banner } from '@spectrum-web-components/banner';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Banner>(Default({})));
+testForMemoryLeaks(Default({}));

--- a/packages/button-group/test/button-group-memory.test.ts
+++ b/packages/button-group/test/button-group-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { buttons } from '../stories/button-group.stories.js';
-import { ButtonGroup } from '@spectrum-web-components/button-group';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<ButtonGroup>(buttons({})));
+testForMemoryLeaks(buttons({}));

--- a/packages/button/test/button-memory.test.ts
+++ b/packages/button/test/button-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/button-accent-fill.stories.js';
-import { Button } from '@spectrum-web-components/button';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Button>(Default({})));
+testForMemoryLeaks(Default({}));

--- a/packages/card/test/card-memory.test.ts
+++ b/packages/card/test/card-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/card.stories.js';
-import { Card } from '@spectrum-web-components/card';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Card>(Default({})));
+testForMemoryLeaks(Default({}));

--- a/packages/checkbox/test/checkbox-memory.test.ts
+++ b/packages/checkbox/test/checkbox-memory.test.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { Default } from '../stories/checkbox.stories.js';
+import { Checkbox } from '@spectrum-web-components/checkbox';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(async () => await fixture<Checkbox>(Default()));

--- a/packages/checkbox/test/checkbox-memory.test.ts
+++ b/packages/checkbox/test/checkbox-memory.test.ts
@@ -9,9 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/checkbox.stories.js';
-import { Checkbox } from '@spectrum-web-components/checkbox';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Checkbox>(Default()));
+testForMemoryLeaks(Default());

--- a/packages/coachmark/test/coach-indicator-memory.test.ts
+++ b/packages/coachmark/test/coach-indicator-memory.test.ts
@@ -9,14 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/coachmark/sp-coach-indicator.js';
-import { CoachIndicator } from '@spectrum-web-components/coachmark';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<CoachIndicator>(html`
-            <sp-coach-indicator></sp-coach-indicator>
-        `)
-);
+testForMemoryLeaks(html`
+    <sp-coach-indicator></sp-coach-indicator>
+`);

--- a/packages/coachmark/test/coach-indicator-memory.test.ts
+++ b/packages/coachmark/test/coach-indicator-memory.test.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/coachmark/sp-coach-indicator.js';
+import { CoachIndicator } from '@spectrum-web-components/coachmark';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<CoachIndicator>(html`
+            <sp-coach-indicator></sp-coach-indicator>
+        `)
+);

--- a/packages/coachmark/test/coach-mark-memory.test.ts
+++ b/packages/coachmark/test/coach-mark-memory.test.ts
@@ -9,9 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/coachmark.stories.js';
-import { Coachmark } from '@spectrum-web-components/coachmark';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Coachmark>(Default()));
+testForMemoryLeaks(Default());

--- a/packages/coachmark/test/coach-mark-memory.test.ts
+++ b/packages/coachmark/test/coach-mark-memory.test.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { Default } from '../stories/coachmark.stories.js';
+import { Coachmark } from '@spectrum-web-components/coachmark';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(async () => await fixture<Coachmark>(Default()));

--- a/packages/color-area/test/color-area-memory.test.ts
+++ b/packages/color-area/test/color-area-memory.test.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/coachmark/sp-coach-indicator.js';
+import { ColorArea } from '@spectrum-web-components/color-area';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ColorArea>(html`
+            <sp-color-area></sp-color-area>
+        `)
+);

--- a/packages/color-area/test/color-area-memory.test.ts
+++ b/packages/color-area/test/color-area-memory.test.ts
@@ -9,14 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/color-area/sp-color-area.js';
-import { ColorArea } from '@spectrum-web-components/color-area';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ColorArea>(html`
-            <sp-color-area></sp-color-area>
-        `)
-);
+testForMemoryLeaks(html`
+    <sp-color-area></sp-color-area>
+`);

--- a/packages/color-area/test/color-area-memory.test.ts
+++ b/packages/color-area/test/color-area-memory.test.ts
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 import { fixture, html } from '@open-wc/testing';
-import '@spectrum-web-components/coachmark/sp-coach-indicator.js';
+import '@spectrum-web-components/color-area/sp-color-area.js';
 import { ColorArea } from '@spectrum-web-components/color-area';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 

--- a/packages/color-field/test/color-field-memory.test.ts
+++ b/packages/color-field/test/color-field-memory.test.ts
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { Template } from '../stories/template.js';
+import { ColorField } from '@spectrum-web-components/color-field';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ColorField>(Template({ label: 'Enter color value' }))
+);

--- a/packages/color-field/test/color-field-memory.test.ts
+++ b/packages/color-field/test/color-field-memory.test.ts
@@ -9,12 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Template } from '../stories/template.js';
-import { ColorField } from '@spectrum-web-components/color-field';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ColorField>(Template({ label: 'Enter color value' }))
-);
+testForMemoryLeaks(Template({ label: 'Enter color value' }));

--- a/packages/color-handle/test/color-handle-memory.test.ts
+++ b/packages/color-handle/test/color-handle-memory.test.ts
@@ -9,14 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/color-handle/sp-color-handle.js';
-import { ColorHandle } from '@spectrum-web-components/color-handle';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ColorHandle>(html`
-            <sp-color-handle></sp-color-handle>
-        `)
-);
+testForMemoryLeaks(html`
+    <sp-color-handle></sp-color-handle>
+`);

--- a/packages/color-handle/test/color-handle-memory.test.ts
+++ b/packages/color-handle/test/color-handle-memory.test.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/color-handle/sp-color-handle.js';
+import { ColorHandle } from '@spectrum-web-components/color-handle';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ColorHandle>(html`
+            <sp-color-handle></sp-color-handle>
+        `)
+);

--- a/packages/color-loupe/test/color-loupe-memory.test.ts
+++ b/packages/color-loupe/test/color-loupe-memory.test.ts
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 import { fixture, html } from '@open-wc/testing';
-import '@spectrum-web-components/color-handle/sp-color-loupe.js';
+import '@spectrum-web-components/color-loupe/sp-color-loupe.js';
 import { ColorLoupe } from '@spectrum-web-components/color-loupe';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 

--- a/packages/color-loupe/test/color-loupe-memory.test.ts
+++ b/packages/color-loupe/test/color-loupe-memory.test.ts
@@ -9,14 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/color-loupe/sp-color-loupe.js';
-import { ColorLoupe } from '@spectrum-web-components/color-loupe';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ColorLoupe>(html`
-            <sp-color-loupe></sp-color-loupe>
-        `)
-);
+testForMemoryLeaks(html`
+    <sp-color-loupe></sp-color-loupe>
+`);

--- a/packages/color-loupe/test/color-loupe-memory.test.ts
+++ b/packages/color-loupe/test/color-loupe-memory.test.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/color-handle/sp-color-loupe.js';
+import { ColorLoupe } from '@spectrum-web-components/color-loupe';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ColorLoupe>(html`
+            <sp-color-loupe></sp-color-loupe>
+        `)
+);

--- a/packages/color-slider/test/color-slider-memory.test.ts
+++ b/packages/color-slider/test/color-slider-memory.test.ts
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 import { fixture, html } from '@open-wc/testing';
-import '@spectrum-web-components/color-handle/sp-color-slider.js';
+import '@spectrum-web-components/color-slider/sp-color-slider.js';
 import { ColorSlider } from '@spectrum-web-components/color-slider';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 

--- a/packages/color-slider/test/color-slider-memory.test.ts
+++ b/packages/color-slider/test/color-slider-memory.test.ts
@@ -9,14 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/color-slider/sp-color-slider.js';
-import { ColorSlider } from '@spectrum-web-components/color-slider';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ColorSlider>(html`
-            <sp-color-slider></sp-color-slider>
-        `)
-);
+testForMemoryLeaks(html`
+    <sp-color-slider></sp-color-slider>
+`);

--- a/packages/color-slider/test/color-slider-memory.test.ts
+++ b/packages/color-slider/test/color-slider-memory.test.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/color-handle/sp-color-slider.js';
+import { ColorSlider } from '@spectrum-web-components/color-slider';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ColorSlider>(html`
+            <sp-color-slider></sp-color-slider>
+        `)
+);

--- a/packages/color-wheel/test/color-wheel-memory.test.ts
+++ b/packages/color-wheel/test/color-wheel-memory.test.ts
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 import { fixture, html } from '@open-wc/testing';
-import '@spectrum-web-components/color-handle/sp-color-wheel.js';
+import '@spectrum-web-components/color-wheel/sp-color-wheel.js';
 import { ColorWheel } from '@spectrum-web-components/color-wheel';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 

--- a/packages/color-wheel/test/color-wheel-memory.test.ts
+++ b/packages/color-wheel/test/color-wheel-memory.test.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/color-handle/sp-color-wheel.js';
+import { ColorWheel } from '@spectrum-web-components/color-wheel';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ColorWheel>(html`
+            <sp-color-wheel></sp-color-wheel>
+        `)
+);

--- a/packages/color-wheel/test/color-wheel-memory.test.ts
+++ b/packages/color-wheel/test/color-wheel-memory.test.ts
@@ -9,14 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/color-wheel/sp-color-wheel.js';
-import { ColorWheel } from '@spectrum-web-components/color-wheel';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ColorWheel>(html`
-            <sp-color-wheel></sp-color-wheel>
-        `)
-);
+testForMemoryLeaks(html`
+    <sp-color-wheel></sp-color-wheel>
+`);

--- a/packages/combobox/test/combobox-memory.test.ts
+++ b/packages/combobox/test/combobox-memory.test.ts
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 import { fixture, html } from '@open-wc/testing';
-import '@spectrum-web-components/color-handle/sp-combobox.js';
+import '@spectrum-web-components/combobox/sp-combobox.js';
 import { Combobox } from '@spectrum-web-components/combobox';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 

--- a/packages/combobox/test/combobox-memory.test.ts
+++ b/packages/combobox/test/combobox-memory.test.ts
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/color-handle/sp-combobox.js';
+import { Combobox } from '@spectrum-web-components/combobox';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Combobox>(html`
+            <sp-combobox></sp-combobox>
+        `)
+);

--- a/packages/combobox/test/combobox-memory.test.ts
+++ b/packages/combobox/test/combobox-memory.test.ts
@@ -9,14 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/combobox/sp-combobox.js';
-import { Combobox } from '@spectrum-web-components/combobox';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Combobox>(html`
-            <sp-combobox></sp-combobox>
-        `)
-);
+testForMemoryLeaks(html`
+    <sp-combobox></sp-combobox>
+`);

--- a/packages/dialog/test/dialog-memory.test.ts
+++ b/packages/dialog/test/dialog-memory.test.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { small } from '../stories/dialog.stories.js';
+import { Dialog } from '@spectrum-web-components/dialog';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(async () => await fixture<Dialog>(small()));

--- a/packages/dialog/test/dialog-memory.test.ts
+++ b/packages/dialog/test/dialog-memory.test.ts
@@ -9,9 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { small } from '../stories/dialog.stories.js';
-import { Dialog } from '@spectrum-web-components/dialog';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Dialog>(small()));
+testForMemoryLeaks(small());

--- a/packages/divider/test/divider-memory.test.ts
+++ b/packages/divider/test/divider-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/divider/sp-divider.js';
+import { Divider } from '@spectrum-web-components/divider';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Divider>(
+            html`
+                <sp-divider></sp-divider>
+            `
+        )
+);

--- a/packages/divider/test/divider-memory.test.ts
+++ b/packages/divider/test/divider-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/divider/sp-divider.js';
-import { Divider } from '@spectrum-web-components/divider';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Divider>(
-            html`
-                <sp-divider></sp-divider>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-divider></sp-divider>
+`);

--- a/packages/dropzone/test/dropzone-memory.test.ts
+++ b/packages/dropzone/test/dropzone-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/dropzone/sp-dropzone.js';
-import { Dropzone } from '@spectrum-web-components/dropzone';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Dropzone>(
-            html`
-                <sp-dropzone></sp-dropzone>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-dropzone></sp-dropzone>
+`);

--- a/packages/dropzone/test/dropzone-memory.test.ts
+++ b/packages/dropzone/test/dropzone-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/dropzone/sp-dropzone.js';
+import { Dropzone } from '@spectrum-web-components/dropzone';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Dropzone>(
+            html`
+                <sp-dropzone></sp-dropzone>
+            `
+        )
+);

--- a/packages/field-group/test/field-group-memory.test.ts
+++ b/packages/field-group/test/field-group-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/field-group/sp-field-group.js';
-import { FieldGroup } from '@spectrum-web-components/field-group';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<FieldGroup>(
-            html`
-                <sp-field-group></sp-field-group>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-field-group></sp-field-group>
+`);

--- a/packages/field-group/test/field-group-memory.test.ts
+++ b/packages/field-group/test/field-group-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/field-group/sp-field-group.js';
+import { FieldGroup } from '@spectrum-web-components/field-group';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<FieldGroup>(
+            html`
+                <sp-field-group></sp-field-group>
+            `
+        )
+);

--- a/packages/field-label/test/field-label-memory.test.ts
+++ b/packages/field-label/test/field-label-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/field-label/sp-field-label.js';
-import { FieldLabel } from '@spectrum-web-components/field-label';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<FieldLabel>(
-            html`
-                <sp-field-label></sp-field-label>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-field-label></sp-field-label>
+`);

--- a/packages/field-label/test/field-label-memory.test.ts
+++ b/packages/field-label/test/field-label-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/field-label/sp-field-label.js';
+import { FieldLabel } from '@spectrum-web-components/field-label';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<FieldLabel>(
+            html`
+                <sp-field-label></sp-field-label>
+            `
+        )
+);

--- a/packages/help-text/test/help-test-memory.test.ts
+++ b/packages/help-text/test/help-test-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/help-text/sp-help-text.js';
-import { HelpText } from '@spectrum-web-components/help-text';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<HelpText>(
-            html`
-                <sp-help-text></sp-help-text>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-help-text></sp-help-text>
+`);

--- a/packages/help-text/test/help-test-memory.test.ts
+++ b/packages/help-text/test/help-test-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/help-text/sp-help-text.js';
+import { HelpText } from '@spectrum-web-components/help-text';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<HelpText>(
+            html`
+                <sp-help-text></sp-help-text>
+            `
+        )
+);

--- a/packages/icon/test/icon-memory.test.ts
+++ b/packages/icon/test/icon-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/icon/sp-icon.js';
-import { Icon } from '@spectrum-web-components/icon';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Icon>(
-            html`
-                <sp-icon name="ui:Chevron200"></sp-icon>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-icon name="ui:Chevron200"></sp-icon>
+`);

--- a/packages/icon/test/icon-memory.test.ts
+++ b/packages/icon/test/icon-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/icon/sp-icon.js';
+import { Icon } from '@spectrum-web-components/icon';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Icon>(
+            html`
+                <sp-icon name="ui:Chevron200"></sp-icon>
+            `
+        )
+);

--- a/packages/icons/test/icons-memory.test.ts
+++ b/packages/icons/test/icons-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/icons/sp-icons-medium.js';
+import { IconsMedium } from '../';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<IconsMedium>(
+            html`
+                <sp-icons-medium></sp-icons-medium>
+            `
+        )
+);

--- a/packages/icons/test/icons-memory.test.ts
+++ b/packages/icons/test/icons-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/icons/sp-icons-medium.js';
-import { IconsMedium } from '../';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<IconsMedium>(
-            html`
-                <sp-icons-medium></sp-icons-medium>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-icons-medium></sp-icons-medium>
+`);

--- a/packages/illustrated-message/test/illustrated-message-memory.test.ts
+++ b/packages/illustrated-message/test/illustrated-message-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/illustrated-message/sp-illustrated-message.js';
-import { IllustratedMessage } from '../';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<IllustratedMessage>(
-            html`
-                <sp-illustrated-message></sp-illustrated-message>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-illustrated-message></sp-illustrated-message>
+`);

--- a/packages/illustrated-message/test/illustrated-message-memory.test.ts
+++ b/packages/illustrated-message/test/illustrated-message-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/illustrated-message/sp-illustrated-message.js';
+import { IllustratedMessage } from '../';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<IllustratedMessage>(
+            html`
+                <sp-illustrated-message></sp-illustrated-message>
+            `
+        )
+);

--- a/packages/infield-button/test/infield-button-memory.test.ts
+++ b/packages/infield-button/test/infield-button-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/infield-button/sp-infield-button.js';
-import { InfieldButton } from '@spectrum-web-components/infield-button';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<InfieldButton>(
-            html`
-                <sp-infield-button></sp-infield-button>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-infield-button></sp-infield-button>
+`);

--- a/packages/infield-button/test/infield-button-memory.test.ts
+++ b/packages/infield-button/test/infield-button-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/infield-button/sp-infield-button.js';
+import { InfieldButton } from '@spectrum-web-components/infield-button';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<InfieldButton>(
+            html`
+                <sp-infield-button></sp-infield-button>
+            `
+        )
+);

--- a/packages/link/test/link-memory.test.ts
+++ b/packages/link/test/link-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/link/sp-link.js';
+import { Link } from '@spectrum-web-components/link';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Link>(
+            html`
+                <sp-link></sp-link>
+            `
+        )
+);

--- a/packages/link/test/link-memory.test.ts
+++ b/packages/link/test/link-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/link/sp-link.js';
-import { Link } from '@spectrum-web-components/link';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Link>(
-            html`
-                <sp-link></sp-link>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-link></sp-link>
+`);

--- a/packages/menu/test/menu-memory.test.ts
+++ b/packages/menu/test/menu-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { singleSelect } from '../stories/menu.stories.js';
-import { Menu } from '@spectrum-web-components/menu';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Menu>(singleSelect()));
+testForMemoryLeaks(singleSelect());

--- a/packages/meter/test/meter-memory.test.ts
+++ b/packages/meter/test/meter-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/meter/sp-meter.js';
+import { Meter } from '@spectrum-web-components/meter';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Meter>(
+            html`
+                <sp-meter></sp-meter>
+            `
+        )
+);

--- a/packages/meter/test/meter-memory.test.ts
+++ b/packages/meter/test/meter-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/meter/sp-meter.js';
-import { Meter } from '@spectrum-web-components/meter';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Meter>(
-            html`
-                <sp-meter></sp-meter>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-meter></sp-meter>
+`);

--- a/packages/number-field/test/number-field-memory.test.ts
+++ b/packages/number-field/test/number-field-memory.test.ts
@@ -9,9 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/number-field.stories.js';
-import { NumberField } from '@spectrum-web-components/number-field';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<NumberField>(Default({})));
+testForMemoryLeaks(Default({}));

--- a/packages/number-field/test/number-field-memory.test.ts
+++ b/packages/number-field/test/number-field-memory.test.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { Default } from '../stories/number-field.stories.js';
+import { NumberField } from '@spectrum-web-components/number-field';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(async () => await fixture<NumberField>(Default({})));

--- a/packages/overlay/test/overlay-memory.test.ts
+++ b/packages/overlay/test/overlay-memory.test.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { Default } from '../stories/overlay.stories.js';
+import { Overlay } from '@spectrum-web-components/overlay';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+// Defualt Overlay
+testForMemoryLeaks(
+    async () =>
+        await fixture<Overlay>(
+            Default({
+                placement: 'bottom',
+                offset: 0,
+            })
+        )
+);

--- a/packages/overlay/test/overlay-memory.test.ts
+++ b/packages/overlay/test/overlay-memory.test.ts
@@ -9,18 +9,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/overlay.stories.js';
-import { Overlay } from '@spectrum-web-components/overlay';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
 // Defualt Overlay
 testForMemoryLeaks(
-    async () =>
-        await fixture<Overlay>(
-            Default({
-                placement: 'bottom',
-                offset: 0,
-            })
-        )
+    Default({
+        placement: 'bottom',
+        offset: 0,
+    })
 );

--- a/packages/picker-button/test/picker-button-memory.test.ts
+++ b/packages/picker-button/test/picker-button-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/picker-button/sp-picker-button.js';
-import { PickerButton } from '@spectrum-web-components/picker-button';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<PickerButton>(
-            html`
-                <sp-picker-button></sp-picker-button>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-picker-button></sp-picker-button>
+`);

--- a/packages/picker-button/test/picker-button-memory.test.ts
+++ b/packages/picker-button/test/picker-button-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/picker-button/sp-picker-button.js';
+import { PickerButton } from '@spectrum-web-components/picker-button';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<PickerButton>(
+            html`
+                <sp-picker-button></sp-picker-button>
+            `
+        )
+);

--- a/packages/picker/test/picker-memory.test.ts
+++ b/packages/picker/test/picker-memory.test.ts
@@ -9,9 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/picker.stories.js';
-import { Picker } from '@spectrum-web-components/picker';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Picker>(Default({})));
+testForMemoryLeaks(Default({}));

--- a/packages/picker/test/picker-memory.test.ts
+++ b/packages/picker/test/picker-memory.test.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { Default } from '../stories/picker.stories.js';
+import { Picker } from '@spectrum-web-components/picker';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(async () => await fixture<Picker>(Default({})));

--- a/packages/popover/test/popover-memory.test.ts
+++ b/packages/popover/test/popover-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/popover/sp-popover.js';
-import { Popover } from '@spectrum-web-components/popover';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Popover>(
-            html`
-                <sp-popover></sp-popover>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-popover></sp-popover>
+`);

--- a/packages/popover/test/popover-memory.test.ts
+++ b/packages/popover/test/popover-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/popover/sp-popover.js';
+import { Popover } from '@spectrum-web-components/popover';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Popover>(
+            html`
+                <sp-popover></sp-popover>
+            `
+        )
+);

--- a/packages/progress-bar/test/progress-bar-memory.test.ts
+++ b/packages/progress-bar/test/progress-bar-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/popover/sp-progress-bar.js';
+import { ProgressBar } from '@spectrum-web-components/progress-bar';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ProgressBar>(
+            html`
+                <sp-progress-bar></sp-progress-bar>
+            `
+        )
+);

--- a/packages/progress-bar/test/progress-bar-memory.test.ts
+++ b/packages/progress-bar/test/progress-bar-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/progress-bar/sp-progress-bar.js';
-import { ProgressBar } from '@spectrum-web-components/progress-bar';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ProgressBar>(
-            html`
-                <sp-progress-bar></sp-progress-bar>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-progress-bar></sp-progress-bar>
+`);

--- a/packages/progress-bar/test/progress-bar-memory.test.ts
+++ b/packages/progress-bar/test/progress-bar-memory.test.ts
@@ -10,7 +10,7 @@ governing permissions and limitations under the License.
 */
 
 import { fixture, html } from '@open-wc/testing';
-import '@spectrum-web-components/popover/sp-progress-bar.js';
+import '@spectrum-web-components/progress-bar/sp-progress-bar.js';
 import { ProgressBar } from '@spectrum-web-components/progress-bar';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 

--- a/packages/progress-circle/test/progress-circle-memory.test.ts
+++ b/packages/progress-circle/test/progress-circle-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/progress-circle/sp-progress-circle.js';
+import { ProgressCircle } from '@spectrum-web-components/progress-circle';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<ProgressCircle>(
+            html`
+                <sp-progress-circle></sp-progress-circle>
+            `
+        )
+);

--- a/packages/progress-circle/test/progress-circle-memory.test.ts
+++ b/packages/progress-circle/test/progress-circle-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/progress-circle/sp-progress-circle.js';
-import { ProgressCircle } from '@spectrum-web-components/progress-circle';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<ProgressCircle>(
-            html`
-                <sp-progress-circle></sp-progress-circle>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-progress-circle></sp-progress-circle>
+`);

--- a/packages/radio/test/radio-memory.test.ts
+++ b/packages/radio/test/radio-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/radio/sp-radio.js';
-import { Radio } from '@spectrum-web-components/radio';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Radio>(
-            html`
-                <sp-radio></sp-radio>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-radio></sp-radio>
+`);

--- a/packages/radio/test/radio-memory.test.ts
+++ b/packages/radio/test/radio-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/radio/sp-radio.js';
+import { Radio } from '@spectrum-web-components/radio';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Radio>(
+            html`
+                <sp-radio></sp-radio>
+            `
+        )
+);

--- a/packages/search/test/search-memory.test.ts
+++ b/packages/search/test/search-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/search/sp-search.js';
-import { Search } from '@spectrum-web-components/search';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Search>(
-            html`
-                <sp-search></sp-search>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-search></sp-search>
+`);

--- a/packages/search/test/search-memory.test.ts
+++ b/packages/search/test/search-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/search/sp-search.js';
+import { Search } from '@spectrum-web-components/search';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Search>(
+            html`
+                <sp-search></sp-search>
+            `
+        )
+);

--- a/packages/sidenav/test/sidenav-memory.test.ts
+++ b/packages/sidenav/test/sidenav-memory.test.ts
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/radio/sp-radio.js';
+import '@spectrum-web-components/sidenav/sp-sidenav.js';
+import '@spectrum-web-components/sidenav/sp-sidenav-item.js';
+import '@spectrum-web-components/sidenav/sp-sidenav-heading.js';
+import { SideNav } from '@spectrum-web-components/sidenav';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<SideNav>(
+            html`
+                <sp-sidenav>
+                    <sp-sidenav-heading label="CATEGORY 1">
+                        <sp-sidenav-item
+                            value="Section 1"
+                            label="Section 1"
+                        ></sp-sidenav-item>
+                        <sp-sidenav-item
+                            value="Section 2"
+                            label="Section 2"
+                        ></sp-sidenav-item>
+                    </sp-sidenav-heading>
+                </sp-sidenav>
+            `
+        )
+);

--- a/packages/sidenav/test/sidenav-memory.test.ts
+++ b/packages/sidenav/test/sidenav-memory.test.ts
@@ -9,30 +9,24 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/radio/sp-radio.js';
 import '@spectrum-web-components/sidenav/sp-sidenav.js';
 import '@spectrum-web-components/sidenav/sp-sidenav-item.js';
 import '@spectrum-web-components/sidenav/sp-sidenav-heading.js';
-import { SideNav } from '@spectrum-web-components/sidenav';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<SideNav>(
-            html`
-                <sp-sidenav>
-                    <sp-sidenav-heading label="CATEGORY 1">
-                        <sp-sidenav-item
-                            value="Section 1"
-                            label="Section 1"
-                        ></sp-sidenav-item>
-                        <sp-sidenav-item
-                            value="Section 2"
-                            label="Section 2"
-                        ></sp-sidenav-item>
-                    </sp-sidenav-heading>
-                </sp-sidenav>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-sidenav>
+        <sp-sidenav-heading label="CATEGORY 1">
+            <sp-sidenav-item
+                value="Section 1"
+                label="Section 1"
+            ></sp-sidenav-item>
+            <sp-sidenav-item
+                value="Section 2"
+                label="Section 2"
+            ></sp-sidenav-item>
+        </sp-sidenav-heading>
+    </sp-sidenav>
+`);

--- a/packages/slider/test/slider-memory.test.ts
+++ b/packages/slider/test/slider-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/slider/sp-slider.js';
+import { Slider } from '@spectrum-web-components/slider';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Slider>(
+            html`
+                <sp-slider></sp-slider>
+            `
+        )
+);

--- a/packages/slider/test/slider-memory.test.ts
+++ b/packages/slider/test/slider-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/slider/sp-slider.js';
-import { Slider } from '@spectrum-web-components/slider';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Slider>(
-            html`
-                <sp-slider></sp-slider>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-slider></sp-slider>
+`);

--- a/packages/split-button/test/split-button-memory.test.ts
+++ b/packages/split-button/test/split-button-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/split-button/sp-split-button.js';
+import { SplitButton } from '@spectrum-web-components/split-button';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<SplitButton>(
+            html`
+                <sp-split-button></sp-split-button>
+            `
+        )
+);

--- a/packages/split-button/test/split-button-memory.test.ts
+++ b/packages/split-button/test/split-button-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/split-button/sp-split-button.js';
-import { SplitButton } from '@spectrum-web-components/split-button';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<SplitButton>(
-            html`
-                <sp-split-button></sp-split-button>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-split-button></sp-split-button>
+`);

--- a/packages/split-view/test/split-view-memory.test.ts
+++ b/packages/split-view/test/split-view-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/split-view/sp-split-view.js';
-import { SplitView } from '@spectrum-web-components/split-view';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<SplitView>(
-            html`
-                <sp-split-view></sp-split-view>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-split-view></sp-split-view>
+`);

--- a/packages/split-view/test/split-view-memory.test.ts
+++ b/packages/split-view/test/split-view-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/split-view/sp-split-view.js';
+import { SplitView } from '@spectrum-web-components/split-view';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<SplitView>(
+            html`
+                <sp-split-view></sp-split-view>
+            `
+        )
+);

--- a/packages/status-light/test/status-light-memory.test.ts
+++ b/packages/status-light/test/status-light-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/status-light/sp-status-light.js';
-import { StatusLight } from '@spectrum-web-components/status-light';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<StatusLight>(
-            html`
-                <sp-status-light></sp-status-light>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-status-light></sp-status-light>
+`);

--- a/packages/status-light/test/status-light-memory.test.ts
+++ b/packages/status-light/test/status-light-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/status-light/sp-status-light.js';
+import { StatusLight } from '@spectrum-web-components/status-light';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<StatusLight>(
+            html`
+                <sp-status-light></sp-status-light>
+            `
+        )
+);

--- a/packages/swatch/test/swatch-memory.test.ts
+++ b/packages/swatch/test/swatch-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/swatch/sp-swatch.js';
-import { Swatch } from '../src/Swatch.js';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Swatch>(
-            html`
-                <sp-swatch></sp-swatch>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-swatch></sp-swatch>
+`);

--- a/packages/swatch/test/swatch-memory.test.ts
+++ b/packages/swatch/test/swatch-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/swatch/sp-swatch.js';
+import { Swatch } from '../src/Swatch.js';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Swatch>(
+            html`
+                <sp-swatch></sp-swatch>
+            `
+        )
+);

--- a/packages/switch/test/switch-memory.test.ts
+++ b/packages/switch/test/switch-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/switch/sp-switch.js';
-import { Switch } from '@spectrum-web-components/switch';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Switch>(
-            html`
-                <sp-switch></sp-switch>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-switch></sp-switch>
+`);

--- a/packages/switch/test/switch-memory.test.ts
+++ b/packages/switch/test/switch-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/switch/sp-switch.js';
+import { Switch } from '@spectrum-web-components/switch';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Switch>(
+            html`
+                <sp-switch></sp-switch>
+            `
+        )
+);

--- a/packages/table/test/table-memory.test.ts
+++ b/packages/table/test/table-memory.test.ts
@@ -9,10 +9,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import '@spectrum-web-components/table/sp-table.js';
-import type { Table } from '@spectrum-web-components/table';
 import { elements } from '../stories/table-elements.stories.js';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Table>(elements()));
+testForMemoryLeaks(elements());

--- a/packages/table/test/table-memory.test.ts
+++ b/packages/table/test/table-memory.test.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import '@spectrum-web-components/table/sp-table.js';
+import type { Table } from '@spectrum-web-components/table';
+import { elements } from '../stories/table-elements.stories.js';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(async () => await fixture<Table>(elements()));

--- a/packages/tabs/test/tabs-memory.test.ts
+++ b/packages/tabs/test/tabs-memory.test.ts
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/tabs/sp-tabs.js';
+import '@spectrum-web-components/tabs/sp-tab.js';
+import { Tabs } from '@spectrum-web-components/tabs';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Tabs>(
+            html`
+                <sp-tabs selected="first">
+                    <sp-tab label="Tab 1" value="first"></sp-tab>
+                    <sp-tab label="Tab 2" value="second"></sp-tab>
+                    <sp-tab label="Tab 3" value="third"></sp-tab>
+                </sp-tabs>
+            `
+        )
+);

--- a/packages/tabs/test/tabs-memory.test.ts
+++ b/packages/tabs/test/tabs-memory.test.ts
@@ -9,21 +9,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/tabs/sp-tabs.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
-import { Tabs } from '@spectrum-web-components/tabs';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Tabs>(
-            html`
-                <sp-tabs selected="first">
-                    <sp-tab label="Tab 1" value="first"></sp-tab>
-                    <sp-tab label="Tab 2" value="second"></sp-tab>
-                    <sp-tab label="Tab 3" value="third"></sp-tab>
-                </sp-tabs>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-tabs selected="first">
+        <sp-tab label="Tab 1" value="first"></sp-tab>
+        <sp-tab label="Tab 2" value="second"></sp-tab>
+        <sp-tab label="Tab 3" value="third"></sp-tab>
+    </sp-tabs>
+`);

--- a/packages/tags/test/tags-memory.test.ts
+++ b/packages/tags/test/tags-memory.test.ts
@@ -9,21 +9,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/tags/sp-tag.js';
 import '@spectrum-web-components/tags/sp-tags.js';
-import { Tags } from '@spectrum-web-components/tags';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Tags>(
-            html`
-                <sp-tags>
-                    <sp-tag>Tag 1</sp-tag>
-                    <sp-tag invalid>Tag 2</sp-tag>
-                    <sp-tag disabled>Tag 3</sp-tag>
-                </sp-tags>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-tags>
+        <sp-tag>Tag 1</sp-tag>
+        <sp-tag invalid>Tag 2</sp-tag>
+        <sp-tag disabled>Tag 3</sp-tag>
+    </sp-tags>
+`);

--- a/packages/tags/test/tags-memory.test.ts
+++ b/packages/tags/test/tags-memory.test.ts
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/tags/sp-tag.js';
+import '@spectrum-web-components/tags/sp-tags.js';
+import { Tags } from '@spectrum-web-components/tags';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Tags>(
+            html`
+                <sp-tags>
+                    <sp-tag>Tag 1</sp-tag>
+                    <sp-tag invalid>Tag 2</sp-tag>
+                    <sp-tag disabled>Tag 3</sp-tag>
+                </sp-tags>
+            `
+        )
+);

--- a/packages/textfield/test/textfield-memory.test.ts
+++ b/packages/textfield/test/textfield-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/textfield/sp-textfield.js';
+import { Textfield } from '@spectrum-web-components/textfield';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Textfield>(
+            html`
+                <sp-textfield></sp-textfield>
+            `
+        )
+);

--- a/packages/textfield/test/textfield-memory.test.ts
+++ b/packages/textfield/test/textfield-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/textfield/sp-textfield.js';
-import { Textfield } from '@spectrum-web-components/textfield';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Textfield>(
-            html`
-                <sp-textfield></sp-textfield>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-textfield></sp-textfield>
+`);

--- a/packages/thumbnail/test/thumbnail-memory.test.ts
+++ b/packages/thumbnail/test/thumbnail-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/thumbnail/sp-thumbnail.js';
+import { Thumbnail } from '..';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Thumbnail>(
+            html`
+                <sp-thumbnail></sp-thumbnail>
+            `
+        )
+);

--- a/packages/thumbnail/test/thumbnail-memory.test.ts
+++ b/packages/thumbnail/test/thumbnail-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/thumbnail/sp-thumbnail.js';
-import { Thumbnail } from '..';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Thumbnail>(
-            html`
-                <sp-thumbnail></sp-thumbnail>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-thumbnail></sp-thumbnail>
+`);

--- a/packages/toast/test/toast-memory.test.ts
+++ b/packages/toast/test/toast-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/toast/sp-toast.js';
-import { Toast } from '@spectrum-web-components/toast';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Toast>(
-            html`
-                <sp-toast></sp-toast>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-toast></sp-toast>
+`);

--- a/packages/toast/test/toast-memory.test.ts
+++ b/packages/toast/test/toast-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/toast/sp-toast.js';
+import { Toast } from '@spectrum-web-components/toast';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Toast>(
+            html`
+                <sp-toast></sp-toast>
+            `
+        )
+);

--- a/packages/tooltip/test/tooltip-memory.test.ts
+++ b/packages/tooltip/test/tooltip-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/tooltip/sp-tooltip.js';
+import { Tooltip } from '@spectrum-web-components/tooltip';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Tooltip>(
+            html`
+                <sp-tooltip></sp-tooltip>
+            `
+        )
+);

--- a/packages/tooltip/test/tooltip-memory.test.ts
+++ b/packages/tooltip/test/tooltip-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/tooltip/sp-tooltip.js';
-import { Tooltip } from '@spectrum-web-components/tooltip';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Tooltip>(
-            html`
-                <sp-tooltip></sp-tooltip>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-tooltip></sp-tooltip>
+`);

--- a/packages/top-nav/test/top-nav-memory.test.ts
+++ b/packages/top-nav/test/top-nav-memory.test.ts
@@ -9,9 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
-import { TopNav } from '@spectrum-web-components/top-nav';
 import { Default } from '../stories/top-nav.stories.js';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<TopNav>(Default()));
+testForMemoryLeaks(Default());

--- a/packages/top-nav/test/top-nav-memory.test.ts
+++ b/packages/top-nav/test/top-nav-memory.test.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture } from '@open-wc/testing';
+import { TopNav } from '@spectrum-web-components/top-nav';
+import { Default } from '../stories/top-nav.stories.js';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(async () => await fixture<TopNav>(Default()));

--- a/packages/tray/test/tray-memory.test.ts
+++ b/packages/tray/test/tray-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/tray/sp-tray.js';
+import { Tray } from '@spectrum-web-components/tray';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Tray>(
+            html`
+                <sp-tray></sp-tray>
+            `
+        )
+);

--- a/packages/tray/test/tray-memory.test.ts
+++ b/packages/tray/test/tray-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/tray/sp-tray.js';
-import { Tray } from '@spectrum-web-components/tray';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Tray>(
-            html`
-                <sp-tray></sp-tray>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-tray></sp-tray>
+`);

--- a/packages/underlay/test/underlay-memory.test.ts
+++ b/packages/underlay/test/underlay-memory.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { fixture, html } from '@open-wc/testing';
+import '@spectrum-web-components/underlay/sp-underlay.js';
+import { Underlay } from '@spectrum-web-components/underlay';
+import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
+
+testForMemoryLeaks(
+    async () =>
+        await fixture<Underlay>(
+            html`
+                <sp-underlay></sp-underlay>
+            `
+        )
+);

--- a/packages/underlay/test/underlay-memory.test.ts
+++ b/packages/underlay/test/underlay-memory.test.ts
@@ -9,16 +9,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture, html } from '@open-wc/testing';
+import { html } from '@open-wc/testing';
 import '@spectrum-web-components/underlay/sp-underlay.js';
-import { Underlay } from '@spectrum-web-components/underlay';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(
-    async () =>
-        await fixture<Underlay>(
-            html`
-                <sp-underlay></sp-underlay>
-            `
-        )
-);
+testForMemoryLeaks(html`
+    <sp-underlay></sp-underlay>
+`);

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -54,7 +54,7 @@ export async function testForLitDevWarnings(
 }
 
 export async function testForMemoryLeaks(
-    element: () => Promise<HTMLElement>
+    element: TemplateResult
 ): Promise<void> {
     describe('Memory usage', () => {
         it('releases references on disconnect', async function () {

--- a/tools/grid/test/grid-memory.test.ts
+++ b/tools/grid/test/grid-memory.test.ts
@@ -10,9 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { fixture } from '@open-wc/testing';
 import { Default } from '../stories/grid.stories.js';
-import { Grid } from '@spectrum-web-components/grid';
 import { testForMemoryLeaks } from '../../../test/testing-helpers.js';
 
-testForMemoryLeaks(async () => await fixture<Grid>(Default()));
+testForMemoryLeaks(Default());

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -26,6 +26,7 @@ export const chromium = playwrightLauncher({
 
 export const chromiumWithMemoryTooling = playwrightLauncher({
     product: 'chromium',
+    concurrency: 1,
     createBrowserContext: ({ browser }) =>
         browser.newContext({
             ignoreHTTPSErrors: true,

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -17,6 +17,7 @@ import fg from 'fast-glob';
 
 export const chromium = playwrightLauncher({
     product: 'chromium',
+    concurrency: 1,
     createBrowserContext: ({ browser }) =>
         browser.newContext({
             ignoreHTTPSErrors: true,
@@ -26,7 +27,6 @@ export const chromium = playwrightLauncher({
 
 export const chromiumWithMemoryTooling = playwrightLauncher({
     product: 'chromium',
-    concurrency: 1,
     createBrowserContext: ({ browser }) =>
         browser.newContext({
             ignoreHTTPSErrors: true,


### PR DESCRIPTION
Added memory tests for remaining packages.

## Objective

fixes #3722

## Background

Memory leaks in web applications can lead to performance issues and degraded user experience. By adding memory tests to each package in the component library, we can proactively identify and fix potential memory leaks, ensuring the overall stability and performance of the library.

## Related Issue:
Building on top of https://github.com/adobe/spectrum-web-components/pull/4228

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
