### PR TITLE
fix(combobox): allow numeric values and trigger change event on keybo…

### DIFF
--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -108,9 +108,12 @@ export class Combobox extends Textfield {
     }
 
     private scrollToActiveDescendant(): void {
-        const activeEl = this.shadowRoot.querySelector(
-            `#${this.activeDescendant?.value}`
-        ) as HTMLElement;
+        if (!this.activeDescendant) {
+            return;
+        }
+        const activeEl = this.shadowRoot.getElementById(
+            this.activeDescendant.value
+        );
         if (activeEl) {
             activeEl.scrollIntoView({ block: 'nearest' });
         }
@@ -211,6 +214,7 @@ export class Combobox extends Textfield {
             return;
         }
         this.value = this.activeDescendant.itemText;
+        this.handleChange();
     }
 
     public filterAvailableOptions(): void {

--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -213,7 +213,6 @@ export class Combobox extends Textfield {
         if (!this.activeDescendant) {
             return;
         }
-        this.value = this.activeDescendant.itemText;
 
         const activeEl = this.shadowRoot.getElementById(
             this.activeDescendant.value

--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -214,7 +214,13 @@ export class Combobox extends Textfield {
             return;
         }
         this.value = this.activeDescendant.itemText;
-        this.handleChange();
+
+        const activeEl = this.shadowRoot.getElementById(
+            this.activeDescendant.value
+        );
+        if (activeEl) {
+            activeEl.click();
+        }
     }
 
     public filterAvailableOptions(): void {

--- a/packages/combobox/test/combobox-a11y.test.ts
+++ b/packages/combobox/test/combobox-a11y.test.ts
@@ -354,4 +354,31 @@ describe('Combobox accessibility', () => {
 
         expect(el.open).to.be.false;
     });
+    it('manages keyboard navigation and selection', async () => {
+        const el = await comboboxFixture();
+
+        await elementUpdated(el);
+
+        expect(el.activeDescendant).to.be.undefined;
+
+        el.focus();
+        await elementUpdated(el);
+
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        await elementUpdated(el);
+
+        expect(el.activeDescendant).to.not.be.undefined;
+        expect(el.activeDescendant.value).to.equal('apple');
+
+        const change = oneEvent(el, 'change');
+        await sendKeys({
+            press: 'Enter',
+        });
+
+        await change;
+        expect(el.value).to.equal('Apple');
+    })
+    
 });

--- a/packages/combobox/test/combobox-a11y.test.ts
+++ b/packages/combobox/test/combobox-a11y.test.ts
@@ -372,6 +372,14 @@ describe('Combobox accessibility', () => {
         expect(el.activeDescendant).to.not.be.undefined;
         expect(el.activeDescendant.value).to.equal('apple');
 
+        const activeDescendant = el.shadowRoot.querySelector(
+            '#apple'
+        ) as MenuItem;
+
+        await elementUpdated(activeDescendant);
+        await nextFrame();
+        await nextFrame();
+
         const change = oneEvent(el, 'change');
         await sendKeys({
             press: 'Enter',
@@ -379,6 +387,5 @@ describe('Combobox accessibility', () => {
 
         await change;
         expect(el.value).to.equal('Apple');
-    })
-    
+    });
 });

--- a/packages/combobox/test/combobox-a11y.test.ts
+++ b/packages/combobox/test/combobox-a11y.test.ts
@@ -354,38 +354,4 @@ describe('Combobox accessibility', () => {
 
         expect(el.open).to.be.false;
     });
-    it('manages keyboard navigation and selection', async () => {
-        const el = await comboboxFixture();
-
-        await elementUpdated(el);
-
-        expect(el.activeDescendant).to.be.undefined;
-
-        el.focus();
-        await elementUpdated(el);
-
-        await sendKeys({
-            press: 'ArrowDown',
-        });
-        await elementUpdated(el);
-
-        expect(el.activeDescendant).to.not.be.undefined;
-        expect(el.activeDescendant.value).to.equal('apple');
-
-        const activeDescendant = el.shadowRoot.querySelector(
-            '#apple'
-        ) as MenuItem;
-
-        await elementUpdated(activeDescendant);
-        await nextFrame();
-        await nextFrame();
-
-        const change = oneEvent(el, 'change');
-        await sendKeys({
-            press: 'Enter',
-        });
-
-        await change;
-        expect(el.value).to.equal('Apple');
-    });
 });

--- a/packages/combobox/test/combobox.data.test.ts
+++ b/packages/combobox/test/combobox.data.test.ts
@@ -15,6 +15,7 @@ import {
     expect,
     html,
     nextFrame,
+    oneEvent,
     waitUntil,
 } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
@@ -51,18 +52,16 @@ describe('Combobox Data', () => {
         expect(el.options).to.deep.equal(options);
     });
     it('accepts options as html', async () => {
-        const el = await fixture<TestableCombobox>(
-            html`
-                <sp-combobox>
-                    Combobox Test
-                    <sp-menu-item value="pineapple">Pineapple</sp-menu-item>
-                    <sp-menu-item value="yuzu">Yuzu</sp-menu-item>
-                    <sp-menu-item value="kumquat">Kumquat</sp-menu-item>
-                    <sp-menu-item value="lychee">Lychee</sp-menu-item>
-                    <sp-menu-item value="durian">Durian</sp-menu-item>
-                </sp-combobox>
-            `
-        );
+        const el = await fixture<TestableCombobox>(html`
+            <sp-combobox>
+                Combobox Test
+                <sp-menu-item value="pineapple">Pineapple</sp-menu-item>
+                <sp-menu-item value="yuzu">Yuzu</sp-menu-item>
+                <sp-menu-item value="kumquat">Kumquat</sp-menu-item>
+                <sp-menu-item value="lychee">Lychee</sp-menu-item>
+                <sp-menu-item value="durian">Durian</sp-menu-item>
+            </sp-combobox>
+        `);
         await elementUpdated(el);
 
         const processedOptions = el.availableOptions.map(
@@ -95,20 +94,18 @@ describe('Combobox Data', () => {
         ]);
     });
     it('accepts additional options as html', async () => {
-        const el = await fixture<TestableCombobox>(
-            html`
-                <sp-combobox>
-                    Combobox Test
-                    ${options.map((option) => {
-                        return html`
-                            <sp-menu-item value=${option.value}>
-                                ${option.itemText}
-                            </sp-menu-item>
-                        `;
-                    })}
-                </sp-combobox>
-            `
-        );
+        const el = await fixture<TestableCombobox>(html`
+            <sp-combobox>
+                Combobox Test
+                ${options.map((option) => {
+                    return html`
+                        <sp-menu-item value=${option.value}>
+                            ${option.itemText}
+                        </sp-menu-item>
+                    `;
+                })}
+            </sp-combobox>
+        `);
         await elementUpdated(el);
 
         let processedOptions = el.availableOptions.map(
@@ -140,20 +137,18 @@ describe('Combobox Data', () => {
         expect(processedOptions).to.deep.equal([...options, newOption]);
     });
     it('accepts updated value as html', async () => {
-        const el = await fixture<TestableCombobox>(
-            html`
-                <sp-combobox>
-                    Combobox Test
-                    ${options.map((option) => {
-                        return html`
-                            <sp-menu-item value=${option.value}>
-                                ${option.itemText}
-                            </sp-menu-item>
-                        `;
-                    })}
-                </sp-combobox>
-            `
-        );
+        const el = await fixture<TestableCombobox>(html`
+            <sp-combobox>
+                Combobox Test
+                ${options.map((option) => {
+                    return html`
+                        <sp-menu-item value=${option.value}>
+                            ${option.itemText}
+                        </sp-menu-item>
+                    `;
+                })}
+            </sp-combobox>
+        `);
         await elementUpdated(el);
 
         let processedOptions = el.availableOptions.map(
@@ -192,20 +187,18 @@ describe('Combobox Data', () => {
         expect(processedOptions).to.deep.equal(newOptions);
     });
     it('accepts updated id as html', async () => {
-        const el = await fixture<TestableCombobox>(
-            html`
-                <sp-combobox>
-                    Combobox Test
-                    ${options.map((option) => {
-                        return html`
-                            <sp-menu-item value=${option.value}>
-                                ${option.itemText}
-                            </sp-menu-item>
-                        `;
-                    })}
-                </sp-combobox>
-            `
-        );
+        const el = await fixture<TestableCombobox>(html`
+            <sp-combobox>
+                Combobox Test
+                ${options.map((option) => {
+                    return html`
+                        <sp-menu-item value=${option.value}>
+                            ${option.itemText}
+                        </sp-menu-item>
+                    `;
+                })}
+            </sp-combobox>
+        `);
         await elementUpdated(el);
 
         let processedOptions = el.availableOptions.map(
@@ -243,20 +236,18 @@ describe('Combobox Data', () => {
         expect(processedOptions).to.deep.equal(newOptions);
     });
     it('accepts replacement options as html', async () => {
-        const el = await fixture<TestableCombobox>(
-            html`
-                <sp-combobox>
-                    Combobox Test
-                    ${options.map((option) => {
-                        return html`
-                            <sp-menu-item value=${option.value}>
-                                ${option.itemText}
-                            </sp-menu-item>
-                        `;
-                    })}
-                </sp-combobox>
-            `
-        );
+        const el = await fixture<TestableCombobox>(html`
+            <sp-combobox>
+                Combobox Test
+                ${options.map((option) => {
+                    return html`
+                        <sp-menu-item value=${option.value}>
+                            ${option.itemText}
+                        </sp-menu-item>
+                    `;
+                })}
+            </sp-combobox>
+        `);
         await elementUpdated(el);
 
         let processedOptions = el.availableOptions.map(
@@ -299,20 +290,18 @@ describe('Combobox Data', () => {
         expect(processedOptions).to.deep.equal(options);
     });
     it('accepts options through slots', async () => {
-        const test = await fixture<SpectrumElement>(
-            html`
-                <combobox-slot-test-el>
-                    Combobox Test
-                    ${options.map((option) => {
-                        return html`
-                            <sp-menu-item value=${option.value}>
-                                ${option.itemText}
-                            </sp-menu-item>
-                        `;
-                    })}
-                </combobox-slot-test-el>
-            `
-        );
+        const test = await fixture<SpectrumElement>(html`
+            <combobox-slot-test-el>
+                Combobox Test
+                ${options.map((option) => {
+                    return html`
+                        <sp-menu-item value=${option.value}>
+                            ${option.itemText}
+                        </sp-menu-item>
+                    `;
+                })}
+            </combobox-slot-test-el>
+        `);
         const el = test.shadowRoot.querySelector(
             'sp-combobox'
         ) as unknown as TestableCombobox;
@@ -333,20 +322,18 @@ describe('Combobox Data', () => {
         expect(processedOptions).to.deep.equal(options);
     });
     it('accepts adding through slots', async function () {
-        const test = await fixture<SpectrumElement>(
-            html`
-                <combobox-slot-test-el>
-                    Combobox Test
-                    ${options.map((option) => {
-                        return html`
-                            <sp-menu-item value=${option.value}>
-                                ${option.itemText}
-                            </sp-menu-item>
-                        `;
-                    })}
-                </combobox-slot-test-el>
-            `
-        );
+        const test = await fixture<SpectrumElement>(html`
+            <combobox-slot-test-el>
+                Combobox Test
+                ${options.map((option) => {
+                    return html`
+                        <sp-menu-item value=${option.value}>
+                            ${option.itemText}
+                        </sp-menu-item>
+                    `;
+                })}
+            </combobox-slot-test-el>
+        `);
         const el = test.shadowRoot.querySelector(
             'sp-combobox'
         ) as unknown as TestableCombobox;
@@ -390,16 +377,16 @@ describe('Combobox Data', () => {
         expect(processedOptions).to.deep.equal([...options, newOption]);
     });
     it('accepts numeric values as html', async () => {
-        const el = await fixture<TestableCombobox>(
-            html`
-                <sp-combobox>
-                    Combobox Test
-                    <sp-menu-item value="1">Mambo no. 1</sp-menu-item>
-                    <sp-menu-item value="2">Mambo no. 2</sp-menu-item>
-                    <sp-menu-item value="3">Mambo no. 5</sp-menu-item>
-                </sp-combobox>
-            `
-        );
+        const el = await fixture<TestableCombobox>(html`
+            <sp-combobox>
+                Combobox Test
+                <sp-menu-item value="1">Mambo no. 1</sp-menu-item>
+                <sp-menu-item value="2">Mambo no. 2</sp-menu-item>
+                <sp-menu-item value="3">Mambo no. 3</sp-menu-item>
+                <sp-menu-item value="4">Mambo no. 4</sp-menu-item>
+                <sp-menu-item value="5">Mambo no. 5</sp-menu-item>
+            </sp-combobox>
+        `);
         await elementUpdated(el);
 
         expect(el.activeDescendant).to.be.undefined;
@@ -413,6 +400,22 @@ describe('Combobox Data', () => {
         await elementUpdated(el);
 
         expect(el.activeDescendant).to.not.be.undefined;
-        expect(el.activeDescendant.value).to.equal('1');   
+        expect(el.activeDescendant.value).to.equal('1');
+
+        const activeDescendant = el.shadowRoot.getElementById('#1') as MenuItem;
+
+        await elementUpdated(activeDescendant);
+        await nextFrame();
+        await nextFrame();
+
+        const change = oneEvent(el, 'change');
+        await sendKeys({
+            press: 'Enter',
+        });
+
+        await change;
+        expect(el.open).to.be.false;
+        expect(el.activeDescendant).to.be.undefined;
+        expect(el.value).to.equal('Mambo no. 1');
     });
 });

--- a/packages/combobox/test/combobox.data.test.ts
+++ b/packages/combobox/test/combobox.data.test.ts
@@ -17,7 +17,7 @@ import {
     nextFrame,
     waitUntil,
 } from '@open-wc/testing';
-
+import { sendKeys } from '@web/test-runner-commands';
 import '@spectrum-web-components/combobox/sp-combobox.js';
 import '@spectrum-web-components/menu/sp-menu-item.js';
 import { fixture } from '../../../test/testing-helpers.js';
@@ -388,5 +388,31 @@ describe('Combobox Data', () => {
             itemText,
         }));
         expect(processedOptions).to.deep.equal([...options, newOption]);
+    });
+    it('accepts numeric values as html', async () => {
+        const el = await fixture<TestableCombobox>(
+            html`
+                <sp-combobox>
+                    Combobox Test
+                    <sp-menu-item value="1">Mambo no. 1</sp-menu-item>
+                    <sp-menu-item value="2">Mambo no. 2</sp-menu-item>
+                    <sp-menu-item value="3">Mambo no. 5</sp-menu-item>
+                </sp-combobox>
+            `
+        );
+        await elementUpdated(el);
+
+        expect(el.activeDescendant).to.be.undefined;
+
+        el.focus();
+        await elementUpdated(el);
+
+        await sendKeys({
+            press: 'ArrowDown',
+        });
+        await elementUpdated(el);
+
+        expect(el.activeDescendant).to.not.be.undefined;
+        expect(el.activeDescendant.value).to.equal('1');   
     });
 });

--- a/test/testing-helpers.ts
+++ b/test/testing-helpers.ts
@@ -70,11 +70,9 @@ export async function testForMemoryLeaks(
             let active = false;
 
             // Call fixture with 'htmlString' as the additional argument
-            const el = await fixture<HTMLElement>(
-                html`
-                    <div></div>
-                `
-            );
+            const el = await fixture<HTMLElement>(html`
+                <div></div>
+            `);
 
             async function toggle(
                 forced: boolean | undefined = undefined
@@ -292,7 +290,7 @@ export async function fixture<T extends Element>(
     dir: 'ltr' | 'rtl' | 'auto' = 'ltr'
 ): Promise<T> {
     const test = await owcFixture<Theme>(html`
-        <sp-theme theme="spectrum" scale="medium" color="light">
+        <sp-theme system="spectrum" scale="medium" color="light">
             ${story}
             <style>
                 sp-theme {


### PR DESCRIPTION
…ard selection

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR aims to fix two issues when navigating in the Combobox using the keyboard.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/4384

## Motivation and context

1. When using numeric values for Combobox options (representing IDs or quantities), an error is thrown in the console and the list does not scroll
2. When pressing "Enter" after navigating to an option, the `change` event is not triggered, as it is triggered on mouse interactions.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://rocss-numeric-combobox-fix--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--controlled)
    3. Click on the Combobox input
    4. Press Arrow-Down
    5. Continue pressing Arrow-Down/Up to navigate in the options list
    6. Observe that no errors are thrown in the browser console
-   [ ] _Test case 2_
    1. Go [here](https://rocss-numeric-combobox-fix--spectrum-web-components.netlify.app/storybook/?path=/story/combobox--controlled)
    3. Click on the Combobox input
    4. Press Arrow-Down
    5. Press Enter
    6. The `change` event is triggered, `event.target.value` is `55`

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
