### PR TITLE
fix(coachmark,overlay): adjust imports of overlay and coachmark

### DIFF
--- a/packages/coachmark/src/Coachmark.ts
+++ b/packages/coachmark/src/Coachmark.ts
@@ -21,7 +21,7 @@ import coachmarkStyles from './coachmark.css.js';
 import chevronStyles from '@spectrum-web-components/icon/src/spectrum-icon-chevron.css.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-chevron200.js';
 import { Popover } from '@spectrum-web-components/popover';
-import { join } from 'lit/directives/join.js';
+import { join } from '@spectrum-web-components/base/src/directives.js';
 import { ifDefined } from '@spectrum-web-components/base/src/directives.js';
 import type { Placement } from '@spectrum-web-components/overlay';
 import { MediaType } from './CoachmarkItem.js';

--- a/packages/overlay/src/overlay-trigger-directive.ts
+++ b/packages/overlay/src/overlay-trigger-directive.ts
@@ -15,7 +15,7 @@ import {
     render,
     TemplateResult,
 } from '@spectrum-web-components/base';
-import { directive } from 'lit/async-directive.js';
+import { directive } from '@spectrum-web-components/base/src/async-directive.js';
 import { strategies } from './strategies.js';
 import type { OverlayOptions, TriggerInteraction } from './overlay-types.js';
 import type { ClickController } from './ClickController.js';


### PR DESCRIPTION
Fixing issue with various lit imports introduced in 0.42.3 release.

Similar to https://github.com/adobe/spectrum-web-components/pull/4416 but found a few more issues that didn't show up on install but did show up when trying to upgrade. I looked at adding a `import/no-unresolved` eslint rule but ran into a few issues but we should probably look at doing this in the future. 

## Description

Both Coachmark and Overlay included imports directly from lit while neither package has lit as a direct dependency. Moving these imports to pull from base as this seems to be the established standard.

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/4454

## Motivation and context

Unable to use the latest release without needing to add additional dependencies.

## How has this been tested?

- Addressing all the various issues in error report
- Code search for any remaining direct lit imports outside of storybook or base

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
