### PR TITLE
feat: add filled state to dropzone component

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 1dfeeaaaeb1eacac0bc3ef4a0aa30a0414d86025
+        default: af18c868191b85b473a68f446d8551c395c342fa
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: 329d613f595f7b1bc3871a585812500cdfc9a156
+        default: a52f23a5b75a5d9fbeff7e534f997c1d2be4690d
     wireit_cache_name:
         type: string
         default: wireit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 parameters:
     current_golden_images_hash:
         type: string
-        default: af18c868191b85b473a68f446d8551c395c342fa
+        default: 329d613f595f7b1bc3871a585812500cdfc9a156
     wireit_cache_name:
         type: string
         default: wireit

--- a/packages/dropzone/README.md
+++ b/packages/dropzone/README.md
@@ -30,7 +30,7 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 
 ```html
 <sp-dropzone id="dropzone-1" style="width: 400px;">
-    <sp-illustrated-message heading="Drag and Drop Your File">
+    <sp-illustrated-message heading="Drag and drop your file">
         <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 150 103"
@@ -70,7 +70,7 @@ When a file is dragged over the `<sp-dropzone>` element, it will display with th
 
 ```html
 <sp-dropzone id="dropzone" dragged style="width: 400px;">
-    <sp-illustrated-message heading="Drag and Drop Your File">
+    <sp-illustrated-message heading="Drag and drop your file">
         <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 150 103"
@@ -108,17 +108,127 @@ When a file is dragged over the `<sp-dropzone>` element, it will display with th
 
 When the `<sp-dropzone>` is in a filled state, set the `filled` attribute, as follows:
 
-```html
-<style>
-    sp-action-button {
-        margin-block-end: 32px;
-    }
-</style>
-<sp-action-button draggable="true">Drag me!</sp-action-button>
-<sp-dropzone id="dropzone" filled>
-    <div>Drop file here to replace</div>
+```html-live
+
+<sp-action-button draggable="true" style="margin-block-end: 16px;">
+    Drag me
+</sp-action-button>
+<sp-dropzone tabindex="0" id="dropzone" drop-effect="copy">
+    <sp-illustrated-message style="--mod-illustrated-message-display: flex;" heading="Drag and drop your file" id="message">
+     <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 150 103"
+            width="150"
+            height="103"
+        >
+            <path
+                d="M133.7,8.5h-118c-1.9,0-3.5,1.6-3.5,3.5v27c0,0.8,0.7,1.5,1.5,1.5s1.5-0.7,1.5-1.5V23.5h119V92c0,0.3-0.2,0.5-0.5,0.5h-118c-0.3,0-0.5-0.2-0.5-0.5V69c0-0.8-0.7-1.5-1.5-1.5s-1.5,0.7-1.5,1.5v23c0,1.9,1.6,3.5,3.5,3.5h118c1.9,0,3.5-1.6,3.5-3.5V12C137.2,10.1,135.6,8.5,133.7,8.5z M15.2,21.5V12c0-0.3,0.2-0.5,0.5-0.5h118c0.3,0,0.5,0.2,0.5,0.5v9.5H15.2z M32.6,16.5c0,0.6-0.4,1-1,1h-10c-0.6,0-1-0.4-1-1s0.4-1,1-1h10C32.2,15.5,32.6,15.9,32.6,16.5z M13.6,56.1l-8.6,8.5C4.8,65,4.4,65.1,4,65.1c-0.4,0-0.8-0.1-1.1-0.4c-0.6-0.6-0.6-1.5,0-2.1l8.6-8.5l-8.6-8.5c-0.6-0.6-0.6-1.5,0-2.1c0.6-0.6,1.5-0.6,2.1,0l8.6,8.5l8.6-8.5c0.6-0.6,1.5-0.6,2.1,0c0.6,0.6,0.6,1.5,0,2.1L15.8,54l8.6,8.5c0.6,0.6,0.6,1.5,0,2.1c-0.3,0.3-0.7,0.4-1.1,0.4c-0.4,0-0.8-0.1-1.1-0.4L13.6,56.1z"
+            ></path>
+        </svg>
+    </sp-illustrated-message>
+    <div>
+        <label for="file-input">
+            <sp-link
+                href="javascript:;"
+                onclick="this.parentElement.nextElementSibling.click()"
+            >
+                Select a File
+            </sp-link>
+            from your computer
+        </label>
+        <input type="file" id="file-input" style="display: none" />
+    </div>
+    <div>
+        or
+        <sp-link href="http://stock.adobe.com" target="blank">
+            Search Adobe Stock
+        </sp-link>
+    </div>
 </sp-dropzone>
+
+<script type="module">
+    customElements.whenDefined('sp-dropzone').then(() => {
+        const dropzone = document.getElementById('dropzone');
+        const message = document.getElementById('message');
+        const fileInput = document.getElementById('file-input');
+        let input;
+        let beingDraggedOver = false;
+
+        const updateMessage = () => {
+            message.heading = input !== undefined
+                ? (beingDraggedOver ? 'Drop here to replace!' : 'You dropped something!')
+                : 'Drag and drop your file';
+        };
+
+        const handleDropOrChange = () => {
+            input = 'mock-file';
+            dropzone.setAttribute("filled", true);
+            beingDraggedOver = false;
+            updateMessage();
+        };
+
+        dropzone.addEventListener('dragover', (event) => {
+            event.preventDefault();
+            beingDraggedOver = true;
+            updateMessage();
+        });
+
+        dropzone.addEventListener('dragleave', () => {
+            beingDraggedOver = false;
+            updateMessage();
+        });
+
+        dropzone.addEventListener('drop', (event) => {
+            event.preventDefault();
+            handleDropOrChange();
+        });
+
+        fileInput.addEventListener('change', handleDropOrChange);
+    });
+</script>
+
 ```
+
+<script type="module">
+    customElements.whenDefined('sp-dropzone').then(() => {
+        const dropzone = document.getElementById('dropzone');
+        const message = document.getElementById('message');
+        const fileInput = document.getElementById('file-input');
+        let input;
+        let beingDraggedOver = false;
+
+        const updateMessage = () => {
+            message.heading = input !== undefined
+                ? (beingDraggedOver ? 'Drop here to replace!' : 'You dropped something!')
+                : 'Drag and drop your file';
+        };
+
+        const handleDropOrChange = () => {
+            input = 'mock-file';
+            dropzone.setAttribute("filled", true);
+            beingDraggedOver = false;
+            updateMessage();
+        };
+
+        dropzone.addEventListener('dragover', (event) => {
+            event.preventDefault();
+            beingDraggedOver = true;
+            updateMessage();
+        });
+
+        dropzone.addEventListener('dragleave', () => {
+            beingDraggedOver = false;
+            updateMessage();
+        });
+
+        dropzone.addEventListener('drop', (event) => {
+            event.preventDefault();
+            handleDropOrChange();
+        });
+
+        fileInput.addEventListener('change', handleDropOrChange);
+    });
+</script>
 
 ## Accessibility
 

--- a/packages/dropzone/README.md
+++ b/packages/dropzone/README.md
@@ -29,7 +29,7 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 ## Example
 
 ```html
-<sp-dropzone id="dropzone-1" style="width: 400px; height: 200px">
+<sp-dropzone id="dropzone-1" style="width: 400px;">
     <sp-illustrated-message heading="Drag and Drop Your File">
         <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -69,7 +69,7 @@ import { Dropzone } from '@spectrum-web-components/dropzone';
 When a file is dragged over the `<sp-dropzone>` element, it will display with the `dragged` attribute, as follows:
 
 ```html
-<sp-dropzone id="dropzone" dragged style="width: 400px; height: 200px">
+<sp-dropzone id="dropzone" dragged style="width: 400px;">
     <sp-illustrated-message heading="Drag and Drop Your File">
         <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -101,6 +101,22 @@ When a file is dragged over the `<sp-dropzone>` element, it will display with th
             Search Adobe Stock
         </sp-link>
     </div>
+</sp-dropzone>
+```
+
+### Filled
+
+When the `<sp-dropzone>` is in a filled state, set the `filled` attribute, as follows:
+
+```html
+<style>
+    sp-action-button {
+        margin-block-end: 32px;
+    }
+</style>
+<sp-action-button draggable="true">Drag me!</sp-action-button>
+<sp-dropzone id="dropzone" filled>
+    <div>Drop file here to replace</div>
 </sp-dropzone>
 ```
 

--- a/packages/dropzone/src/Dropzone.ts
+++ b/packages/dropzone/src/Dropzone.ts
@@ -58,8 +58,17 @@ export class Dropzone extends SpectrumElement {
     }
     private _dropEffect: DropEffects = 'copy';
 
+    /**
+     * Indicates that files are currently being dragged over the dropzone.
+     */
     @property({ type: Boolean, reflect: true, attribute: 'dragged' })
     public isDragged = false;
+
+    /**
+     * Set this property to indicate that the component is in a filled state.
+     */
+    @property({ type: Boolean, attribute: 'filled' })
+    public isFilled = false;
 
     private debouncedDragLeave: number | null = null;
 

--- a/packages/dropzone/src/spectrum-config.js
+++ b/packages/dropzone/src/spectrum-config.js
@@ -27,6 +27,7 @@ const config = {
             components: [
                 converter.classToHost(),
                 converter.classToAttribute('is-dragged', 'dragged'),
+                converter.classToAttribute('is-filled', 'filled'),
                 converter.classToSlotted(
                     'spectrum-IllustratedMessage-illustration'
                 ),

--- a/packages/dropzone/src/spectrum-dropzone.css
+++ b/packages/dropzone/src/spectrum-dropzone.css
@@ -228,7 +228,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host .is-filled {
+:host([filled]) {
     --mod-drop-zone-background-color: rgba(
         var(--spectrum-drop-zone-background-color),
         var(
@@ -239,7 +239,7 @@ governing permissions and limitations under the License.
     --mod-illustrated-message-display: none;
 }
 
-:host([dragged]) .is-filled {
+:host([filled][dragged]) {
     --mod-drop-zone-content-display: flex;
 }
 

--- a/packages/dropzone/stories/dropzone.stories.ts
+++ b/packages/dropzone/stories/dropzone.stories.ts
@@ -122,14 +122,8 @@ Dragged.args = {
 
 export const Filled = (args: StoryArgs): TemplateResult => {
     return html`
-        <style>
-            sp-action-button {
-                margin-block-end: 32px;
-            }
-        </style>
-        <sp-action-button draggable="true">Drag me!</sp-action-button>
         <sp-dropzone id="dropzone" ?filled=${args.isFilled}>
-            <div>Drop file here to replace</div>
+            Filled dropzone
         </sp-dropzone>
     `;
 };
@@ -138,7 +132,8 @@ Filled.args = {
 };
 
 class ControlledDropzone extends LitElement {
-    private fileName = 'mock_file.png';
+    @state()
+    private beingDraggedOver: boolean = false;
 
     @state()
     private input?: string = undefined;
@@ -146,15 +141,29 @@ class ControlledDropzone extends LitElement {
     override render(): TemplateResult {
         return html`
             <span>
-                ${this.renderMockFile()}
+                <sp-action-button
+                    draggable="true"
+                    style="margin-block-end: 16px;"
+                >
+                    Drag me
+                </sp-action-button>
                 <sp-dropzone
                     tabindex="0"
                     id="dropzone"
                     drop-effect="copy"
-                    ?dragged=${this.input !== undefined}
+                    ?filled=${this.input !== undefined}
                     @sp-dropzone-drop=${this.onChange}
+                    @sp-dropzone-dragover=${this.onDragOver}
+                    @sp-dropzone-dragleave=${this.onDragLeave}
                 >
-                    <sp-illustrated-message heading="Drag and Drop Your File">
+                    <sp-illustrated-message
+                        style="--mod-illustrated-message-display: flex;"
+                        heading=${this.input !== undefined
+                            ? this.beingDraggedOver
+                                ? 'Drop here to replace!'
+                                : 'You dropped something!'
+                            : 'Drag and drop your file'}
+                    >
                         ${illustration}
                     </sp-illustrated-message>
                     <div>
@@ -174,41 +183,22 @@ class ControlledDropzone extends LitElement {
                             @change=${this.onChange}
                         />
                     </div>
-                    ${this.renderUploadButton()}
                 </sp-dropzone>
             </span>
         `;
     }
 
-    private renderMockFile(): TemplateResult {
-        return this.input === undefined
-            ? html`
-                  <sp-action-button
-                      draggable="true"
-                      style="margin-bottom: 16px;"
-                  >
-                      Drag ${this.fileName}
-                  </sp-action-button>
-              `
-            : html`
-                  <sp-action-button style="margin-bottom: 16px;">
-                      Added ${this.fileName}
-                  </sp-action-button>
-              `;
-    }
-
-    private renderUploadButton(): TemplateResult | null {
-        return this.input === undefined
-            ? null
-            : html`
-                  <sp-action-button autofocus style="margin-top: 16px;">
-                      Upload ${this.fileName}
-                  </sp-action-button>
-              `;
-    }
-
     private onChange(): void {
-        this.input = this.fileName;
+        this.input = 'mock-file';
+        this.beingDraggedOver = false;
+    }
+
+    private onDragOver(): void {
+        this.beingDraggedOver = true;
+    }
+
+    private onDragLeave(): void {
+        this.beingDraggedOver = false;
     }
 }
 defineElement('controlled-dropzone', ControlledDropzone);

--- a/packages/dropzone/stories/dropzone.stories.ts
+++ b/packages/dropzone/stories/dropzone.stories.ts
@@ -18,6 +18,7 @@ import { defineElement } from '@spectrum-web-components/base/src/define-element.
 import { state } from '@spectrum-web-components/base/src/decorators.js';
 
 import '@spectrum-web-components/dropzone/sp-dropzone.js';
+import '@spectrum-web-components/action-button/sp-action-button.js';
 import { illustration } from '../test/test-svg';
 import '@spectrum-web-components/illustrated-message/sp-illustrated-message.js';
 import '@spectrum-web-components/link/sp-link.js';
@@ -27,10 +28,22 @@ export default {
     title: 'Dropzone',
     args: {
         isDragged: false,
+        isFilled: false,
     },
     argTypes: {
         isDragged: {
             name: 'isDragged',
+            type: { name: 'boolean', required: false },
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: false },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
+        isFilled: {
+            name: 'isFilled',
             type: { name: 'boolean', required: false },
             table: {
                 type: { summary: 'boolean' },
@@ -45,6 +58,7 @@ export default {
 
 type StoryArgs = {
     isDragged?: boolean;
+    isFilled?: boolean;
 };
 
 export const Default = (args: StoryArgs): TemplateResult => {
@@ -104,6 +118,23 @@ export const Dragged = (args: StoryArgs): TemplateResult => {
 };
 Dragged.args = {
     isDragged: true,
+};
+
+export const Filled = (args: StoryArgs): TemplateResult => {
+    return html`
+        <style>
+            sp-action-button {
+                margin-block-end: 32px;
+            }
+        </style>
+        <sp-action-button draggable="true">Drag me!</sp-action-button>
+        <sp-dropzone id="dropzone" ?filled=${args.isFilled}>
+            <div>Drop file here to replace</div>
+        </sp-dropzone>
+    `;
+};
+Filled.args = {
+    isFilled: true,
 };
 
 class ControlledDropzone extends LitElement {

--- a/packages/dropzone/test/dropzone.test.ts
+++ b/packages/dropzone/test/dropzone.test.ts
@@ -17,38 +17,33 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 
 describe('Dropzone', () => {
     it('loads', async () => {
-        const el = await fixture<Dropzone>(
-            html`
-                <sp-dropzone id="dropzone">
-                    <sp-illustrated-message heading="Drag and Drop Your File">
-                        ${illustration}
-                    </sp-illustrated-message>
+        const el = await fixture<Dropzone>(html`
+            <sp-dropzone id="dropzone">
+                <sp-illustrated-message heading="Drag and Drop Your File">
+                    ${illustration}
+                </sp-illustrated-message>
 
-                    <div style="color: grey">
-                        <div>
-                            <label for="file-input">
-                                <sp-link>Select a File</sp-link>
-                                from your computer
-                            </label>
-                            <input
-                                type="file"
-                                id="file-input"
-                                style="display: none"
-                            />
-                        </div>
-                        <div>
-                            or
-                            <sp-link
-                                href="http://stock.adobe.com"
-                                target="blank"
-                            >
-                                Search Adobe Stock
-                            </sp-link>
-                        </div>
+                <div style="color: grey">
+                    <div>
+                        <label for="file-input">
+                            <sp-link>Select a File</sp-link>
+                            from your computer
+                        </label>
+                        <input
+                            type="file"
+                            id="file-input"
+                            style="display: none"
+                        />
                     </div>
-                </sp-dropzone>
-            `
-        );
+                    <div>
+                        or
+                        <sp-link href="http://stock.adobe.com" target="blank">
+                            Search Adobe Stock
+                        </sp-link>
+                    </div>
+                </div>
+            </sp-dropzone>
+        `);
         expect(el).to.not.equal(undefined);
         if (!el.shadowRoot) throw new Error('No shadowRoot');
         const slot = el.shadowRoot.querySelector('slot') as HTMLSlotElement;
@@ -56,11 +51,9 @@ describe('Dropzone', () => {
         return true;
     });
     it('manages `dropEffects`', async () => {
-        const el = await fixture<Dropzone>(
-            html`
-                <sp-dropzone id="dropzone"></sp-dropzone>
-            `
-        );
+        const el = await fixture<Dropzone>(html`
+            <sp-dropzone id="dropzone"></sp-dropzone>
+        `);
 
         await elementUpdated(el);
 
@@ -73,11 +66,9 @@ describe('Dropzone', () => {
         expect(el.dropEffect).to.equal('move');
     });
     it('manages `dragover` events', async () => {
-        const el = await fixture<Dropzone>(
-            html`
-                <sp-dropzone id="dropzone"></sp-dropzone>
-            `
-        );
+        const el = await fixture<Dropzone>(html`
+            <sp-dropzone id="dropzone"></sp-dropzone>
+        `);
 
         await elementUpdated(el);
 
@@ -109,14 +100,12 @@ describe('Dropzone', () => {
         const canceledDrag = (event: DragEvent): void => {
             event.preventDefault();
         };
-        const el = await fixture<Dropzone>(
-            html`
-                <sp-dropzone
-                    id="dropzone"
-                    @sp-dropzone-should-accept=${canceledDrag}
-                ></sp-dropzone>
-            `
-        );
+        const el = await fixture<Dropzone>(html`
+            <sp-dropzone
+                id="dropzone"
+                @sp-dropzone-should-accept=${canceledDrag}
+            ></sp-dropzone>
+        `);
 
         await elementUpdated(el);
 
@@ -144,14 +133,12 @@ describe('Dropzone', () => {
         const onDragLeave = (): void => {
             dragLeftCount += 1;
         };
-        const el = await fixture<Dropzone>(
-            html`
-                <sp-dropzone
-                    id="dropzone"
-                    @sp-dropzone-dragleave=${onDragLeave}
-                ></sp-dropzone>
-            `
-        );
+        const el = await fixture<Dropzone>(html`
+            <sp-dropzone
+                id="dropzone"
+                @sp-dropzone-dragleave=${onDragLeave}
+            ></sp-dropzone>
+        `);
 
         await elementUpdated(el);
 
@@ -170,14 +157,12 @@ describe('Dropzone', () => {
         const onDrop = (): void => {
             dropped = true;
         };
-        const el = await fixture<Dropzone>(
-            html`
-                <sp-dropzone
-                    id="dropzone"
-                    @sp-dropzone-drop=${onDrop}
-                ></sp-dropzone>
-            `
-        );
+        const el = await fixture<Dropzone>(html`
+            <sp-dropzone
+                id="dropzone"
+                @sp-dropzone-drop=${onDrop}
+            ></sp-dropzone>
+        `);
 
         await elementUpdated(el);
 
@@ -186,5 +171,16 @@ describe('Dropzone', () => {
         el.dispatchEvent(new DragEvent('drop'));
 
         expect(dropped).to.be.true;
+    });
+
+    it('sets `filled` attribute', async () => {
+        const el = await fixture<Dropzone>(html`
+            <sp-dropzone id="dropzone" filled></sp-dropzone>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.isFilled).to.be.true;
+        expect(el.hasAttribute('filled')).to.be.true;
     });
 });


### PR DESCRIPTION
## Description

There is a new design for the dropzone component when it is in a "filled state". This PR adds this functionality to the component and respective documentation.


## Related issue(s)


<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://github.com/adobe/spectrum-web-components/issues/3232


## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Catching up the implementation with the most up to date designs.
 
## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [x] _Check the new `filled` state_
    1. Go to [Storybook](https://feat-filled-dropzone--spectrum-web-components.netlify.app/storybook/?path=/story/dropzone--filled)
    2. Toggle the `isFilled` control.
-   [ ] _Added integration test for the `filled` attribute_


## Screenshots

<img width="459" alt="Screenshot 2024-07-25 at 14 28 24" src="https://github.com/user-attachments/assets/6ca8d17e-ae1a-400d-b38a-306359effea9">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
