### PR TITLE
ci: run unit and memory tests separately

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,12 +146,23 @@ jobs:
         steps:
             - downstream
             - run:
-                  name: Run tests
-                  command: yarn test:ci --config web-test-runner.config.ci-chromium.js --group unit --coverage
+                  name: Run unit tests
+                  command: yarn test:ci --config web-test-runner.config.ci-chromium.js --group no-memory-ci --coverage
             - store_test_results:
                   path: /root/project/results/
             - store_artifacts:
                   path: coverage
+
+    test-chromium-memory:
+        executor: node
+
+        steps:
+            - downstream
+            - run:
+                  name: Run memory tests
+                  command: yarn test:ci --config web-test-runner.config.ci-chromium.js --group memory-ci
+            - store_test_results:
+                  path: /root/project/results/
 
     test-firefox:
         executor: node
@@ -306,6 +317,7 @@ workflows:
     build:
         jobs:
             - test-chromium
+            - test-chromium-memory
             - test-firefox
             - test-webkit
             - lint

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -17,7 +17,10 @@ import {
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import {
+    ifDefined,
+    styleMap,
+} from '@spectrum-web-components/base/src/directives.js';
 import {
     property,
     query,
@@ -445,15 +448,15 @@ export class ColorArea extends SpectrumElement {
             }
         ).format(this.y);
 
+        const style = {
+            background: `linear-gradient(to top, black 0%, hsla(${this.hue}, 100%, 0.01%, 0) 100%),linear-gradient(to right, white 0%, hsla(${this.hue}, 100%, 0.01%, 0) 100%), hsl(${this.hue}, 100%, 50%);`,
+        };
+
         return html`
             <div
                 @pointerdown=${this.handleAreaPointerdown}
                 class="gradient"
-                style=${ifDefined(
-                    this.hue
-                        ? 'background:linear-gradient(to top, black 0%, hsla(${this.hue}, 100%, 0.01%, 0) 100%),linear-gradient(to right, white 0%, hsla(${this.hue}, 100%, 0.01%, 0) 100%), hsl(${this.hue}, 100%, 50%);'
-                        : undefined
-                )}
+                style=${styleMap(style)}
             >
                 <slot name="gradient"></slot>
             </div>

--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -449,11 +449,11 @@ export class ColorArea extends SpectrumElement {
             <div
                 @pointerdown=${this.handleAreaPointerdown}
                 class="gradient"
-                style="background:
-                    linear-gradient(to top, black 0%, hsla(${this
-                    .hue}, 100%, 0.01%, 0) 100%),
-                    linear-gradient(to right, white 0%, hsla(${this
-                    .hue}, 100%, 0.01%, 0) 100%), hsl(${this.hue}, 100%, 50%);"
+                style=${ifDefined(
+                    this.hue
+                        ? 'background:linear-gradient(to top, black 0%, hsla(${this.hue}, 100%, 0.01%, 0) 100%),linear-gradient(to right, white 0%, hsla(${this.hue}, 100%, 0.01%, 0) 100%), hsl(${this.hue}, 100%, 50%);'
+                        : undefined
+                )}
             >
                 <slot name="gradient"></slot>
             </div>

--- a/packages/color-handle/src/ColorHandle.ts
+++ b/packages/color-handle/src/ColorHandle.ts
@@ -20,7 +20,7 @@ import {
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 
 import '@spectrum-web-components/color-loupe/sp-color-loupe.js';
-import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerboard/src/is-opacity-checkerboard.css.js';
+import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerboard/src/opacity-checkerboard.css.js';
 import styles from './color-handle.css.js';
 
 /**

--- a/packages/color-handle/src/ColorHandle.ts
+++ b/packages/color-handle/src/ColorHandle.ts
@@ -20,7 +20,7 @@ import {
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 
 import '@spectrum-web-components/color-loupe/sp-color-loupe.js';
-import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerboard/src/opacity-checkerboard.css.js';
+import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerboard/src/is-opacity-checkerboard.css.js';
 import styles from './color-handle.css.js';
 
 /**

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -311,9 +311,11 @@ export class ColorSlider extends Focusable {
                 <div
                     class="gradient"
                     role="presentation"
-                    style="background: linear-gradient(to ${this.vertical
-                        ? 'top'
-                        : 'right'}, var(--sp-color-slider-gradient, var(--sp-color-slider-gradient-fallback)));"
+                    style=${ifDefined(
+                        this.vertical
+                            ? "background: linear-gradient(to ${this.vertical ? 'top' : 'right'}, var(--sp-color-slider-gradient, var(--sp-color-slider-gradient-fallback)));"
+                            : undefined
+                    )}
                 >
                     <slot name="gradient"></slot>
                 </div>

--- a/packages/color-slider/src/ColorSlider.ts
+++ b/packages/color-slider/src/ColorSlider.ts
@@ -16,7 +16,11 @@ import {
     PropertyValues,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
+import {
+    ifDefined,
+    StyleInfo,
+    styleMap,
+} from '@spectrum-web-components/base/src/directives.js';
 import {
     property,
     query,
@@ -301,6 +305,13 @@ export class ColorSlider extends Focusable {
         }%`;
     }
 
+    private get getColorSliderStyle(): StyleInfo {
+        const orientation = this.vertical ? 'top' : 'right';
+        return {
+            background: `linear-gradient(to ${orientation}, var(--sp-color-slider-gradient, var(--sp-color-slider-gradient-fallback)))`,
+        };
+    }
+
     protected override render(): TemplateResult {
         return html`
             <div
@@ -311,11 +322,7 @@ export class ColorSlider extends Focusable {
                 <div
                     class="gradient"
                     role="presentation"
-                    style=${ifDefined(
-                        this.vertical
-                            ? "background: linear-gradient(to ${this.vertical ? 'top' : 'right'}, var(--sp-color-slider-gradient, var(--sp-color-slider-gradient-fallback)));"
-                            : undefined
-                    )}
+                    style=${styleMap(this.getColorSliderStyle)}
                 >
                     <slot name="gradient"></slot>
                 </div>

--- a/packages/swatch/src/Swatch.ts
+++ b/packages/swatch/src/Swatch.ts
@@ -19,7 +19,7 @@ import {
 import { property } from '@spectrum-web-components/base/src/decorators.js';
 import { when } from '@spectrum-web-components/base/src/directives.js';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
-import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerboard/src/opacity-checkerboard.css.js';
+import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerboard/src/is-opacity-checkerboard.css.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-dash75.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-dash100.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-dash200.js';
@@ -73,7 +73,7 @@ export class Swatch extends SizedMixin(Focusable, {
     @property({ reflect: true })
     public border: SwatchBorder;
 
-    @property()
+    @property({ type: String, reflect: true })
     public color = '';
 
     @property()

--- a/packages/swatch/src/Swatch.ts
+++ b/packages/swatch/src/Swatch.ts
@@ -17,9 +17,12 @@ import {
     TemplateResult,
 } from '@spectrum-web-components/base';
 import { property } from '@spectrum-web-components/base/src/decorators.js';
-import { when } from '@spectrum-web-components/base/src/directives.js';
+import {
+    ifDefined,
+    when,
+} from '@spectrum-web-components/base/src/directives.js';
 import { Focusable } from '@spectrum-web-components/shared/src/focusable.js';
-import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerboard/src/is-opacity-checkerboard.css.js';
+import opacityCheckerboardStyles from '@spectrum-web-components/opacity-checkerboard/src/opacity-checkerboard.css.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-dash75.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-dash100.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-dash200.js';
@@ -201,7 +204,11 @@ export class Swatch extends SizedMixin(Focusable, {
         return html`
             <div
                 class="opacity-checkerboard fill"
-                style="--spectrum-picked-color: ${this.color}"
+                style=${ifDefined(
+                    this.color
+                        ? `--spectrum-picked-color: ${this.color}`
+                        : undefined
+                )}
             >
                 <slot name="image"></slot>
                 ${when(this.disabled, this.renderDisabled)}

--- a/packages/swatch/src/Swatch.ts
+++ b/packages/swatch/src/Swatch.ts
@@ -73,7 +73,7 @@ export class Swatch extends SizedMixin(Focusable, {
     @property({ reflect: true })
     public border: SwatchBorder;
 
-    @property({ type: String, reflect: true })
+    @property()
     public color = '';
 
     @property()

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -149,9 +149,9 @@ export default {
             name: 'memory-ci',
             files: [
                 '{packages,tools}/**/*-memory.test.js',
-                'packages/color-area/test/*-memory.test.js',
-                'packages/color-wheel/test/*-memory.test.js',
-                'packages/color-slider/test/*-memory.test.js',
+                '!packages/color-area/test/*-memory.test.js',
+                '!packages/color-wheel/test/*-memory.test.js',
+                '!packages/color-slider/test/*-memory.test.js',
             ],
             browsers: [chromiumWithMemoryToolingCI],
         },

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -18,6 +18,7 @@ import { sendMousePlugin } from './test/plugins/send-mouse-plugin.js';
 import {
     chromium,
     chromiumWithMemoryTooling,
+    chromiumWithMemoryToolingCI,
     configuredVisualRegressionPlugin,
     firefox,
     packages,
@@ -145,7 +146,19 @@ export default {
             browsers: [chromiumWithMemoryTooling],
         },
         {
+            name: 'memory-ci',
+            files: ['{packages,tools}/**/*-memory.test.js'],
+            browsers: [chromiumWithMemoryToolingCI],
+        },
+        {
             name: 'unit-ci',
+        },
+        {
+            name: 'no-memory-ci',
+            files: [
+                '{packages,tools}/**/*.test.js',
+                '!{packages,tools}/**/*-memory.test.js',
+            ],
         },
     ],
     group: 'unit',

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -147,7 +147,12 @@ export default {
         },
         {
             name: 'memory-ci',
-            files: ['{packages,tools}/**/*-memory.test.js'],
+            files: [
+                '{packages,tools}/**/*-memory.test.js',
+                'packages/color-area/test/*-memory.test.js',
+                'packages/color-wheel/test/*-memory.test.js',
+                'packages/color-slider/test/*-memory.test.js',
+            ],
             browsers: [chromiumWithMemoryToolingCI],
         },
         {

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -17,7 +17,6 @@ import fg from 'fast-glob';
 
 export const chromium = playwrightLauncher({
     product: 'chromium',
-    concurrency: 1,
     createBrowserContext: ({ browser }) =>
         browser.newContext({
             ignoreHTTPSErrors: true,
@@ -27,6 +26,29 @@ export const chromium = playwrightLauncher({
 
 export const chromiumWithMemoryTooling = playwrightLauncher({
     product: 'chromium',
+    createBrowserContext: ({ browser }) =>
+        browser.newContext({
+            ignoreHTTPSErrors: true,
+            permissions: ['clipboard-read', 'clipboard-write'],
+        }),
+    launchOptions: {
+        headless: false,
+        args: [
+            '--js-flags=--expose-gc',
+            '--headless=new',
+            /**
+             * Cause `measureUserAgentSpecificMemory()` to GC immediately,
+             * instead of up to 20s later:
+             * https://web.dev/articles/monitor-total-page-memory-usage#local_testing
+             **/
+            '--enable-blink-features=ForceEagerMeasureMemory',
+        ],
+    },
+});
+
+export const chromiumWithMemoryToolingCI = playwrightLauncher({
+    product: 'chromium',
+    concurrency: 1,
     createBrowserContext: ({ browser }) =>
         browser.newContext({
             ignoreHTTPSErrors: true,

--- a/web-test-runner.utils.js
+++ b/web-test-runner.utils.js
@@ -48,7 +48,7 @@ export const chromiumWithMemoryTooling = playwrightLauncher({
 
 export const chromiumWithMemoryToolingCI = playwrightLauncher({
     product: 'chromium',
-    concurrency: 1,
+    concurrency: 2,
     createBrowserContext: ({ browser }) =>
         browser.newContext({
             ignoreHTTPSErrors: true,


### PR DESCRIPTION
## Description
Separate unit and memory tests for CI time efficiencies.

@Rajdeepc @TarunAdobe it looks like we were previously skipping all of the memory tests in CI, because CI runs against non-memory tooling Chrome by default which skips those tests. This move puts the memory tests back into the workflow and four of them seem to be failing. Would yall prefer to work against this branch or to see them skipped herein so you can PR them back on, in a passing state, in individual PRs, later?

I'll also test whether we can run memory tests with concurrency in this setup.

## How has this been tested?
-   [ ] _Test case 1_
    1. [Go to CI](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/21745/workflows/c6de2dcf-9667-44dc-916d-baf2663a04f7)
    2. See that [test-chromium](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/21745/workflows/c6de2dcf-9667-44dc-916d-baf2663a04f7/jobs/567560) and [test-chromium-memory](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/21745/workflows/c6de2dcf-9667-44dc-916d-baf2663a04f7/jobs/567579) are now separate jobs
    3. See that allowing concurrency in Chrome while unit testing gets the job [under 4 minutes](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/21745/workflows/c6de2dcf-9667-44dc-916d-baf2663a04f7/jobs/567560) with appropriately cached
    4. See that the memory tests have [some failures](https://app.circleci.com/pipelines/github/adobe/spectrum-web-components/21745/workflows/c6de2dcf-9667-44dc-916d-baf2663a04f7/jobs/567579)

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.