### PR TITLE
docs: manage search overlay

### DIFF
--- a/packages/overlay/src/Overlay.ts
+++ b/packages/overlay/src/Overlay.ts
@@ -393,6 +393,7 @@ export class Overlay extends OverlayFeatures {
             return ancestors;
         };
         if (
+            this.receivesFocus !== 'false' &&
             (this.triggerElement as HTMLElement)?.focus &&
             (this.contains((this.getRootNode() as Document).activeElement) ||
                 getAncestors().includes(this) ||

--- a/projects/documentation/src/components/side-nav-search.ts
+++ b/projects/documentation/src/components/side-nav-search.ts
@@ -23,8 +23,9 @@ import {
     query,
 } from '@spectrum-web-components/base/src/decorators.js';
 import sideNavSearchMenuStyles from './side-nav-search.css';
-import { Search } from '@spectrum-web-components/search';
-import { Popover } from '@spectrum-web-components/popover';
+import type { Search } from '@spectrum-web-components/search';
+import type { Overlay } from '@spectrum-web-components/overlay';
+import type { Popover } from '@spectrum-web-components/popover';
 import type { ResultGroup } from './search-index.js';
 import { Menu } from '@spectrum-web-components/menu';
 import '@spectrum-web-components/overlay/sp-overlay.js';
@@ -34,16 +35,17 @@ const stopPropagation = (event: Event): void => event.stopPropagation();
 
 @customElement('docs-search')
 export class SearchComponent extends LitElement {
-    private closeOverlay?: () => void;
-
-    @query('sp-popover')
-    private popoverEl!: Popover;
+    @query('sp-menu')
+    private menuEl!: Menu;
 
     @property({ type: Boolean })
     private open = false;
 
-    @query('sp-menu')
-    private menuEl!: Menu;
+    @query('sp-overlay')
+    private overlayEl!: Overlay;
+
+    @query('sp-popover')
+    private popoverEl!: Popover;
 
     @query('sp-search')
     private searchField!: Search;
@@ -59,11 +61,22 @@ export class SearchComponent extends LitElement {
         this.searchField.focus();
     }
 
-    private handleSearchInput(event: InputEvent) {
-        if (event.target) {
-            const { value } = event.target as Search;
-            this.updateSearchResults(value);
-        }
+    private handleSearchPointerdown(): void {
+        const abortController = new AbortController();
+        const { signal } = abortController;
+        const handlePointerup = () => {
+            this.overlayEl.manuallyKeepOpen();
+        };
+        const cleanup = () => abortController.abort();
+        this.searchField.addEventListener('pointerup', handlePointerup, {
+            signal,
+        });
+        document.addEventListener('pointerup', cleanup, {
+            signal,
+        });
+        document.addEventListener('pointercancel', cleanup, {
+            signal,
+        });
     }
 
     private handleKeydown(event: KeyboardEvent) {
@@ -109,20 +122,15 @@ export class SearchComponent extends LitElement {
         this.open = false;
     }
 
-    private handleClosed(): void {
-        if (this.closeOverlay) {
-            delete this.closeOverlay;
-        }
-    }
-
     handleSubmit(event: Event): void {
         event.preventDefault();
         if (this.results.length < 0) return;
         this.menuEl.focus();
     }
 
-    private async updateSearchResults(value: string): Promise<boolean> {
-        if (value.length < 3) {
+    private async updateSearchResults(): Promise<boolean> {
+        const { value } = this.searchField;
+        if (value.length < 3 || !this.searchField.focused) {
             this.closePopover();
             return false;
         }
@@ -181,9 +189,10 @@ export class SearchComponent extends LitElement {
             <div id="search-container">
                 <sp-search
                     id="search"
-                    @focusin=${this.handleSearchInput}
-                    @input=${this.handleSearchInput}
-                    @change=${this.handleSearchInput}
+                    @pointerdown=${this.handleSearchPointerdown}
+                    @focusin=${this.updateSearchResults}
+                    @input=${this.updateSearchResults}
+                    @change=${this.updateSearchResults}
                     @keydown=${this.handleKeydown}
                     @click=${stopPropagation}
                     @submit=${this.handleSubmit}
@@ -196,10 +205,7 @@ export class SearchComponent extends LitElement {
                     trigger="search"
                     type="auto"
                 >
-                    <sp-popover
-                        id="search-results-menu"
-                        @sp-overlay-closed=${this.handleClosed}
-                    >
+                    <sp-popover id="search-results-menu">
                         ${this.renderResults()}
                     </sp-popover>
                 </sp-overlay>


### PR DESCRIPTION
## Description
- in Overlay, prevent `receivesFocus="false"` elements from returning focus when closed as they'll have never received focus
- in Docs, leverage `manuallyKeepOpen()` directly being we're not consuming an Interaction Controller there

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://docs-search--spectrum-web-components.netlify.app/)
    2. Start searching for `too`
    3. See that the Search Overlay opens
    4. Click away from the Search Field and Overlay
    5. See that the Search Overlay closes
    6. Click back on the Search Field while the value is still `too`
    7. See that the Search Overlay opens

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
