### PR TITLE
fix(combobox): process styles for invalid state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 7563a4f7674e3d799edc0555058b6f9ba1fa75ea
+        default: 6f0c5b300aeb3aa4cd978f0aac3edb6b0b0d84b3
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -147,6 +147,33 @@ Whenever the currently-typed input exactly matches the `value` of a popup menu i
 
 The popup menu items are filtered to only those completing the currently-input value.
 
+## States
+
+### Disabled
+
+```html
+<sp-field-label for="color">Color</sp-field-label>
+<sp-combobox id="color" disabled>
+    <sp-menu-item value="red">Red</sp-menu-item>
+    <sp-menu-item value="green">Green</sp-menu-item>
+    <sp-menu-item value="blue">Blue</sp-menu-item>
+</sp-combobox>
+```
+
+### Invalid
+
+```html
+<sp-field-label for="color">Color</sp-field-label>
+<sp-combobox id="color" invalid>
+    <sp-menu-item value="red">Red</sp-menu-item>
+    <sp-menu-item value="green">Green</sp-menu-item>
+    <sp-menu-item value="blue">Blue</sp-menu-item>
+    <sp-help-text slot="negative-help-text">
+        Choose or add at least one color.
+    </sp-help-text>
+</sp-combobox>
+```
+
 ## Focus and Accessibility
 
 The combobox supports both mouse and keyboard navigation.

--- a/packages/combobox/src/spectrum-combobox.css
+++ b/packages/combobox/src/spectrum-combobox.css
@@ -543,7 +543,7 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Combobox-textfield {
+#textfield {
     inline-size: 100%;
 }
 
@@ -616,7 +616,7 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Combobox-textfield #input,
+:host([focused]) #textfield #input,
 #input:focus {
     --mod-textfield-background-color: var(
         --mod-combobox-background-color-focus
@@ -690,14 +690,14 @@ governing permissions and limitations under the License.
         );
     }
 
-    .spectrum-Combobox-textfield #input,
+    #textfield:hover #input,
     #input:hover {
         --mod-textfield-background-color: var(
             --mod-combobox-background-color-hover
         );
     }
 
-    .spectrum-Combobox-textfield #input:hover,
+    :host([focused]) #textfield #input:hover,
     #input:focus:hover {
         --mod-textfield-background-color: var(
             --mod-combobox-background-color-focus-hover
@@ -705,14 +705,14 @@ governing permissions and limitations under the License.
     }
 }
 
-.spectrum-Combobox-textfield #input {
+:host([keyboard-focused]) #textfield #input {
     --mod-textfield-background-color: var(
         --mod-combobox-background-color-key-focus
     );
 }
 
-.spectrum-Combobox-textfield #input,
-.spectrum-Combobox-textfield #input {
+:host([invalid]) #textfield #input,
+#textfield.is-loading #input {
     padding-inline-end: calc(
         var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) +
             var(
@@ -735,7 +735,7 @@ governing permissions and limitations under the License.
     );
 }
 
-.spectrum-Combobox-textfield .spectrum-Textfield-validationIcon {
+:host([invalid]) #textfield .icon {
     inline-size: var(
         --mod-combobox-icon-size,
         var(--spectrum-combobox-icon-size)
@@ -764,9 +764,9 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([disabled]) .spectrum-Textfield .spectrum-Textfield-validationIcon,
-.spectrum-Textfield.is-readOnly .spectrum-Textfield-validationIcon,
-.spectrum-Textfield.is-loading .spectrum-Textfield-validationIcon {
+:host([disabled]) .spectrum-Textfield .icon,
+.spectrum-Textfield.is-readOnly .icon,
+.spectrum-Textfield.is-loading .icon {
     display: none;
 }
 
@@ -774,7 +774,7 @@ governing permissions and limitations under the License.
     border-radius: 0;
 }
 
-:host([quiet]) .spectrum-Combobox-textfield .spectrum-Textfield-validationIcon {
+:host([quiet][invalid]) #textfield .icon {
     inset-inline-end: var(
         --mod-combobox-button-width,
         var(--spectrum-combobox-button-width)
@@ -817,8 +817,8 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([quiet]) .spectrum-Combobox-textfield #input,
-:host([quiet]) .spectrum-Combobox-textfield #input {
+:host([quiet][invalid]) #textfield #input,
+:host([quiet]) #textfield.is-loading #input {
     padding-inline-end: calc(
         var(--mod-combobox-button-width, var(--spectrum-combobox-button-width)) +
             var(

--- a/packages/combobox/src/spectrum-config.js
+++ b/packages/combobox/src/spectrum-config.js
@@ -101,11 +101,11 @@ const config = {
                     hoist: true,
                 },
                 converter.classToId('spectrum-Combobox-input'),
-                {
-                    find: [builder.class('spectrum-Combobox-textfield')],
-                    replace: [],
-                    collapseSelector: true,
-                },
+                converter.classToId('spectrum-Combobox-textfield'),
+                converter.classToClass(
+                    'spectrum-Textfield-validationIcon',
+                    'icon'
+                ),
             ],
             excludeByComponents: [
                 {

--- a/packages/combobox/stories/combobox.stories.ts
+++ b/packages/combobox/stories/combobox.stories.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -50,6 +50,19 @@ export const disabled = (): TemplateResult => {
             .options=${countries}
             value="Azerbaijan"
         ></sp-combobox>
+    `;
+};
+
+export const invalid = (): TemplateResult => {
+    return html`
+        <sp-field-label for="combobox-invalid">
+            What would you like to eat for dessert?
+        </sp-field-label>
+        <sp-combobox id="combobox-invalid" .options=${fruits} invalid>
+            <sp-help-text slot="negative-help-text">
+                Choose or add at least one fruit.
+            </sp-help-text>
+        </sp-combobox>
     `;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR aims to fix a misalignment for the "Invalid" icon inside the combobox.
![Screenshot 2024-04-30 at 13 58 22](https://github.com/adobe/spectrum-web-components/assets/13311865/000de68f-17b5-4fa5-b8e2-64b7593d49d0)

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/4330

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

See https://github.com/adobe/spectrum-web-components/issues/4330 for more details.

**Disclaimer**: While this looks OK now for default state, for `quiet` state the layout is still a little bit broken. This seems to be due to `sp-picker-button` which no longer has the `quiet` styles. I propose to fix this in a different PR, since it seems to be a different issue and it affects a different component as well.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://rocss-invalid-combobox--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--invalid)
    2. Open the "Invalid" story and compare it against [Spectrum CSS](https://opensource.adobe.com/spectrum-css/combobox.html#invalid)
-   [ ] _Test case 2_
    1. Go [here](https://rocss-invalid-combobox--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--invalid)
    2. Switch to RTL 
    3. Validation icon should be correctly positioned to the left
-   [ ] _Test case 3_
    1. `disabled` + `invalid`
    2. Validation icon should not be visible
-   [ ] _Test case 4_
    1. `readonly` + `invalid`
    2. Validation icon should not be visible
-   [ ] _Test case 5_
    1. Go [here](https://rocss-invalid-combobox--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--invalid)
    2. Insert a very long text
    3. Text is not overlapping with the icon and it is displayed in ellipsis

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
