### PR TITLE
chore(search): added logic to hold search value on escape

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 8385907444b2bfd2a11c61d3fc67fc0eefdb07eb
+        default: f79f2f2992118450c7eaa91801630c19781af30e
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: c5a1a42567a3c179a5e89f57c99e12c1058d682a
+        default: 987a0abd032990fd08c1124fd2db0fbaf525be5c
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -77,3 +77,12 @@ import { Search } from '@spectrum-web-components/search';
 ## Events
 
 The `submit` event fires when the `<sp-search>` is submitted. This is a non-`composed` event inline with what you would expect a [`<form />`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event){:target="\_blank"} to fire. If you choose to prevent the default of this event, the default action for the underlying `<form />` element will also be prevented, which will allow you to handle the search action in javascript.
+
+## Properties
+
+### holdValueOnEscape
+
+-   Type: `boolean`
+-   Default: `false`
+
+If `holdValueOnEscape` controls whether the typed value should be held (i.e., not cleared or reset) when the Escape key is pressed. If set to true, pressing the Escape key will not affect the value in the search field.

--- a/packages/search/src/Search.ts
+++ b/packages/search/src/Search.ts
@@ -55,6 +55,9 @@ export class Search extends Textfield {
     @property()
     public override placeholder = 'Search';
 
+    @property({ type: Boolean })
+    public holdValueOnEscape!: boolean;
+
     @query('#form')
     public form!: HTMLFormElement;
 
@@ -72,6 +75,9 @@ export class Search extends Textfield {
 
     private handleKeydown(event: KeyboardEvent): void {
         const { code } = event;
+        if (code === 'Escape' && this.holdValueOnEscape) {
+            return;
+        }
         if (!this.value || code !== 'Escape') {
             return;
         }
@@ -130,7 +136,10 @@ export class Search extends Textfield {
 
     public override firstUpdated(changedProperties: PropertyValues): void {
         super.firstUpdated(changedProperties);
-        this.inputElement.setAttribute('type', 'search');
+        // if holdValueOnEscape is not set, default to search type
+        if (!this.hasAttribute('holdValueOnEscape')) {
+            this.inputElement.setAttribute('type', 'search');
+        }
     }
 
     public override willUpdate(): void {

--- a/packages/search/stories/search.stories.ts
+++ b/packages/search/stories/search.stories.ts
@@ -36,3 +36,7 @@ export const Quiet = (): TemplateResult => html`
     <sp-search quiet></sp-search>
     <sp-search quiet disabled></sp-search>
 `;
+
+export const holdValueOnEscape = (): TemplateResult => html`
+    <sp-search holdValueOnEscape></sp-search>
+`;

--- a/packages/search/test/search.test.ts
+++ b/packages/search/test/search.test.ts
@@ -20,29 +20,23 @@ import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 describe('Search', () => {
     testForLitDevWarnings(
         async () =>
-            await litFixture<Search>(
-                html`
-                    <sp-search></sp-search>
-                `
-            )
+            await litFixture<Search>(html`
+                <sp-search></sp-search>
+            `)
     );
     it('loads accessibly', async () => {
-        const el = await litFixture<Search>(
-            html`
-                <sp-search></sp-search>
-            `
-        );
+        const el = await litFixture<Search>(html`
+            <sp-search></sp-search>
+        `);
 
         await elementUpdated(el);
 
         await expect(el).to.be.accessible();
     });
     it('can be cleared', async () => {
-        const el = await litFixture<Search>(
-            html`
-                <sp-search value="Test"></sp-search>
-            `
-        );
+        const el = await litFixture<Search>(html`
+            <sp-search value="Test"></sp-search>
+        `);
 
         await elementUpdated(el);
         expect(el.value).to.equal('Test');
@@ -56,11 +50,9 @@ describe('Search', () => {
         expect(el.value).to.equal('');
     });
     it('captures keyboard events to the clear button', async () => {
-        const el = await litFixture<Search>(
-            html`
-                <sp-search value="Test"></sp-search>
-            `
-        );
+        const el = await litFixture<Search>(html`
+            <sp-search value="Test"></sp-search>
+        `);
 
         await elementUpdated(el);
         expect(el.value).to.equal('Test');
@@ -84,15 +76,13 @@ describe('Search', () => {
             const target = event.target as HTMLInputElement;
             changeSpy(target.value);
         };
-        const el = await litFixture<Search>(
-            html`
-                <sp-search
-                    value="Test"
-                    @change=${handleChange}
-                    @input=${handleInput}
-                ></sp-search>
-            `
-        );
+        const el = await litFixture<Search>(html`
+            <sp-search
+                value="Test"
+                @change=${handleChange}
+                @input=${handleInput}
+            ></sp-search>
+        `);
 
         await elementUpdated(el);
         expect(el.value).to.equal('Test');
@@ -122,15 +112,13 @@ describe('Search', () => {
             const target = event.target as HTMLInputElement;
             changeSpy(target.value);
         };
-        const el = await litFixture<Search>(
-            html`
-                <sp-search
-                    value="Test"
-                    @change=${handleChange}
-                    @input=${handleInput}
-                ></sp-search>
-            `
-        );
+        const el = await litFixture<Search>(html`
+            <sp-search
+                value="Test"
+                @change=${handleChange}
+                @input=${handleInput}
+            ></sp-search>
+        `);
 
         await elementUpdated(el);
         expect(el.value).to.equal('Test');
@@ -151,12 +139,45 @@ describe('Search', () => {
         expect(changeSpy.calledOnce, 'one change').to.be.true;
         expect(changeSpy.calledWith(''), 'was blank').to.be.true;
     });
+    it('cannot be cleared via "Escape" if holdValueOnEscape is true', async () => {
+        const inputSpy = spy();
+        const changeSpy = spy();
+        const handleInput = (event: Event): void => {
+            const target = event.target as HTMLInputElement;
+            inputSpy(target.value);
+        };
+        const handleChange = (event: Event): void => {
+            const target = event.target as HTMLInputElement;
+            changeSpy(target.value);
+        };
+        const el = await litFixture<Search>(html`
+            <sp-search
+                value="Test"
+                @change=${handleChange}
+                @input=${handleInput}
+                holdValueOnEscape
+            ></sp-search>
+        `);
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('Test');
+        el.focusElement.dispatchEvent(spaceEvent());
+
+        await elementUpdated(el);
+        expect(el.value).to.equal('Test');
+
+        inputSpy.resetHistory();
+        changeSpy.resetHistory();
+        el.focusElement.dispatchEvent(escapeEvent());
+
+        await elementUpdated(el);
+
+        expect(el.value).to.equal('Test');
+    });
     it('cannot be multiline', async () => {
-        const el = await litFixture<Search>(
-            html`
-                <sp-search multiline></sp-search>
-            `
-        );
+        const el = await litFixture<Search>(html`
+            <sp-search multiline></sp-search>
+        `);
 
         await elementUpdated(el);
 
@@ -170,11 +191,9 @@ describe('Search', () => {
     });
     it('accepts `placeholder` and `label` properties', async () => {
         const testString = 'Search for images';
-        const el = await litFixture<Search>(
-            html`
-                <sp-search></sp-search>
-            `
-        );
+        const el = await litFixture<Search>(html`
+            <sp-search></sp-search>
+        `);
 
         await elementUpdated(el);
         el.placeholder = testString;
@@ -186,15 +205,13 @@ describe('Search', () => {
         expect(el.focusElement.getAttribute('aria-label')).to.equal(testString);
     });
     it('can have default prevented', async () => {
-        const el = await litFixture<Search>(
-            html`
-                <sp-search
-                    @submit=${(event: Event) => {
-                        event.preventDefault();
-                    }}
-                ></sp-search>
-            `
-        );
+        const el = await litFixture<Search>(html`
+            <sp-search
+                @submit=${(event: Event) => {
+                    event.preventDefault();
+                }}
+            ></sp-search>
+        `);
 
         await elementUpdated(el);
         const searchForm = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Background
The current implementation uses `type="search"` on the input element, causing the search value to be cleared whenever the `ESC` key is pressed. This default behavior is not always desirable.

## Objective
To provide an API that allows users to determine whether the search value should be retained when the `ESC` key is pressed. This will be achieved through a new property `holdValueOnEscape`.

## Implementation Details
Property Introduction: A new Boolean property `holdValueOnEscape` is introduced. When set to `true`, the `type `attribute of the input element is set to `'text'`, preventing the default behavior of clearing the input value on `ESC`.

Default Behavior: By default, `holdValueOnEscape` is true, ensuring the value is retained when `ESC` is pressed.
Conditionally Setting Type: In the `firstUpdated` lifecycle method, the type attribute of the input element is conditionally set to 'text' based on the `holdValueOnEscape` property.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] Storybook
    1. Go [here](https://feature-search-escape--spectrum-web-components.netlify.app/storybook/?path=/story/search--hold-value-on-escape)
    2. Type something on the Searchbox
    3. Press ESC
    4. See the value doesn't reset
-   [ ] _Test case 2_
    1. Go here
    2. Do this

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
