### PR TITLE
chore(color-area, thumbnail): added some tests

### DIFF
--- a/packages/color-area/src/ColorArea.ts
+++ b/packages/color-area/src/ColorArea.ts
@@ -121,12 +121,11 @@ export class ColorArea extends SpectrumElement {
             return;
         }
         const oldValue = this.x;
+        this._x = x;
         if (this.inputX) {
             // Use the native `input[type='range']` control to validate this value after `firstUpdate`
             this.inputX.value = x.toString();
             this._x = this.inputX.valueAsNumber;
-        } else {
-            this._x = x;
         }
         this.requestUpdate('x', oldValue);
         this.colorController.applyColorFromState();
@@ -144,12 +143,11 @@ export class ColorArea extends SpectrumElement {
             return;
         }
         const oldValue = this.y;
+        this._y = y;
         if (this.inputY) {
             // Use the native `input[type='range']` control to validate this value after `firstUpdate`
             this.inputY.value = y.toString();
             this._y = this.inputY.valueAsNumber;
-        } else {
-            this._y = y;
         }
         this.requestUpdate('y', oldValue);
         this.colorController.applyColorFromState();
@@ -191,7 +189,7 @@ export class ColorArea extends SpectrumElement {
         this._valueChanged = false;
     }
 
-    private handleBlur(): void {
+    public handleBlur(): void {
         if (this._pointerDown) {
             return;
         }
@@ -312,7 +310,7 @@ export class ColorArea extends SpectrumElement {
     }
 
     private boundingClientRect!: DOMRect;
-    private _pointerDown = false;
+    public _pointerDown = false;
 
     private handlePointerdown(event: PointerEvent): void {
         if (event.button !== 0) {

--- a/packages/color-area/test/color-area.test.ts
+++ b/packages/color-area/test/color-area.test.ts
@@ -43,6 +43,56 @@ describe('ColorArea', () => {
 
         await expect(el).to.be.accessible();
     });
+    it('handleBlur returns early if _pointerDown is true', async () => {
+        const el = await fixture<ColorArea>(html`
+            <sp-color-area></sp-color-area>
+        `);
+
+        await sendKeys({ press: 'Tab' });
+        await el.updateComplete;
+
+        el._pointerDown = true;
+        await el.updateComplete;
+
+        el.handleBlur();
+        await el.updateComplete;
+
+        expect(el.focused).to.be.true;
+    });
+    it('updates color when x value changes', async () => {
+        const el = await fixture<ColorArea>(html`
+            <sp-color-area></sp-color-area>
+        `);
+
+        await el.updateComplete;
+
+        expect(el.x).to.equal(1);
+
+        el.x = 0.3;
+        await el.updateComplete;
+
+        expect(el.x).to.equal(0.3);
+
+        const handle = el.shadowRoot.querySelector('.handle') as ColorHandle;
+        expect(handle.color).to.equal('hsl(0, 100%, 85%)');
+    });
+    it('updates color when y value changes', async () => {
+        const el = await fixture<ColorArea>(html`
+            <sp-color-area></sp-color-area>
+        `);
+
+        await el.updateComplete;
+
+        expect(el.y).to.equal(1);
+
+        el.y = 0.5;
+        await el.updateComplete;
+
+        expect(el.y).to.equal(0.5);
+
+        const handle = el.shadowRoot.querySelector('.handle') as ColorHandle;
+        expect(handle.color).to.equal('hsl(0, 100%, 25%)');
+    });
     it('manages a single tab stop', async () => {
         const test = await fixture<HTMLDivElement>(html`
             <div>
@@ -306,6 +356,31 @@ describe('ColorArea', () => {
         });
         await changeEvent;
 
+        expect(el.x).to.equal(0.67);
+        expect(el.y).to.equal(0.75);
+        el.setAttribute('dir', 'rtl');
+        changeEvent = oneEvent(el, 'change');
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        await changeEvent;
+        changeEvent = oneEvent(el, 'change');
+        await sendKeys({
+            press: 'ArrowLeft',
+        });
+        await changeEvent;
+        expect(el.x).to.equal(0.69);
+        expect(el.y).to.equal(0.75);
+        changeEvent = oneEvent(el, 'change');
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        await changeEvent;
+        changeEvent = oneEvent(el, 'change');
+        await sendKeys({
+            press: 'ArrowRight',
+        });
+        await changeEvent;
         expect(el.x).to.equal(0.67);
         expect(el.y).to.equal(0.75);
     });

--- a/packages/contextual-help/src/ContextualHelp.ts
+++ b/packages/contextual-help/src/ContextualHelp.ts
@@ -43,7 +43,7 @@ import styles from './contextual-help.css.js';
  * @slot link - link to additional informations
  */
 export class ContextualHelp extends SpectrumElement {
-    protected isMobile = new MatchMediaController(this, IS_MOBILE);
+    public isMobile = new MatchMediaController(this, IS_MOBILE);
 
     public static override get styles(): CSSResultArray {
         return [styles];
@@ -82,7 +82,7 @@ export class ContextualHelp extends SpectrumElement {
     @property({ type: Boolean })
     open = false;
 
-    private get buttonAriaLabel(): string {
+    public get buttonAriaLabel(): string {
         if (this.label) {
             return this.label;
         } else {

--- a/packages/contextual-help/test/contextual-help.test.ts
+++ b/packages/contextual-help/test/contextual-help.test.ts
@@ -15,6 +15,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 import { ContextualHelp } from '../src/ContextualHelp.js';
 import { ContextualHelpMarkup } from '../stories';
+import { render, TemplateResult } from 'lit';
 
 describe('ContextualHelp', () => {
     testForLitDevWarnings(
@@ -68,5 +69,65 @@ describe('ContextualHelp', () => {
 
         popover = el.shadowRoot?.querySelector('sp-popover');
         expect(el.shadowRoot?.querySelector('sp-popover')).not.to.exist;
+    });
+    it('returns the label if set', async () => {
+        const el = await fixture<ContextualHelp>(ContextualHelpMarkup());
+        el.label = 'Custom Label';
+        expect(el.buttonAriaLabel).to.equal('Custom Label');
+    });
+
+    it('returns "Help" if variant is "help" and label is not set', async () => {
+        const el = await fixture<ContextualHelp>(ContextualHelpMarkup());
+        el.variant = 'help';
+        expect(el.buttonAriaLabel).to.equal('Help');
+    });
+
+    it('returns "Informations" if variant is not "help" and label is not set', async () => {
+        const el = await fixture<ContextualHelp>(ContextualHelpMarkup());
+        expect(el.buttonAriaLabel).to.equal('Informations');
+    });
+    it('renders correctly when actualPlacement is undefined', async () => {
+        const el = await fixture<ContextualHelp>(ContextualHelpMarkup());
+
+        el.isMobile.matches = true;
+
+        await elementUpdated(el);
+
+        const trigger = el.shadowRoot?.querySelector('#trigger') as HTMLElement;
+        expect(trigger).to.exist;
+        expect(trigger).to.have.attribute('aria-label', 'Informations');
+
+        const overlay = el.shadowRoot?.querySelector(
+            'sp-overlay'
+        ) as HTMLElement;
+        expect(overlay).to.exist;
+        expect(overlay).to.have.attribute('trigger', 'trigger@click');
+        expect(overlay).to.have.attribute('receives-focus', 'true');
+        expect(overlay).to.have.property('offset', el.offset);
+        expect(overlay).to.have.property('open', el.open);
+    });
+    it('renders dialog content when isMobile.matches is true', async () => {
+        const el = await fixture<ContextualHelp>(ContextualHelpMarkup());
+
+        el.isMobile.matches = true;
+
+        await elementUpdated(el);
+
+        const template: TemplateResult = el['renderOverlayContent']();
+
+        const container = document.createElement('div');
+        render(template, container);
+
+        const dialogBase = container.querySelector('sp-dialog-base');
+        const dialog = container.querySelector('sp-dialog');
+        const headingSlot = container.querySelector('slot[name="heading"]');
+        const linkSlot = container.querySelector('slot[name="link"]');
+
+        expect(dialogBase).to.exist;
+        expect(dialog).to.exist;
+        expect(dialog).to.have.attribute('dismissable');
+        expect(dialog).to.have.attribute('size', 's');
+        expect(headingSlot).to.exist;
+        expect(linkSlot).to.exist;
     });
 });

--- a/packages/thumbnail/test/thumbnail.test.ts
+++ b/packages/thumbnail/test/thumbnail.test.ts
@@ -59,6 +59,24 @@ describe('Thumbnail', () => {
         const background = el.shadowRoot.querySelector('.background');
         expect(background).to.not.be.null;
     });
+    it('renders the opacity checkerboard and slot', async () => {
+        const el = await fixture<Thumbnail>(html`
+            <sp-thumbnail>
+                <img src=${thumbnail} alt="Woman crouching" />
+            </sp-thumbnail>
+        `);
+
+        await elementUpdated(el);
+        el.setAttribute('layer', 'true');
+        await elementUpdated(el);
+        const checkerboard = el.shadowRoot.querySelector(
+            '.opacity-checkerboard.layer-inner'
+        );
+        expect(checkerboard).to.not.be.null;
+
+        const slot = checkerboard?.querySelector('slot');
+        expect(slot).to.not.be.null;
+    });
     describe('dev mode', () => {
         let consoleWarnStub!: ReturnType<typeof stub>;
         before(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added some tests to improve code coverage
## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

-



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
