### PR TITLE
fix(number-field): add missing stepper conversion config and variable definition

### DIFF
--- a/packages/number-field/src/number-field-overrides.css
+++ b/packages/number-field/src/number-field-overrides.css
@@ -112,7 +112,7 @@
     --spectrum-stepper-height: var(--system-stepper-size-s-height);
 }
 
-#textfield.spectrum-Stepper--sizeM {
+:host([size='m']) #textfield {
     --spectrum-stepper-button-width: var(--system-stepper-size-m-button-width);
     --spectrum-stepper-height: var(--system-stepper-size-m-height);
 }

--- a/packages/number-field/src/number-field.css
+++ b/packages/number-field/src/number-field.css
@@ -32,6 +32,7 @@ governing permissions and limitations under the License.
             ) * 2
     );
     --mod-infield-button-border-width: var(--unset-value-resets-inheritance);
+    --spectrum-stepper-width: var(--swc-number-field-width);
 }
 
 :host([size='s']) {

--- a/packages/number-field/src/spectrum-config.js
+++ b/packages/number-field/src/spectrum-config.js
@@ -258,6 +258,7 @@ const config = {
                 ...converter.enumerateAttributes(
                     [
                         ['spectrum-Stepper--sizeS', 's'],
+                        ['spectrum-Stepper--sizeM', 'm'],
                         ['spectrum-Stepper--sizeL', 'l'],
                         ['spectrum-Stepper--sizeXL', 'xl'],
                     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the missing `spectrum-Stepper--sizeM` conversion to the `number-field` config and add the missing `--spectrum-stepper-width` definition (that affects both the `no size` and `size-m` variants).

## Related issue(s)

<!---
    This project only accepts pull requests related to open issues

    - If suggesting a new feature or change, please discuss it in an issue first.
    - If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

- https://jira.corp.adobe.com/browse/SWC-518

## Screenshots (if appropriate)

Before:
<img width="205" alt="Screenshot 2024-10-14 at 16 01 40" src="https://github.com/user-attachments/assets/04ecaa84-9be2-423e-b7f6-1a42f9614f26">

After:
<img width="104" alt="Screenshot 2024-10-14 at 16 01 59" src="https://github.com/user-attachments/assets/19917374-fd94-407c-b525-de276dbc5d73">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] If my change required a change to the documentation, I have updated the documentation in this pull request.
-   [x] I have read the **[CONTRIBUTING](<(https://github.com/adobe/spectrum-web-components/blob/main/CONTRIBUTING.md)>)** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] I have reviewed at the Accessibility Practices for this feature, see: [Aria Practices](https://www.w3.org/TR/wai-aria-practices/)

## Best practices

This repository uses conventional commit syntax for each commit message; note that the GitHub UI does not use this by default so be cautious when accepting suggested changes. Avoid the "Update branch" button on the pull request and opt instead for rebasing your branch against `main`.
