### PR TITLE
docs: Add missing label-only jsdoc

### DIFF
--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -32,8 +32,9 @@ import { SlottableRequestEvent } from '@spectrum-web-components/overlay/src/slot
  *
  * @slot - menu items to be listed in the Action Menu
  * @slot icon - The icon to use for Action Menu
- * @slot label - The label to use on for the Action Menu
- * @slot tooltip - Tooltip to to be applied to the the Action Button
+ * @slot label - The label to use for the Action Menu
+ * @slot label-only - The label to use for the Action Menu (no icon space reserved)
+ * @slot tooltip - Tooltip to to be applied to the Action Button
  * @attr selects - By default `sp-action-menu` does not manage a selection. If
  *   you'd like for a selection to be held by the `sp-menu` that it presents in
  *   its overlay, use `selects="single" to activate this functionality.


### PR DESCRIPTION
Also fix some typos in comments. Without this change the linter complains about use of label-only slot.