### PR TITLE
fix(number-field): updated number field to respect all locales 

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -223,9 +223,7 @@ export class NumberField extends TextfieldBase {
                 value = value.replace(sourceDecimal, replacementDecimal);
             }
         }
-        return this.numberParser.parse(
-            this.valueFormatter.format(Number(value))
-        );
+        return this.numberParser.parse(value);
     }
 
     private get _step(): number {
@@ -325,7 +323,7 @@ export class NumberField extends TextfieldBase {
 
         this.requestUpdate();
         this._value = this.validateInput(value);
-        this.inputElement.value = value.toString();
+        this.inputElement.value = this.numberFormatter.format(value); //value.toString();
 
         this.inputElement.dispatchEvent(
             new Event('input', { bubbles: true, composed: true })
@@ -589,7 +587,6 @@ export class NumberField extends TextfieldBase {
             this._valueFormatter = new NumberFormatter(
                 this.languageResolver.language,
                 {
-                    ...this.formatOptions,
                     useGrouping: false,
                     maximumFractionDigits: digitsAfterDecimal,
                 }

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -223,7 +223,9 @@ export class NumberField extends TextfieldBase {
                 value = value.replace(sourceDecimal, replacementDecimal);
             }
         }
-        return this.numberParser.parse(value);
+        return this.numberParser.parse(
+            this.valueFormatter.format(Number(value))
+        );
     }
 
     private get _step(): number {
@@ -523,7 +525,7 @@ export class NumberField extends TextfieldBase {
                     value -= this.step;
                 }
             }
-            value = parseFloat(this.valueFormatter.format(value));
+            value = this.numberParser.parse(this.valueFormatter.format(value));
         }
         value *= signMultiplier;
         return value;
@@ -587,8 +589,9 @@ export class NumberField extends TextfieldBase {
             this._valueFormatter = new NumberFormatter(
                 this.languageResolver.language,
                 {
-                    maximumFractionDigits: digitsAfterDecimal,
+                    ...this.formatOptions,
                     useGrouping: false,
+                    maximumFractionDigits: digitsAfterDecimal,
                 }
             );
         }

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -323,7 +323,7 @@ export class NumberField extends TextfieldBase {
 
         this.requestUpdate();
         this._value = this.validateInput(value);
-        this.inputElement.value = this.numberFormatter.format(value); //value.toString();
+        this.inputElement.value = this.numberFormatter.format(value);
 
         this.inputElement.dispatchEvent(
             new Event('input', { bubbles: true, composed: true })
@@ -523,7 +523,7 @@ export class NumberField extends TextfieldBase {
                     value -= this.step;
                 }
             }
-            value = this.numberParser.parse(this.valueFormatter.format(value));
+            value = parseFloat(this.valueFormatter.format(value));
         }
         value *= signMultiplier;
         return value;
@@ -584,13 +584,10 @@ export class NumberField extends TextfieldBase {
                     ? this.step.toString().split('.')[1].length
                     : 0
                 : 0;
-            this._valueFormatter = new NumberFormatter(
-                this.languageResolver.language,
-                {
-                    useGrouping: false,
-                    maximumFractionDigits: digitsAfterDecimal,
-                }
-            );
+            this._valueFormatter = new NumberFormatter('en', {
+                useGrouping: false,
+                maximumFractionDigits: digitsAfterDecimal,
+            });
         }
 
         return this._valueFormatter;

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -24,6 +24,7 @@ import {
     currency,
     decimals,
     Default,
+    germanDecimals,
     indeterminate,
     percents,
     pixels,
@@ -133,7 +134,25 @@ describe('NumberField', () => {
             expect(el.valueAsString).to.equal('5');
             expect(el.focusElement.value).to.equal('5');
         });
+        it('respects other locales', async () => {
+            const el = await getElFrom(
+                germanDecimals({
+                    step: 0.01,
+                })
+            );
+            el.value = 2.42;
+            await elementUpdated(el);
+            el.size = 'xl';
+            expect(el.value).to.equal(2.42);
+            expect(el.formattedValue).to.equal('+2,42');
+            expect(el.focusElement.value).to.equal('+2,42');
 
+            await clickBySelector(el, '.step-up');
+
+            expect(el.value).to.equal(2.43);
+            expect(el.formattedValue).to.equal('+2,43');
+            expect(el.focusElement.value).to.equal('+2,43');
+        });
         it('supports both positive and negative decimal values', async () => {
             const el = await getElFrom(
                 Default({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Number-field was not respecting other locales than 'en'.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #4483 

## Motivation and context

The function `convertValueToNumber` was not receiving correct input when locale was anything other than 'en'.
In function `stepBy` earlier we were doing `this.inputElement.value = value.toString();` which was not respecting locales.
Thus to respect locales we are now formating the value like this `this.inputElement.value = this.numberFormatter.format(value);`

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I wrote some tests in `Number-field.test.ts`
Test [here](https://bug-number-field-not-respecting-locale--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--german-decimals)
## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
