### PR TITLE
chore: expand gray boundaries to support s2 migration

### DIFF
--- a/tools/theme/src/express/theme-dark.css
+++ b/tools/theme/src/express/theme-dark.css
@@ -14,3 +14,10 @@ governing permissions and limitations under the License.
 @import url('@spectrum-web-components/styles/tokens/dark-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-dark-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/custom-dark-vars.css');
+
+/* Temporary patch to support extdended gray boundaries after S2 migration */
+:host,
+:root {
+    --spectrum-gray-25: var(--spectrum-gray-50);
+    --spectrum-gray-1000: var(--spectrum-global-color-gray-900);
+}

--- a/tools/theme/src/express/theme-light.css
+++ b/tools/theme/src/express/theme-light.css
@@ -14,3 +14,10 @@ governing permissions and limitations under the License.
 @import url('@spectrum-web-components/styles/tokens/light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/express/custom-light-vars.css');
+
+/* Temporary patch to support extdended gray boundaries after S2 migration */
+:host,
+:root {
+    --spectrum-gray-25: var(--spectrum-gray-50);
+    --spectrum-gray-1000: var(--spectrum-global-color-gray-900);
+}

--- a/tools/theme/src/theme-dark.css
+++ b/tools/theme/src/theme-dark.css
@@ -13,3 +13,10 @@ governing permissions and limitations under the License.
 @import url('@spectrum-web-components/styles/theme-dark.css');
 @import url('@spectrum-web-components/styles/tokens/dark-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-dark-vars.css');
+
+/* Temporary patch to support extdended gray boundaries after S2 migration */
+:host,
+:root {
+    --spectrum-gray-25: var(--spectrum-gray-50);
+    --spectrum-gray-1000: var(--spectrum-global-color-gray-900);
+}

--- a/tools/theme/src/theme-darkest.css
+++ b/tools/theme/src/theme-darkest.css
@@ -13,3 +13,10 @@ governing permissions and limitations under the License.
 @import url('@spectrum-web-components/styles/theme-darkest.css');
 @import url('@spectrum-web-components/styles/tokens/darkest-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-darkest-vars.css');
+
+/* Temporary patch to support extdended gray boundaries after S2 migration */
+:host,
+:root {
+    --spectrum-gray-25: var(--spectrum-gray-50);
+    --spectrum-gray-1000: var(--spectrum-global-color-gray-900);
+}

--- a/tools/theme/src/theme-light.css
+++ b/tools/theme/src/theme-light.css
@@ -13,3 +13,10 @@ governing permissions and limitations under the License.
 @import url('@spectrum-web-components/styles/theme-light.css');
 @import url('@spectrum-web-components/styles/tokens/light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-light-vars.css');
+
+/* Temporary patch to support extdended gray boundaries after S2 migration */
+:host,
+:root {
+    --spectrum-gray-25: var(--spectrum-gray-50);
+    --spectrum-gray-1000: var(--spectrum-global-color-gray-900);
+}

--- a/tools/theme/src/theme-lightest.css
+++ b/tools/theme/src/theme-lightest.css
@@ -13,3 +13,10 @@ governing permissions and limitations under the License.
 @import url('@spectrum-web-components/styles/theme-lightest.css');
 @import url('@spectrum-web-components/styles/tokens/light-vars.css');
 @import url('@spectrum-web-components/styles/tokens/spectrum/custom-light-vars.css');
+
+/* Temporary patch to support extdended gray boundaries after S2 migration */
+:host,
+:root {
+    --spectrum-gray-25: var(--spectrum-gray-50);
+    --spectrum-gray-1000: var(--spectrum-global-color-gray-900);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Spectrum 2 introduces gray-25 and gray-1000 which don’t exist in Spectrum 1 or Express themes. The SWC team has effectively duplicated the existing boundaries, gray-50 and gray-900 as gray-25 and gray-1000, respectively. In a Spectrum 1 or Express theme only, when design references gray-25 it would just be mapped to the same value as gray-50 in SWC’s themes—which both equal white. This would also mean that gray-1000 maps to gray-900 which are very slightly different grays, but conceptually close—this fake gray-1000 would map to S1’s gray-900 which is #000 in both S1. 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this
-   [ ] _Test case 2_

    1. Go here
    2. Do this

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [ ] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
