### PR TITLE
feat(date-time-picker): added precision and value interactions

### DIFF
--- a/packages/calendar/src/Calendar.ts
+++ b/packages/calendar/src/Calendar.ts
@@ -182,8 +182,6 @@ export class Calendar extends SpectrumElement {
         changesMin: boolean,
         changesMax: boolean
     ): void {
-        this.convertToCalendarDates();
-
         if ((changesMin || changesMax) && this.min && this.max) {
             const isValidInterval = this.min.compare(this.max) < 0;
             if (!isValidInterval) {
@@ -225,7 +223,10 @@ export class Calendar extends SpectrumElement {
         const changesValue = changedProperties.has('value');
         const changesDates = changesMin || changesMax || changesValue;
 
-        if (changesDates) this.checkDatesCompliance(changesMin, changesMax);
+        if (changesDates) {
+            this.convertToCalendarDates();
+            this.checkDatesCompliance(changesMin, changesMax);
+        }
 
         const previousMonth = changedProperties.get('currentDate');
         const changesMonth =

--- a/packages/calendar/src/Calendar.ts
+++ b/packages/calendar/src/Calendar.ts
@@ -179,7 +179,6 @@ export class Calendar extends SpectrumElement {
     }
 
     private checkDatesCompliance(
-        changesValue: boolean,
         changesMin: boolean,
         changesMax: boolean
     ): void {
@@ -198,7 +197,7 @@ export class Calendar extends SpectrumElement {
             }
         }
 
-        if (changesValue && this.value) {
+        if (this.value) {
             const isNonCompliantValue =
                 (this.min && this.value.compare(this.min) < 0) ||
                 (this.max && this.value.compare(this.max) > 0);
@@ -226,8 +225,7 @@ export class Calendar extends SpectrumElement {
         const changesValue = changedProperties.has('value');
         const changesDates = changesMin || changesMax || changesValue;
 
-        if (changesDates)
-            this.checkDatesCompliance(changesValue, changesMin, changesMax);
+        if (changesDates) this.checkDatesCompliance(changesMin, changesMax);
 
         const previousMonth = changedProperties.get('currentDate');
         const changesMonth =

--- a/packages/calendar/src/Calendar.ts
+++ b/packages/calendar/src/Calendar.ts
@@ -161,6 +161,9 @@ export class Calendar extends SpectrumElement {
         document.removeEventListener('mousedown', this.resetDateFocusIntent);
     }
 
+    /**
+     * Resets the component's value
+     */
     public clear(): void {
         this.value = undefined;
     }
@@ -178,11 +181,15 @@ export class Calendar extends SpectrumElement {
         this.value = this.value && toCalendarDate(this.value);
     }
 
-    private checkDatesCompliance(
-        changesMin: boolean,
-        changesMax: boolean
-    ): void {
-        if ((changesMin || changesMax) && this.min && this.max) {
+    /**
+     * Validates the component's date properties (min, max and value) compliance with one another.
+     * If the [min, max] constraint interval is invalid, both properties are reset.
+     * If the value is not within the [min, max] (valid) interval, it is reset.
+     *
+     * @param checkInterval - Whether to check the [min, max] interval
+     */
+    private checkDatePropsCompliance(checkInterval: boolean): void {
+        if (checkInterval && this.min && this.max) {
             const isValidInterval = this.min.compare(this.max) < 0;
             if (!isValidInterval) {
                 window.__swc.warn(
@@ -225,7 +232,7 @@ export class Calendar extends SpectrumElement {
 
         if (changesDates) {
             this.convertToCalendarDates();
-            this.checkDatesCompliance(changesMin, changesMax);
+            this.checkDatePropsCompliance(changesMin || changesMax);
         }
 
         const previousMonth = changedProperties.get('currentDate');

--- a/packages/calendar/test/calendar.test.ts
+++ b/packages/calendar/test/calendar.test.ts
@@ -517,6 +517,8 @@ describe('Calendar', () => {
             expect(element.value).to.be.undefined;
         });
 
+        it("by invalidating the current value when it doesn't comply with the new interval", async () => {});
+
         describe('stopping navigation when they are set', () => {
             beforeEach(async () => {
                 element = await fixtureElement({

--- a/packages/calendar/test/calendar.test.ts
+++ b/packages/calendar/test/calendar.test.ts
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 import {
     CalendarDate,
     endOfMonth,
+    getLocalTimeZone,
     parseDate,
     today,
 } from '@internationalized/date';
@@ -29,7 +30,6 @@ import {
     sendKeyMultipleTimes,
 } from './helpers.js';
 
-const LOCAL_TIME_ZONE = new Intl.DateTimeFormat().resolvedOptions().timeZone;
 const NEXT_BUTTON_SELECTOR = '[data-test-id="next-btn"]';
 const PREV_BUTTON_SELECTOR = '[data-test-id="prev-btn"]';
 
@@ -40,7 +40,7 @@ describe('Calendar', () => {
     const fixedMonth = 5;
     const fixedDay = 15;
 
-    before(async () => {
+    before(() => {
         const fixedTime = new Date(
             fixedYear,
             fixedMonth - 1, // 0-indexed in Date but 1-indexed in CalendarDate
@@ -51,7 +51,6 @@ describe('Calendar', () => {
 
     beforeEach(async () => {
         element = await fixtureElement();
-        await elementUpdated(element);
     });
 
     after(() => {
@@ -66,34 +65,34 @@ describe('Calendar', () => {
     );
 
     it('loads default calendar accessibly', async () => {
-        const el = await fixtureElement();
-        await expect(el).to.be.accessible();
+        element = await fixtureElement();
+        await expect(element).to.be.accessible();
     });
 
-    describe('Displays the correct initial month', () => {
-        it('with no pre-selected value provided', async () => {
-            const localToday = today(LOCAL_TIME_ZONE);
+    describe('Initial month', () => {
+        it("should display today's month when no pre-selected value is provided", async () => {
+            element = await fixtureElement();
+            const localToday = today(getLocalTimeZone());
 
             expectSameDates(element['currentDate'], localToday);
         });
 
-        it('with a valid pre-selected value', async () => {
+        it("should display the provided value's month when it is provided", async () => {
             const value = new CalendarDate(2024, 7, 21);
-            const element = await fixtureElement({
+            element = await fixtureElement({
                 props: { value },
             });
-            await elementUpdated(element);
 
             expectSameDates(element['currentDate'], value);
         });
     });
 
-    describe('Correctly manages the focusable day when changing months', () => {
+    describe('Focus', () => {
         let focusableDay: HTMLElement;
         let nextButton: Button;
         let prevButton: Button;
 
-        beforeEach(async () => {
+        beforeEach(() => {
             focusableDay = element.shadowRoot.querySelector(
                 "td.tableCell[tabindex='0']"
             ) as HTMLElement;
@@ -103,7 +102,7 @@ describe('Calendar', () => {
                 element.shadowRoot.querySelector(PREV_BUTTON_SELECTOR)!;
         });
 
-        it('after selecting a date', async () => {
+        it("should focus the first day when the displayed month doesn't have the selected/today's date", async () => {
             focusableDay.focus();
             await sendKeys({ press: 'ArrowRight' });
             await elementUpdated(element);
@@ -128,7 +127,7 @@ describe('Calendar', () => {
             expect(element['currentDate'].day).to.equal(1);
         });
 
-        it('coming back to a selected date', async () => {
+        it('should focus the selected date when the displayed month includes it', async () => {
             focusableDay.focus();
             await sendKeys({ press: 'ArrowRight' });
             await elementUpdated(element);
@@ -156,7 +155,7 @@ describe('Calendar', () => {
             expectSameDates(focusedCalendarDate, element.value!);
         });
 
-        it("coming back to today's date", async () => {
+        it("should focus today's date when the displayed month includes it and it doesn't include the selected date", async () => {
             nextButton.focus();
             await sendKeys({ press: 'Enter' });
             await elementUpdated(element);
@@ -178,12 +177,13 @@ describe('Calendar', () => {
         });
     });
 
-    describe('Navigates', () => {
+    describe('Navigation', () => {
         let nextButton: Button;
         let prevButton: Button;
+        let focusableDay: HTMLElement;
 
         const resetElementPosition = (): void => {
-            element['currentDate'] = today(LOCAL_TIME_ZONE);
+            element['currentDate'] = today(getLocalTimeZone());
         };
 
         beforeEach(() => {
@@ -192,262 +192,234 @@ describe('Calendar', () => {
 
             nextButton =
                 element.shadowRoot.querySelector(NEXT_BUTTON_SELECTOR)!;
+
+            focusableDay = element.shadowRoot.querySelector(
+                "td.tableCell[tabindex='0']"
+            )!;
         });
 
         afterEach(async () => {
             resetElementPosition();
         });
 
-        describe('via header buttons', () => {
-            it('using pointer on the next month button', async () => {
-                nextButton.click();
-                await elementUpdated(element);
+        it("should navigate to the next month by clicking on the 'next month' button", async () => {
+            nextButton.click();
+            await elementUpdated(element);
 
-                expect(element['currentDate'].year).to.equal(fixedYear);
-                expect(element['currentDate'].month).to.equal(fixedMonth + 1);
-                expect(element['currentDate'].day).to.equal(1);
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth + 1);
+            expect(element['currentDate'].day).to.equal(1);
 
-                nextButton.click();
-                await elementUpdated(element);
+            nextButton.click();
+            await elementUpdated(element);
 
-                expect(element['currentDate'].year).to.equal(fixedYear);
-                expect(element['currentDate'].month).to.equal(fixedMonth + 2);
-                expect(element['currentDate'].day).to.equal(1);
-            });
-
-            it('using pointer on the previous month button', async () => {
-                prevButton.click();
-                await elementUpdated(element);
-
-                expect(element['currentDate'].year).to.equal(fixedYear);
-                expect(element['currentDate'].month).to.equal(fixedMonth - 1);
-                expect(element['currentDate'].day).to.equal(1);
-
-                prevButton.click();
-                await elementUpdated(element);
-
-                expect(element['currentDate'].year).to.equal(fixedYear);
-                expect(element['currentDate'].month).to.equal(fixedMonth - 2);
-                expect(element['currentDate'].day).to.equal(1);
-            });
-
-            it('using keyboard action on the next month button', async () => {
-                nextButton.focus();
-                await sendKeys({ press: 'Space' });
-                await elementUpdated(element);
-
-                expect(element['currentDate'].year).to.equal(fixedYear);
-                expect(element['currentDate'].month).to.equal(fixedMonth + 1);
-                expect(element['currentDate'].day).to.equal(1);
-
-                await sendKeys({ press: 'Enter' });
-                await elementUpdated(element);
-
-                expect(element['currentDate'].year).to.equal(fixedYear);
-                expect(element['currentDate'].month).to.equal(fixedMonth + 2);
-                expect(element['currentDate'].day).to.equal(1);
-            });
-
-            it('using keyboard action on the previous month button', async () => {
-                prevButton.focus();
-                await sendKeys({ press: 'Space' });
-                await elementUpdated(element);
-
-                expect(element['currentDate'].year).to.equal(fixedYear);
-                expect(element['currentDate'].month).to.equal(fixedMonth - 1);
-                expect(element['currentDate'].day).to.equal(1);
-
-                await sendKeys({ press: 'Enter' });
-                await elementUpdated(element);
-
-                expect(element['currentDate'].year).to.equal(fixedYear);
-                expect(element['currentDate'].month).to.equal(fixedMonth - 2);
-                expect(element['currentDate'].day).to.equal(1);
-            });
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth + 2);
+            expect(element['currentDate'].day).to.equal(1);
         });
 
-        describe('via days buttons', () => {
-            beforeEach(() => {
-                const focusableDay = element.shadowRoot.querySelector(
-                    "td.tableCell[tabindex='0']"
-                ) as HTMLElement;
-                focusableDay.focus();
-            });
+        it("should navigate to the previous month by clicking on the 'previous month' button", async () => {
+            prevButton.click();
+            await elementUpdated(element);
 
-            describe('in the current month', () => {
-                it('using the right arrow key', async () => {
-                    await sendKeys({ press: 'ArrowRight' });
-                    await elementUpdated(element);
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth - 1);
+            expect(element['currentDate'].day).to.equal(1);
 
-                    expect(element['currentDate'].year).to.equal(fixedYear);
-                    expect(element['currentDate'].month).to.equal(fixedMonth);
-                    expect(element['currentDate'].day).to.equal(fixedDay + 1);
-                });
+            prevButton.click();
+            await elementUpdated(element);
 
-                it('using the left arrow key', async () => {
-                    await sendKeys({ press: 'ArrowLeft' });
-                    await elementUpdated(element);
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth - 2);
+            expect(element['currentDate'].day).to.equal(1);
+        });
 
-                    expect(element['currentDate'].year).to.equal(fixedYear);
-                    expect(element['currentDate'].month).to.equal(fixedMonth);
-                    expect(element['currentDate'].day).to.equal(fixedDay - 1);
-                });
+        it("should navigate to the next month by keyboard action on the 'next month' button", async () => {
+            nextButton.focus();
+            await sendKeys({ press: 'Space' });
+            await elementUpdated(element);
 
-                it('using the up arrow key', async () => {
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth + 1);
+            expect(element['currentDate'].day).to.equal(1);
 
-                    expect(element['currentDate'].year).to.equal(fixedYear);
-                    expect(element['currentDate'].month).to.equal(fixedMonth);
-                    expect(element['currentDate'].day).to.equal(
-                        fixedDay - DAYS_PER_WEEK
-                    );
-                });
+            await sendKeys({ press: 'Enter' });
+            await elementUpdated(element);
 
-                it('using the down arrow key', async () => {
-                    await sendKeys({ press: 'ArrowDown' });
-                    await elementUpdated(element);
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth + 2);
+            expect(element['currentDate'].day).to.equal(1);
+        });
 
-                    expect(element['currentDate'].year).to.equal(fixedYear);
-                    expect(element['currentDate'].month).to.equal(fixedMonth);
-                    expect(element['currentDate'].day).to.equal(
-                        fixedDay + DAYS_PER_WEEK
-                    );
-                });
-            });
+        it("should navigate to the previous month by keyboard action on the 'previous month' button", async () => {
+            prevButton.focus();
+            await sendKeys({ press: 'Space' });
+            await elementUpdated(element);
 
-            describe('through different months', () => {
-                it('using the right arrow key', async () => {
-                    const currentEndOfMonthDay = endOfMonth(
-                        element['currentDate']
-                    ).day;
-                    const nextMonthDay = 4;
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth - 1);
+            expect(element['currentDate'].day).to.equal(1);
 
-                    await sendKeyMultipleTimes(
-                        'ArrowRight',
-                        currentEndOfMonthDay -
-                            element['currentDate'].day +
-                            nextMonthDay
-                    );
-                    await elementUpdated(element);
+            await sendKeys({ press: 'Enter' });
+            await elementUpdated(element);
 
-                    expect(element['currentDate'].year).to.equal(fixedYear);
-                    expect(element['currentDate'].month).to.equal(
-                        fixedMonth + 1
-                    );
-                    expect(element['currentDate'].day).to.equal(nextMonthDay);
-                });
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth - 2);
+            expect(element['currentDate'].day).to.equal(1);
+        });
 
-                it('using the left arrow key', async () => {
-                    const previousEndOfMonthDay = endOfMonth(
-                        element['currentDate'].set({ month: fixedMonth - 1 })
-                    ).day;
-                    const prevMonthDay = 23;
+        it('should navigate in the current month - ArrowRight', async () => {
+            focusableDay.focus();
+            await sendKeys({ press: 'ArrowRight' });
+            await elementUpdated(element);
 
-                    await sendKeyMultipleTimes(
-                        'ArrowLeft',
-                        element['currentDate'].day +
-                            previousEndOfMonthDay -
-                            prevMonthDay
-                    );
-                    await elementUpdated(element);
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth);
+            expect(element['currentDate'].day).to.equal(fixedDay + 1);
+        });
 
-                    expect(element['currentDate'].year).to.equal(fixedYear);
-                    expect(element['currentDate'].month).to.equal(
-                        fixedMonth - 1
-                    );
-                    expect(element['currentDate'].day).to.equal(prevMonthDay);
-                });
+        it('should navigate in the current month - ArrowLeft', async () => {
+            focusableDay.focus();
+            await sendKeys({ press: 'ArrowLeft' });
+            await elementUpdated(element);
 
-                it('using the up arrow key', async () => {
-                    const previousEndOfMonthDay = endOfMonth(
-                        element['currentDate'].set({ month: fixedMonth - 1 })
-                    ).day;
-                    const initialDay = element['currentDate'].day;
-                    const completedWeeks = Math.floor(
-                        initialDay / DAYS_PER_WEEK
-                    );
-                    const daysIntoCurrentWeek = initialDay % DAYS_PER_WEEK;
-                    const previousMonthDay =
-                        previousEndOfMonthDay +
-                        daysIntoCurrentWeek -
-                        DAYS_PER_WEEK;
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth);
+            expect(element['currentDate'].day).to.equal(fixedDay - 1);
+        });
 
-                    await sendKeyMultipleTimes('ArrowUp', completedWeeks + 1);
-                    await elementUpdated(element);
+        it('should navigate in the current month - ArrowUp', async () => {
+            focusableDay.focus();
+            await sendKeys({ press: 'ArrowUp' });
+            await elementUpdated(element);
 
-                    expect(element['currentDate'].year).to.equal(fixedYear);
-                    expect(element['currentDate'].month).to.equal(
-                        fixedMonth - 1
-                    );
-                    expect(element['currentDate'].day).to.equal(
-                        previousMonthDay
-                    );
-                });
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth);
+            expect(element['currentDate'].day).to.equal(
+                fixedDay - DAYS_PER_WEEK
+            );
+        });
 
-                it('using the down arrow key', async () => {
-                    const currentEndOfMonthDay = endOfMonth(
-                        element['currentDate']
-                    ).day;
-                    const initialDay = element['currentDate'].day;
-                    const uncompletedWeeks = Math.floor(
-                        (currentEndOfMonthDay - initialDay) / DAYS_PER_WEEK
-                    );
-                    const nextMonthDay =
-                        initialDay +
-                        (uncompletedWeeks + 1) * DAYS_PER_WEEK -
-                        currentEndOfMonthDay;
+        it('should navigate in the current month - ArrowDown', async () => {
+            focusableDay.focus();
+            await sendKeys({ press: 'ArrowDown' });
+            await elementUpdated(element);
 
-                    await sendKeyMultipleTimes(
-                        'ArrowDown',
-                        uncompletedWeeks + 1
-                    );
-                    await elementUpdated(element);
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth);
+            expect(element['currentDate'].day).to.equal(
+                fixedDay + DAYS_PER_WEEK
+            );
+        });
 
-                    expect(element['currentDate'].year).to.equal(fixedYear);
-                    expect(element['currentDate'].month).to.equal(
-                        fixedMonth + 1
-                    );
-                    expect(element['currentDate'].day).to.equal(nextMonthDay);
-                });
-            });
+        it('should navigate to the next month - ArrowRight', async () => {
+            focusableDay.focus();
+            const currentEndOfMonthDay = endOfMonth(element['currentDate']).day;
+            const nextMonthDay = 4;
+
+            await sendKeyMultipleTimes(
+                'ArrowRight',
+                currentEndOfMonthDay - element['currentDate'].day + nextMonthDay
+            );
+            await elementUpdated(element);
+
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth + 1);
+            expect(element['currentDate'].day).to.equal(nextMonthDay);
+        });
+
+        it('should navigate to the next month - ArrowDown', async () => {
+            focusableDay.focus();
+            const currentEndOfMonthDay = endOfMonth(element['currentDate']).day;
+            const initialDay = element['currentDate'].day;
+            const uncompletedWeeks = Math.floor(
+                (currentEndOfMonthDay - initialDay) / DAYS_PER_WEEK
+            );
+            const nextMonthDay =
+                initialDay +
+                (uncompletedWeeks + 1) * DAYS_PER_WEEK -
+                currentEndOfMonthDay;
+
+            await sendKeyMultipleTimes('ArrowDown', uncompletedWeeks + 1);
+            await elementUpdated(element);
+
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth + 1);
+            expect(element['currentDate'].day).to.equal(nextMonthDay);
+        });
+
+        it('should navigate to the previous month - ArrowLeft', async () => {
+            focusableDay.focus();
+            const previousEndOfMonthDay = endOfMonth(
+                element['currentDate'].set({ month: fixedMonth - 1 })
+            ).day;
+            const prevMonthDay = 23;
+
+            await sendKeyMultipleTimes(
+                'ArrowLeft',
+                element['currentDate'].day +
+                    previousEndOfMonthDay -
+                    prevMonthDay
+            );
+            await elementUpdated(element);
+
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth - 1);
+            expect(element['currentDate'].day).to.equal(prevMonthDay);
+        });
+
+        it('should navigate to the previous month - ArrowUp', async () => {
+            focusableDay.focus();
+            const previousEndOfMonthDay = endOfMonth(
+                element['currentDate'].set({ month: fixedMonth - 1 })
+            ).day;
+            const initialDay = element['currentDate'].day;
+            const completedWeeks = Math.floor(initialDay / DAYS_PER_WEEK);
+            const daysIntoCurrentWeek = initialDay % DAYS_PER_WEEK;
+            const previousMonthDay =
+                previousEndOfMonthDay + daysIntoCurrentWeek - DAYS_PER_WEEK;
+
+            await sendKeyMultipleTimes('ArrowUp', completedWeeks + 1);
+            await elementUpdated(element);
+
+            expect(element['currentDate'].year).to.equal(fixedYear);
+            expect(element['currentDate'].month).to.equal(fixedMonth - 1);
+            expect(element['currentDate'].day).to.equal(previousMonthDay);
         });
     });
 
-    describe('Manages min and max constraints', () => {
+    describe('Min-max constraints', () => {
         let min: CalendarDate;
         let max: CalendarDate;
         const dayOffset = 5;
 
-        before(async () => {
+        before(() => {
             min = new CalendarDate(fixedYear, fixedMonth, fixedDay - dayOffset);
             max = new CalendarDate(fixedYear, fixedMonth, fixedDay + dayOffset);
         });
 
-        it('when min > max date by ignoring them', async () => {
+        it('should ignore the provided min and max properties when the interval is invalid', async () => {
             const min = max.set({ day: max.day + 1 });
             element = await fixtureElement({
                 props: { min, max },
             });
 
-            expect(element.min).to.be.undefined;
-            expect(element.max).to.be.undefined;
+            expect(element.min, 'min not undefined').to.be.undefined;
+            expect(element.max, 'max not undefined').to.be.undefined;
         });
 
-        it("when a pre-selected value doesn't comply by ignoring it", async () => {
+        it("should ignore the provided value property when it doesn't comply with the min-max interval", async () => {
             const value = max.set({ day: max.day + 1 });
             element = await fixtureElement({
                 props: { min, max, value },
             });
 
             expect(element.value).to.be.undefined;
-            expect(element.min).to.not.be.undefined;
-            expect(element.max).to.not.be.undefined;
-            expectSameDates(element.min!, min);
-            expectSameDates(element.max!, max);
+            expectSameDates(element.min!, min, 'min value mismatch');
+            expectSameDates(element.max!, max, 'max value mismatch');
         });
 
-        it("by not selecting a day that doesn't comply", async () => {
+        it("should not select a day that doesn't comply with the min-max interval", async () => {
             const changeSpy = spy();
             element = await fixtureElement({
                 props: { min, max },
@@ -484,85 +456,127 @@ describe('Calendar', () => {
             expect(element.value).to.be.undefined;
         });
 
-        it("by invalidating the current value when it doesn't comply with the new interval", async () => {
-            const value = min.set({ day: min.day + 1 });
+        it("should invalidate the current value when it doesn't comply with min changes", async () => {
             element = await fixtureElement({
-                props: { min, max, value },
+                props: { min, max, value: min },
             });
 
             expect(element.value).to.not.be.undefined;
             expect(element.min).to.not.be.undefined;
             expect(element.max).to.not.be.undefined;
 
-            const newMin = max.set({ day: max.day - 1 });
+            const newMin = min.set({ day: min.day + 1 });
             element.min = newMin;
             await elementUpdated(element);
 
             expect(element.value).to.be.undefined;
-            expect(element.min).to.not.be.undefined;
-            expectSameDates(element.min!, newMin);
-            expect(element.max).to.not.be.undefined;
-            expectSameDates(element.max!, max);
+            expectSameDates(element.min!, newMin, 'min value mismatch');
+            expectSameDates(element.max!, max, 'max value mismatch');
+        });
 
-            const newMax = max.set({ day: max.day + 1 });
+        it("should invalidate the current value when it doesn't comply with max changes", async () => {
+            element = await fixtureElement({
+                props: { min, max, value: max },
+            });
+
+            expect(element.value).to.not.be.undefined;
+            expect(element.min).to.not.be.undefined;
+            expect(element.max).to.not.be.undefined;
+
+            const newMax = max.set({ day: max.day - 1 });
             element.max = newMax;
             await elementUpdated(element);
 
             expect(element.value).to.be.undefined;
-            expect(element.min).to.not.be.undefined;
-            expectSameDates(element.min!, newMin);
-            expect(element.max).to.not.be.undefined;
-            expectSameDates(element.max!, newMax);
+            expectSameDates(element.min!, min, 'min value mismatch');
+            expectSameDates(element.max!, newMax, 'max value mismatch');
         });
 
-        describe('stopping navigation when they are set', () => {
-            beforeEach(async () => {
-                element = await fixtureElement({
-                    props: { min, max },
-                });
-                const focusableDay = element.shadowRoot.querySelector(
-                    "td.tableCell[tabindex='0']"
-                ) as HTMLElement;
-                focusableDay.focus();
+        it("should invalidate the current value when it doesn't comply with min and max changes", async () => {
+            element = await fixtureElement({
+                props: { min, max, value: min.set({ day: min.day + 1 }) },
             });
 
-            it('using the right arrow key', async () => {
-                await sendKeyMultipleTimes('ArrowRight', dayOffset + 3);
-                await elementUpdated(element);
+            expect(element.value).to.not.be.undefined;
+            expect(element.min).to.not.be.undefined;
+            expect(element.max).to.not.be.undefined;
 
-                expectSameDates(element['currentDate'], max);
+            const newMin = min.set({ day: min.day + 2 });
+            const newMax = max.set({ day: max.day - 2 });
+
+            element.min = newMin;
+            element.max = newMax;
+            await elementUpdated(element);
+
+            expect(element.value).to.be.undefined;
+            expectSameDates(element.min!, newMin, 'min value mismatch');
+            expectSameDates(element.max!, newMax, 'max value mismatch');
+        });
+
+        it("should not allow navigation to days that don't comply with the min-max interval - ArrowRight", async () => {
+            element = await fixtureElement({
+                props: { min, max },
             });
+            const focusableDay = element.shadowRoot.querySelector(
+                "td.tableCell[tabindex='0']"
+            ) as HTMLElement;
+            focusableDay.focus();
+            await sendKeyMultipleTimes('ArrowRight', dayOffset + 3);
+            await elementUpdated(element);
 
-            it('using the left arrow key', async () => {
-                await sendKeyMultipleTimes('ArrowLeft', dayOffset + 3);
-                await elementUpdated(element);
+            expectSameDates(element['currentDate'], max);
+        });
 
-                expectSameDates(element['currentDate'], min);
+        it("should not allow navigation to days that don't comply with the min-max interval - ArrowLeft", async () => {
+            element = await fixtureElement({
+                props: { min, max },
             });
+            const focusableDay = element.shadowRoot.querySelector(
+                "td.tableCell[tabindex='0']"
+            ) as HTMLElement;
+            focusableDay.focus();
+            await sendKeyMultipleTimes('ArrowLeft', dayOffset + 3);
+            await elementUpdated(element);
 
-            it('using the up arrow key', async () => {
-                await sendKeyMultipleTimes(
-                    'ArrowUp',
-                    dayOffset / DAYS_PER_WEEK + 1
-                );
-                await elementUpdated(element);
+            expectSameDates(element['currentDate'], min);
+        });
 
-                expectSameDates(element['currentDate'], min);
+        it("should not allow navigation to days that don't comply with the min-max interval - ArrowUp", async () => {
+            element = await fixtureElement({
+                props: { min, max },
             });
+            const focusableDay = element.shadowRoot.querySelector(
+                "td.tableCell[tabindex='0']"
+            ) as HTMLElement;
+            focusableDay.focus();
+            await sendKeyMultipleTimes(
+                'ArrowUp',
+                dayOffset / DAYS_PER_WEEK + 1
+            );
+            await elementUpdated(element);
 
-            it('using the down arrow key', async () => {
-                await sendKeyMultipleTimes(
-                    'ArrowDown',
-                    dayOffset / DAYS_PER_WEEK + 1
-                );
-                await elementUpdated(element);
+            expectSameDates(element['currentDate'], min);
+        });
 
-                expectSameDates(element['currentDate'], max);
+        it("should not allow navigation to days that don't comply with the min-max interval - ArrowDown", async () => {
+            element = await fixtureElement({
+                props: { min, max },
             });
+            const focusableDay = element.shadowRoot.querySelector(
+                "td.tableCell[tabindex='0']"
+            ) as HTMLElement;
+            focusableDay.focus();
+            await sendKeyMultipleTimes(
+                'ArrowDown',
+                dayOffset / DAYS_PER_WEEK + 1
+            );
+            await elementUpdated(element);
+
+            expectSameDates(element['currentDate'], max);
         });
     });
 
-    describe('Correctly changes the selected date', () => {
+    describe('Value', () => {
         let availableDateToSelect: CalendarDate;
         let availableDayElement: HTMLElement;
 
@@ -577,7 +591,7 @@ describe('Calendar', () => {
             ) as HTMLElement;
         });
 
-        it('when an available day is clicked', async () => {
+        it('should update value when an available day is clicked', async () => {
             const rect = availableDayElement.getBoundingClientRect();
             const centerX = rect.left + rect.width / 2;
             const centerY = rect.top + rect.height / 2;
@@ -588,35 +602,32 @@ describe('Calendar', () => {
             });
             await elementUpdated(element);
 
-            expect(element.value).to.not.be.undefined;
             expectSameDates(element.value!, availableDateToSelect);
         });
 
-        it('when an available day is acted upon using Enter', async () => {
+        it('should update value when an available day is acted upon using Enter', async () => {
             availableDayElement.focus();
             await sendKeys({ press: 'Enter' });
             await elementUpdated(element);
 
-            expect(element.value).to.not.be.undefined;
             expectSameDates(element.value!, availableDateToSelect);
         });
 
-        it('when an available day is acted upon using Space', async () => {
+        it('should update value when an available day is acted upon using Space', async () => {
             availableDayElement.focus();
             await sendKeys({ press: 'Space' });
             await elementUpdated(element);
 
-            expect(element.value).to.not.be.undefined;
             expectSameDates(element.value!, availableDateToSelect);
         });
     });
 
-    describe('Correctly dispatches the change event', () => {
+    describe('Dispatched change', () => {
         let changeSpy: sinon.SinonSpy;
         let availableDateToSelect: CalendarDate;
         let availableDayElement: HTMLElement;
 
-        before(async () => {
+        before(() => {
             changeSpy = spy();
         });
 
@@ -636,7 +647,7 @@ describe('Calendar', () => {
             changeSpy.resetHistory();
         });
 
-        it('when an available day is selected by clicking', async () => {
+        it("should dispatch 'change' when an available day is selected by clicking", async () => {
             const rect = availableDayElement.getBoundingClientRect();
             const centerX = rect.left + rect.width / 2;
             const centerY = rect.top + rect.height / 2;
@@ -658,7 +669,7 @@ describe('Calendar', () => {
             expect(changeSpy.callCount).to.equal(0);
         });
 
-        it('when an available day is selected using Enter', async () => {
+        it("should dispatch 'change' when an available day is selected using Enter", async () => {
             availableDayElement.focus();
             await sendKeys({ press: 'Enter' });
             await elementUpdated(element);
@@ -671,7 +682,7 @@ describe('Calendar', () => {
             expect(changeSpy.callCount).to.equal(0);
         });
 
-        it('when an available day is selected using Space', async () => {
+        it("should dispatch 'change' when an available day is selected using Space", async () => {
             availableDayElement.focus();
             await sendKeys({ press: 'Space' });
             await elementUpdated(element);
@@ -685,7 +696,7 @@ describe('Calendar', () => {
         });
     });
 
-    describe('Warns in dev mode', () => {
+    describe('Dev mode', () => {
         let consoleWarnStub: ReturnType<typeof stub>;
         let max: CalendarDate;
 
@@ -704,7 +715,7 @@ describe('Calendar', () => {
             consoleWarnStub.restore();
         });
 
-        it("when the pre-selected value doesn't comply", async () => {
+        it("should warn when the preselected value doesn't comply with the min-max interval", async () => {
             const value = max.set({ day: max.day + 1 });
             element = await fixtureElement({
                 props: { max, value },
@@ -716,7 +727,7 @@ describe('Calendar', () => {
                 .be.true;
         });
 
-        it('when min > max', async () => {
+        it('should warn when the min-max interval is invalid', async () => {
             const min = max.set({ day: max.day + 1 });
             element = await fixtureElement({
                 props: { min, max },
@@ -732,13 +743,11 @@ describe('Calendar', () => {
         });
     });
 
-    describe('Manages the disabled state', () => {
-        it('by disabling the next and previous month buttons', async () => {});
-        it("by not accepting focus on the calendar's days", async () => {});
-        it("by not selecting a day when it's clicked", async () => {});
+    describe('Disabled', () => {
+        it('should disable the next and previous month buttons');
+        it("should not focus the calendar's days");
+        it("should not select a day when it's clicked");
     });
 
-    it('should render localized dates', async () => {
-        // TODO
-    });
+    describe('Localized', () => {});
 });

--- a/packages/calendar/test/calendar.test.ts
+++ b/packages/calendar/test/calendar.test.ts
@@ -484,7 +484,36 @@ describe('Calendar', () => {
             expect(element.value).to.be.undefined;
         });
 
-        it("by invalidating the current value when it doesn't comply with the new interval", async () => {});
+        it("by invalidating the current value when it doesn't comply with the new interval", async () => {
+            const value = min.set({ day: min.day + 1 });
+            element = await fixtureElement({
+                props: { min, max, value },
+            });
+
+            expect(element.value).to.not.be.undefined;
+            expect(element.min).to.not.be.undefined;
+            expect(element.max).to.not.be.undefined;
+
+            const newMin = max.set({ day: max.day - 1 });
+            element.min = newMin;
+            await elementUpdated(element);
+
+            expect(element.value).to.be.undefined;
+            expect(element.min).to.not.be.undefined;
+            expectSameDates(element.min!, newMin);
+            expect(element.max).to.not.be.undefined;
+            expectSameDates(element.max!, max);
+
+            const newMax = max.set({ day: max.day + 1 });
+            element.max = newMax;
+            await elementUpdated(element);
+
+            expect(element.value).to.be.undefined;
+            expect(element.min).to.not.be.undefined;
+            expectSameDates(element.min!, newMin);
+            expect(element.max).to.not.be.undefined;
+            expectSameDates(element.max!, newMax);
+        });
 
         describe('stopping navigation when they are set', () => {
             beforeEach(async () => {

--- a/packages/calendar/test/calendar.test.ts
+++ b/packages/calendar/test/calendar.test.ts
@@ -439,8 +439,8 @@ describe('Calendar', () => {
             await elementUpdated(element);
 
             const rect = unavailableDayElement.getBoundingClientRect();
-            const centerX = rect.left + rect.width / 2;
-            const centerY = rect.top + rect.height / 2;
+            const centerX = Math.round(rect.left + rect.width / 2);
+            const centerY = Math.round(rect.top + rect.height / 2);
 
             await sendMouse({
                 type: 'click',
@@ -593,8 +593,8 @@ describe('Calendar', () => {
 
         it('should update value when an available day is clicked', async () => {
             const rect = availableDayElement.getBoundingClientRect();
-            const centerX = rect.left + rect.width / 2;
-            const centerY = rect.top + rect.height / 2;
+            const centerX = Math.round(rect.left + rect.width / 2);
+            const centerY = Math.round(rect.top + rect.height / 2);
 
             await sendMouse({
                 type: 'click',
@@ -649,8 +649,8 @@ describe('Calendar', () => {
 
         it("should dispatch 'change' when an available day is selected by clicking", async () => {
             const rect = availableDayElement.getBoundingClientRect();
-            const centerX = rect.left + rect.width / 2;
-            const centerY = rect.top + rect.height / 2;
+            const centerX = Math.round(rect.left + rect.width / 2);
+            const centerY = Math.round(rect.top + rect.height / 2);
 
             await sendMouse({
                 type: 'click',

--- a/packages/calendar/test/helpers.ts
+++ b/packages/calendar/test/helpers.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+import { isSameDay } from '@internationalized/date';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { Calendar, DateValue } from '@spectrum-web-components/calendar';
+import '@spectrum-web-components/date-time-picker/sp-date-time-picker.js';
+import '@spectrum-web-components/theme/sp-theme.js';
+import { sendKeys } from '@web/test-runner-commands';
+import { spreadProps } from '../../../test/lit-helpers.js';
+
+export async function fixtureElement({
+    locale = 'en-US',
+    props = {},
+}: {
+    locale?: string;
+    props?: { [prop: string]: unknown };
+} = {}): Promise<Calendar> {
+    const wrapped = await fixture<HTMLElement>(html`
+        <sp-theme lang=${locale} color="light" scale="medium">
+            <sp-calendar ...=${spreadProps(props)}></sp-calendar>
+        </sp-theme>
+    `);
+    const el = wrapped.querySelector('sp-calendar') as Calendar;
+    await elementUpdated(el);
+    return el;
+}
+
+export function sendKeyMultipleTimes(
+    key: string,
+    times: number
+): Promise<void[]> {
+    return Promise.all(
+        Array.from({ length: times }).map(() => sendKeys({ press: key }))
+    );
+}
+
+export function expectSameDates(a: DateValue, b: DateValue): void {
+    expect(isSameDay(a, b)).to.be.true;
+}

--- a/packages/calendar/test/helpers.ts
+++ b/packages/calendar/test/helpers.ts
@@ -43,6 +43,10 @@ export function sendKeyMultipleTimes(
     );
 }
 
-export function expectSameDates(a: DateValue, b: DateValue): void {
-    expect(isSameDay(a, b)).to.be.true;
+export function expectSameDates(
+    a: DateValue,
+    b: DateValue,
+    message?: string
+): void {
+    expect(isSameDay(a, b), message).to.be.true;
 }

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -467,7 +467,6 @@ export class DateTimePicker extends ManageHelpText(
                 </span>
             </div>
         `;
-        // asdadsaa
     }
 
     public renderLiteralSegment(segment: LiteralSegment): TemplateResult {

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -399,6 +399,7 @@ export class DateTimePicker extends ManageHelpText(
                 </span>
             </div>
         `;
+        // asdadsaa
     }
 
     public renderLiteralSegment(segment: LiteralSegment): TemplateResult {

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -72,7 +72,6 @@ import '@spectrum-web-components/popover/sp-popover.js';
 import {
     isCalendarDate,
     isCalendarDateTime,
-    isNumber,
     isZonedDateTime,
 } from './helpers.js';
 import { DateTimeSegments } from './segments/DateTimeSegments.js';
@@ -495,9 +494,7 @@ export class DateTimePicker extends ManageHelpText(
         };
 
         const segmentStyles: StyleInfo = {
-            'min-width': isNumber(segment.maxValue)
-                ? `${String(segment.maxValue).length}ch`
-                : undefined,
+            'min-width': `${String(segment.maxValue).length}ch`,
         };
 
         /**

--- a/packages/date-time-picker/src/DateTimePicker.ts
+++ b/packages/date-time-picker/src/DateTimePicker.ts
@@ -223,7 +223,6 @@ export class DateTimePicker extends ManageHelpText(
     }
 
     private checkDatesCompliance(
-        changesValue: boolean,
         changesMin: boolean,
         changesMax: boolean
     ): void {
@@ -242,7 +241,7 @@ export class DateTimePicker extends ManageHelpText(
             }
         }
 
-        if (changesValue && this.value) {
+        if (this.value) {
             const isNonCompliantValue =
                 (this.min && this.value.compare(this.min) < 0) ||
                 (this.max && this.value.compare(this.max) > 0);
@@ -272,7 +271,7 @@ export class DateTimePicker extends ManageHelpText(
         if (changesLocale || changesPrecision) this.setDateFormatter();
 
         if (changesValue || changesMin || changesMax)
-            this.checkDatesCompliance(changesValue, changesMin, changesMax);
+            this.checkDatesCompliance(changesMin, changesMax);
 
         if (changesValue || changesLocale || changesPrecision)
             this.setSegments();

--- a/packages/date-time-picker/src/date-time-picker.css
+++ b/packages/date-time-picker/src/date-time-picker.css
@@ -26,13 +26,17 @@ governing permissions and limitations under the License.
         --mod-textfield-spacing-inline,
         var(--spectrum-textfield-spacing-inline)
     );
-    --input-border: var(
+    --input-border-width: var(
         --mod-textfield-border-width,
         var(--spectrum-textfield-border-width)
     );
+    --spectrum-datepicker-input-width: var(--spectrum-textfield-width);
+    --mod-datepicker-min-width: calc(
+        var(--spectrum-datepicker-input-width) + var(--spectrum-spacing-300) +
+            var(--spectrum-spacing-75)
+    );
 
     flex-wrap: wrap;
-    min-inline-size: min-content;
 }
 
 :host #textfield {
@@ -43,10 +47,10 @@ governing permissions and limitations under the License.
 :host([quiet]) .input,
 :host([valid]) .input,
 :host([invalid]) .input {
-    inline-size: var(--spectrum-datepicker-input-width);
+    inline-size: 100%;
     padding-inline-end: calc(
         var(--status-icon-size) + var(--picker-button-size) +
-            (var(--input-spacing) - var(--input-border))
+            (var(--input-spacing) - var(--input-border-width))
     );
 }
 

--- a/packages/date-time-picker/src/date-time-picker.css
+++ b/packages/date-time-picker/src/date-time-picker.css
@@ -30,10 +30,13 @@ governing permissions and limitations under the License.
         --mod-textfield-border-width,
         var(--spectrum-textfield-border-width)
     );
+    --text-to-icon: var(
+        --mod-textfield-icon-spacing-inline-start-invalid,
+        var(--spectrum-textfield-icon-spacing-inline-start-invalid)
+    );
     --spectrum-datepicker-input-width: var(--spectrum-textfield-width);
     --mod-datepicker-min-width: calc(
-        var(--spectrum-datepicker-input-width) + var(--spectrum-spacing-300) +
-            var(--spectrum-spacing-75)
+        var(--spectrum-datepicker-initial-width) * 2 + var(--text-to-icon)
     );
 
     flex-wrap: wrap;
@@ -50,7 +53,8 @@ governing permissions and limitations under the License.
     inline-size: 100%;
     padding-inline-end: calc(
         var(--status-icon-size) + var(--picker-button-size) +
-            (var(--input-spacing) - var(--input-border-width))
+            (var(--input-spacing) - var(--input-border-width)) +
+            var(--text-to-icon)
     );
 }
 

--- a/packages/date-time-picker/src/segments/DateTimeSegments.ts
+++ b/packages/date-time-picker/src/segments/DateTimeSegments.ts
@@ -119,13 +119,14 @@ export class DateTimeSegments {
             return new CalendarDateTime(year, month, day, hour);
 
         const minute = this.minute?.value;
-        if (precision === Precisions.Minute) {
-            if (!isNumber(minute)) return;
+        if (!isNumber(minute)) return;
+
+        if (precision === Precisions.Minute)
             return new CalendarDateTime(year, month, day, hour, minute);
-        }
 
         const second = this.second?.value;
         if (!isNumber(second)) return;
+
         return new CalendarDateTime(year, month, day, hour, minute, second);
     }
 }

--- a/packages/date-time-picker/src/segments/SegmentsFactory.ts
+++ b/packages/date-time-picker/src/segments/SegmentsFactory.ts
@@ -35,7 +35,7 @@ export class SegmentsFactory {
     ): DateTimeSegments {
         const date = new Date(
             currentDate.year,
-            currentDate.month - 1,
+            currentDate.month - 1, // 0-indexed in Date but 1-indexed in ZonedDateTime
             currentDate.day,
             currentDate.hour,
             currentDate.minute,

--- a/packages/date-time-picker/src/segments/SegmentsFactory.ts
+++ b/packages/date-time-picker/src/segments/SegmentsFactory.ts
@@ -33,7 +33,15 @@ export class SegmentsFactory {
         currentDate: ZonedDateTime,
         shouldSetSegmentsValues: boolean = false
     ): DateTimeSegments {
-        const date = currentDate.toDate();
+        const date = new Date(
+            currentDate.year,
+            currentDate.month - 1,
+            currentDate.day,
+            currentDate.hour,
+            currentDate.minute,
+            currentDate.second
+        );
+
         const createdSegments = this.dateFormatter
             .formatToParts(date)
             .map((part) => {

--- a/packages/date-time-picker/stories/date-time-picker.stories.ts
+++ b/packages/date-time-picker/stories/date-time-picker.stories.ts
@@ -10,22 +10,22 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import {
+    CalendarDate,
+    CalendarDateTime,
+    toZoned,
+} from '@internationalized/date';
+import {
     css,
     html,
     TemplateResult,
     unsafeCSS,
 } from '@spectrum-web-components/base';
+import { DateValue } from '@spectrum-web-components/calendar';
 import {
     DateTimePickerValue,
     Precision,
     Precisions,
 } from '@spectrum-web-components/date-time-picker';
-import {
-    CalendarDate,
-    CalendarDateTime,
-    ZonedDateTime,
-} from '@internationalized/date';
-import { DateValue } from '@spectrum-web-components/calendar';
 
 import { spreadProps } from '../../../test/lit-helpers.js';
 
@@ -228,17 +228,9 @@ export const minAndMaxDates = (args: StoryArgs): TemplateResult => {
         <sp-date-time-picker
             ...=${spreadProps(args)}
             .value=${new CalendarDate(2022, 4, 16)}
-            .min=${new ZonedDateTime(
-                // Date
-                2022,
-                4,
-                12,
-                // Time zone and UTC offset
-                'America/Los_Angeles',
-                -28800000,
-                // Time
-                9,
-                15
+            .min=${toZoned(
+                new CalendarDateTime(2022, 4, 12, 9, 15),
+                'Europe/Bucharest'
             )}
             .max=${new CalendarDateTime(2022, 4, 19, 20, 30)}
         ></sp-date-time-picker>

--- a/packages/date-time-picker/test/date-time-picker.test.ts
+++ b/packages/date-time-picker/test/date-time-picker.test.ts
@@ -231,10 +231,6 @@ describe('DateTimePicker', () => {
                 valueZoned.timeZone,
                 'timeZone mismatch'
             );
-            expect((element.value as ZonedDateTime).offset).to.equal(
-                valueZoned.offset,
-                'offset mismatch'
-            );
         });
 
         it('should update the value as ZonedDateTime when it is the most specific date value', async () => {
@@ -257,10 +253,6 @@ describe('DateTimePicker', () => {
             expect((element.value as ZonedDateTime).timeZone).to.equal(
                 valueZoned.timeZone,
                 'timeZone mismatch'
-            );
-            expect((element.value as ZonedDateTime).offset).to.equal(
-                valueZoned.offset,
-                'offset mismatch'
             );
         });
 
@@ -768,10 +760,6 @@ describe('DateTimePicker', () => {
                     (element.value as ZonedDateTime).timeZone,
                     'timeZone mismatch'
                 ).to.equal(valueZoned.timeZone);
-                expect(
-                    (element.value as ZonedDateTime).offset,
-                    'offset mismatch'
-                ).to.equal(valueZoned.offset);
                 expect(year.innerText).to.equal('2022');
                 expect(month.innerText).to.equal('05');
                 expect(day.innerText).to.equal('15');
@@ -2898,10 +2886,6 @@ describe('DateTimePicker', () => {
             expect(element['currentDate'].timeZone).to.equal(
                 valueZoned.timeZone,
                 'timeZone mismatch'
-            );
-            expect(element['currentDate'].offset).to.equal(
-                valueZoned.offset,
-                'offset mismatch'
             );
 
             element.value = valueDate;

--- a/packages/date-time-picker/test/date-time-picker.test.ts
+++ b/packages/date-time-picker/test/date-time-picker.test.ts
@@ -13,7 +13,6 @@ governing permissions and limitations under the License.
 import {
     CalendarDate,
     CalendarDateTime,
-    isSameDay,
     ZonedDateTime,
 } from '@internationalized/date';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
@@ -2021,8 +2020,8 @@ describe('DateTimePicker', () => {
             expect(element.value).to.be.undefined;
             expect(element.min).to.not.be.undefined;
             expect(element.max).to.not.be.undefined;
-            expect(isSameDay(element.min!, min)).to.be.true;
-            expect(isSameDay(element.max!, max)).to.be.true;
+            expectSameDates(element.min!, min);
+            expectSameDates(element.max!, max);
         });
 
         it(
@@ -2056,8 +2055,11 @@ describe('DateTimePicker', () => {
                 await elementUpdated(element);
 
                 expect(element.value).to.be.instanceOf(CalendarDate);
+                expectSameDates(element.value!, value);
                 expect(element.min).to.be.instanceOf(CalendarDate);
+                expectSameDates(element.min!, min);
                 expect(element.max).to.be.instanceOf(CalendarDate);
+                expectSameDates(element.max!, max);
             });
 
             it('when the type is CalendarDateTime', async () => {
@@ -2077,8 +2079,11 @@ describe('DateTimePicker', () => {
                 });
 
                 expect(element.value).to.be.instanceOf(CalendarDateTime);
+                expectSameDates(element.value!, value);
                 expect(element.min).to.be.instanceOf(CalendarDateTime);
+                expectSameDates(element.min!, min);
                 expect(element.max).to.be.instanceOf(CalendarDateTime);
+                expectSameDates(element.max!, max);
             });
 
             it('when the type is ZonedDateTime', async () => {
@@ -2100,8 +2105,11 @@ describe('DateTimePicker', () => {
                 });
 
                 expect(element.value).to.be.instanceOf(ZonedDateTime);
+                expectSameDates(element.value!, value);
                 expect(element.min).to.be.instanceOf(ZonedDateTime);
+                expectSameDates(element.min!, min);
                 expect(element.max).to.be.instanceOf(ZonedDateTime);
+                expectSameDates(element.max!, max);
             });
         });
 
@@ -2121,8 +2129,9 @@ describe('DateTimePicker', () => {
                 });
 
                 expect(element.value).to.be.instanceOf(CalendarDateTime);
-                expect(isSameDay(element.value!, value)).to.be.true;
+                expectSameDates(element.value!, value);
                 expect(element.min).to.be.instanceOf(CalendarDateTime);
+                expectSameDates(element.min!, min);
                 expect(element.max).to.be.undefined;
             });
 
@@ -2147,8 +2156,9 @@ describe('DateTimePicker', () => {
                 });
 
                 expect(element.value).to.be.instanceOf(ZonedDateTime);
+                expectSameDates(element.value!, value);
                 expect(element.max).to.be.instanceOf(ZonedDateTime);
-                expect(isSameDay(element.max!, max)).to.be.true;
+                expectSameDates(element.max!, max);
                 expect(element.min).to.be.undefined;
             });
 
@@ -2171,8 +2181,9 @@ describe('DateTimePicker', () => {
                 });
 
                 expect(element.min).to.be.instanceOf(ZonedDateTime);
+                expectSameDates(element.min!, min);
                 expect(element.max).to.be.instanceOf(ZonedDateTime);
-                expect(isSameDay(element.max!, max)).to.be.true;
+                expectSameDates(element.max!, max);
                 expect(element.value).to.be.undefined;
             });
 
@@ -2203,9 +2214,9 @@ describe('DateTimePicker', () => {
 
                 expect(element.value).to.be.instanceOf(ZonedDateTime);
                 expect(element.min).to.be.instanceOf(ZonedDateTime);
+                expectSameDates(element.min!, min);
                 expect(element.max).to.be.instanceOf(ZonedDateTime);
-                expect(isSameDay(element.min!, min)).to.be.true;
-                expect(isSameDay(element.max!, max)).to.be.true;
+                expectSameDates(element.max!, max);
             });
         });
     });

--- a/packages/date-time-picker/test/date-time-picker.test.ts
+++ b/packages/date-time-picker/test/date-time-picker.test.ts
@@ -605,8 +605,8 @@ describe('DateTimePicker', () => {
             ) as PickerButton;
 
             const rect = calendarButton.getBoundingClientRect();
-            const centerX = rect.left + rect.width / 2;
-            const centerY = rect.top + rect.height / 2;
+            const centerX = Math.round(rect.left + rect.width / 2);
+            const centerY = Math.round(rect.top + rect.height / 2);
 
             const opened = oneEvent(element, 'sp-opened');
             await sendMouse({

--- a/packages/date-time-picker/test/date-time-picker.test.ts
+++ b/packages/date-time-picker/test/date-time-picker.test.ts
@@ -14,6 +14,7 @@ import {
     CalendarDate,
     CalendarDateTime,
     getLocalTimeZone,
+    toZoned,
     ZonedDateTime,
 } from '@internationalized/date';
 import {
@@ -26,6 +27,7 @@ import {
 import { Calendar } from '@spectrum-web-components/calendar';
 import {
     DateTimePicker,
+    DateTimePickerValue,
     EditableSegmentType,
     Precisions,
     SegmentTypes,
@@ -53,8 +55,11 @@ describe('DateTimePicker', () => {
     const fixedYear = 2022;
     const fixedMonth = 5;
     const fixedDay = 15;
+    let valueDateTime: CalendarDateTime;
+    let valueZoned: ZonedDateTime;
+    let valueDate: CalendarDate;
 
-    before(async () => {
+    before(() => {
         const fixedTime = new Date(
             fixedYear,
             fixedMonth - 1, // 0-indexed in Date but 1-indexed in CalendarDate
@@ -62,11 +67,29 @@ describe('DateTimePicker', () => {
             15
         ).getTime();
         Date.now = () => fixedTime;
+        valueDate = new CalendarDate(fixedYear, fixedMonth, fixedDay);
+        valueDateTime = new CalendarDateTime(
+            fixedYear,
+            fixedMonth,
+            fixedDay,
+            15,
+            15,
+            15
+        );
+        valueZoned = new ZonedDateTime(
+            fixedYear,
+            fixedMonth,
+            fixedDay,
+            'America/Los_Angeles',
+            -28800000,
+            9,
+            15,
+            30
+        );
     });
 
     beforeEach(async () => {
         element = await fixtureElement();
-        await elementUpdated(element);
         editableSegments = getEditableSegments(element);
     });
 
@@ -86,41 +109,165 @@ describe('DateTimePicker', () => {
         await expect(element).to.be.accessible();
     });
 
-    describe.only('Manages the value', () => {
-        describe('by defining it only when all segments are defined', () => {
-            Object.values(Precisions).forEach((precision) => {
-                it(`on '${precision}' precision`, async () => {
-                    element = await fixtureElement({
-                        props: { precision },
-                    });
-                    await elementUpdated(element);
-                    editableSegments = getEditableSegments(element);
-
-                    expect(element.value).to.be.undefined;
-
-                    while (editableSegments.length > 0) {
-                        const segment = editableSegments.shift()!;
-                        segment.focus();
-
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-
-                        if (editableSegments.length > 0)
-                            expect(element.value).to.be.undefined;
-                    }
-
-                    expect(element.value).to.not.be.undefined;
+    describe('Value property', () => {
+        Object.values(Precisions).forEach((precision) => {
+            it(`should define value only when all segments are defined - '${precision}' precision`, async () => {
+                element = await fixtureElement({
+                    props: { precision },
                 });
+                editableSegments = getEditableSegments(element);
+
+                expect(element.value).to.be.undefined;
+
+                while (editableSegments.length > 0) {
+                    const segment = editableSegments.shift()!;
+                    segment.focus();
+
+                    await sendKeys({ press: 'ArrowUp' });
+                    await elementUpdated(element);
+
+                    if (editableSegments.length > 0)
+                        expect(element.value).to.be.undefined;
+                }
+
+                expect(element.value).to.not.be.undefined;
             });
         });
 
-        it('by being a CalendarDate when precision is Day', async () => {
-            element = await fixtureElement({
-                props: {
-                    precision: Precisions.Day,
-                },
-            });
+        it('should define the value as CalendarDate when it is the most specific date value', async () => {
+            element = await fixtureElement({ props: { min: valueDate } });
+            editableSegments = getEditableSegments(element);
+
+            while (editableSegments.length > 0) {
+                const segment = editableSegments.shift()!;
+                segment.focus();
+
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+            }
+
+            expectSameDates(element.value!, new CalendarDate(fixedYear, 1, 1));
+            expect(
+                element.value,
+                'value not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+        });
+
+        it('should update the value as CalendarDate when it is the most specific date value', async () => {
+            element = await fixtureElement({ props: { value: valueDate } });
+            editableSegments = getEditableSegments(element);
+
+            const year = editableSegments.getByType(SegmentTypes.Year);
+            year.focus();
+            await sendKeys({ type: '1032' });
             await elementUpdated(element);
+
+            expectSameDates(
+                element.value!,
+                new CalendarDate(1032, valueDate.month, valueDate.day)
+            );
+            expect(
+                element.value!,
+                'value not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+        });
+
+        it('should define the value as CalendarDateTime when it is the most specific date value', async () => {
+            element = await fixtureElement({ props: { min: valueDateTime } });
+            editableSegments = getEditableSegments(element);
+
+            while (editableSegments.length > 0) {
+                const segment = editableSegments.shift()!;
+                segment.focus();
+
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+            }
+
+            expectSameDates(element.value!, new CalendarDate(fixedYear, 1, 1));
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+        });
+
+        it('should update the value as CalendarDateTime when it is the most specific date value', async () => {
+            element = await fixtureElement({ props: { value: valueDateTime } });
+            editableSegments = getEditableSegments(element);
+
+            const year = editableSegments.getByType(SegmentTypes.Year);
+            year.focus();
+            await sendKeys({ type: '1032' });
+            await elementUpdated(element);
+
+            expectSameDates(
+                element.value!,
+                new CalendarDate(1032, valueDateTime.month, valueDateTime.day)
+            );
+            expect(
+                element.value!,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+        });
+
+        it('should define the value as ZonedDateTime when it is the most specific date value', async () => {
+            element = await fixtureElement({ props: { min: valueZoned } });
+            editableSegments = getEditableSegments(element);
+
+            while (editableSegments.length > 0) {
+                const segment = editableSegments.shift()!;
+                segment.focus();
+
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+            }
+
+            expectSameDates(element.value!, new CalendarDate(fixedYear, 1, 1));
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expect((element.value as ZonedDateTime).timeZone).to.equal(
+                valueZoned.timeZone,
+                'timeZone mismatch'
+            );
+            expect((element.value as ZonedDateTime).offset).to.equal(
+                valueZoned.offset,
+                'offset mismatch'
+            );
+        });
+
+        it('should update the value as ZonedDateTime when it is the most specific date value', async () => {
+            element = await fixtureElement({ props: { value: valueZoned } });
+            editableSegments = getEditableSegments(element);
+
+            const year = editableSegments.getByType(SegmentTypes.Year);
+            year.focus();
+            await sendKeys({ type: '1032' });
+            await elementUpdated(element);
+
+            expectSameDates(
+                element.value!,
+                new CalendarDate(1032, valueZoned.month, valueZoned.day)
+            );
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expect((element.value as ZonedDateTime).timeZone).to.equal(
+                valueZoned.timeZone,
+                'timeZone mismatch'
+            );
+            expect((element.value as ZonedDateTime).offset).to.equal(
+                valueZoned.offset,
+                'offset mismatch'
+            );
+        });
+
+        it("should define the value as CalendarDate when no date property is provided and precision is 'day'", async () => {
+            element = await fixtureElement({
+                props: { precision: Precisions.Day },
+            });
             editableSegments = getEditableSegments(element);
 
             const year = editableSegments.getByType(SegmentTypes.Year);
@@ -136,25 +283,157 @@ describe('DateTimePicker', () => {
             await elementUpdated(element);
 
             expectSameDates(element.value!, new CalendarDate(2022, 5, 4));
-            expect(element.value).to.be.instanceOf(CalendarDate);
+            expect(
+                element.value,
+                'value not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
 
             month.focus();
             await sendKeys({ type: '6' });
             await elementUpdated(element);
 
             expectSameDates(element.value!, new CalendarDate(2022, 6, 4));
-            expect(element.value).to.be.instanceOf(CalendarDate);
+            expect(
+                element.value,
+                'value not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+        });
+
+        it('should update the value as CalendarDate when no date property is provided and precision is Day', async () => {
+            element = await fixtureElement({
+                props: { precision: Precisions.Day },
+            });
+            editableSegments = getEditableSegments(element);
+            const month = editableSegments.getByType(SegmentTypes.Month);
+
+            // set the value
+            while (editableSegments.length > 0) {
+                const segment = editableSegments.shift()!;
+                segment.focus();
+
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+            }
+
+            // update the value
+            month.focus();
+            await sendKeys({ type: '5' });
+            await elementUpdated(element);
+
+            expectSameDates(element.value!, new CalendarDate(fixedYear, 5, 1));
+            expect(
+                element.value,
+                'value not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+        });
+
+        it('should define the value as CalendarDateTime when CalendarDate is provided and precision includes time', async () => {
+            element = await fixtureElement({
+                props: { precision: Precisions.Second, min: valueDate },
+            });
+            editableSegments = getEditableSegments(element);
+
+            // set the value
+            while (editableSegments.length > 0) {
+                const segment = editableSegments.shift()!;
+                segment.focus();
+
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+            }
+
+            expectSameDates(
+                element.value!,
+                new CalendarDateTime(fixedYear, 1, 1)
+            );
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+        });
+
+        it('should update the value as CalendarDateTime when CalendarDate is provided and precision includes time', async () => {
+            element = await fixtureElement({
+                props: { precision: Precisions.Second, min: valueDate },
+            });
+            editableSegments = getEditableSegments(element);
+            const month = editableSegments.getByType(SegmentTypes.Month);
+
+            // set the value
+            while (editableSegments.length > 0) {
+                const segment = editableSegments.shift()!;
+                segment.focus();
+
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+            }
+
+            // update the value
+            month.focus();
+            await sendKeys({ type: '5' });
+            await elementUpdated(element);
+
+            expectSameDates(
+                element.value!,
+                new CalendarDateTime(fixedYear, 5, 1, 0, 0, 0)
+            );
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+        });
+
+        it('should define the value as CalendarDateTime when no date property nor precision is provided', async () => {
+            element = await fixtureElement();
+            editableSegments = getEditableSegments(element);
+
+            while (editableSegments.length > 0) {
+                const segment = editableSegments.shift()!;
+                segment.focus();
+
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+            }
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+        });
+
+        it('should update the value as CalendarDateTime when no date property nor precision is provided', async () => {
+            element = await fixtureElement();
+            editableSegments = getEditableSegments(element);
+            const month = editableSegments.getByType(SegmentTypes.Month);
+
+            // set the value
+            while (editableSegments.length > 0) {
+                const segment = editableSegments.shift()!;
+                segment.focus();
+
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+            }
+
+            // update the value
+            month.focus();
+            await sendKeys({ type: '5' });
+            await elementUpdated(element);
+
+            expectSameDates(
+                element.value!,
+                new CalendarDateTime(fixedYear, 5, 1, 0, 0, 0)
+            );
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
         });
 
         [Precisions.Hour, Precisions.Minute, Precisions.Second].forEach(
             (precision) => {
-                it(`by being a CalendarDateTime when precision is ${precision}`, async () => {
-                    element = await fixtureElement({
-                        props: {
-                            precision,
-                        },
-                    });
-                    await elementUpdated(element);
+                it(`should define and update the value as CalendarDateTime when no date property is provided and precision is ${precision}`, async () => {
+                    element = await fixtureElement({ props: { precision } });
                     editableSegments = getEditableSegments(element);
                     const month = editableSegments.getByType(
                         SegmentTypes.Month
@@ -172,7 +451,10 @@ describe('DateTimePicker', () => {
                         element.value!,
                         new CalendarDateTime(fixedYear, 1, 1, 0, 0, 0)
                     );
-                    expect(element.value).to.be.instanceOf(CalendarDateTime);
+                    expect(
+                        element.value,
+                        'value not an instance of CalendarDateTime'
+                    ).to.be.instanceOf(CalendarDateTime);
 
                     month.focus();
                     await sendKeys({ type: '5' });
@@ -181,181 +463,132 @@ describe('DateTimePicker', () => {
                         element.value!,
                         new CalendarDateTime(fixedYear, 5, 1, 0, 0, 0)
                     );
-                    expect(element.value).to.be.instanceOf(CalendarDateTime);
+                    expect(
+                        element.value,
+                        'value not an instance of CalendarDateTime'
+                    ).to.be.instanceOf(CalendarDateTime);
                 });
             }
         );
 
-        it('by being a ZonedDateTime when it is the most specific date value', async () => {
-            const timeZone = 'America/Los_Angeles';
-            const offset = -28800000;
-            element = await fixtureElement({
-                locale: 'en-GB',
-                props: {
-                    precision: Precisions.Minute,
-                    min: new ZonedDateTime(2000, 1, 10, timeZone, offset),
-                    max: new CalendarDateTime(3000, 12, 20, 15, 15, 15),
-                },
-            });
-            await elementUpdated(element);
-            editableSegments = getEditableSegments(element);
-            const month = editableSegments.getByType(SegmentTypes.Month);
-
-            while (editableSegments.length > 0) {
-                const segment = editableSegments.shift()!;
-                segment.focus();
-
-                await sendKeys({ press: 'ArrowUp' });
-                await elementUpdated(element);
-            }
-
-            expectSameDates(
-                element.value!,
-                new ZonedDateTime(fixedYear, 1, 1, timeZone, offset)
-            );
-            expect(element.value).to.be.instanceOf(ZonedDateTime);
-
-            month.focus();
-            await sendKeys({ type: '5' });
-            await elementUpdated(element);
-            expectSameDates(
-                element.value!,
-                new ZonedDateTime(fixedYear, 5, 1, timeZone, offset)
-            );
-            expect(element.value).to.be.instanceOf(ZonedDateTime);
-        });
-
-        describe('by updating it on a 24h format', () => {
-            const dateValue = new CalendarDateTime(2022, 5, 15, 15, 15, 15);
-
-            beforeEach(async () => {
+        [
+            SegmentTypes.Year,
+            SegmentTypes.Month,
+            SegmentTypes.Day,
+            SegmentTypes.Hour,
+            SegmentTypes.Minute,
+            SegmentTypes.Second,
+        ].forEach((segmentType) => {
+            it(`should update the value when the ${segmentType} segment is changed on a 24h format`, async () => {
                 element = await fixtureElement({
                     locale: 'en-GB',
-                    props: { precision: Precisions.Second, value: dateValue },
+                    props: {
+                        precision: Precisions.Second,
+                        value: valueDateTime,
+                    },
                 });
                 editableSegments = getEditableSegments(element);
-            });
+                const segment = editableSegments.getByType(segmentType);
 
-            [
-                SegmentTypes.Year,
-                SegmentTypes.Month,
-                SegmentTypes.Day,
-                SegmentTypes.Hour,
-                SegmentTypes.Minute,
-                SegmentTypes.Second,
-            ].forEach((segmentType) => {
-                it(`when the ${segmentType} segment is changed`, async () => {
-                    const segment = editableSegments.getByType(segmentType);
-
-                    segment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-
-                    expectSameDates(
-                        element.value!,
-                        dateValue.set({
-                            [segmentType]: dateValue[segmentType] + 1,
-                        })
-                    );
-                });
-            });
-        });
-
-        describe('by updating it on a 12h format', () => {
-            const dateValue = new CalendarDateTime(2022, 5, 15, 5, 15, 15);
-
-            beforeEach(async () => {
-                element = await fixtureElement({
-                    props: { precision: Precisions.Second, value: dateValue },
-                });
-                editableSegments = getEditableSegments(element);
-            });
-
-            [
-                SegmentTypes.Year,
-                SegmentTypes.Month,
-                SegmentTypes.Day,
-                SegmentTypes.Hour,
-                SegmentTypes.Minute,
-                SegmentTypes.Second,
-            ].forEach((segmentType) => {
-                it(`when the ${segmentType} segment is changed`, async () => {
-                    const segment = editableSegments.getByType(segmentType);
-
-                    segment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-
-                    expectSameDates(
-                        element.value!,
-                        dateValue.set({
-                            [segmentType]: dateValue[segmentType] + 1,
-                        })
-                    );
-                });
-            });
-
-            it('when the dayPeriod segment is changed', async () => {
-                const dayPeriodSegment = editableSegments.getByType(
-                    SegmentTypes.DayPeriod
-                );
-
-                dayPeriodSegment.focus();
+                segment.focus();
                 await sendKeys({ press: 'ArrowUp' });
                 await elementUpdated(element);
 
                 expectSameDates(
                     element.value!,
-                    dateValue.set({
-                        hour: dateValue.hour! + 12,
+                    valueDateTime.set({
+                        [segmentType]: valueDateTime[segmentType] + 1,
+                    })
+                );
+            });
+
+            it(`should update the value when the ${segmentType} segment is changed on a 12h format`, async () => {
+                element = await fixtureElement({
+                    props: {
+                        precision: Precisions.Second,
+                        value: valueDateTime,
+                    },
+                });
+                editableSegments = getEditableSegments(element);
+                const segment = editableSegments.getByType(segmentType);
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expectSameDates(
+                    element.value!,
+                    valueDateTime.set({
+                        [segmentType]: valueDateTime[segmentType] + 1,
                     })
                 );
             });
         });
 
-        describe('by clearing it and the segments ', () => {
-            it('when a full value is defined/ all segments have a value', async () => {
-                element = await fixtureElement({
-                    props: {
-                        value: new CalendarDateTime(2022, 5, 15, 15, 15, 15),
-                    },
-                });
-                await elementUpdated(element);
+        it('should update the value when the dayPeriod segment is changed', async () => {
+            element = await fixtureElement({
+                props: {
+                    precision: Precisions.Second,
+                    value: valueDateTime,
+                },
+            });
+            editableSegments = getEditableSegments(element);
+            const dayPeriodSegment = editableSegments.getByType(
+                SegmentTypes.DayPeriod
+            );
 
-                element.clear();
-                await elementUpdated(element);
+            dayPeriodSegment.focus();
+            await sendKeys({ press: 'ArrowUp' });
+            await elementUpdated(element);
 
-                expect(element.value).to.be.undefined;
-                expectPlaceholders(getEditableSegments(element));
+            expectSameDates(
+                element.value!,
+                valueDateTime.set({
+                    hour: (valueDateTime.hour! + 12) % 24,
+                })
+            );
+        });
+
+        it('should clear the value and the segments when the clear method is called with a fully defined value', async () => {
+            element = await fixtureElement({
+                props: {
+                    value: valueDateTime,
+                },
             });
 
-            it('when not all segments have a value', async () => {
-                const year = editableSegments.getByType(SegmentTypes.Year);
-                const minute = editableSegments.getByType(SegmentTypes.Minute);
+            element.clear();
+            await elementUpdated(element);
 
-                year.focus();
-                await sendKeys({ press: 'ArrowUp' });
-                minute.focus();
-                await sendKeys({ press: 'ArrowUp' });
+            expect(element.value).to.be.undefined;
+            expectPlaceholders(getEditableSegments(element));
+        });
 
-                expect(element.value).to.be.undefined;
-                expectPlaceholders(editableSegments, [year, minute]);
+        it('should clear the value and the segments when the clear method is called with a partially defined value', async () => {
+            const year = editableSegments.getByType(SegmentTypes.Year);
+            const minute = editableSegments.getByType(SegmentTypes.Minute);
 
-                element.clear();
-                await elementUpdated(element);
+            year.focus();
+            await sendKeys({ press: 'ArrowUp' });
+            minute.focus();
+            await sendKeys({ press: 'ArrowUp' });
 
-                expect(element.value).to.be.undefined;
-                expectPlaceholders(editableSegments);
-            });
+            expect(element.value).to.be.undefined;
+            expectPlaceholders(editableSegments, [year, minute]);
+
+            element.clear();
+            await elementUpdated(element);
+
+            expect(element.value).to.be.undefined;
+            expectPlaceholders(editableSegments);
         });
     });
 
-    describe('Manages the calendar', () => {
-        it('by displaying the component with the calendar closed by default', () => {
+    describe('Calendar', () => {
+        it('should have the calendar closed by default', () => {
             expect(element['isCalendarOpen']).to.be.false;
         });
 
-        it('opening and closing it using the keyboard', async () => {
+        it('should open and close the calendar using the keyboard', async () => {
             const calendarButton = element.shadowRoot!.querySelector(
                 'sp-picker-button'
             ) as PickerButton;
@@ -374,7 +607,7 @@ describe('DateTimePicker', () => {
             expect(element['isCalendarOpen']).to.be.false;
         });
 
-        it('opening and closing it using the pointer', async () => {
+        it('should open and close the calendar using the pointer', async () => {
             const calendarButton = element.shadowRoot!.querySelector(
                 'sp-picker-button'
             ) as PickerButton;
@@ -402,7 +635,7 @@ describe('DateTimePicker', () => {
             expect(element['isCalendarOpen']).to.be.false;
         });
 
-        it('passing the value and min/max constraints', async () => {
+        it('should pass the value and min/max constraints to the calendar', async () => {
             const min = new CalendarDateTime(2022, 5, 1, 15, 30, 20);
             const max = new CalendarDate(2022, 5, 31);
             const value = new CalendarDate(2022, 5, 15);
@@ -414,268 +647,766 @@ describe('DateTimePicker', () => {
                     value,
                 },
             });
-            await elementUpdated(element);
 
             const calendarEl = element.shadowRoot!.querySelector(
                 'sp-calendar'
             ) as Calendar;
 
-            expectSameDates(calendarEl.min!, element.min!);
-            expectSameDates(calendarEl.max!, element.max!);
-            expectSameDates(calendarEl.value!, element.value!);
+            expectSameDates(calendarEl.min!, element.min!, 'min mismatch');
+            expectSameDates(calendarEl.max!, element.max!, 'max mismatch');
+            expectSameDates(
+                calendarEl.value!,
+                element.value!,
+                'value mismatch'
+            );
         });
 
-        describe("handling the 'change' event", () => {
-            it('by closing the calendar', async () => {
+        describe('change event', () => {
+            it('should close the calendar when handling its change event', async () => {
                 await openCalendar(element);
                 expect(element['isCalendarOpen']).to.be.true;
 
                 const closed = oneEvent(element, 'sp-closed');
-                dispatchCalendarChange(element, new CalendarDate(2022, 5, 15));
+                await dispatchCalendarChange(
+                    element,
+                    new CalendarDate(2022, 5, 15)
+                );
                 await closed;
 
                 expect(element['isCalendarOpen']).to.be.false;
             });
 
-            it('by updating the value with the CalendarDate type', async () => {
+            it('should update the value as CalendarDate when its the most specific date value', async () => {
                 element = await fixtureElement({
-                    props: { precision: Precisions.Day },
+                    props: { min: new CalendarDate(1000, 3, 10) },
                 });
-                await elementUpdated(element);
                 editableSegments = getEditableSegments(element);
-                await openCalendar(element);
-
-                const calendarValue = new CalendarDate(2022, 5, 15);
-                dispatchCalendarChange(element, calendarValue);
-                await elementUpdated(element);
-
-                expectSameDates(element.value!, calendarValue);
-                expect(element.value!).to.be.instanceOf(CalendarDate);
-
                 const year = editableSegments.getByType(SegmentTypes.Year);
                 const month = editableSegments.getByType(SegmentTypes.Month);
                 const day = editableSegments.getByType(SegmentTypes.Day);
+                await openCalendar(element);
+
+                const calendarValue = new CalendarDate(2022, 5, 15);
+                await dispatchCalendarChange(element, calendarValue);
+
+                expectSameDates(element.value!, calendarValue);
+                expect(
+                    element.value!,
+                    'value not an instance of CalendarDate'
+                ).to.be.instanceOf(CalendarDate);
 
                 expect(year.innerText).to.equal('2022');
                 expect(month.innerText).to.equal('05');
                 expect(day.innerText).to.equal('15');
             });
 
-            it('by updating the value with the CalendarDateTime type including user-selected time values', async () => {
+            it('should update the value as CalendarDateTime when its the most specific date value', async () => {
                 element = await fixtureElement({
-                    locale: 'en-GB',
-                    props: { precision: Precisions.Second },
+                    props: { min: new CalendarDateTime(1000, 3, 10) },
                 });
-                await elementUpdated(element);
                 editableSegments = getEditableSegments(element);
+
                 const year = editableSegments.getByType(SegmentTypes.Year);
                 const month = editableSegments.getByType(SegmentTypes.Month);
                 const day = editableSegments.getByType(SegmentTypes.Day);
                 const hour = editableSegments.getByType(SegmentTypes.Hour);
                 const minute = editableSegments.getByType(SegmentTypes.Minute);
-                const second = editableSegments.getByType(SegmentTypes.Second);
-
                 hour.focus();
-                await sendKeys({ type: '14' });
-                await elementUpdated(element);
-
+                await sendKeys({ type: '5' });
                 await openCalendar(element);
+
                 const calendarValue = new CalendarDate(2022, 5, 15);
-                dispatchCalendarChange(element, calendarValue);
-                await elementUpdated(element);
+                await dispatchCalendarChange(element, calendarValue);
 
                 expectSameDates(element.value!, calendarValue);
-                expect(element.value!).to.be.instanceOf(CalendarDateTime);
+                expect(
+                    element.value!,
+                    'value not an instance of CalendarDateTime'
+                ).to.be.instanceOf(CalendarDateTime);
+
                 expect(year.innerText).to.equal('2022');
                 expect(month.innerText).to.equal('05');
                 expect(day.innerText).to.equal('15');
-                expect(hour.innerText).to.equal('14');
+                expect(hour.innerText).to.equal('05');
                 expect(minute.innerText).to.equal('00');
-                expect(second.innerText).to.equal('00');
+                expect((element.value! as CalendarDateTime).hour).to.equal(5);
+                expect((element.value! as CalendarDateTime).minute).to.equal(0);
+                expect((element.value! as CalendarDateTime).second).to.equal(0);
             });
 
-            it('by updating the value with the ZonedDateTime type including user-selected time values', async () => {
-                const timeZone = 'America/Los_Angeles';
+            it('should update the value as ZonedDateTime when its the most specific date value', async () => {
                 element = await fixtureElement({
-                    locale: 'en-GB',
                     props: {
-                        precision: Precisions.Second,
                         min: new ZonedDateTime(
-                            2022,
-                            5,
-                            15,
-                            timeZone,
-                            -28800000
+                            1000,
+                            3,
+                            10,
+                            valueZoned.timeZone,
+                            valueZoned.offset
                         ),
                     },
                 });
-                await elementUpdated(element);
                 editableSegments = getEditableSegments(element);
                 const year = editableSegments.getByType(SegmentTypes.Year);
                 const month = editableSegments.getByType(SegmentTypes.Month);
                 const day = editableSegments.getByType(SegmentTypes.Day);
                 const hour = editableSegments.getByType(SegmentTypes.Hour);
                 const minute = editableSegments.getByType(SegmentTypes.Minute);
-                const second = editableSegments.getByType(SegmentTypes.Second);
-                minute.focus();
-                await sendKeys({ type: '36' });
-                await elementUpdated(element);
-
+                hour.focus();
+                await sendKeys({ type: '5' });
                 await openCalendar(element);
-                const calendarValue = new CalendarDate(2022, 5, 20);
-                dispatchCalendarChange(element, calendarValue);
-                await elementUpdated(element);
+
+                const calendarValue = new CalendarDate(2022, 5, 15);
+                await dispatchCalendarChange(element, calendarValue);
 
                 expectSameDates(element.value!, calendarValue);
-                expect(element.value!).to.be.instanceOf(ZonedDateTime);
+                expect(
+                    element.value!,
+                    'value not an instance of ZonedDateTime'
+                ).to.be.instanceOf(ZonedDateTime);
+                expect(
+                    (element.value as ZonedDateTime).timeZone,
+                    'timeZone mismatch'
+                ).to.equal(valueZoned.timeZone);
+                expect(
+                    (element.value as ZonedDateTime).offset,
+                    'offset mismatch'
+                ).to.equal(valueZoned.offset);
                 expect(year.innerText).to.equal('2022');
                 expect(month.innerText).to.equal('05');
-                expect(day.innerText).to.equal('20');
-                expect(hour.innerText).to.equal('00');
-                expect(minute.innerText).to.equal('36');
-                expect(second.innerText).to.equal('00');
-                expect((element.value! as ZonedDateTime).timeZone).to.equal(
-                    timeZone
-                );
+                expect(day.innerText).to.equal('15');
+                expect(hour.innerText).to.equal('05');
+                expect(minute.innerText).to.equal('00');
+                expect((element.value! as ZonedDateTime).hour).to.equal(5);
+                expect((element.value! as ZonedDateTime).minute).to.equal(0);
+                expect((element.value! as ZonedDateTime).second).to.equal(0);
+            });
+
+            it("should update the value as CalendarDate when no date property is provided and precision is 'day'", async () => {
+                element = await fixtureElement({
+                    props: { precision: Precisions.Day },
+                });
+                editableSegments = getEditableSegments(element);
+                const year = editableSegments.getByType(SegmentTypes.Year);
+                const month = editableSegments.getByType(SegmentTypes.Month);
+                const day = editableSegments.getByType(SegmentTypes.Day);
+                await openCalendar(element);
+
+                const calendarValue = new CalendarDate(2022, 5, 15);
+                await dispatchCalendarChange(element, calendarValue);
+
+                expectSameDates(element.value!, calendarValue);
+                expect(
+                    element.value!,
+                    'value not an instance of CalendarDate'
+                ).to.be.instanceOf(CalendarDate);
+
+                expect(year.innerText).to.equal('2022');
+                expect(month.innerText).to.equal('05');
+                expect(day.innerText).to.equal('15');
+            });
+
+            it('should update the value as CalendarDateTime when CalendarDate is provided and precision includes time', async () => {
+                element = await fixtureElement({
+                    props: { min: valueDate, precision: Precisions.Second },
+                });
+                editableSegments = getEditableSegments(element);
+                const year = editableSegments.getByType(SegmentTypes.Year);
+                const month = editableSegments.getByType(SegmentTypes.Month);
+                const day = editableSegments.getByType(SegmentTypes.Day);
+                const hour = editableSegments.getByType(SegmentTypes.Hour);
+                const minute = editableSegments.getByType(SegmentTypes.Minute);
+                hour.focus();
+                await sendKeys({ type: '5' });
+                await openCalendar(element);
+
+                const calendarValue = new CalendarDate(2022, 5, 15);
+                await dispatchCalendarChange(element, calendarValue);
+
+                expectSameDates(element.value!, calendarValue);
+                expect(
+                    element.value!,
+                    'value not an instance of CalendarDateTime'
+                ).to.be.instanceOf(CalendarDateTime);
+
+                expect(year.innerText).to.equal('2022');
+                expect(month.innerText).to.equal('05');
+                expect(day.innerText).to.equal('15');
+                expect(hour.innerText).to.equal('05');
+                expect(minute.innerText).to.equal('00');
+                expect((element.value! as CalendarDateTime).hour).to.equal(5);
+                expect((element.value! as CalendarDateTime).minute).to.equal(0);
+                expect((element.value! as CalendarDateTime).second).to.equal(0);
+            });
+
+            it('should update the value as CalendarDateTime when no date property nor precision is provided', async () => {
+                element = await fixtureElement();
+                editableSegments = getEditableSegments(element);
+                const year = editableSegments.getByType(SegmentTypes.Year);
+                const month = editableSegments.getByType(SegmentTypes.Month);
+                const day = editableSegments.getByType(SegmentTypes.Day);
+                const hour = editableSegments.getByType(SegmentTypes.Hour);
+                const minute = editableSegments.getByType(SegmentTypes.Minute);
+                hour.focus();
+                await sendKeys({ type: '3' });
+                await openCalendar(element);
+
+                const calendarValue = new CalendarDate(2022, 5, 15);
+                await dispatchCalendarChange(element, calendarValue);
+
+                expectSameDates(element.value!, calendarValue);
+                expect(
+                    element.value!,
+                    'value not an instance of CalendarDateTime'
+                ).to.be.instanceOf(CalendarDateTime);
+
+                expect(year.innerText).to.equal('2022');
+                expect(month.innerText).to.equal('05');
+                expect(day.innerText).to.equal('15');
+                expect(hour.innerText).to.equal('03');
+                expect(minute.innerText).to.equal('00');
+                expect((element.value! as CalendarDateTime).hour).to.equal(3);
+                expect((element.value! as CalendarDateTime).minute).to.equal(0);
+                expect((element.value! as CalendarDateTime).second).to.equal(0);
+            });
+
+            it('should update the value as CalendarDateTime when no date property is provided and precision includes time', async () => {
+                element = await fixtureElement({
+                    props: { precision: Precisions.Second },
+                });
+                editableSegments = getEditableSegments(element);
+                const year = editableSegments.getByType(SegmentTypes.Year);
+                const month = editableSegments.getByType(SegmentTypes.Month);
+                const day = editableSegments.getByType(SegmentTypes.Day);
+                const hour = editableSegments.getByType(SegmentTypes.Hour);
+                const minute = editableSegments.getByType(SegmentTypes.Minute);
+                hour.focus();
+                await sendKeys({ type: '5' });
+                await openCalendar(element);
+
+                const calendarValue = new CalendarDate(2022, 5, 15);
+                await dispatchCalendarChange(element, calendarValue);
+
+                expectSameDates(element.value!, calendarValue);
+                expect(
+                    element.value!,
+                    'value not an instance of CalendarDateTime'
+                ).to.be.instanceOf(CalendarDateTime);
+
+                expect(year.innerText).to.equal('2022');
+                expect(month.innerText).to.equal('05');
+                expect(day.innerText).to.equal('15');
+                expect(hour.innerText).to.equal('05');
+                expect(minute.innerText).to.equal('00');
+                expect((element.value! as CalendarDateTime).hour).to.equal(5);
+                expect((element.value! as CalendarDateTime).minute).to.equal(0);
+                expect((element.value! as CalendarDateTime).second).to.equal(0);
             });
         });
     });
 
-    // TODO: with the precision update PR
-    describe('Correctly creates segments according to precision', () => {
-        describe("when precision is 'day'", async () => {
-            it('showing placeholders when no preselected value is provided');
-            it('showing the correct preselected value');
-        });
-
-        describe('on a 12h format', () => {
-            describe("when precision is 'hour'", async () => {
-                it(
-                    'showing placeholders when no preselected value is provided'
-                );
-                it('showing the correct preselected value');
-            });
-            describe("when precision is 'minute'", async () => {
-                it(
-                    'showing placeholders when no preselected value is provided'
-                );
-                it('showing the correct preselected value');
-            });
-            describe("when precision is 'second'", async () => {
-                it(
-                    'showing placeholders when no preselected value is provided'
-                );
-                it('showing the correct preselected value');
-            });
-        });
-
-        describe('on a 24h format', () => {
-            describe("when precision is 'hour'", async () => {
-                it(
-                    'showing placeholders when no preselected value is provided'
-                );
-                it('showing the correct preselected value');
-            });
-            describe("when precision is 'minute'", async () => {
-                it(
-                    'showing placeholders when no preselected value is provided'
-                );
-                it('showing the correct preselected value');
-            });
-            describe("when precision is 'second'", async () => {
-                it(
-                    'showing placeholders when no preselected value is provided'
-                );
-                it('showing the correct preselected value');
-            });
-        });
-    });
-
-    describe("Correctly manages subcomponents' focus", () => {
-        describe('focusing segments', () => {
-            it('by pointer');
-            it('by keyboard using the right arrow key');
-            it('by keyboard using the left arrow key');
-            it('by keyboard using the delete/backspace key on a placeholder');
-            it('when a date is selected using the calendar');
-        });
-
+    describe('Focus', () => {
+        it('should focus segments by clicking on them');
+        it(
+            "should change segment focus to right by using the 'Right Arrow' key"
+        );
+        it("should change segment focus to left by using the 'Left Arrow' key");
+        it(
+            'should change segment focus to left by using the Backspace/Delete key on a placeholder'
+        );
         // TODO: one TAB press should focus the calendar button, not the next segment
-        it("focusing the calendar's button");
+        it("should focus the calendar button by using the 'Tab' key");
+        it('should focus the calendar button after the Calendar closes');
     });
 
-    describe('Changes the values of the segments', () => {
+    describe('ArrowUp key', () => {
         beforeEach(async () => {
             element = await fixtureElement({
                 props: { precision: Precisions.Second },
             });
-            await elementUpdated(element);
-
             editableSegments = getEditableSegments(element);
         });
 
-        describe('using the up arrow key', () => {
-            it("defining the year segment's value", async () => {
+        it("should define the year segment's value on ArrowUp key", async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Year);
+
+            segment.focus();
+            await sendKeys({ press: 'ArrowUp' });
+            await elementUpdated(element);
+
+            expect(segment.innerText).to.equal(`${fixedYear}`);
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it("should increment the year segment's value on ArrowUp key", async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Year);
+
+            segment.focus();
+            await sendKeys({ press: 'ArrowUp' });
+            await sendKeys({ press: 'ArrowUp' });
+            await sendKeys({ press: 'ArrowUp' });
+            await elementUpdated(element);
+
+            expect(segment.innerText).to.equal(`${fixedYear + 2}`);
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        [SegmentTypes.Month, SegmentTypes.Day].forEach((segmentType) => {
+            it(`should define the ${segmentType} segment's value on ArrowUp key`, async () => {
+                const segment = editableSegments.getByType(
+                    segmentType as EditableSegmentType
+                );
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal(`01`);
+                expectPlaceholders(editableSegments, [segment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it(`should increment the ${segmentType} segment's value on ArrowUp key`, async () => {
+                const segment = editableSegments.getByType(
+                    segmentType as EditableSegmentType
+                );
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal(`03`);
+                expectPlaceholders(editableSegments, [segment]);
+                expect(element.value).to.be.undefined;
+            });
+        });
+
+        [SegmentTypes.Minute, SegmentTypes.Second].forEach((segmentType) => {
+            it(`should define the ${segmentType} segment's value on ArrowUp key`, async () => {
+                const segment = editableSegments.getByType(
+                    segmentType as EditableSegmentType
+                );
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal(`00`);
+                expectPlaceholders(editableSegments, [segment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it(`should increment the ${segmentType} segment's value on ArrowUp key`, async () => {
+                const segment = editableSegments.getByType(
+                    segmentType as EditableSegmentType
+                );
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal(`02`);
+                expectPlaceholders(editableSegments, [segment]);
+                expect(element.value).to.be.undefined;
+            });
+        });
+
+        describe('12h format', () => {
+            it("should define the hour segment's value on ArrowUp key", async () => {
+                const hourSegment = editableSegments.getByType(
+                    SegmentTypes.Hour
+                );
+
+                hourSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`12`); // as 12AM is 00:00
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it("should increment the hour segment's value on ArrowUp key", async () => {
+                const hourSegment = editableSegments.getByType(
+                    SegmentTypes.Hour
+                );
+
+                hourSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`02`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it('should reset the hour when the max is reached on ArrowUp key', async () => {
+                const hourSegment = editableSegments.getByType(
+                    SegmentTypes.Hour
+                );
+
+                hourSegment.focus();
+                await sendKeyMultipleTimes('ArrowUp', 13);
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`12`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it("should define the dayPeriod segment's value on ArrowUp key", async () => {
+                const dayPeriodSegment = editableSegments.getByType(
+                    SegmentTypes.DayPeriod
+                );
+
+                dayPeriodSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(dayPeriodSegment.innerText).to.equal(`AM`);
+                expectPlaceholders(editableSegments, [dayPeriodSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it("should toggle the dayPeriod segment's value on ArrowUp key", async () => {
+                const dayPeriodSegment = editableSegments.getByType(
+                    SegmentTypes.DayPeriod
+                );
+
+                dayPeriodSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(dayPeriodSegment.innerText).to.equal(`PM`);
+                expectPlaceholders(editableSegments, [dayPeriodSegment]);
+                expect(element.value).to.be.undefined;
+            });
+        });
+
+        describe('24h format', () => {
+            let hourSegment: HTMLElement;
+
+            beforeEach(async () => {
+                element = await fixtureElement({ locale: 'en-GB' });
+                await elementUpdated(element);
+
+                editableSegments = getEditableSegments(element);
+                hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            });
+
+            it("should define the hour segment's value on ArrowUp key", async () => {
+                hourSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`00`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it("should increment the hour segment's value on ArrowUp key", async () => {
+                hourSegment.focus();
+                await sendKeyMultipleTimes('ArrowUp', 14);
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`13`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it('should reset the hour when the max is reached on ArrowUp key', async () => {
+                hourSegment.focus();
+                await sendKeyMultipleTimes('ArrowUp', 25);
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`00`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+        });
+
+        describe('day segment updates', () => {
+            let daySegment: HTMLElement;
+            let monthSegment: HTMLElement;
+            let yearSegment: HTMLElement;
+
+            beforeEach(async () => {
+                element = await fixtureElement({
+                    props: { precision: Precisions.Day },
+                });
+                editableSegments = getEditableSegments(element);
+
+                daySegment = editableSegments.getByType(SegmentTypes.Day);
+                monthSegment = editableSegments.getByType(SegmentTypes.Month);
+                yearSegment = editableSegments.getByType(SegmentTypes.Year);
+
+                daySegment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+            });
+
+            it('when the month changes to February on ArrowUp key, with no year selected', async () => {
+                monthSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(monthSegment.innerText).to.equal(`02`);
+                expect(daySegment.innerText).to.equal(`29`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                ]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it('when the month changes to February on ArrowUp key, in a common year', async () => {
+                yearSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+                monthSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal(`2022`); // Common year in the Gregorian calendar
+                expect(monthSegment.innerText).to.equal(`02`);
+                expect(daySegment.innerText).to.equal(`28`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(2022, 2, 28));
+            });
+
+            it('when the month changes to February on ArrowUp key, in a leap year', async () => {
+                yearSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+                monthSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal(`2024`); // Leap year in the Gregorian calendar
+                expect(monthSegment.innerText).to.equal(`02`);
+                expect(daySegment.innerText).to.equal(`29`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(2024, 2, 29));
+            });
+
+            it('when the year changes to a leap year on ArrowUp key, and the month is February', async () => {
+                monthSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+                yearSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal(`2024`); // Leap year in the Gregorian calendar
+                expect(monthSegment.innerText).to.equal(`02`);
+                expect(daySegment.innerText).to.equal(`28`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(2024, 2, 28));
+            });
+        });
+
+        describe("segment's value resets to minimum", () => {
+            let value: CalendarDateTime;
+
+            before(() => {
+                value = valueDateTime;
+            });
+
+            it('when the max year is reached on a defined date value', async () => {
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
+                });
+                editableSegments = getEditableSegments(element);
+
+                const max = value.calendar.getYearsInEra(value);
+                element.value = value.set({ year: max });
+                await elementUpdated(element);
                 const segment = editableSegments.getByType(SegmentTypes.Year);
 
                 segment.focus();
                 await sendKeys({ press: 'ArrowUp' });
                 await elementUpdated(element);
 
-                expect(segment.innerText).to.equal(`${fixedYear}`);
+                expect(segment.innerText).to.equal('1');
+                expectSameDates(element.value!, value.set({ year: 1 }));
+            });
+
+            it('when the max month is reached', async () => {
+                const segment = editableSegments.getByType(SegmentTypes.Month);
+
+                segment.focus();
+                await sendKeyMultipleTimes('ArrowUp', 12 + 1);
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal(`01`);
                 expectPlaceholders(editableSegments, [segment]);
                 expect(element.value).to.be.undefined;
             });
 
-            it("incrementing the year segment's value", async () => {
-                const segment = editableSegments.getByType(SegmentTypes.Year);
+            it('when the max month is reached on a defined date value', async () => {
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
+                });
+                editableSegments = getEditableSegments(element);
+
+                const max = value.calendar.getMonthsInYear(value);
+                element.value = value.set({ month: max });
+                await elementUpdated(element);
+                const segment = editableSegments.getByType(SegmentTypes.Month);
 
                 segment.focus();
                 await sendKeys({ press: 'ArrowUp' });
-                await sendKeys({ press: 'ArrowUp' });
-                await sendKeys({ press: 'ArrowUp' });
                 await elementUpdated(element);
 
-                expect(segment.innerText).to.equal(`${fixedYear + 2}`);
+                expect(segment.innerText).to.equal('01');
+                expectSameDates(element.value!, value.set({ month: 1 }));
+            });
+
+            it('when the max day is reached with no month/year defined', async () => {
+                const segment = editableSegments.getByType(SegmentTypes.Day);
+
+                segment.focus();
+                await sendKeyMultipleTimes('ArrowUp', 31 + 1);
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal(`01`);
                 expectPlaceholders(editableSegments, [segment]);
                 expect(element.value).to.be.undefined;
             });
 
-            [SegmentTypes.Month, SegmentTypes.Day].forEach((segmentType) => {
-                it(`defining the ${segmentType} segment's value`, async () => {
-                    const segment = editableSegments.getByType(
-                        segmentType as EditableSegmentType
-                    );
+            it('when the max day is reached in February with no year defined', async () => {
+                const daySegment = editableSegments.getByType(SegmentTypes.Day);
+                const monthSegment = editableSegments.getByType(
+                    SegmentTypes.Month
+                );
+                monthSegment.focus();
+                await sendKeyMultipleTimes('ArrowUp', 2);
 
-                    segment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
+                daySegment.focus();
+                await sendKeyMultipleTimes('ArrowUp', 29 + 1);
+                await elementUpdated(element);
 
-                    expect(segment.innerText).to.equal(`01`);
-                    expectPlaceholders(editableSegments, [segment]);
-                    expect(element.value).to.be.undefined;
+                expect(daySegment.innerText).to.equal(`01`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                ]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it('when the max day is reached on a defined date value - month with 31 days', async () => {
+                value = new CalendarDateTime(2024, 3, 15, 15, 15, 15);
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
                 });
+                editableSegments = getEditableSegments(element);
 
-                it(`incrementing the ${segmentType} segment's value`, async () => {
-                    const segment = editableSegments.getByType(
-                        segmentType as EditableSegmentType
-                    );
+                element.value = value.set({ day: 31 });
+                await elementUpdated(element);
+                const segment = editableSegments.getByType(SegmentTypes.Day);
 
-                    segment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
+                segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
 
-                    expect(segment.innerText).to.equal(`03`);
-                    expectPlaceholders(editableSegments, [segment]);
-                    expect(element.value).to.be.undefined;
+                expect(segment.innerText).to.equal('01');
+                expectSameDates(element.value!, value.set({ day: 1 }));
+            });
+
+            it('when the max day is reached on a defined date value - common year February', async () => {
+                const commonYear = 2022;
+                value = new CalendarDateTime(commonYear, 2, 15, 15, 15, 15);
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
                 });
+                editableSegments = getEditableSegments(element);
+
+                element.value = value.set({ day: 28 });
+                await elementUpdated(element);
+                const segment = editableSegments.getByType(SegmentTypes.Day);
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal('01');
+                expectSameDates(element.value!, value.set({ day: 1 }));
+            });
+
+            it('when the max day is reached on a defined date value - leap year February', async () => {
+                const leapYear = 2024;
+                value = new CalendarDateTime(leapYear, 2, 15, 15, 15, 15);
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
+                });
+                editableSegments = getEditableSegments(element);
+
+                element.value = value.set({ day: 29 });
+                await elementUpdated(element);
+                const segment = editableSegments.getByType(SegmentTypes.Day);
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal('01');
+                expectSameDates(element.value!, value.set({ day: 1 }));
             });
 
             [SegmentTypes.Minute, SegmentTypes.Second].forEach(
                 (segmentType) => {
-                    it(`defining the ${segmentType} segment's value`, async () => {
+                    it(`when the max ${segmentType} is reached on a defined date value`, async () => {
+                        element = await fixtureElement({
+                            props: {
+                                value,
+                                precision: Precisions.Second,
+                            },
+                        });
+                        editableSegments = getEditableSegments(element);
+
+                        const currentValue = element.value!;
+                        element.value = currentValue.set({
+                            [segmentType]: 59,
+                        });
+                        await elementUpdated(element);
                         const segment = editableSegments.getByType(
                             segmentType as EditableSegmentType
                         );
@@ -684,530 +1415,368 @@ describe('DateTimePicker', () => {
                         await sendKeys({ press: 'ArrowUp' });
                         await elementUpdated(element);
 
-                        expect(segment.innerText).to.equal(`00`);
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
-                    });
-
-                    it(`incrementing the ${segmentType} segment's value`, async () => {
-                        const segment = editableSegments.getByType(
-                            segmentType as EditableSegmentType
+                        expect(segment.innerText).to.equal('00');
+                        expectSameDates(
+                            element.value!,
+                            value.set({ [segmentType]: 1 })
                         );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await sendKeys({ press: 'ArrowUp' });
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`02`);
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
                     });
                 }
             );
+        });
+    });
 
-            describe('on a 12h format', () => {
-                it("defining the hour segment's value", async () => {
-                    const hourSegment = editableSegments.getByType(
-                        SegmentTypes.Hour
-                    );
+    describe('ArrowDown key', () => {
+        beforeEach(async () => {
+            element = await fixtureElement({
+                props: { precision: Precisions.Second },
+            });
+            editableSegments = getEditableSegments(element);
+        });
 
-                    hourSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
+        it("should define the year segment's value on ArrowDown key", async () => {
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
 
-                    expect(hourSegment.innerText).to.equal(`12`); // as 12AM is 00:00
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
+            yearSegment.focus();
+            await sendKeys({ press: 'ArrowDown' });
+            await elementUpdated(element);
 
-                it("incrementing the hour segment's value", async () => {
-                    const hourSegment = editableSegments.getByType(
-                        SegmentTypes.Hour
-                    );
+            expect(yearSegment.innerText).to.equal(`${fixedYear}`);
+            expectPlaceholders(editableSegments, [yearSegment]);
+            expect(element.value).to.be.undefined;
+        });
 
-                    hourSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
+        it("should decrement the year segment's value on ArrowDown key", async () => {
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
 
-                    expect(hourSegment.innerText).to.equal(`02`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
+            yearSegment.focus();
+            await sendKeys({ press: 'ArrowDown' });
+            await sendKeys({ press: 'ArrowDown' });
+            await sendKeys({ press: 'ArrowDown' });
+            await elementUpdated(element);
 
-                it('resetting the hour when the max is reached', async () => {
-                    const hourSegment = editableSegments.getByType(
-                        SegmentTypes.Hour
-                    );
+            expect(yearSegment.innerText).to.equal(`${fixedYear - 2}`);
+            expectPlaceholders(editableSegments, [yearSegment]);
+            expect(element.value).to.be.undefined;
+        });
 
-                    hourSegment.focus();
-                    await sendKeyMultipleTimes('ArrowUp', 13);
-                    await elementUpdated(element);
+        it(`should define the month segment's value on ArrowDown key`, async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Month);
 
-                    expect(hourSegment.innerText).to.equal(`12`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
+            segment.focus();
+            await sendKeys({ press: 'ArrowDown' });
+            await elementUpdated(element);
 
-                it("defining the dayPeriod segment's value", async () => {
-                    const dayPeriodSegment = editableSegments.getByType(
-                        SegmentTypes.DayPeriod
-                    );
+            expect(segment.innerText).to.equal(`12`);
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
 
-                    dayPeriodSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
+        it(`should decrement the month segment's value on ArrowDown key`, async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Month);
 
-                    expect(dayPeriodSegment.innerText).to.equal(`AM`);
-                    expectPlaceholders(editableSegments, [dayPeriodSegment]);
-                    expect(element.value).to.be.undefined;
-                });
+            segment.focus();
+            await sendKeys({ press: 'ArrowDown' });
+            await sendKeys({ press: 'ArrowDown' });
+            await sendKeys({ press: 'ArrowDown' });
+            await elementUpdated(element);
 
-                it("toggling the dayPeriod segment's value", async () => {
-                    const dayPeriodSegment = editableSegments.getByType(
-                        SegmentTypes.DayPeriod
-                    );
+            expect(segment.innerText).to.equal(`10`);
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
 
-                    dayPeriodSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
+        it(`should define the day segment's value on ArrowDown key`, async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Day);
 
-                    expect(dayPeriodSegment.innerText).to.equal(`PM`);
-                    expectPlaceholders(editableSegments, [dayPeriodSegment]);
-                    expect(element.value).to.be.undefined;
-                });
+            segment.focus();
+            await sendKeys({ press: 'ArrowDown' });
+            await elementUpdated(element);
+
+            expect(segment.innerText).to.equal(`31`);
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it(`should decrement the day segment's value on ArrowDown key`, async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Day);
+
+            segment.focus();
+            await sendKeys({ press: 'ArrowDown' });
+            await sendKeys({ press: 'ArrowDown' });
+            await sendKeys({ press: 'ArrowDown' });
+            await elementUpdated(element);
+
+            expect(segment.innerText).to.equal(`29`);
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        [SegmentTypes.Minute, SegmentTypes.Second].forEach((segmentType) => {
+            it(`should define the ${segmentType} segment's value on ArrowDown key`, async () => {
+                const segment = editableSegments.getByType(
+                    segmentType as EditableSegmentType
+                );
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal(`59`);
+                expectPlaceholders(editableSegments, [segment]);
+                expect(element.value).to.be.undefined;
             });
 
-            describe('on a 24h format', () => {
-                let hourSegment: HTMLElement;
+            it(`should decrement the ${segmentType} segment's value on ArrowDown key`, async () => {
+                const segment = editableSegments.getByType(
+                    segmentType as EditableSegmentType
+                );
 
-                beforeEach(async () => {
-                    element = await fixtureElement({ locale: 'en-GB' });
-                    await elementUpdated(element);
+                segment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+                await sendKeys({ press: 'ArrowDown' });
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
 
-                    editableSegments = getEditableSegments(element);
-                    hourSegment = editableSegments.getByType(SegmentTypes.Hour);
-                });
-
-                it("defining the hour segment's value ", async () => {
-                    hourSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`00`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it("incrementing the hour segment's value ", async () => {
-                    hourSegment.focus();
-                    await sendKeyMultipleTimes('ArrowUp', 14);
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`13`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it('resetting the hour when the max is reached', async () => {
-                    hourSegment.focus();
-                    await sendKeyMultipleTimes('ArrowUp', 25);
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`00`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-            });
-
-            describe('updating the day', () => {
-                let daySegment: HTMLElement;
-                let monthSegment: HTMLElement;
-                let yearSegment: HTMLElement;
-
-                beforeEach(async () => {
-                    element = await fixtureElement({
-                        props: { precision: Precisions.Day },
-                    });
-                    editableSegments = getEditableSegments(element);
-
-                    daySegment = editableSegments.getByType(SegmentTypes.Day);
-                    monthSegment = editableSegments.getByType(
-                        SegmentTypes.Month
-                    );
-                    yearSegment = editableSegments.getByType(SegmentTypes.Year);
-
-                    daySegment.focus();
-                    await sendKeys({ press: 'ArrowDown' });
-                });
-
-                it('when the month changes to February with no year selected', async () => {
-                    monthSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-
-                    expect(monthSegment.innerText).to.equal(`02`);
-                    expect(daySegment.innerText).to.equal(`29`);
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                    ]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it('when the month changes to February in a common year', async () => {
-                    yearSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-                    monthSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal(`2022`); // Common year in the Gregorian calendar
-                    expect(monthSegment.innerText).to.equal(`02`);
-                    expect(daySegment.innerText).to.equal(`28`);
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(
-                        element.value!,
-                        new CalendarDate(2022, 2, 28)
-                    );
-                });
-
-                it('when the month changes to February in a leap year', async () => {
-                    yearSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-                    monthSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal(`2024`); // Leap year in the Gregorian calendar
-                    expect(monthSegment.innerText).to.equal(`02`);
-                    expect(daySegment.innerText).to.equal(`29`);
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(
-                        element.value!,
-                        new CalendarDate(2024, 2, 29)
-                    );
-                });
-
-                it('when the year changes to a leap year and the month is February', async () => {
-                    monthSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-                    yearSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal(`2024`); // Leap year in the Gregorian calendar
-                    expect(monthSegment.innerText).to.equal(`02`);
-                    expect(daySegment.innerText).to.equal(`28`);
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(
-                        element.value!,
-                        new CalendarDate(2024, 2, 28)
-                    );
-                });
-            });
-
-            describe("resetting segment's value to minimum", () => {
-                describe('with a defined date value', () => {
-                    let value = new CalendarDateTime(
-                        fixedYear,
-                        fixedMonth,
-                        fixedDay,
-                        15,
-                        15,
-                        15
-                    );
-
-                    it('when the max year is reached', async () => {
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        const max = value.calendar.getYearsInEra(value);
-                        element.value = value.set({ year: max });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Year
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal('1');
-                        expectSameDates(element.value!, value.set({ year: 1 }));
-                    });
-
-                    it('when the max month is reached', async () => {
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        const max = value.calendar.getMonthsInYear(value);
-                        element.value = value.set({ month: max });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Month
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal('01');
-                        expectSameDates(
-                            element.value!,
-                            value.set({ month: 1 })
-                        );
-                    });
-
-                    it('when the max day is reached in a month with 31 days', async () => {
-                        value = new CalendarDateTime(2024, 3, 15, 15, 15, 15);
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        element.value = value.set({ day: 31 });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal('01');
-                        expectSameDates(element.value!, value.set({ day: 1 }));
-                    });
-
-                    it('when the max day is reached in February of a common year', async () => {
-                        const commonYear = 2022;
-                        value = new CalendarDateTime(
-                            commonYear,
-                            2,
-                            15,
-                            15,
-                            15,
-                            15
-                        );
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        element.value = value.set({ day: 28 });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal('01');
-                        expectSameDates(element.value!, value.set({ day: 1 }));
-                    });
-
-                    it('when the max day is reached in February of a leap year', async () => {
-                        const leapYear = 2024;
-                        value = new CalendarDateTime(
-                            leapYear,
-                            2,
-                            15,
-                            15,
-                            15,
-                            15
-                        );
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        element.value = value.set({ day: 29 });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal('01');
-                        expectSameDates(element.value!, value.set({ day: 1 }));
-                    });
-
-                    [SegmentTypes.Minute, SegmentTypes.Second].forEach(
-                        (segmentType) => {
-                            it(`when the max ${segmentType} is reached`, async () => {
-                                element = await fixtureElement({
-                                    props: {
-                                        value,
-                                        precision: Precisions.Second,
-                                    },
-                                });
-                                await elementUpdated(element);
-                                editableSegments = getEditableSegments(element);
-
-                                const currentValue = element.value!;
-                                element.value = currentValue.set({
-                                    [segmentType]: 59,
-                                });
-                                await elementUpdated(element);
-                                const segment = editableSegments.getByType(
-                                    segmentType as EditableSegmentType
-                                );
-
-                                segment.focus();
-                                await sendKeys({ press: 'ArrowUp' });
-                                await elementUpdated(element);
-
-                                expect(segment.innerText).to.equal('00');
-                                expectSameDates(
-                                    element.value!,
-                                    value.set({ [segmentType]: 1 })
-                                );
-                            });
-                        }
-                    );
-                });
-
-                describe('with no fully defined date value', () => {
-                    it('when the max month is reached', async () => {
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Month
-                        );
-
-                        segment.focus();
-                        await sendKeyMultipleTimes('ArrowUp', 12 + 1);
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`01`);
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
-                    });
-
-                    it('when the max day is reached as a single segment', async () => {
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-
-                        segment.focus();
-                        await sendKeyMultipleTimes('ArrowUp', 31 + 1);
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`01`);
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
-                    });
-
-                    it('when the max day is reached in February', async () => {
-                        const daySegment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-                        const monthSegment = editableSegments.getByType(
-                            SegmentTypes.Month
-                        );
-                        monthSegment.focus();
-                        await sendKeyMultipleTimes('ArrowUp', 2);
-
-                        daySegment.focus();
-                        await sendKeyMultipleTimes('ArrowUp', 29 + 1);
-                        await elementUpdated(element);
-
-                        expect(daySegment.innerText).to.equal(`01`);
-                        expectPlaceholders(editableSegments, [
-                            daySegment,
-                            monthSegment,
-                        ]);
-                        expect(element.value).to.be.undefined;
-                    });
-                });
+                expect(segment.innerText).to.equal(`57`);
+                expectPlaceholders(editableSegments, [segment]);
+                expect(element.value).to.be.undefined;
             });
         });
 
-        describe('using the down arrow key', () => {
-            it("defining the year segment's value", async () => {
-                const yearSegment = editableSegments.getByType(
-                    SegmentTypes.Year
-                );
+        describe('12h format', () => {
+            let hourSegment: HTMLElement;
+            let dayPeriodSegment: HTMLElement;
 
-                yearSegment.focus();
+            beforeEach(async () => {
+                hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+                dayPeriodSegment = editableSegments.getByType(
+                    SegmentTypes.DayPeriod
+                );
+            });
+
+            it("should define the hour segment's value on ArrowDown key", async () => {
+                hourSegment.focus();
                 await sendKeys({ press: 'ArrowDown' });
                 await elementUpdated(element);
 
-                expect(yearSegment.innerText).to.equal(`${fixedYear}`);
-                expectPlaceholders(editableSegments, [yearSegment]);
+                expect(hourSegment.innerText).to.equal(`11`);
+                expectPlaceholders(editableSegments, [hourSegment]);
                 expect(element.value).to.be.undefined;
             });
 
-            it("decrementing the year segment's value", async () => {
-                const yearSegment = editableSegments.getByType(
-                    SegmentTypes.Year
-                );
-
-                yearSegment.focus();
+            it("should decrement the hour segment's value on ArrowDown key", async () => {
+                hourSegment.focus();
                 await sendKeys({ press: 'ArrowDown' });
                 await sendKeys({ press: 'ArrowDown' });
                 await sendKeys({ press: 'ArrowDown' });
                 await elementUpdated(element);
 
-                expect(yearSegment.innerText).to.equal(`${fixedYear - 2}`);
-                expectPlaceholders(editableSegments, [yearSegment]);
+                expect(hourSegment.innerText).to.equal(`09`);
+                expectPlaceholders(editableSegments, [hourSegment]);
                 expect(element.value).to.be.undefined;
             });
 
-            it(`defining the month segment's value`, async () => {
+            it('should reset the hour when the min is reached on ArrowDown key', async () => {
+                hourSegment.focus();
+                await sendKeyMultipleTimes('ArrowDown', 13);
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`11`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it("should define the dayPeriod segment's value on ArrowDown key", async () => {
+                dayPeriodSegment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
+
+                expect(dayPeriodSegment.innerText).to.equal(`PM`);
+                expectPlaceholders(editableSegments, [dayPeriodSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it("toggling the dayPeriod segment's value on ArrowDown key", async () => {
+                dayPeriodSegment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
+
+                expect(dayPeriodSegment.innerText).to.equal(`AM`);
+                expectPlaceholders(editableSegments, [dayPeriodSegment]);
+                expect(element.value).to.be.undefined;
+            });
+        });
+
+        describe('24h format', () => {
+            let hourSegment: HTMLElement;
+
+            beforeEach(async () => {
+                element = await fixtureElement({ locale: 'en-GB' });
+                editableSegments = getEditableSegments(element);
+                hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            });
+
+            it("should define the hour segment's value", async () => {
+                hourSegment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`23`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it("should decrement the hour segment's value", async () => {
+                hourSegment.focus();
+                await sendKeyMultipleTimes('ArrowDown', 15);
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`09`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it('should reset the hour when the min is reached', async () => {
+                hourSegment.focus();
+                await sendKeyMultipleTimes('ArrowDown', 25);
+                await elementUpdated(element);
+
+                expect(hourSegment.innerText).to.equal(`23`);
+                expectPlaceholders(editableSegments, [hourSegment]);
+                expect(element.value).to.be.undefined;
+            });
+        });
+
+        describe('day segment updates', () => {
+            let daySegment: HTMLElement;
+            let monthSegment: HTMLElement;
+            let yearSegment: HTMLElement;
+
+            beforeEach(async () => {
+                element = await fixtureElement({
+                    props: { precision: Precisions.Day },
+                });
+                editableSegments = getEditableSegments(element);
+                daySegment = editableSegments.getByType(SegmentTypes.Day);
+                monthSegment = editableSegments.getByType(SegmentTypes.Month);
+                yearSegment = editableSegments.getByType(SegmentTypes.Year);
+
+                daySegment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+            });
+
+            it('when the month changes to February on ArrowDown key, with no year selected', async () => {
+                monthSegment.focus();
+                await sendKeyMultipleTimes('ArrowDown', 11);
+                await elementUpdated(element);
+
+                expect(monthSegment.innerText).to.equal(`02`);
+                expect(daySegment.innerText).to.equal(`29`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                ]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it('when the month changes to February on ArrowDown key, in a common year', async () => {
+                yearSegment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
+                monthSegment.focus();
+                await sendKeyMultipleTimes('ArrowDown', 11);
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal(`2022`); // Common year in the Gregorian calendar
+                expect(monthSegment.innerText).to.equal(`02`);
+                expect(daySegment.innerText).to.equal(`28`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(2022, 2, 28));
+            });
+
+            it('when the month changes to February on ArrowDown key, in a leap year', async () => {
+                yearSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+                monthSegment.focus();
+                await sendKeyMultipleTimes('ArrowDown', 11);
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal(`2024`); // Leap year in the Gregorian calendar
+                expect(monthSegment.innerText).to.equal(`02`);
+                expect(daySegment.innerText).to.equal(`29`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(2024, 2, 29));
+            });
+
+            it('when the year changes to a leap year on ArrowDown key, and the month is February', async () => {
+                monthSegment.focus();
+                await sendKeyMultipleTimes('ArrowDown', 11);
+                await elementUpdated(element);
+                yearSegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal(`2024`); // Leap year in the Gregorian calendar
+                expect(monthSegment.innerText).to.equal(`02`);
+                expect(daySegment.innerText).to.equal(`28`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(2024, 2, 28));
+            });
+        });
+
+        describe("segment's value resets to maximum ", () => {
+            let value: CalendarDateTime;
+
+            before(() => {
+                value = valueDateTime;
+            });
+
+            it('when the min year is reached on a defined date value', async () => {
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
+                });
+                editableSegments = getEditableSegments(element);
+
+                const max = value.calendar.getYearsInEra(value);
+                element.value = value.set({ year: 1 });
+                await elementUpdated(element);
+                const segment = editableSegments.getByType(SegmentTypes.Year);
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal(`${max}`);
+                expectSameDates(element.value!, value.set({ year: max }));
+            });
+
+            it('when the min month is reached', async () => {
                 const segment = editableSegments.getByType(SegmentTypes.Month);
 
                 segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
                 await sendKeys({ press: 'ArrowDown' });
                 await elementUpdated(element);
 
@@ -1216,24 +1785,33 @@ describe('DateTimePicker', () => {
                 expect(element.value).to.be.undefined;
             });
 
-            it(`decrementing the month segment's value`, async () => {
+            it('when the min month is reached on a defined date value', async () => {
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
+                });
+                editableSegments = getEditableSegments(element);
+
+                const max = value.calendar.getMonthsInYear(value);
+                element.value = value.set({ month: 1 });
+                await elementUpdated(element);
                 const segment = editableSegments.getByType(SegmentTypes.Month);
 
                 segment.focus();
                 await sendKeys({ press: 'ArrowDown' });
-                await sendKeys({ press: 'ArrowDown' });
-                await sendKeys({ press: 'ArrowDown' });
                 await elementUpdated(element);
 
-                expect(segment.innerText).to.equal(`10`);
-                expectPlaceholders(editableSegments, [segment]);
-                expect(element.value).to.be.undefined;
+                expect(segment.innerText).to.equal(`${max}`);
+                expectSameDates(element.value!, value.set({ month: max }));
             });
 
-            it(`defining the day segment's value`, async () => {
+            it('when the min day is reached with no month/year defined', async () => {
                 const segment = editableSegments.getByType(SegmentTypes.Day);
 
                 segment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
                 await sendKeys({ press: 'ArrowDown' });
                 await elementUpdated(element);
 
@@ -1242,1048 +1820,666 @@ describe('DateTimePicker', () => {
                 expect(element.value).to.be.undefined;
             });
 
-            it(`decrementing the day segment's value`, async () => {
+            it('when the min day is reached in February with no year defined', async () => {
+                const daySegment = editableSegments.getByType(SegmentTypes.Day);
+                const monthSegment = editableSegments.getByType(
+                    SegmentTypes.Month
+                );
+                monthSegment.focus();
+                await sendKeyMultipleTimes('ArrowUp', 2);
+
+                daySegment.focus();
+                await sendKeys({ press: 'ArrowUp' });
+                await elementUpdated(element);
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
+
+                expect(daySegment.innerText).to.equal(`29`);
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                ]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it('when the min day is reached on a defined date value - month with 31 days', async () => {
+                value = new CalendarDateTime(2024, 3, 15, 15, 15, 15);
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
+                });
+                editableSegments = getEditableSegments(element);
+
+                element.value = value.set({ day: 1 });
+                await elementUpdated(element);
                 const segment = editableSegments.getByType(SegmentTypes.Day);
 
                 segment.focus();
                 await sendKeys({ press: 'ArrowDown' });
-                await sendKeys({ press: 'ArrowDown' });
-                await sendKeys({ press: 'ArrowDown' });
                 await elementUpdated(element);
 
-                expect(segment.innerText).to.equal(`29`);
-                expectPlaceholders(editableSegments, [segment]);
-                expect(element.value).to.be.undefined;
+                expect(segment.innerText).to.equal('31');
+                expectSameDates(element.value!, value.set({ day: 31 }));
             });
 
-            [SegmentTypes.Minute, SegmentTypes.Second].forEach(
-                (segmentType) => {
-                    it(`defining the ${segmentType} segment's value`, async () => {
-                        const segment = editableSegments.getByType(
-                            segmentType as EditableSegmentType
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`59`);
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
-                    });
-
-                    it(`decrementing the ${segmentType} segment's value`, async () => {
-                        const segment = editableSegments.getByType(
-                            segmentType as EditableSegmentType
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowDown' });
-                        await sendKeys({ press: 'ArrowDown' });
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`57`);
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
-                    });
-                }
-            );
-
-            describe('on a 12h format', () => {
-                let hourSegment: HTMLElement;
-                let dayPeriodSegment: HTMLElement;
-
-                beforeEach(async () => {
-                    hourSegment = editableSegments.getByType(SegmentTypes.Hour);
-                    dayPeriodSegment = editableSegments.getByType(
-                        SegmentTypes.DayPeriod
-                    );
-                });
-
-                it("defining the hour segment's value", async () => {
-                    hourSegment.focus();
-                    await sendKeys({ press: 'ArrowDown' });
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`11`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it("decrementing the hour segment's value", async () => {
-                    hourSegment.focus();
-                    await sendKeys({ press: 'ArrowDown' });
-                    await sendKeys({ press: 'ArrowDown' });
-                    await sendKeys({ press: 'ArrowDown' });
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`09`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it('resetting the hour when the min is reached', async () => {
-                    hourSegment.focus();
-                    await sendKeyMultipleTimes('ArrowDown', 13);
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`11`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it("defining the dayPeriod segment's value", async () => {
-                    dayPeriodSegment.focus();
-                    await sendKeys({ press: 'ArrowDown' });
-                    await elementUpdated(element);
-
-                    expect(dayPeriodSegment.innerText).to.equal(`PM`);
-                    expectPlaceholders(editableSegments, [dayPeriodSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it("toggling the dayPeriod segment's value", async () => {
-                    dayPeriodSegment.focus();
-                    await sendKeys({ press: 'ArrowDown' });
-                    await sendKeys({ press: 'ArrowDown' });
-                    await elementUpdated(element);
-
-                    expect(dayPeriodSegment.innerText).to.equal(`AM`);
-                    expectPlaceholders(editableSegments, [dayPeriodSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-            });
-
-            describe('on a 24h format', () => {
-                let hourSegment: HTMLElement;
-
-                beforeEach(async () => {
-                    element = await fixtureElement({ locale: 'en-GB' });
-                    await elementUpdated(element);
-
-                    editableSegments = getEditableSegments(element);
-                    hourSegment = editableSegments.getByType(SegmentTypes.Hour);
-                });
-
-                it("defining the hour segment's value", async () => {
-                    hourSegment.focus();
-                    await sendKeys({ press: 'ArrowDown' });
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`23`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it("decrementing the hour segment's value", async () => {
-                    hourSegment.focus();
-                    await sendKeyMultipleTimes('ArrowDown', 15);
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`09`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it('resetting the hour when the min is reached', async () => {
-                    hourSegment.focus();
-                    await sendKeyMultipleTimes('ArrowDown', 25);
-                    await elementUpdated(element);
-
-                    expect(hourSegment.innerText).to.equal(`23`);
-                    expectPlaceholders(editableSegments, [hourSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-            });
-
-            describe('updating the day', () => {
-                let daySegment: HTMLElement;
-                let monthSegment: HTMLElement;
-                let yearSegment: HTMLElement;
-
-                beforeEach(async () => {
-                    element = await fixtureElement({
-                        props: { precision: Precisions.Day },
-                    });
-                    editableSegments = getEditableSegments(element);
-
-                    daySegment = editableSegments.getByType(SegmentTypes.Day);
-                    monthSegment = editableSegments.getByType(
-                        SegmentTypes.Month
-                    );
-                    yearSegment = editableSegments.getByType(SegmentTypes.Year);
-
-                    daySegment.focus();
-                    await sendKeys({ press: 'ArrowDown' });
-                });
-
-                it('when the month changes to February with no year selected', async () => {
-                    monthSegment.focus();
-                    await sendKeyMultipleTimes('ArrowDown', 11);
-                    await elementUpdated(element);
-
-                    expect(monthSegment.innerText).to.equal(`02`);
-                    expect(daySegment.innerText).to.equal(`29`);
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                    ]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it('when the month changes to February in a common year', async () => {
-                    yearSegment.focus();
-                    await sendKeys({ press: 'ArrowDown' });
-                    await elementUpdated(element);
-                    monthSegment.focus();
-                    await sendKeyMultipleTimes('ArrowDown', 11);
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal(`2022`); // Common year in the Gregorian calendar
-                    expect(monthSegment.innerText).to.equal(`02`);
-                    expect(daySegment.innerText).to.equal(`28`);
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(
-                        element.value!,
-                        new CalendarDate(2022, 2, 28)
-                    );
-                });
-
-                it('when the month changes to February in a leap year', async () => {
-                    yearSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-                    monthSegment.focus();
-                    await sendKeyMultipleTimes('ArrowDown', 11);
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal(`2024`); // Leap year in the Gregorian calendar
-                    expect(monthSegment.innerText).to.equal(`02`);
-                    expect(daySegment.innerText).to.equal(`29`);
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(
-                        element.value!,
-                        new CalendarDate(2024, 2, 29)
-                    );
-                });
-
-                it('when the year changes to a leap year and the month is February', async () => {
-                    monthSegment.focus();
-                    await sendKeyMultipleTimes('ArrowDown', 11);
-                    await elementUpdated(element);
-                    yearSegment.focus();
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await sendKeys({ press: 'ArrowUp' });
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal(`2024`); // Leap year in the Gregorian calendar
-                    expect(monthSegment.innerText).to.equal(`02`);
-                    expect(daySegment.innerText).to.equal(`28`);
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(
-                        element.value!,
-                        new CalendarDate(2024, 2, 28)
-                    );
-                });
-            });
-
-            describe("resetting segment's value to maximum", () => {
-                describe('with a defined date value', () => {
-                    let value = new CalendarDateTime(
-                        fixedYear,
-                        fixedMonth,
-                        fixedDay,
-                        15,
-                        15,
-                        15
-                    );
-
-                    it('when the min year is reached', async () => {
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        const max = value.calendar.getYearsInEra(value);
-                        element.value = value.set({ year: 1 });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Year
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`${max}`);
-                        expectSameDates(
-                            element.value!,
-                            value.set({ year: max })
-                        );
-                    });
-
-                    it('when the min month is reached', async () => {
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        const max = value.calendar.getMonthsInYear(value);
-                        element.value = value.set({ month: 1 });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Month
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`${max}`);
-                        expectSameDates(
-                            element.value!,
-                            value.set({ month: max })
-                        );
-                    });
-
-                    it('when the min day is reached in a month with 31 days', async () => {
-                        value = new CalendarDateTime(2024, 3, 15, 15, 15, 15);
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        element.value = value.set({ day: 1 });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal('31');
-                        expectSameDates(element.value!, value.set({ day: 31 }));
-                    });
-
-                    it('when the min day is reached in February of a common year', async () => {
-                        const commonYear = 2022;
-                        value = new CalendarDateTime(
-                            commonYear,
-                            2,
-                            15,
-                            15,
-                            15,
-                            15
-                        );
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        element.value = value.set({ day: 1 });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal('28');
-                        expectSameDates(element.value!, value.set({ day: 28 }));
-                    });
-
-                    it('when the min day is reached in February of a leap year', async () => {
-                        const leapYear = 2024;
-                        value = new CalendarDateTime(
-                            leapYear,
-                            2,
-                            15,
-                            15,
-                            15,
-                            15
-                        );
-                        element = await fixtureElement({
-                            props: {
-                                value,
-                            },
-                        });
-                        await elementUpdated(element);
-                        editableSegments = getEditableSegments(element);
-
-                        element.value = value.set({ day: 1 });
-                        await elementUpdated(element);
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal('29');
-                        expectSameDates(element.value!, value.set({ day: 29 }));
-                    });
-
-                    [SegmentTypes.Minute, SegmentTypes.Second].forEach(
-                        (segmentType) => {
-                            it(`when the min ${segmentType} is reached`, async () => {
-                                element = await fixtureElement({
-                                    props: {
-                                        value,
-                                        precision: Precisions.Second,
-                                    },
-                                });
-                                await elementUpdated(element);
-                                editableSegments = getEditableSegments(element);
-
-                                const currentValue = element.value!;
-                                element.value = currentValue.set({
-                                    [segmentType]: 0,
-                                });
-                                await elementUpdated(element);
-                                const segment = editableSegments.getByType(
-                                    segmentType as EditableSegmentType
-                                );
-
-                                segment.focus();
-                                await sendKeys({ press: 'ArrowDown' });
-                                await elementUpdated(element);
-
-                                expect(segment.innerText).to.equal('59');
-                                expectSameDates(
-                                    element.value!,
-                                    value.set({ [segmentType]: 59 })
-                                );
-                            });
-                        }
-                    );
-                });
-
-                describe('with no fully defined date value', () => {
-                    it('when the min month is reached', async () => {
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Month
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`12`);
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
-                    });
-
-                    it('when the min day is reached as a single segment', async () => {
-                        const segment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-
-                        segment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(segment.innerText).to.equal(`31`);
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
-                    });
-
-                    it('when the min day is reached in February', async () => {
-                        const daySegment = editableSegments.getByType(
-                            SegmentTypes.Day
-                        );
-                        const monthSegment = editableSegments.getByType(
-                            SegmentTypes.Month
-                        );
-                        monthSegment.focus();
-                        await sendKeyMultipleTimes('ArrowUp', 2);
-
-                        daySegment.focus();
-                        await sendKeys({ press: 'ArrowUp' });
-                        await elementUpdated(element);
-                        await sendKeys({ press: 'ArrowDown' });
-                        await elementUpdated(element);
-
-                        expect(daySegment.innerText).to.equal(`29`);
-                        expectPlaceholders(editableSegments, [
-                            daySegment,
-                            monthSegment,
-                        ]);
-                        expect(element.value).to.be.undefined;
-                    });
-                });
-            });
-        });
-
-        describe('using typed in values', () => {
-            [SegmentTypes.Year, SegmentTypes.Month, SegmentTypes.Day].forEach(
-                (segmentType) => {
-                    it(`the ${segmentType} segment should ignore initial zeros`, async () => {
-                        const segment = editableSegments.getByType(
-                            segmentType as EditableSegmentType
-                        );
-
-                        segment.focus();
-                        await sendKeys({ type: '0' });
-                        await elementUpdated(element);
-
-                        expectPlaceholders(editableSegments);
-                        expect(element.value).to.be.undefined;
-                    });
-                }
-            );
-
-            it("on the year segment's value", async () => {
-                const segment = editableSegments.getByType(SegmentTypes.Year);
-
-                segment.focus();
-                await sendKeys({ type: '2' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('2');
-                await sendKeys({ type: '03' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('203');
-                await sendKeys({ type: '0' });
-                expect(segment.innerText).to.equal('2030');
-                await sendKeys({ type: '5' });
-                expect(segment.innerText).to.equal('305');
-
-                expectPlaceholders(editableSegments, [segment]);
-                expect(element.value).to.be.undefined;
-            });
-
-            it("on the month segment's value", async () => {
-                const segment = editableSegments.getByType(SegmentTypes.Month);
-
-                segment.focus();
-                await sendKeys({ type: '2' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('02');
-                await sendKeys({ type: '4' });
-                expect(segment.innerText).to.equal('04');
-                await sendKeys({ type: '1' });
-                expect(segment.innerText).to.equal('01');
-                await sendKeys({ type: '2' });
-                expect(segment.innerText).to.equal('12');
-                await sendKeys({ type: '9' });
-                expect(segment.innerText).to.equal('09');
-                await sendKeys({ type: '0' });
-                expect(segment.innerText).to.equal('09');
-
-                expectPlaceholders(editableSegments, [segment]);
-                expect(element.value).to.be.undefined;
-            });
-
-            describe("on the day segment's value", async () => {
-                let yearSegment: HTMLElement;
-                let monthSegment: HTMLElement;
-                let daySegment: HTMLElement;
-
-                beforeEach(async () => {
-                    yearSegment = editableSegments.getByType(SegmentTypes.Year);
-                    monthSegment = editableSegments.getByType(
-                        SegmentTypes.Month
-                    );
-                    daySegment = editableSegments.getByType(SegmentTypes.Day);
-                });
-
-                it('when no month/year is defined', async () => {
-                    daySegment.focus();
-                    await sendKeys({ type: '5' });
-                    await elementUpdated(element);
-                    expect(daySegment.innerText).to.equal('05');
-                    await sendKeys({ type: '4' });
-                    await elementUpdated(element);
-                    expect(daySegment.innerText).to.equal('04');
-                    await sendKeys({ type: '0' });
-                    await elementUpdated(element);
-                    expect(daySegment.innerText).to.equal('04');
-
-                    expectPlaceholders(editableSegments, [daySegment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                describe('when the month is February in a common year', async () => {
-                    beforeEach(async () => {
-                        yearSegment.focus();
-                        await sendKeys({ type: '2022' }); // Common year in the Gregorian calendar
-                        await elementUpdated(element);
-                        monthSegment.focus();
-                        await sendKeys({ type: '2' });
-                        await elementUpdated(element);
-                        daySegment.focus();
-                    });
-
-                    it('should not set the day to 31, 30 or 29', async () => {
-                        // Tries to set the day to 31
-                        await sendKeys({ type: '3' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('03');
-                        await sendKeys({ type: '1' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('01');
-
-                        // Tries to set the day to 30
-                        await sendKeys({ type: '3' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('13');
-                        await sendKeys({ type: '0' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('13');
-
-                        // Tries to set the day to 29
-                        await sendKeys({ type: '2' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('02');
-                        await sendKeys({ type: '9' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('09');
-
-                        expectPlaceholders(editableSegments, [
-                            daySegment,
-                            monthSegment,
-                            yearSegment,
-                        ]);
-                        expect(element.value).to.be.undefined;
-                    });
-
-                    it('should set the day to 28', async () => {
-                        await sendKeys({ type: '2' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('02');
-                        await sendKeys({ type: '8' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('28');
-
-                        expectPlaceholders(editableSegments, [
-                            daySegment,
-                            monthSegment,
-                            yearSegment,
-                        ]);
-                        expect(element.value).to.be.undefined;
-                    });
-                });
-
-                describe('when the month is February in a leap year', async () => {
-                    beforeEach(async () => {
-                        yearSegment.focus();
-                        await sendKeys({ type: '2024' }); // Leap year in the Gregorian calendar
-                        await elementUpdated(element);
-                        monthSegment.focus();
-                        await sendKeys({ type: '2' });
-                        await elementUpdated(element);
-                        daySegment.focus();
-                    });
-
-                    it('should not set the day to 31 or 30', async () => {
-                        await sendKeys({ type: '3' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('03');
-                        await sendKeys({ type: '1' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('01');
-
-                        await sendKeys({ type: '3' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('13');
-                        await sendKeys({ type: '0' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('13');
-
-                        expectPlaceholders(editableSegments, [
-                            daySegment,
-                            monthSegment,
-                            yearSegment,
-                        ]);
-                        expect(element.value).to.be.undefined;
-                    });
-
-                    it('should set the day to 29 or 28', async () => {
-                        await sendKeys({ type: '2' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('02');
-                        await sendKeys({ type: '9' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('29');
-
-                        await sendKeys({ type: '2' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('02');
-                        await sendKeys({ type: '8' });
-                        await elementUpdated(element);
-                        expect(daySegment.innerText).to.equal('28');
-
-                        expectPlaceholders(editableSegments, [
-                            daySegment,
-                            monthSegment,
-                            yearSegment,
-                        ]);
-                        expect(element.value).to.be.undefined;
-                    });
-                });
-            });
-
-            describe('in a 12h format', () => {
-                it("on the hour segment's value", async () => {
-                    const segment = editableSegments.getByType(
-                        SegmentTypes.Hour
-                    );
-
-                    segment.focus();
-                    await sendKeys({ type: '1' });
-                    await elementUpdated(element);
-                    expect(segment.innerText).to.equal('01');
-                    await sendKeys({ type: '2' });
-                    await elementUpdated(element);
-                    expect(segment.innerText).to.equal('12');
-                    await sendKeys({ type: '3' });
-                    await elementUpdated(element);
-                    expect(segment.innerText).to.equal('03');
-                    await sendKeys({ type: '0' });
-                    await elementUpdated(element);
-                    expect(segment.innerText).to.equal('03');
-
-                    expectPlaceholders(editableSegments, [segment]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it("on the dayPeriod segment's value using A/P keys", async () => {
-                    const dayPeriodSegment = editableSegments.getByType(
-                        SegmentTypes.DayPeriod
-                    );
-
-                    dayPeriodSegment.focus();
-                    await sendKeys({ type: 'A' });
-                    await elementUpdated(element);
-
-                    expect(dayPeriodSegment.innerText).to.equal(`AM`);
-                    expectPlaceholders(editableSegments, [dayPeriodSegment]);
-                    expect(element.value).to.be.undefined;
-
-                    await sendKeys({ type: 'P' });
-                    await elementUpdated(element);
-
-                    expect(dayPeriodSegment.innerText).to.equal(`PM`);
-                    expectPlaceholders(editableSegments, [dayPeriodSegment]);
-                    expect(element.value).to.be.undefined;
-                });
-            });
-
-            it("in a 24h format on the hour segment's value", async () => {
-                element = await fixtureElement({ locale: 'en-GB' });
-                await elementUpdated(element);
-                editableSegments = getEditableSegments(element);
-                const segment = editableSegments.getByType(SegmentTypes.Hour);
-
-                segment.focus();
-                await sendKeys({ type: '0' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('00');
-                await sendKeys({ type: '1' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('01');
-                await sendKeys({ type: '2' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('12');
-                await sendKeys({ type: '3' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('23');
-                await sendKeys({ type: '5' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('05');
-                await sendKeys({ type: '0' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal('00');
-
-                expectPlaceholders(editableSegments, [segment]);
-                expect(element.value).to.be.undefined;
-            });
-
-            [SegmentTypes.Minute, SegmentTypes.Second].forEach(
-                (segmentType) => {
-                    it(`on the ${segmentType} segment's value`, async () => {
-                        const segment = editableSegments.getByType(
-                            segmentType as EditableSegmentType
-                        );
-
-                        segment.focus();
-                        await sendKeys({ type: '5' });
-                        await elementUpdated(element);
-                        expect(segment.innerText).to.equal('05');
-                        await sendKeys({ type: '8' });
-                        await elementUpdated(element);
-                        expect(segment.innerText).to.equal('58');
-                        await sendKeys({ type: '0' });
-                        await elementUpdated(element);
-                        expect(segment.innerText).to.equal('00');
-
-                        expectPlaceholders(editableSegments, [segment]);
-                        expect(element.value).to.be.undefined;
-                    });
-                }
-            );
-
-            describe('updating the day', () => {
-                let yearSegment: HTMLElement;
-                let monthSegment: HTMLElement;
-                let daySegment: HTMLElement;
-
-                beforeEach(async () => {
-                    element = await fixtureElement({
-                        props: { precision: Precisions.Day },
-                    });
-                    editableSegments = getEditableSegments(element);
-
-                    yearSegment = editableSegments.getByType(SegmentTypes.Year);
-                    monthSegment = editableSegments.getByType(
-                        SegmentTypes.Month
-                    );
-                    daySegment = editableSegments.getByType(SegmentTypes.Day);
-
-                    daySegment.focus();
-                    await sendKeys({ type: '31' });
-                    await elementUpdated(element);
-                });
-
-                it('when the month changes to February with no year selected', async () => {
-                    monthSegment.focus();
-                    await sendKeys({ type: '2' });
-                    await elementUpdated(element);
-
-                    expect(monthSegment.innerText).to.equal('02');
-                    expect(daySegment.innerText).to.equal('29');
-
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                    ]);
-                    expect(element.value).to.be.undefined;
-                });
-
-                it('when the month changes to February in a common year', async () => {
-                    yearSegment.focus();
-                    await sendKeys({ type: '2022' }); // Common year in the Gregorian calendar
-                    await elementUpdated(element);
-                    monthSegment.focus();
-                    await sendKeys({ type: '2' });
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal('2022');
-                    expect(monthSegment.innerText).to.equal('02');
-                    expect(daySegment.innerText).to.equal('28');
-
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(
-                        element.value!,
-                        new CalendarDate(2022, 2, 28)
-                    );
-                });
-
-                it('when the month changes to February in a leap year', async () => {
-                    yearSegment.focus();
-                    await sendKeys({ type: '2024' }); // Leap year in the Gregorian calendar
-                    await elementUpdated(element);
-                    monthSegment.focus();
-                    await sendKeys({ type: '2' });
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal('2024');
-                    expect(monthSegment.innerText).to.equal('02');
-                    expect(daySegment.innerText).to.equal('29');
-
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(
-                        element.value!,
-                        new CalendarDate(2024, 2, 29)
-                    );
-                });
-
-                it('when the year changes to a leap year and the month is February', async () => {
-                    monthSegment.focus();
-                    await sendKeys({ type: '2' });
-                    await elementUpdated(element);
-                    yearSegment.focus();
-                    await sendKeys({ type: '4' }); // Leap year in the Gregorian calendar
-                    await elementUpdated(element);
-
-                    expect(yearSegment.innerText).to.equal('4');
-                    expect(monthSegment.innerText).to.equal('02');
-                    expect(daySegment.innerText).to.equal('29');
-
-                    expectPlaceholders(editableSegments, [
-                        daySegment,
-                        monthSegment,
-                        yearSegment,
-                    ]);
-                    expectSameDates(element.value!, new CalendarDate(4, 2, 29));
-                });
-            });
-        });
-
-        describe('deleting values', () => {
-            const day = 15;
-            const month = 11;
-            const hour = 15;
-            const minute = 15;
-            const second = 15;
-
-            beforeEach(async () => {
-                const value = new CalendarDateTime(
-                    2022,
-                    month,
-                    day,
-                    hour,
-                    minute,
-                    second
-                );
+            it('when the min day is reached on a defined date value - common year February', async () => {
+                const commonYear = 2022;
+                value = new CalendarDateTime(commonYear, 2, 15, 15, 15, 15);
                 element = await fixtureElement({
                     props: {
                         value,
-                        precision: Precisions.Second,
                     },
                 });
-                await elementUpdated(element);
                 editableSegments = getEditableSegments(element);
-            });
 
-            it('from the year segment using incremental deletion', async () => {
-                const segment = editableSegments.getByType(SegmentTypes.Year);
+                element.value = value.set({ day: 1 });
+                await elementUpdated(element);
+                const segment = editableSegments.getByType(SegmentTypes.Day);
 
                 segment.focus();
-                await sendKeys({ press: 'Delete' });
+                await sendKeys({ press: 'ArrowDown' });
                 await elementUpdated(element);
-                expect(segment.innerText).to.equal(`202`);
-                expectSameDates(
-                    element.value!,
-                    new CalendarDateTime(202, month, day, hour, minute, second)
+
+                expect(segment.innerText).to.equal('28');
+                expectSameDates(element.value!, value.set({ day: 28 }));
+            });
+
+            it('when the min day is reached on a defined date value - leap year February', async () => {
+                const leapYear = 2024;
+                value = new CalendarDateTime(leapYear, 2, 15, 15, 15, 15);
+                element = await fixtureElement({
+                    props: {
+                        value,
+                    },
+                });
+                editableSegments = getEditableSegments(element);
+
+                element.value = value.set({ day: 1 });
+                await elementUpdated(element);
+                const segment = editableSegments.getByType(SegmentTypes.Day);
+
+                segment.focus();
+                await sendKeys({ press: 'ArrowDown' });
+                await elementUpdated(element);
+
+                expect(segment.innerText).to.equal('29');
+                expectSameDates(element.value!, value.set({ day: 29 }));
+            });
+
+            [SegmentTypes.Minute, SegmentTypes.Second].forEach(
+                (segmentType) => {
+                    it(`when the min ${segmentType} is reached on a defined date value`, async () => {
+                        element = await fixtureElement({
+                            props: {
+                                value,
+                                precision: Precisions.Second,
+                            },
+                        });
+                        editableSegments = getEditableSegments(element);
+
+                        const currentValue = element.value!;
+                        element.value = currentValue.set({
+                            [segmentType]: 0,
+                        });
+                        await elementUpdated(element);
+                        const segment = editableSegments.getByType(
+                            segmentType as EditableSegmentType
+                        );
+
+                        segment.focus();
+                        await sendKeys({ press: 'ArrowDown' });
+                        await elementUpdated(element);
+
+                        expect(segment.innerText).to.equal('59');
+                        expectSameDates(
+                            element.value!,
+                            value.set({ [segmentType]: 59 })
+                        );
+                    });
+                }
+            );
+        });
+    });
+
+    describe('Typed-in values', () => {
+        beforeEach(async () => {
+            element = await fixtureElement({
+                props: { precision: Precisions.Second },
+            });
+            editableSegments = getEditableSegments(element);
+        });
+
+        [SegmentTypes.Year, SegmentTypes.Month, SegmentTypes.Day].forEach(
+            (segmentType) => {
+                it(`should ignore initial zeros typed in the ${segmentType} segment`, async () => {
+                    const segment = editableSegments.getByType(
+                        segmentType as EditableSegmentType
+                    );
+
+                    segment.focus();
+                    await sendKeys({ type: '0' });
+                    await elementUpdated(element);
+
+                    expectPlaceholders(editableSegments);
+                    expect(element.value).to.be.undefined;
+                });
+            }
+        );
+
+        it('should update the year segment on type-in', async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Year);
+
+            segment.focus();
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('2');
+            await sendKeys({ type: '03' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('203');
+            await sendKeys({ type: '0' });
+            expect(segment.innerText).to.equal('2030');
+            await sendKeys({ type: '5' });
+            expect(segment.innerText).to.equal('305');
+
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should update the month segment on type-in', async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Month);
+
+            segment.focus();
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('02');
+            await sendKeys({ type: '4' });
+            expect(segment.innerText).to.equal('04');
+            await sendKeys({ type: '1' });
+            expect(segment.innerText).to.equal('01');
+            await sendKeys({ type: '2' });
+            expect(segment.innerText).to.equal('12');
+            await sendKeys({ type: '9' });
+            expect(segment.innerText).to.equal('09');
+            await sendKeys({ type: '0' });
+            expect(segment.innerText).to.equal('09');
+
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should update the day segment on type-in when no month/year is defined', async () => {
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            daySegment.focus();
+            await sendKeys({ type: '5' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('05');
+            await sendKeys({ type: '4' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('04');
+            await sendKeys({ type: '0' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('04');
+
+            expectPlaceholders(editableSegments, [daySegment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should not update the day segment when the typed in value is 31, 30 or 29 - common year February', async () => {
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+            yearSegment.focus();
+            await sendKeys({ type: '2022' }); // Common year in the Gregorian calendar
+            await elementUpdated(element);
+            monthSegment.focus();
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            daySegment.focus();
+
+            // Tries to set the day to 31
+            await sendKeys({ type: '3' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('03');
+            await sendKeys({ type: '1' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('01');
+
+            // Tries to set the day to 30
+            await sendKeys({ type: '3' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('13');
+            await sendKeys({ type: '0' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('13');
+
+            // Tries to set the day to 29
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('02');
+            await sendKeys({ type: '9' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('09');
+
+            expectPlaceholders(editableSegments, [
+                daySegment,
+                monthSegment,
+                yearSegment,
+            ]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should update the day segment when the typed in value is 28 - common year February', async () => {
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+            yearSegment.focus();
+            await sendKeys({ type: '2022' }); // Common year in the Gregorian calendar
+            await elementUpdated(element);
+            monthSegment.focus();
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            daySegment.focus();
+
+            // Tries to set the day to 28
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('02');
+            await sendKeys({ type: '8' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('28');
+
+            expectPlaceholders(editableSegments, [
+                daySegment,
+                monthSegment,
+                yearSegment,
+            ]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should not update the day segment when the typed in value is 31 or 30 - leap year February', async () => {
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+            yearSegment.focus();
+            await sendKeys({ type: '2024' }); // Leap year in the Gregorian calendar
+            await elementUpdated(element);
+            monthSegment.focus();
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            daySegment.focus();
+
+            // Tries to set the day to 31
+            await sendKeys({ type: '3' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('03');
+            await sendKeys({ type: '1' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('01');
+
+            // Tries to set the day to 30
+            await sendKeys({ type: '3' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('13');
+            await sendKeys({ type: '0' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('13');
+
+            expectPlaceholders(editableSegments, [
+                daySegment,
+                monthSegment,
+                yearSegment,
+            ]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should update the day segment when the typed in value is 29 or 28 - leap year February', async () => {
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+            yearSegment.focus();
+            await sendKeys({ type: '2024' }); // Leap year in the Gregorian calendar
+            await elementUpdated(element);
+            monthSegment.focus();
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            daySegment.focus();
+
+            // Tries to set the day to 29
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('02');
+            await sendKeys({ type: '9' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('29');
+
+            // Tries to set the day to 28
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('02');
+            await sendKeys({ type: '8' });
+            await elementUpdated(element);
+            expect(daySegment.innerText).to.equal('28');
+
+            expectPlaceholders(editableSegments, [
+                daySegment,
+                monthSegment,
+                yearSegment,
+            ]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should update the hour segment on type-in on a 12h format', async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Hour);
+
+            segment.focus();
+            await sendKeys({ type: '1' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('01');
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('12');
+            await sendKeys({ type: '3' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('03');
+            await sendKeys({ type: '0' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('03');
+
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should update the dayPeriod segment on type-in on a 12h format', async () => {
+            const dayPeriodSegment = editableSegments.getByType(
+                SegmentTypes.DayPeriod
+            );
+
+            dayPeriodSegment.focus();
+            await sendKeys({ type: 'A' });
+            await elementUpdated(element);
+
+            expect(dayPeriodSegment.innerText).to.equal(`AM`);
+            expectPlaceholders(editableSegments, [dayPeriodSegment]);
+            expect(element.value).to.be.undefined;
+
+            await sendKeys({ type: 'P' });
+            await elementUpdated(element);
+
+            expect(dayPeriodSegment.innerText).to.equal(`PM`);
+            expectPlaceholders(editableSegments, [dayPeriodSegment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        it('should update the hour segment on type-in on a 24h format', async () => {
+            element = await fixtureElement({ locale: 'en-GB' });
+            editableSegments = getEditableSegments(element);
+            const segment = editableSegments.getByType(SegmentTypes.Hour);
+
+            segment.focus();
+            await sendKeys({ type: '0' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('00');
+            await sendKeys({ type: '1' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('01');
+            await sendKeys({ type: '2' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('12');
+            await sendKeys({ type: '3' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('23');
+            await sendKeys({ type: '5' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('05');
+            await sendKeys({ type: '0' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal('00');
+
+            expectPlaceholders(editableSegments, [segment]);
+            expect(element.value).to.be.undefined;
+        });
+
+        [SegmentTypes.Minute, SegmentTypes.Second].forEach((segmentType) => {
+            it(`should update the ${segmentType} segment on type-in`, async () => {
+                const segment = editableSegments.getByType(
+                    segmentType as EditableSegmentType
                 );
 
-                await sendKeys({ press: 'Delete' });
+                segment.focus();
+                await sendKeys({ type: '5' });
                 await elementUpdated(element);
-                expect(segment.innerText).to.equal(`20`);
-                expectSameDates(
-                    element.value!,
-                    new CalendarDateTime(20, month, day, hour, minute, second)
+                expect(segment.innerText).to.equal('05');
+                await sendKeys({ type: '8' });
+                await elementUpdated(element);
+                expect(segment.innerText).to.equal('58');
+                await sendKeys({ type: '0' });
+                await elementUpdated(element);
+                expect(segment.innerText).to.equal('00');
+
+                expectPlaceholders(editableSegments, [segment]);
+                expect(element.value).to.be.undefined;
+            });
+        });
+
+        describe('day segment updates', () => {
+            let yearSegment: HTMLElement;
+            let monthSegment: HTMLElement;
+            let daySegment: HTMLElement;
+
+            beforeEach(async () => {
+                element = await fixtureElement({
+                    props: { precision: Precisions.Day },
+                });
+                editableSegments = getEditableSegments(element);
+
+                yearSegment = editableSegments.getByType(SegmentTypes.Year);
+                monthSegment = editableSegments.getByType(SegmentTypes.Month);
+                daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+                daySegment.focus();
+                await sendKeys({ type: '31' });
+                await elementUpdated(element);
+            });
+
+            it('when the month changes to February on type-in, with no year selected', async () => {
+                monthSegment.focus();
+                await sendKeys({ type: '2' });
+                await elementUpdated(element);
+
+                expect(monthSegment.innerText).to.equal('02');
+                expect(daySegment.innerText).to.equal('29');
+
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                ]);
+                expect(element.value).to.be.undefined;
+            });
+
+            it('when the month changes to February on type-in, in a common year', async () => {
+                yearSegment.focus();
+                await sendKeys({ type: '2022' }); // Common year in the Gregorian calendar
+                await elementUpdated(element);
+                monthSegment.focus();
+                await sendKeys({ type: '2' });
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal('2022');
+                expect(monthSegment.innerText).to.equal('02');
+                expect(daySegment.innerText).to.equal('28');
+
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(2022, 2, 28));
+            });
+
+            it('when the month changes to February on type-in, in a leap year', async () => {
+                yearSegment.focus();
+                await sendKeys({ type: '2024' }); // Leap year in the Gregorian calendar
+                await elementUpdated(element);
+                monthSegment.focus();
+                await sendKeys({ type: '2' });
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal('2024');
+                expect(monthSegment.innerText).to.equal('02');
+                expect(daySegment.innerText).to.equal('29');
+
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(2024, 2, 29));
+            });
+
+            it('when the year changes to a leap year on type-in, and the month is February', async () => {
+                monthSegment.focus();
+                await sendKeys({ type: '2' });
+                await elementUpdated(element);
+                yearSegment.focus();
+                await sendKeys({ type: '4' }); // Leap year in the Gregorian calendar
+                await elementUpdated(element);
+
+                expect(yearSegment.innerText).to.equal('4');
+                expect(monthSegment.innerText).to.equal('02');
+                expect(daySegment.innerText).to.equal('29');
+
+                expectPlaceholders(editableSegments, [
+                    daySegment,
+                    monthSegment,
+                    yearSegment,
+                ]);
+                expectSameDates(element.value!, new CalendarDate(4, 2, 29));
+            });
+        });
+    });
+
+    describe("Segments' value deletion", () => {
+        const day = 15;
+        const month = 11;
+        const hour = 15;
+        const minute = 15;
+        const second = 15;
+
+        beforeEach(async () => {
+            const value = new CalendarDateTime(
+                2022,
+                month,
+                day,
+                hour,
+                minute,
+                second
+            );
+            element = await fixtureElement({
+                props: {
+                    value,
+                    precision: Precisions.Second,
+                },
+            });
+            editableSegments = getEditableSegments(element);
+        });
+
+        it("should delete the year segment's value using incremental deletion", async () => {
+            const segment = editableSegments.getByType(SegmentTypes.Year);
+
+            segment.focus();
+            await sendKeys({ press: 'Delete' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal(`202`);
+            expectSameDates(
+                element.value!,
+                new CalendarDateTime(202, month, day, hour, minute, second)
+            );
+
+            await sendKeys({ press: 'Delete' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal(`20`);
+            expectSameDates(
+                element.value!,
+                new CalendarDateTime(20, month, day, hour, minute, second)
+            );
+
+            await sendKeys({ press: 'Delete' });
+            await elementUpdated(element);
+            expect(segment.innerText).to.equal(`2`);
+            expectSameDates(
+                element.value!,
+                new CalendarDateTime(2, month, day, hour, minute, second)
+            );
+
+            await sendKeys({ press: 'Delete' });
+            await elementUpdated(element);
+
+            expectPlaceholder(segment);
+            expect(element.value).to.be.undefined;
+        });
+
+        [
+            SegmentTypes.Month,
+            SegmentTypes.Day,
+            SegmentTypes.Hour,
+            SegmentTypes.Minute,
+            SegmentTypes.Second,
+            SegmentTypes.DayPeriod,
+        ].forEach((segmentType) => {
+            it(`should delete the ${segmentType} segment's value using mass deletion`, async () => {
+                const segment = editableSegments.getByType(
+                    segmentType as EditableSegmentType
                 );
 
-                await sendKeys({ press: 'Delete' });
-                await elementUpdated(element);
-                expect(segment.innerText).to.equal(`2`);
-                expectSameDates(
-                    element.value!,
-                    new CalendarDateTime(2, month, day, hour, minute, second)
-                );
-
+                segment.focus();
                 await sendKeys({ press: 'Delete' });
                 await elementUpdated(element);
 
                 expectPlaceholder(segment);
                 expect(element.value).to.be.undefined;
             });
-
-            [
-                SegmentTypes.Month,
-                SegmentTypes.Day,
-                SegmentTypes.Hour,
-                SegmentTypes.Minute,
-                SegmentTypes.Second,
-                SegmentTypes.DayPeriod,
-            ].forEach((segmentType) => {
-                it(`from the ${segmentType} segment using mass deletion`, async () => {
-                    const segment = editableSegments.getByType(
-                        segmentType as EditableSegmentType
-                    );
-
-                    segment.focus();
-                    await sendKeys({ press: 'Delete' });
-                    await elementUpdated(element);
-
-                    expectPlaceholder(segment);
-                    expect(element.value).to.be.undefined;
-                });
-            });
         });
     });
 
-    describe('Correctly dispatches', () => {
-        describe('the change event', () => {
-            it('when all segments have a value for the first time');
-            it("when segments' value changes and user commits");
+    describe('Dispatched events', () => {
+        it(
+            "should dispatch 'change' when all segments have a value for the first time"
+        );
+        it("should dispatch 'change' when the value changes are committed");
+        it("should not dispatch 'change' if the committed value is the same");
 
-            // As per React Spectrum it should send one change event when the change that made the
-            // date incomplete is made and none after that until the date is complete again
-            it("when a segment's value is deleted");
-        });
+        // As per React Spectrum it should send one change event when the change that made the
+        // date incomplete is made and none after that until the date is complete again
+        it("should dispatch 'change' when a segment is deleted");
 
-        describe('the input event', () => {
-            it(
-                "when a segment's value changes through typing on an existing value"
-            );
+        it(
+            "should dispatch 'input' when a segment changes through typing on an existing value"
+        );
 
-            it(
-                "when a segment's value changes through typing on an empty value"
-            );
+        // test for multiple inputs not only the first one
+        it(
+            "should dispatch 'input' when a segment changes through typing on an empty value"
+        );
 
-            it(
-                "when a segment's value changes through incrementing/decrementing on an existing value"
-            );
-
-            it(
-                "when a segment's value changes through incrementing/decrementing on an empty value"
-            );
-        });
+        it(
+            "should dispatch 'input' when a segment changes through incrementing/should decrement on an existing value"
+        );
+        it(
+            "should dispatch 'input' when a segment changes through incrementing/decrementing on an empty value"
+        );
     });
 
-    describe('Manages min and max constraints', () => {
+    describe('Min-max constraints', () => {
+        const dayOffset = 5;
         let min: CalendarDateTime;
         let max: CalendarDateTime;
-        const dayOffset = 5;
 
-        before(async () => {
+        before(() => {
             min = new CalendarDateTime(
                 fixedYear,
                 fixedMonth,
@@ -2302,7 +2498,7 @@ describe('DateTimePicker', () => {
             );
         });
 
-        it('when min > max date by ignoring them', async () => {
+        it('should ignore the provided min and max properties when the interval is invalid', async () => {
             const min = max.set({ day: max.day + 1 });
             element = await fixtureElement({
                 props: { min, max },
@@ -2312,244 +2508,440 @@ describe('DateTimePicker', () => {
             expect(element.max).to.be.undefined;
         });
 
-        it("when a preselected value date doesn't comply by ignoring it", async () => {
+        it("should ignore the provided value property when it doesn't comply with the min-max interval", async () => {
             const value = max.set({ day: max.day + 1 });
             element = await fixtureElement({
                 props: { min, max, value },
             });
 
             expect(element.value).to.be.undefined;
-            expect(element.min).to.not.be.undefined;
-            expect(element.max).to.not.be.undefined;
-            expectSameDates(element.min!, min);
-            expectSameDates(element.max!, max);
+            expectSameDates(element.min!, min, 'min mismatch');
+            expectSameDates(element.max!, max, 'max mismatch');
         });
 
-        it("by invalidating the current value when it doesn't comply with the new interval", async () => {
+        it("should invalidate the current value when it doesn't comply with min changes", async () => {
             const value = min.set({ day: min.day + 1 });
             element = await fixtureElement({
                 props: { min, max, value },
             });
 
-            expect(element.value).to.not.be.undefined;
-            expect(element.min).to.not.be.undefined;
-            expect(element.max).to.not.be.undefined;
+            expect(element.value, 'value not undefined').to.not.be.undefined;
+            expect(element.min, 'min not undefined').to.not.be.undefined;
+            expect(element.max, 'max not undefined').to.not.be.undefined;
 
-            const newMin = max.set({ day: max.day - 1 });
+            const newMin = value.set({ day: value.day + 1 });
             element.min = newMin;
             await elementUpdated(element);
 
             expect(element.value).to.be.undefined;
-            expect(element.min).to.not.be.undefined;
-            expectSameDates(element.min!, newMin);
-            expect(element.max).to.not.be.undefined;
-            expectSameDates(element.max!, max);
+            expectSameDates(element.min!, newMin, 'min mismatch');
+            expectSameDates(element.max!, max, 'max mismatch');
+        });
 
-            const newMax = max.set({ day: max.day + 1 });
+        it("should invalidate the current value when it doesn't comply with max changes", async () => {
+            const value = min.set({ day: min.day + 5 });
+
+            element = await fixtureElement({
+                props: { min, max, value },
+            });
+
+            const newMax = value.set({ day: value.day - 1 });
             element.max = newMax;
             await elementUpdated(element);
 
             expect(element.value).to.be.undefined;
-            expect(element.min).to.not.be.undefined;
-            expectSameDates(element.min!, newMin);
-            expect(element.max).to.not.be.undefined;
-            expectSameDates(element.max!, newMax);
+            expectSameDates(element.min!, min, 'min mismatch');
+            expectSameDates(element.max!, newMax, 'max mismatch');
+        });
+
+        it("should invalidate the current value when it doesn't comply with min and max changes", async () => {
+            const value = min.set({ day: min.day + 1 });
+            element = await fixtureElement({
+                props: { min, max, value },
+            });
+
+            const newMin = value.set({ day: value.day + 1 });
+            const newMax = max.set({ day: max.day + 1 });
+            element.min = newMin;
+            element.max = newMax;
+            await elementUpdated(element);
+
+            expect(element.value).to.be.undefined;
+            expectSameDates(element.min!, newMin, 'min mismatch');
+            expectSameDates(element.max!, newMax, 'max mismatch');
         });
 
         // TODO: with the Space/Enter/Blur value commit PR
         it(
-            "by triggering the 'invalid' state when a value that doesn't comply is commited"
+            "should trigger the 'invalid' state when a value that doesn't comply is commited"
         );
     });
 
-    describe('Manages multiple types', () => {
-        // TODO: with the precision update PR
-        it("updating precision to 'day' when no time information is given");
+    describe('Multiple types for min, max and value properties', () => {
+        it('should keep the type when all types are CalendarDates', async () => {
+            const value = valueDate;
+            const min = value.set({ day: value.day - 5 });
+            const max = value.set({ day: value.day + 5 });
 
-        // TODO: with the precision update PR
-        it(
-            'by not overriding the precision if it was provided by the consumer'
-        );
-
-        describe('keeping the type when all types for given properties match', () => {
-            it('when the type is CalendarDate', async () => {
-                const value = new CalendarDate(fixedYear, fixedMonth, fixedDay);
-                const min = value.set({ day: value.day - 5 });
-                const max = value.set({ day: value.day + 5 });
-
-                element = await fixtureElement({
-                    props: { min, max, value, precision: Precisions.Day },
-                });
-                await elementUpdated(element);
-
-                expect(element.value).to.be.instanceOf(CalendarDate);
-                expectSameDates(element.value!, value);
-                expect(element.min).to.be.instanceOf(CalendarDate);
-                expectSameDates(element.min!, min);
-                expect(element.max).to.be.instanceOf(CalendarDate);
-                expectSameDates(element.max!, max);
+            element = await fixtureElement({
+                props: { min, max, value },
             });
 
-            it('when the type is CalendarDateTime', async () => {
-                const value = new CalendarDateTime(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay - 5,
-                    9,
-                    15,
-                    30
-                );
-                const min = value.set({ day: value.day - 5 });
-                const max = value.set({ day: value.day + 5 });
-
-                element = await fixtureElement({
-                    props: { min, max, value },
-                });
-
-                expect(element.value).to.be.instanceOf(CalendarDateTime);
-                expectSameDates(element.value!, value);
-                expect(element.min).to.be.instanceOf(CalendarDateTime);
-                expectSameDates(element.min!, min);
-                expect(element.max).to.be.instanceOf(CalendarDateTime);
-                expectSameDates(element.max!, max);
-            });
-
-            it('when the type is ZonedDateTime', async () => {
-                const value = new ZonedDateTime(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay,
-                    'America/Los_Angeles',
-                    -28800000,
-                    9,
-                    15,
-                    30
-                );
-                const min = value.set({ day: value.day - 5 });
-                const max = value.set({ day: value.day + 5 });
-
-                element = await fixtureElement({
-                    props: { min, max, value },
-                });
-
-                expect(element.value).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.value!, value);
-                expect(element.min).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.min!, min);
-                expect(element.max).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.max!, max);
-            });
+            expect(
+                element.value,
+                'value not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+            expectSameDates(element.value!, value, 'value mismatch');
+            expect(
+                element.min,
+                'min not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+            expectSameDates(element.min!, min, 'min mismatch');
+            expect(
+                element.max,
+                'max not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+            expectSameDates(element.max!, max, 'max mismatch');
         });
 
-        describe('converting to the most specific type', () => {
-            it('when value and min are provided', async () => {
-                const value = new CalendarDate(fixedYear, fixedMonth, fixedDay);
-                const min = new CalendarDateTime(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay - 5,
-                    9,
-                    15
-                );
+        it('should keep the type when all types are CalendarDateTimes', async () => {
+            const value = valueDateTime;
+            const min = value.set({ day: value.day - 5 });
+            const max = value.set({ day: value.day + 5 });
 
-                element = await fixtureElement({
-                    props: { min, value },
-                });
-
-                expect(element.value).to.be.instanceOf(CalendarDateTime);
-                expectSameDates(element.value!, value);
-                expect(element.min).to.be.instanceOf(CalendarDateTime);
-                expectSameDates(element.min!, min);
-                expect(element.max).to.be.undefined;
+            element = await fixtureElement({
+                props: { min, max, value },
             });
 
-            it('when value and max are provided', async () => {
-                const value = new ZonedDateTime(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay,
-                    'America/Los_Angeles',
-                    -28800000
-                );
-                const max = new CalendarDateTime(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay + 5,
-                    9,
-                    15
-                );
-
-                element = await fixtureElement({
-                    props: { max, value },
-                });
-
-                expect(element.value).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.value!, value);
-                expect(element.max).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.max!, max);
-                expect(element.min).to.be.undefined;
-            });
-
-            it('when min and max are provided', async () => {
-                const min = new ZonedDateTime(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay,
-                    'America/Los_Angeles',
-                    -28800000
-                );
-                const max = new CalendarDate(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay + 5
-                );
-
-                element = await fixtureElement({
-                    props: { max, min },
-                });
-
-                expect(element.min).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.min!, min);
-                expect(element.max).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.max!, max);
-                expect(element.value).to.be.undefined;
-            });
-
-            it('when value, min and max are provided', async () => {
-                const value = new ZonedDateTime(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay,
-                    'America/Los_Angeles',
-                    -28800000
-                );
-                const min = new CalendarDate(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay - 5
-                );
-                const max = new CalendarDateTime(
-                    fixedYear,
-                    fixedMonth,
-                    fixedDay + 5,
-                    9,
-                    15
-                );
-
-                element = await fixtureElement({
-                    props: { min, max, value },
-                });
-
-                expect(element.value).to.be.instanceOf(ZonedDateTime);
-                expect(element.min).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.min!, min);
-                expect(element.max).to.be.instanceOf(ZonedDateTime);
-                expectSameDates(element.max!, max);
-            });
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, value, 'value mismatch');
+            expect(
+                element.min,
+                'min not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.min!, min, 'min mismatch');
+            expect(
+                element.max,
+                'max not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.max!, max, 'max mismatch');
         });
 
-        it("resetting currentDate's timeZone to local when the type changes back to one with no timeZone", async () => {
-            const value = new ZonedDateTime(
+        it('should keep the type when all types are ZonedDateTimes', async () => {
+            const value = valueZoned;
+            const min = value.set({ day: value.day - 5 });
+            const max = value.set({ day: value.day + 5 });
+
+            element = await fixtureElement({
+                props: { min, max, value },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, value, 'value mismatch');
+            expect(
+                element.min,
+                'min not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.min!, min, 'min mismatch');
+            expect(
+                element.max,
+                'max not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.max!, max, 'max mismatch');
+        });
+
+        it('should keep the CalendarDate type when precision is Day', async () => {
+            element = await fixtureElement({
+                props: { value: valueDate, precision: Precisions.Day },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+            expectSameDates(element.value!, valueDate);
+        });
+
+        it('should keep the CalendarDateTime type when precision is Day', async () => {
+            element = await fixtureElement({
+                props: { value: valueDateTime, precision: Precisions.Day },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, valueDateTime);
+        });
+
+        it('should keep the ZonedDateTime type when precision is Day', async () => {
+            element = await fixtureElement({
+                props: { value: valueZoned, precision: Precisions.Day },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, valueZoned);
+        });
+
+        it('should convert CalendarDate to CalendarDateTime when precision includes time', async () => {
+            const value = valueDate;
+            element = await fixtureElement({
+                props: { value, precision: Precisions.Hour },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, value);
+
+            element.value = value;
+            element.precision = Precisions.Minute;
+            await elementUpdated(element);
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, value);
+
+            element.value = value;
+            element.precision = Precisions.Second;
+            await elementUpdated(element);
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, value);
+        });
+
+        it('should keep the CalendarDateTime type when precision includes time', async () => {
+            const value = valueDateTime;
+            element = await fixtureElement({
+                props: { value, precision: Precisions.Hour },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, value);
+
+            element.precision = Precisions.Minute;
+            await elementUpdated(element);
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, value);
+
+            element.precision = Precisions.Second;
+            await elementUpdated(element);
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, value);
+        });
+
+        it('should keep the ZonedDateTime type when the precision includes time', async () => {
+            const value = valueZoned;
+            element = await fixtureElement({
+                props: { value, precision: Precisions.Hour },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, value);
+
+            element.precision = Precisions.Minute;
+            await elementUpdated(element);
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, value);
+
+            element.precision = Precisions.Second;
+            await elementUpdated(element);
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, value);
+        });
+
+        it("should convert the types to the most specific type when they're mixed - CalendarDate and CalendarDateTime", async () => {
+            const minDateTime = valueDateTime.set({
+                day: valueDateTime.day - 5,
+            });
+            element = await fixtureElement({
+                props: {
+                    value: valueDate,
+                    min: minDateTime,
+                },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.value!, valueDate, 'value mismatch');
+            expect(
+                element.min,
+                'min not an instance of CalendarDateTime'
+            ).to.be.instanceOf(CalendarDateTime);
+            expectSameDates(element.min!, minDateTime, 'min mismatch');
+            expect(element.max).to.be.undefined;
+        });
+
+        it("should convert the types to the most specific type when they're mixed - CalendarDateTime and ZonedDateTime", async () => {
+            const maxDateTime = valueDateTime.set({
+                year: valueDateTime.year + 5,
+            });
+            element = await fixtureElement({
+                props: { max: maxDateTime, value: valueZoned },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, valueZoned, 'value mismatch');
+            expect(
+                element.max,
+                'max not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.max!, maxDateTime, 'max mismatch');
+            expect(element.min).to.be.undefined;
+        });
+
+        it("should convert the types to the most specific type when they're mixed - CalendarDate and ZonedDateTime", async () => {
+            const minDate = valueDate.set({ day: valueDate.day - 5 });
+            element = await fixtureElement({
+                props: {
+                    value: valueZoned,
+                    min: minDate,
+                },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, valueZoned, 'value mismatch');
+            expect(
+                element.min,
+                'min not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.min!, minDate, 'min mismatch');
+            expect(element.max).to.be.undefined;
+        });
+
+        it("should convert the types to the most specific type when they're mixed - CalendarDate, CalendarDateTime and ZonedDateTime", async () => {
+            const minDate = valueDate.set({ day: valueDate.day - 5 });
+            const maxDateTime = valueDateTime.set({
+                year: valueDateTime.year + 5,
+            });
+            element = await fixtureElement({
+                props: {
+                    value: valueZoned,
+                    min: minDate,
+                    max: maxDateTime,
+                },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, valueZoned, 'value mismatch');
+            expect(
+                element.min,
+                'min not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.min!, minDate, 'min mismatch');
+            expect(
+                element.max,
+                'max not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.max!, maxDateTime, 'max mismatch');
+        });
+
+        it("should reset currentDate's timeZone to local when type changes to no timeZone", async () => {
+            element = await fixtureElement({
+                props: { value: valueZoned },
+            });
+
+            expect(
+                element.value,
+                'value not an instance of ZonedDateTime'
+            ).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, valueZoned, 'value mismatch');
+            expectSameDates(element['currentDate'], valueZoned);
+            expect(element['currentDate'].timeZone).to.equal(
+                valueZoned.timeZone,
+                'timeZone mismatch'
+            );
+            expect(element['currentDate'].offset).to.equal(
+                valueZoned.offset,
+                'offset mismatch'
+            );
+
+            element.value = valueDate;
+            await elementUpdated(element);
+
+            expect(
+                element.value,
+                'value not an instance of CalendarDate'
+            ).to.be.instanceOf(CalendarDate);
+            expectSameDates(element.value!, valueDate, 'value mismatch');
+            expect(element['currentDate'].timeZone).to.equal(
+                getLocalTimeZone()
+            );
+        });
+    });
+
+    describe('Precision', () => {
+        it("should default precision to 'minute' when no props are provided", async () => {
+            element = await fixtureElement();
+
+            expect(element.precision).to.equal(Precisions.Minute);
+        });
+
+        it("should default precision to 'minute' when CalendarDateTime type is provided", async () => {
+            const min = new CalendarDateTime(
+                fixedYear,
+                fixedMonth,
+                fixedDay,
+                15,
+                15
+            );
+            element = await fixtureElement({
+                props: { min },
+            });
+
+            expect(element.precision).to.equal(Precisions.Minute);
+        });
+
+        it("should default precision to 'minute' when ZonedDateTime type is provided", async () => {
+            const max = new ZonedDateTime(
                 fixedYear,
                 fixedMonth,
                 fixedDay,
@@ -2557,28 +2949,491 @@ describe('DateTimePicker', () => {
                 -28800000
             );
             element = await fixtureElement({
+                props: { max },
+            });
+
+            expect(element.precision).to.equal(Precisions.Minute);
+        });
+
+        it("should default precision to 'day' when CalendarDate type is provided", async () => {
+            const value = new CalendarDate(fixedYear, fixedMonth, fixedDay);
+            element = await fixtureElement({
                 props: { value },
             });
 
-            expect(element.value).to.be.instanceOf(ZonedDateTime);
-            expectSameDates(element.value!, value);
-            expectSameDates(element['currentDate'], value);
-            expect(element['currentDate'].timeZone).to.equal(
-                'America/Los_Angeles'
-            );
+            expect(element.precision).to.equal(Precisions.Day);
+        });
 
-            element.value = new CalendarDate(fixedYear, fixedMonth, fixedDay);
-            await elementUpdated(element);
+        it('should default precision to the provided one when no date is provided', async () => {
+            const precisions = Object.values(Precisions);
 
-            expect(element.value).to.be.instanceOf(CalendarDate);
-            expectSameDates(element.value!, value);
-            expect(element['currentDate'].timeZone).to.equal(
-                getLocalTimeZone()
+            for (const precision of precisions) {
+                element = await fixtureElement({
+                    props: { precision },
+                });
+
+                expect(element.precision).to.equal(precision);
+            }
+        });
+
+        it('should default precision to the provided one when a date value type is provided', async () => {
+            const precisions = Object.values(Precisions);
+
+            // CalendarDate
+            const min = new CalendarDate(fixedYear, fixedMonth, fixedDay);
+            for (const precision of precisions) {
+                element = await fixtureElement({
+                    props: { min, precision },
+                });
+
+                expect(element.precision).to.equal(precision);
+            }
+
+            // CalendarDateTime
+            const max = new CalendarDateTime(
+                fixedYear,
+                fixedMonth,
+                fixedDay,
+                15,
+                15
             );
+            for (const precision of precisions) {
+                element = await fixtureElement({
+                    props: { max, precision },
+                });
+
+                expect(element.precision).to.equal(precision);
+            }
+
+            // ZonedDateTime
+            const value = toZoned(max, 'America/Los_Angeles');
+            for (const precision of precisions) {
+                element = await fixtureElement({
+                    props: { value, precision },
+                });
+
+                expect(element.precision).to.equal(precision);
+            }
         });
     });
 
-    describe('Warns in dev mode', () => {
+    describe('Segments creation on a 12h format', () => {
+        const locale = 'en-US';
+        const value: DateTimePickerValue = new ZonedDateTime(
+            fixedYear,
+            fixedMonth,
+            fixedDay,
+            'America/Los_Angeles',
+            -28800000,
+            15,
+            45,
+            23
+        );
+        const paddedYear = String(fixedYear).padStart(4, '0');
+        const paddedMonth = String(fixedMonth).padStart(2, '0');
+        const paddedDay = String(fixedDay).padStart(2, '0');
+        const paddedHour = '03';
+        const paddedMinute = '45';
+        const paddedSecond = '23';
+
+        it("should create placeholder segments up to 'day' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Day },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+            expect(editableSegments.length).to.equal(3);
+            expectPlaceholders(editableSegments);
+            expect(yearSegment).to.not.be.undefined;
+            expect(monthSegment).to.not.be.undefined;
+            expect(daySegment).to.not.be.undefined;
+        });
+
+        it("should create placeholder segments up to 'hour' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Hour },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const dayPeriodSegment = editableSegments.getByType(
+                SegmentTypes.DayPeriod
+            );
+
+            expect(editableSegments.length).to.equal(5);
+            expectPlaceholders(editableSegments);
+            expect(yearSegment).to.not.be.undefined;
+            expect(monthSegment).to.not.be.undefined;
+            expect(daySegment).to.not.be.undefined;
+            expect(hourSegment).to.not.be.undefined;
+            expect(dayPeriodSegment).to.not.be.undefined;
+        });
+
+        it("should create placeholder segments up to 'minute' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Minute },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const minuteSegment = editableSegments.getByType(
+                SegmentTypes.Minute
+            );
+            const dayPeriodSegment = editableSegments.getByType(
+                SegmentTypes.DayPeriod
+            );
+
+            expect(editableSegments.length).to.equal(6);
+            expectPlaceholders(editableSegments);
+            expect(yearSegment).to.not.be.undefined;
+            expect(monthSegment).to.not.be.undefined;
+            expect(daySegment).to.not.be.undefined;
+            expect(hourSegment).to.not.be.undefined;
+            expect(minuteSegment).to.not.be.undefined;
+            expect(dayPeriodSegment).to.not.be.undefined;
+        });
+
+        it("should create placeholder segments up to 'second' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Second },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const minuteSegment = editableSegments.getByType(
+                SegmentTypes.Minute
+            );
+            const secondSegment = editableSegments.getByType(
+                SegmentTypes.Second
+            );
+            const dayPeriodSegment = editableSegments.getByType(
+                SegmentTypes.DayPeriod
+            );
+
+            expect(editableSegments.length).to.equal(7);
+            expectPlaceholders(editableSegments);
+            expect(yearSegment).to.not.be.undefined;
+            expect(monthSegment).to.not.be.undefined;
+            expect(daySegment).to.not.be.undefined;
+            expect(hourSegment).to.not.be.undefined;
+            expect(minuteSegment).to.not.be.undefined;
+            expect(secondSegment).to.not.be.undefined;
+            expect(dayPeriodSegment).to.not.be.undefined;
+        });
+
+        it("should format segments up to 'day' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Day, value },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+            expect(editableSegments.length).to.equal(3);
+            expect(yearSegment.innerText).to.equal(paddedYear);
+            expect(monthSegment.innerText).to.equal(paddedMonth);
+            expect(daySegment.innerText).to.equal(paddedDay);
+        });
+
+        it("should format segments up to 'hour' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Hour, value },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const dayPeriodSegment = editableSegments.getByType(
+                SegmentTypes.DayPeriod
+            );
+
+            expect(editableSegments.length).to.equal(5);
+            expect(yearSegment.innerText).to.equal(paddedYear);
+            expect(monthSegment.innerText).to.equal(paddedMonth);
+            expect(daySegment.innerText).to.equal(paddedDay);
+            expect(hourSegment.innerText).to.equal(paddedHour);
+            expect(dayPeriodSegment.innerText).to.equal('PM');
+        });
+
+        it("should format segments up to 'minute' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Minute, value },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const minuteSegment = editableSegments.getByType(
+                SegmentTypes.Minute
+            );
+            const dayPeriodSegment = editableSegments.getByType(
+                SegmentTypes.DayPeriod
+            );
+
+            expect(editableSegments.length).to.equal(6);
+            expect(yearSegment.innerText).to.equal(paddedYear);
+            expect(monthSegment.innerText).to.equal(paddedMonth);
+            expect(daySegment.innerText).to.equal(paddedDay);
+            expect(hourSegment.innerText).to.equal(paddedHour);
+            expect(minuteSegment.innerText).to.equal(paddedMinute);
+            expect(dayPeriodSegment.innerText).to.equal('PM');
+        });
+
+        it("should format segments up to 'second' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Second, value },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const minuteSegment = editableSegments.getByType(
+                SegmentTypes.Minute
+            );
+            const secondSegment = editableSegments.getByType(
+                SegmentTypes.Second
+            );
+            const dayPeriodSegment = editableSegments.getByType(
+                SegmentTypes.DayPeriod
+            );
+
+            expect(editableSegments.length).to.equal(7);
+            expect(yearSegment.innerText).to.equal(paddedYear);
+            expect(monthSegment.innerText).to.equal(paddedMonth);
+            expect(daySegment.innerText).to.equal(paddedDay);
+            expect(hourSegment.innerText).to.equal(paddedHour);
+            expect(minuteSegment.innerText).to.equal(paddedMinute);
+            expect(secondSegment.innerText).to.equal(paddedSecond);
+            expect(dayPeriodSegment.innerText).to.equal('PM');
+        });
+    });
+
+    describe('Segments creation on a 24h format', () => {
+        const locale = 'en-GB';
+        const value: DateTimePickerValue = new ZonedDateTime(
+            fixedYear,
+            fixedMonth,
+            fixedDay,
+            'America/Los_Angeles',
+            -28800000,
+            15,
+            45,
+            23
+        );
+        const paddedYear = String(fixedYear).padStart(4, '0');
+        const paddedMonth = String(fixedMonth).padStart(2, '0');
+        const paddedDay = String(fixedDay).padStart(2, '0');
+        const paddedHour = '15';
+        const paddedMinute = '45';
+        const paddedSecond = '23';
+
+        it("should create placeholder segments up to 'day' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Day },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+            expect(editableSegments.length).to.equal(3);
+            expectPlaceholders(editableSegments);
+            expect(yearSegment).to.not.be.undefined;
+            expect(monthSegment).to.not.be.undefined;
+            expect(daySegment).to.not.be.undefined;
+        });
+
+        it("should create placeholder segments up to 'hour' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Hour },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+
+            expect(editableSegments.length).to.equal(4);
+            expectPlaceholders(editableSegments);
+            expect(yearSegment).to.not.be.undefined;
+            expect(monthSegment).to.not.be.undefined;
+            expect(daySegment).to.not.be.undefined;
+            expect(hourSegment).to.not.be.undefined;
+        });
+
+        it("should create placeholder segments up to 'minute' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Minute },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const minuteSegment = editableSegments.getByType(
+                SegmentTypes.Minute
+            );
+
+            expect(editableSegments.length).to.equal(5);
+            expectPlaceholders(editableSegments);
+            expect(yearSegment).to.not.be.undefined;
+            expect(monthSegment).to.not.be.undefined;
+            expect(daySegment).to.not.be.undefined;
+            expect(hourSegment).to.not.be.undefined;
+            expect(minuteSegment).to.not.be.undefined;
+        });
+
+        it("should create placeholder segments up to 'second' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Second },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const minuteSegment = editableSegments.getByType(
+                SegmentTypes.Minute
+            );
+            const secondSegment = editableSegments.getByType(
+                SegmentTypes.Second
+            );
+
+            expect(editableSegments.length).to.equal(6);
+            expectPlaceholders(editableSegments);
+            expect(yearSegment).to.not.be.undefined;
+            expect(monthSegment).to.not.be.undefined;
+            expect(daySegment).to.not.be.undefined;
+            expect(hourSegment).to.not.be.undefined;
+            expect(minuteSegment).to.not.be.undefined;
+            expect(secondSegment).to.not.be.undefined;
+        });
+
+        it("should format segments up to 'day' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Day, value },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+
+            expect(editableSegments.length).to.equal(3);
+            expect(yearSegment.innerText).to.equal(paddedYear);
+            expect(monthSegment.innerText).to.equal(paddedMonth);
+            expect(daySegment.innerText).to.equal(paddedDay);
+        });
+
+        it("should format segments up to 'hour' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Hour, value },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+
+            expect(editableSegments.length).to.equal(4);
+            expect(yearSegment.innerText).to.equal(paddedYear);
+            expect(monthSegment.innerText).to.equal(paddedMonth);
+            expect(daySegment.innerText).to.equal(paddedDay);
+            expect(hourSegment.innerText).to.equal(paddedHour);
+        });
+
+        it("should format segments up to 'minute' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Minute, value },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const minuteSegment = editableSegments.getByType(
+                SegmentTypes.Minute
+            );
+
+            expect(editableSegments.length).to.equal(5);
+            expect(yearSegment.innerText).to.equal(paddedYear);
+            expect(monthSegment.innerText).to.equal(paddedMonth);
+            expect(daySegment.innerText).to.equal(paddedDay);
+            expect(hourSegment.innerText).to.equal(paddedHour);
+            expect(minuteSegment.innerText).to.equal(paddedMinute);
+        });
+
+        it("should format segments up to 'second' precision", async () => {
+            element = await fixtureElement({
+                locale,
+                props: { precision: Precisions.Second, value },
+            });
+            editableSegments = getEditableSegments(element);
+
+            const yearSegment = editableSegments.getByType(SegmentTypes.Year);
+            const monthSegment = editableSegments.getByType(SegmentTypes.Month);
+            const daySegment = editableSegments.getByType(SegmentTypes.Day);
+            const hourSegment = editableSegments.getByType(SegmentTypes.Hour);
+            const minuteSegment = editableSegments.getByType(
+                SegmentTypes.Minute
+            );
+            const secondSegment = editableSegments.getByType(
+                SegmentTypes.Second
+            );
+
+            expect(editableSegments.length).to.equal(6);
+            expect(yearSegment.innerText).to.equal(paddedYear);
+            expect(monthSegment.innerText).to.equal(paddedMonth);
+            expect(daySegment.innerText).to.equal(paddedDay);
+            expect(hourSegment.innerText).to.equal(paddedHour);
+            expect(minuteSegment.innerText).to.equal(paddedMinute);
+            expect(secondSegment.innerText).to.equal(paddedSecond);
+        });
+    });
+
+    describe('Dev mode', () => {
         let consoleWarnStub: ReturnType<typeof stub>;
         let max: CalendarDate;
 
@@ -2597,7 +3452,7 @@ describe('DateTimePicker', () => {
             consoleWarnStub.restore();
         });
 
-        it("when the preselected value doesn't comply", async () => {
+        it("should warn when the preselected value doesn't comply with the min-max interval", async () => {
             const value = max.set({ day: max.day + 1 });
             element = await fixtureElement({
                 props: { max, value },
@@ -2609,7 +3464,7 @@ describe('DateTimePicker', () => {
                 .be.true;
         });
 
-        it('when min > max date', async () => {
+        it('should warn when the min-max interval is invalid', async () => {
             const min = max.set({ day: max.day + 1 });
             element = await fixtureElement({
                 props: { min, max },
@@ -2625,14 +3480,12 @@ describe('DateTimePicker', () => {
         });
     });
 
-    describe('Manages the disabled state', () => {
-        it('by not accepting focus');
-        it('by not accepting typed in values');
-        it('by not accepting arrow key inputs');
-        it('by not opening the calendar');
+    describe('Disabled', () => {
+        it('should not accept focus');
+        it('should not accept typed in values');
+        it('should not accept arrow key inputs');
+        it('should not open the calendar');
     });
 
-    describe("Manages different locales' formats", () => {
-        // TODO
-    });
+    describe('Non-english formats', () => {});
 });

--- a/packages/date-time-picker/test/date-time-picker.test.ts
+++ b/packages/date-time-picker/test/date-time-picker.test.ts
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import {
     CalendarDate,
     CalendarDateTime,
+    getLocalTimeZone,
     ZonedDateTime,
 } from '@internationalized/date';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
@@ -2245,6 +2246,35 @@ describe('DateTimePicker', () => {
                 expect(element.max).to.be.instanceOf(ZonedDateTime);
                 expectSameDates(element.max!, max);
             });
+        });
+
+        it("resetting currentDate's timeZone to local when the type changes back to one with no timeZone", async () => {
+            const value = new ZonedDateTime(
+                fixedYear,
+                fixedMonth,
+                fixedDay,
+                'America/Los_Angeles',
+                -28800000
+            );
+            element = await fixtureElement({
+                props: { value },
+            });
+
+            expect(element.value).to.be.instanceOf(ZonedDateTime);
+            expectSameDates(element.value!, value);
+            expectSameDates(element['currentDate'], value);
+            expect(element['currentDate'].timeZone).to.equal(
+                'America/Los_Angeles'
+            );
+
+            element.value = new CalendarDate(fixedYear, fixedMonth, fixedDay);
+            await elementUpdated(element);
+
+            expect(element.value).to.be.instanceOf(CalendarDate);
+            expectSameDates(element.value!, value);
+            expect(element['currentDate'].timeZone).to.equal(
+                getLocalTimeZone()
+            );
         });
     });
 

--- a/packages/date-time-picker/test/date-time-picker.test.ts
+++ b/packages/date-time-picker/test/date-time-picker.test.ts
@@ -2024,9 +2024,36 @@ describe('DateTimePicker', () => {
             expectSameDates(element.max!, max);
         });
 
-        it(
-            "by invalidating the current value when it doesn't comply with the new interval"
-        );
+        it("by invalidating the current value when it doesn't comply with the new interval", async () => {
+            const value = min.set({ day: min.day + 1 });
+            element = await fixtureElement({
+                props: { min, max, value },
+            });
+
+            expect(element.value).to.not.be.undefined;
+            expect(element.min).to.not.be.undefined;
+            expect(element.max).to.not.be.undefined;
+
+            const newMin = max.set({ day: max.day - 1 });
+            element.min = newMin;
+            await elementUpdated(element);
+
+            expect(element.value).to.be.undefined;
+            expect(element.min).to.not.be.undefined;
+            expectSameDates(element.min!, newMin);
+            expect(element.max).to.not.be.undefined;
+            expectSameDates(element.max!, max);
+
+            const newMax = max.set({ day: max.day + 1 });
+            element.max = newMax;
+            await elementUpdated(element);
+
+            expect(element.value).to.be.undefined;
+            expect(element.min).to.not.be.undefined;
+            expectSameDates(element.min!, newMin);
+            expect(element.max).to.not.be.undefined;
+            expectSameDates(element.max!, newMax);
+        });
 
         // TODO: with the Space/Enter/Blur value commit PR
         it(

--- a/packages/date-time-picker/test/helpers.ts
+++ b/packages/date-time-picker/test/helpers.ts
@@ -9,7 +9,9 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+import { isSameDay } from '@internationalized/date';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { DateValue } from '@spectrum-web-components/calendar';
 import {
     DateTimePicker,
     EditableSegmentType,
@@ -88,4 +90,8 @@ export function sendKeyMultipleTimes(
     return Promise.all(
         Array.from({ length: times }).map(() => sendKeys({ press: key }))
     );
+}
+
+export function expectSameDates(a: DateValue, b: DateValue): void {
+    expect(isSameDay(a, b)).to.be.true;
 }

--- a/packages/date-time-picker/test/helpers.ts
+++ b/packages/date-time-picker/test/helpers.ts
@@ -10,8 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 import { isSameDay } from '@internationalized/date';
-import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
-import { DateValue } from '@spectrum-web-components/calendar';
+import {
+    elementUpdated,
+    expect,
+    fixture,
+    html,
+    oneEvent,
+} from '@open-wc/testing';
+import { Calendar, DateValue } from '@spectrum-web-components/calendar';
 import {
     DateTimePicker,
     EditableSegmentType,
@@ -94,4 +100,29 @@ export function sendKeyMultipleTimes(
 
 export function expectSameDates(a: DateValue, b: DateValue): void {
     expect(isSameDay(a, b)).to.be.true;
+}
+
+export function dispatchCalendarChange(
+    element: DateTimePicker,
+    date: DateValue
+): void {
+    const calendarEl = element.shadowRoot!.querySelector(
+        'sp-calendar'
+    ) as Calendar;
+
+    calendarEl.value = date;
+    calendarEl.dispatchEvent(
+        new CustomEvent('change', { bubbles: true, composed: true })
+    );
+}
+
+export async function openCalendar(element: DateTimePicker): Promise<void> {
+    const calendarButton = element.shadowRoot!.querySelector(
+        'sp-picker-button'
+    ) as HTMLElement;
+
+    const opened = oneEvent(element, 'sp-opened');
+    calendarButton.focus();
+    await sendKeys({ press: 'Enter' });
+    await opened;
 }

--- a/packages/date-time-picker/test/helpers.ts
+++ b/packages/date-time-picker/test/helpers.ts
@@ -98,14 +98,18 @@ export function sendKeyMultipleTimes(
     );
 }
 
-export function expectSameDates(a: DateValue, b: DateValue): void {
-    expect(isSameDay(a, b)).to.be.true;
+export function expectSameDates(
+    a: DateValue,
+    b: DateValue,
+    message?: string
+): void {
+    expect(isSameDay(a, b), message).to.be.true;
 }
 
-export function dispatchCalendarChange(
+export async function dispatchCalendarChange(
     element: DateTimePicker,
     date: DateValue
-): void {
+): Promise<void> {
     const calendarEl = element.shadowRoot!.querySelector(
         'sp-calendar'
     ) as Calendar;
@@ -114,6 +118,7 @@ export function dispatchCalendarChange(
     calendarEl.dispatchEvent(
         new CustomEvent('change', { bubbles: true, composed: true })
     );
+    await elementUpdated(element);
 }
 
 export async function openCalendar(element: DateTimePicker): Promise<void> {


### PR DESCRIPTION
## Description
### Precision and value interactions
Previously, the DateTimePicker had a property named `timeGranularity`. This PR changes its name to `precision` and adds the `day` option to `hour | minute | second`. 

The image below explains the different interactions between the precision property and the most specific type of the date value props (min, max or value). 

![image (1)](https://github.com/user-attachments/assets/a3ce10be-3257-4057-bf9c-476b5e9ac3df)

_A few examples:_
If there is a date value prop (`min`, `max` or `value`) provided, the default precision will change to accomodate said prop. For example, if `CalendarDate` is provided but the precision isn't, the default precision will be `day`. If the type provided is `CalendarDateTime` or `ZonedDateTime`, the default precision will be `minute`.
If the precision is provided by the consumer it shouldn't be overridden. etc.

> [!NOTE]  
> _These will all be included in the final documentation of the component in some way_

### Other changes
- now the value clears if only the interval changes
- fixed some ZonedDateTime edge-cases
- tests now include assertions for the date value props types (checks for CalendarDate/CalendarDateTime/ZonedDateTime)
- improved unit tests readability in DateTimePicker as well as Calendar source files by removing unnecessary describe groupings and changing the test functions' titles to be more descriptive
- fixed a visual issue where the seconds segment would be partially overlapping with the invalid icon
- fixed visual issues on large scale

## Related issue(s)

- https://github.com/adobe/spectrum-web-components/issues/2559
- https://github.com/adobe/spectrum-web-components/issues/2560

## Motivation and context

This change gives the consumer more flexibility on the type of objects can be used to represent dates and makes sure that all of them aligns and interacts accordingly with the precision property and its new option. Also, the effort to improve tests readability will prove beneficial in any future development/debugging sessions.

## How has this been tested?

Unit tests.


## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
