### PR TITLE
fix(overlay): persist "host" in directive rendered Overlay content

### DIFF
--- a/packages/overlay/src/overlay-trigger-directive.ts
+++ b/packages/overlay/src/overlay-trigger-directive.ts
@@ -10,10 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import {
-    ElementPart,
+    type ElementPart,
     nothing,
     render,
-    TemplateResult,
+    type RenderOptions,
+    type TemplateResult,
 } from '@spectrum-web-components/base';
 import { directive } from '@spectrum-web-components/base/src/async-directive.js';
 import { strategies } from './strategies.js';
@@ -41,6 +42,7 @@ export type OverlayTriggerOptions = {
 };
 
 export class OverlayTriggerDirective extends SlottableRequestDirective {
+    private host?: object;
     private overlay!: AbstractOverlay;
     private strategy!: ClickController | HoverController | LongpressController;
 
@@ -77,6 +79,7 @@ export class OverlayTriggerDirective extends SlottableRequestDirective {
         };
         this.insertionOptions = options?.insertionOptions;
         this.template = template;
+        this.host = part.options?.host;
         let newTarget = false;
         const triggerInteraction = (options?.triggerInteraction ||
             this.defaultOptions.triggerInteraction) as TriggerInteraction;
@@ -107,7 +110,15 @@ export class OverlayTriggerDirective extends SlottableRequestDirective {
         if (event.target !== event.currentTarget) return;
 
         const willRemoveSlottable = event.data === removeSlottableRequest;
-        render(willRemoveSlottable ? undefined : this.template(), this.overlay);
+        const options = {} as RenderOptions;
+        if (this.host) {
+            options.host = this.host;
+        }
+        render(
+            willRemoveSlottable ? undefined : this.template(),
+            this.overlay,
+            options
+        );
 
         if (willRemoveSlottable) {
             this.overlay.remove();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensure the `lit-html` renderer shares the same `host` between the Overlay Trigger Directive's `ElementPart` and the content it renders.

## Related issue(s)
- fixes #4471

## How has this been tested?
-   [ ] _Test case 1_
    1. Go [here](https://overlay-tigger-host--spectrum-web-components.netlify.app/)
    2. In a mobile context
    3. Open the Site Settings menu with the Gear Icon
    4. Choose a different theme "System"
    5. Close the Site Settings menu
    6. See that the "System" was applied
    7. Open the Site Settings menu again
    8. See that the new "System" persists in the selection UI

## Types of changes
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.