### PR TITLE
fix(base,reactive-controllers): add delegates API and downstate delegate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 171002bd5c878baa0f931adf4d0d05da1b8ed130
+        default: f7b764c5d5370f0abd7b9830d99b9c2a60afa981
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -71,7 +71,7 @@
         "@spectrum-web-components/shared": "^0.42.2"
     },
     "devDependencies": {
-        "@spectrum-css/checkbox": "^8.1.5"
+        "@spectrum-css/checkbox": "^14.0.0-next.2"
     },
     "types": "./src/index.d.ts",
     "customElements": "custom-elements.json",

--- a/packages/checkbox/src/Checkbox.ts
+++ b/packages/checkbox/src/Checkbox.ts
@@ -116,6 +116,10 @@ export class Checkbox extends SizedMixin(CheckboxMixin(SpectrumElement), {
         delegatesFocus: true,
     };
 
+    override spectrumConfig = {
+        downstate: ['spectrum-two'],
+    };
+
     /**
      * Disable this control. It will not receive focus or events
      */

--- a/packages/checkbox/src/spectrum-checkbox.css
+++ b/packages/checkbox/src/spectrum-checkbox.css
@@ -34,7 +34,7 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-control-color-disabled: var(
         --spectrum-disabled-content-color
     );
-    --spectrum-checkbox-checkmark-color: var(--spectrum-gray-75);
+    --spectrum-checkbox-checkmark-color: var(--spectrum-gray-50);
     --spectrum-checkbox-invalid-color-default: var(
         --spectrum-negative-color-900
     );
@@ -76,7 +76,9 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-control-size: var(
         --spectrum-checkbox-control-size-medium
     );
-    --spectrum-checkbox-control-corner-radius: var(--spectrum-corner-radius-75);
+    --spectrum-checkbox-control-corner-radius: var(
+        --spectrum-corner-radius-small-size-medium
+    );
     --spectrum-checkbox-focus-indicator-gap: var(
         --spectrum-focus-indicator-gap
     );
@@ -95,6 +97,9 @@ governing permissions and limitations under the License.
 }
 
 :host([size='s']) {
+    --spectrum-checkbox-control-corner-radius: var(
+        --spectrum-corner-radius-small-size-small
+    );
     --spectrum-checkbox-font-size: var(--spectrum-font-size-75);
     --spectrum-checkbox-height: var(--spectrum-component-height-75);
     --spectrum-checkbox-control-size: var(
@@ -104,17 +109,10 @@ governing permissions and limitations under the License.
     --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-75);
 }
 
-:host {
-    --spectrum-checkbox-font-size: var(--spectrum-font-size-100);
-    --spectrum-checkbox-height: var(--spectrum-component-height-100);
-    --spectrum-checkbox-control-size: var(
-        --spectrum-checkbox-control-size-medium
-    );
-    --spectrum-checkbox-top-to-text: var(--spectrum-component-top-to-text-100);
-    --spectrum-checkbox-text-to-control: var(--spectrum-text-to-control-100);
-}
-
 :host([size='l']) {
+    --spectrum-checkbox-control-corner-radius: var(
+        --spectrum-corner-radius-small-size-large
+    );
     --spectrum-checkbox-font-size: var(--spectrum-font-size-200);
     --spectrum-checkbox-height: var(--spectrum-component-height-200);
     --spectrum-checkbox-control-size: var(
@@ -125,6 +123,9 @@ governing permissions and limitations under the License.
 }
 
 :host([size='xl']) {
+    --spectrum-checkbox-control-corner-radius: var(
+        --spectrum-corner-radius-small-size-extra-large
+    );
     --spectrum-checkbox-font-size: var(--spectrum-font-size-300);
     --spectrum-checkbox-height: var(--spectrum-component-height-300);
     --spectrum-checkbox-control-size: var(
@@ -178,6 +179,13 @@ governing permissions and limitations under the License.
             var(--spectrum-checkbox-content-color-down)
         )
     );
+}
+
+:host(:not([readonly]):is(:active, [active])) #input:not(:disabled) + #box {
+    transform: perspective(
+            var(--spectrum-component-size-minimum-perspective-down)
+        )
+        translateZ(var(--spectrum-component-size-difference-down));
 }
 
 :host([invalid][invalid]) #input:checked + #box:before,
@@ -340,6 +348,36 @@ governing permissions and limitations under the License.
 }
 
 @media (hover: hover) {
+    :host(:hover) #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-control-color-hover,
+                var(--spectrum-checkbox-control-color-hover)
+            )
+        );
+    }
+
+    :host(:hover) #input:checked + #box:before {
+        border-color: var(
+            --highcontrast-checkbox-highlight-color-hover,
+            var(
+                --mod-checkbox-control-selected-color-hover,
+                var(--spectrum-checkbox-control-selected-color-hover)
+            )
+        );
+    }
+
+    :host(:hover) #label {
+        color: var(
+            --highcontrast-checkbox-content-color-hover,
+            var(
+                --mod-checkbox-content-color-hover,
+                var(--spectrum-checkbox-content-color-hover)
+            )
+        );
+    }
+
     :host([invalid][invalid]:hover) #input:checked + #box:before,
     :host([invalid][invalid]:hover) #box:before {
         border-color: var(
@@ -383,27 +421,6 @@ governing permissions and limitations under the License.
         );
     }
 
-    :host(:hover) #box:before {
-        border-color: var(
-            --highcontrast-checkbox-highlight-color-hover,
-            var(
-                --mod-checkbox-control-color-hover,
-                var(--spectrum-checkbox-control-color-hover)
-            )
-        );
-    }
-
-    :host(:hover) #input:checked + #box:before {
-        border-color: var(
-            --highcontrast-checkbox-highlight-color-hover,
-            var(
-                --mod-checkbox-control-selected-color-hover,
-                var(--spectrum-checkbox-control-selected-color-hover)
-            )
-        );
-    }
-
-    :host(:hover) #label,
     :host([invalid][invalid][indeterminate]:hover) #label {
         color: var(
             --highcontrast-checkbox-content-color-hover,
@@ -453,8 +470,8 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([emphasized]:is(:active, [active])[indeterminate]) #box:before,
-:host([emphasized]:is(:active, [active])[indeterminate])
+:host([emphasized][indeterminate]:is(:active, [active])) #box:before,
+:host([emphasized][indeterminate]:is(:active, [active]))
     #input:checked
     + #box:before,
 :host([emphasized]:is(:active, [active])) #input:checked + #box:before {

--- a/packages/checkbox/src/spectrum-config.js
+++ b/packages/checkbox/src/spectrum-config.js
@@ -11,7 +11,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { converterFor } from '../../../tasks/process-spectrum-utils.js';
+import {
+    builder,
+    converterFor,
+} from '../../../tasks/process-spectrum-utils.js';
 
 const converter = converterFor('spectrum-Checkbox');
 
@@ -49,6 +52,20 @@ const config = {
                                 },
                             ],
                         ],
+                    },
+
+                    hoist: true,
+                },
+                {
+                    find: {
+                        type: 'pseudo-class',
+                        kind: 'not',
+                        selectors: [[builder.class('is-readOnly')]],
+                    },
+                    replace: {
+                        type: 'pseudo-class',
+                        kind: 'not',
+                        selectors: [[builder.attribute('readonly')]],
                     },
                     hoist: true,
                 },

--- a/projects/story-decorator/src/StoryDecorator.ts
+++ b/projects/story-decorator/src/StoryDecorator.ts
@@ -91,6 +91,7 @@ const reduceMotionProperties = css`
     --spectrum-animation-duration-2000: 0ms;
     --spectrum-animation-duration-4000: 0ms;
     --spectrum-animation-duration-6000: 0ms;
+    --spectrum-button-animation-duration: 0ms;
     --pending-delay: 0s;
     --spectrum-coachmark-animation-indicator-ring-duration: 0ms;
     --swc-test-duration: 1ms;
@@ -276,6 +277,12 @@ export class StoryDecorator extends SpectrumElement {
                 ...(descendent.querySelectorAll('*') || []),
             ] as SpectrumElement[];
             descendents.push(...gathered);
+        });
+        // run over the slotted descendants and add theme property
+        descendents.forEach((element) => {
+            if (element instanceof SpectrumElement) {
+                element.spectrumDelegates.theme = this.theme;
+            }
         });
         const litElementDescendents = descendents.filter(
             (el) =>

--- a/tools/base/src/Base.ts
+++ b/tools/base/src/Base.ts
@@ -12,6 +12,8 @@ governing permissions and limitations under the License.
 
 import { LitElement, ReactiveElement } from 'lit';
 import { version } from '@spectrum-web-components/base/src/version.js';
+import { Delegates } from '@spectrum-web-components/reactive-controllers/src/delegates.js';
+
 type ThemeRoot = HTMLElement & {
     startManagingContentDirection: (el: HTMLElement) => void;
     stopManagingContentDirection: (el: HTMLElement) => void;
@@ -185,8 +187,14 @@ export function SpectrumMixin<T extends Constructor<ReactiveElement>>(
     return SpectrumMixinElement;
 }
 
+export type SpectrumConfig = {
+    downstate?: string[];
+};
+
 export class SpectrumElement extends SpectrumMixin(LitElement) {
     static VERSION = version;
+    public spectrumConfig: SpectrumConfig = {};
+    public spectrumDelegates = new Delegates(this);
 }
 
 if (window.__swc.DEBUG) {

--- a/tools/reactive-controllers/README.md
+++ b/tools/reactive-controllers/README.md
@@ -10,3 +10,4 @@
 -   LanguageReslutionController
 -   [MatchMediaController](../match-media)
 -   [RovingTabindexController](../roving-tab-index)
+-   [Downstate](../downstate)

--- a/tools/reactive-controllers/downstate.md
+++ b/tools/reactive-controllers/downstate.md
@@ -1,0 +1,45 @@
+## Description
+
+The `downstate` controller is designed to manage the down state styles of a custom element in a web application. This controller is particularly useful for creating interactive elements that visually respond to user input, such as buttons or interactive components.
+
+### Usage
+
+[![See it on NPM!](https://img.shields.io/npm/v/@spectrum-web-components/reactive-controllers?style=for-the-badge)](https://www.npmjs.com/package/@spectrum-web-components/reactive-controllers)
+[![How big is this package in your project?](https://img.shields.io/bundlephobia/minzip/@spectrum-web-components/reactive-controllers?style=for-the-badge)](https://bundlephobia.com/result?p=@spectrum-web-components/reactive-controllers)
+
+```
+yarn add @spectrum-web-components/reactive-controllers
+```
+
+Import the `Downstate Controller` via:
+
+```js
+import { Downstate } from '@spectrum-web-components/reactive-controllers/downstate.js';
+```
+
+### Example
+
+To enable a `downstate` on an element, you can add a `spectrumConfig` property to the element's class and specify the downstate configuration. Here's an example of how you can do this:
+
+```js
+import { html, LitElement } from 'lit';
+import { Downstate } from '@spectrum-web-components/reactive-controllers/downstate.js';
+
+class Host extends LitElement {
+    downstate = new DownState(this);
+    constructor() {
+        super();
+        this.spectrumConfig = {
+            downstate: ['spectrum-two'],
+        };
+    }
+    render() {
+        return html`
+            <slot></slot>
+        `;
+    }
+}
+```
+
+Here `spectrum-two` is the name of the system on which the downstate will be applied to.
+The above will add a downstate trigger into the slotted element and will add a pressed effect into the element's active state

--- a/tools/reactive-controllers/package.json
+++ b/tools/reactive-controllers/package.json
@@ -53,6 +53,14 @@
             "development": "./src/RovingTabindex.dev.js",
             "default": "./src/RovingTabindex.js"
         },
+        "./src/delegates.js": {
+            "development": "./src/delegates.dev.js",
+            "default": "./src/delegates.js"
+        },
+        "./src/downstate.js": {
+            "development": "./src/downstate.dev.js",
+            "default": "./src/downstate.js"
+        },
         "./src/index.js": {
             "development": "./src/index.dev.js",
             "default": "./src/index.js"

--- a/tools/reactive-controllers/src/delegates.ts
+++ b/tools/reactive-controllers/src/delegates.ts
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import type { LitElement, ReactiveController } from 'lit';
+import { DownState } from './downstate.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const DelegatesList: Record<string, any> = {
+    downstate: DownState,
+};
+
+export type SpectrumConfig = {
+    downstate?: string[];
+};
+
+export class Delegates implements ReactiveController {
+    private host: LitElement;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private controllers: Record<string, any> = {};
+
+    set theme(value: string) {
+        const { spectrumConfig } = this.host as unknown as {
+            spectrumConfig: SpectrumConfig;
+        };
+        Object.entries(spectrumConfig as SpectrumConfig).forEach(
+            ([controller, systems]) => {
+                if (systems.includes(value)) {
+                    const ControllerClass = DelegatesList[controller];
+                    this.controllers[controller] = new ControllerClass(
+                        this.host
+                    );
+                }
+            }
+        );
+    }
+
+    constructor(host: LitElement) {
+        this.host = host;
+        this.host.addController(this);
+    }
+
+    public hostConnected(): void {}
+
+    public hostDisconnected(): void {}
+}

--- a/tools/reactive-controllers/src/downstate.ts
+++ b/tools/reactive-controllers/src/downstate.ts
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import type { LitElement, ReactiveController } from 'lit';
+
+export class DownState implements ReactiveController {
+    private host: LitElement;
+    private controller: AbortController;
+
+    constructor(host: LitElement) {
+        this.host = host;
+        this.controller = new AbortController();
+        this.host.addController(this);
+    }
+
+    public getElement(): LitElement {
+        return this.host;
+    }
+    public hostConnected(): void {
+        this.manage();
+    }
+
+    public hostDisconnected(): void {
+        this.removeEventListeners();
+        this.controller.abort(); // Abort the controller when disconnecting
+    }
+
+    public manage(): void {
+        this.addEventListeners();
+    }
+
+    public unmanage(): void {
+        this.removeEventListeners();
+    }
+
+    addEventListeners(): void {
+        this.host?.addEventListener('pointerdown', this.handlePointerDown, {
+            signal: this.controller.signal,
+        });
+        this.host?.addEventListener('pointerup', this.handlePointerUp, {
+            signal: this.controller.signal,
+        });
+    }
+
+    removeEventListeners(): void {
+        this.host?.removeEventListener('pointerdown', this.handlePointerDown);
+        this.host?.removeEventListener('pointerup', this.handlePointerUp);
+    }
+
+    private handlePointerDown = (): void => {
+        this.updateDownStateStyles(true);
+    };
+
+    private handlePointerUp = (): void => {
+        this.updateDownStateStyles(false);
+    };
+
+    private updateDownStateStyles(isPressed: boolean): void {
+        if (isPressed) {
+            const height = this.host.offsetHeight;
+            const width = this.host.offsetWidth;
+            this.host.style.setProperty(
+                '--spectrum-downstate-width',
+                `${width}px`
+            );
+            this.host.style.setProperty(
+                '--spectrum-downstate-height',
+                `${height}px`
+            );
+        } else {
+            this.host.style.removeProperty('--spectrum-downstate-width');
+            this.host.style.removeProperty('--spectrum-downstate-height');
+        }
+    }
+}

--- a/tools/reactive-controllers/test/delegate.test.ts
+++ b/tools/reactive-controllers/test/delegate.test.ts
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { html, LitElement } from 'lit';
+import { expect, fixture, nextFrame } from '@open-wc/testing';
+import { DownState } from '@spectrum-web-components/reactive-controllers/src/downstate.js';
+
+class TestEl extends LitElement {}
+customElements.define('test-downstate-el', TestEl);
+
+describe('DownState', () => {
+    it('adds downstate to SpectrumElement', async () => {
+        const el = await fixture(
+            html`
+                <test-downstate-el></test-downstate-el>
+            `
+        );
+        const controller = new DownState(
+            el as LitElement & { shadowRoot: ShadowRoot }
+        );
+        await nextFrame();
+        await nextFrame();
+        expect(
+            controller
+                .getElement()
+                .style.getPropertyValue('--spectrum-downstate-width')
+        ).to.equal('');
+        expect(
+            controller
+                .getElement()
+                .style.getPropertyValue('--spectrum-downstate-height')
+        ).to.equal('');
+
+        controller.getElement().dispatchEvent(new PointerEvent('pointerdown'));
+
+        await nextFrame();
+        await nextFrame();
+
+        // Checking if downstate is applied
+        const widthStyle = controller
+            .getElement()
+            .style.getPropertyValue('--spectrum-downstate-width');
+        const heightStyle = controller
+            .getElement()
+            .style.getPropertyValue('--spectrum-downstate-height');
+        expect(widthStyle).to.include('px');
+        expect(heightStyle).to.include('px');
+
+        controller.getElement().dispatchEvent(new PointerEvent('pointerup'));
+
+        await nextFrame();
+        await nextFrame();
+
+        // Checking if downstate is removed
+        expect(
+            controller
+                .getElement()
+                .style.getPropertyValue('--spectrum-downstate-width')
+        ).to.equal('');
+        expect(
+            controller
+                .getElement()
+                .style.getPropertyValue('--spectrum-downstate-height')
+        ).to.equal('');
+    });
+});

--- a/tools/styles/tokens/express/global-vars.css
+++ b/tools/styles/tokens/express/global-vars.css
@@ -1008,6 +1008,8 @@
     --system-spectrum-checkbox-control-color-focus: var(--spectrum-gray-900);
 }
 
+/*# sourceMappingURL=components/checkbox/themes/express.css.map */
+
 :host,
 :root {
     --system-spectrum-closebutton-background-color-default: transparent;

--- a/tools/styles/tokens/spectrum/global-vars.css
+++ b/tools/styles/tokens/spectrum/global-vars.css
@@ -1026,6 +1026,8 @@
     --system-spectrum-checkbox-control-color-focus: var(--spectrum-gray-700);
 }
 
+/*# sourceMappingURL=components/checkbox/themes/spectrum.css.map */
+
 :host,
 :root {
     --system-spectrum-closebutton-background-color-default: transparent;

--- a/tools/theme/src/Theme.ts
+++ b/tools/theme/src/Theme.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CSSResult,
     CSSResultGroup,
+    SpectrumElement,
     supportsAdoptingStyleSheets,
 } from '@spectrum-web-components/base';
 import { version } from '@spectrum-web-components/base/src/version.js';
@@ -533,6 +534,10 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
                 this.shadowRoot.appendChild(style);
             });
         }
+        this.trackedChildren.forEach((el) => {
+            const elm = el as unknown as SpectrumElement;
+            elm.spectrumDelegates.theme = this.theme;
+        });
     }
 
     static registerThemeFragment(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5101,10 +5101,10 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/card/-/card-7.0.2.tgz#4db4772fa6e67ce46a823faca390d57f3afe4512"
   integrity sha512-ftp5BEts14oCFxy9iA0RmndZs0lbbqQCO8Yovd60E73gJmlzlk9SuSiRTGJCGzfPZjm7kZN5q2qfXG9Iwr5Qdw==
 
-"@spectrum-css/checkbox@^8.1.5":
-  version "8.1.5"
-  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-8.1.5.tgz#4dd8ff605f37e8d24b4991528939c2c84ecaba5a"
-  integrity sha512-91xOm+Hj4IrfbPlyNchLf5YW4ohBJlEQq1Urw+mqHSrzjqH9MG+IXLRT9OAY9zhuKTHfEOTqXatgYtfFqR6ILQ==
+"@spectrum-css/checkbox@^14.0.0-next.2":
+  version "14.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/@spectrum-css/checkbox/-/checkbox-14.0.0-next.4.tgz#abbfc2e35e5538373a250a60e4cbbc658dac8994"
+  integrity sha512-JBLBJESd492ooOz33AJCK1Z7hLiAGfNTdk7lhr3R5a8N30LLIj0ozSaYPgqnSIv4lGtSLOw+ZZU8FWYO7iWwLw==
 
 "@spectrum-css/clearbutton@^5.1.4":
   version "5.1.4"
@@ -5391,8 +5391,82 @@
   resolved "https://registry.yarnpkg.com/@spectrum-css/vars/-/vars-9.0.8.tgz#6af3bcdace903b8461f5fcd4c9aa23e70128a456"
   integrity sha512-rGfd7jqXOdR69bEjrRP58ynuIeJU0czPfwQvzhtCzg7jKVukV+efNHqrs086sC6xutB3W4TF71K/dZMr3oyTyg==
 
+"@spectrum-web-components/base@^0.40.5":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/base/-/base-0.40.5.tgz#5e67bab5aa835d5ec3fa141abd14aaf5344ab9ee"
+  integrity sha512-lGvAkpWzaPuLBdKfFqQW5J4dBTsn8I9OxpfKoEifR9OdNEELJshNVs+9iZY+3AYx3s3Y2WRLnsGrxtWuNg595g==
+  dependencies:
+    lit "^2.5.0"
+
+"@spectrum-web-components/button-group@^0.40.4-next.0":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/button-group/-/button-group-0.40.5.tgz#27a1ba1de8ceba2b09598126bd9769a470481f34"
+  integrity sha512-vgxgy4UcAOkiWQh/qN6Oex08Zxj24vP2uwUSBt4DqYqhKY/yupg8P+RhyQ0xfSQC70sTHyeGb1nxMZYus5qQUQ==
+  dependencies:
+    "@spectrum-web-components/base" "^0.40.5"
+    "@spectrum-web-components/button" "^0.40.5"
+
+"@spectrum-web-components/button@^0.40.5":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/button/-/button-0.40.5.tgz#19424d1591390ca1b2255e4f6a3d60eacf4243bb"
+  integrity sha512-RWneeVltJgS3XWZlWd4cpzY6f8ZTaBRIJEy8RqPXeut90jb+VWZLdF/zhme8JpGK7hEfBcYGst31P06KebaIzw==
+  dependencies:
+    "@spectrum-web-components/base" "^0.40.5"
+    "@spectrum-web-components/clear-button" "^0.40.5"
+    "@spectrum-web-components/close-button" "^0.40.5"
+    "@spectrum-web-components/icon" "^0.40.5"
+    "@spectrum-web-components/icons-ui" "^0.40.5"
+    "@spectrum-web-components/shared" "^0.40.5"
+
+"@spectrum-web-components/clear-button@^0.40.5":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/clear-button/-/clear-button-0.40.5.tgz#33c8d4ea19fc94bc4b2db6cb1076bd831011f855"
+  integrity sha512-5BzW9qGNYJj8O3WLaeVBVGt71bK60tpX6NTLQJWV/lcfSENMPEsO1ztziCrxJ5ENz8Y4hG20HTGlqamVfFmt6Q==
+  dependencies:
+    "@spectrum-web-components/base" "^0.40.5"
+
+"@spectrum-web-components/close-button@^0.40.5":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/close-button/-/close-button-0.40.5.tgz#63a32235b7d6cc3c0a0e3ea6c19318d59174a781"
+  integrity sha512-ooSiUg1C7+GB6y2CoNusLmBor2huBSABG3Exo3BrQM2/viPf2BRUwnRj5ROh37VjdLCu3EUCpjxQ+n8nEcFKAA==
+  dependencies:
+    "@spectrum-web-components/base" "^0.40.5"
+
 "@spectrum-web-components/eslint-plugin@file:./linters/eslint":
   version "0.42.2"
+
+"@spectrum-web-components/icon@^0.40.5":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/icon/-/icon-0.40.5.tgz#901013ae5f44fe27a19fcf02e0f8a43fe3e0df8a"
+  integrity sha512-uWzrsZshOfUSy33aep5/ww9ZVoL2asKSUnUAIz6DTH4cmPiT9kNdJXJr0Srru+Xy0DhjGIrpKRCMGLThfYB8Ow==
+  dependencies:
+    "@spectrum-web-components/base" "^0.40.5"
+    "@spectrum-web-components/iconset" "^0.40.5"
+
+"@spectrum-web-components/icons-ui@^0.40.5":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/icons-ui/-/icons-ui-0.40.5.tgz#27b8e337fb162d090ea65ce7f1917a877bc1d226"
+  integrity sha512-bHYtTkFwAnz4jHWnmckOgvoEZPtskXfZXcM+us5J6kkOSfss4G6Npjra6+2Ud0OByGWD6KBilXbny3DBYLzAaA==
+  dependencies:
+    "@spectrum-web-components/base" "^0.40.5"
+    "@spectrum-web-components/icon" "^0.40.5"
+    "@spectrum-web-components/iconset" "^0.40.5"
+
+"@spectrum-web-components/iconset@^0.40.5":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/iconset/-/iconset-0.40.5.tgz#1b202059e26d4cbb7607596d3c4f7985494b1f01"
+  integrity sha512-MY0VFg7yH/j3M7BIIROFR0LGFNj3WJs8VVbV47Req4nQTx6VPOIndnK8uhjFFMleXqEX8w/jVSqZgiD1PQ6w/w==
+  dependencies:
+    "@spectrum-web-components/base" "^0.40.5"
+
+"@spectrum-web-components/shared@^0.40.5":
+  version "0.40.5"
+  resolved "https://registry.yarnpkg.com/@spectrum-web-components/shared/-/shared-0.40.5.tgz#d02311beed2b058f9d0930d7c2e4d2db58d6c09b"
+  integrity sha512-JyeBukaNmaacvl8Q0ezdbFRzBm/o/2uHmF7kOmWjElpe1KGH6RQ7JgRP9eiUW4ofMYKTOu5F7X5qqeTdvG9Z3g==
+  dependencies:
+    "@lit-labs/observers" "^2.0.0"
+    "@spectrum-web-components/base" "^0.40.5"
+    focus-visible "^5.1.0"
 
 "@storybook/addon-a11y@^7.5.0":
   version "7.6.17"


### PR DESCRIPTION
## Description

This PR adds the delegate strategy in SWC that allows us to add custom JS functionality over our existing components. This is needed so that we can support features like `downstate` in Spectrum 2 while keeping everything as it is in Spectrum 1

[Technical Document](https://paper.dropbox.com/doc/Tech-Adding-downstate-in-SWC-with-delegates--CM7vMhN7q6jYexR156mMlhl2Ag-V2v21xDURLM1rFpoacWTI)

## Motivation and context

The downstate feature in spectrum-two enhances user interaction by providing visual feedback when components are clicked or activated. It improves accessibility and user experience by clearly indicating the active state of elements. Developers can enable downstate for components, and it seamlessly integrates with existing functionality in the framework. This addition enriches the user interface, making interactions more intuitive and engaging.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] Button Downstate in storybook
    1. Go [here](https://delegate-controllers--spectrum-web-components.netlify.app/storybook/?path=/story/button-accent-fill--default)
    2. Click on the button and verify it has a downstate now.
    
## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
