### PR TITLE
chore(overlay): overlay-trigger adds receives focus attribute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: dee4a3674e6e3f676e0e388854f079b24a79ef3c
+        default: 95163520fcb80ef4d262f72fc07e8c4d8a9dd45a
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/overlay/src/OverlayTrigger.ts
+++ b/packages/overlay/src/OverlayTrigger.ts
@@ -70,6 +70,9 @@ export class OverlayTrigger extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public disabled = false;
 
+    @property({ attribute: 'receives-focus' })
+    public receivesFocus: 'true' | 'false' | 'auto' = 'auto';
+
     @state()
     private clickContent: HTMLElement[] = [];
 
@@ -197,6 +200,7 @@ export class OverlayTrigger extends SpectrumElement {
                 .triggerInteraction=${'click'}
                 .type=${this.type !== 'modal' ? 'auto' : 'modal'}
                 @beforetoggle=${this.handleBeforetoggle}
+                .receivesFocus=${this.receivesFocus}
             >
                 ${slot}
             </sp-overlay>
@@ -222,6 +226,7 @@ export class OverlayTrigger extends SpectrumElement {
                 .triggerInteraction=${'hover'}
                 .type=${'hint'}
                 @beforetoggle=${this.handleBeforetoggle}
+                .receivesFocus=${this.receivesFocus}
             >
                 ${slot}
             </sp-overlay>
@@ -246,6 +251,7 @@ export class OverlayTrigger extends SpectrumElement {
                 .triggerInteraction=${'longpress'}
                 .type=${'auto'}
                 @beforetoggle=${this.handleBeforetoggle}
+                .receivesFocus=${this.receivesFocus}
             >
                 ${slot}
             </sp-overlay>

--- a/packages/overlay/stories/overlay.stories.ts
+++ b/packages/overlay/stories/overlay.stories.ts
@@ -46,6 +46,7 @@ import '@spectrum-web-components/theme/sp-theme.js';
 import '@spectrum-web-components/theme/src/themes.js';
 import '@spectrum-web-components/accordion/sp-accordion.js';
 import '@spectrum-web-components/accordion/sp-accordion-item.js';
+import '@spectrum-web-components/button-group/sp-button-group.js';
 import '../../../projects/story-decorator/src/types.js';
 
 import './overlay-story-components.js';
@@ -970,6 +971,51 @@ export const modalLoose = (): TemplateResult => {
             </sp-dialog>
         </overlay-trigger>
         ${extraText}
+    `;
+};
+
+export const modalNoFocus = (): TemplateResult => {
+    const closeEvent = new Event('close', { bubbles: true, composed: true });
+    return html`
+        <overlay-trigger type="modal" receives-focus="false">
+            <sp-button slot="trigger">Open</sp-button>
+            <sp-dialog-wrapper
+                underlay
+                slot="click-content"
+                headline="Wrapped Dialog w/ Hero Image"
+                size="s"
+            >
+                <p>
+                    The
+                    <code>sp-dialog-wrapper</code>
+                    element has been prepared for use in an
+                    <code>overlay-trigger</code>
+                    element by it's combination of modal, underlay, etc. styles
+                    and features.
+                </p>
+                <sp-button-group style="margin-inline-start: auto">
+                    <sp-button
+                        data-test-id="dialog-cancel-btn"
+                        variant="secondary"
+                        treatment="outline"
+                        size="l"
+                        @click=${(event: Event & { target: DialogWrapper }) =>
+                            event.target.dispatchEvent(closeEvent)}
+                    >
+                        ${'Cancel'}
+                    </sp-button>
+                    <sp-button
+                        data-test-id="dialog-override-btn"
+                        variant="negative"
+                        size="l"
+                        @click=${(event: Event & { target: DialogWrapper }) =>
+                            event.target.dispatchEvent(closeEvent)}
+                    >
+                        ${'Override'}
+                    </sp-button>
+                </sp-button-group>
+            </sp-dialog-wrapper>
+        </overlay-trigger>
     `;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


Currently if we use a slotted button content in `sp-dialog-wrapper`, the focus is moving in inside a `overlay-trigger` since we don't bring in `receivesFocus` from overlay. Adding `receivesFocus` makes sure that the focus can be switched off inside the dialog components

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #4562

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Test case 1_
    1. Go [here](https://bug-overlay-trigger-receivesfocus--spectrum-web-components.netlify.app/storybook/?path=/story/overlay--modal-no-focus)
    2. Click on Open
    3. Press ESC and close the Dialog
    4. Click or Press Enter
    5. See there is no focus on any element


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
