### PR TITLE
fix(breadcrumbs): trigger change event on breadcrumbs via keyboard

### DIFF
--- a/packages/breadcrumbs/src/BreadcrumbItem.ts
+++ b/packages/breadcrumbs/src/BreadcrumbItem.ts
@@ -82,17 +82,22 @@ export class BreadcrumbItem extends LikeAnchor(Focusable) {
         }
     }
 
+    protected handleKeyDown(event: KeyboardEvent): void {
+        if (event.key === 'Enter' || event.keyCode === 13) {
+            this.handleClick(event);
+        }
+    }
+
     protected renderLink(): TemplateResult {
         return html`
             <a
                 id="item-link"
-                href=${ifDefined(
-                    !this.isLastOfType ? this.href || '#' : undefined
-                )}
+                href=${ifDefined(!this.isLastOfType ? this.href : undefined)}
                 tabindex=${0}
                 aria-current=${ifDefined(
                     this.isLastOfType ? 'page' : undefined
                 )}
+                @keydown=${this.handleKeyDown}
                 @click=${this.handleClick}
             >
                 <slot></slot>

--- a/packages/breadcrumbs/src/BreadcrumbItem.ts
+++ b/packages/breadcrumbs/src/BreadcrumbItem.ts
@@ -86,7 +86,9 @@ export class BreadcrumbItem extends LikeAnchor(Focusable) {
         return html`
             <a
                 id="item-link"
-                href=${ifDefined(!this.isLastOfType ? this.href : undefined)}
+                href=${ifDefined(
+                    !this.isLastOfType ? this.href || '#' : undefined
+                )}
                 tabindex=${0}
                 aria-current=${ifDefined(
                     this.isLastOfType ? 'page' : undefined

--- a/packages/breadcrumbs/test/breadcrumbs.test.ts
+++ b/packages/breadcrumbs/test/breadcrumbs.test.ts
@@ -28,6 +28,7 @@ import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 
 import '@spectrum-web-components/breadcrumbs/sp-breadcrumbs.js';
 import '@spectrum-web-components/breadcrumbs/sp-breadcrumb-item.js';
+import { sendKeys } from '@web/test-runner-commands';
 
 describe('Breadcrumbs', () => {
     testForLitDevWarnings(
@@ -165,5 +166,32 @@ describe('Breadcrumbs', () => {
         await elementUpdated(el);
         expect(changeSpy).to.have.been.calledOnce;
         expect(changeSpy).to.have.been.calledWith('0');
+    });
+
+    it('should emit a change event on Enter keypress', async () => {
+        const changeSpy = spy();
+
+        const el = await fixture<Breadcrumbs>(html`
+            <sp-breadcrumbs
+                @change=${(
+                    event: Event & { detail: BreadcrumbSelectDetail }
+                ) => {
+                    changeSpy(event.detail.value);
+                }}
+            >
+                ${getBreadcrumbs(4)}
+            </sp-breadcrumbs>
+        `);
+
+        await elementUpdated(el);
+
+        // Simulate a click from the visible breadcrumb.
+        const breadcrumbs = el.querySelectorAll('sp-breadcrumb-item');
+
+        breadcrumbs[1].focus();
+        await sendKeys({ press: 'Enter' });
+
+        expect(changeSpy).to.have.been.calledOnce;
+        expect(changeSpy).to.have.been.calledWith('1');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to `undefined` href attribute, breadcrumb items without hrefs would not trigger change events on keyboard Enter press.
I added a similar fix which is used for `sp-sidenav-item`, which is a placeholder href value.

<!--- Describe your changes in detail -->

## Related issue(s)
Fix for #4733

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

-   [ ] _Test case 1_
    1. Go [here](https://4733--spectrum-web-components.netlify.app/storybook/?path=/story/breadcrumbs--default)
    2. Using the keyboard, navigate through the breadcrumb items and press "Enter"
    3. In the "Actions" addon, you should see the change event was triggered.

-   [x] Did it pass in Desktop?
-   [ ] Did it pass in Mobile? - N/A
-   [ ] Did it pass in iPad? - N/A

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
