### PR TITLE
fix(combobox): update selected item state in menu

### DIFF
--- a/packages/combobox/src/Combobox.ts
+++ b/packages/combobox/src/Combobox.ts
@@ -493,6 +493,8 @@ export class Combobox extends Textfield {
                                                   ? 'true'
                                                   : 'false'}
                                               .value=${option.value}
+                                              .selected=${option.value ===
+                                              this.itemValue}
                                           >
                                               ${option.itemText}
                                           </sp-menu-item>

--- a/packages/combobox/test/combobox.test.ts
+++ b/packages/combobox/test/combobox.test.ts
@@ -565,6 +565,62 @@ describe('Combobox', () => {
             expect(el.open).to.be.false;
             expect(el.activeDescendant).to.be.undefined;
         });
+        it('reflects the selected value in menu on reopening', async () => {
+            const el = await comboboxFixture();
+
+            await elementUpdated(el);
+
+            expect(el.value).to.equal('');
+            expect(el.activeDescendant).to.be.undefined;
+            expect(el.open).to.be.false;
+
+            let opened = oneEvent(el, 'sp-opened');
+            el.focusElement.click();
+            await opened;
+
+            const item = el.shadowRoot.querySelector(
+                '[value="banana"]'
+            ) as MenuItem;
+            await elementUpdated(item);
+
+            expect(el.open).to.be.true;
+
+            const itemValue = item.itemText;
+            const rect = item.getBoundingClientRect();
+            const closed = oneEvent(el, 'sp-closed');
+            await sendMouse({
+                steps: [
+                    {
+                        position: [
+                            rect.left + rect.width / 2,
+                            rect.top + rect.height / 2,
+                        ],
+                        type: 'click',
+                    },
+                ],
+            });
+            await closed;
+
+            expect(el.value).to.equal(itemValue);
+            expect(el.open).to.be.false;
+            expect(el.activeDescendant).to.be.undefined;
+
+            opened = oneEvent(el, 'sp-opened');
+            el.focusElement.click();
+            await opened;
+
+            await elementUpdated(el);
+            await elementUpdated(item);
+
+            expect(el.open).to.be.true;
+
+            // item should be selected
+            expect(
+                el.shadowRoot
+                    .querySelector('sp-menu')
+                    ?.querySelector('[selected]')?.textContent
+            ).to.equal(item.textContent);
+        });
         it('sets the value when an item is clicked programatically', async () => {
             const el = await comboboxFixture();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a user selects a value in sp-combobox and afterwards opens the menu list of values, they expect to see a checkmark before the selected value (default menu behavior).

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- #4711

## Motivation and context

Triggering the menu-open with mouse doesn't show a selected menu-item at all, only if cursor-down is used (and focus is thrown to menu-item), checkmark will be visible when menu-items are focussed and user cycles through values with cursor keys.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go here
    2. Do this

-   [ ] Did it pass in Desktop?
-   [ ] Did it pass in Mobile?
-   [ ] Did it pass in iPad?

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
