### PR TITLE
fix(swatch): sync `aria-label` with changes in label, color, and mixed …

### DIFF
--- a/packages/swatch/src/Swatch.ts
+++ b/packages/swatch/src/Swatch.ts
@@ -234,18 +234,21 @@ export class Swatch extends SizedMixin(Focusable, {
                 this.selected ? 'true' : 'false'
             );
         }
-        if (changes.has('label')) {
+
+        // aria-label should be in sync with changes in label and color.
+        if (
+            changes.has('label') ||
+            changes.has('color') ||
+            changes.has('mixedValue')
+        ) {
             if (this.label !== this.color && this.label?.length) {
                 this.setAttribute('aria-label', this.label);
-            } else if (this.color !== '') {
+            } else if (this.color) {
                 this.setAttribute('aria-label', this.color);
+            } else if (this.mixedValue) {
+                this.setAttribute('aria-label', 'Mixed');
             } else {
                 this.removeAttribute('aria-label');
-            }
-        }
-        if (changes.has('mixedValue')) {
-            if (this.mixedValue) {
-                this.setAttribute('aria-checked', 'mixed');
             }
         }
     }

--- a/packages/swatch/test/swatch.test.ts
+++ b/packages/swatch/test/swatch.test.ts
@@ -21,21 +21,17 @@ import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 describe('Swatch', () => {
     let el: Swatch;
     beforeEach(async () => {
-        el = await fixture<Swatch>(
-            html`
-                <sp-swatch color="red" label="Red"></sp-swatch>
-            `
-        );
+        el = await fixture<Swatch>(html`
+            <sp-swatch color="red" label="Red"></sp-swatch>
+        `);
 
         await elementUpdated(el);
     });
     testForLitDevWarnings(
         async () =>
-            await fixture<Swatch>(
-                html`
-                    <sp-swatch color="red" label="Red"></sp-swatch>
-                `
-            )
+            await fixture<Swatch>(html`
+                <sp-swatch color="red" label="Red"></sp-swatch>
+            `)
     );
     it(`loads default swatch accessibly`, async () => {
         await expect(el).to.be.accessible();
@@ -43,7 +39,21 @@ describe('Swatch', () => {
     it('loads [mixed-value] swatch accessibly', async () => {
         el.mixedValue = true;
         await expect(el).to.be.accessible();
-        expect(el.getAttribute('aria-checked')).to.equal('mixed');
+
+        // The provided label takes precedence over any default label.
+        expect(el.getAttribute('aria-label')).to.equal('Red');
+
+        el.removeAttribute('label');
+        await elementUpdated(el);
+
+        // The color takes precedence over the "mixed" label.
+        expect(el.getAttribute('aria-label')).to.equal('red');
+
+        el.removeAttribute('color');
+        await elementUpdated(el);
+
+        // No label + no color => the default label for the current state is used.
+        expect(el.getAttribute('aria-label')).to.equal('Mixed');
     });
     it('loads [nothing] swatch accessibly', async () => {
         el.nothing = true;


### PR DESCRIPTION
…state

Right now `sp-swatch` has some accessibility bugs:
1. For mixed state, there is an accessibility error thrown because of the use of `aria-checked="mixed"` on an element with `role=button`.
2. On color change, the `aria-label` is not in sync with it and it has the old color value.

## Description

- Synced `aria-label` with changes in color, when there's no `label` provided
- Removed the use of `aria-checked="mixed"`, as the mixed state in this case is more of a value, I moved this information in the `aria-label` attribute.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/4518

## Motivation and context

Screen reader accessibility

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://rocss-4518-swatch-a11y--spectrum-web-components.netlify.app/storybook/?path=/story/swatch--mixed-value)
    3. Open the "Accessibility" add-on
    4. We should see "0 Violations"
    5. Inspect the element and observe `aria-label="Mixed"`. This is the default accessible label in case the user does not provide one.
-   [ ] _Test case 2_
    1. Go [here](https://rocss-4518-swatch-a11y--spectrum-web-components.netlify.app/storybook/?path=/story/swatch--default)
    2. Change the color of the Swatch
    3. Observe that the `aria-label` attribute is changed too to reflect the selected color

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
