### PR TITLE
fix(number-field): multiple separators use-cases in decimal inputs in iOS devices

### DIFF
--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -117,6 +117,40 @@ describe('NumberField', () => {
             expect(el.focusElement.value).to.equal('13 377 331');
         });
     });
+    xit('correctly interprets decimal point on iPhone', async () => {
+        // setUserAgent is not currently supported by Playwright
+        await setUserAgent(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1'
+        );
+        const el = await getElFrom(decimals({ value: 1234 }));
+        expect(el.formattedValue).to.equal('1,234');
+
+        el.focus();
+        await sendKeys({ press: 'Backspace' });
+        el.blur();
+        expect(el.formattedValue).to.equal('123');
+
+        el.focus();
+        await sendKeys({ type: '45' });
+        el.blur();
+        expect(el.formattedValue).to.equal('12,345');
+
+        el.focus();
+        await sendKeys({ type: ',6' });
+        el.blur();
+        expect(el.formattedValue).to.equal('12,345.6');
+
+        el.focus();
+        await sendKeys({ type: ',7' });
+        el.blur();
+        expect(el.formattedValue).to.equal('123,456.7');
+
+        el.focus();
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        el.blur();
+        expect(el.formattedValue).to.equal('123,456');
+    });
     describe('Step', () => {
         it('can be 0', async () => {
             const el = await getElFrom(


### PR DESCRIPTION
## Description

Updated the special `convertValueToNumber` case for iPhones to correctly identify user's intent of using a decimal point.
Also changed the `,` or `.` that's being replaced with the website language specific decimal character from the first occurrence left-to-right to right-to-left. (e.g. for 1,234,56 previously the value would've been 1.23456, now it is 1,234.56 to better reflect user's intent).

(for history discussions see https://github.com/adobe/spectrum-web-components/pull/4552)
## Related issue(s)
- https://github.com/adobe/spectrum-web-components/issues/4531


## Motivation and context

This solves the problem of a comma used as a separator in the number-field being interpreted as a decimal point when the user didn't want that. These changes came as a necessity since iOS keyboard shows either `,` or `.` based on device's settings.

## How has this been tested?

-   [x] _Test case 1_
    1. Open storybook on an iPhone
    2. Select the number-field component
    3. Enter a value that would have a separator, such as 1000
    4. Blur the number-field
    5. Remove a digit from the input's value
    6. Blur the number-field (the value should be 100)
-   [x] _Test case 2_
    1. Open storybook on an iPhone
    2. Select the number-field component
    3. Enter a value that would have a separator and a decimal, such as 1000.5
    4. Blur the number-field
    5. Remove/Add a digit from/to the input's value
    6. Blur the number-field
-   [x] _Test case 3_
    1. Open storybook on an iPhone
    2. Select the number-field component
    3. Enter a value that would have a separator and a decimal, such as 1000.5
    4. Blur the number-field
    5. Remove/Add a digit and a comma/dot from/to the input's value
    6. Blur the number-field

Below you can find videos of some of these testings done on two different types of keyboard.

https://github.com/adobe/spectrum-web-components/assets/67201262/ca9e1781-ff1f-437a-8139-2bfa4c4df148

https://github.com/adobe/spectrum-web-components/assets/67201262/9486c881-2e98-4284-b538-a833f2ea9ba2



## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
