### PR TITLE
fix(number-field): handles values greater than 1000

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -575,7 +575,10 @@ export class NumberField extends TextfieldBase {
                 : 0;
             this._valueFormatter = new NumberFormatter(
                 this.languageResolver.language,
-                { maximumFractionDigits: digitsAfterDecimal }
+                {
+                    maximumFractionDigits: digitsAfterDecimal,
+                    useGrouping: false,
+                }
             );
         }
 

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -146,9 +146,7 @@ describe('NumberField', () => {
             expect(el.valueAsString).to.equal('-2.4');
             expect(el.focusElement.value).to.equal('-2.4');
         });
-    });
-    describe('it handles values greater than 1000', () => {
-        it('correctly handles values greater than 1000 with step=1', async () => {
+        it('correctly handles max values greater than 1000 with step=1', async () => {
             const el = await getElFrom(
                 Default({
                     step: 1,
@@ -157,15 +155,17 @@ describe('NumberField', () => {
                     value: 999,
                 })
             );
-            // Test increment button
+
             await clickBySelector(el, '.step-up');
+
             expect(el.value).to.equal(1000);
             expect(el.valueAsString).to.equal('1000');
             expect(el.formattedValue).to.equal('1,000');
             expect(el.focusElement.value).to.equal('1,000');
-            // Test direct input
+
             el.value = 15000;
             await elementUpdated(el);
+
             expect(el.value).to.equal(15000);
             expect(el.valueAsString).to.equal('15000');
             expect(el.formattedValue).to.equal('15,000');

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -147,6 +147,31 @@ describe('NumberField', () => {
             expect(el.focusElement.value).to.equal('-2.4');
         });
     });
+    describe('it handles values greater than 1000', () => {
+        it('correctly handles values greater than 1000 with step=1', async () => {
+            const el = await getElFrom(
+                Default({
+                    step: 1,
+                    min: 0,
+                    max: 200000,
+                    value: 999,
+                })
+            );
+            // Test increment button
+            await clickBySelector(el, '.step-up');
+            expect(el.value).to.equal(1000);
+            expect(el.valueAsString).to.equal('1000');
+            expect(el.formattedValue).to.equal('1,000');
+            expect(el.focusElement.value).to.equal('1,000');
+            // Test direct input
+            el.value = 15000;
+            await elementUpdated(el);
+            expect(el.value).to.equal(15000);
+            expect(el.valueAsString).to.equal('15000');
+            expect(el.formattedValue).to.equal('15,000');
+            expect(el.focusElement.value).to.equal('15,000');
+        });
+    });
     describe('Increments', () => {
         let el: NumberField;
 
@@ -164,6 +189,7 @@ describe('NumberField', () => {
             expect(el.value).to.be.NaN;
             expect(el.focusElement.value).to.equal('');
         });
+
         it('via pointer', async () => {
             await clickBySelector(el, '.step-up');
             expect(el.formattedValue).to.equal('0');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR addresses an issue where large numbers were being incorrectly formatted or rounded in the valueFormatter of the component. The problem was occurring due to the default behavior of the NumberFormatter which was using grouping for large numbers. This caused values greater than 1000 to be formatted incorrectly.

### Changes Made:

Added the `useGrouping: false` option to the NumberFormatter instantiation in the valueFormatter method.
This change ensures that large numbers are formatted without grouping, preventing the rounding or truncation issues observed previously.



## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #4415 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This fix improves the accuracy of number formatting for large numbers in the component, ensuring that they are displayed correctly to the user.

## How has this been tested?
Tested the fix with various large numbers and confirmed that they are now formatted correctly without any rounding or truncation.
Checked that the formatting behavior for numbers less than 1000 remains unchanged.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://blunteshwar-truncating-values--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--quiet&args=value:995;min:4;max:3400;step:1)
    2. Increment the value beyond 1000.
-   [ ] _Test case 2_
    1. Go [here](https://blunteshwar-truncating-values--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--quiet&args=value:995;min:4;max:3400;step:1)
    2. enter any value above 1000

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
