### PR TITLE
chore: remove 'variant' and 'static' attributes from coach indicator

### DIFF
--- a/packages/coachmark/coach-indicator.md
+++ b/packages/coachmark/coach-indicator.md
@@ -23,16 +23,16 @@ When looking to leverage the `CoachIndicator` base class as a type and/or for ex
 import { CoachIndicator } from '@spectrum-web-components/coachmark';
 ```
 
-## Variants
+## Static color variants
 
-<sp-tabs selected="standard" auto label="Variant Options">
+<sp-tabs selected="standard" auto label="Static Color Options">
 <sp-tab value="standard">Standard</sp-tab>
 <sp-tab-panel value="standard">
 
 ```html
 <sp-coach-indicator></sp-coach-indicator>
-<sp-coach-indicator variant="dark"></sp-coach-indicator>
-<sp-coach-indicator variant="light"></sp-coach-indicator>
+<sp-coach-indicator static-color="dark"></sp-coach-indicator>
+<sp-coach-indicator static-color="light"></sp-coach-indicator>
 ```
 
 </sp-tab-panel>
@@ -41,8 +41,8 @@ import { CoachIndicator } from '@spectrum-web-components/coachmark';
 
 ```html
 <sp-coach-indicator quiet></sp-coach-indicator>
-<sp-coach-indicator quiet variant="dark"></sp-coach-indicator>
-<sp-coach-indicator quiet variant="light"></sp-coach-indicator>
+<sp-coach-indicator quiet static-color="dark"></sp-coach-indicator>
+<sp-coach-indicator quiet static-color="light"></sp-coach-indicator>
 ```
 
 </sp-tab-panel>

--- a/packages/coachmark/src/CoachIndicator.ts
+++ b/packages/coachmark/src/CoachIndicator.ts
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 import {
     CSSResultArray,
     html,
-    PropertyValues,
     SpectrumElement,
     TemplateResult,
 } from '@spectrum-web-components/base';
@@ -30,17 +29,8 @@ export class CoachIndicator extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public quiet = false;
 
-    /**
-     * @deprecated Use `staticColor` instead.
-     */
-    @property({ reflect: true })
-    public static?: 'white' | 'black';
-
     @property({ reflect: true, attribute: 'static-color' })
     public staticColor?: 'white' | 'black';
-
-    @property({ reflect: true })
-    public variant?: 'white' | 'black';
 
     protected override render(): TemplateResult {
         return html`
@@ -48,37 +38,5 @@ export class CoachIndicator extends SpectrumElement {
             <div class="ring"></div>
             <div class="ring"></div>
         `;
-    }
-
-    protected override updated(changes: PropertyValues): void {
-        super.updated(changes);
-        if (
-            changes.has('variant') &&
-            (this.variant || typeof changes.get('variant'))
-        ) {
-            this.staticColor = this.variant;
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "variant" attribute/property of <${this.localName}> have been deprecated. Use "static" with any of the same values instead. "variant" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/badge/#fixed',
-                    { level: 'deprecation' }
-                );
-            }
-        }
-        if (
-            changes.has('static') &&
-            (this.static || typeof changes.get('static'))
-        ) {
-            this.staticColor = this.static;
-            if (window.__swc.DEBUG) {
-                window.__swc.warn(
-                    this,
-                    `The "static" attribute/property of <${this.localName}> have been deprecated. Use "static-color" with any of the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/coach-indicator',
-                    { level: 'deprecation' }
-                );
-            }
-        }
     }
 }

--- a/packages/coachmark/stories/coach-indicator-static.stories.ts
+++ b/packages/coachmark/stories/coach-indicator-static.stories.ts
@@ -22,14 +22,14 @@ export default {
 
 export const staticWhite = (): TemplateResult => {
     return html`
-        <sp-coach-indicator variant="white"></sp-coach-indicator>
-        <sp-coach-indicator quiet variant="white"></sp-coach-indicator>
+        <sp-coach-indicator static-color="white"></sp-coach-indicator>
+        <sp-coach-indicator quiet static-color="white"></sp-coach-indicator>
     `;
 };
 
 export const staticBlack = (): TemplateResult => {
     return html`
-        <sp-coach-indicator variant="black"></sp-coach-indicator>
-        <sp-coach-indicator quiet variant="black"></sp-coach-indicator>
+        <sp-coach-indicator static-color="black"></sp-coach-indicator>
+        <sp-coach-indicator quiet static-color="black"></sp-coach-indicator>
     `;
 };

--- a/packages/coachmark/test/coach-indicator.test.ts
+++ b/packages/coachmark/test/coach-indicator.test.ts
@@ -14,7 +14,6 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import '@spectrum-web-components/coachmark/sp-coach-indicator.js';
 import { CoachIndicator } from '@spectrum-web-components/coachmark';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
-import { stub } from 'sinon';
 
 describe('CoachIndicator', () => {
     testForLitDevWarnings(
@@ -29,77 +28,5 @@ describe('CoachIndicator', () => {
         `);
         await elementUpdated(el);
         await expect(el).to.be.accessible();
-    });
-    it('loads coach-indicator white static-color when static is set', async () => {
-        const el = await fixture<CoachIndicator>(html`
-            <sp-coach-indicator static="white"></sp-coach-indicator>
-        `);
-        await elementUpdated(el);
-        expect(el.staticColor == 'white').to.be.true;
-        expect(el.getAttribute('static-color')).to.equal('white');
-    });
-    it('loads coach-indicator white static-color variant', async () => {
-        const el = await fixture<CoachIndicator>(html`
-            <sp-coach-indicator variant="white"></sp-coach-indicator>
-        `);
-        await elementUpdated(el);
-        expect(el.staticColor == 'white').to.be.true;
-    });
-});
-
-describe('dev mode', () => {
-    let consoleWarnStub!: ReturnType<typeof stub>;
-    before(() => {
-        window.__swc.verbose = true;
-        consoleWarnStub = stub(console, 'warn');
-    });
-    afterEach(() => {
-        consoleWarnStub.resetHistory();
-    });
-    after(() => {
-        window.__swc.verbose = false;
-        consoleWarnStub.restore();
-    });
-
-    it('warns in Dev Mode when deprecated `static` attribute is used', async () => {
-        const el = await fixture<CoachIndicator>(html`
-            <sp-coach-indicator static="white"></sp-coach-indicator>
-        `);
-        await elementUpdated(el);
-        expect(consoleWarnStub.called).to.be.true;
-
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            (spyCall.args.at(0) as string).includes('deprecated'),
-            'confirm deprecated static warning'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-coach-indicator',
-                type: 'api',
-                level: 'deprecation',
-            },
-        });
-    });
-
-    it('warns in Dev Mode when deprecated `variant` attribute is used', async () => {
-        const el = await fixture<CoachIndicator>(html`
-            <sp-coach-indicator variant="white"></sp-coach-indicator>
-        `);
-        await elementUpdated(el);
-        expect(consoleWarnStub.called).to.be.true;
-
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            (spyCall.args.at(0) as string).includes('The "variant" attribute'),
-            'confirm deprecated static warning'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-coach-indicator',
-                type: 'api',
-                level: 'deprecation',
-            },
-        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removed the `sp-coach-indicator` "variant" and "static" attributes, along with all associated references and dependencies.
<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- Task: [SWC-302](https://jira.corp.adobe.com/browse/SWC-302)
- Subtask: [SWC-448](https://jira.corp.adobe.com/browse/SWC-448)

## Motivation and context

For the upcoming 1.0.0 release of Spectrum Web Components, we will remove the deprecated components and features.

<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
