### PR TITLE
feat: add `static-color` to replace `static`

### DIFF
--- a/packages/action-bar/src/ActionBar.ts
+++ b/packages/action-bar/src/ActionBar.ts
@@ -100,7 +100,7 @@ export class ActionBar extends FocusVisiblePolyfillMixin(SpectrumElement) {
             <sp-popover ?open=${this.open} id="popover">
                 <slot name="override">
                     <sp-close-button
-                        staticColor=${ifDefined(
+                        static-color=${ifDefined(
                             this.emphasized ? 'white' : undefined
                         )}
                         class="close-button"
@@ -113,7 +113,7 @@ export class ActionBar extends FocusVisiblePolyfillMixin(SpectrumElement) {
                     <sp-action-group
                         class="action-group"
                         quiet
-                        staticColor=${ifDefined(
+                        static-color=${ifDefined(
                             this.emphasized ? 'white' : undefined
                         )}
                     >

--- a/packages/action-bar/src/ActionBar.ts
+++ b/packages/action-bar/src/ActionBar.ts
@@ -100,7 +100,7 @@ export class ActionBar extends FocusVisiblePolyfillMixin(SpectrumElement) {
             <sp-popover ?open=${this.open} id="popover">
                 <slot name="override">
                     <sp-close-button
-                        static=${ifDefined(
+                        staticColor=${ifDefined(
                             this.emphasized ? 'white' : undefined
                         )}
                         class="close-button"
@@ -113,7 +113,7 @@ export class ActionBar extends FocusVisiblePolyfillMixin(SpectrumElement) {
                     <sp-action-group
                         class="action-group"
                         quiet
-                        static=${ifDefined(
+                        staticColor=${ifDefined(
                             this.emphasized ? 'white' : undefined
                         )}
                     >

--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -276,7 +276,7 @@ export class ActionButton extends SizedMixin(ButtonBase, {
             if (window.__swc.DEBUG) {
                 window.__swc.warn(
                     this,
-                    `The "variant" attribute/property of <${this.localName}> has been deprecated. Use "staticColor" with the same values instead. "variant" will be removed in a future release.`,
+                    `The "variant" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "variant" will be removed in a future release.`,
                     'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
                 );
             }
@@ -289,7 +289,7 @@ export class ActionButton extends SizedMixin(ButtonBase, {
             if (window.__swc.DEBUG) {
                 window.__swc.warn(
                     this,
-                    `The "static" attribute/property of <${this.localName}> has been deprecated. Use "staticColor" with the same values instead. "static" will be removed in a future release.`,
+                    `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
                     'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
                 );
             }

--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -46,7 +46,7 @@ export type LongpressEvent = {
  * @slot icon - The icon to use for Action Button
  * @fires change - Announces a change in the `selected` property of an action button
  * @fires longpress - Synthesizes a "longpress" interaction that signifies a
- * `pointerdown` event that is >=300ms or a keyboard event wher code is `Space` or code is `ArrowDown`
+ * `pointerdown` event that is >=300ms or a keyboard event where code is `Space` or code is `ArrowDown`
  * while `altKey===true`.
  */
 export class ActionButton extends SizedMixin(ButtonBase, {
@@ -84,9 +84,21 @@ export class ActionButton extends SizedMixin(ButtonBase, {
     @property({ type: Boolean, reflect: true })
     public toggles = false;
 
+    /**
+     * The static color variant to use for the action button.
+     */
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'white' | 'black';
+
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ reflect: true })
     public static?: 'white' | 'black';
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ reflect: true })
     public variant?: 'white' | 'black';
 
@@ -258,14 +270,27 @@ export class ActionButton extends SizedMixin(ButtonBase, {
         }
         if (
             changes.has('variant') &&
-            (this.variant || typeof changes.get('variant'))
+            (this.variant !== undefined || changes.get('variant') !== undefined)
         ) {
-            this.static = this.variant;
+            this.staticColor = this.variant;
             if (window.__swc.DEBUG) {
                 window.__swc.warn(
                     this,
-                    `The "variant" attribute/property of <${this.localName}> have been deprecated. Use "static" with any of the same values instead. "variant" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/badge/#fixed'
+                    `The "variant" attribute/property of <${this.localName}> has been deprecated. Use "staticColor" with the same values instead. "variant" will be removed in a future release.`,
+                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                );
+            }
+        }
+        if (
+            changes.has('static') &&
+            (this.static !== undefined || changes.get('static') !== undefined)
+        ) {
+            this.staticColor = this.static;
+            if (window.__swc.DEBUG) {
+                window.__swc.warn(
+                    this,
+                    `The "static" attribute/property of <${this.localName}> has been deprecated. Use "staticColor" with the same values instead. "static" will be removed in a future release.`,
+                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
                 );
             }
         }

--- a/packages/action-button/src/ActionButton.ts
+++ b/packages/action-button/src/ActionButton.ts
@@ -277,7 +277,8 @@ export class ActionButton extends SizedMixin(ButtonBase, {
                 window.__swc.warn(
                     this,
                     `The "variant" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "variant" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/',
+                    { level: 'deprecation' }
                 );
             }
         }
@@ -290,7 +291,8 @@ export class ActionButton extends SizedMixin(ButtonBase, {
                 window.__swc.warn(
                     this,
                     `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/',
+                    { level: 'deprecation' }
                 );
             }
         }

--- a/packages/action-button/src/spectrum-action-button.css
+++ b/packages/action-button/src/spectrum-action-button.css
@@ -764,7 +764,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black'][quiet]) {
+:host([static-color='black'][quiet]) {
     --spectrum-actionbutton-border-color-default: var(
         --system-spectrum-actionbutton-staticblack-quiet-border-color-default
     );
@@ -782,7 +782,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white'][quiet]) {
+:host([static-color='white'][quiet]) {
     --spectrum-actionbutton-border-color-default: var(
         --system-spectrum-actionbutton-staticwhite-quiet-border-color-default
     );
@@ -800,7 +800,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black']) {
+:host([static-color='black']) {
     --spectrum-actionbutton-background-color-default: var(
         --system-spectrum-actionbutton-staticblack-background-color-default
     );
@@ -851,7 +851,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black'][selected]) {
+:host([static-color='black'][selected]) {
     --mod-actionbutton-background-color-default: var(
         --system-spectrum-actionbutton-staticblack-selected-mod-actionbutton-background-color-default
     );
@@ -896,7 +896,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white']) {
+:host([static-color='white']) {
     --spectrum-actionbutton-background-color-default: var(
         --system-spectrum-actionbutton-staticwhite-background-color-default
     );
@@ -947,7 +947,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white'][selected]) {
+:host([static-color='white'][selected]) {
     --mod-actionbutton-background-color-default: var(
         --system-spectrum-actionbutton-staticwhite-selected-mod-actionbutton-background-color-default
     );

--- a/packages/action-button/src/spectrum-config.js
+++ b/packages/action-button/src/spectrum-config.js
@@ -76,7 +76,7 @@ const config = {
                         ['spectrum-ActionButton--staticWhite', 'white'],
                         ['spectrum-ActionButton--staticBlack', 'black'],
                     ],
-                    'static'
+                    'static-color'
                 ),
                 // Default to `size='m'` without needing the attribute
                 converter.classToHost('spectrum-ActionButton--sizeM'),

--- a/packages/action-button/stories/index.ts
+++ b/packages/action-button/stories/index.ts
@@ -38,7 +38,7 @@ export function renderButton(properties: Properties): TemplateResult {
         <sp-action-button
             ?quiet="${!!properties.quiet}"
             ?emphasized="${!!properties.emphasized}"
-            static="${ifDefined(properties.variant)}"
+            static-color="${ifDefined(properties.variant)}"
             ?disabled=${!!properties.disabled}
             ?selected=${!!properties.selected}
             ?toggles=${!!properties.toggles}

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -351,6 +351,7 @@ describe('ActionButton', () => {
             await elementUpdated(el);
             expect(el.staticColor).to.equal('white');
             expect(el.static).to.equal('white');
+            expect(el.getAttribute('static-color')).to.equal('white');
         });
     });
 });

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -313,7 +313,7 @@ describe('ActionButton', () => {
                 data: {
                     localName: 'sp-action-button',
                     type: 'api',
-                    level: 'default',
+                    level: 'deprecation',
                 },
             });
         });
@@ -335,7 +335,7 @@ describe('ActionButton', () => {
                 data: {
                     localName: 'sp-action-button',
                     type: 'api',
-                    level: 'default',
+                    level: 'deprecation',
                 },
             });
         });

--- a/packages/action-button/test/action-button.test.ts
+++ b/packages/action-button/test/action-button.test.ts
@@ -36,11 +36,9 @@ describe('ActionButton', () => {
             )
     );
     it('loads default', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button>Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button>Button</sp-action-button>
+        `);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
@@ -48,11 +46,9 @@ describe('ActionButton', () => {
         await expect(el).to.be.accessible();
     });
     it('gardens "value" as a property', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button>Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button>Button</sp-action-button>
+        `);
 
         await elementUpdated(el);
         expect(el.hasAttribute('value')).to.be.false;
@@ -64,11 +60,9 @@ describe('ActionButton', () => {
         expect(el.hasAttribute('value')).to.be.false;
     });
     it('loads [hold-affordance]', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button hold-affordance>Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button hold-affordance>Button</sp-action-button>
+        `);
 
         await elementUpdated(el);
         expect(el).to.not.be.undefined;
@@ -76,11 +70,9 @@ describe('ActionButton', () => {
         await expect(el).to.be.accessible();
     });
     it('manages a `tabindex`', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button>Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button>Button</sp-action-button>
+        `);
 
         expect(el.tabIndex).to.equal(0);
         expect(el.disabled).to.be.false;
@@ -104,11 +96,9 @@ describe('ActionButton', () => {
         expect(el.disabled).to.be.false;
     });
     it('manages a `size` attribute', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button size="xl">Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button size="xl">Button</sp-action-button>
+        `);
 
         await elementUpdated(el);
         expect(el.size).to.equal('xl');
@@ -119,11 +109,9 @@ describe('ActionButton', () => {
         expect(el.hasAttribute('size')).to.be.false;
     });
     it('does not apply a default `size` attribute', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button>Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button>Button</sp-action-button>
+        `);
 
         await elementUpdated(el);
         expect(el.size).to.equal('m');
@@ -131,16 +119,14 @@ describe('ActionButton', () => {
     });
     it('dispatches `longpress` events when [hold-affordance]', async () => {
         const longpressSpy = spy();
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button
-                    hold-affordance
-                    @longpress=${() => longpressSpy()}
-                >
-                    Button
-                </sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button
+                hold-affordance
+                @longpress=${() => longpressSpy()}
+            >
+                Button
+            </sp-action-button>
+        `);
 
         await elementUpdated(el);
 
@@ -162,16 +148,14 @@ describe('ActionButton', () => {
     });
     it('does not dispatch `longpress` events when "right click"ed', async () => {
         const longpressSpy = spy();
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button
-                    hold-affordance
-                    @longpress=${() => longpressSpy()}
-                >
-                    Button
-                </sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button
+                hold-affordance
+                @longpress=${() => longpressSpy()}
+            >
+                Button
+            </sp-action-button>
+        `);
 
         await elementUpdated(el);
         expect(longpressSpy.callCount).to.equal(0);
@@ -182,11 +166,9 @@ describe('ActionButton', () => {
         expect(longpressSpy.callCount).to.equal(0);
     });
     it(':not([toggles])', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button>Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button>Button</sp-action-button>
+        `);
 
         await elementUpdated(el);
         const button = el.focusElement;
@@ -203,11 +185,9 @@ describe('ActionButton', () => {
         expect(button.hasAttribute('aria-pressed')).to.be.false;
     });
     it('responds to [selected]', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button>Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button>Button</sp-action-button>
+        `);
 
         await elementUpdated(el);
         const button = el.focusElement;
@@ -231,11 +211,9 @@ describe('ActionButton', () => {
         expect(button.hasAttribute('aria-pressed')).to.be.false;
     });
     it('toggles', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button toggles>Button</sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button toggles>Button</sp-action-button>
+        `);
 
         await elementUpdated(el);
         const button = el.focusElement;
@@ -263,17 +241,15 @@ describe('ActionButton', () => {
         expect(button.getAttribute('aria-pressed')).to.equal('true');
     });
     it('toggles [aria-haspopup][aria-expanded]', async () => {
-        const el = await fixture<ActionButton>(
-            html`
-                <sp-action-button
-                    toggles
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                >
-                    Button
-                </sp-action-button>
-            `
-        );
+        const el = await fixture<ActionButton>(html`
+            <sp-action-button
+                toggles
+                aria-haspopup="true"
+                aria-expanded="false"
+            >
+                Button
+            </sp-action-button>
+        `);
 
         await elementUpdated(el);
         const button = el.focusElement;
@@ -321,11 +297,9 @@ describe('ActionButton', () => {
         });
 
         it('warns that `variant` is deprecated', async () => {
-            const el = await fixture<ActionButton>(
-                html`
-                    <sp-action-button variant="white">Button</sp-action-button>
-                `
-            );
+            const el = await fixture<ActionButton>(html`
+                <sp-action-button variant="white">Button</sp-action-button>
+            `);
 
             await elementUpdated(el);
 
@@ -342,6 +316,41 @@ describe('ActionButton', () => {
                     level: 'default',
                 },
             });
+        });
+
+        it('warns that `variant` is deprecated', async () => {
+            const el = await fixture<ActionButton>(html`
+                <sp-action-button static="white">Button</sp-action-button>
+            `);
+
+            await elementUpdated(el);
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes('"static"'),
+                'confirm static-centric message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-action-button',
+                    type: 'api',
+                    level: 'default',
+                },
+            });
+        });
+
+        it('prefers `staticColor` over `static`', async () => {
+            const el = await fixture<ActionButton>(html`
+                <sp-action-button static="white">Button</sp-action-button>
+            `);
+
+            await elementUpdated(el);
+            expect(el.staticColor).to.equal('white');
+            el.setAttribute('static', 'white');
+            await elementUpdated(el);
+            expect(el.staticColor).to.equal('white');
+            expect(el.static).to.equal('white');
         });
     });
 });

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -112,8 +112,14 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
     @property({ type: String })
     public selects: undefined | 'single' | 'multiple';
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ reflect: true })
     public static?: 'white' | 'black';
+
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'white' | 'black';
 
     @property({ type: Boolean, reflect: true })
     public vertical = false;
@@ -385,7 +391,18 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
                 button.emphasized = this.emphasized;
             }
             if (this.static || changes?.get('static')) {
-                button.static = this.static;
+                if (window.__swc.DEBUG) {
+                    window.__swc.warn(
+                        this,
+                        `The "static" attribute/property of <${this.localName}> has been deprecated. Use "staticColor" with the same values instead. "static" will be removed in a future release.`,
+                        'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                    );
+                }
+                this.staticColor = this.static;
+                button.staticColor = this.staticColor;
+            }
+            if (this.staticColor || changes?.get('staticColor')) {
+                button.staticColor = this.staticColor;
             }
             if (this.selects || !this.hasManaged) {
                 button.selected = this.selected.includes(button.value);

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -394,7 +394,7 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
                 if (window.__swc.DEBUG) {
                     window.__swc.warn(
                         this,
-                        `The "static" attribute/property of <${this.localName}> has been deprecated. Use "staticColor" with the same values instead. "static" will be removed in a future release.`,
+                        `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
                         'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
                     );
                 }

--- a/packages/action-group/src/ActionGroup.ts
+++ b/packages/action-group/src/ActionGroup.ts
@@ -365,7 +365,8 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
             changes.has('quiet') ||
             changes.has('emphasized') ||
             changes.has('size') ||
-            changes.has('static')
+            changes.has('static') ||
+            changes.has('staticColor')
         ) {
             this.manageChildren(changes);
         }
@@ -395,7 +396,8 @@ export class ActionGroup extends SizedMixin(SpectrumElement, {
                     window.__swc.warn(
                         this,
                         `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                        'https://opensource.adobe.com/spectrum-web-components/components/action-group/api/',
+                        { level: 'deprecation' }
                     );
                 }
                 this.staticColor = this.static;

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -350,9 +350,9 @@ describe('ActionGroup', () => {
         expect(el.getAttribute('role')).to.equal('toolbar');
         expect(el.children[0].getAttribute('role')).to.equal('button');
     });
-    it('applies `static` attribute to its children', async () => {
+    it('applies `static-color` attribute to its children', async () => {
         const el = await fixture<ActionGroup>(html`
-            <sp-action-group static="white">
+            <sp-action-group static-color="white">
                 <sp-action-button id="first">First</sp-action-button>
                 <sp-action-button id="second">Second</sp-action-button>
             </sp-action-group>
@@ -362,15 +362,15 @@ describe('ActionGroup', () => {
 
         await elementUpdated(el);
 
-        expect(firstButton.static).to.equal('white');
-        expect(secondButton.static).to.equal('white');
+        expect(firstButton.staticColor).to.equal('white');
+        expect(secondButton.staticColor).to.equal('white');
 
-        el.static = undefined;
+        el.staticColor = undefined;
 
         await elementUpdated(el);
 
-        expect(firstButton.static).to.be.undefined;
-        expect(secondButton.static).to.be.undefined;
+        expect(firstButton.staticColor).to.be.undefined;
+        expect(secondButton.staticColor).to.be.undefined;
     });
     it('manages "label"', async () => {
         const testLabel = 'Testable action group';

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -1539,6 +1539,7 @@ describe('ActionGroup', () => {
         await elementUpdated(el);
         expect(el.staticColor).to.equal('white');
         expect(el.static).to.equal('white');
+        expect(el.getAttribute('static-color')).to.equal('white');
     });
 });
 
@@ -1570,7 +1571,7 @@ describe('dev mode', () => {
         expect(consoleWarnStub.called).to.be.true;
         const spyCall = consoleWarnStub.getCall(0);
         expect(
-            (spyCall.args.at(0) as string).includes('The "static" attribute'),
+            (spyCall.args.at(0) as string).includes('deprecated'),
             'confirm attribute deprecation message'
         ).to.be.true;
         expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({

--- a/packages/action-group/test/action-group.test.ts
+++ b/packages/action-group/test/action-group.test.ts
@@ -49,7 +49,7 @@ import {
 import { sendKeys } from '@web/test-runner-commands';
 import '@spectrum-web-components/action-group/sp-action-group.js';
 import { controlled } from '../stories/action-group-tooltip.stories.js';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 import { sendMouse } from '../../../test/plugins/browser.js';
 import { HasActionMenuAsChild } from '../stories/action-group.stories.js';
 import '../stories/action-group.stories.js';
@@ -1521,5 +1521,64 @@ describe('ActionGroup', () => {
         expect(actionButtons[0].selected).to.be.false;
         expect(actionButtons[1].selected).to.be.true;
         expect(actionButtons[2].selected).to.be.false;
+    });
+    it('prefers `staticColor` over `static`', async () => {
+        const el = await fixture<ActionGroup>(html`
+            <sp-action-group
+                label="Selects Single Group"
+                selects="single"
+                static="white"
+                dir="ltr"
+            >
+                <sp-action-button>First</sp-action-button>
+            </sp-action-group>
+        `);
+        await elementUpdated(el);
+        expect(el.staticColor).to.equal('white');
+        el.setAttribute('static', 'white');
+        await elementUpdated(el);
+        expect(el.staticColor).to.equal('white');
+        expect(el.static).to.equal('white');
+    });
+});
+
+describe('dev mode', () => {
+    let consoleWarnStub!: ReturnType<typeof stub>;
+    before(() => {
+        window.__swc.verbose = true;
+        consoleWarnStub = stub(console, 'warn');
+    });
+    afterEach(() => {
+        consoleWarnStub.resetHistory();
+    });
+    after(() => {
+        window.__swc.verbose = false;
+        consoleWarnStub.restore();
+    });
+    it('warns in Dev Mode when static attribute is supplied', async () => {
+        const el = await fixture<ActionGroup>(html`
+            <sp-action-group
+                label="Selects Single Group"
+                selects="single"
+                static="white"
+                dir="ltr"
+            >
+                <sp-action-button>First</sp-action-button>
+            </sp-action-group>
+        `);
+        await elementUpdated(el);
+        expect(consoleWarnStub.called).to.be.true;
+        const spyCall = consoleWarnStub.getCall(0);
+        expect(
+            (spyCall.args.at(0) as string).includes('The "static" attribute'),
+            'confirm attribute deprecation message'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-action-group',
+                type: 'api',
+                level: 'deprecation',
+            },
+        });
     });
 });

--- a/packages/action-menu/src/ActionMenu.ts
+++ b/packages/action-menu/src/ActionMenu.ts
@@ -50,8 +50,14 @@ export class ActionMenu extends ObserveSlotPresence(
     @property({ type: String })
     public override selects: undefined | 'single' = undefined;
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ type: String, reflect: true })
     public static: 'white' | 'black' | undefined = undefined;
+
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'white' | 'black';
 
     protected override listRole: 'listbox' | 'menu' = 'menu';
     protected override itemRole = 'menuitem';
@@ -104,7 +110,7 @@ export class ActionMenu extends ObserveSlotPresence(
                 aria-describedby=${DESCRIPTION_ID}
                 ?quiet=${this.quiet}
                 ?selected=${this.open}
-                static=${ifDefined(this.static)}
+                static-color=${ifDefined(this.staticColor)}
                 aria-haspopup="true"
                 aria-controls=${ifDefined(this.open ? 'menu' : undefined)}
                 aria-expanded=${this.open ? 'true' : 'false'}

--- a/packages/action-menu/stories/action-menu.stories.ts
+++ b/packages/action-menu/stories/action-menu.stories.ts
@@ -120,10 +120,11 @@ export default {
                 type: 'boolean',
             },
         },
-        staticValue: {
-            name: 'static',
+        staticColorValue: {
+            name: 'static-color',
             type: { name: 'string', required: false },
-            description: 'The visual static variant to apply to the button.',
+            description:
+                'The visual static color variant to apply to the button.',
             table: {
                 type: { summary: 'string' },
                 defaultValue: { summary: 'none' },

--- a/packages/action-menu/stories/index.ts
+++ b/packages/action-menu/stories/index.ts
@@ -44,7 +44,7 @@ export const ActionMenuMarkup = ({
             ?disabled=${disabled}
             ?open=${open}
             ?quiet=${quiet}
-            static=${ifDefined(
+            static-color=${ifDefined(
                 staticValue === 'none'
                     ? undefined
                     : (staticValue as 'black' | 'white')

--- a/packages/alert-banner/README.md
+++ b/packages/alert-banner/README.md
@@ -50,7 +50,7 @@ Use the action slot for the contextual action that a user can take in response t
 ```html
 <sp-alert-banner open dismissible>
     Your trial has expired
-    <sp-button treatment="outline" static="white" slot="action">
+    <sp-button treatment="outline" static-color="white" slot="action">
         Buy now
     </sp-button>
 </sp-alert-banner>
@@ -63,7 +63,7 @@ Use the action slot for the contextual action that a user can take in response t
 ```html
 <sp-alert-banner open variant="info" dismissible>
     Your trial will expire in 3 days
-    <sp-button treatment="outline" static="white" slot="action">
+    <sp-button treatment="outline" static-color="white" slot="action">
         Buy now
     </sp-button>
 </sp-alert-banner>

--- a/packages/alert-banner/src/AlertBanner.ts
+++ b/packages/alert-banner/src/AlertBanner.ts
@@ -154,7 +154,7 @@ export class AlertBanner extends SpectrumElement {
                           <sp-close-button
                               @click=${this.shouldClose}
                               label="Close"
-                              static="white"
+                              static-color="white"
                           ></sp-close-button>
                       `
                     : html``}

--- a/packages/alert-banner/stories/index.ts
+++ b/packages/alert-banner/stories/index.ts
@@ -29,7 +29,7 @@ export const AlertBannerMarkup = ({
         ?open=${open}
     >
         ${text}
-        <sp-button treatment="outline" static="white" slot="action">
+        <sp-button treatment="outline" static-color="white" slot="action">
             ${actionLabel}
         </sp-button>
     </sp-alert-banner>

--- a/packages/badge/src/spectrum-config.js
+++ b/packages/badge/src/spectrum-config.js
@@ -80,7 +80,7 @@ const config = {
                 ),
                 ...converter.enumerateAttributes(
                     [['spectrum-Badge--black-text', 'black']],
-                    'static'
+                    'static-color'
                 ),
                 converter.classToClass('spectrum-Badge-label'),
                 converter.classToSlotted('spectrum-Badge-icon', 'icon'),

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -177,12 +177,12 @@ attribute defaults to `accent` but also accepts the following value: `accent`, `
 
 ```html demo
 <sp-button-group style="min-width: max-content">
-    <sp-button static="black">Label only</sp-button>
-    <sp-button static="black">
+    <sp-button static-color="black">Label only</sp-button>
+    <sp-button static-color="black">
         <sp-icon-help slot="icon"></sp-icon-help>
         Icon + Label
     </sp-button>
-    <sp-button static="black" label="Icon only" icon-only>
+    <sp-button static-color="black" label="Icon only" icon-only>
         <sp-icon-help slot="icon"></sp-icon-help>
     </sp-button>
 </sp-button-group>
@@ -194,12 +194,12 @@ attribute defaults to `accent` but also accepts the following value: `accent`, `
 
 ```html demo
 <sp-button-group style="min-width: max-content">
-    <sp-button static="white">Label only</sp-button>
-    <sp-button static="white">
+    <sp-button static-color="white">Label only</sp-button>
+    <sp-button static-color="white">
         <sp-icon-help slot="icon"></sp-icon-help>
         Icon + Label
     </sp-button>
-    <sp-button static="white" label="Icon only" icon-only>
+    <sp-button static-color="white" label="Icon only" icon-only>
         <sp-icon-help slot="icon"></sp-icon-help>
     </sp-button>
 </sp-button-group>
@@ -250,12 +250,17 @@ The `treatment` attribute accepts `fill` and `outline` as values, and defaults t
 <sp-button-group
     style="background: var(--spectrum-seafoam-600); padding: 0.5em; min-width: max-content"
 >
-    <sp-button treatment="outline" static="black">Label only</sp-button>
-    <sp-button treatment="outline" static="black">
+    <sp-button treatment="outline" static-color="black">Label only</sp-button>
+    <sp-button treatment="outline" static-color="black">
         <sp-icon-help slot="icon"></sp-icon-help>
         Icon + Label
     </sp-button>
-    <sp-button treatment="outline" static="black" label="Icon only" icon-only>
+    <sp-button
+        treatment="outline"
+        static-color="black"
+        label="Icon only"
+        icon-only
+    >
         <sp-icon-help slot="icon"></sp-icon-help>
     </sp-button>
 </sp-button-group>
@@ -269,12 +274,17 @@ The `treatment` attribute accepts `fill` and `outline` as values, and defaults t
 <sp-button-group
     style="background: var(--spectrum-seafoam-600); padding: 0.5em; min-width: max-content"
 >
-    <sp-button treatment="outline" static="white">Label only</sp-button>
-    <sp-button treatment="outline" static="white">
+    <sp-button treatment="outline" static-color="white">Label only</sp-button>
+    <sp-button treatment="outline" static-color="white">
         <sp-icon-help slot="icon"></sp-icon-help>
         Icon + Label
     </sp-button>
-    <sp-button treatment="outline" static="white" label="Icon only" icon-only>
+    <sp-button
+        treatment="outline"
+        static-color="white"
+        label="Icon only"
+        icon-only
+    >
         <sp-icon-help slot="icon"></sp-icon-help>
     </sp-button>
 </sp-button-group>

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2024 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -9,7 +9,6 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
 import {
     CSSResultArray,
     html,
@@ -23,13 +22,13 @@ import buttonStyles from './button.css.js';
 import { PendingStateController } from '@spectrum-web-components/reactive-controllers/src/PendingState.js';
 
 export type DeprecatedButtonVariants = 'cta' | 'overBackground';
-export type ButtonStatics = 'white' | 'black';
+export type ButtonStaticColors = 'white' | 'black';
 export type ButtonVariants =
     | 'accent'
     | 'primary'
     | 'secondary'
     | 'negative'
-    | ButtonStatics
+    | ButtonStaticColors
     | DeprecatedButtonVariants;
 export const VALID_VARIANTS = [
     'accent',
@@ -39,7 +38,7 @@ export const VALID_VARIANTS = [
     'white',
     'black',
 ];
-export const VALID_STATICS = ['white', 'black'];
+export const VALID_STATIC_COLORS = ['white', 'black'];
 
 export type ButtonTreatments = 'fill' | 'outline';
 
@@ -57,7 +56,7 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
     @property({ type: String, attribute: 'pending-label' })
     public pendingLabel = 'Pending';
 
-    // pending is the property that consumers can use to set the button into a pending state
+    // Use this property to set the button into a pending state
     @property({ type: Boolean, reflect: true, attribute: true })
     public pending = false;
 
@@ -103,25 +102,25 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                 break;
             case 'overBackground':
                 this.removeAttribute('variant');
-                this.static = 'white';
+                this.staticColor = 'white';
                 this.treatment = 'outline';
                 if (window.__swc.DEBUG) {
                     window.__swc.warn(
                         this,
-                        `The "overBackground" value of the "variant" attribute on <${this.localName}> has been deprecated and will be removed in a future release. Use "static='white'" with "treatment='outline'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button#static'
+                        `The "overBackground" value of the "variant" attribute on <${this.localName}> has been deprecated and will be removed in a future release. Use "staticColor='white'" with "treatment='outline'" instead.`,
+                        'https://opensource.adobe.com/spectrum-web-components/components/button#staticColor'
                     );
                 }
                 return;
             case 'white':
             case 'black':
-                this.static = variant;
+                this.staticColor = variant;
                 this.removeAttribute('variant');
                 if (window.__swc.DEBUG) {
                     window.__swc.warn(
                         this,
-                        `The "black" and "white" values of the "variant" attribute on <${this.localName}> has been deprecated and will be removed in a future release. Use "static='black'" or "static='white'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button#static'
+                        `The "black" and "white" values of the "variant" attribute on <${this.localName}> have been deprecated and will be removed in a future release. Use "staticColor='black'" or "staticColor='white'" instead.`,
+                        'https://opensource.adobe.com/spectrum-web-components/components/button#staticColor'
                     );
                 }
                 return;
@@ -139,11 +138,20 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
     }
     private _variant: ButtonVariants = 'accent';
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ type: String, reflect: true })
-    public static: 'black' | 'white' | undefined;
+    public static?: 'black' | 'white';
 
     /**
-     * The visual variant to apply to this button.
+     * The static color variant to use for this button.
+     */
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'black' | 'white';
+
+    /**
+     * The visual treatment to apply to this button.
      */
     @property({ reflect: true })
     public treatment: ButtonTreatments = 'fill';
@@ -164,6 +172,7 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
         super.firstUpdated(changes);
         // There is no Spectrum design context for an `<sp-button>` without a variant
         // apply one manually when a consumer has not applied one themselves.
+
         if (!this.hasAttribute('variant')) {
             this.setAttribute('variant', this.variant);
         }
@@ -172,12 +181,34 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
         }
     }
 
-    protected override update(changes: PropertyValues): void {
-        super.update(changes);
-    }
-
     protected override updated(changed: PropertyValues): void {
         super.updated(changed);
+        if (changed.has('variant')) {
+            if (['white', 'black'].includes(this.variant)) {
+                this.staticColor = this.variant as 'white' | 'black';
+                this.removeAttribute('variant');
+                if (window.__swc.DEBUG) {
+                    window.__swc.warn(
+                        this,
+                        `The "variant" attribute values "white" and "black" are deprecated and will be removed in a future release. Use "staticColor='${this.variant}'" instead.`,
+                        'https://opensource.adobe.com/spectrum-web-components/components/button'
+                    );
+                }
+            }
+        }
+
+        if (changed.has('static')) {
+            if (this.static) {
+                this.staticColor = this.static;
+                if (window.__swc.DEBUG) {
+                    window.__swc.warn(
+                        this,
+                        `The "static" attribute/property on <${this.localName}> has been deprecated. Use "staticColor" instead. "static" will be removed in a future release.`,
+                        'https://opensource.adobe.com/spectrum-web-components/components/button'
+                    );
+                }
+            }
+        }
     }
 
     protected override renderButton(): TemplateResult {

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -115,6 +115,17 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                 }
                 return;
             case 'white':
+                this.staticColor = variant;
+                this.removeAttribute('variant');
+                if (window.__swc.DEBUG) {
+                    window.__swc.warn(
+                        this,
+                        `The "black" and "white" values of the "variant" attribute on <${this.localName}> have been deprecated and will be removed in a future release. Use "static-color='black'" or "static-color='white'" instead.`,
+                        'https://opensource.adobe.com/spectrum-web-components/components/button/api',
+                        { level: 'deprecation' }
+                    );
+                }
+                return;
             case 'black':
                 this.staticColor = variant;
                 this.removeAttribute('variant');
@@ -195,20 +206,6 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
 
     protected override updated(changed: PropertyValues): void {
         super.updated(changed);
-        if (changed.has('variant')) {
-            if (['white', 'black'].includes(this.variant)) {
-                this.staticColor = this.variant as 'white' | 'black';
-                this.removeAttribute('variant');
-                if (window.__swc.DEBUG) {
-                    window.__swc.warn(
-                        this,
-                        `The "variant" attribute values "white" and "black" are deprecated and will be removed in a future release. Use "static-color='${this.variant}'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button/api',
-                        { level: 'deprecation' }
-                    );
-                }
-            }
-        }
 
         if (changed.has('static')) {
             if (this.static) {

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -108,7 +108,7 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                     window.__swc.warn(
                         this,
                         `The "overBackground" value of the "variant" attribute on <${this.localName}> has been deprecated and will be removed in a future release. Use "staticColor='white'" with "treatment='outline'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button#staticColor'
+                        'https://opensource.adobe.com/spectrum-web-components/components/button'
                     );
                 }
                 return;
@@ -119,8 +119,8 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                 if (window.__swc.DEBUG) {
                     window.__swc.warn(
                         this,
-                        `The "black" and "white" values of the "variant" attribute on <${this.localName}> have been deprecated and will be removed in a future release. Use "staticColor='black'" or "staticColor='white'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button#staticColor'
+                        `The "black" and "white" values of the "variant" attribute on <${this.localName}> have been deprecated and will be removed in a future release. Use "static-color='black'" or "static-color='white'" instead.`,
+                        'https://opensource.adobe.com/spectrum-web-components/components/button'
                     );
                 }
                 return;
@@ -190,7 +190,7 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                 if (window.__swc.DEBUG) {
                     window.__swc.warn(
                         this,
-                        `The "variant" attribute values "white" and "black" are deprecated and will be removed in a future release. Use "staticColor='${this.variant}'" instead.`,
+                        `The "variant" attribute values "white" and "black" are deprecated and will be removed in a future release. Use "static-color='${this.variant}'" instead.`,
                         'https://opensource.adobe.com/spectrum-web-components/components/button'
                     );
                 }
@@ -203,7 +203,7 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                 if (window.__swc.DEBUG) {
                     window.__swc.warn(
                         this,
-                        `The "static" attribute/property on <${this.localName}> has been deprecated. Use "staticColor" instead. "static" will be removed in a future release.`,
+                        `The "static" attribute/property on <${this.localName}> has been deprecated. Use "static-color" instead. "static" will be removed in a future release.`,
                         'https://opensource.adobe.com/spectrum-web-components/components/button'
                     );
                 }

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -213,7 +213,8 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                     window.__swc.warn(
                         this,
                         `The "static" attribute/property on <${this.localName}> has been deprecated. Use "static-color" instead. "static" will be removed in a future release.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button'
+                        'https://opensource.adobe.com/spectrum-web-components/components/button/api',
+                        { level: 'deprecation' }
                     );
                 }
             }

--- a/packages/button/src/Button.ts
+++ b/packages/button/src/Button.ts
@@ -96,7 +96,8 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                     window.__swc.warn(
                         this,
                         `The "cta" value of the "variant" attribute on <${this.localName}> has been deprecated and will be removed in a future release. Use "variant='accent'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button/#variants'
+                        'https://opensource.adobe.com/spectrum-web-components/components/button/#variants',
+                        { level: 'deprecation' }
                     );
                 }
                 break;
@@ -108,7 +109,8 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                     window.__swc.warn(
                         this,
                         `The "overBackground" value of the "variant" attribute on <${this.localName}> has been deprecated and will be removed in a future release. Use "staticColor='white'" with "treatment='outline'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button'
+                        'https://opensource.adobe.com/spectrum-web-components/components/button',
+                        { level: 'deprecation' }
                     );
                 }
                 return;
@@ -120,7 +122,8 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                     window.__swc.warn(
                         this,
                         `The "black" and "white" values of the "variant" attribute on <${this.localName}> have been deprecated and will be removed in a future release. Use "static-color='black'" or "static-color='white'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button'
+                        'https://opensource.adobe.com/spectrum-web-components/components/button/api',
+                        { level: 'deprecation' }
                     );
                 }
                 return;
@@ -200,7 +203,8 @@ export class Button extends SizedMixin(ButtonBase, { noDefaultSize: true }) {
                     window.__swc.warn(
                         this,
                         `The "variant" attribute values "white" and "black" are deprecated and will be removed in a future release. Use "static-color='${this.variant}'" instead.`,
-                        'https://opensource.adobe.com/spectrum-web-components/components/button'
+                        'https://opensource.adobe.com/spectrum-web-components/components/button/api',
+                        { level: 'deprecation' }
                     );
                 }
             }

--- a/packages/button/src/CloseButton.ts
+++ b/packages/button/src/CloseButton.ts
@@ -24,7 +24,7 @@ import '@spectrum-web-components/icons-ui/icons/sp-icon-cross300.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-cross400.js';
 import '@spectrum-web-components/icons-ui/icons/sp-icon-cross500.js';
 import crossMediumStyles from '@spectrum-web-components/icon/src/spectrum-icon-cross.css.js';
-import type { ButtonStatics } from './Button.js';
+import type { ButtonStaticColors } from './Button.js';
 
 const crossIcon: Record<string, () => TemplateResult> = {
     s: () => html`
@@ -70,10 +70,10 @@ export class CloseButton extends SizedMixin(StyledButton, {
      * The visual variant to apply to this button.
      */
     @property({ reflect: true })
-    public variant: ButtonStatics | '' = '';
+    public variant: ButtonStaticColors | '' = '';
 
     @property({ type: String, reflect: true })
-    public static: 'black' | 'white' | undefined;
+    public staticColor: 'black' | 'white' | undefined;
 
     protected override get buttonContent(): TemplateResult[] {
         return [crossIcon[this.size]()];

--- a/packages/button/src/CloseButton.ts
+++ b/packages/button/src/CloseButton.ts
@@ -72,8 +72,8 @@ export class CloseButton extends SizedMixin(StyledButton, {
     @property({ reflect: true })
     public variant: ButtonStaticColors | '' = '';
 
-    @property({ type: String, reflect: true })
-    public staticColor: 'black' | 'white' | undefined;
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'black' | 'white';
 
     protected override get buttonContent(): TemplateResult[] {
         return [crossIcon[this.size]()];

--- a/packages/button/src/spectrum-button.css
+++ b/packages/button/src/spectrum-button.css
@@ -699,8 +699,8 @@ governing permissions and limitations under the License.
     overflow: hidden;
 }
 
-:host([static='black']),
-:host([static='white']) {
+:host([static-color='black']),
+:host([static-color='white']) {
     --spectrum-button-focus-indicator-color: var(
         --mod-static-black-focus-indicator-color,
         var(--spectrum-static-black-focus-indicator-color)
@@ -1288,7 +1288,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black'][quiet]) {
+:host([static-color='black'][quiet]) {
     --spectrum-button-border-color-default: var(
         --system-spectrum-button-staticblack-quiet-border-color-default
     );
@@ -1306,7 +1306,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white'][quiet]) {
+:host([static-color='white'][quiet]) {
     --spectrum-button-border-color-default: var(
         --system-spectrum-button-staticwhite-quiet-border-color-default
     );
@@ -1324,7 +1324,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white']) {
+:host([static-color='white']) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticwhite-background-color-default
     );
@@ -1375,7 +1375,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white'][treatment='outline']) {
+:host([static-color='white'][treatment='outline']) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticwhite-outline-background-color-default
     );
@@ -1426,7 +1426,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white'][selected]) {
+:host([static-color='white'][selected]) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticwhite-selected-background-color-default
     );
@@ -1463,7 +1463,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white'][variant='secondary']) {
+:host([static-color='white'][variant='secondary']) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticwhite-secondary-background-color-default
     );
@@ -1514,7 +1514,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white'][variant='secondary'][treatment='outline']) {
+:host([static-color='white'][variant='secondary'][treatment='outline']) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticwhite-secondary-outline-background-color-default
     );
@@ -1565,7 +1565,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black']) {
+:host([static-color='black']) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticblack-background-color-default
     );
@@ -1616,7 +1616,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black'][treatment='outline']) {
+:host([static-color='black'][treatment='outline']) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticblack-outline-background-color-default
     );
@@ -1667,7 +1667,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black'][variant='secondary']) {
+:host([static-color='black'][variant='secondary']) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticblack-secondary-background-color-default
     );
@@ -1718,7 +1718,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black'][variant='secondary'][treatment='outline']) {
+:host([static-color='black'][variant='secondary'][treatment='outline']) {
     --spectrum-button-background-color-default: var(
         --system-spectrum-button-staticblack-secondary-outline-background-color-default
     );

--- a/packages/button/src/spectrum-config.js
+++ b/packages/button/src/spectrum-config.js
@@ -131,7 +131,7 @@ const config = {
                         ['spectrum-Button--staticWhite', 'white'],
                         ['spectrum-Button--staticBlack', 'black'],
                     ],
-                    'static'
+                    'static-color'
                 ),
                 converter.classToId('spectrum-Button-label'),
                 converter.classToSlotted('spectrum-Icon', 'icon'),

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -75,7 +75,29 @@ describe('Button', () => {
                 },
             });
         });
+        it('warns in devMode when white/black static is provided', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button tabindex="0" static="white">Button</sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(consoleWarnStub.called).to.be.true;
+
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes('deprecated'),
+                'confirm deprecated static warning'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-button',
+                    type: 'api',
+                    level: 'deprecation',
+                },
+            });
+        });
     });
+
     it('loads default', async () => {
         const el = await fixture<Button>(html`
             <sp-button tabindex="0">Button</sp-button>

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -21,13 +21,12 @@ import {
     waitUntil,
 } from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
-import { stub } from 'sinon';
 import {
     a11ySnapshot,
     findAccessibilityNode,
     sendKeys,
 } from '@web/test-runner-commands';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 
 type TestableButtonType = {
     hasLabel: boolean;

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -70,7 +70,28 @@ describe('Button', () => {
                 data: {
                     localName: 'sp-button',
                     type: 'api',
-                    level: 'default',
+                    level: 'deprecation',
+                },
+            });
+        });
+        it('warns in devMode when white/black static is provided', async () => {
+            const el = await fixture<Button>(html`
+                <sp-button tabindex="0" static="black">Button</sp-button>
+            `);
+
+            await elementUpdated(el);
+            expect(consoleWarnStub.called).to.be.true;
+
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes('deprecated'),
+                'confirm deprecated static warning'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-button',
+                    type: 'api',
+                    level: 'deprecation',
                 },
             });
         });

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -751,7 +751,7 @@ describe('Button', () => {
             await elementUpdated(el);
             expect(el.hasAttribute('variant')).to.not.equal('overBackground');
             expect(el.treatment).to.equal('outline');
-            expect(el.static).to.equal('white');
+            expect(el.staticColor).to.equal('white');
         });
         it('forces [variant="accent"]', async () => {
             const el = await fixture<Button>(html`

--- a/packages/button/test/button.test.ts
+++ b/packages/button/test/button.test.ts
@@ -791,9 +791,23 @@ describe('Button', () => {
             `);
 
             await elementUpdated(el);
-            expect(el.hasAttribute('variant')).to.not.equal('overBackground');
+            expect(el.getAttribute('variant')).to.not.equal('overBackground');
             expect(el.treatment).to.equal('outline');
             expect(el.staticColor).to.equal('white');
+        });
+        ['white', 'black'].forEach((variant) => {
+            it(`manages [variant="${variant}"]`, async () => {
+                const el = await fixture<Button>(html`
+                    <sp-button variant="${variant as 'white' | 'black'}">
+                        Button
+                    </sp-button>
+                `);
+
+                await elementUpdated(el);
+                expect(el.hasAttribute('variant')).to.not.equal(variant);
+                expect(el.staticColor).to.equal(variant);
+                expect(el.getAttribute('static-color')).to.equal(variant);
+            });
         });
         it('forces [variant="accent"]', async () => {
             const el = await fixture<Button>(html`

--- a/packages/checkbox/test/checkbox.test.ts
+++ b/packages/checkbox/test/checkbox.test.ts
@@ -50,32 +50,30 @@ describe('Checkbox', () => {
     let testFixture: HTMLDivElement;
 
     beforeEach(async () => {
-        testFixture = await fixture<HTMLDivElement>(
-            html`
-                <div>
-                    <div id="test-checkbox">
-                        <sp-checkbox id="checkbox0" tabindex="5">
-                            Component
-                        </sp-checkbox>
-                        <sp-checkbox id="checkbox1" tabindex="2" checked>
-                            Check 1
-                        </sp-checkbox>
-                        <sp-checkbox id="checkbox2" tabindex="3" disabled>
-                            Check 2
-                        </sp-checkbox>
-                        <sp-checkbox id="checkbox3" tabindex="1" autofocus>
-                            Check 3
-                        </sp-checkbox>
-                        <sp-checkbox id="checkbox4" tabindex="0">
-                            Check 4
-                        </sp-checkbox>
-                        <sp-checkbox id="checkbox5" tabindex="-1">
-                            Check 5
-                        </sp-checkbox>
-                    </div>
+        testFixture = await fixture<HTMLDivElement>(html`
+            <div>
+                <div id="test-checkbox">
+                    <sp-checkbox id="checkbox0" tabindex="5">
+                        Component
+                    </sp-checkbox>
+                    <sp-checkbox id="checkbox1" tabindex="2" checked>
+                        Check 1
+                    </sp-checkbox>
+                    <sp-checkbox id="checkbox2" tabindex="3" disabled>
+                        Check 2
+                    </sp-checkbox>
+                    <sp-checkbox id="checkbox3" tabindex="1" autofocus>
+                        Check 3
+                    </sp-checkbox>
+                    <sp-checkbox id="checkbox4" tabindex="0">
+                        Check 4
+                    </sp-checkbox>
+                    <sp-checkbox id="checkbox5" tabindex="-1">
+                        Check 5
+                    </sp-checkbox>
                 </div>
-            `
-        );
+            </div>
+        `);
     });
 
     it('loads', async () => {
@@ -87,19 +85,15 @@ describe('Checkbox', () => {
     });
     testForLitDevWarnings(
         async () =>
-            await fixture<Checkbox>(
-                html`
-                    <sp-checkbox>Not Checked</sp-checkbox>
-                `
-            )
+            await fixture<Checkbox>(html`
+                <sp-checkbox>Not Checked</sp-checkbox>
+            `)
     );
 
     it('loads default checkbox accessibly', async () => {
-        const el = await fixture<Checkbox>(
-            html`
-                <sp-checkbox>Not Checked</sp-checkbox>
-            `
-        );
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox>Not Checked</sp-checkbox>
+        `);
 
         await elementUpdated(el);
 
@@ -135,11 +129,9 @@ describe('Checkbox', () => {
     });
 
     it('loads `checked` checkbox accessibly', async () => {
-        const el = await fixture<Checkbox>(
-            html`
-                <sp-checkbox checked>Checked</sp-checkbox>
-            `
-        );
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox checked>Checked</sp-checkbox>
+        `);
 
         await elementUpdated(el);
 
@@ -175,11 +167,9 @@ describe('Checkbox', () => {
     });
 
     it('is `invalid` checkbox accessibly', async () => {
-        const el = await fixture<Checkbox>(
-            html`
-                <sp-checkbox invalid>Invalid Not Checked</sp-checkbox>
-            `
-        );
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox invalid>Invalid Not Checked</sp-checkbox>
+        `);
 
         await elementUpdated(el);
 
@@ -209,11 +199,9 @@ describe('Checkbox', () => {
     });
 
     it('`click()`ing host clicks `focusElement`', async () => {
-        const el = await fixture<Checkbox>(
-            html`
-                <sp-checkbox checked autofocus>Checked</sp-checkbox>
-            `
-        );
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox checked autofocus>Checked</sp-checkbox>
+        `);
 
         await elementUpdated(el);
 
@@ -394,5 +382,18 @@ describe('Checkbox', () => {
         expect(getPartialCheckmarkLocalName()).to.not.equal(
             partialCheckmarkLocalname
         );
+    });
+
+    it('updates tabindex when no longer disabled', async function () {
+        const el = await fixture<Checkbox>(html`
+            <sp-checkbox disabled>disabled checkbox</sp-checkbox>
+        `);
+        el.click();
+        await elementUpdated(el);
+        expect(el.checked).to.be.false;
+        expect(el.tabIndex).to.equal(-1);
+        el.removeAttribute('disabled');
+        await elementUpdated(el);
+        expect(el.tabIndex).to.equal(0);
     });
 });

--- a/packages/close-button/src/spectrum-close-button.css
+++ b/packages/close-button/src/spectrum-close-button.css
@@ -157,7 +157,7 @@ governing permissions and limitations under the License.
     --spectrum-closebutton-border-radius: var(--spectrum-closebutton-size-600);
 }
 
-:host([static='white']) {
+:host([static-color='white']) {
     --spectrum-closebutton-static-background-color-default: transparent;
     --spectrum-closebutton-static-background-color-hover: var(
         --spectrum-transparent-white-300
@@ -177,7 +177,7 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black']) {
+:host([static-color='black']) {
     --spectrum-closebutton-static-background-color-default: transparent;
     --spectrum-closebutton-static-background-color-hover: var(
         --spectrum-transparent-black-300
@@ -228,13 +228,13 @@ governing permissions and limitations under the License.
                 ease-out;
     }
 
-    :host([static='black']) {
+    :host([static-color='black']) {
         --highcontrast-closebutton-static-background-color-default: ButtonFace;
         --highcontrast-closebutton-icon-color-default: Highlight;
         --highcontrast-closebutton-icon-color-disabled: GrayText;
     }
 
-    :host([static='white']) {
+    :host([static-color='white']) {
         --highcontrast-closebutton-static-background-color-default: ButtonFace;
         --highcontrast-closebutton-icon-color-default: Highlight;
         --highcontrast-closebutton-icon-color-disabled: Highlight;
@@ -402,8 +402,8 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black']:not([disabled])),
-:host([static='white']:not([disabled])) {
+:host([static-color='black']:not([disabled])),
+:host([static-color='white']:not([disabled])) {
     background-color: var(
         --highcontrast-closebutton-static-background-color-default,
         var(
@@ -431,8 +431,8 @@ governing permissions and limitations under the License.
         );
     }
 
-    :host([static='black']:not([disabled]):hover),
-    :host([static='white']:not([disabled]):hover) {
+    :host([static-color='black']:not([disabled]):hover),
+    :host([static-color='white']:not([disabled]):hover) {
         background-color: var(
             --highcontrast-closebutton-static-background-color-hover,
             var(
@@ -442,8 +442,8 @@ governing permissions and limitations under the License.
         );
     }
 
-    :host([static='black']:not([disabled]):hover) .icon,
-    :host([static='white']:not([disabled]):hover) .icon {
+    :host([static-color='black']:not([disabled]):hover) .icon,
+    :host([static-color='white']:not([disabled]):hover) .icon {
         color: var(
             --highcontrast-closebutton-icon-color-default,
             var(
@@ -454,8 +454,8 @@ governing permissions and limitations under the License.
     }
 }
 
-:host([static='black']:not([disabled]):is(:active, [active])),
-:host([static='white']:not([disabled]):is(:active, [active])) {
+:host([static-color='black']:not([disabled]):is(:active, [active])),
+:host([static-color='white']:not([disabled]):is(:active, [active])) {
     background-color: var(
         --highcontrast-closebutton-static-background-color-down,
         var(
@@ -465,8 +465,8 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black']:not([disabled]):is(:active, [active])) .icon,
-:host([static='white']:not([disabled]):is(:active, [active])) .icon {
+:host([static-color='black']:not([disabled]):is(:active, [active])) .icon,
+:host([static-color='white']:not([disabled]):is(:active, [active])) .icon {
     color: var(
         --highcontrast-closebutton-icon-color-default,
         var(
@@ -476,10 +476,10 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black'][focused]:not([disabled])),
-:host([static='black']:not([disabled]):focus-visible),
-:host([static='white'][focused]:not([disabled])),
-:host([static='white']:not([disabled]):focus-visible) {
+:host([static-color='black'][focused]:not([disabled])),
+:host([static-color='black']:not([disabled]):focus-visible),
+:host([static-color='white'][focused]:not([disabled])),
+:host([static-color='white']:not([disabled]):focus-visible) {
     background-color: var(
         --highcontrast-closebutton-static-background-color-focus,
         var(
@@ -489,14 +489,14 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black'][focused]:not([disabled])) .icon,
-:host([static='black'][focused]:not([disabled])) .icon,
-:host([static='black']:not([disabled]):focus) .icon,
-:host([static='black']:not([disabled]):focus-visible) .icon,
-:host([static='white'][focused]:not([disabled])) .icon,
-:host([static='white'][focused]:not([disabled])) .icon,
-:host([static='white']:not([disabled]):focus) .icon,
-:host([static='white']:not([disabled]):focus-visible) .icon {
+:host([static-color='black'][focused]:not([disabled])) .icon,
+:host([static-color='black'][focused]:not([disabled])) .icon,
+:host([static-color='black']:not([disabled]):focus) .icon,
+:host([static-color='black']:not([disabled]):focus-visible) .icon,
+:host([static-color='white'][focused]:not([disabled])) .icon,
+:host([static-color='white'][focused]:not([disabled])) .icon,
+:host([static-color='white']:not([disabled]):focus) .icon,
+:host([static-color='white']:not([disabled]):focus-visible) .icon {
     color: var(
         --highcontrast-closebutton-icon-color-default,
         var(
@@ -506,16 +506,16 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='black']:not([disabled])) .icon,
-:host([static='white']:not([disabled])) .icon {
+:host([static-color='black']:not([disabled])) .icon,
+:host([static-color='white']:not([disabled])) .icon {
     color: var(
         --mod-closebutton-icon-color-default,
         var(--spectrum-closebutton-icon-color-default)
     );
 }
 
-:host([static='black'][disabled]) .icon,
-:host([static='white'][disabled]) .icon {
+:host([static-color='black'][disabled]) .icon,
+:host([static-color='white'][disabled]) .icon {
     color: var(
         --highcontrast-closebutton-icon-disabled,
         var(

--- a/packages/close-button/src/spectrum-config.js
+++ b/packages/close-button/src/spectrum-config.js
@@ -60,7 +60,7 @@ const config = {
                         ['spectrum-CloseButton--staticWhite', 'white'],
                         ['spectrum-CloseButton--staticBlack', 'black'],
                     ],
-                    'static'
+                    'static-color'
                 ),
                 // Default to `size='m'` without needing the attribute
                 converter.classToHost('spectrum-Closebutton--sizeM'),

--- a/packages/coachmark/src/CoachIndicator.ts
+++ b/packages/coachmark/src/CoachIndicator.ts
@@ -30,8 +30,14 @@ export class CoachIndicator extends SpectrumElement {
     @property({ type: Boolean, reflect: true })
     public quiet = false;
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ reflect: true })
     public static?: 'white' | 'black';
+
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'white' | 'black';
 
     @property({ reflect: true })
     public variant?: 'white' | 'black';
@@ -50,11 +56,25 @@ export class CoachIndicator extends SpectrumElement {
             changes.has('variant') &&
             (this.variant || typeof changes.get('variant'))
         ) {
-            this.static = this.variant;
+            this.staticColor = this.variant;
             if (window.__swc.DEBUG) {
                 window.__swc.warn(
                     this,
                     `The "variant" attribute/property of <${this.localName}> have been deprecated. Use "static" with any of the same values instead. "variant" will be removed in a future release.`,
+                    'https://opensource.adobe.com/spectrum-web-components/components/badge/#fixed',
+                    { level: 'deprecation' }
+                );
+            }
+        }
+        if (
+            changes.has('static') &&
+            (this.static || typeof changes.get('static'))
+        ) {
+            this.staticColor = this.static;
+            if (window.__swc.DEBUG) {
+                window.__swc.warn(
+                    this,
+                    `The "static" attribute/property of <${this.localName}> have been deprecated. Use "static-color" with any of the same values instead. "static" will be removed in a future release.`,
                     'https://opensource.adobe.com/spectrum-web-components/components/badge/#fixed',
                     { level: 'deprecation' }
                 );

--- a/packages/coachmark/src/CoachIndicator.ts
+++ b/packages/coachmark/src/CoachIndicator.ts
@@ -75,7 +75,7 @@ export class CoachIndicator extends SpectrumElement {
                 window.__swc.warn(
                     this,
                     `The "static" attribute/property of <${this.localName}> have been deprecated. Use "static-color" with any of the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/badge/#fixed',
+                    'https://opensource.adobe.com/spectrum-web-components/components/coach-indicator',
                     { level: 'deprecation' }
                 );
             }

--- a/packages/coachmark/src/spectrum-coach-indicator.css
+++ b/packages/coachmark/src/spectrum-coach-indicator.css
@@ -264,14 +264,14 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white']) .ring {
+:host([static-color='white']) .ring {
     border-color: var(
         --mod-coach-indicator-ring-light-color,
         var(--spectrum-coach-indicator-ring-light-color)
     );
 }
 
-:host([static='black']) .ring {
+:host([static-color='black']) .ring {
     border-color: var(
         --mod-coach-indicator-ring-dark-color,
         var(--spectrum-coach-indicator-ring-dark-color)

--- a/packages/coachmark/src/spectrum-config.js
+++ b/packages/coachmark/src/spectrum-config.js
@@ -36,7 +36,7 @@ const config = {
                         ['spectrum-CoachIndicator--dark', 'black'],
                         ['spectrum-CoachIndicator--light', 'white'],
                     ],
-                    'static'
+                    'static-color'
                 ),
             ],
         },

--- a/packages/coachmark/test/coach-indicator.test.ts
+++ b/packages/coachmark/test/coach-indicator.test.ts
@@ -18,28 +18,22 @@ import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
 describe('CoachIndicator', () => {
     testForLitDevWarnings(
         async () =>
-            await fixture<CoachIndicator>(
-                html`
-                    <sp-coach-indicator></sp-coach-indicator>
-                `
-            )
+            await fixture<CoachIndicator>(html`
+                <sp-coach-indicator></sp-coach-indicator>
+            `)
     );
     it('loads default coach-indicator accessibly', async () => {
-        const el = await fixture<CoachIndicator>(
-            html`
-                <sp-coach-indicator></sp-coach-indicator>
-            `
-        );
+        const el = await fixture<CoachIndicator>(html`
+            <sp-coach-indicator></sp-coach-indicator>
+        `);
         await elementUpdated(el);
         await expect(el).to.be.accessible();
     });
-    it('loads coach-indicator white static variant', async () => {
-        const el = await fixture<CoachIndicator>(
-            html`
-                <sp-coach-indicator variant="white"></sp-coach-indicator>
-            `
-        );
+    it('loads coach-indicator white static-color variant', async () => {
+        const el = await fixture<CoachIndicator>(html`
+            <sp-coach-indicator variant="white"></sp-coach-indicator>
+        `);
         await elementUpdated(el);
-        expect(el.static == 'white').to.be.true;
+        expect(el.staticColor == 'white').to.be.true;
     });
 });

--- a/packages/coachmark/test/coach-indicator.test.ts
+++ b/packages/coachmark/test/coach-indicator.test.ts
@@ -61,7 +61,28 @@ describe('dev mode', () => {
         consoleWarnStub.restore();
     });
 
-    it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
+    it('warns in Dev Mode when deprecated `static` attribute is used', async () => {
+        const el = await fixture<CoachIndicator>(html`
+            <sp-coach-indicator static="white"></sp-coach-indicator>
+        `);
+        await elementUpdated(el);
+        expect(consoleWarnStub.called).to.be.true;
+
+        const spyCall = consoleWarnStub.getCall(0);
+        expect(
+            (spyCall.args.at(0) as string).includes('deprecated'),
+            'confirm deprecated static warning'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-coach-indicator',
+                type: 'api',
+                level: 'deprecation',
+            },
+        });
+    });
+
+    it('warns in Dev Mode when deprecated `variant` attribute is used', async () => {
         const el = await fixture<CoachIndicator>(html`
             <sp-coach-indicator variant="white"></sp-coach-indicator>
         `);
@@ -70,7 +91,7 @@ describe('dev mode', () => {
 
         const spyCall = consoleWarnStub.getCall(0);
         expect(
-            (spyCall.args.at(0) as string).includes('deprecated'),
+            (spyCall.args.at(0) as string).includes('The "variant" attribute'),
             'confirm deprecated static warning'
         ).to.be.true;
         expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({

--- a/packages/coachmark/test/coach-indicator.test.ts
+++ b/packages/coachmark/test/coach-indicator.test.ts
@@ -14,6 +14,7 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import '@spectrum-web-components/coachmark/sp-coach-indicator.js';
 import { CoachIndicator } from '@spectrum-web-components/coachmark';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
+import { stub } from 'sinon';
 
 describe('CoachIndicator', () => {
     testForLitDevWarnings(
@@ -29,11 +30,55 @@ describe('CoachIndicator', () => {
         await elementUpdated(el);
         await expect(el).to.be.accessible();
     });
+    it('loads coach-indicator white static-color when static is set', async () => {
+        const el = await fixture<CoachIndicator>(html`
+            <sp-coach-indicator static="white"></sp-coach-indicator>
+        `);
+        await elementUpdated(el);
+        expect(el.staticColor == 'white').to.be.true;
+        expect(el.getAttribute('static-color')).to.equal('white');
+    });
     it('loads coach-indicator white static-color variant', async () => {
         const el = await fixture<CoachIndicator>(html`
             <sp-coach-indicator variant="white"></sp-coach-indicator>
         `);
         await elementUpdated(el);
         expect(el.staticColor == 'white').to.be.true;
+    });
+});
+
+describe('dev mode', () => {
+    let consoleWarnStub!: ReturnType<typeof stub>;
+    before(() => {
+        window.__swc.verbose = true;
+        consoleWarnStub = stub(console, 'warn');
+    });
+    afterEach(() => {
+        consoleWarnStub.resetHistory();
+    });
+    after(() => {
+        window.__swc.verbose = false;
+        consoleWarnStub.restore();
+    });
+
+    it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
+        const el = await fixture<CoachIndicator>(html`
+            <sp-coach-indicator variant="white"></sp-coach-indicator>
+        `);
+        await elementUpdated(el);
+        expect(consoleWarnStub.called).to.be.true;
+
+        const spyCall = consoleWarnStub.getCall(0);
+        expect(
+            (spyCall.args.at(0) as string).includes('deprecated'),
+            'confirm deprecated static warning'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-coach-indicator',
+                type: 'api',
+                level: 'deprecation',
+            },
+        });
     });
 });

--- a/packages/contextual-help/src/ContextualHelp.ts
+++ b/packages/contextual-help/src/ContextualHelp.ts
@@ -137,6 +137,7 @@ export class ContextualHelp extends SpectrumElement {
     }
 
     protected override render(): TemplateResult {
+        /* c8 ignore next 3 */
         const actualPlacement = this.isMobile.matches
             ? undefined
             : this.placement;

--- a/packages/divider/src/spectrum-config.js
+++ b/packages/divider/src/spectrum-config.js
@@ -41,7 +41,7 @@ const config = {
                         ['spectrum-Divider--staticWhite', 'white'],
                         ['spectrum-Divider--staticBlack', 'black'],
                     ],
-                    'static'
+                    'static-color'
                 ),
             ],
         },

--- a/packages/divider/src/spectrum-divider.css
+++ b/packages/divider/src/spectrum-divider.css
@@ -94,42 +94,42 @@ governing permissions and limitations under the License.
     overflow: visible;
 }
 
-:host([static='white'][size='s']) {
+:host([static-color='white'][size='s']) {
     --spectrum-divider-background-color: var(
         --mod-divider-background-color-small-static-white,
         var(--spectrum-divider-background-color-small-static-white)
     );
 }
 
-:host([static='white']) {
+:host([static-color='white']) {
     --spectrum-divider-background-color: var(
         --mod-divider-background-color-medium-static-white,
         var(--spectrum-divider-background-color-medium-static-white)
     );
 }
 
-:host([static='white'][size='l']) {
+:host([static-color='white'][size='l']) {
     --spectrum-divider-background-color: var(
         --mod-divider-background-color-large-static-white,
         var(--spectrum-divider-background-color-large-static-white)
     );
 }
 
-:host([static='black'][size='s']) {
+:host([static-color='black'][size='s']) {
     --spectrum-divider-background-color: var(
         --mod-divider-background-color-small-static-black,
         var(--spectrum-divider-background-color-small-static-black)
     );
 }
 
-:host([static='black']) {
+:host([static-color='black']) {
     --spectrum-divider-background-color: var(
         --mod-divider-background-color-medium-static-black,
         var(--spectrum-divider-background-color-medium-static-black)
     );
 }
 
-:host([static='black'][size='l']) {
+:host([static-color='black'][size='l']) {
     --spectrum-divider-background-color: var(
         --mod-divider-background-color-large-static-black,
         var(--spectrum-divider-background-color-large-static-black)

--- a/packages/link/README.md
+++ b/packages/link/README.md
@@ -74,7 +74,7 @@ When a link needs to be placed on top of a colored background or a visual it may
 >
     <p style="color: rgb(240, 240, 240);">
         This
-        <sp-link static="white" href="#">link</sp-link>
+        <sp-link static-color="white" href="#">link</sp-link>
         is over a background.
     </p>
 </div>
@@ -90,7 +90,7 @@ When a link needs to be placed on top of a colored background or a visual it may
 >
     <p style="color: rgb(15, 15, 15);">
         This
-        <sp-link static="black" href="#">link</sp-link>
+        <sp-link static-color="black" href="#">link</sp-link>
         is over a background.
     </p>
 </div>
@@ -112,7 +112,7 @@ All links can have a quiet style, which means they don’t have an underline. Th
 >
     <p style="color: rgb(240, 240, 240);">
         This is a
-        <sp-link static="white" quiet href="#">quiet link</sp-link>
+        <sp-link static-color="white" quiet href="#">quiet link</sp-link>
         over a background.
     </p>
 </div>

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -10,7 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { CSSResultArray, TemplateResult } from '@spectrum-web-components/base';
+import {
+    CSSResultArray,
+    PropertyValues,
+    TemplateResult,
+} from '@spectrum-web-components/base';
 import {
     property,
     query,
@@ -34,8 +38,14 @@ export class Link extends LikeAnchor(Focusable) {
     @property({ type: String, reflect: true })
     public variant: 'secondary' | undefined;
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ type: String, reflect: true })
     public static: 'black' | 'white' | undefined;
+
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'black' | 'white';
 
     /**
      * Uses quiet styles or not
@@ -49,5 +59,22 @@ export class Link extends LikeAnchor(Focusable) {
 
     protected override render(): TemplateResult {
         return this.renderAnchor({ id: 'anchor' });
+    }
+
+    protected override updated(changes: PropertyValues): void {
+        super.updated(changes);
+        if (
+            changes.has('static') &&
+            (this.static !== undefined || changes.get('static') !== undefined)
+        ) {
+            this.staticColor = this.static;
+            if (window.__swc.DEBUG) {
+                window.__swc.warn(
+                    this,
+                    `The "static" attribute of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
+                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                );
+            }
+        }
     }
 }

--- a/packages/link/src/Link.ts
+++ b/packages/link/src/Link.ts
@@ -72,7 +72,8 @@ export class Link extends LikeAnchor(Focusable) {
                 window.__swc.warn(
                     this,
                     `The "static" attribute of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                    'https://opensource.adobe.com/spectrum-web-components/components/link/api/',
+                    { level: 'deprecation' }
                 );
             }
         }

--- a/packages/link/src/spectrum-config.js
+++ b/packages/link/src/spectrum-config.js
@@ -126,42 +126,50 @@ const config = {
                     'variant',
                     'secondary'
                 ),
-                includeAnchor('spectrum-Link--staticWhite', 'static', 'white'),
+                includeAnchor(
+                    'spectrum-Link--staticWhite',
+                    'static-color',
+                    'white'
+                ),
                 includeAnchorWithPseudoClass(
                     'hover',
                     'spectrum-Link--staticWhite',
-                    'static',
+                    'static-color',
                     'white'
                 ),
                 includeAnchorWithPseudoClass(
                     'active',
                     'spectrum-Link--staticWhite',
-                    'static',
+                    'static-color',
                     'white'
                 ),
                 includeAnchorWithPseudoClass(
                     'focus',
                     'spectrum-Link--staticWhite',
-                    'static',
+                    'static-color',
                     'white'
                 ),
-                includeAnchor('spectrum-Link--staticBlack', 'static', 'black'),
+                includeAnchor(
+                    'spectrum-Link--staticBlack',
+                    'static-color',
+                    'black'
+                ),
                 includeAnchorWithPseudoClass(
                     'hover',
                     'spectrum-Link--staticBlack',
-                    'static',
+                    'static-color',
                     'black'
                 ),
                 includeAnchorWithPseudoClass(
                     'active',
                     'spectrum-Link--staticBlack',
-                    'static',
+                    'static-color',
                     'black'
                 ),
                 includeAnchorWithPseudoClass(
                     'focus',
                     'spectrum-Link--staticBlack',
-                    'static',
+                    'static-color',
                     'black'
                 ),
                 {

--- a/packages/link/src/spectrum-link.css
+++ b/packages/link/src/spectrum-link.css
@@ -137,18 +137,18 @@ a:focus-visible {
     text-decoration: none;
 }
 
-:host([static='white']) a,
-:host([static='white']) a:active,
-:host([static='white']) a:focus {
+:host([static-color='white']) a,
+:host([static-color='white']) a:active,
+:host([static-color='white']) a:focus {
     color: var(
         --highcontrast-link-text-color-white,
         var(--mod-link-text-color-white, var(--spectrum-link-text-color-white))
     );
 }
 
-:host([static='black']) a,
-:host([static='black']) a:active,
-:host([static='black']) a:focus {
+:host([static-color='black']) a,
+:host([static-color='black']) a:active,
+:host([static-color='black']) a:focus {
     color: var(
         --highcontrast-link-text-color-black,
         var(--mod-link-text-color-black, var(--spectrum-link-text-color-black))
@@ -181,7 +181,7 @@ a:focus-visible {
         text-decoration: underline;
     }
 
-    :host([static='white']) a:hover {
+    :host([static-color='white']) a:hover {
         color: var(
             --highcontrast-link-text-color-white,
             var(
@@ -191,7 +191,7 @@ a:focus-visible {
         );
     }
 
-    :host([static='black']) a:hover {
+    :host([static-color='black']) a:hover {
         color: var(
             --highcontrast-link-text-color-black,
             var(

--- a/packages/link/stories/link.stories.ts
+++ b/packages/link/stories/link.stories.ts
@@ -60,7 +60,7 @@ export const staticWhite = (): TemplateResult => {
         >
             <p style="color: rgb(240, 240, 240);">
                 This
-                <sp-link static="white" href="#">link</sp-link>
+                <sp-link static-color="white" href="#">link</sp-link>
                 has a background.
             </p>
         </div>
@@ -74,7 +74,7 @@ export const staticBlack = (): TemplateResult => {
         >
             <p style="color: rgb(15, 15, 15);">
                 This
-                <sp-link static="black" href="#">link</sp-link>
+                <sp-link static-color="black" href="#">link</sp-link>
                 has a background.
             </p>
         </div>
@@ -88,7 +88,7 @@ export const staticWhiteQuiet = (): TemplateResult => {
         >
             <p style="color: rgb(240, 240, 240);">
                 This
-                <sp-link static="white" quiet href="#">link</sp-link>
+                <sp-link static-color="white" quiet href="#">link</sp-link>
                 has a background.
             </p>
         </div>
@@ -102,7 +102,7 @@ export const staticBlackQuiet = (): TemplateResult => {
         >
             <p style="color: rgb(15, 15, 15);">
                 This
-                <sp-link static="black" quiet href="#">link</sp-link>
+                <sp-link static-color="black" quiet href="#">link</sp-link>
                 has a background.
             </p>
         </div>

--- a/packages/link/test/link.test.ts
+++ b/packages/link/test/link.test.ts
@@ -14,7 +14,7 @@ import '@spectrum-web-components/link/sp-link.js';
 import { Link } from '@spectrum-web-components/link';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { testForLitDevWarnings } from '../../../test/testing-helpers.js';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 
 describe('Link', () => {
     testForLitDevWarnings(
@@ -75,5 +75,54 @@ describe('Link', () => {
         await expect(el).to.be.accessible();
         el.click();
         expect(clickSpy.callCount).to.equal(0);
+    });
+
+    it('prefers `staticColor` over `static`', async () => {
+        const el = await fixture<Link>(html`
+            <sp-link static="white" href="test_url">Default Link</sp-link>
+        `);
+        await elementUpdated(el);
+        expect(el.staticColor).to.equal('white');
+        el.setAttribute('static', 'white');
+        await elementUpdated(el);
+        expect(el.staticColor).to.equal('white');
+        expect(el.static).to.equal('white');
+        expect(el.getAttribute('static-color')).to.equal('white');
+    });
+});
+
+describe('dev mode', () => {
+    let consoleWarnStub!: ReturnType<typeof stub>;
+    before(() => {
+        window.__swc.verbose = true;
+        consoleWarnStub = stub(console, 'warn');
+    });
+    afterEach(() => {
+        consoleWarnStub.resetHistory();
+    });
+    after(() => {
+        window.__swc.verbose = false;
+        consoleWarnStub.restore();
+    });
+
+    it('warns in Dev Mode when deprecated `static` attribute is used', async () => {
+        const el = await fixture<Link>(html`
+            <sp-link static="white" href="test_url">Default Link</sp-link>
+        `);
+        await elementUpdated(el);
+        expect(consoleWarnStub.called).to.be.true;
+
+        const spyCall = consoleWarnStub.getCall(0);
+        expect(
+            (spyCall.args.at(0) as string).includes('deprecated'),
+            'confirm deprecated static warning'
+        ).to.be.true;
+        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+            data: {
+                localName: 'sp-link',
+                type: 'api',
+                level: 'deprecation',
+            },
+        });
     });
 });

--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -32,7 +32,7 @@ import styles from './meter.css.js';
 
 export const meterVariants = ['positive', 'notice', 'negative'];
 
-export type MeterVariants = typeof meterVariants[number];
+export type MeterVariants = (typeof meterVariants)[number];
 
 /**
  * @element sp-meter
@@ -89,8 +89,14 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, ''), {
     // called sideLabel
     public sideLabel = false;
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ type: String, reflect: true })
     public static: 'white' | undefined;
+
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'white';
 
     protected override render(): TemplateResult {
         return html`
@@ -135,6 +141,19 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, ''), {
                 this.setAttribute('aria-label', this.label);
             } else {
                 this.removeAttribute('aria-label');
+            }
+        }
+        if (
+            changes.has('static') &&
+            (this.static !== undefined || changes.get('static') !== undefined)
+        ) {
+            this.staticColor = this.static;
+            if (window.__swc.DEBUG) {
+                window.__swc.warn(
+                    this,
+                    `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
+                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                );
             }
         }
     }

--- a/packages/meter/src/Meter.ts
+++ b/packages/meter/src/Meter.ts
@@ -152,7 +152,8 @@ export class Meter extends SizedMixin(ObserveSlotText(SpectrumElement, ''), {
                 window.__swc.warn(
                     this,
                     `The "static" attribute/property of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                    'https://opensource.adobe.com/spectrum-web-components/components/meter/api/',
+                    { level: 'deprecation' }
                 );
             }
         }

--- a/packages/meter/src/spectrum-config.js
+++ b/packages/meter/src/spectrum-config.js
@@ -56,7 +56,7 @@ const config = {
                         ['spectrum-ProgressBar--staticBlack', 'black'],
                         ['spectrum-ProgressBar--staticWhite', 'white'],
                     ],
-                    'static'
+                    'static-color'
                 ),
                 ...converter.enumerateAttributes(
                     [

--- a/packages/meter/src/spectrum-meter.css
+++ b/packages/meter/src/spectrum-meter.css
@@ -303,23 +303,23 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white']) .fill {
+:host([static-color='white']) .fill {
     background: var(
         --mod-progressbar-fill-color-white,
         var(--spectrum-progressbar-fill-color-white)
     );
 }
 
-:host([static='white']) .fill,
-:host([static='white']) .label,
-:host([static='white']) .percentage {
+:host([static-color='white']) .fill,
+:host([static-color='white']) .label,
+:host([static-color='white']) .percentage {
     color: var(
         --mod-progressbar-label-and-value-white,
         var(--spectrum-progressbar-label-and-value-white)
     );
 }
 
-:host([static='white']) .track {
+:host([static-color='white']) .track {
     background: var(--spectrum-progressbar-track-color-white);
 }
 

--- a/packages/meter/stories/meter.stories.ts
+++ b/packages/meter/stories/meter.stories.ts
@@ -68,9 +68,10 @@ export const positive = (): TemplateResult => {
 
 export const staticWhite = (): TemplateResult => {
     return makeOverBackground('white')(
-        (): TemplateResult =>
-            html`
-                <sp-meter static="white" progress="50">Storage Space</sp-meter>
-            `
+        (): TemplateResult => html`
+            <sp-meter static-color="white" progress="50">
+                Storage Space
+            </sp-meter>
+        `
     );
 };

--- a/packages/meter/stories/meter.stories.ts
+++ b/packages/meter/stories/meter.stories.ts
@@ -66,7 +66,7 @@ export const positive = (): TemplateResult => {
     `;
 };
 
-export const staticColorWhite = (): TemplateResult => {
+export const staticWhite = (): TemplateResult => {
     return makeOverBackground('white')(
         (): TemplateResult => html`
             <sp-meter static-color="white" progress="50">

--- a/packages/meter/stories/meter.stories.ts
+++ b/packages/meter/stories/meter.stories.ts
@@ -66,7 +66,7 @@ export const positive = (): TemplateResult => {
     `;
 };
 
-export const staticWhite = (): TemplateResult => {
+export const staticColorWhite = (): TemplateResult => {
     return makeOverBackground('white')(
         (): TemplateResult => html`
             <sp-meter static-color="white" progress="50">

--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -60,8 +60,14 @@ export class ProgressBar extends SizedMixin(
     @property({ type: Number })
     public progress = 0;
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ type: String, reflect: true })
     public static: 'white' | undefined;
+
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'white';
 
     @query('slot')
     private slotEl!: HTMLSlotElement;
@@ -122,6 +128,19 @@ export class ProgressBar extends SizedMixin(
 
     protected override updated(changes: PropertyValues): void {
         super.updated(changes);
+        if (
+            changes.has('static') &&
+            (this.static !== undefined || changes.get('static') !== undefined)
+        ) {
+            this.staticColor = this.static;
+            if (window.__swc.DEBUG) {
+                window.__swc.warn(
+                    this,
+                    `The "static" attribute of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
+                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                );
+            }
+        }
         if (changes.has('indeterminate')) {
             if (this.indeterminate) {
                 this.removeAttribute('aria-valuemin');

--- a/packages/progress-bar/src/ProgressBar.ts
+++ b/packages/progress-bar/src/ProgressBar.ts
@@ -137,7 +137,8 @@ export class ProgressBar extends SizedMixin(
                 window.__swc.warn(
                     this,
                     `The "static" attribute of <${this.localName}> has been deprecated. Use "static-color" with the same values instead. "static" will be removed in a future release.`,
-                    'https://opensource.adobe.com/spectrum-web-components/components/action-button/api/'
+                    'https://opensource.adobe.com/spectrum-web-components/components/progress-bar/api/',
+                    { level: 'deprecation' }
                 );
             }
         }

--- a/packages/progress-bar/src/spectrum-config.js
+++ b/packages/progress-bar/src/spectrum-config.js
@@ -63,7 +63,7 @@ const config = {
                         ['spectrum-ProgressBar--staticBlack', 'black'],
                         ['spectrum-ProgressBar--staticWhite', 'white'],
                     ],
-                    'static'
+                    'static-color'
                 ),
             ],
             excludeByComponents: [

--- a/packages/progress-bar/src/spectrum-progress-bar.css
+++ b/packages/progress-bar/src/spectrum-progress-bar.css
@@ -303,23 +303,23 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white']) .fill {
+:host([static-color='white']) .fill {
     background: var(
         --mod-progressbar-fill-color-white,
         var(--spectrum-progressbar-fill-color-white)
     );
 }
 
-:host([static='white']) .fill,
-:host([static='white']) .label,
-:host([static='white']) .percentage {
+:host([static-color='white']) .fill,
+:host([static-color='white']) .label,
+:host([static-color='white']) .percentage {
     color: var(
         --mod-progressbar-label-and-value-white,
         var(--spectrum-progressbar-label-and-value-white)
     );
 }
 
-:host([static='white']) .track {
+:host([static-color='white']) .track {
     background: var(--spectrum-progressbar-track-color-white);
 }
 

--- a/packages/progress-bar/stories/progress-bar.stories.ts
+++ b/packages/progress-bar/stories/progress-bar.stories.ts
@@ -77,7 +77,10 @@ const makeOverBackground =
 export const staticWhite = (): TemplateResult => {
     return makeOverBackground('white')(
         () => html`
-            <sp-progress-bar progress="50" static="white"></sp-progress-bar>
+            <sp-progress-bar
+                progress="50"
+                static-color="white"
+            ></sp-progress-bar>
         `
     );
 };
@@ -88,7 +91,7 @@ export const staticWhiteLabel = (): TemplateResult => {
             <sp-progress-bar
                 label="Loading"
                 progress="50"
-                static="white"
+                static-color="white"
             ></sp-progress-bar>
         `
     );
@@ -100,7 +103,7 @@ export const staticWhiteIndeterminate = (): TemplateResult => {
             <sp-progress-bar
                 label="Loading"
                 indeterminate
-                static="white"
+                static-color="white"
             ></sp-progress-bar>
         `
     );
@@ -112,7 +115,7 @@ export const staticWhiteSideLabel = (): TemplateResult => {
             <sp-progress-bar
                 label="Loading"
                 progress="50"
-                static="white"
+                static-color="white"
                 side-label
             ></sp-progress-bar>
         `
@@ -125,7 +128,7 @@ export const staticWhiteSideLabelIndeterminate = (): TemplateResult => {
             <sp-progress-bar
                 label="Loading"
                 indeterminate
-                static="white"
+                static-color="white"
                 side-label
             ></sp-progress-bar>
         `

--- a/packages/progress-bar/test/progress-bar.test.ts
+++ b/packages/progress-bar/test/progress-bar.test.ts
@@ -147,28 +147,63 @@ describe('ProgressBar', () => {
 
         expect(el.hasAttribute('aria-valuenow')).to.be.false;
     });
-    it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
-        const consoleWarnStub = stub(console, 'warn');
-        const el = await fixture<ProgressBar>(html`
-            <sp-progress-bar progress="50"></sp-progress-bar>
-        `);
 
-        await elementUpdated(el);
-
-        expect(consoleWarnStub.called).to.be.true;
-        const spyCall = consoleWarnStub.getCall(0);
-        expect(
-            spyCall.args.at(0).includes('accessible'),
-            'confirm accessibility-centric message'
-        ).to.be.true;
-        expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
-            data: {
-                localName: 'sp-progress-bar',
-                type: 'accessibility',
-                level: 'default',
-            },
+    describe('dev mode', () => {
+        let consoleWarnStub!: ReturnType<typeof stub>;
+        before(() => {
+            window.__swc.verbose = true;
+            consoleWarnStub = stub(console, 'warn');
         });
-        consoleWarnStub.restore();
+        afterEach(() => {
+            consoleWarnStub.resetHistory();
+        });
+        after(() => {
+            window.__swc.verbose = false;
+            consoleWarnStub.restore();
+        });
+
+        it('warns in Dev Mode when accessible attributes are not leveraged', async () => {
+            const el = await fixture<ProgressBar>(html`
+                <sp-progress-bar progress="50"></sp-progress-bar>
+            `);
+
+            await elementUpdated(el);
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes('accessible'),
+                'confirm accessibility-centric message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-progress-bar',
+                    type: 'accessibility',
+                    level: 'default',
+                },
+            });
+        });
+
+        it('warns in devMode when white/black static is provided', async () => {
+            const el = await fixture<ProgressBar>(html`
+                <sp-progress-bar progress="50" static="white"></sp-progress-bar>
+            `);
+            await elementUpdated(el);
+            expect(consoleWarnStub.called).to.be.true;
+
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes('deprecated'),
+                'confirm deprecated static warning'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-progress-bar',
+                    type: 'api',
+                    level: 'deprecation',
+                },
+            });
+        });
     });
 
     it('resolves a language (en-US)', async () => {

--- a/packages/progress-circle/README.md
+++ b/packages/progress-circle/README.md
@@ -62,18 +62,18 @@ If you display your `<sp-progress-cicle>` element over the top of other content,
     <sp-progress-circle
         label="A small representation of a partially completed action"
         progress="42"
-        static="white"
+        static-color="white"
         size="s"
     ></sp-progress-circle>
     <sp-progress-circle
         label="A medium representation of a barely started action"
         progress="7"
-        static="white"
+        static-color="white"
     ></sp-progress-circle>
     <sp-progress-circle
         label="A large representation of a somewhat completed action"
         progress="68"
-        static="white"
+        static-color="white"
         size="l"
     ></sp-progress-circle>
 </div>

--- a/packages/progress-circle/src/ProgressCircle.ts
+++ b/packages/progress-circle/src/ProgressCircle.ts
@@ -43,11 +43,20 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
     @property({ type: String })
     public label = '';
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ type: Boolean, reflect: true, attribute: 'over-background' })
     public overBackground = false;
 
+    /**
+     * @deprecated Use `staticColor` instead.
+     */
     @property({ reflect: true })
     public static?: 'white';
+
+    @property({ reflect: true, attribute: 'static-color' })
+    public staticColor?: 'white';
 
     @property({ type: Number })
     public progress = 0;
@@ -63,16 +72,31 @@ export class ProgressCircle extends SizedMixin(SpectrumElement, {
 
     protected override willUpdate(changes: PropertyValues<this>): void {
         if (changes.has('overBackground')) {
-            // Apply "static" from "overBackground", preferring "static",
+            // Apply "staticColor" from "overBackground", preferring "staticColor",
             // until the deprecation period is over.
-            this.static = this.overBackground
+            this.staticColor = this.overBackground
                 ? 'white'
-                : this.static || undefined;
+                : this.staticColor || undefined;
             if (window.__swc.DEBUG) {
                 if (this.overBackground) {
                     window.__swc.warn(
                         this,
-                        `<${this.localName}> element will stop accepting the "over-background" attribute, and its related "overBackground" property in a future release. Use the "static" attribute/property with a value of "white" instead.`,
+                        `<${this.localName}> element will stop accepting the "over-background" attribute, and its related "overBackground" property in a future release. Use the "static-color" attribute with a value of "white" instead.`,
+                        'https://opensource.adobe.com/spectrum-web-components/components/progress-circle/#static',
+                        { level: 'deprecation' }
+                    );
+                }
+            }
+        }
+        if (changes.has('static')) {
+            // Apply "staticColor" from "static", preferring "staticColor",
+            // until the deprecation period is over.
+            this.staticColor = this.static;
+            if (window.__swc.DEBUG) {
+                if (this.static) {
+                    window.__swc.warn(
+                        this,
+                        `<${this.localName}> element will stop accepting the "static" attribute. Use the "static-color" attribute with a value of "white" instead.`,
                         'https://opensource.adobe.com/spectrum-web-components/components/progress-circle/#static',
                         { level: 'deprecation' }
                     );

--- a/packages/progress-circle/src/spectrum-config.js
+++ b/packages/progress-circle/src/spectrum-config.js
@@ -44,7 +44,7 @@ const config = {
                 ),
                 ...converter.enumerateAttributes(
                     [['spectrum-ProgressCircle--staticWhite', 'white']],
-                    'static'
+                    'static-color'
                 ),
                 converter.classToClass('spectrum-ProgressCircle-track'),
                 converter.classToClass('spectrum-ProgressCircle-fills'),

--- a/packages/progress-circle/src/spectrum-progress-circle.css
+++ b/packages/progress-circle/src/spectrum-progress-circle.css
@@ -632,14 +632,14 @@ governing permissions and limitations under the License.
     );
 }
 
-:host([static='white']) .track {
+:host([static-color='white']) .track {
     border-color: var(
         --mod-progress-circle-track-border-color-over-background,
         var(--spectrum-progress-circle-track-border-color-over-background)
     );
 }
 
-:host([static='white']) .fill {
+:host([static-color='white']) .fill {
     border-color: var(
         --highcontrast-progress-circle-fill-border-color-over-background,
         var(

--- a/packages/progress-circle/stories/progress-circle.stories.ts
+++ b/packages/progress-circle/stories/progress-circle.stories.ts
@@ -76,20 +76,20 @@ export const staticWhite = ({
         >
             <sp-progress-circle
                 progress="53"
-                static="white"
+                static-color="white"
                 size="s"
                 ?indeterminate=${indeterminate}
                 label="Loading progress demo"
             ></sp-progress-circle>
             <sp-progress-circle
                 progress="53"
-                static="white"
+                static-color="white"
                 ?indeterminate=${indeterminate}
                 label="Loading progress demo"
             ></sp-progress-circle>
             <sp-progress-circle
                 progress="53"
-                static="white"
+                static-color="white"
                 size="l"
                 ?indeterminate=${indeterminate}
                 label="Loading progress demo"
@@ -113,7 +113,7 @@ export const inButton = ({
     <sp-button variant="black" style="color: white">
         <sp-progress-circle
             progress="53"
-            static="white"
+            static-color="white"
             size="s"
             ?indeterminate=${indeterminate}
             slot="icon"

--- a/packages/progress-circle/test/progress-circle.test.ts
+++ b/packages/progress-circle/test/progress-circle.test.ts
@@ -59,6 +59,32 @@ describe('ProgressCircle', () => {
                 },
             });
         });
+        it('warns in Dev Mode when static attribute is supplied', async () => {
+            const el = await fixture<ProgressCircle>(html`
+                <sp-progress-circle
+                    progress="50"
+                    static="white"
+                ></sp-progress-circle>
+            `);
+
+            await elementUpdated(el);
+
+            expect(consoleWarnStub.called).to.be.true;
+            const spyCall = consoleWarnStub.getCall(0);
+            expect(
+                (spyCall.args.at(0) as string).includes(
+                    'element will stop accepting the "static" attribute'
+                ),
+                'confirm attribute deprecation message'
+            ).to.be.true;
+            expect(spyCall.args.at(-1), 'confirm `data` shape').to.deep.equal({
+                data: {
+                    localName: 'sp-progress-circle',
+                    type: 'api',
+                    level: 'deprecation',
+                },
+            });
+        });
         it('warns in Dev Mode when overBackground attribute is supplied', async () => {
             const el = await fixture<ProgressCircle>(html`
                 <sp-progress-circle
@@ -183,5 +209,23 @@ describe('ProgressCircle', () => {
 
         expect(el.hasAttribute('aria-label')).to.be.true;
         expect(el.getAttribute('aria-label')).to.equal('Loading');
+    });
+    it('prefers `staticColor` over `static`', async () => {
+        const el = await fixture<ProgressCircle>(html`
+            <sp-progress-circle
+                progress="50"
+                static="white"
+            ></sp-progress-circle>
+        `);
+
+        await elementUpdated(el);
+
+        expect(el.staticColor).to.equal('white');
+
+        el.setAttribute('static', 'white');
+        await elementUpdated(el);
+
+        expect(el.staticColor).to.equal('white');
+        expect(el.static).to.equal('white');
     });
 });

--- a/packages/progress-circle/test/progress-circle.test.ts
+++ b/packages/progress-circle/test/progress-circle.test.ts
@@ -227,5 +227,6 @@ describe('ProgressCircle', () => {
 
         expect(el.staticColor).to.equal('white');
         expect(el.static).to.equal('white');
+        expect(el.getAttribute('static-color')).to.equal('white');
     });
 });

--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -39,7 +39,7 @@ import { Toast } from '@spectrum-web-components/toast';
     This is important information that you should read, soon.
     <sp-button
         slot="action"
-        static="white"
+        static-color="white"
         variant="secondary"
         treatment="outline"
     >
@@ -55,7 +55,7 @@ import { Toast } from '@spectrum-web-components/toast';
     This is important information that you should read, soon.
     <sp-button
         slot="action"
-        static="white"
+        static-color="white"
         variant="secondary"
         treatment="outline"
     >

--- a/packages/toast/src/Toast.ts
+++ b/packages/toast/src/Toast.ts
@@ -216,7 +216,7 @@ export class Toast extends FocusVisiblePolyfillMixin(SpectrumElement) {
                 <sp-close-button
                     @click=${this.shouldClose}
                     label="Close"
-                    static="white"
+                    static-color="white"
                 ></sp-close-button>
             </div>
         `;

--- a/packages/toast/stories/toast.stories.ts
+++ b/packages/toast/stories/toast.stories.ts
@@ -37,7 +37,7 @@ const toast = ({
         ${content}
         <sp-button
             slot="action"
-            static="white"
+            static-color="white"
             variant="secondary"
             treatment="outline"
         >

--- a/packages/toast/test/toast.test.ts
+++ b/packages/toast/test/toast.test.ts
@@ -35,18 +35,14 @@ interface TestableToast {
 describe('Toast', () => {
     testForLitDevWarnings(
         async () =>
-            await fixture<Toast>(
-                html`
-                    <sp-toast open>Help text.</sp-toast>
-                `
-            )
+            await fixture<Toast>(html`
+                <sp-toast open>Help text.</sp-toast>
+            `)
     );
     it('loads', async () => {
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast open>Help text.</sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast open>Help text.</sp-toast>
+        `);
 
         await elementUpdated(el);
 
@@ -54,13 +50,11 @@ describe('Toast', () => {
     });
     toastVariants.map((variant) => {
         it(`loads - [variant="${variant}"]`, async () => {
-            const el = await fixture<Toast>(
-                html`
-                    <sp-toast variant=${variant} open>
-                        This toast is of the \`${variant}\` variant.
-                    </sp-toast>
-                `
-            );
+            const el = await fixture<Toast>(html`
+                <sp-toast variant=${variant} open>
+                    This toast is of the \`${variant}\` variant.
+                </sp-toast>
+            `);
 
             await elementUpdated(el);
 
@@ -68,11 +62,9 @@ describe('Toast', () => {
         });
     });
     it('loads - timeout', async () => {
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast timeout="100">Help text.</sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast timeout="100">Help text.</sp-toast>
+        `);
 
         await elementUpdated(el);
         expect(el.open).to.be.false;
@@ -85,11 +77,9 @@ describe('Toast', () => {
         expect(el.open).to.be.false;
     });
     it('`timeout` updates `countdownStart`', async () => {
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast timeout="100">Help text.</sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast timeout="100">Help text.</sp-toast>
+        `);
 
         await elementUpdated(el);
         expect(el.open).to.be.false;
@@ -123,11 +113,9 @@ describe('Toast', () => {
         expect(thirdStart).to.equal(0);
     });
     it('stops timeout on `focusin`', async () => {
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast timeout="100">Help text.</sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast timeout="100">Help text.</sp-toast>
+        `);
 
         await elementUpdated(el);
 
@@ -158,11 +146,9 @@ describe('Toast', () => {
         expect(el.open, 'not open to end').to.be.false;
     });
     it('closes', async () => {
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast open>Help text.</sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast open>Help text.</sp-toast>
+        `);
 
         await elementUpdated(el);
         expect(el.open).to.be.true;
@@ -179,13 +165,11 @@ describe('Toast', () => {
     it('`close` can be prevented', async () => {
         const handleClose = (event: CustomEvent): void =>
             event.preventDefault();
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast open timeout="100" @close=${handleClose}>
-                    Help text.
-                </sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast open timeout="100" @close=${handleClose}>
+                Help text.
+            </sp-toast>
+        `);
 
         await elementUpdated(el);
         expect(el.open).to.be.true;
@@ -205,13 +189,11 @@ describe('Toast', () => {
             event.preventDefault();
             closeSpy();
         };
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast open timeout="100" @close=${handleClose}>
-                    Help text.
-                </sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast open timeout="100" @close=${handleClose}>
+                Help text.
+            </sp-toast>
+        `);
 
         await elementUpdated(el);
         expect(el.open).to.be.true;
@@ -233,13 +215,11 @@ describe('Toast', () => {
         expect(closeSpy.callCount).to.equal(1);
     });
     it('validates variants', async () => {
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast variant="invalid" open>
-                    This toast validates variants.
-                </sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast variant="invalid" open>
+                This toast validates variants.
+            </sp-toast>
+        `);
 
         await elementUpdated(el);
         expect(el.variant).to.equal('');
@@ -255,13 +235,11 @@ describe('Toast', () => {
         expect(el.variant).to.equal(toastVariants[0]);
     });
     it('maintains [variant] when disconnected/connected', async () => {
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast variant="positive" open>
-                    This toast maintains variants.
-                </sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast variant="positive" open>
+                This toast maintains variants.
+            </sp-toast>
+        `);
 
         await elementUpdated(el);
         expect(el.variant).to.equal('positive');
@@ -277,19 +255,17 @@ describe('Toast', () => {
     });
     it('reopens', async () => {
         const closeSpy = spy();
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast
-                    variant="positive"
-                    open
-                    @close=${() => {
-                        closeSpy();
-                    }}
-                >
-                    This toast maintains variants.
-                </sp-toast>
-            `
-        );
+        const el = await fixture<Toast>(html`
+            <sp-toast
+                variant="positive"
+                open
+                @close=${() => {
+                    closeSpy();
+                }}
+            >
+                This toast maintains variants.
+            </sp-toast>
+        `);
 
         await elementUpdated(el);
         expect(el.open).to.be.true;
@@ -308,12 +284,10 @@ describe('Toast', () => {
         expect(el.open).to.be.true;
         expect(closeSpy.callCount).to.equal(1);
     });
-    it('sp close button renders with static="white"', async () => {
-        const el = await fixture<Toast>(
-            html`
-                <sp-toast open>Help text.</sp-toast>
-            `
-        );
+    it('sp close button renders with static-color="white"', async () => {
+        const el = await fixture<Toast>(html`
+            <sp-toast open>Help text.</sp-toast>
+        `);
         const renderRoot = el.shadowRoot ? el.shadowRoot : el;
         const closeButton = renderRoot.querySelector(
             'sp-close-button'
@@ -321,6 +295,6 @@ describe('Toast', () => {
 
         expect(closeButton).to.exist;
 
-        expect(closeButton.getAttribute('static')).to.equal('white');
+        expect(closeButton.getAttribute('static-color')).to.equal('white');
     });
 });

--- a/tools/theme/src/Theme.ts
+++ b/tools/theme/src/Theme.ts
@@ -339,6 +339,7 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
 
         const target = event.composedPath()[0] as HTMLElement;
 
+        /* c8 ignore next 4 */
         // Avoid duplicate registrations
         if (this._systemContextConsumers.has(target)) {
             return;
@@ -466,6 +467,7 @@ export class Theme extends HTMLElement implements ThemeKindProvider {
      * passing the current system variant and the unsubscribe function. This ensures that any component
      * consuming the system context receives the updated system variant when the `system` (or `theme`) attribute changes.
      */
+    /* c8 ignore next 5 */
     private _provideSystemContext(): void {
         this._systemContextConsumers.forEach(([callback, unsubscribe]) =>
             callback(this.system, unsubscribe)

--- a/tools/truncated/src/Truncated.ts
+++ b/tools/truncated/src/Truncated.ts
@@ -175,6 +175,7 @@ export class Truncated extends SpectrumElement {
             .trim();
         navigator.clipboard.writeText(textToCopy);
         this.hasCopied = true;
+        /* c8 ignore next 3 */
         setTimeout(() => {
             this.hasCopied = false;
         }, 6000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR deprecates the static attribute and introduces the new staticColor attribute.

<!--- Describe your changes in detail -->

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- [SWC-512](https://jira.corp.adobe.com/browse/SWC-512)

## Motivation and context
 The `staticColor` attribute more clearly conveys the attribute’s purpose, addressing confusion caused by the reserved `static` keyword in JavaScript/TypeScript and aligning better with the Spectrum design system documentation.
<!--- Why is this change required? What problem does it solve? -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
