### PR TITLE
perf(button): condense style into a helper function

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -47,9 +47,17 @@
         },
         "./src/button-base.css.js": "./src/button-base.css.js",
         "./src/button.css.js": "./src/button.css.js",
+        "./src/constructed-styles.js": {
+            "development": "./src/constructed-styles.dev.js",
+            "default": "./src/constructed-styles.js"
+        },
         "./src/index.js": {
             "development": "./src/index.dev.js",
             "default": "./src/index.js"
+        },
+        "./src/styles.js": {
+            "development": "./src/styles.dev.js",
+            "default": "./src/styles.js"
         },
         "./sp-button.js": {
             "development": "./sp-button.dev.js",

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -19,6 +19,7 @@ import {
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { ButtonBase } from './ButtonBase.js';
+import builtStyles from './constructed-styles.js';
 import buttonStyles from './button.css.js';
 import { when } from '@spectrum-web-components/base/src/directives.js';
 
@@ -51,7 +52,7 @@ export type ButtonTreatments = 'fill' | 'outline';
  */
 export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
     public static override get styles(): CSSResultArray {
-        return [...super.styles, buttonStyles];
+        return [...super.styles, builtStyles, buttonStyles];
     }
 
     @property({ type: String, attribute: 'pending-label' })

--- a/packages/button/src/button.css
+++ b/packages/button/src/button.css
@@ -10,7 +10,694 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-@import url('./spectrum-button.css');
+/* stylelint-disable */
+:host {
+    cursor: pointer;
+    -webkit-user-select: none;
+    user-select: none;
+    box-sizing: border-box;
+    font-family: var(
+        --mod-button-font-family,
+        var(
+            --mod-sans-font-family-stack,
+            var(--spectrum-sans-font-family-stack)
+        )
+    );
+    line-height: var(
+        --mod-button-line-height,
+        var(--mod-line-height-100, var(--spectrum-line-height-100))
+    );
+    text-transform: none;
+    vertical-align: top;
+    -webkit-appearance: button;
+    transition: background
+            var(
+                --mod-button-animation-duration,
+                var(
+                    --mod-animation-duration-100,
+                    var(--spectrum-animation-duration-100)
+                )
+            )
+            ease-out,
+        border-color
+            var(
+                --mod-button-animation-duration,
+                var(
+                    --mod-animation-duration-100,
+                    var(--spectrum-animation-duration-100)
+                )
+            )
+            ease-out,
+        color
+            var(
+                --mod-button-animation-duration,
+                var(
+                    --mod-animation-duration-100,
+                    var(--spectrum-animation-duration-100)
+                )
+            )
+            ease-out,
+        box-shadow
+            var(
+                --mod-button-animation-duration,
+                var(
+                    --mod-animation-duration-100,
+                    var(--spectrum-animation-duration-100)
+                )
+            )
+            ease-out;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    border-style: solid;
+    justify-content: center;
+    align-items: center;
+    margin: 0;
+    text-decoration: none;
+    display: inline-flex;
+    position: relative;
+    overflow: visible;
+}
+
+:host(:focus) {
+    outline: none;
+}
+
+:host([disabled]),
+:host .is-disabled {
+    cursor: default;
+}
+
+:host:after {
+    content: '';
+    margin: calc(
+        var(
+                --mod-button-focus-indicator-gap,
+                var(
+                    --mod-focus-indicator-gap,
+                    var(--spectrum-focus-indicator-gap)
+                )
+            ) * -1
+    );
+    transition: opacity
+            var(
+                --mod-button-animation-duration,
+                var(
+                    --mod-button-animation-duration,
+                    var(
+                        --mod-animation-duration-100,
+                        var(--spectrum-animation-duration-100)
+                    )
+                )
+            )
+            ease-out,
+        margin
+            var(
+                --mod-button-animation-duration,
+                var(
+                    --mod-button-animation-duration,
+                    var(
+                        --mod-animation-duration-100,
+                        var(--spectrum-animation-duration-100)
+                    )
+                )
+            )
+            ease-out;
+    display: block;
+    position: absolute;
+    inset-block: 0;
+    inset-inline: 0;
+}
+
+:host(:focus-visible):after {
+    margin: calc(
+        var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap)) * -2
+    );
+}
+
+#label {
+    text-align: center;
+    place-self: center;
+}
+
+#label[hidden] {
+    display: none;
+}
+
+:host {
+    --spectrum-button-animation-duration: var(
+        --spectrum-animation-duration-100
+    );
+    --spectrum-button-border-radius: var(--spectrum-corner-radius-100);
+    --spectrum-button-border-width: var(--spectrum-border-width-200);
+    --spectrum-button-line-height: 1.2;
+    --spectrum-button-focus-ring-gap: var(--spectrum-focus-indicator-gap);
+    --spectrum-button-focus-ring-border-radius: calc(
+        var(--spectrum-button-border-radius) +
+            var(--spectrum-button-focus-ring-gap)
+    );
+    --spectrum-button-focus-ring-thickness: var(
+        --spectrum-focus-indicator-thickness
+    );
+    --spectrum-button-focus-indicator-color: var(
+        --spectrum-focus-indicator-color
+    );
+    --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-50);
+}
+
+:host([size='s']) {
+    --spectrum-button-min-width: calc(
+        var(--spectrum-component-height-75) *
+            var(--spectrum-button-minimum-width-multiplier)
+    );
+    --spectrum-button-border-radius: var(
+        --spectrum-component-pill-edge-to-text-75
+    );
+    --spectrum-button-height: var(--spectrum-component-height-75);
+    --spectrum-button-font-size: var(--spectrum-font-size-75);
+    --spectrum-button-edge-to-visual: calc(
+        var(--spectrum-component-pill-edge-to-visual-75) -
+            var(--spectrum-button-border-width)
+    );
+    --spectrum-button-edge-to-visual-only: var(
+        --spectrum-component-pill-edge-to-visual-only-75
+    );
+    --spectrum-button-edge-to-text: calc(
+        var(--spectrum-component-pill-edge-to-text-75) -
+            var(--spectrum-button-border-width)
+    );
+    --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-75);
+    --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-small);
+    --spectrum-button-bottom-to-text: var(
+        --spectrum-button-bottom-to-text-small
+    );
+    --spectrum-button-top-to-icon: var(
+        --spectrum-component-top-to-workflow-icon-75
+    );
+    --spectrum-button-intended-icon-size: var(--spectrum-workflow-icon-size-75);
+}
+
+:host {
+    --spectrum-button-min-width: calc(
+        var(--spectrum-component-height-100) *
+            var(--spectrum-button-minimum-width-multiplier)
+    );
+    --spectrum-button-border-radius: var(
+        --spectrum-component-pill-edge-to-text-100
+    );
+    --spectrum-button-height: var(--spectrum-component-height-100);
+    --spectrum-button-font-size: var(--spectrum-font-size-100);
+    --spectrum-button-edge-to-visual: calc(
+        var(--spectrum-component-pill-edge-to-visual-100) -
+            var(--spectrum-button-border-width)
+    );
+    --spectrum-button-edge-to-visual-only: var(
+        --spectrum-component-pill-edge-to-visual-only-100
+    );
+    --spectrum-button-edge-to-text: calc(
+        var(--spectrum-component-pill-edge-to-text-100) -
+            var(--spectrum-button-border-width)
+    );
+    --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-100);
+    --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-medium);
+    --spectrum-button-bottom-to-text: var(
+        --spectrum-button-bottom-to-text-medium
+    );
+    --spectrum-button-top-to-icon: var(
+        --spectrum-component-top-to-workflow-icon-100
+    );
+    --spectrum-button-intended-icon-size: var(
+        --spectrum-workflow-icon-size-100
+    );
+}
+
+:host([pending]),
+:host([pending]) {
+    --mod-button-edge-to-visual-only: calc(
+        1px + var(--spectrum-button-edge-to-visual-only)
+    );
+}
+
+:host([size='l']) {
+    --spectrum-button-min-width: calc(
+        var(--spectrum-component-height-200) *
+            var(--spectrum-button-minimum-width-multiplier)
+    );
+    --spectrum-button-border-radius: var(
+        --spectrum-component-pill-edge-to-text-200
+    );
+    --spectrum-button-height: var(--spectrum-component-height-200);
+    --spectrum-button-font-size: var(--spectrum-font-size-200);
+    --spectrum-button-edge-to-visual: calc(
+        var(--spectrum-component-pill-edge-to-visual-200) -
+            var(--spectrum-button-border-width)
+    );
+    --spectrum-button-edge-to-visual-only: var(
+        --spectrum-component-pill-edge-to-visual-only-200
+    );
+    --spectrum-button-edge-to-text: calc(
+        var(--spectrum-component-pill-edge-to-text-200) -
+            var(--spectrum-button-border-width)
+    );
+    --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-200);
+    --spectrum-button-top-to-text: var(--spectrum-button-top-to-text-large);
+    --spectrum-button-bottom-to-text: var(
+        --spectrum-button-bottom-to-text-large
+    );
+    --spectrum-button-top-to-icon: var(
+        --spectrum-component-top-to-workflow-icon-200
+    );
+    --spectrum-button-intended-icon-size: var(
+        --spectrum-workflow-icon-size-200
+    );
+}
+
+:host([size='l'][pending]),
+:host([size='l'][pending]) {
+    --mod-button-edge-to-visual-only: calc(
+        2px + var(--spectrum-button-edge-to-visual-only)
+    );
+}
+
+:host([size='xl']) {
+    --spectrum-button-min-width: calc(
+        var(--spectrum-component-height-300) *
+            var(--spectrum-button-minimum-width-multiplier)
+    );
+    --spectrum-button-border-radius: var(
+        --spectrum-component-pill-edge-to-text-300
+    );
+    --spectrum-button-height: var(--spectrum-component-height-300);
+    --spectrum-button-font-size: var(--spectrum-font-size-300);
+    --spectrum-button-edge-to-visual: calc(
+        var(--spectrum-component-pill-edge-to-visual-300) -
+            var(--spectrum-button-border-width)
+    );
+    --spectrum-button-edge-to-visual-only: var(
+        --spectrum-component-pill-edge-to-visual-only-300
+    );
+    --spectrum-button-edge-to-text: calc(
+        var(--spectrum-component-pill-edge-to-text-300) -
+            var(--spectrum-button-border-width)
+    );
+    --spectrum-button-padding-label-to-icon: var(--spectrum-text-to-visual-300);
+    --spectrum-button-top-to-text: var(
+        --spectrum-button-top-to-text-extra-large
+    );
+    --spectrum-button-bottom-to-text: var(
+        --spectrum-button-bottom-to-text-extra-large
+    );
+    --spectrum-button-top-to-icon: var(
+        --spectrum-component-top-to-workflow-icon-300
+    );
+    --spectrum-button-intended-icon-size: var(
+        --spectrum-workflow-icon-size-300
+    );
+}
+
+:host([size='xl'][pending]) .spectrum--medium,
+:host([size='xl'][pending]) .spectrum--medium {
+    --mod-button-edge-to-visual-only: calc(
+        3px + var(--spectrum-button-edge-to-visual-only)
+    );
+}
+
+:host([size='xl'][pending]) .spectrum--large,
+:host([size='xl'][pending]) .spectrum--large {
+    --mod-button-edge-to-visual-only: calc(
+        4px + var(--spectrum-button-edge-to-visual-only)
+    );
+}
+
+:host {
+    border-radius: var(
+        --mod-button-border-radius,
+        var(--spectrum-button-border-radius)
+    );
+    border-width: var(
+        --mod-button-border-width,
+        var(--spectrum-button-border-width)
+    );
+    font-size: var(--mod-button-font-size, var(--spectrum-button-font-size));
+    font-weight: var(--mod-bold-font-weight, var(--spectrum-bold-font-weight));
+    gap: var(
+        --mod-button-padding-label-to-icon,
+        var(--spectrum-button-padding-label-to-icon)
+    );
+    min-inline-size: var(
+        --mod-button-min-width,
+        var(--spectrum-button-min-width)
+    );
+    min-block-size: var(--mod-button-height, var(--spectrum-button-height));
+    padding-block: 0;
+    padding-inline: var(
+        --mod-button-edge-to-text,
+        var(--spectrum-button-edge-to-text)
+    );
+    color: inherit;
+    margin-block: var(--mod-button-margin-block);
+    border-style: solid;
+    margin-inline-start: var(--mod-button-margin-left);
+    margin-inline-end: var(--mod-button-margin-right);
+    position: relative;
+}
+
+:host(:is(:active, [active])) {
+    box-shadow: none;
+}
+
+::slotted([slot='icon']) {
+    --_icon-size-difference: max(
+        0px,
+        var(--spectrum-button-intended-icon-size) -
+            var(
+                --spectrum-icon-block-size,
+                var(--spectrum-button-intended-icon-size)
+            )
+    );
+    color: inherit;
+    flex-shrink: 0;
+    align-self: flex-start;
+    margin-block-start: var(
+        --mod-button-icon-margin-block-start,
+        max(
+            0px,
+            var(--mod-button-top-to-icon, var(--spectrum-button-top-to-icon)) -
+                var(
+                    --mod-button-border-width,
+                    var(--spectrum-button-border-width)
+                ) + (var(--_icon-size-difference, 0px) / 2)
+        )
+    );
+    margin-inline-start: calc(
+        var(--mod-button-edge-to-visual, var(--spectrum-button-edge-to-visual)) -
+            var(--mod-button-edge-to-text, var(--spectrum-button-edge-to-text))
+    );
+}
+
+:host:after {
+    border-radius: calc(
+        var(--mod-button-border-radius, var(--spectrum-button-border-radius)) +
+            var(--mod-focus-indicator-gap, var(--spectrum-focus-indicator-gap))
+    );
+}
+
+:host([icon-only]) {
+    min-inline-size: unset;
+    padding: calc(
+        var(
+                --mod-button-edge-to-visual-only,
+                var(--spectrum-button-edge-to-visual-only)
+            ) -
+            var(--mod-button-border-width, var(--spectrum-button-border-width))
+    );
+    border-radius: 50%;
+}
+
+:host([icon-only]) ::slotted([slot='icon']) {
+    align-self: center;
+    margin-block-start: 0;
+    margin-inline-start: 0;
+}
+
+:host([icon-only]):after {
+    border-radius: 50%;
+}
+
+#label {
+    line-height: var(
+        --mod-button-line-height,
+        var(--spectrum-button-line-height)
+    );
+    text-align: var(--mod-button-text-align, center);
+    align-self: start;
+    padding-block-start: calc(
+        var(--mod-button-top-to-text, var(--spectrum-button-top-to-text)) -
+            var(--mod-button-border-width, var(--spectrum-button-border-width))
+    );
+    padding-block-end: calc(
+        var(--mod-button-bottom-to-text, var(--spectrum-button-bottom-to-text)) -
+            var(--mod-button-border-width, var(--spectrum-button-border-width))
+    );
+}
+
+[name='icon'] + #label {
+    text-align: var(--mod-button-text-align-with-icon, start);
+}
+
+:host(:focus-visible):after,
+:host([focused]):after {
+    box-shadow: 0 0 0
+        var(
+            --mod-button-focus-ring-thickness,
+            var(--spectrum-button-focus-ring-thickness)
+        )
+        var(
+            --mod-button-focus-ring-color,
+            var(--spectrum-button-focus-indicator-color)
+        );
+}
+
+:host {
+    transition: border-color
+        var(
+            --mod-button-animation-duration,
+            var(--spectrum-button-animation-duration)
+        )
+        ease-in-out;
+}
+
+:host:after {
+    margin: calc(
+        (
+                var(
+                        --mod-button-focus-ring-gap,
+                        var(--spectrum-button-focus-ring-gap)
+                    ) +
+                    var(
+                        --mod-button-border-width,
+                        var(--spectrum-button-border-width)
+                    )
+            ) * -1
+    );
+    border-radius: var(
+        --mod-button-focus-ring-border-radius,
+        var(--spectrum-button-focus-ring-border-radius)
+    );
+    transition: box-shadow
+        var(
+            --mod-button-animation-duration,
+            var(--spectrum-button-animation-duration)
+        )
+        ease-in-out;
+    pointer-events: none;
+    content: '';
+    position: absolute;
+    inset: 0;
+}
+
+:host(:focus-visible) {
+    box-shadow: none;
+    outline: none;
+}
+
+:host(:focus-visible):after {
+    box-shadow: 0 0 0
+        var(
+            --mod-button-focus-ring-thickness,
+            var(--spectrum-button-focus-ring-thickness)
+        )
+        var(
+            --highcontrast-button-focus-ring-color,
+            var(
+                --mod-button-focus-ring-color,
+                var(
+                    --mod-button-focus-ring-color,
+                    var(--spectrum-button-focus-indicator-color)
+                )
+            )
+        );
+}
+
+:host {
+    background-color: var(
+        --highcontrast-button-background-color-default,
+        var(
+            --mod-button-background-color-default,
+            var(--spectrum-button-background-color-default)
+        )
+    );
+    border-color: var(
+        --highcontrast-button-border-color-default,
+        var(
+            --mod-button-border-color-default,
+            var(--spectrum-button-border-color-default)
+        )
+    );
+    color: var(
+        --highcontrast-button-content-color-default,
+        var(
+            --mod-button-content-color-default,
+            var(--spectrum-button-content-color-default)
+        )
+    );
+}
+
+@media (hover: hover) {
+    :host(:hover) {
+        box-shadow: none;
+        background-color: var(
+            --highcontrast-button-background-color-hover,
+            var(
+                --mod-button-background-color-hover,
+                var(--spectrum-button-background-color-hover)
+            )
+        );
+        border-color: var(
+            --highcontrast-button-border-color-hover,
+            var(
+                --mod-button-border-color-hover,
+                var(--spectrum-button-border-color-hover)
+            )
+        );
+        color: var(
+            --highcontrast-button-content-color-hover,
+            var(
+                --mod-button-content-color-hover,
+                var(--spectrum-button-content-color-hover)
+            )
+        );
+    }
+}
+
+:host(:focus-visible) {
+    background-color: var(
+        --highcontrast-button-background-color-focus,
+        var(
+            --mod-button-background-color-focus,
+            var(--spectrum-button-background-color-focus)
+        )
+    );
+    border-color: var(
+        --highcontrast-button-border-color-focus,
+        var(
+            --mod-button-border-color-focus,
+            var(--spectrum-button-border-color-focus)
+        )
+    );
+    color: var(
+        --highcontrast-button-content-color-focus,
+        var(
+            --mod-button-content-color-focus,
+            var(--spectrum-button-content-color-focus)
+        )
+    );
+}
+
+:host(:is(:active, [active])) {
+    background-color: var(
+        --highcontrast-button-background-color-down,
+        var(
+            --mod-button-background-color-down,
+            var(--spectrum-button-background-color-down)
+        )
+    );
+    border-color: var(
+        --highcontrast-button-border-color-down,
+        var(
+            --mod-button-border-color-down,
+            var(--spectrum-button-border-color-down)
+        )
+    );
+    color: var(
+        --highcontrast-button-content-color-down,
+        var(
+            --mod-button-content-color-down,
+            var(--spectrum-button-content-color-down)
+        )
+    );
+}
+
+:host([disabled]),
+:host .is-disabled,
+:host([pending]),
+:host([pending]) {
+    background-color: var(
+        --highcontrast-button-background-color-disabled,
+        var(
+            --mod-button-background-color-disabled,
+            var(--spectrum-button-background-color-disabled)
+        )
+    );
+    border-color: var(
+        --highcontrast-button-border-color-disabled,
+        var(
+            --mod-button-border-color-disabled,
+            var(--spectrum-button-border-color-disabled)
+        )
+    );
+    color: var(
+        --highcontrast-button-content-color-disabled,
+        var(
+            --mod-button-content-color-disabled,
+            var(--spectrum-button-content-color-disabled)
+        )
+    );
+}
+
+:host([pending]),
+:host([pending]) {
+    cursor: default;
+}
+
+:host([static='white']),
+:host([static='black']) {
+    --spectrum-button-focus-indicator-color: var(
+        --mod-static-black-focus-indicator-color,
+        var(--spectrum-static-black-focus-indicator-color)
+    );
+}
+
+@media (forced-colors: active) {
+    :host {
+        --highcontrast-button-content-color-disabled: GrayText;
+        --highcontrast-button-border-color-disabled: GrayText;
+        --mod-progress-circle-track-border-color: ButtonText;
+        --mod-progress-circle-track-border-color-over-background: ButtonText;
+        --mod-progress-circle-thickness: var(
+            --spectrum-progress-circle-thickness-medium
+        );
+    }
+
+    :host(:focus-visible):after {
+        forced-color-adjust: none;
+        box-shadow: 0 0 0
+            var(
+                --mod-button-focus-ring-thickness,
+                var(--spectrum-button-focus-ring-thickness)
+            )
+            ButtonText;
+    }
+
+    :host([variant='accent'][treatment='fill']) {
+        --highcontrast-button-background-color-default: ButtonText;
+        --highcontrast-button-content-color-default: ButtonFace;
+        --highcontrast-button-background-color-disabled: ButtonFace;
+        --highcontrast-button-background-color-hover: Highlight;
+        --highcontrast-button-background-color-down: Highlight;
+        --highcontrast-button-background-color-focus: Highlight;
+        --highcontrast-button-content-color-hover: ButtonFace;
+        --highcontrast-button-content-color-down: ButtonFace;
+        --highcontrast-button-content-color-focus: ButtonFace;
+    }
+
+    :host([variant='accent'][treatment='fill']) #label {
+        forced-color-adjust: none;
+    }
+}
+
+/* stylelint-enable */
+
+/* Original */
 
 @media (forced-colors: active) {
     :host([treatment][disabled]) {

--- a/packages/button/src/constructed-styles.ts
+++ b/packages/button/src/constructed-styles.ts
@@ -1,0 +1,176 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { css } from '@spectrum-web-components/base';
+import variant from './styles.js';
+
+export default css`
+    ${variant()}
+    ${variant({ variant: css`accent` })}
+${variant({ variant: css`accent`, treatment: css`outline` })}
+${variant({ variant: css`negative` })}
+${variant({ variant: css`negative`, treatment: css`outline` })}
+${variant({ variant: css`primary` })}
+${variant({ variant: css`primary`, treatment: css`outline` })}
+${variant({ variant: css`secondary` })}
+${variant({ variant: css`secondary`, treatment: css`outline` })}
+
+:host([quiet]) {
+        --spectrum-button-background-color-default: var(
+            --system-spectrum-button-quiet-background-color-default
+        );
+        --spectrum-button-background-color-hover: var(
+            --system-spectrum-button-quiet-background-color-hover
+        );
+        --spectrum-button-background-color-down: var(
+            --system-spectrum-button-quiet-background-color-down
+        );
+        --spectrum-button-background-color-focus: var(
+            --system-spectrum-button-quiet-background-color-focus
+        );
+        --spectrum-button-border-color-default: var(
+            --system-spectrum-button-quiet-border-color-default
+        );
+        --spectrum-button-border-color-hover: var(
+            --system-spectrum-button-quiet-border-color-hover
+        );
+        --spectrum-button-border-color-down: var(
+            --system-spectrum-button-quiet-border-color-down
+        );
+        --spectrum-button-border-color-focus: var(
+            --system-spectrum-button-quiet-border-color-focus
+        );
+        --spectrum-button-background-color-disabled: var(
+            --system-spectrum-button-quiet-background-color-disabled
+        );
+        --spectrum-button-border-color-disabled: var(
+            --system-spectrum-button-quiet-border-color-disabled
+        );
+    }
+
+    ${variant({ selected: css`selected` })}
+
+    :host([selected][emphasized]) {
+        --spectrum-button-background-color-default: var(
+            --system-spectrum-button-selected-emphasized-background-color-default
+        );
+        --spectrum-button-background-color-hover: var(
+            --system-spectrum-button-selected-emphasized-background-color-hover
+        );
+        --spectrum-button-background-color-down: var(
+            --system-spectrum-button-selected-emphasized-background-color-down
+        );
+        --spectrum-button-background-color-focus: var(
+            --system-spectrum-button-selected-emphasized-background-color-focus
+        );
+    }
+
+    :host([static='black'][quiet]) {
+        --spectrum-button-border-color-default: var(
+            --system-spectrum-button-staticblack-quiet-border-color-default
+        );
+        --spectrum-button-border-color-hover: var(
+            --system-spectrum-button-staticblack-quiet-border-color-hover
+        );
+        --spectrum-button-border-color-down: var(
+            --system-spectrum-button-staticblack-quiet-border-color-down
+        );
+        --spectrum-button-border-color-focus: var(
+            --system-spectrum-button-staticblack-quiet-border-color-focus
+        );
+        --spectrum-button-border-color-disabled: var(
+            --system-spectrum-button-staticblack-quiet-border-color-disabled
+        );
+    }
+
+    :host([static='white'][quiet]) {
+        --spectrum-button-border-color-default: var(
+            --system-spectrum-button-staticwhite-quiet-border-color-default
+        );
+        --spectrum-button-border-color-hover: var(
+            --system-spectrum-button-staticwhite-quiet-border-color-hover
+        );
+        --spectrum-button-border-color-down: var(
+            --system-spectrum-button-staticwhite-quiet-border-color-down
+        );
+        --spectrum-button-border-color-focus: var(
+            --system-spectrum-button-staticwhite-quiet-border-color-focus
+        );
+        --spectrum-button-border-color-disabled: var(
+            --system-spectrum-button-staticwhite-quiet-border-color-disabled
+        );
+    }
+
+    ${variant({ staticValue: css`white` })}
+    ${variant({ staticValue: css`white`, treatment: css`outline` })}
+
+:host([static='white'][selected]) {
+        --spectrum-button-background-color-default: var(
+            --system-spectrum-button-staticwhite-selected-background-color-default
+        );
+        --spectrum-button-background-color-hover: var(
+            --system-spectrum-button-staticwhite-selected-background-color-hover
+        );
+        --spectrum-button-background-color-down: var(
+            --system-spectrum-button-staticwhite-selected-background-color-down
+        );
+        --spectrum-button-background-color-focus: var(
+            --system-spectrum-button-staticwhite-selected-background-color-focus
+        );
+        --spectrum-button-content-color-default: var(
+            --mod-button-static-content-color,
+            var(
+                --system-spectrum-button-staticwhite-selected-content-color-default
+            )
+        );
+        --spectrum-button-content-color-hover: var(
+            --mod-button-static-content-color,
+            var(
+                --system-spectrum-button-staticwhite-selected-content-color-hover
+            )
+        );
+        --spectrum-button-content-color-down: var(
+            --mod-button-static-content-color,
+            var(
+                --system-spectrum-button-staticwhite-selected-content-color-down
+            )
+        );
+        --spectrum-button-content-color-focus: var(
+            --mod-button-static-content-color,
+            var(
+                --system-spectrum-button-staticwhite-selected-content-color-focus
+            )
+        );
+        --spectrum-button-background-color-disabled: var(
+            --system-spectrum-button-staticwhite-selected-background-color-disabled
+        );
+        --spectrum-button-border-color-disabled: var(
+            --system-spectrum-button-staticwhite-selected-border-color-disabled
+        );
+    }
+
+    ${variant({ staticValue: css`white`, variant: css`secondary` })}
+    ${variant({
+        staticValue: css`white`,
+        variant: css`secondary`,
+        treatment: css`outline`,
+    })}
+
+${variant({ staticValue: css`black` })}
+${variant({ staticValue: css`black`, treatment: css`outline` })}
+${variant({ staticValue: css`black`, variant: css`secondary` })}
+${variant({
+        staticValue: css`black`,
+        variant: css`secondary`,
+        treatment: css`outline`,
+    })}
+`;

--- a/packages/button/src/styles.ts
+++ b/packages/button/src/styles.ts
@@ -1,0 +1,108 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { css, type CSSResult } from '@spectrum-web-components/base';
+
+export default ({
+    staticValue,
+    variant,
+    selected,
+    treatment,
+}: {
+    staticValue?: CSSResult;
+    variant?: CSSResult;
+    selected?: CSSResult;
+    treatment?: CSSResult;
+} = {}): CSSResult => {
+    let modifier = css``;
+    let selector = css``;
+    if (staticValue && variant && !selected && treatment) {
+        modifier = css`static${staticValue}-${variant}-${treatment}-`;
+        selector = css`[static='${staticValue}'][variant='${variant}'][treatment='${treatment}']`;
+    } else if (staticValue && variant && !selected && !treatment) {
+        modifier = css`static${staticValue}-${variant}-`;
+        selector = css`[static='${staticValue}'][variant='${variant}']`;
+    } else if (staticValue && !variant && !selected && treatment) {
+        modifier = css`static${staticValue}-${treatment}-`;
+        selector = css`[static='${staticValue}'][treatment='${treatment}']`;
+    } else if (staticValue && !variant && !selected && !treatment) {
+        modifier = css`static${staticValue}-`;
+        selector = css`[static='${staticValue}']`;
+    } else if (!staticValue && variant && !selected && treatment) {
+        modifier = css`
+            ${variant}-${treatment}-
+        `;
+        selector = css`[variant='${variant}'][treatment='${treatment}']`;
+    } else if (!staticValue && variant && !selected && !treatment) {
+        modifier = css`
+            ${variant}-
+        `;
+        selector = css`[variant='${variant}']`;
+    } else if (!staticValue && !variant && selected && !treatment) {
+        modifier = css`
+            ${selected}-
+        `;
+        selector = css`[${selected}]`;
+    }
+    return css`
+        :host(${selector}) {
+            --spectrum-button-background-color-default: var(
+                --system-spectrum-button-${modifier}background-color-default
+            );
+            --spectrum-button-background-color-hover: var(
+                --system-spectrum-button-${modifier}background-color-hover
+            );
+            --spectrum-button-background-color-down: var(
+                --system-spectrum-button-${modifier}background-color-down
+            );
+            --spectrum-button-background-color-focus: var(
+                --system-spectrum-button-${modifier}background-color-focus
+            );
+            --spectrum-button-border-color-default: var(
+                --system-spectrum-button-${modifier}border-color-default
+            );
+            --spectrum-button-border-color-hover: var(
+                --system-spectrum-button-${modifier}border-color-hover
+            );
+            --spectrum-button-border-color-down: var(
+                --system-spectrum-button-${modifier}border-color-down
+            );
+            --spectrum-button-border-color-focus: var(
+                --system-spectrum-button-${modifier}border-color-focus
+            );
+            --spectrum-button-content-color-default: var(
+                --system-spectrum-button-${modifier}content-color-default
+            );
+            --spectrum-button-content-color-hover: var(
+                --system-spectrum-button-${modifier}content-color-hover
+            );
+            --spectrum-button-content-color-down: var(
+                --system-spectrum-button-${modifier}content-color-down
+            );
+            --spectrum-button-content-color-focus: var(
+                --system-spectrum-button-${modifier}content-color-focus
+            );
+            --spectrum-button-focus-indicator-color: var(
+                --system-spectrum-button-${modifier}focus-indicator-color
+            );
+            --spectrum-button-background-color-disabled: var(
+                --system-spectrum-button-${modifier}background-color-disabled
+            );
+            --spectrum-button-border-color-disabled: var(
+                --system-spectrum-button-${modifier}border-color-disabled
+            );
+            --spectrum-button-content-color-disabled: var(
+                --system-spectrum-button-${modifier}content-color-disabled
+            );
+        }
+    `;
+};


### PR DESCRIPTION
## Description
CSS for Button and Action Button represent a large amount of the local minimum of code required to delivery SWC. This experiments with a more brittle conversion of the Spectrum CSS source for Button to a helper function that reduced a large amount of duplication ~1000 lines of it.

⚠️ This currently does _more_ than the default CSS in most cases, but also leaves out Focus Ring modifiers for the static variants.

Testing docs site output and perf results to empower a larger conversation here.

Additional testing for Action Button forthcoming.

## How has this been tested?

-   [ ] _Test case 1_
    1. See the VRT tests pass
    2. They might not right now
-   [ ] _Test case 2_
    1. See the Tachometer tests
    2. Do they show a positive files size and possibly a positive runtime change?
-   [ ] _Test case 3_
    1. See the Lighthouse results
    2. Do they show a positive files size and possibly overall score change?

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.