### PR TITLE
chore(number-field): added default-value example to the doc site

### DIFF
--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -229,3 +229,41 @@ If the user types a value that is between two steps and blurs the input, the val
     step="3"
 ></sp-number-field>
 ```
+
+## Default value
+
+The number-field component doesn't manage a default value by itself. This means that consumers can set the value of the number-field as an empty string by clearing the input. If we want the number-field to reset to a `default-value` when the user clears the input, we can listen for the `change` event on the number-field component and set its value to the desired `default-value` if the input is empty.
+
+```html-live
+<sp-field-label for="default">
+    Default value of this number field is 42
+</sp-field-label>
+<sp-number-field id="default" value="20"></sp-number-field>
+
+<script type="module">
+    customElements.whenDefined('sp-number-field').then(() => {
+        const numberField = document.querySelector('#default');
+
+        numberField.addEventListener('change', (event) => {
+            const target = event.target;
+            if (isNaN(target.value)) {
+                target.value = '42';
+            }
+        });
+    });
+</script>
+
+```
+
+<script type="module">
+    customElements.whenDefined('sp-number-field').then(() => {
+        const numberField = document.querySelector('#default');
+
+        numberField.addEventListener('change', (event) => {
+            const target = event.target;
+            if (isNaN(target.value)) {
+                target.value = '42';
+            }
+        });
+    });
+</script>

--- a/packages/number-field/README.md
+++ b/packages/number-field/README.md
@@ -232,7 +232,7 @@ If the user types a value that is between two steps and blurs the input, the val
 
 ## Default value
 
-The number-field component doesn't manage a default value by itself. This means that consumers can set the value of the number-field as an empty string by clearing the input. If we want the number-field to reset to a `default-value` when the user clears the input, we can listen for the `change` event on the number-field component and set its value to the desired `default-value` if the input is empty.
+The `<sp-number-field>` component doesn't manage a default value by itself. This means that consumers can set the value of the number-field as an empty string by clearing the input. If we want the number-field to reset to a `default-value` when the user clears the input, we can listen for the `change` event on the number-field component and set its value to the desired `default-value` if the input is empty.
 
 ```html-live
 <sp-field-label for="default">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expand `number-field` doc.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #4109

## Motivation and context

Currently, removing the number in the number field leaves the number field blank. It would be nice if the number field could repopulate to either the previous value, or the default value (ex. 0).


## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
