### PR TITLE
feat(number-field): add missing `--mod-*` tokens

### DIFF
--- a/packages/number-field/src/number-field.css
+++ b/packages/number-field/src/number-field.css
@@ -65,7 +65,14 @@ governing permissions and limitations under the License.
 }
 
 :host([hide-stepper]:not([quiet])) #textfield input {
-    border: var(--spectrum-textfield-border-width) solid
-        var(--spectrum-textfield-border-color);
+    border: var(
+            --mod-textfield-border-width,
+            var(--spectrum-textfield-border-width)
+        )
+        solid
+        var(
+            --mod-textfield-border-color,
+            var(--spectrum-textfield-border-color)
+        );
     border-radius: var(--spectrum-textfield-corner-radius);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Adds two more `--mod-*` tokens as per https://github.com/adobe/spectrum-web-components/issues/4527
`--mod-textfield-border-width`
and
`--mod-textfield-border-color`.

I did not add a mod token for `--spectrum-textfield-corner-radius` because the focus outline would look weird if you modify this CSS property.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/4527

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Consumers are able to override border's width and color when `hide-stepper` is true.


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://rocss-4527--spectrum-web-components.netlify.app/storybook/?path=/story/number-field--hide-stepper)
    2. Open the developer console and define `--mod-textfield-border-width` and `--mod-textfield-border-color` on the `sp-number-field` component
    3. The changes should be visible on the component.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
