### PR TITLE
docs(overlay,tooltip): document directive usage

### DIFF
--- a/packages/overlay/slottable-request.md
+++ b/packages/overlay/slottable-request.md
@@ -1,0 +1,85 @@
+## Description
+
+When working with a large amount of content that lives whithin an overlay, a page may encounter performance issues for placing a large amount of content within `<sp-overlay>` or `<overlay-trigger>` elements. To avoid this, an empty `<sp-overlay>` could be used instead. When triggered, the `<sp-overlay>` element will dispatch `slottable-request` just before it begins to open and just after it finished closing. When handling these events the contents of an overlay can be lazily rendered into the `<sp-overlay>` element as it opens and then, as needed, removed from the DOM once the overlay has closed.
+
+### Usage
+
+```
+yarn add @spectrum-web-components/overlay
+```
+
+Import the side effectful registration of `<sp-overlay>` as follows:
+
+```
+import '@spectrum-web-components/overlay/sp-overlay.js';
+```
+
+Import type information about the `slottable-request` event and a symbol to signify that the request is for the DOM to be removed:
+
+```
+import {
+    removeSlottableRequest,
+    SlottableRequestEvent,
+} from '@spectrum-web-components/overlay/src/slottable-request-event.js';
+```
+
+#### Javascript based consumption
+
+When leveraging the `<sp-overlay>` in a javascript only context, you can leverage the `slottable-request` event and its `data` property to decide whether and what to render into the `<sp-overlay>` event.
+
+```html-live
+<sp-button id="js-trigger">Trigger</sp-button>
+<sp-overlay trigger="js-trigger@click" placement="right-start"></sp-overlay>
+
+<script type="module">
+    import { removeSlottableRequest } from '@spectrum-web-components/overlay/src/slottable-request-event.js';
+
+    function initOverlay() {
+        const overlay = document.querySelector('[trigger="js-trigger@click"]');
+        overlay.addEventListener('slottable-request', function (event) {
+            if (event.data === removeSlottableRequest) {
+                this.innerHTML = '';
+            } else {
+                this.innerHTML = `
+                <sp-popover>
+                    <p>This content will display within the Overlay and <em>only</em> be on the DOM when the Overlay is open.</p>
+                </sp-popover>
+                `;
+            }
+        });
+    }
+
+    customElements.whenDefined('code-example').then(() => {
+        customElements.whenDefined('sp-overlay').then(() => {
+            initOverlay();
+        });
+    });
+</script>
+```
+
+<script type="module">
+    import { removeSlottableRequest } from '@spectrum-web-components/overlay/src/slottable-request-event.js';
+
+    function initOverlay() {
+        const overlay = document.querySelector('[trigger="js-trigger@click"]');
+        overlay.addEventListener('slottable-request', function (event) {
+            if (event.data === removeSlottableRequest) {
+                this.innerHTML = '';
+            } else {
+                this.innerHTML = `
+                <sp-popover>
+                    <p>This content will display within the Overlay and <em>only</em> be on the DOM when the Overlay is open.</p>
+                </sp-popover>
+                `;
+            }
+        });
+    }
+
+    customElements.whenDefined('code-example').then(() => {
+        customElements.whenDefined('sp-overlay').then(() => {
+            initOverlay();
+        });
+    });
+</script>
+
+Starting with no DOM in the `<sp-overlay>` element and returning to that when the Overlay element is no longer showing can support an application in releasing memory back to other activities.

--- a/packages/overlay/trigger-directive.md
+++ b/packages/overlay/trigger-directive.md
@@ -1,0 +1,61 @@
+## Description
+
+To support consumers that leverage `lit-html`, Spectrum Web Components also vends a [directive](https://lit.dev/docs/api/directives/) to further simplify the management of content conditional to whether or not the Overlay is currently visible.
+
+### Usage
+
+```
+yarn add @spectrum-web-components/overlay
+```
+
+Import the `trigger` directive as follows:
+
+```
+import { trigger } from '@spectrum-web-components/overlay';
+```
+
+## Types
+
+The `trigger()` directive accepts two arguments: a required method returning the `TemplateResult` defining the content of the open overlay and an options object. The options object is shaped as follows:
+
+```ts
+{
+    open?: boolean; // Whether the Overlay in question should be rendered open.
+    triggerInteraction: TriggerInteraction; // 'click' | 'longpress' | 'hover'
+    overlayOptions: OverlayOptions;
+    insertionOptions?: InsertionOptions;
+}
+```
+
+The options are of type `OverlayOptions` (outlined [here](https://opensource.adobe.com/spectrum-web-components/components/imperative-api/#overlayoptions)) and `InsertionOptions` are leveraged to outline where in the DOM the Overlay should be inserted:
+
+```ts
+type InsertionOptions = {
+    el: HTMLElement | (() => HTMLElement); // returning a reference to the element the Overlay should be inserted adjacent to
+    where: InsertPosition; // 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend'
+};
+```
+
+#### Consumption via `lit-html`
+
+Pass a `TemplateResult` into the `trigger()` directive, as follows in order to have it rendered to the DOM when the associated Overlay is about to open and the removed after the Overlay has closed.
+
+```js
+import { trigger } from '@spectrum-web-components/overlay';
+
+// ...
+
+const renderOverlayContent = () => html`
+    <sp-popover>
+        <p>
+            This content will display within the Overlay and
+            <em>only</em>
+            be on the DOM when the Overlay is open.
+        </p>
+    </sp-popover>
+`;
+
+const template = html`
+    <sp-button ${trigger(renderOverlayContent)}>Trigger</sp-button>
+`;
+```

--- a/packages/tooltip/directive.md
+++ b/packages/tooltip/directive.md
@@ -1,0 +1,60 @@
+## Description
+
+While `<sp-tooltip>` element are general fairly innocumous amounts of DOM, it is possible that your page will quickly leverage so many Tooltips that their presence could begin to negatively effect its performane. To support consumers that leverage `lit-html`, Spectrum Web Components also vends a [directive](https://lit.dev/docs/api/directives/) to further simplify the delivery of `<sp-tooltip>` elements.
+
+### Uusage
+
+```
+yarn add @spectrum-web-components/tooltip
+```
+
+Import the `trigger` directive as follows:
+
+```
+import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
+```
+
+## Types
+
+The `tooltip()` directive accepts two arguments: a required method returning the `TemplateResult` defining the content of the open overlay and an options object. The options object is expects a partial of the following:
+
+```ts
+{
+    open?: boolean; // Whether the Overlay in question should be rendered open.
+    triggerInteraction: TriggerInteraction; // 'click' | 'longpress' | 'hover'
+    overlayOptions: OverlayOptions;
+    insertionOptions?: InsertionOptions;
+    variant: 'info' | 'positive' | 'negative';
+}
+```
+
+The `triggerInteraction` is applied as `hover` when using the `tooltip()` directive.
+
+The options are of type `OverlayOptions` (outlined [here](https://opensource.adobe.com/spectrum-web-components/components/imperative-api/#overlayoptions)) and `InsertionOptions` are leveraged to outline where in the DOM the Overlay should be inserted:
+
+```ts
+type InsertionOptions = {
+    el: HTMLElement | (() => HTMLElement); // returning a reference to the element the Overlay should be inserted adjacent to
+    where: InsertPosition; // 'afterbegin' | 'afterend' | 'beforebegin' | 'beforeend'
+};
+```
+
+#### Consumption via `lit-html`
+
+Pass a `TemplateResult` into the `tooltip()` directive, as follows in order to have it rendered to the DOM when the associated Tooltip is about to open and the removed after the Tooltip has closed.
+
+```js
+import { tooltip } from '@spectrum-web-components/tooltip/src/tooltip-directive.js';
+
+// ...
+
+const renderOverlayContent = () => html`
+    <p>Tooltip content</p>
+`;
+
+const template = html`
+    <sp-button ${tooltip(renderOverlayContent)}>Trigger</sp-button>
+`;
+```
+
+The `tooltip()` directive will automatically wrap whatever content you provide in an `<sp-tooltip>` element for you, so you will not need to supply one in this case.


### PR DESCRIPTION
## Description
Begin directive documentation

## How has this been tested?
-   [ ] _Test case 1_
    1. Go to the branch docs preview
    2. Visit the docs additions for:
      - Slottable Requests
      - The `trigger()` directive
      - The `tooltip()` directive
    3. See that they make sense for a consumer

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.