### PR TITLE
fix(number-field): update IME change detection

### DIFF
--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -63,8 +63,17 @@ export const remapMultiByteCharacters: Record<string, string> = {
     '％': '%',
     '＋': '+',
     ー: '-',
+    一: '1',
+    二: '2',
+    三: '3',
+    四: '4',
+    五: '5',
+    六: '6',
+    七: '7',
+    八: '8',
+    九: '9',
+    零: '0',
 };
-
 const chevronIcon: Record<string, (dir: 'Down' | 'Up') => TemplateResult> = {
     s: (dir) => html`
         <sp-icon-chevron50
@@ -214,7 +223,13 @@ export class NumberField extends TextfieldBase {
     private valueBeforeFocus: string = '';
     private isIntentDecimal: boolean = false;
 
-    private convertValueToNumber(value: string): number {
+    private convertValueToNumber(inputValue: string): number {
+        // Normalize full-width characters to their ASCII equivalents
+        let normalizedValue = inputValue
+            .split('')
+            .map((char) => remapMultiByteCharacters[char] || char)
+            .join('');
+
         const separators = this.valueBeforeFocus
             .split('')
             .filter((char) => this.decimalsChars.has(char));
@@ -223,7 +238,7 @@ export class NumberField extends TextfieldBase {
         if (
             isIPhone() &&
             this.inputElement.inputMode === 'decimal' &&
-            value !== this.valueBeforeFocus
+            normalizedValue !== this.valueBeforeFocus
         ) {
             const parts = this.numberFormatter.formatToParts(1000.1);
 
@@ -234,12 +249,15 @@ export class NumberField extends TextfieldBase {
             for (const separator of uniqueSeparators) {
                 const isDecimalSeparator = separator === replacementDecimal;
                 if (!isDecimalSeparator && !this.isIntentDecimal) {
-                    value = value.replace(new RegExp(separator, 'g'), '');
+                    normalizedValue = normalizedValue.replace(
+                        new RegExp(separator, 'g'),
+                        ''
+                    );
                 }
             }
 
             let hasReplacedDecimal = false;
-            const valueChars = value.split('');
+            const valueChars = normalizedValue.split('');
             for (let index = valueChars.length - 1; index >= 0; index--) {
                 const char = valueChars[index];
                 if (this.decimalsChars.has(char)) {
@@ -249,11 +267,10 @@ export class NumberField extends TextfieldBase {
                     } else valueChars[index] = '';
                 }
             }
-            value = valueChars.join('');
+            normalizedValue = valueChars.join('');
         }
-        return this.numberParser.parse(value);
+        return this.numberParser.parse(normalizedValue);
     }
-
     private get _step(): number {
         if (typeof this.step !== 'undefined') {
             return this.step;
@@ -492,6 +509,7 @@ export class NumberField extends TextfieldBase {
             .split('')
             .map((char) => remapMultiByteCharacters[char] || char)
             .join('');
+
         if (this.numberParser.isValidPartialNumber(value)) {
             // Use starting value as this.value is the `input` value.
             this.lastCommitedValue = this.lastCommitedValue ?? this.value;

--- a/packages/number-field/src/NumberField.ts
+++ b/packages/number-field/src/NumberField.ts
@@ -184,20 +184,25 @@ export class NumberField extends TextfieldBase {
     private _trackingValue = '';
     private lastCommitedValue?: number;
 
-    private setValue(value: number = this.value): void {
-        this.value = value;
+    private setValue(newValue: number = this.value): void {
+        // Capture previous value for accurate IME change detection
+        const previousValue = this.lastCommitedValue;
+
+        this.value = newValue;
+
         if (
-            typeof this.lastCommitedValue === 'undefined' ||
-            this.lastCommitedValue === this.value
+            typeof previousValue === 'undefined' ||
+            previousValue === this.value
         ) {
             // Do not announce when the value is unchanged.
             return;
         }
 
+        this.lastCommitedValue = this.value;
+
         this.dispatchEvent(
             new Event('change', { bubbles: true, composed: true })
         );
-        this.lastCommitedValue = this.value;
     }
 
     /**

--- a/packages/number-field/test/number-field.test.ts
+++ b/packages/number-field/test/number-field.test.ts
@@ -502,6 +502,18 @@ describe('NumberField', () => {
             el.value = 52;
             expect(changeSpy.callCount).to.equal(0);
         });
+        it('handles IME input correctly and dispatches change event', async () => {
+            el.focus();
+            el.dispatchEvent(new CompositionEvent('compositionstart'));
+            // input multibyte characters
+            await sendKeys({ type: '１２３' });
+            await elementUpdated(el);
+            el.dispatchEvent(new CompositionEvent('compositionend'));
+            await elementUpdated(el);
+            await sendKeys({ press: 'Enter' });
+            expect(el.value).to.equal(50123);
+            expect(changeSpy.callCount).to.equal(1);
+        });
         it('via scroll', async () => {
             el.focus();
             await elementUpdated(el);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR resolves an issue in Safari where multi-byte characters were being improperly converted, resulting in `NaN` and updates the function responsible for triggering the `change` event to ensure it behaves consistently across all supported browsers.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- fixes https://github.com/adobe/spectrum-web-components/issues/4579

## Motivation and context

`sp-number-field` + Safari + IME were in need of some love.

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] Storybook actions
    1. Open the Safari browser
    2. Go to the deployed/locahost `/storybook/index.html?path=/story/number-field--default`
    3. In your system settings, select "Japanese" as the IME
    4. Type any number in the `sp-number-field` component
    5. Observe the `actions` tab on `Enter` keypress and `blur` for the expected behaviour

-   [x] Did it pass in Desktop?
-   [x] Did it pass in Mobile?
-   [x] Did it pass in iPad (simulator)?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
