### PR TITLE
chore: updated copy functionality to include element imports

### DIFF
--- a/projects/documentation/src/components/copy-to-clipboard.ts
+++ b/projects/documentation/src/components/copy-to-clipboard.ts
@@ -20,8 +20,19 @@ function createNode(text: string): Element {
 }
 
 export function copyNode(node: Element): Promise<void> {
+    const text: string | null = node.textContent;
+    if (!text) {
+        return Promise.reject(new Error('Node has no text content'));
+    }
+    /**
+     * include import statements both for the element being documented and any other
+     * top level elements used that would otherwise not be imported directly in the element.
+     */
+    const customElements = extractNodeCustomElements(text);
+    const importStatements = generateImportStatements(customElements);
+    const fullCopiedText = `${importStatements}\n${node.textContent}`;
     if ('clipboard' in navigator) {
-        return navigator.clipboard.writeText(node.textContent || '');
+        return navigator.clipboard.writeText(fullCopiedText || '');
     }
 
     const selection = getSelection();
@@ -38,6 +49,29 @@ export function copyNode(node: Element): Promise<void> {
     document.execCommand('copy');
     selection.removeAllRanges();
     return Promise.resolve();
+}
+
+function extractNodeCustomElements(text: string): Set<string> {
+    const customElements = new Set<string>();
+    const regex = /<sp-[a-zA-Z-]+/g;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+        customElements.add(match[0].substring(1)); // Remove the '<' character
+    }
+    return customElements;
+}
+
+function generateImportStatements(elements: Set<string>): string {
+    let imports = '';
+    elements.forEach((element) => {
+        const elementName = element.substring(3); // Remove the 'sp-' prefix
+        if (element.includes('sp-icon')) {
+            imports += `import '@spectrum-web-components/icons-workflow/icons/${element}.js';\n`;
+        } else {
+            imports += `import '@spectrum-web-components/${elementName}/${element}.js';\n`;
+        }
+    });
+    return imports;
 }
 
 export function copyText(text: string): Promise<void> {

--- a/projects/documentation/src/components/copy-to-clipboard.ts
+++ b/projects/documentation/src/components/copy-to-clipboard.ts
@@ -51,6 +51,11 @@ export function copyNode(node: Element): Promise<void> {
     return Promise.resolve();
 }
 
+/**
+ * scans the custom elements in the copied text and returns custom-elements array starting with sp
+ * @param text
+ * @returns customElements which need to be added to the import statements
+ */
 function extractNodeCustomElements(text: string): Set<string> {
     const customElements = new Set<string>();
     const regex = /<sp-[a-zA-Z-]+/g;
@@ -61,6 +66,11 @@ function extractNodeCustomElements(text: string): Set<string> {
     return customElements;
 }
 
+/**
+ * Function to generate import statements for each element used in the copied text
+ * @param elements
+ * @returns list of import statements of each element
+ */
 function generateImportStatements(elements: Set<string>): string {
     let imports = '';
     elements.forEach((element) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`extractNodeCustomElements` method which runs over the copied node text and finds out the custom lit elements starting with `sp-`
`generateImportStatements` returns the created import statements of the elements which returns
```js
const fullCopiedText = `${importStatements}\n${node.textContent}`;
```



<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/2291
- https://github.com/adobe/spectrum-web-components/issues/3517

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] Copy to clipboard of code snippets with dependencies
    1. Go [here](https://docs-copy-paste--spectrum-web-components.netlify.app/components/accordion/#example)
    2. Click on "Copy to Clipboard" button
    3. Paste it on any notepad
    4. See how the dependencies are imported with the code snippet
-   [ ] Copy to clipboard for only dependencies
    1. Go [here](https://docs-copy-paste--spectrum-web-components.netlify.app/components/accordion/#usage)
    2. Click on "Copy to Clipboard" button
    3. Paste it on any notepad
    4. See how the dependencies are not imported with the line

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
