### PR TITLE
docs: externalize lit in the build

### DIFF
--- a/projects/documentation/scripts/build-ts.js
+++ b/projects/documentation/scripts/build-ts.js
@@ -72,7 +72,13 @@ async function main() {
                 },
             }),
         ],
-        external: ['@spectrum-web-components/*'],
+        external: [
+            '@spectrum-web-components/*',
+            'lit-html',
+            'lit-element',
+            'lit',
+            '@lit/reactive-element',
+        ],
     });
     process.exit(0);
 }


### PR DESCRIPTION
Ensure we only get one copy of lit in the docs build.