### PR TITLE
fix(menu): allow menu-item to support arbitrary element as the submenu root

### DIFF
--- a/packages/menu/menu-item.md
+++ b/packages/menu/menu-item.md
@@ -106,7 +106,7 @@ An `<sp-menu-item>` can also accept content addressed to its `submenu` slot. Usi
 </sp-menu>
 ```
 
-Note: `sp-menu-item` can support any arbitrary content in the `submenu` slot, but in that case, it will not manage selection or keyboard navigation. It is recommended to use `sp-menu` in the `submenu` slot to ensure proper keyboard navigation and selection management.
+Note: While `sp-menu-item` can accommodate any custom content in the `submenu` slot, it will not handle selection or keyboard navigation for such content. To ensure proper management of selection and keyboard navigation, it is recommended to use `sp-menu` within the `submenu` slot```
 
 ```html
 <sp-menu style="width: 200px;">

--- a/packages/menu/menu-item.md
+++ b/packages/menu/menu-item.md
@@ -106,6 +106,24 @@ An `<sp-menu-item>` can also accept content addressed to its `submenu` slot. Usi
 </sp-menu>
 ```
 
+Note: `sp-menu-item` can support any arbitrary content in the `submenu` slot, but in that case, it will not manage selection or keyboard navigation. It is recommended to use `sp-menu` in the `submenu` slot to ensure proper keyboard navigation and selection management.
+
+```html
+<sp-menu style="width: 200px;">
+    <sp-menu-item>
+        Item with arbitrary content in submenu
+        <div role="menuitem" slot="submenu" style="padding: 12px">
+            <img
+                src="https://placekitten.com/200/200"
+                alt="Kitten"
+                style="width: 100%; height: auto; border-radius: 4px"
+            />
+            <p>I am an arbitrary content in submenu</p>
+        </div>
+    </sp-menu-item>
+</sp-menu>
+```
+
 ### Value attribute
 
 When displayed as a descendent of an element that manages selection (e.g. `<sp-action-menu>`, `<sp-picker>`, `<sp-split-button>`, etc.), an `<sp-menu-item>` will represent the "selected" value of that ancestor when its `value` attribute or the trimmed `textContent` (represeted by `el.itemText`) matches the `value` of the ancestor element.

--- a/packages/menu/src/Menu.ts
+++ b/packages/menu/src/Menu.ts
@@ -375,7 +375,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
         }) as MenuItem;
         if (event.defaultPrevented) {
             const index = this.childItems.indexOf(target);
-            if (target?.menuData.focusRoot === this && index > -1) {
+            if (target?.menuData?.focusRoot === this && index > -1) {
                 this.focusedItemIndex = index;
             }
             return;
@@ -391,7 +391,7 @@ export class Menu extends SizedMixin(SpectrumElement, { noDefaultSize: true }) {
             );
             return;
         } else if (
-            target?.menuData.selectionRoot === this &&
+            target?.menuData?.selectionRoot === this &&
             this.childItems.length
         ) {
             event.preventDefault();

--- a/packages/menu/stories/submenu.stories.ts
+++ b/packages/menu/stories/submenu.stories.ts
@@ -368,3 +368,26 @@ export const contextMenu = (): TemplateResult => {
         </sp-overlay>
     `;
 };
+
+export const customRootSubmenu = (): TemplateResult => {
+    return html`
+        <sp-action-menu label="More Actions">
+            <sp-menu-item>Bronx</sp-menu-item>
+            <sp-menu-item id="submenu-item-1">
+                Brooklyn
+                <div role="menuitem" slot="submenu" style="padding: 12px">
+                    <img
+                        src="https://placekitten.com/200/200"
+                        alt="Kitten"
+                        style="width: 100%; height: auto; border-radius: 4px"
+                    />
+                    <p>I am an arbitrary content in submenu</p>
+                </div>
+            </sp-menu-item>
+        </sp-action-menu>
+    `;
+};
+
+customRootSubmenu.swc_vrt = {
+    skip: true,
+};

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -1068,7 +1068,7 @@ describe('Submenu', () => {
         expect(rootItem1.open, 'finally closed 1').to.be.false;
         expect(rootItem2.open, 'finally closed 2').to.be.false;
     });
-    it('supports using non-menu-item elements as the root of a submenu', async () => {
+    it('allows using non-menu-item elements as the root of a submenu', async () => {
         const el = await fixture<Menu>(html`
             <sp-menu>
                 <sp-menu-item class="root">

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -1068,7 +1068,7 @@ describe('Submenu', () => {
         expect(rootItem1.open, 'finally closed 1').to.be.false;
         expect(rootItem2.open, 'finally closed 2').to.be.false;
     });
-    it.only('supports using non-menu-item elements as the root of a submenu', async () => {
+    it('supports using non-menu-item elements as the root of a submenu', async () => {
         const el = await fixture<Menu>(html`
             <sp-menu>
                 <sp-menu-item class="root">

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -1074,7 +1074,7 @@ describe('Submenu', () => {
                 <sp-menu-item class="root">
                     Has submenu
                     <div role="menuitem" slot="submenu">
-                        <sp-menu-item>One</sp-menu-item>
+                        <sp-menu-item class="submenu-1">One</sp-menu-item>
                         <sp-menu-item>Two</sp-menu-item>
                         <sp-menu-item>Three</sp-menu-item>
                     </div

--- a/packages/menu/test/submenu.test.ts
+++ b/packages/menu/test/submenu.test.ts
@@ -1068,4 +1068,65 @@ describe('Submenu', () => {
         expect(rootItem1.open, 'finally closed 1').to.be.false;
         expect(rootItem2.open, 'finally closed 2').to.be.false;
     });
+    it.only('supports using non-menu-item elements as the root of a submenu', async () => {
+        const el = await fixture<Menu>(html`
+            <sp-menu>
+                <sp-menu-item class="root">
+                    Has submenu
+                    <div role="menuitem" slot="submenu">
+                        <sp-menu-item>One</sp-menu-item>
+                        <sp-menu-item>Two</sp-menu-item>
+                        <sp-menu-item>Three</sp-menu-item>
+                    </div
+                ></div>
+                </sp-menu-item>
+            </sp-menu>
+        `);
+        await elementUpdated(el);
+        const rootItem = el.querySelector('.root') as MenuItem;
+        const rootItemBoundingRect = rootItem.getBoundingClientRect();
+
+        // Open the first submenu
+        await sendMouse({
+            steps: [
+                {
+                    type: 'move',
+                    position: [
+                        rootItemBoundingRect.left +
+                            rootItemBoundingRect.width / 2,
+                        rootItemBoundingRect.top +
+                            rootItemBoundingRect.height / 2,
+                    ],
+                },
+            ],
+        });
+
+        expect(rootItem.open).to.be.true;
+
+        const firstSubMenuItemRect = el
+            .querySelector('.submenu-1')
+            ?.getBoundingClientRect();
+
+        if (!firstSubMenuItemRect) {
+            throw new Error('Submenu item not found');
+        }
+
+        // click to select
+        await sendMouse({
+            steps: [
+                {
+                    type: 'click',
+                    position: [
+                        firstSubMenuItemRect.left +
+                            firstSubMenuItemRect.width / 2,
+                        firstSubMenuItemRect.top +
+                            firstSubMenuItemRect.height / 2,
+                    ],
+                },
+            ],
+        });
+
+        // This test will fail if the click event throws an error
+        // because the submenu root is not a menu-item
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow using non-menu-item components as submenu.

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #4456

## Motivation and context

Using arbitrary components as submenu items and clicking them produces the TypeError:
Cannot read properties of undefined (reading 'selectionRoot') in Menu.handlePointerBasedSelection

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   Added a test and it passed.

-   [x] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
