### PR TITLE
ci: notify the swc maintainers team when creating dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,7 @@ updates:
           timezone: 'America/Los_Angeles'
       open-pull-requests-limit: 5
       reviewers:
-          - 'hunterloftis'
-          - 'najikahalsema'
-          - 'westbrook'
+          - 'adobe/swc-maintainers'
       groups:
           # Specify a name for the group, which will be used in pull request titles
           # and branch names


### PR DESCRIPTION
Ensure Dependabot notifies people on the project when opening new pRs.