### PR TITLE
chore: remove thumbnail deprecated sizes

### DIFF
--- a/packages/thumbnail/src/Thumbnail.ts
+++ b/packages/thumbnail/src/Thumbnail.ts
@@ -36,7 +36,7 @@ const validSizes = [
     '900',
     '1000',
 ];
-export type ThumbnailSize = typeof validSizes[number];
+export type ThumbnailSize = (typeof validSizes)[number];
 
 const defaultSize = validSizes[6];
 
@@ -66,30 +66,6 @@ export class Thumbnail extends SpectrumElement {
     }
 
     public set size(value: ThumbnailSize) {
-        const deprecatedSizes = ['xxs', 'xs', 's', 'm', 'l'];
-        type DeprecatedThumbnailSize = typeof deprecatedSizes[number];
-        const managedSizes: Record<DeprecatedThumbnailSize, ThumbnailSize> = {
-            xxs: '100',
-            xs: '300',
-            s: '500',
-            m: '700',
-            l: '900',
-        };
-        const usesDeprecatedSize = deprecatedSizes.includes(value);
-        if (usesDeprecatedSize) {
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "size" attribute/property for <${this.localName}> no longer supports the value "${value}". Use one of the following values, instead:`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/thumbnail/#sizes',
-                    {
-                        level: 'deprecation',
-                        issues: validSizes as unknown as string[],
-                    }
-                );
-            }
-            value = managedSizes[value];
-        }
         const size = (
             validSizes.includes(value) ? value : defaultSize
         ) as ThumbnailSize;

--- a/packages/thumbnail/test/thumbnail.test.ts
+++ b/packages/thumbnail/test/thumbnail.test.ts
@@ -90,31 +90,5 @@ describe('Thumbnail', () => {
             window.__swc.verbose = false;
             consoleWarnStub.restore();
         });
-
-        it('warns in devMode when white/black variant is provided', async () => {
-            const el = await fixture<Thumbnail>(html`
-                <sp-thumbnail background="blue" size="xxs">
-                    <img src=${thumbnail} alt="Woman crouching" />
-                </sp-thumbnail>
-            `);
-
-            await elementUpdated(el);
-            expect(consoleWarnStub.called).to.be.true;
-
-            const spyCall = consoleWarnStub.getCall(0);
-            expect(
-                (spyCall.args.at(0) as string).includes(
-                    'no longer supports the value'
-                ),
-                'confirm deprecated size warning'
-            ).to.be.true;
-            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-                data: {
-                    localName: 'sp-thumbnail',
-                    type: 'api',
-                    level: 'deprecation',
-                },
-            });
-        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed the `sp-thumbnail` deprecated sizes, along with all associated references and dependencies.
<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Task: [SWC-302](https://jira.corp.adobe.com/browse/SWC-302)
- Subtask: [SWC-452](https://jira.corp.adobe.com/browse/SWC-452)

## Motivation and context

For the upcoming 1.0.0 release of Spectrum Web Components, we will remove the deprecated components and features.

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
