### PR TITLE
build: expand templating to support #1822 by default

### DIFF
--- a/projects/templates/plop-templates/args.ts.hbs
+++ b/projects/templates/plop-templates/args.ts.hbs
@@ -1,0 +1,3 @@
+export const argTypes = {
+
+}

--- a/projects/templates/plop-templates/stories.ts.hbs
+++ b/projects/templates/plop-templates/stories.ts.hbs
@@ -1,12 +1,12 @@
-import { html, TemplateResult } from '@spectrum-web-components/base';
+import { TemplateResult } from '@spectrum-web-components/base';
 
-import '../{{> tagnamePartial }}.js';
+import { Template } from './template.js';
+import { argTypes } from './args.js';
 
 export default {
     title: '{{displayName name}}',
     component: '{{> tagnamePartial}}',
+    argTypes,
 };
 
-export const Default = (): TemplateResult => {
-    return html`<{{> tagnamePartial}}></{{> tagnamePartial}}>`;
-};
+export const Default = (): TemplateResult => Template({});

--- a/projects/templates/plop-templates/template.ts.hbs
+++ b/projects/templates/plop-templates/template.ts.hbs
@@ -1,0 +1,13 @@
+import { html, TemplateResult } from '@spectrum-web-components/base';
+
+import '@spectrum-web-components/{{ name }}/{{> tagnamePartial }}.js';
+
+export interface Properties {
+}
+
+export const Template = (props: Properties): TemplateResult => {
+    // Remove the console.log() when you're ready to consume `props` in the element below.
+    // eslint-disable-next-line no-console
+    console.log('template properties', props);
+    return html`<{{> tagnamePartial}}></{{> tagnamePartial}}>`;
+};

--- a/projects/templates/plop-templates/test.ts.hbs
+++ b/projects/templates/plop-templates/test.ts.hbs
@@ -1,7 +1,7 @@
 import { fixture, elementUpdated, expect, html } from '@open-wc/testing';
 
-import '../{{> tagnamePartial }}.js';
-import { {{className name}} } from '..';
+import '@spectrum-web-components/{{name}}/{{> tagnamePartial }}.js';
+import { {{className name}} } from '@spectrum-web-components/{{name}}';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
 describe('{{className name}}', () => {

--- a/projects/templates/plopfile.js
+++ b/projects/templates/plopfile.js
@@ -54,7 +54,7 @@ module.exports = function (plop) {
 
     plop.setActionType('format files', function (answers) {
         execSync(
-            `cd ../../ && yarn prettier --write packages/${answers.name} && eslint --fix -f pretty packages/${answers.name} && stylelint --fix packages/${answers.name}`
+            `cd ../../ && yarn prettier --write packages/${answers.name} && yarn eslint --fix -f pretty packages/${answers.name} && yarn stylelint --fix packages/${answers.name}`
         );
     });
 
@@ -125,6 +125,16 @@ module.exports = function (plop) {
                 type: 'add',
                 path: '../../packages/{{name}}/stories/{{name}}.stories.ts',
                 templateFile: 'plop-templates/stories.ts.hbs',
+            },
+            {
+                type: 'add',
+                path: '../../packages/{{name}}/stories/args.ts',
+                templateFile: 'plop-templates/args.ts.hbs',
+            },
+            {
+                type: 'add',
+                path: '../../packages/{{name}}/stories/template.ts',
+                templateFile: 'plop-templates/template.ts.hbs',
             },
             {
                 type: 'add',


### PR DESCRIPTION
## Description
Split `package.stories.ts` into `args.ts`, `template.ts` and `package.stories.ts` in order to support automatically forwarding Storybook content into the documentation site when generating new packages.

## Related issue(s)
- refs #1822

## How has this been tested?

-   [ ] _Test case 1_
    1. Take the branch onto your local device
    2. Use `yarn new-package` to generate a new component
    3. I used `inline-alert` and `inlinealert` as my test answers
    4. Manually manage the fact that CSS has allowed canary releases onto its `latest` channel by updating the version in the generated package JSON for `@spectrum-css/inlinealert` to [`^8.1.0`](https://www.npmjs.com/package/@spectrum-css/inlinealert/v/8.1.0).
    5. Run `yarn` again.
    6. Run `yarn storybook`
    7. See that the "new package" is included in storybook
    8. Run `yarn docs:start`
    9. See that the package listing in the docs includes a demo at the top of the page.

## Screenshots (if appropriate)
<img width="1000" alt="image" src="https://github.com/adobe/spectrum-web-components/assets/1156657/aee03ada-1c94-4485-9dca-c4fff3d9f5ee">

## Types of changes
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist
-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.