### PR TITLE
add more tests to improve code coverage across the library

### DIFF
--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -21,6 +21,7 @@ import {
     waitUntil,
 } from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
+import { stub } from 'sinon';
 import {
     a11ySnapshot,
     findAccessibilityNode,
@@ -35,18 +36,50 @@ type TestableButtonType = {
 describe('Button', () => {
     testForLitDevWarnings(
         async () =>
-            await fixture<Button>(
-                html`
-                    <sp-button tabindex="0">Button</sp-button>
-                `
-            )
-    );
-    it('loads default', async () => {
-        const el = await fixture<Button>(
-            html`
+            await fixture<Button>(html`
                 <sp-button tabindex="0">Button</sp-button>
-            `
-        );
+            `)
+    );
+    describe('dev mode', () => {
+        let consoleWarnStub!: ReturnType<typeof stub>;
+        before(() => {
+            window.__swc.verbose = true;
+            consoleWarnStub = stub(console, 'warn');
+        });
+        afterEach(() => {
+            consoleWarnStub.resetHistory();
+        });
+        after(() => {
+            window.__swc.verbose = false;
+            consoleWarnStub.restore();
+        });
+
+        it('warns in devMode when white/black variant is provided', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button tabindex="0" variant="white">Button</sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(consoleWarnStub.called).to.be.true;
+
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes('deprecated'),
+                'confirm deprecated variant warning'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-button',
+                    type: 'api',
+                    level: 'default',
+                },
+            });
+        });
+    });
+    it('loads default', async () => {
+        const el = await fixture<Button>(html`
+            <sp-button tabindex="0">Button</sp-button>
+        `);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
@@ -58,25 +91,21 @@ describe('Button', () => {
         expect(el.getAttribute('variant')).to.equal('accent');
     });
     it('loads default w/ element content', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button label="Button"><svg></svg></sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button label="Button"><svg></svg></sp-button>
+        `);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
         await expect(el).to.be.accessible();
     });
     it('loads default w/ an icon', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button label="">
-                    Button
-                    <svg slot="icon"></svg>
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button label="">
+                Button
+                <svg slot="icon"></svg>
+            </sp-button>
+        `);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
@@ -85,24 +114,20 @@ describe('Button', () => {
         await expect(el).to.be.accessible();
     });
     it('loads default only icon', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button label="Button" icon-only>
-                    <svg slot="icon"></svg>
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button label="Button" icon-only>
+                <svg slot="icon"></svg>
+            </sp-button>
+        `);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
         await expect(el).to.be.accessible();
     });
     it('has a stable/predictable `updateComplete`', async () => {
-        const test = await fixture<HTMLDivElement>(
-            html`
-                <div></div>
-            `
-        );
+        const test = await fixture<HTMLDivElement>(html`
+            <div></div>
+        `);
 
         let keydownTime = -1;
         let updateComplete1 = -1;
@@ -133,11 +158,9 @@ describe('Button', () => {
         expect(updateComplete2).lte(keydownTime);
     });
     it('manages "role"', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button>Button</sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button>Button</sp-button>
+        `);
 
         await elementUpdated(el);
         expect(el.getAttribute('role')).to.equal('button');
@@ -154,14 +177,12 @@ describe('Button', () => {
     });
     it('allows label to be toggled', async () => {
         const testNode = document.createTextNode('Button');
-        const el = await fixture<Button>(
-            html`
-                <sp-button>
-                    ${testNode}
-                    <svg slot="icon"></svg>
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button>
+                ${testNode}
+                <svg slot="icon"></svg>
+            </sp-button>
+        `);
 
         await elementUpdated(el);
 
@@ -182,24 +203,18 @@ describe('Button', () => {
         expect(labelTestableEl.hasLabel, 'label is returned').to.be.true;
     });
     it('loads with href', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button href="test_url">With Href</sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button href="test_url">With Href</sp-button>
+        `);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
         expect(el.textContent).to.include('With Href');
     });
     it('loads with href and target', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button href="test_url" target="_blank">
-                    With Target
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button href="test_url" target="_blank">With Target</sp-button>
+        `);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
@@ -207,13 +222,9 @@ describe('Button', () => {
     });
     it('accepts shit+tab interactions', async () => {
         let focusedCount = 0;
-        const el = await fixture<Button>(
-            html`
-                <sp-button href="test_url" target="_blank">
-                    With Target
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button href="test_url" target="_blank">With Target</sp-button>
+        `);
 
         await elementUpdated(el);
         const input = document.createElement('input');
@@ -244,11 +255,9 @@ describe('Button', () => {
     });
     it('manages `disabled`', async () => {
         const clickSpy = spy();
-        const el = await fixture<Button>(
-            html`
-                <sp-button @click=${() => clickSpy()}>Button</sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button @click=${() => clickSpy()}>Button</sp-button>
+        `);
 
         await elementUpdated(el);
         el.click();
@@ -275,11 +284,9 @@ describe('Button', () => {
         expect(clickSpy.calledOnce).to.be.true;
     });
     it('`disabled` manages `tabindex`', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button disabled>Button</sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button disabled>Button</sp-button>
+        `);
 
         await elementUpdated(el);
         expect(el.tabIndex).to.equal(-1);
@@ -298,13 +305,9 @@ describe('Button', () => {
         expect(el.getAttribute('tabindex')).to.equal('-1');
     });
     it('manages `aria-disabled`', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button href="test_url" target="_blank">
-                    With Target
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button href="test_url" target="_blank">With Target</sp-button>
+        `);
 
         await elementUpdated(el);
 
@@ -321,19 +324,17 @@ describe('Button', () => {
         expect(el.hasAttribute('aria-disabled'), 'finally not').to.be.false;
     });
     it('manages aria-label from disabled state', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button
-                    href="test_url"
-                    target="_blank"
-                    label="clickable"
-                    disabled
-                    pending-label="Pending Button"
-                >
-                    Click me
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button
+                href="test_url"
+                target="_blank"
+                label="clickable"
+                disabled
+                pending-label="Pending Button"
+            >
+                Click me
+            </sp-button>
+        `);
 
         await elementUpdated(el);
 
@@ -356,18 +357,16 @@ describe('Button', () => {
     });
 
     it('manages aria-label from pending state', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button
-                    href="test_url"
-                    target="_blank"
-                    label="clickable"
-                    pending
-                >
-                    Click me
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button
+                href="test_url"
+                target="_blank"
+                label="clickable"
+                pending
+            >
+                Click me
+            </sp-button>
+        `);
         await elementUpdated(el);
         expect(el.getAttribute('aria-label')).to.equal('Pending');
 
@@ -388,18 +387,16 @@ describe('Button', () => {
     });
 
     it('manages aria-label set from outside', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button
-                    href="test_url"
-                    target="_blank"
-                    aria-label="test"
-                    pending-label="Pending Button"
-                >
-                    Click me
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button
+                href="test_url"
+                target="_blank"
+                aria-label="test"
+                pending-label="Pending Button"
+            >
+                Click me
+            </sp-button>
+        `);
         await elementUpdated(el);
         expect(el.getAttribute('aria-label')).to.equal('test');
 
@@ -425,11 +422,9 @@ describe('Button', () => {
     });
 
     it('updates pending label accessibly', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button href="test_url" target="_blank">Button</sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button href="test_url" target="_blank">Button</sp-button>
+        `);
 
         await elementUpdated(el);
         el.pending = true;
@@ -474,13 +469,9 @@ describe('Button', () => {
     });
 
     it('manages tabIndex while disabled', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button href="test_url" target="_blank">
-                    With Target
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button href="test_url" target="_blank">With Target</sp-button>
+        `);
 
         await elementUpdated(el);
 
@@ -503,13 +494,9 @@ describe('Button', () => {
     });
     it('swallows `click` interaction when `[disabled]`', async () => {
         const clickSpy = spy();
-        const el = await fixture<Button>(
-            html`
-                <sp-button disabled @click=${() => clickSpy()}>
-                    Button
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button disabled @click=${() => clickSpy()}>Button</sp-button>
+        `);
 
         await elementUpdated(el);
         expect(clickSpy.callCount).to.equal(0);
@@ -521,11 +508,9 @@ describe('Button', () => {
     });
     it('translates keyboard interactions to click', async () => {
         const clickSpy = spy();
-        const el = await fixture<Button>(
-            html`
-                <sp-button @click=${() => clickSpy()}>Button</sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button @click=${() => clickSpy()}>Button</sp-button>
+        `);
 
         await elementUpdated(el);
 
@@ -652,22 +637,20 @@ describe('Button', () => {
     it('proxies clicks by "type"', async () => {
         const submitSpy = spy();
         const resetSpy = spy();
-        const test = await fixture<HTMLFormElement>(
-            html`
-                <form
-                    @submit=${(event: Event): void => {
-                        event.preventDefault();
-                        submitSpy();
-                    }}
-                    @reset=${(event: Event): void => {
-                        event.preventDefault();
-                        resetSpy();
-                    }}
-                >
-                    <sp-button>Button</sp-button>
-                </form>
-            `
-        );
+        const test = await fixture<HTMLFormElement>(html`
+            <form
+                @submit=${(event: Event): void => {
+                    event.preventDefault();
+                    submitSpy();
+                }}
+                @reset=${(event: Event): void => {
+                    event.preventDefault();
+                    resetSpy();
+                }}
+            >
+                <sp-button>Button</sp-button>
+            </form>
+        `);
         const el = test.querySelector('sp-button') as Button;
 
         await elementUpdated(el);
@@ -697,11 +680,9 @@ describe('Button', () => {
     });
     it('proxies click by [href]', async () => {
         const clickSpy = spy();
-        const el = await fixture<Button>(
-            html`
-                <sp-button href="test_url">With Href</sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button href="test_url">With Href</sp-button>
+        `);
 
         await elementUpdated(el);
         (
@@ -720,13 +701,11 @@ describe('Button', () => {
         expect(clickSpy.callCount).to.equal(1);
     });
     it('manages "active" while focused', async () => {
-        const el = await fixture<Button>(
-            html`
-                <sp-button label="Button">
-                    <svg slot="icon"></svg>
-                </sp-button>
-            `
-        );
+        const el = await fixture<Button>(html`
+            <sp-button label="Button">
+                <svg slot="icon"></svg>
+            </sp-button>
+        `);
 
         await elementUpdated(el);
         el.focus();
@@ -744,11 +723,9 @@ describe('Button', () => {
     });
     describe('deprecated variants and attributes', () => {
         it('manages [quiet]', async () => {
-            const el = await fixture<Button>(
-                html`
-                    <sp-button quiet>Button</sp-button>
-                `
-            );
+            const el = await fixture<Button>(html`
+                <sp-button quiet>Button</sp-button>
+            `);
 
             await elementUpdated(el);
             expect(el.treatment).to.equal('outline');
@@ -759,21 +736,17 @@ describe('Button', () => {
             expect(el.treatment).to.equal('fill');
         });
         it('upgrades [variant="cta"] to [variant="accent"]', async () => {
-            const el = await fixture<Button>(
-                html`
-                    <sp-button variant="cta">Button</sp-button>
-                `
-            );
+            const el = await fixture<Button>(html`
+                <sp-button variant="cta">Button</sp-button>
+            `);
 
             await elementUpdated(el);
             expect(el.variant).to.equal('accent');
         });
         it('manages [variant="overBackground"]', async () => {
-            const el = await fixture<Button>(
-                html`
-                    <sp-button variant="overBackground">Button</sp-button>
-                `
-            );
+            const el = await fixture<Button>(html`
+                <sp-button variant="overBackground">Button</sp-button>
+            `);
 
             await elementUpdated(el);
             expect(el.hasAttribute('variant')).to.not.equal('overBackground');
@@ -781,11 +754,9 @@ describe('Button', () => {
             expect(el.static).to.equal('white');
         });
         it('forces [variant="accent"]', async () => {
-            const el = await fixture<Button>(
-                html`
-                    <sp-button variant="not-supported">Button</sp-button>
-                `
-            );
+            const el = await fixture<Button>(html`
+                <sp-button variant="not-supported">Button</sp-button>
+            `);
 
             await elementUpdated(el);
             expect(el.variant).to.equal('accent');

--- a/packages/progress-circle/test/progress-circle.test.ts
+++ b/packages/progress-circle/test/progress-circle.test.ts
@@ -24,6 +24,68 @@ describe('ProgressCircle', () => {
                 <sp-progress-circle label="Loading"></sp-progress-circle>
             `)
     );
+    describe('dev mode', () => {
+        let consoleWarnStub!: ReturnType<typeof stub>;
+        before(() => {
+            window.__swc.verbose = true;
+            consoleWarnStub = stub(console, 'warn');
+        });
+        afterEach(() => {
+            consoleWarnStub.resetHistory();
+        });
+        after(() => {
+            window.__swc.verbose = false;
+            consoleWarnStub.restore();
+        });
+
+        it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
+            const el = await fixture<ProgressCircle>(html`
+                <sp-progress-circle progress="50"></sp-progress-circle>
+            `);
+
+            await elementUpdated(el);
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes('accessible'),
+                'confirm accessibility-centric message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-progress-circle',
+                    type: 'accessibility',
+                    level: 'default',
+                },
+            });
+        });
+        it('warns in Dev Mode when overBackground attribute is supplied', async () => {
+            const el = await fixture<ProgressCircle>(html`
+                <sp-progress-circle
+                    progress="50"
+                    ?over-background=${true}
+                ></sp-progress-circle>
+            `);
+
+            await elementUpdated(el);
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes(
+                    'element will stop accepting the "over-background" attribute'
+                ),
+                'confirm attribute deprecation message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-progress-circle',
+                    type: 'api',
+                    level: 'deprecation',
+                },
+            });
+        });
+    });
     it('loads', async () => {
         const el = await fixture<ProgressCircle>(html`
             <sp-progress-circle label="Loading"></sp-progress-circle>
@@ -88,30 +150,6 @@ describe('ProgressCircle', () => {
         await elementUpdated(el);
 
         expect(el.hasAttribute('aria-valuenow')).to.be.false;
-    });
-
-    it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
-        const consoleWarnStub = stub(console, 'warn');
-        const el = await fixture<ProgressCircle>(html`
-            <sp-progress-circle progress="50"></sp-progress-circle>
-        `);
-
-        await elementUpdated(el);
-
-        expect(consoleWarnStub.called).to.be.true;
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            spyCall.args.at(0).includes('accessible'),
-            'confirm accessibility-centric message'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-progress-circle',
-                type: 'accessibility',
-                level: 'default',
-            },
-        });
-        consoleWarnStub.restore();
     });
     it('accepts `aria-label`', async () => {
         const el = await fixture<ProgressCircle>(html`

--- a/packages/progress-circle/test/progress-circle.test.ts
+++ b/packages/progress-circle/test/progress-circle.test.ts
@@ -89,8 +89,18 @@ describe('ProgressCircle', () => {
 
         expect(el.hasAttribute('aria-valuenow')).to.be.false;
     });
+
     it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
-        const consoleWarnStub = stub(console, 'warn');
+        let consoleWarnStub!: SinonStub;
+        before(() => {
+            consoleWarnStub = stub(console, 'warn');
+        });
+        afterEach(() => {
+            consoleWarnStub.resetHistory();
+        });
+        after(() => {
+            consoleWarnStub.restore();
+        });
         const el = await fixture<ProgressCircle>(html`
             <sp-progress-circle progress="50"></sp-progress-circle>
         `);
@@ -98,9 +108,9 @@ describe('ProgressCircle', () => {
         await elementUpdated(el);
 
         expect(consoleWarnStub.called).to.be.true;
-        const spyCall = consoleWarnStub.getCall(0);
+        let spyCall = consoleWarnStub.getCall(0);
         expect(
-            spyCall.args.at(0).includes('accessible'),
+            (spyCall.args.at(0) as string).includes('accessible'),
             'confirm accessibility-centric message'
         ).to.be.true;
         expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
@@ -110,7 +120,23 @@ describe('ProgressCircle', () => {
                 level: 'default',
             },
         });
-        consoleWarnStub.restore();
+
+        el.overBackground = true;
+        await elementUpdated(el);
+
+        expect(consoleWarnStub.called).to.be.true;
+        spyCall = consoleWarnStub.getCall(0);
+        expect(
+            (spyCall.args.at(0) as string).includes('overBackground'),
+            'confirm a warning message'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-progress-circle',
+                level: 'deprecation',
+                type: 'api',
+            },
+        });
     });
     it('accepts `aria-label`', async () => {
         const el = await fixture<ProgressCircle>(html`

--- a/packages/progress-circle/test/progress-circle.test.ts
+++ b/packages/progress-circle/test/progress-circle.test.ts
@@ -91,16 +91,7 @@ describe('ProgressCircle', () => {
     });
 
     it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
-        let consoleWarnStub!: SinonStub;
-        before(() => {
-            consoleWarnStub = stub(console, 'warn');
-        });
-        afterEach(() => {
-            consoleWarnStub.resetHistory();
-        });
-        after(() => {
-            consoleWarnStub.restore();
-        });
+        const consoleWarnStub = stub(console, 'warn');
         const el = await fixture<ProgressCircle>(html`
             <sp-progress-circle progress="50"></sp-progress-circle>
         `);
@@ -108,9 +99,9 @@ describe('ProgressCircle', () => {
         await elementUpdated(el);
 
         expect(consoleWarnStub.called).to.be.true;
-        let spyCall = consoleWarnStub.getCall(0);
+        const spyCall = consoleWarnStub.getCall(0);
         expect(
-            (spyCall.args.at(0) as string).includes('accessible'),
+            spyCall.args.at(0).includes('accessible'),
             'confirm accessibility-centric message'
         ).to.be.true;
         expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
@@ -120,23 +111,7 @@ describe('ProgressCircle', () => {
                 level: 'default',
             },
         });
-
-        el.overBackground = true;
-        await elementUpdated(el);
-
-        expect(consoleWarnStub.called).to.be.true;
-        spyCall = consoleWarnStub.getCall(0);
-        expect(
-            (spyCall.args.at(0) as string).includes('overBackground'),
-            'confirm a warning message'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-progress-circle',
-                level: 'deprecation',
-                type: 'api',
-            },
-        });
+        consoleWarnStub.restore();
     });
     it('accepts `aria-label`', async () => {
         const el = await fixture<ProgressCircle>(html`

--- a/packages/thumbnail/test/thumbnail.test.ts
+++ b/packages/thumbnail/test/thumbnail.test.ts
@@ -16,54 +16,87 @@ import '@spectrum-web-components/thumbnail/sp-thumbnail.js';
 import { Thumbnail } from '..';
 import { thumbnail } from '../stories/images.js';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
+import { stub } from 'sinon';
 
 describe('Thumbnail', () => {
     testForLitDevWarnings(
         async () =>
-            await fixture<Thumbnail>(
-                html`
-                    <sp-thumbnail>
-                        <img src=${thumbnail} alt="Woman crouching" />
-                    </sp-thumbnail>
-                `
-            )
-    );
-    it('loads default thumbnail accessibly', async () => {
-        const el = await fixture<Thumbnail>(
-            html`
+            await fixture<Thumbnail>(html`
                 <sp-thumbnail>
                     <img src=${thumbnail} alt="Woman crouching" />
                 </sp-thumbnail>
-            `
-        );
+            `)
+    );
+    it('loads default thumbnail accessibly', async () => {
+        const el = await fixture<Thumbnail>(html`
+            <sp-thumbnail>
+                <img src=${thumbnail} alt="Woman crouching" />
+            </sp-thumbnail>
+        `);
 
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
     });
     it('can be size `50`', async () => {
-        const el = await fixture<Thumbnail>(
-            html`
-                <sp-thumbnail size="50">
-                    <img src=${thumbnail} alt="Woman crouching" />
-                </sp-thumbnail>
-            `
-        );
+        const el = await fixture<Thumbnail>(html`
+            <sp-thumbnail size="50">
+                <img src=${thumbnail} alt="Woman crouching" />
+            </sp-thumbnail>
+        `);
 
         await elementUpdated(el);
 
         expect(el.size).to.equal('50');
     });
     it('accepts `background`', async () => {
-        const el = await fixture<Thumbnail>(
-            html`
-                <sp-thumbnail background="blue">
-                    <img src=${thumbnail} alt="Woman crouching" />
-                </sp-thumbnail>
-            `
-        );
+        const el = await fixture<Thumbnail>(html`
+            <sp-thumbnail background="blue">
+                <img src=${thumbnail} alt="Woman crouching" />
+            </sp-thumbnail>
+        `);
 
         const background = el.shadowRoot.querySelector('.background');
         expect(background).to.not.be.null;
+    });
+    describe('dev mode', () => {
+        let consoleWarnStub!: ReturnType<typeof stub>;
+        before(() => {
+            window.__swc.verbose = true;
+            consoleWarnStub = stub(console, 'warn');
+        });
+        afterEach(() => {
+            consoleWarnStub.resetHistory();
+        });
+        after(() => {
+            window.__swc.verbose = false;
+            consoleWarnStub.restore();
+        });
+
+        it('warns in devMode when white/black variant is provided', async () => {
+            const el = await fixture<Thumbnail>(html`
+                <sp-thumbnail background="blue" size="xxs">
+                    <img src=${thumbnail} alt="Woman crouching" />
+                </sp-thumbnail>
+            `);
+
+            await elementUpdated(el);
+            expect(consoleWarnStub.called).to.be.true;
+
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes(
+                    'no longer supports the value'
+                ),
+                'confirm deprecated size warning'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-thumbnail',
+                    type: 'api',
+                    level: 'deprecation',
+                },
+            });
+        });
     });
 });

--- a/packages/underlay/test/underlay.test.ts
+++ b/packages/underlay/test/underlay.test.ts
@@ -15,25 +15,38 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import '@spectrum-web-components/underlay/sp-underlay.js';
 import { Underlay } from '@spectrum-web-components/underlay';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
+import { spy } from 'sinon';
 
 describe('Underlay', () => {
     testForLitDevWarnings(
         async () =>
-            await fixture<Underlay>(
-                html`
-                    <sp-underlay></sp-underlay>
-                `
-            )
+            await fixture<Underlay>(html`
+                <sp-underlay></sp-underlay>
+            `)
     );
     it('loads default underlay accessibly', async () => {
-        const el = await fixture<Underlay>(
-            html`
-                <sp-underlay></sp-underlay>
-            `
-        );
+        const el = await fixture<Underlay>(html`
+            <sp-underlay></sp-underlay>
+        `);
 
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
+    });
+
+    it('fires a close event when clicked', async () => {
+        const el = await fixture<Underlay>(html`
+            <sp-underlay></sp-underlay>
+        `);
+
+        await elementUpdated(el);
+        const closeSpy = spy();
+        el.addEventListener('close', () => closeSpy());
+        expect(closeSpy.callCount).to.equal(0);
+
+        el.dispatchEvent(new PointerEvent('pointerdown', { button: 0 }));
+        el.dispatchEvent(new PointerEvent('pointerup'));
+
+        expect(closeSpy.callCount).to.equal(1);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds more tests to SWC components in order to improve the overall code coverage across the library. 
The simple criteria that I'm following here is to have a >95% code coverage for every component.

## Motivation and context

Recently we have added a lot of `Dev Mode` warnings for in our library but didn't add respective tests for that which caused the ci to fail in main. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
