### PR TITLE
chore(picker): ensure dev mode is run after external labelling may have been applied

### DIFF
--- a/packages/picker/src/Picker.ts
+++ b/packages/picker/src/Picker.ts
@@ -598,26 +598,6 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
             this.deprecatedMenu?.setAttribute('selects', 'inherit');
         }
         if (window.__swc.DEBUG) {
-            if (
-                !this.label &&
-                !this.getAttribute('aria-label') &&
-                !this.getAttribute('aria-labelledby') &&
-                !this.appliedLabel
-            ) {
-                window.__swc.warn(
-                    this,
-                    '<sp-picker> needs one of the following to be accessible:',
-                    'https://opensource.adobe.com/spectrum-web-components/components/picker/#accessibility',
-                    {
-                        type: 'accessibility',
-                        issues: [
-                            'an <sp-field-label> element with a `for` attribute referencing the `id` of the `<sp-picker>`, or',
-                            'value supplied to the "label" attribute, which will be displayed visually as placeholder text, or',
-                            'text content supplied in a <span> with slot="label", which will also be displayed visually as placeholder text.',
-                        ],
-                    }
-                );
-            }
             if (!this.hasUpdated && this.querySelector(':scope > sp-menu')) {
                 const { localName } = this;
                 window.__swc.warn(
@@ -627,6 +607,32 @@ export class PickerBase extends SizedMixin(Focusable, { noDefaultSize: true }) {
                     { level: 'deprecation' }
                 );
             }
+            this.updateComplete.then(async () => {
+                // Attributes should be user supplied, making them available before first update.
+                // However, `appliesLabel` is applied by external elements that must be update complete as well to be bound appropriately.
+                await new Promise((res) => requestAnimationFrame(res));
+                await new Promise((res) => requestAnimationFrame(res));
+                if (
+                    !this.label &&
+                    !this.getAttribute('aria-label') &&
+                    !this.getAttribute('aria-labelledby') &&
+                    !this.appliedLabel
+                ) {
+                    window.__swc.warn(
+                        this,
+                        '<sp-picker> needs one of the following to be accessible:',
+                        'https://opensource.adobe.com/spectrum-web-components/components/picker/#accessibility',
+                        {
+                            type: 'accessibility',
+                            issues: [
+                                'an <sp-field-label> element with a `for` attribute referencing the `id` of the `<sp-picker>`, or',
+                                'value supplied to the "label" attribute, which will be displayed visually as placeholder text, or',
+                                'text content supplied in a <span> with slot="label", which will also be displayed visually as placeholder text.',
+                            ],
+                        }
+                    );
+                }
+            });
         }
         super.update(changes);
     }

--- a/packages/picker/test/index.ts
+++ b/packages/picker/test/index.ts
@@ -74,28 +74,22 @@ const isMenuActiveElement = function (el: Picker): boolean {
 export function runPickerTests(): void {
     let el: Picker;
     const pickerFixture = async (): Promise<Picker> => {
-        const test = await fixture<HTMLDivElement>(
-            html`
-                <sp-theme scale="medium" color="light">
-                    <sp-field-label for="picker">
-                        Where do you live?
-                    </sp-field-label>
-                    <sp-picker
-                        id="picker"
-                        style="width: 200px; --spectrum-alias-ui-icon-chevron-size-100: 10px;"
-                    >
-                        <sp-menu-item>Deselect</sp-menu-item>
-                        <sp-menu-item value="option-2">
-                            Select Inverse
-                        </sp-menu-item>
-                        <sp-menu-item>Feather...</sp-menu-item>
-                        <sp-menu-item>Select and Mask...</sp-menu-item>
-                        <sp-menu-item>Save Selection</sp-menu-item>
-                        <sp-menu-item disabled>Make Work Path</sp-menu-item>
-                    </sp-picker>
-                </sp-theme>
-            `
-        );
+        const test = await fixture<HTMLDivElement>(html`
+            <sp-theme scale="medium" color="light">
+                <sp-field-label for="picker">Where do you live?</sp-field-label>
+                <sp-picker
+                    id="picker"
+                    style="width: 200px; --spectrum-alias-ui-icon-chevron-size-100: 10px;"
+                >
+                    <sp-menu-item>Deselect</sp-menu-item>
+                    <sp-menu-item value="option-2">Select Inverse</sp-menu-item>
+                    <sp-menu-item>Feather...</sp-menu-item>
+                    <sp-menu-item>Select and Mask...</sp-menu-item>
+                    <sp-menu-item>Save Selection</sp-menu-item>
+                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                </sp-picker>
+            </sp-theme>
+        `);
 
         return test.querySelector('sp-picker') as Picker;
     };
@@ -1333,30 +1327,28 @@ export function runPickerTests(): void {
     });
     describe('grouped', async () => {
         const groupedFixture = async (): Promise<Picker> => {
-            return fixture<Picker>(
-                html`
-                    <sp-picker
-                        quiet
-                        label="I would like to use Spectrum Web Components"
-                        value="0"
-                    >
-                        <sp-menu-group>
-                            <span slot="header">Timeline</span>
-                            <sp-menu-item value="0" id="should-be-selected">
-                                Immediately
-                            </sp-menu-item>
-                            <sp-menu-item value="1">
-                                I'm already using them
-                            </sp-menu-item>
-                            <sp-menu-item value="2">Soon</sp-menu-item>
-                            <sp-menu-item value="3">
-                                As part of my next project
-                            </sp-menu-item>
-                            <sp-menu-item value="4">In the future</sp-menu-item>
-                        </sp-menu-group>
-                    </sp-picker>
-                `
-            );
+            return fixture<Picker>(html`
+                <sp-picker
+                    quiet
+                    label="I would like to use Spectrum Web Components"
+                    value="0"
+                >
+                    <sp-menu-group>
+                        <span slot="header">Timeline</span>
+                        <sp-menu-item value="0" id="should-be-selected">
+                            Immediately
+                        </sp-menu-item>
+                        <sp-menu-item value="1">
+                            I'm already using them
+                        </sp-menu-item>
+                        <sp-menu-item value="2">Soon</sp-menu-item>
+                        <sp-menu-item value="3">
+                            As part of my next project
+                        </sp-menu-item>
+                        <sp-menu-item value="4">In the future</sp-menu-item>
+                    </sp-menu-group>
+                </sp-picker>
+            `);
         };
         beforeEach(async () => {
             el = await groupedFixture();
@@ -1371,29 +1363,27 @@ export function runPickerTests(): void {
     });
     describe('slotted label', () => {
         const pickerFixture = async (): Promise<Picker> => {
-            const test = await fixture<Picker>(
-                html`
-                    <div>
-                        <sp-field-label for="picker-slotted">
-                            Where do you live?
-                        </sp-field-label>
-                        <sp-picker id="picker-slotted">
-                            <span slot="label">
-                                Select a Country with a very long label, too
-                                long in fact
-                            </span>
-                            <sp-menu-item>Deselect</sp-menu-item>
-                            <sp-menu-item value="option-2">
-                                Select Inverse
-                            </sp-menu-item>
-                            <sp-menu-item>Feather...</sp-menu-item>
-                            <sp-menu-item>Select and Mask...</sp-menu-item>
-                            <sp-menu-item>Save Selection</sp-menu-item>
-                            <sp-menu-item disabled>Make Work Path</sp-menu-item>
-                        </sp-picker>
-                    </div>
-                `
-            );
+            const test = await fixture<Picker>(html`
+                <div>
+                    <sp-field-label for="picker-slotted">
+                        Where do you live?
+                    </sp-field-label>
+                    <sp-picker id="picker-slotted">
+                        <span slot="label">
+                            Select a Country with a very long label, too long in
+                            fact
+                        </span>
+                        <sp-menu-item>Deselect</sp-menu-item>
+                        <sp-menu-item value="option-2">
+                            Select Inverse
+                        </sp-menu-item>
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and Mask...</sp-menu-item>
+                        <sp-menu-item>Save Selection</sp-menu-item>
+                        <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                    </sp-picker>
+                </div>
+            `);
 
             return test.querySelector('sp-picker') as Picker;
         };
@@ -1434,36 +1424,53 @@ export function runPickerTests(): void {
         });
 
         const pickerFixture = async (): Promise<Picker> => {
-            const test = await fixture<Picker>(
-                html`
-                    <div>
-                        <sp-field-label for="picker-deprecated">
-                            Where do you live?
-                        </sp-field-label>
-                        <sp-picker
-                            id="picker-deprecated"
-                            label="Select a Country with a very long label, too long in fact"
-                        >
-                            <sp-menu>
-                                <sp-menu-item>Deselect</sp-menu-item>
-                                <sp-menu-item value="option-2">
-                                    Select Inverse
-                                </sp-menu-item>
-                                <sp-menu-item>Feather...</sp-menu-item>
-                                <sp-menu-item>Select and Mask...</sp-menu-item>
-                                <sp-menu-item>Save Selection</sp-menu-item>
-                                <sp-menu-item disabled>
-                                    Make Work Path
-                                </sp-menu-item>
-                            </sp-menu>
-                        </sp-picker>
-                    </div>
-                `
-            );
+            const test = await fixture<Picker>(html`
+                <div>
+                    <sp-field-label for="picker-deprecated">
+                        Where do you live?
+                    </sp-field-label>
+                    <sp-picker
+                        id="picker-deprecated"
+                        label="Select a Country with a very long label, too long in fact"
+                    >
+                        <sp-menu>
+                            <sp-menu-item>Deselect</sp-menu-item>
+                            <sp-menu-item value="option-2">
+                                Select Inverse
+                            </sp-menu-item>
+                            <sp-menu-item>Feather...</sp-menu-item>
+                            <sp-menu-item>Select and Mask...</sp-menu-item>
+                            <sp-menu-item>Save Selection</sp-menu-item>
+                            <sp-menu-item disabled>Make Work Path</sp-menu-item>
+                        </sp-menu>
+                    </sp-picker>
+                </div>
+            `);
 
             return test.querySelector('sp-picker') as Picker;
         };
-        it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
+        it('does not warn in Dev Mode when accessible elements leveraged', async () => {
+            const test = await fixture<Picker>(html`
+                <div>
+                    <sp-field-label for="test">Test label</sp-field-label>
+                    <sp-picker id="test">
+                        <sp-menu-item>Feather...</sp-menu-item>
+                        <sp-menu-item>Select and Mask...</sp-menu-item>
+                        <sp-menu-item>Save Selection</sp-menu-item>
+                    </sp-picker>
+                </div>
+            `);
+
+            el = test.querySelector('sp-picker') as Picker;
+
+            await elementUpdated(el);
+            await nextFrame();
+            await nextFrame();
+
+            expect(consoleWarnStub.called).to.be.false;
+        });
+        it('warns in Dev Mode when accessible attributes are not leveraged', async function () {
+            this.retries(0);
             el = await fixture<Picker>(html`
                 <sp-picker>
                     <sp-menu-item>Feather...</sp-menu-item>
@@ -1473,6 +1480,8 @@ export function runPickerTests(): void {
             `);
 
             await elementUpdated(el);
+            await nextFrame();
+            await nextFrame();
 
             expect(consoleWarnStub.called).to.be.true;
             const spyCall = consoleWarnStub.getCall(0);
@@ -1636,21 +1645,19 @@ export function runPickerTests(): void {
         expect(el1.open).to.be.false;
     });
     it('displays selected item text by default', async () => {
-        const el = await fixture<Picker>(
-            html`
-                <sp-picker
-                    value="inverse"
-                    label="Select a Country with a very long label, too long in fact"
-                >
-                    <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
-                    <sp-menu-item value="inverse">Select Inverse</sp-menu-item>
-                    <sp-menu-item>Feather...</sp-menu-item>
-                    <sp-menu-item>Select and Mask...</sp-menu-item>
-                    <sp-menu-item>Save Selection</sp-menu-item>
-                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
-                </sp-picker>
-            `
-        );
+        const el = await fixture<Picker>(html`
+            <sp-picker
+                value="inverse"
+                label="Select a Country with a very long label, too long in fact"
+            >
+                <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
+                <sp-menu-item value="inverse">Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-picker>
+        `);
         await nextFrame();
 
         await elementUpdated(el);
@@ -1699,21 +1706,19 @@ export function runPickerTests(): void {
         ).to.equal(secondItem.id);
     });
     it('resets value when item not available', async () => {
-        const el = await fixture<Picker>(
-            html`
-                <sp-picker
-                    value="missing"
-                    label="Select a Country with a very long label, too long in fact"
-                >
-                    <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
-                    <sp-menu-item value="inverse">Select Inverse</sp-menu-item>
-                    <sp-menu-item>Feather...</sp-menu-item>
-                    <sp-menu-item>Select and Mask...</sp-menu-item>
-                    <sp-menu-item>Save Selection</sp-menu-item>
-                    <sp-menu-item disabled>Make Work Path</sp-menu-item>
-                </sp-picker>
-            `
-        );
+        const el = await fixture<Picker>(html`
+            <sp-picker
+                value="missing"
+                label="Select a Country with a very long label, too long in fact"
+            >
+                <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
+                <sp-menu-item value="inverse">Select Inverse</sp-menu-item>
+                <sp-menu-item>Feather...</sp-menu-item>
+                <sp-menu-item>Select and Mask...</sp-menu-item>
+                <sp-menu-item>Save Selection</sp-menu-item>
+                <sp-menu-item disabled>Make Work Path</sp-menu-item>
+            </sp-picker>
+        `);
 
         await elementUpdated(el);
         await waitUntil(() => el.value === '');
@@ -1724,20 +1729,15 @@ export function runPickerTests(): void {
     it('allows event listeners on child items', async () => {
         const mouseenterSpy = spy();
         const handleMouseenter = (): void => mouseenterSpy();
-        const el = await fixture<Picker>(
-            html`
-                <sp-picker
-                    label="Select a Country with a very long label, too long in fact"
-                >
-                    <sp-menu-item
-                        value="deselect"
-                        @mouseenter=${handleMouseenter}
-                    >
-                        Deselect Text
-                    </sp-menu-item>
-                </sp-picker>
-            `
-        );
+        const el = await fixture<Picker>(html`
+            <sp-picker
+                label="Select a Country with a very long label, too long in fact"
+            >
+                <sp-menu-item value="deselect" @mouseenter=${handleMouseenter}>
+                    Deselect Text
+                </sp-menu-item>
+            </sp-picker>
+        `);
 
         await elementUpdated(el);
 
@@ -1768,17 +1768,15 @@ export function runPickerTests(): void {
         const handleOpenedSpy = (event: Event): void => openedSpy(event);
         const handleClosedSpy = (event: Event): void => closedSpy(event);
 
-        const el = await fixture<Picker>(
-            html`
-                <sp-picker
-                    label="Select a Country with a very long label, too long in fact"
-                    @sp-opened=${handleOpenedSpy}
-                    @sp-closed=${handleClosedSpy}
-                >
-                    <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
-                </sp-picker>
-            `
-        );
+        const el = await fixture<Picker>(html`
+            <sp-picker
+                label="Select a Country with a very long label, too long in fact"
+                @sp-opened=${handleOpenedSpy}
+                @sp-closed=${handleClosedSpy}
+            >
+                <sp-menu-item value="deselect">Deselect Text</sp-menu-item>
+            </sp-picker>
+        `);
 
         await elementUpdated(el);
         const opened = oneEvent(el, 'sp-opened');


### PR DESCRIPTION
## Description
Picker would publish a false positive on non-accessible consumption of its API. This corrects that.

## How has this been tested?
-   [ ] _Test case 1_
    1. Open the branch locally.
    2. Run Storybook
    3. See that there are not Picker Dev Mode messages in the console

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.