### PR TITLE
fix(progress-bar): removed duplicate label

### DIFF
--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -71,7 +71,6 @@ export class ProgressBar extends SizedMixin(
             ${this.slotHasContent || this.label
                 ? html`
                       <sp-field-label size=${this.size} class="label">
-                          ${this.slotHasContent ? html`` : this.label}
                           <slot @slotchange=${this.handleSlotchange}>
                               ${this.label}
                           </slot>


### PR DESCRIPTION
## Description

Removes duplicate label from progress bar.

## Related issue(s)

- fixes #4225

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_
    1. Go here
    2. Do this


## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes. _(Note: Testing won't allow an empty an empty label, so I can't test for this.)_
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)
