### PR TITLE
fix(action-bar): include focus-visible polyfilling

### DIFF
--- a/packages/action-bar/src/ActionBar.ts
+++ b/packages/action-bar/src/ActionBar.ts
@@ -14,7 +14,6 @@ import {
     CSSResultArray,
     html,
     SpectrumElement,
-    SizedMixin,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
@@ -31,9 +30,7 @@ export const actionBarVariants = ['sticky', 'fixed'];
  * @element sp-action-bar
  * @slot - Content to display with the Action Bar
  */
-export class ActionBar extends SizedMixin(
-    FocusVisiblePolyfillMixin(SpectrumElement)
-) {
+export class ActionBar extends FocusVisiblePolyfillMixin(SpectrumElement) {
     public static override get styles(): CSSResultArray {
         return [actionBarStyles];
     }

--- a/packages/action-bar/src/ActionBar.ts
+++ b/packages/action-bar/src/ActionBar.ts
@@ -14,6 +14,7 @@ import {
     CSSResultArray,
     html,
     SpectrumElement,
+    SizedMixin,
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
@@ -23,13 +24,16 @@ import '@spectrum-web-components/button/sp-close-button.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
 import actionBarStyles from './action-bar.css.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import { FocusVisiblePolyfillMixin } from "@spectrum-web-components/shared/src/focus-visible.js";
 export const actionBarVariants = ['sticky', 'fixed'];
 
 /**
  * @element sp-action-bar
  * @slot - Content to display with the Action Bar
  */
-export class ActionBar extends SpectrumElement {
+export class ActionBar extends SizedMixin(
+    FocusVisiblePolyfillMixin(SpectrumElement)
+) {
     public static override get styles(): CSSResultArray {
         return [actionBarStyles];
     }


### PR DESCRIPTION
## Description
For older browser and UXP, we have to rely on focus-visible polyfill to match behaviour with the modern browser where the corresponding pseudo-selector is supported.

<!--- Describe your changes in detail -->

## Related issue(s)
fixes https://github.com/adobe/spectrum-web-components/issues/4279

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
